### PR TITLE
Reduce the docker image size

### DIFF
--- a/dockerfiles/run/guice/Dockerfile
+++ b/dockerfiles/run/guice/Dockerfile
@@ -18,10 +18,10 @@ EXPOSE 25 110 143 465 587 993
 WORKDIR /root
 
 # Get data we need to run James : build results and configuration
-ADD destination/james-server-cassandra-guice-*.jar /root/james-server.jar
-ADD destination/james-server-cassandra-guice-3.0.0-beta5-SNAPSHOT.lib /root/james-server-cassandra-guice-3.0.0-beta5-SNAPSHOT.lib
-ADD destination/james-server-cli-3.0.0-beta5-SNAPSHOT.jar /root/james-cli.jar
-ADD destination/james-server-cli-3.0.0-beta5-SNAPSHOT.lib /root/james-server-cli-3.0.0-beta5-SNAPSHOT.lib
-ADD destination/conf /root/conf
+COPY destination/james-server-cassandra-guice-*.jar /root/james-server.jar
+COPY destination/james-server-cassandra-guice-3.0.0-beta5-SNAPSHOT.lib /root/james-server-cassandra-guice-3.0.0-beta5-SNAPSHOT.lib
+COPY destination/james-server-cli-3.0.0-beta5-SNAPSHOT.jar /root/james-cli.jar
+COPY destination/james-server-cli-3.0.0-beta5-SNAPSHOT.lib /root/james-server-cli-3.0.0-beta5-SNAPSHOT.lib
+COPY destination/conf /root/conf
 
 ENTRYPOINT java -Dworking.directory=/root/ -jar james-server.jar 


### PR DESCRIPTION
I will check the produced image on Docker Hub. (jdk -> 420 MB)