### PR TITLE
Imap 370 - Consider supporting the upcoming MOVE extension

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
@@ -69,6 +69,13 @@ import org.slf4j.Logger;
 
 public interface MailboxManager extends RequestAware, MailboxListenerSupport {
 
+    enum Capabilities {
+        Basic,
+        Move
+    }
+
+    List<Capabilities> getSupportedCapabilities();
+
     /**
      * Return the delimiter to use for folders
      * 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxManager.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxManager.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mailbox.cassandra;
 
+import java.util.List;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -35,6 +37,8 @@ import org.apache.james.mailbox.store.StoreMessageManager;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailbox;
 import org.apache.james.mailbox.store.search.MessageSearchIndex;
+
+import com.google.common.collect.Lists;
 
 /**
  * Cassandra implementation of {@link StoreMailboxManager}
@@ -57,6 +61,11 @@ public class CassandraMailboxManager extends StoreMailboxManager<CassandraId> {
     @Inject
     public void setMessageSearchIndex(MessageSearchIndex<CassandraId> index) {
         super.setMessageSearchIndex(index);
+    }
+
+    @Override
+    public List<Capabilities> getSupportedCapabilities() {
+        return Lists.newArrayList(Capabilities.Basic, Capabilities.Move);
     }
 
     @Override

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -246,15 +246,8 @@ public class CassandraMessageMapper implements MessageMapper<CassandraId> {
 
     @Override
     public MessageMetaData copy(Mailbox<CassandraId> mailbox, MailboxMessage<CassandraId> original) throws MailboxException {
-
-        original.setUid(uidProvider.nextUid(mailboxSession, mailbox));
-        original.setModSeq(modSeqProvider.nextModSeq(mailboxSession, mailbox));
-        incrementCount(mailbox.getMailboxId());
-        if(!original.isSeen()) {
-            incrementUnseen(mailbox.getMailboxId());
-        }
         original.setFlags(new FlagsBuilder().add(original.createFlags()).add(Flag.RECENT).build());
-        return save(mailbox, original);
+        return add(mailbox, original);
     }
 
     @Override

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -201,8 +201,9 @@ public class CassandraMessageMapper implements MessageMapper<CassandraId> {
 
     @Override
     public MessageMetaData move(Mailbox<CassandraId> destinationMailbox, MailboxMessage<CassandraId> original) throws MailboxException {
+        MessageMetaData messageMetaData = copy(destinationMailbox, original);
         deleteUsingMailboxId(original.getMailboxId(), original);
-        return copy(destinationMailbox, original);
+        return messageMetaData;
     }
 
     @Override

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -151,14 +151,18 @@ public class CassandraMessageMapper implements MessageMapper<CassandraId> {
 
     @Override
     public void delete(Mailbox<CassandraId> mailbox, MailboxMessage<CassandraId> message) {
+        deleteUsingMailboxId(mailbox.getMailboxId(), message);
+    }
+
+    private void deleteUsingMailboxId(CassandraId mailboxId, MailboxMessage<CassandraId> message) {
         session.execute(
             QueryBuilder.delete()
                 .from(TABLE_NAME)
-                .where(eq(MAILBOX_ID, mailbox.getMailboxId().asUuid()))
+                .where(eq(MAILBOX_ID, mailboxId.asUuid()))
                 .and(eq(IMAP_UID, message.getUid())));
-        decrementCount(mailbox);
+        decrementCount(mailboxId);
         if (!message.isSeen()) {
-            decrementUnseen(mailbox);
+            decrementUnseen(mailboxId);
         }
     }
 
@@ -196,8 +200,9 @@ public class CassandraMessageMapper implements MessageMapper<CassandraId> {
     }
 
     @Override
-    public MessageMetaData move(Mailbox<CassandraId> mailbox, MailboxMessage<CassandraId> original) throws MailboxException {
-        throw new UnsupportedOperationException("Not implemented - see https://issues.apache.org/jira/browse/IMAP-370");
+    public MessageMetaData move(Mailbox<CassandraId> destinationMailbox, MailboxMessage<CassandraId> original) throws MailboxException {
+        deleteUsingMailboxId(original.getMailboxId(), original);
+        return copy(destinationMailbox, original);
     }
 
     @Override
@@ -216,9 +221,9 @@ public class CassandraMessageMapper implements MessageMapper<CassandraId> {
         message.setModSeq(modSeqProvider.nextModSeq(mailboxSession, mailbox));
         MessageMetaData messageMetaData = save(mailbox, message);
         if (!message.isSeen()) {
-            incrementUnseen(mailbox);
+            incrementUnseen(mailbox.getMailboxId());
         }
-        incrementCount(mailbox);
+        incrementCount(mailbox.getMailboxId());
         return messageMetaData;
     }
 
@@ -243,9 +248,9 @@ public class CassandraMessageMapper implements MessageMapper<CassandraId> {
 
         original.setUid(uidProvider.nextUid(mailboxSession, mailbox));
         original.setModSeq(modSeqProvider.nextModSeq(mailboxSession, mailbox));
-        incrementCount(mailbox);
+        incrementCount(mailbox.getMailboxId());
         if(!original.isSeen()) {
-            incrementUnseen(mailbox);
+            incrementUnseen(mailbox.getMailboxId());
         }
         original.setFlags(new FlagsBuilder().add(original.createFlags()).add(Flag.RECENT).build());
         return save(mailbox, original);
@@ -256,24 +261,24 @@ public class CassandraMessageMapper implements MessageMapper<CassandraId> {
         return uidProvider.lastUid(mailboxSession, mailbox);
     }
 
-    private void decrementCount(Mailbox<CassandraId> mailbox) {
-        updateMailbox(mailbox, decr(CassandraMailboxCountersTable.COUNT));
+    private void decrementCount(CassandraId mailboxId) {
+        updateMailbox(mailboxId, decr(CassandraMailboxCountersTable.COUNT));
     }
 
-    private void incrementCount(Mailbox<CassandraId> mailbox) {
-        updateMailbox(mailbox, incr(CassandraMailboxCountersTable.COUNT));
+    private void incrementCount(CassandraId mailboxId) {
+        updateMailbox(mailboxId, incr(CassandraMailboxCountersTable.COUNT));
     }
 
-    private void decrementUnseen(Mailbox<CassandraId> mailbox) {
-        updateMailbox(mailbox, decr(CassandraMailboxCountersTable.UNSEEN));
+    private void decrementUnseen(CassandraId mailboxId) {
+        updateMailbox(mailboxId, decr(CassandraMailboxCountersTable.UNSEEN));
     }
 
-    private void incrementUnseen(Mailbox<CassandraId> mailbox) {
-        updateMailbox(mailbox, incr(CassandraMailboxCountersTable.UNSEEN));
+    private void incrementUnseen(CassandraId mailboxId) {
+        updateMailbox(mailboxId, incr(CassandraMailboxCountersTable.UNSEEN));
     }
 
-    private void updateMailbox(Mailbox<CassandraId> mailbox, Assignment operation) {
-        session.execute(update(CassandraMailboxCountersTable.TABLE_NAME).with(operation).where(eq(CassandraMailboxCountersTable.MAILBOX_ID, mailbox.getMailboxId().asUuid())));
+    private void updateMailbox(CassandraId mailboxId, Assignment operation) {
+        session.execute(update(CassandraMailboxCountersTable.TABLE_NAME).with(operation).where(eq(CassandraMailboxCountersTable.MAILBOX_ID, mailboxId.asUuid())));
     }
 
     private MailboxMessage<CassandraId> message(Row row) {
@@ -366,10 +371,10 @@ public class CassandraMessageMapper implements MessageMapper<CassandraId> {
 
     private void manageUnseenMessageCounts(Mailbox<CassandraId> mailbox, Flags oldFlags, Flags newFlags) {
         if (oldFlags.contains(Flag.SEEN) && !newFlags.contains(Flag.SEEN)) {
-            incrementUnseen(mailbox);
+            incrementUnseen(mailbox.getMailboxId());
         }
         if (!oldFlags.contains(Flag.SEEN) && newFlags.contains(Flag.SEEN)) {
-            decrementUnseen(mailbox);
+            decrementUnseen(mailbox.getMailboxId());
         }
     }
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMoveTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMoveTest.java
@@ -1,0 +1,30 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail;
+
+import org.apache.james.mailbox.cassandra.CassandraId;
+import org.apache.james.mailbox.store.mail.model.AbstractMessageMoveTest;
+
+public class CassandraMessageMoveTest extends AbstractMessageMoveTest<CassandraId> {
+
+    public CassandraMessageMoveTest() {
+        super(new CassandraMapperProvider());
+    }
+}

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/InMemoryMailboxManager.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/InMemoryMailboxManager.java
@@ -1,0 +1,43 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.inmemory;
+
+import java.util.List;
+
+import org.apache.james.mailbox.MailboxPathLocker;
+import org.apache.james.mailbox.acl.GroupMembershipResolver;
+import org.apache.james.mailbox.acl.MailboxACLResolver;
+import org.apache.james.mailbox.store.Authenticator;
+import org.apache.james.mailbox.store.StoreMailboxManager;
+
+import com.google.common.collect.Lists;
+
+public class InMemoryMailboxManager extends StoreMailboxManager<InMemoryId> {
+
+    public InMemoryMailboxManager(Authenticator authenticator, MailboxPathLocker locker, MailboxACLResolver aclResolver, GroupMembershipResolver groupMembershipResolver) {
+        super(new InMemoryMailboxSessionMapperFactory(), authenticator, locker, aclResolver, groupMembershipResolver);
+    }
+
+    @Override
+    public List<Capabilities> getSupportedCapabilities() {
+        return Lists.newArrayList(Capabilities.Basic, Capabilities.Move);
+
+    }
+}

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMessageMapper.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMessageMapper.java
@@ -55,10 +55,14 @@ public class InMemoryMessageMapper extends AbstractMessageMapper<InMemoryId> {
     }
 
     private Map<Long, MailboxMessage<InMemoryId>> getMembershipByUidForMailbox(Mailbox<InMemoryId> mailbox) {
-        Map<Long, MailboxMessage<InMemoryId>> membershipByUid = mailboxByUid.get(mailbox.getMailboxId());
+        return getMembershipByUidForId(mailbox.getMailboxId());
+    }
+
+    private Map<Long, MailboxMessage<InMemoryId>> getMembershipByUidForId(InMemoryId id) {
+        Map<Long, MailboxMessage<InMemoryId>> membershipByUid = mailboxByUid.get(id);
         if (membershipByUid == null) {
             membershipByUid = new ConcurrentHashMap<Long, MailboxMessage<InMemoryId>>(INITIAL_SIZE);
-            mailboxByUid.put(mailbox.getMailboxId(), membershipByUid);
+            mailboxByUid.put(id, membershipByUid);
         }
         return membershipByUid;
     }
@@ -89,6 +93,15 @@ public class InMemoryMessageMapper extends AbstractMessageMapper<InMemoryId> {
      */
     public void delete(Mailbox<InMemoryId> mailbox, MailboxMessage<InMemoryId> message) throws MailboxException {
         getMembershipByUidForMailbox(mailbox).remove(message.getUid());
+    }
+
+    @Override
+    public MessageMetaData move(Mailbox<InMemoryId> mailbox, MailboxMessage<InMemoryId> original) throws MailboxException {
+        InMemoryId originalMailboxId = original.getMailboxId();
+        MailboxMessage<InMemoryId> copy = SimpleMailboxMessage.copy(mailbox.getMailboxId(), original);
+        MessageMetaData messageMetaData = copy(mailbox, copy);
+        getMembershipByUidForId(originalMailboxId).remove(original.getUid());
+        return messageMetaData;
     }
 
     /**
@@ -188,17 +201,6 @@ public class InMemoryMessageMapper extends AbstractMessageMapper<InMemoryId> {
 
     public void deleteAll() {
         mailboxByUid.clear();
-    }
-
-    /**
-     * (non-Javadoc)
-     * 
-     * @see org.apache.james.mailbox.store.mail.MessageMapper#move(org.apache.james.mailbox.store.mail.model.Mailbox,
-     *      MailboxMessage)
-     */
-    @Override
-    public MessageMetaData move(Mailbox<InMemoryId> mailbox, MailboxMessage<InMemoryId> original) throws MailboxException {
-        throw new UnsupportedOperationException("Not implemented - see https://issues.apache.org/jira/browse/IMAP-370");
     }
 
     /**

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMessageMapper.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMessageMapper.java
@@ -98,9 +98,9 @@ public class InMemoryMessageMapper extends AbstractMessageMapper<InMemoryId> {
     @Override
     public MessageMetaData move(Mailbox<InMemoryId> mailbox, MailboxMessage<InMemoryId> original) throws MailboxException {
         InMemoryId originalMailboxId = original.getMailboxId();
-        MailboxMessage<InMemoryId> copy = SimpleMailboxMessage.copy(mailbox.getMailboxId(), original);
-        MessageMetaData messageMetaData = copy(mailbox, copy);
-        getMembershipByUidForId(originalMailboxId).remove(original.getUid());
+        long uid = original.getUid();
+        MessageMetaData messageMetaData = copy(mailbox, original);
+        getMembershipByUidForId(originalMailboxId).remove(uid);
         return messageMetaData;
     }
 

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/InMemoryMailboxManagerTest.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/InMemoryMailboxManagerTest.java
@@ -31,6 +31,7 @@ import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.MailboxMetaData;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MailboxQuery;
+import org.apache.james.mailbox.store.JVMMailboxPathLocker;
 import org.apache.james.mailbox.store.MockAuthenticator;
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.junit.After;
@@ -67,7 +68,7 @@ public class InMemoryMailboxManagerTest extends AbstractMailboxManagerTest {
      * @throws BadCredentialsException 
      */
     @After
-    public void tearDown() throws BadCredentialsException, MailboxException {
+    public void tearDown() throws MailboxException {
         getMailboxManager().logout(session, true);
         getMailboxManager().endProcessingRequest(session);
         getMailboxManager().createSystemSession("test", LoggerFactory.getLogger("Test")).close();
@@ -78,12 +79,11 @@ public class InMemoryMailboxManagerTest extends AbstractMailboxManagerTest {
      */
     @Override
     protected void createMailboxManager() throws MailboxException {
-        
-        InMemoryMailboxSessionMapperFactory factory = new InMemoryMailboxSessionMapperFactory();
+
         MailboxACLResolver aclResolver = new UnionMailboxACLResolver();
         GroupMembershipResolver groupMembershipResolver = new SimpleGroupMembershipResolver();
 
-        StoreMailboxManager<InMemoryId> mailboxManager = new StoreMailboxManager<InMemoryId>(factory, new MockAuthenticator(), aclResolver, groupMembershipResolver);
+        StoreMailboxManager<InMemoryId> mailboxManager = new InMemoryMailboxManager(new MockAuthenticator(), new JVMMailboxPathLocker(), aclResolver, groupMembershipResolver);
         mailboxManager.init();
         
         setMailboxManager(mailboxManager);

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/mail/InMemoryMapperProvider.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/mail/InMemoryMapperProvider.java
@@ -1,0 +1,45 @@
+package org.apache.james.mailbox.inmemory.mail;
+
+import java.util.Random;
+
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.inmemory.InMemoryId;
+import org.apache.james.mailbox.inmemory.InMemoryMailboxSessionMapperFactory;
+import org.apache.james.mailbox.mock.MockMailboxSession;
+import org.apache.james.mailbox.store.mail.MailboxMapper;
+import org.apache.james.mailbox.store.mail.MessageMapper;
+import org.apache.james.mailbox.store.mail.model.MapperProvider;
+
+public class InMemoryMapperProvider implements MapperProvider<InMemoryId> {
+
+    private final Random random;
+
+    public InMemoryMapperProvider() {
+        random = new Random();
+    }
+
+    @Override
+    public MailboxMapper<InMemoryId> createMailboxMapper() throws MailboxException {
+        return new InMemoryMailboxSessionMapperFactory().createMailboxMapper(new MockMailboxSession("user"));
+    }
+
+    @Override
+    public MessageMapper<InMemoryId> createMessageMapper() throws MailboxException {
+        return new InMemoryMailboxSessionMapperFactory().createMessageMapper(new MockMailboxSession("user"));
+    }
+
+    @Override
+    public InMemoryId generateId() {
+        return InMemoryId.of(random.nextInt());
+    }
+
+    @Override
+    public void clearMapper() throws MailboxException {
+
+    }
+
+    @Override
+    public void ensureMapperPrepared() throws MailboxException {
+
+    }
+}

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/mail/InMemoryMessageMoveTest.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/mail/InMemoryMessageMoveTest.java
@@ -1,0 +1,30 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.inmemory.mail;
+
+import org.apache.james.mailbox.inmemory.InMemoryId;
+import org.apache.james.mailbox.store.mail.model.AbstractMessageMoveTest;
+
+public class InMemoryMessageMoveTest extends AbstractMessageMoveTest<InMemoryId> {
+
+    public InMemoryMessageMoveTest() {
+        super(new InMemoryMapperProvider());
+    }
+}

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/manager/InMemoryIntegrationResources.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/manager/InMemoryIntegrationResources.java
@@ -25,6 +25,7 @@ import org.apache.james.mailbox.acl.SimpleGroupMembershipResolver;
 import org.apache.james.mailbox.acl.UnionMailboxACLResolver;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.inmemory.InMemoryId;
+import org.apache.james.mailbox.inmemory.InMemoryMailboxManager;
 import org.apache.james.mailbox.inmemory.InMemoryMailboxSessionMapperFactory;
 import org.apache.james.mailbox.inmemory.quota.InMemoryCurrentQuotaManager;
 import org.apache.james.mailbox.inmemory.quota.InMemoryPerUserMaxQuotaManager;
@@ -52,8 +53,7 @@ public class InMemoryIntegrationResources implements IntegrationResources {
         MockAuthenticator mockAuthenticator = new MockAuthenticator();
         mockAuthenticator.addUser(ManagerTestResources.USER, ManagerTestResources.USER_PASS);
         MailboxSessionMapperFactory<InMemoryId> factory = new InMemoryMailboxSessionMapperFactory();
-        final StoreMailboxManager<InMemoryId> manager = new StoreMailboxManager<InMemoryId>(
-            factory,
+        final StoreMailboxManager<InMemoryId> manager = new InMemoryMailboxManager(
             mockAuthenticator,
             new NoMailboxPathLocker(),
             new UnionMailboxACLResolver(),

--- a/mailbox/src/site/site.xml
+++ b/mailbox/src/site/site.xml
@@ -45,6 +45,7 @@
     </menu>
     <menu name="Implementations">
       <item name="Mailbox Memory" href="/mailbox-memory.html" />
+      <item name="Mailbox Cassandra" href="/mailbox-cassandra.html" />
       <item name="Mailbox Maildir" href="/mailbox-maildir.html" />
       <item name="Mailbox JPA" href="/mailbox-jpa.html" />
       <item name="Mailbox JCR" href="/mailbox-jcr.html" />
@@ -52,7 +53,6 @@
     </menu>
     <menu name="Wiring">
       <item name="Spring" href="/mailbox-spring.html" />
-      <item name="Guice" href="/mailbox-guice.html" />
     </menu>  
      
     <menu name="References">

--- a/mailbox/src/site/xdoc/index.xml
+++ b/mailbox/src/site/xdoc/index.xml
@@ -46,6 +46,14 @@
     <p>You can <a href="http://james.apache.org/download.cgi">download</a> current 0.4 release. 
        The <a href="apidocs/">API</a> as the schemas for the different implementations are susceptible to evolve.
     </p>
+      <ul>Here are the different implementations of the mailbox we propose :
+          <li><a href="mailbox-memory.html">Memory</a> for testing purposes</li>
+          <li><a href="mailbox-cassandra.html">Cassandra</a></li>
+          <li><a href="mailbox-maildir.html">Maildir</a></li>
+          <li><a href="mailbox-jpa.html">JPA</a> </li>
+          <li><a href="mailbox-jcr.html">JCR</a> </li>
+          <li><a href="mailbox-hbase.html">HBase</a>)</li>
+      </ul>
   </section>
 
   <section name="Apache James Mailbox in Server">

--- a/mailbox/src/site/xdoc/mailbox-api.xml
+++ b/mailbox/src/site/xdoc/mailbox-api.xml
@@ -49,7 +49,15 @@
   
     <subsection name="Mailbox Manager">
       <p>The Mailbox Manager is responsible for session creation, operations on mailbox (create, delete, search)
-         and to return a Message Manager. It also allows to copy and list messages.</p>
+         and to return a Message Manager. It also allows to copy and list messages.
+      </p>
+
+        <ul>
+            Mailbox manager capabilities represents which operations a mailbox manager is able to support. For now the list is :
+            <li>Basic : supports all basic operations</li>
+            <li>Move : implements the move capability</li>
+        </ul>
+
 <!-- 
 Image is no more in line with trunk
       <p><img src="images/uml/org-apache-james-mailbox-api-mailboxmanager.png"/></p>

--- a/mailbox/src/site/xdoc/mailbox-api.xml
+++ b/mailbox/src/site/xdoc/mailbox-api.xml
@@ -54,8 +54,8 @@
 
         <ul>
             Mailbox manager capabilities represents which operations a mailbox manager is able to support. For now the list is :
-            <li>Basic : supports all basic operations</li>
-            <li>Move : implements the move capability</li>
+            <li>Basic: supports all basic operations</li>
+            <li>Move: implements the move capability</li>
         </ul>
 
 <!-- 

--- a/mailbox/src/site/xdoc/mailbox-cassandra.xml
+++ b/mailbox/src/site/xdoc/mailbox-cassandra.xml
@@ -19,15 +19,22 @@
 -->
 <document>
 
-  <properties>
-     <title>Mailbox Guice</title>
-  </properties>
+    <properties>
+        <title>Mailbox Cassandra</title>
+    </properties>
 
-<body>
+    <body>
 
-  <section name="Mailbox Guice Responsability">
-  </section>
+        <section name="Mailbox Cassandra">
+            <p>This module provides a mailbox implementation for persisting mailboxes (messages, and subscriptions) in a Cassandra cluster.</p>
+            <p>It supports the Basic and Move capabilities.</p>
+        </section>
 
-</body>
+        <section name="Overview">
+            <p>The Cassandra implementation comes with a CassandraMailboxManager and a CassandraMessageManager for persisting users mailboxes.</p>
+            <p>This implementation also have a CurrentQuotaManager and a MaxQuotaManager, for storing users quotas in a Cassandra cluster.</p>
+        </section>
+
+    </body>
 
 </document>

--- a/mailbox/src/site/xdoc/mailbox-hbase.xml
+++ b/mailbox/src/site/xdoc/mailbox-hbase.xml
@@ -26,7 +26,8 @@
     <body>
 
         <section name="Mailbox HBase Responsibility">
-      This module provides a mailbox implementation for peristing mailboxes (messages, and subscriptions) in a HBase cluster. 
+          <p>This module provides a mailbox implementation for persisting mailboxes (messages, and subscriptions) in a HBase cluster.</p>
+          <p>It only supports the Basic capability.</p>
         </section>
         
         <section name="Overview">
@@ -68,8 +69,8 @@
                 </ul>
             </subsection>
             <subsection name="Misc">
-                <p>Message bodyes (more importantly big attachements) sent to many users are stored many times. There is no space sharing yet.</p>
-                <p>Message data and mssage meta-data (flags and properties) are stored in different column families 
+                <p>Message bodies (more importantly big attachements) sent to many users are stored many times. There is no space sharing yet.</p>
+                <p>Message data and message meta-data (flags and properties) are stored in different column families
                 so the column family optimization options can apply. Keep in mind that message data does not change, while meta-data does change.
                 </p>
             </subsection>
@@ -83,7 +84,7 @@
         </section>
         
         <section name="Mailbox HBase Classes">
-            <p>This is a onverview of the most important classes in the implementation. </p>
+            <p>This is a overview of the most important classes in the implementation. </p>
             <subsection name="HBaseMailboxManager">
                 <p> 
                     <strong>HBaseMailboxManager</strong> extends the  
@@ -105,7 +106,7 @@
                 <p>Message bodies can have varying sizes. Some have attachements of up to 25Mb, some even greater. 
                 There are practical limits to the size of a HBase column (see 
                     <a href="http://hbase.apache.org/book.html#supported.datatypes">http://hbase.apache.org/book.html#supported.datatypes</a>).
-                To adress this issue, the implementation splits the message into smaller chunks and saves each chunk into a separate column. 
+                To address this issue, the implementation splits the message into smaller chunks and saves each chunk into a separate column.
                 The columns have increasing integer names starting with 1 and there can be at most Long.MAX_VALUE chunks. 
                 </p>
                 <p>

--- a/mailbox/src/site/xdoc/mailbox-jcr.xml
+++ b/mailbox/src/site/xdoc/mailbox-jcr.xml
@@ -30,6 +30,7 @@
             <p>The default JCR provider used is 
                 <a hfre="http://jackrabbit.apache.org/">Apache Jackrabbit</a>.
             </p>
+            <p>It only supports the Basic capability.</p>
         </section>
 <!-- 
         <section name="Installation">

--- a/mailbox/src/site/xdoc/mailbox-jpa.xml
+++ b/mailbox/src/site/xdoc/mailbox-jpa.xml
@@ -35,10 +35,11 @@
                 but you can roll your own by extending JPAMailboxManager and JPAMessageManager in the same way
                 as OpenJPAMailboxManager and OpenJPAMessageManager do. 
             </p>
+            <p>It only supports the Basic capability.</p>
         </section>
   
         <section name="Overview">
-            <p>The JPA implementation uses Java Persistenca API Annotations to map Java objects to data base tables. 
+            <p>The JPA implementation uses Java Persistence API Annotations to map Java objects to data base tables.
             The current implementation also supports features such as storing messages in an encrypted database and provide 
             on the fly encryption/decryption.
             </p>

--- a/mailbox/src/site/xdoc/mailbox-maildir.xml
+++ b/mailbox/src/site/xdoc/mailbox-maildir.xml
@@ -26,7 +26,8 @@
 <body>
 
   <section name="Mailbox Maildir Responsibility">
-      <p>This implementation stores messages using the popular <a href="http://en.wikipedia.org/wiki/Maildir">Maildir</a> format.</p> 
+      <p>This implementation stores messages using the popular <a href="http://en.wikipedia.org/wiki/Maildir">Maildir</a> format.</p>
+      <p>It only supports the Basic capability. This implementation do not support namespaces.</p>
   </section>
 <!-- 
   <section name="Mailbox Maildir Classes">

--- a/mailbox/src/site/xdoc/mailbox-memory.xml
+++ b/mailbox/src/site/xdoc/mailbox-memory.xml
@@ -27,6 +27,7 @@
 
         <section name="Mailbox Memory Responsibility">
             <p>Provides an in-memory mail store.</p>
+            <p>It only supports the Basic capability.</p>
         </section>
 <!-- 
         <section name="Mailbox Memory Classes">

--- a/mailbox/src/site/xdoc/mailbox-spring.xml
+++ b/mailbox/src/site/xdoc/mailbox-spring.xml
@@ -25,7 +25,7 @@
 
     <body>
         
-        <section name="Mailbox Spring Responsability">
+        <section name="Mailbox Spring Responsibility">
             <p>The Mailbox Spring module is designed to test the loading of mailbox implementations. </p>
         </section>
         

--- a/mailbox/src/site/xdoc/mailbox-store.xml
+++ b/mailbox/src/site/xdoc/mailbox-store.xml
@@ -44,7 +44,7 @@ Image is no more in line with trunk
   
     <subsection name="Store Mailbox Manager">
       <p>All public and protected methods that can be used by a Mailbox Manager implementations.</p>
-      <p>You need to instanciate the StoreMailboxManager with a mailboxSessionMapperFactory,
+      <p>You need to instantiate the StoreMailboxManager with a mailboxSessionMapperFactory,
          an authenticator, a uidProvider and a mailboxPathlocker.</p>
 <!-- 
 Image is no more in line with trunk
@@ -54,7 +54,7 @@ Image is no more in line with trunk
 
     <subsection name="Store Message Manager">
       <p>All public and protected methods that can be used by a Message Manager implementations.</p>
-      <p>You need to instanciate the StoreMessageManager with a messageSessionMapperFactory,
+      <p>You need to instantiate the StoreMessageManager with a messageSessionMapperFactory,
          a uidProvider, a mailboxEventDispatcher and a mailbox.</p>
 <!-- 
 Image is no more in line with trunk
@@ -64,7 +64,7 @@ Image is no more in line with trunk
 
     <subsection name="Store Subscription Manager">
       <p>All public and protected methods that can be used by a Subscription Manager implementations.</p>
-      <p>You need to instanciate the StoreSubscriptionManager with a subscriptionSessionMapperFactory.</p>
+      <p>You need to instantiate the StoreSubscriptionManager with a subscriptionSessionMapperFactory.</p>
 <!-- 
 Image is no more in line with trunk
       <p><img src="images/uml/org-apache-james-mailbox-store-subscriptionmanager.png"/></p>

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageBatcher.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageBatcher.java
@@ -1,0 +1,56 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.store;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.store.mail.model.MailboxId;
+import org.msgpack.core.Preconditions;
+
+public class MessageBatcher {
+
+    public interface BatchedOperation {
+        List<MessageRange> execute(MessageRange messageRange) throws MailboxException;
+    }
+
+    private final int moveBatchSize;
+
+    public MessageBatcher(int moveBatchSize) {
+        Preconditions.checkArgument(moveBatchSize >= 0);
+        this.moveBatchSize = moveBatchSize;
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<MessageRange> batchMessages(MessageRange set, BatchedOperation batchedOperation) throws MailboxException {
+        if (moveBatchSize > 0) {
+            List<MessageRange> movedRanges = new ArrayList<MessageRange>();
+            for (MessageRange messageRange : set.split(moveBatchSize)) {
+                movedRanges.addAll(batchedOperation.execute(messageRange));
+            }
+            return movedRanges;
+        } else {
+            return batchedOperation.execute(set);
+        }
+    }
+
+}

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageBatcher.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageBatcher.java
@@ -29,6 +29,8 @@ import org.msgpack.core.Preconditions;
 
 public class MessageBatcher {
 
+    public static final int NO_BATCH_SIZE = 0;
+
     public interface BatchedOperation {
         List<MessageRange> execute(MessageRange messageRange) throws MailboxException;
     }
@@ -36,7 +38,7 @@ public class MessageBatcher {
     private final int moveBatchSize;
 
     public MessageBatcher(int moveBatchSize) {
-        Preconditions.checkArgument(moveBatchSize >= 0);
+        Preconditions.checkArgument(moveBatchSize >= NO_BATCH_SIZE);
         this.moveBatchSize = moveBatchSize;
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageBatcher.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageBatcher.java
@@ -40,7 +40,6 @@ public class MessageBatcher {
         this.moveBatchSize = moveBatchSize;
     }
 
-    @SuppressWarnings("unchecked")
     public List<MessageRange> batchMessages(MessageRange set, BatchedOperation batchedOperation) throws MailboxException {
         if (moveBatchSize > 0) {
             List<MessageRange> movedRanges = new ArrayList<MessageRange>();

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/MoveResult.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/MoveResult.java
@@ -1,0 +1,43 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.store;
+
+import java.util.Iterator;
+
+import org.apache.james.mailbox.model.MessageMetaData;
+
+public class MoveResult {
+
+    private final Iterator<MessageMetaData> movedMessages;
+    private final Iterator<MessageMetaData> originalMessages;
+
+    public MoveResult(Iterator<MessageMetaData> movedMessages, Iterator<MessageMetaData> originalMessages) {
+        this.movedMessages = movedMessages;
+        this.originalMessages = originalMessages;
+    }
+
+    public Iterator<MessageMetaData> getMovedMessages() {
+        return movedMessages;
+    }
+
+    public Iterator<MessageMetaData> getOriginalMessages() {
+        return originalMessages;
+    }
+}

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -191,10 +191,10 @@ public class StoreMailboxManager<Id extends MailboxId> implements MailboxManager
             this.addGlobalListener((MailboxListener) quotaUpdater, null);
         }
         if (copyBatcher == null) {
-            copyBatcher = new MessageBatcher(0);
+            copyBatcher = new MessageBatcher(MessageBatcher.NO_BATCH_SIZE);
         }
         if (moveBatcher == null) {
-            moveBatcher = new MessageBatcher(0);
+            moveBatcher = new MessageBatcher(MessageBatcher.NO_BATCH_SIZE);
         }
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -71,6 +71,8 @@ import org.apache.james.mailbox.store.transaction.Mapper;
 import org.apache.james.mailbox.store.transaction.TransactionalMapper;
 import org.slf4j.Logger;
 
+import com.google.common.collect.Lists;
+
 /**
  * This base class of an {@link MailboxManager} implementation provides a high-level api for writing your own
  * {@link MailboxManager} implementation. If you plan to write your own {@link MailboxManager} its most times so easiest
@@ -194,6 +196,11 @@ public class StoreMailboxManager<Id extends MailboxId> implements MailboxManager
         if (moveBatcher == null) {
             moveBatcher = new MessageBatcher(0);
         }
+    }
+
+    @Override
+    public List<Capabilities> getSupportedCapabilities() {
+        return Lists.newArrayList(Capabilities.Basic);
     }
 
     /**

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -21,7 +21,6 @@ package org.apache.james.mailbox.store;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
@@ -99,9 +98,9 @@ public class StoreMailboxManager<Id extends MailboxId> implements MailboxManager
 
     private final static Random RANDOM = new Random();
 
-    private int copyBatchSize = 0;
+    private MessageBatcher copyBatcher;
 
-    private int moveBatchSize = 0;
+    private MessageBatcher moveBatcher;
 
     private final MailboxPathLocker locker;
 
@@ -148,11 +147,11 @@ public class StoreMailboxManager<Id extends MailboxId> implements MailboxManager
     }
 
     public void setCopyBatchSize(int copyBatchSize) {
-        this.copyBatchSize = copyBatchSize;
+        this.copyBatcher = new MessageBatcher(copyBatchSize);
     }
 
     public void setMoveBatchSize(int moveBatchSize) {
-        this.moveBatchSize = moveBatchSize;
+        this.moveBatcher = new MessageBatcher(moveBatchSize);
     }
 
     public void setFetchBatchSize(int fetchBatchSize) {
@@ -188,6 +187,12 @@ public class StoreMailboxManager<Id extends MailboxId> implements MailboxManager
         }
         if (quotaUpdater != null && quotaUpdater instanceof MailboxListener) {
             this.addGlobalListener((MailboxListener) quotaUpdater, null);
+        }
+        if (copyBatcher == null) {
+            copyBatcher = new MessageBatcher(0);
+        }
+        if (moveBatcher == null) {
+            moveBatcher = new MessageBatcher(0);
         }
     }
 
@@ -505,38 +510,28 @@ public class StoreMailboxManager<Id extends MailboxId> implements MailboxManager
 
     @Override
     @SuppressWarnings("unchecked")
-    public List<MessageRange> copyMessages(MessageRange set, MailboxPath from, MailboxPath to, MailboxSession session) throws MailboxException {
-        StoreMessageManager<Id> toMailbox = (StoreMessageManager<Id>) getMailbox(to, session);
-        StoreMessageManager<Id> fromMailbox = (StoreMessageManager<Id>) getMailbox(from, session);
+    public List<MessageRange> copyMessages(MessageRange set, MailboxPath from, MailboxPath to, final MailboxSession session) throws MailboxException {
+        final StoreMessageManager<Id> toMailbox = (StoreMessageManager<Id>) getMailbox(to, session);
+        final StoreMessageManager<Id> fromMailbox = (StoreMessageManager<Id>) getMailbox(from, session);
 
-        if (copyBatchSize > 0) {
-            List<MessageRange> copiedRanges = new ArrayList<MessageRange>();
-            Iterator<MessageRange> ranges = set.split(copyBatchSize).iterator();
-            while (ranges.hasNext()) {
-                copiedRanges.addAll(fromMailbox.copyTo(ranges.next(), toMailbox, session));
+        return copyBatcher.batchMessages(set, new MessageBatcher.BatchedOperation() {
+            public List<MessageRange> execute(MessageRange messageRange) throws MailboxException {
+                return fromMailbox.copyTo(messageRange, toMailbox, session);
             }
-            return copiedRanges;
-        } else {
-            return fromMailbox.copyTo(set, toMailbox, session);
-        }
+        });
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public List<MessageRange> moveMessages(MessageRange set, MailboxPath from, MailboxPath to, MailboxSession session) throws MailboxException {
-        StoreMessageManager<Id> toMailbox = (StoreMessageManager<Id>) getMailbox(to, session);
-        StoreMessageManager<Id> fromMailbox = (StoreMessageManager<Id>) getMailbox(from, session);
+    public List<MessageRange> moveMessages(MessageRange set, MailboxPath from, MailboxPath to, final MailboxSession session) throws MailboxException {
+        final StoreMessageManager<Id> toMailbox = (StoreMessageManager<Id>) getMailbox(to, session);
+        final StoreMessageManager<Id> fromMailbox = (StoreMessageManager<Id>) getMailbox(from, session);
 
-        if (moveBatchSize > 0) {
-            List<MessageRange> movedRanges = new ArrayList<MessageRange>();
-            Iterator<MessageRange> ranges = set.split(moveBatchSize).iterator();
-            while (ranges.hasNext()) {
-                movedRanges.addAll(fromMailbox.moveTo(ranges.next(), toMailbox, session));
+        return moveBatcher.batchMessages(set, new MessageBatcher.BatchedOperation() {
+            public List<MessageRange> execute(MessageRange messageRange) throws MailboxException {
+                return fromMailbox.moveTo(messageRange, toMailbox, session);
             }
-            return movedRanges;
-        } else {
-            return fromMailbox.moveTo(set, toMailbox, session);
-        }
+        });
     }
 
     @Override

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/AbstractMessageMoveTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/AbstractMessageMoveTest.java
@@ -89,7 +89,9 @@ public abstract class AbstractMessageMoveTest<Id extends MailboxId> {
 
         MessageMetaData messageMetaData = messageMapper.move(benwaWorkMailbox, message1);
 
-        assertThat(messageMetaData.getFlags()).isEqualTo(message1.createFlags());
+        Flags expectedFlags = message1.createFlags();
+        expectedFlags.add(Flags.Flag.RECENT);
+        assertThat(messageMetaData.getFlags()).isEqualTo(expectedFlags);
         assertThat(messageMetaData.getUid()).isEqualTo(messageMapper.getLastUid(benwaWorkMailbox));
         assertThat(messageMetaData.getModSeq()).isEqualTo(messageMapper.getHighestModSeq(benwaWorkMailbox));
     }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/AbstractMessageMoveTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/AbstractMessageMoveTest.java
@@ -1,0 +1,145 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.store.mail.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+
+import javax.mail.Flags;
+import javax.mail.util.SharedByteArrayInputStream;
+
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.MessageMetaData;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.store.mail.MessageMapper;
+import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
+import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailbox;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public abstract class AbstractMessageMoveTest<Id extends MailboxId> {
+
+    private final static char DELIMITER = ':';
+    private static final int LIMIT = 10;
+    private static final int BODY_START = 16;
+    public static final int UID_VALIDITY = 42;
+
+    private MapperProvider<Id> mapperProvider;
+    private MessageMapper<Id> messageMapper;
+
+    private SimpleMailbox<Id> benwaInboxMailbox;
+    private SimpleMailbox<Id> benwaWorkMailbox;
+
+    private SimpleMailboxMessage<Id> message1;
+
+    public AbstractMessageMoveTest(MapperProvider<Id> mapperProvider) {
+        this.mapperProvider = mapperProvider;
+    }
+
+    @Before
+    public void setUp() throws MailboxException {
+        mapperProvider.ensureMapperPrepared();
+        messageMapper = mapperProvider.createMessageMapper();
+        benwaInboxMailbox = createMailbox(new MailboxPath("#private", "benwa", "INBOX"));
+        benwaWorkMailbox = createMailbox( new MailboxPath("#private", "benwa", "INBOX"+DELIMITER+"work"));
+        message1 = createMessage(benwaInboxMailbox, "Subject: Test1 \n\nBody1\n.\n", BODY_START, new PropertyBuilder());
+    }
+
+    @After
+    public void tearDown() throws MailboxException {
+        mapperProvider.clearMapper();
+    }
+
+    @Test
+    public void movingAMessageShoudlWork() throws Exception {
+        messageMapper.add(benwaInboxMailbox, message1);
+        message1.setModSeq(messageMapper.getHighestModSeq(benwaInboxMailbox));
+
+        messageMapper.move(benwaWorkMailbox, message1);
+
+        assertThat(retrieveMessageFromStorage(benwaWorkMailbox, message1)).isEqualTo(message1);
+    }
+
+    @Test
+    public void movingAMessageShoudlReturnCorrectMetadata() throws Exception {
+        messageMapper.add(benwaInboxMailbox, message1);
+        message1.setModSeq(messageMapper.getHighestModSeq(benwaInboxMailbox));
+
+        MessageMetaData messageMetaData = messageMapper.move(benwaWorkMailbox, message1);
+
+        assertThat(messageMetaData.getFlags()).isEqualTo(message1.createFlags());
+        assertThat(messageMetaData.getUid()).isEqualTo(messageMapper.getLastUid(benwaWorkMailbox));
+        assertThat(messageMetaData.getModSeq()).isEqualTo(messageMapper.getHighestModSeq(benwaWorkMailbox));
+    }
+
+    @Test
+    public void movingAMessageShoudlNotViolateMessageCount() throws Exception {
+        messageMapper.add(benwaInboxMailbox, message1);
+        message1.setModSeq(messageMapper.getHighestModSeq(benwaInboxMailbox));
+
+        messageMapper.move(benwaWorkMailbox, message1);
+
+        assertThat(messageMapper.countMessagesInMailbox(benwaInboxMailbox)).isEqualTo(0);
+        assertThat(messageMapper.countMessagesInMailbox(benwaWorkMailbox)).isEqualTo(1);
+    }
+
+    @Test
+    public void movingAMessageShoudlNotViolateUnseenMessageCount() throws Exception {
+        messageMapper.add(benwaInboxMailbox, message1);
+        message1.setModSeq(messageMapper.getHighestModSeq(benwaInboxMailbox));
+
+        messageMapper.move(benwaWorkMailbox, message1);
+
+        assertThat(messageMapper.countUnseenMessagesInMailbox(benwaInboxMailbox)).isEqualTo(0);
+        assertThat(messageMapper.countUnseenMessagesInMailbox(benwaWorkMailbox)).isEqualTo(1);
+    }
+
+    @Test
+    public void movingASeenMessageShoudlNotIncrementUnseenMessageCount() throws Exception {
+        message1.setFlags(new Flags(Flags.Flag.SEEN));
+        messageMapper.add(benwaInboxMailbox, message1);
+        message1.setModSeq(messageMapper.getHighestModSeq(benwaInboxMailbox));
+
+        messageMapper.move(benwaWorkMailbox, message1);
+
+        assertThat(messageMapper.countUnseenMessagesInMailbox(benwaInboxMailbox)).isEqualTo(0);
+        assertThat(messageMapper.countUnseenMessagesInMailbox(benwaWorkMailbox)).isEqualTo(0);
+    }
+
+    private SimpleMailbox<Id> createMailbox(MailboxPath mailboxPath) {
+        SimpleMailbox<Id> mailbox = new SimpleMailbox<Id>(mailboxPath, UID_VALIDITY);
+        Id id = mapperProvider.generateId();
+        mailbox.setMailboxId(id);
+        return mailbox;
+    }
+
+    private MailboxMessage<Id> retrieveMessageFromStorage(Mailbox<Id> mailbox, MailboxMessage<Id> message) throws MailboxException {
+        return messageMapper.findInMailbox(mailbox, MessageRange.one(message.getUid()), FetchType.Metadata, LIMIT).next();
+    }
+    
+    private SimpleMailboxMessage<Id> createMessage(Mailbox<Id> mailbox, String content, int bodyStart, PropertyBuilder propertyBuilder) {
+        return new SimpleMailboxMessage<Id>(new Date(), content.length(), bodyStart, new SharedByteArrayInputStream(content.getBytes()), new Flags(), propertyBuilder, mailbox.getMailboxId());
+    }
+}

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/AbstractMessageMoveTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/AbstractMessageMoveTest.java
@@ -73,7 +73,7 @@ public abstract class AbstractMessageMoveTest<Id extends MailboxId> {
     }
 
     @Test
-    public void movingAMessageShoudlWork() throws Exception {
+    public void movingAMessageShouldWork() throws Exception {
         messageMapper.add(benwaInboxMailbox, message1);
         message1.setModSeq(messageMapper.getHighestModSeq(benwaInboxMailbox));
 
@@ -83,7 +83,7 @@ public abstract class AbstractMessageMoveTest<Id extends MailboxId> {
     }
 
     @Test
-    public void movingAMessageShoudlReturnCorrectMetadata() throws Exception {
+    public void movingAMessageShouldReturnCorrectMetadata() throws Exception {
         messageMapper.add(benwaInboxMailbox, message1);
         message1.setModSeq(messageMapper.getHighestModSeq(benwaInboxMailbox));
 
@@ -95,7 +95,7 @@ public abstract class AbstractMessageMoveTest<Id extends MailboxId> {
     }
 
     @Test
-    public void movingAMessageShoudlNotViolateMessageCount() throws Exception {
+    public void movingAMessageShouldNotViolateMessageCount() throws Exception {
         messageMapper.add(benwaInboxMailbox, message1);
         message1.setModSeq(messageMapper.getHighestModSeq(benwaInboxMailbox));
 
@@ -106,7 +106,7 @@ public abstract class AbstractMessageMoveTest<Id extends MailboxId> {
     }
 
     @Test
-    public void movingAMessageShoudlNotViolateUnseenMessageCount() throws Exception {
+    public void movingAMessageShouldNotViolateUnseenMessageCount() throws Exception {
         messageMapper.add(benwaInboxMailbox, message1);
         message1.setModSeq(messageMapper.getHighestModSeq(benwaInboxMailbox));
 
@@ -117,7 +117,7 @@ public abstract class AbstractMessageMoveTest<Id extends MailboxId> {
     }
 
     @Test
-    public void movingASeenMessageShoudlNotIncrementUnseenMessageCount() throws Exception {
+    public void movingASeenMessageShouldNotIncrementUnseenMessageCount() throws Exception {
         message1.setFlags(new Flags(Flags.Flag.SEEN));
         messageMapper.add(benwaInboxMailbox, message1);
         message1.setModSeq(messageMapper.getHighestModSeq(benwaInboxMailbox));

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraMailboxTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraMailboxTest.java
@@ -28,6 +28,7 @@ import org.apache.james.mpt.imapmailbox.suite.FetchBodySection;
 import org.apache.james.mpt.imapmailbox.suite.FetchBodyStructure;
 import org.apache.james.mpt.imapmailbox.suite.FetchHeaders;
 import org.apache.james.mpt.imapmailbox.suite.Listing;
+import org.apache.james.mpt.imapmailbox.suite.Move;
 import org.apache.james.mpt.imapmailbox.suite.NonAuthenticatedState;
 import org.apache.james.mpt.imapmailbox.suite.PartialFetch;
 import org.apache.james.mpt.imapmailbox.suite.QuotaTest;
@@ -65,7 +66,8 @@ import org.junit.runners.Suite;
     SelectedState.class,
     UidSearch.class,
     UserFlagsSupport.class,
-    QuotaTest.class
+    QuotaTest.class,
+    Move.class
 })
 @GuiceModules({ CassandraMailboxTestModule.class })
 public class CassandraMailboxTest {

--- a/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/imapmailbox/suite/Move.java
+++ b/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/imapmailbox/suite/Move.java
@@ -1,0 +1,44 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.imapmailbox.suite;
+
+import java.util.Locale;
+
+import javax.inject.Inject;
+
+import org.apache.james.mpt.api.HostSystem;
+import org.apache.james.mpt.imapmailbox.suite.base.BaseSelectedState;
+import org.junit.Test;
+
+public class Move  extends BaseSelectedState {
+
+    @Inject
+    private static HostSystem system;
+
+    public Move() throws Exception {
+        super(system);
+    }
+
+    @Test
+    public void moveShouldWork() throws Exception {
+        scriptTest("Move", Locale.US);
+    }
+
+}

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Move.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Move.test
@@ -1,0 +1,69 @@
+################################################################
+# Licensed to the Apache Software Foundation (ASF) under one   #
+# or more contributor license agreements.  See the NOTICE file #
+# distributed with this work for additional information        #
+# regarding copyright ownership.  The ASF licenses this file   #
+# to you under the Apache License, Version 2.0 (the            #
+# "License"); you may not use this file except in compliance   #
+# with the License.  You may obtain a copy of the License at   #
+#                                                              #
+#   http://www.apache.org/licenses/LICENSE-2.0                 #
+#                                                              #
+# Unless required by applicable law or agreed to in writing,   #
+# software distributed under the License is distributed on an  #
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       #
+# KIND, either express or implied.  See the License for the    #
+# specific language governing permissions and limitations      #
+# under the License.                                           #
+################################################################
+C: a1 CREATE moved
+S: a1 OK CREATE completed.
+
+C: a2 STATUS moved (MESSAGES)
+S: \* STATUS "moved" \(MESSAGES 0\)
+S: a2 OK STATUS completed.
+
+# mark one message as deleted before moving it (to check that flags are moved)
+C: a3 STORE 3 FLAGS (\Deleted)
+S: \* 3 FETCH \(FLAGS \(\\Deleted \\Recent\)\)
+S: a3 OK STORE completed.
+
+# Check there's 4 messages in the selected mailbox
+C: a5 STATUS selected (MESSAGES)
+S: \* STATUS "selected" \(MESSAGES 4\)
+S: a5 OK STATUS completed.
+
+# move messages 2-3
+C: a4 MOVE 2:3 moved
+S: \* 2 EXPUNGE
+S: \* 2 EXPUNGE
+S: a4 OK (\[.+\] )?MOVE completed.
+
+# Check there's 2 messages in the moved mailbox
+C: a5 STATUS moved (MESSAGES)
+S: \* STATUS "moved" \(MESSAGES 2\)
+S: a5 OK STATUS completed.
+
+# Check there's 2 messages in the selected mailbox
+C: a5 STATUS selected (MESSAGES)
+S: \* STATUS "selected" \(MESSAGES 2\)
+S: a5 OK STATUS completed.
+
+C: a7 SELECT moved
+S: \* FLAGS \(\\Answered \\Deleted \\Draft \\Flagged \\Seen\)
+S: \* 2 EXISTS
+S: \* \d+ RECENT
+S: \* OK \[UIDVALIDITY \d+\].*
+S: \* OK \[UNSEEN \d+\].*
+S: \* OK \[PERMANENTFLAGS \(\\Answered \\Deleted \\Draft \\Flagged \\\Seen( \\\*)?\)\].*
+S: \* OK \[HIGHESTMODSEQ \d+\].*
+S: \* OK \[UIDNEXT \d+\].*
+S: a7 OK \[READ-WRITE\] SELECT completed.
+
+C: a8 FETCH 1:2 (FLAGS)
+S: \* 1 FETCH \(FLAGS \(\\Recent\)\)
+S: \* 2 FETCH \(FLAGS \(\\Deleted \\Recent\)\)
+S: a8 OK FETCH completed.
+
+C: a9 DELETE moved
+S: a9 OK DELETE completed.

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Move.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Move.test
@@ -16,6 +16,11 @@
 # specific language governing permissions and limitations      #
 # under the License.                                           #
 ################################################################
+
+C: a0 CAPABILITY
+S: \* CAPABILITY .* MOVE .*
+S: a0 OK CAPABILITY completed.
+
 C: a1 CREATE moved
 S: a1 OK CREATE completed.
 

--- a/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/InMemoryMailboxTest.java
+++ b/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/InMemoryMailboxTest.java
@@ -27,6 +27,7 @@ import org.apache.james.mpt.imapmailbox.suite.FetchBodySection;
 import org.apache.james.mpt.imapmailbox.suite.FetchBodyStructure;
 import org.apache.james.mpt.imapmailbox.suite.FetchHeaders;
 import org.apache.james.mpt.imapmailbox.suite.Listing;
+import org.apache.james.mpt.imapmailbox.suite.Move;
 import org.apache.james.mpt.imapmailbox.suite.NonAuthenticatedState;
 import org.apache.james.mpt.imapmailbox.suite.PartialFetch;
 import org.apache.james.mpt.imapmailbox.suite.QuotaTest;
@@ -62,7 +63,8 @@ import org.junit.runners.Suite;
     SelectedInbox.class,
     SelectedState.class,
     UidSearch.class,
-    QuotaTest.class
+    QuotaTest.class,
+    Move.class
 })
 @GuiceModules({ InMemoryMailboxTestModule.class })
 public class InMemoryMailboxTest {

--- a/protocols/imap/pom.xml
+++ b/protocols/imap/pom.xml
@@ -86,6 +86,12 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj-1.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jmock</groupId>
             <artifactId>jmock</artifactId>
             <scope>test</scope>

--- a/protocols/imap/pom.xml
+++ b/protocols/imap/pom.xml
@@ -96,6 +96,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.james</groupId>
             <artifactId>apache-james-mailbox-store</artifactId>
             <scope>test</scope>

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/AbstractMessageRangeCommandParser.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/AbstractMessageRangeCommandParser.java
@@ -17,19 +17,29 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.imap.message.request;
+package org.apache.james.imap.decode.parser;
 
 import org.apache.james.imap.api.ImapCommand;
+import org.apache.james.imap.api.ImapMessage;
 import org.apache.james.imap.api.message.IdRange;
-import org.apache.james.imap.api.message.request.ImapRequest;
+import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.decode.ImapRequestLineReader;
+import org.apache.james.imap.message.request.AbstractMessageRangeRequest;
+import org.apache.james.protocols.imap.DecodingException;
 
-/**
- * {@link ImapRequest} which request the move of messages
- */
-public class MoveRequest extends AbstractMessageRangeRequest {
+public abstract class AbstractMessageRangeCommandParser extends AbstractUidCommandParser {
 
-	public MoveRequest(ImapCommand command, IdRange[] idSet, String mailboxName, boolean useUids, String tag) {
-		super(command, idSet, mailboxName, useUids, tag);
-	}
+    public AbstractMessageRangeCommandParser(ImapCommand command) {
+        super(command);
+    }
+
+    protected ImapMessage decode(ImapCommand command, ImapRequestLineReader request, String tag, boolean useUids, ImapSession session) throws DecodingException {
+        IdRange[] idSet = request.parseIdRange(session);
+        String mailboxName = request.mailbox();
+        request.eol();
+        return createRequest(command, tag, useUids, idSet, mailboxName);
+    }
+
+    abstract protected AbstractMessageRangeRequest createRequest(ImapCommand command, String tag, boolean useUids, IdRange[] idSet, String mailboxName);
 
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/CopyCommandParser.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/CopyCommandParser.java
@@ -37,8 +37,8 @@ public class CopyCommandParser extends AbstractMessageRangeCommandParser {
     }
 
     @Override
-	protected CopyRequest createRequest(ImapCommand command, String tag, boolean useUids, IdRange[] idSet, String mailboxName) {
-		return new CopyRequest(command, idSet, mailboxName, useUids, tag);
+    protected CopyRequest createRequest(ImapCommand command, String tag, boolean useUids, IdRange[] idSet, String mailboxName) {
+        return new CopyRequest(command, idSet, mailboxName, useUids, tag);
     }
 
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/CopyCommandParser.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/CopyCommandParser.java
@@ -30,31 +30,15 @@ import org.apache.james.protocols.imap.DecodingException;
 /**
  * Parse COPY commands
  */
-public class CopyCommandParser extends AbstractUidCommandParser {
+public class CopyCommandParser extends AbstractMessageRangeCommandParser {
 
     public CopyCommandParser() {
-        this(ImapCommand.selectedStateCommand(ImapConstants.COPY_COMMAND_NAME));
+        super(ImapCommand.selectedStateCommand(ImapConstants.COPY_COMMAND_NAME));
     }
 
-    protected CopyCommandParser(ImapCommand command) {
-    	super(command);
-    }
-    /**
-     * @see
-     * org.apache.james.imap.decode.parser.AbstractUidCommandParser#decode(org.apache.james.imap.api.ImapCommand,
-     * org.apache.james.imap.decode.ImapRequestLineReader, java.lang.String,
-     * boolean, org.apache.james.imap.api.process.ImapSession)
-     */
-    protected ImapMessage decode(ImapCommand command, ImapRequestLineReader request, String tag, boolean useUids, ImapSession session) throws DecodingException {
-        IdRange[] idSet = request.parseIdRange(session);
-        String mailboxName = request.mailbox();
-        request.eol();
-        return createRequest(command, tag, useUids, idSet, mailboxName);
-    }
-
-	protected CopyRequest createRequest(ImapCommand command, String tag,
-			boolean useUids, IdRange[] idSet, String mailboxName) {
+    @Override
+	protected CopyRequest createRequest(ImapCommand command, String tag, boolean useUids, IdRange[] idSet, String mailboxName) {
 		return new CopyRequest(command, idSet, mailboxName, useUids, tag);
-}
+    }
 
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/MoveCommandParser.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/MoveCommandParser.java
@@ -8,12 +8,13 @@ import org.apache.james.imap.message.request.MoveRequest;
 /**
  * Parse MOVE commands
  */
-public class MoveCommandParser extends CopyCommandParser {
+public class MoveCommandParser extends AbstractMessageRangeCommandParser {
 	
 	public MoveCommandParser() {
 		super(ImapCommand.selectedStateCommand(ImapConstants.MOVE_COMMAND_NAME));
 	}
-	
+
+	@Override
 	protected MoveRequest createRequest(ImapCommand command, String tag,
 			boolean useUids, IdRange[] idSet, String mailboxName) {
 		return new MoveRequest(command, idSet, mailboxName, useUids, tag);

--- a/protocols/imap/src/main/java/org/apache/james/imap/message/request/AbstractMessageRangeRequest.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/message/request/AbstractMessageRangeRequest.java
@@ -19,8 +19,14 @@
 
 package org.apache.james.imap.message.request;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.james.imap.api.ImapCommand;
 import org.apache.james.imap.api.message.IdRange;
+
+import com.google.common.base.Objects;
+import com.google.common.hash.HashCode;
 
 public abstract class AbstractMessageRangeRequest extends AbstractImapRequest {
 
@@ -45,5 +51,27 @@ public abstract class AbstractMessageRangeRequest extends AbstractImapRequest {
 
     public final boolean isUseUids() {
         return useUids;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AbstractMessageRangeRequest that = (AbstractMessageRangeRequest) o;
+
+        return equals(this.idSet, that.idSet)
+            && Objects.equal(this.mailboxName, that.mailboxName)
+            && Objects.equal(this.useUids, that.useUids);
+    }
+
+    private boolean equals(IdRange[] idSet1, IdRange[] idSet2) {
+        List<IdRange> idRanges1 = Arrays.asList(idSet1);
+        List<IdRange> idRanges2 = Arrays.asList(idSet2);
+        return Objects.equal(idRanges1, idRanges2);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(idSet, mailboxName, useUids);
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/message/request/AbstractMessageRangeRequest.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/message/request/AbstractMessageRangeRequest.java
@@ -21,15 +21,29 @@ package org.apache.james.imap.message.request;
 
 import org.apache.james.imap.api.ImapCommand;
 import org.apache.james.imap.api.message.IdRange;
-import org.apache.james.imap.api.message.request.ImapRequest;
 
-/**
- * {@link ImapRequest} which request the move of messages
- */
-public class MoveRequest extends AbstractMessageRangeRequest {
+public abstract class AbstractMessageRangeRequest extends AbstractImapRequest {
 
-	public MoveRequest(ImapCommand command, IdRange[] idSet, String mailboxName, boolean useUids, String tag) {
-		super(command, idSet, mailboxName, useUids, tag);
-	}
+    private final IdRange[] idSet;
+    private final String mailboxName;
+    private final boolean useUids;
 
+    public AbstractMessageRangeRequest(ImapCommand command, IdRange[] idSet, String mailboxName, boolean useUids, String tag) {
+        super(tag, command);
+        this.idSet = idSet;
+        this.mailboxName = mailboxName;
+        this.useUids = useUids;
+    }
+
+    public final IdRange[] getIdSet() {
+        return idSet;
+    }
+
+    public final String getMailboxName() {
+        return mailboxName;
+    }
+
+    public final boolean isUseUids() {
+        return useUids;
+    }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/message/request/CopyRequest.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/message/request/CopyRequest.java
@@ -25,40 +25,9 @@ import org.apache.james.imap.api.message.request.ImapRequest;
 /**
  * {@link ImapRequest} which request the copy of messages
  */
-public class CopyRequest extends AbstractImapRequest {
-
-    private final IdRange[] idSet;
-
-    private final String mailboxName;
-
-    private final boolean useUids;
+public class CopyRequest extends AbstractMessageRangeRequest {
 
     public CopyRequest(ImapCommand command, IdRange[] idSet, String mailboxName, boolean useUids, String tag) {
-        super(tag, command);
-        this.idSet = idSet;
-        this.mailboxName = mailboxName;
-        this.useUids = useUids;
-    }
-
-    /**
-     * Return an Array of {@link IdRange} to copy
-     * 
-     * @return range
-     */
-    public final IdRange[] getIdSet() {
-        return idSet;
-    }
-
-    /**
-     * Return the name of the mailbox
-     * 
-     * @return mailbox
-     */
-    public final String getMailboxName() {
-        return mailboxName;
-    }
-
-    public final boolean isUseUids() {
-        return useUids;
+        super(command, idSet, mailboxName, useUids, tag);
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/message/request/MoveRequest.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/message/request/MoveRequest.java
@@ -1,3 +1,22 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
 package org.apache.james.imap.message.request;
 
 import org.apache.james.imap.api.ImapCommand;

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMessageRangeProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMessageRangeProcessor.java
@@ -1,0 +1,114 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.imap.processor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.james.imap.api.ImapCommand;
+import org.apache.james.imap.api.ImapSessionUtils;
+import org.apache.james.imap.api.display.HumanReadableText;
+import org.apache.james.imap.api.message.IdRange;
+import org.apache.james.imap.api.message.response.StatusResponse;
+import org.apache.james.imap.api.message.response.StatusResponseFactory;
+import org.apache.james.imap.api.process.ImapProcessor;
+import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.api.process.SelectedMailbox;
+import org.apache.james.imap.message.request.AbstractMessageRangeRequest;
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.exception.MessageRangeException;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.MessageRange;
+
+public abstract class AbstractMessageRangeProcessor<M extends AbstractMessageRangeRequest> extends AbstractMailboxProcessor<M> {
+
+    public AbstractMessageRangeProcessor(Class<M> acceptableClass, ImapProcessor next, MailboxManager mailboxManager, StatusResponseFactory factory) {
+        super(acceptableClass, next, mailboxManager, factory);
+    }
+
+    abstract protected List<MessageRange> process(final MailboxPath targetMailbox,
+                                         final SelectedMailbox currentMailbox,
+                                         final MailboxSession mailboxSession,
+                                         final MailboxManager mailboxManager,
+                                         MessageRange messageSet) throws MailboxException;
+
+    abstract protected String getOperationName();
+
+    @Override
+    protected void doProcess(M request, ImapSession session, String tag, ImapCommand command, Responder responder) {
+        final MailboxPath targetMailbox = buildFullPath(session, request.getMailboxName());
+        final IdRange[] idSet = request.getIdSet();
+        final boolean useUids = request.isUseUids();
+        final SelectedMailbox currentMailbox = session.getSelected();
+        try {
+            final MailboxSession mailboxSession = ImapSessionUtils.getMailboxSession(session);
+            final MailboxManager mailboxManager = getMailboxManager();
+            final boolean mailboxExists = mailboxManager.mailboxExists(targetMailbox, mailboxSession);
+
+            if (!mailboxExists) {
+                no(command, tag, responder, HumanReadableText.FAILURE_NO_SUCH_MAILBOX, StatusResponse.ResponseCode.tryCreate());
+            } else {
+
+                final MessageManager mailbox = mailboxManager.getMailbox(targetMailbox, mailboxSession);
+
+                List<IdRange> resultRanges = new ArrayList<IdRange>();
+                for (IdRange range : idSet) {
+                    MessageRange messageSet = messageRange(currentMailbox, range, useUids);
+                    if (messageSet != null) {
+                        List<MessageRange> processedUids = process(
+                            targetMailbox, currentMailbox, mailboxSession,
+                            mailboxManager, messageSet);
+                        for (MessageRange mr : processedUids) {
+                            // Set recent flag on copied message as this SHOULD be
+                            // done.
+                            // See RFC 3501 6.4.7. COPY Command
+                            // See IMAP-287
+                            //
+                            // Disable this as this is now done directly in the scope of the copy operation.
+                            // See MAILBOX-85
+                            //mailbox.setFlags(new Flags(Flags.Flag.RECENT), true, false, mr, mailboxSession);
+                            resultRanges.add(new IdRange(mr.getUidFrom(), mr.getUidTo()));
+                        }
+                    }
+                }
+                IdRange[] resultUids = IdRange.mergeRanges(resultRanges).toArray(new IdRange[0]);
+
+                // get folder UIDVALIDITY
+                Long uidValidity = mailbox.getMetaData(false, mailboxSession, MessageManager.MetaData.FetchGroup.NO_UNSEEN).getUidValidity();
+
+                unsolicitedResponses(session, responder, useUids);
+                okComplete(command, tag, StatusResponse.ResponseCode.copyUid(uidValidity, idSet, resultUids), responder);
+            }
+        } catch (MessageRangeException e) {
+            if (session.getLog().isDebugEnabled()) {
+                session.getLog().debug(getOperationName() + " failed from mailbox " + currentMailbox.getPath() + " to " + targetMailbox + " for invalid sequence-set " + idSet.toString(), e);
+            }
+            taggedBad(command, tag, responder, HumanReadableText.INVALID_MESSAGESET);
+        } catch (MailboxException e) {
+            if (session.getLog().isInfoEnabled()) {
+                session.getLog().info(getOperationName() + " failed from mailbox " + currentMailbox.getPath() + " to " + targetMailbox + " for sequence-set " + idSet.toString(), e);
+            }
+            no(command, tag, responder, HumanReadableText.GENERIC_FAILURE_DURING_PROCESSING);
+        }
+    }
+}

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/CopyProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/CopyProcessor.java
@@ -19,107 +19,34 @@
 
 package org.apache.james.imap.processor;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.james.imap.api.ImapCommand;
-import org.apache.james.imap.api.ImapSessionUtils;
-import org.apache.james.imap.api.display.HumanReadableText;
-import org.apache.james.imap.api.message.IdRange;
-import org.apache.james.imap.api.message.response.StatusResponse.ResponseCode;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
-import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.api.process.SelectedMailbox;
 import org.apache.james.imap.message.request.CopyRequest;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
-import org.apache.james.mailbox.MessageManager;
-import org.apache.james.mailbox.MessageManager.MetaData.FetchGroup;
 import org.apache.james.mailbox.exception.MailboxException;
-import org.apache.james.mailbox.exception.MessageRangeException;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageRange;
 
-public class CopyProcessor extends AbstractMailboxProcessor<CopyRequest> {
+public class CopyProcessor extends AbstractMessageRangeProcessor<CopyRequest> {
 
     public CopyProcessor(ImapProcessor next, MailboxManager mailboxManager, StatusResponseFactory factory) {
-        this(CopyRequest.class, next, mailboxManager, factory);
-    }
-
-    protected CopyProcessor(Class<? extends CopyRequest> acceptableClass, ImapProcessor next, MailboxManager mailboxManager, StatusResponseFactory factory) {
         super(CopyRequest.class, next, mailboxManager, factory);
     }
 
-    /**
-     * @see
-     * org.apache.james.imap.processor.AbstractMailboxProcessor#doProcess(org.apache.james.imap.api.message.request.ImapRequest,
-     * org.apache.james.imap.api.process.ImapSession, java.lang.String,
-     * org.apache.james.imap.api.ImapCommand,
-     * org.apache.james.imap.api.process.ImapProcessor.Responder)
-     */
-    protected void doProcess(CopyRequest request, ImapSession session, String tag, ImapCommand command, Responder responder) {
-        final MailboxPath targetMailbox = buildFullPath(session, request.getMailboxName());
-        final IdRange[] idSet = request.getIdSet();
-        final boolean useUids = request.isUseUids();
-        final SelectedMailbox currentMailbox = session.getSelected();
-        try {
-            final MailboxSession mailboxSession = ImapSessionUtils.getMailboxSession(session);
-            final MailboxManager mailboxManager = getMailboxManager();
-            final boolean mailboxExists = mailboxManager.mailboxExists(targetMailbox, mailboxSession);
-
-            if (!mailboxExists) {
-                no(command, tag, responder, HumanReadableText.FAILURE_NO_SUCH_MAILBOX, ResponseCode.tryCreate());
-            } else {
-
-                final MessageManager mailbox = mailboxManager.getMailbox(targetMailbox, mailboxSession);
-
-                List<IdRange> resultRanges = new ArrayList<IdRange>();
-                for (IdRange range : idSet) {
-                    MessageRange messageSet = messageRange(currentMailbox, range, useUids);
-                    if (messageSet != null) {
-                        List<MessageRange> processedUids = process(
-                            targetMailbox, currentMailbox, mailboxSession,
-                            mailboxManager, messageSet);
-                        for (MessageRange mr : processedUids) {
-                            // Set recent flag on copied message as this SHOULD be
-                            // done.
-                            // See RFC 3501 6.4.7. COPY Command
-                            // See IMAP-287
-                            //
-                            // Disable this as this is now done directly in the scope of the copy operation.
-                            // See MAILBOX-85
-                            //mailbox.setFlags(new Flags(Flags.Flag.RECENT), true, false, mr, mailboxSession);
-                            resultRanges.add(new IdRange(mr.getUidFrom(), mr.getUidTo()));
-                        }
-                    }
-                }
-                IdRange[] resultUids = IdRange.mergeRanges(resultRanges).toArray(new IdRange[0]);
-
-                // get folder UIDVALIDITY
-                Long uidValidity = mailbox.getMetaData(false, mailboxSession, FetchGroup.NO_UNSEEN).getUidValidity();
-
-                unsolicitedResponses(session, responder, useUids);
-                okComplete(command, tag, ResponseCode.copyUid(uidValidity, idSet, resultUids), responder);
-            }
-        } catch (MessageRangeException e) {
-            if (session.getLog().isDebugEnabled()) {
-                session.getLog().debug("Copy failed from mailbox " + currentMailbox.getPath() + " to " + targetMailbox + " for invalid sequence-set " + idSet.toString(), e);
-            }
-            taggedBad(command, tag, responder, HumanReadableText.INVALID_MESSAGESET);
-        } catch (MailboxException e) {
-            if (session.getLog().isInfoEnabled()) {
-                session.getLog().info("Copy failed from mailbox " + currentMailbox.getPath() + " to " + targetMailbox + " for sequence-set " + idSet.toString(), e);
-            }
-            no(command, tag, responder, HumanReadableText.GENERIC_FAILURE_DURING_PROCESSING);
-        }
+    @Override
+    protected String getOperationName() {
+        return "Copy";
     }
 
-	protected List<MessageRange> process(MailboxPath targetMailbox,
-			final SelectedMailbox currentMailbox,
-			final MailboxSession mailboxSession,
-			final MailboxManager mailboxManager, MessageRange messageSet)
-			throws MailboxException {
+    @Override
+    protected List<MessageRange> process(MailboxPath targetMailbox,
+                                         SelectedMailbox currentMailbox,
+                                         MailboxSession mailboxSession,
+                                         MailboxManager mailboxManager, MessageRange messageSet) throws MailboxException {
         return mailboxManager.copyMessages(messageSet, currentMailbox.getPath(), targetMailbox, mailboxSession);
-}
+    }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/DefaultProcessorChain.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/DefaultProcessorChain.java
@@ -57,8 +57,14 @@ public class DefaultProcessorChain {
         final UnsubscribeProcessor unsubscribeProcessor = new UnsubscribeProcessor(closeProcessor, mailboxManager, subscriptionManager, statusResponseFactory);
         final SubscribeProcessor subscribeProcessor = new SubscribeProcessor(unsubscribeProcessor, mailboxManager, subscriptionManager, statusResponseFactory);
         final CopyProcessor copyProcessor = new CopyProcessor(subscribeProcessor, mailboxManager, statusResponseFactory);
-        final MoveProcessor moveProcessor = new MoveProcessor(copyProcessor, mailboxManager, statusResponseFactory);
-        final AuthenticateProcessor authenticateProcessor = new AuthenticateProcessor(moveProcessor, mailboxManager, statusResponseFactory);
+        AuthenticateProcessor authenticateProcessor;
+        if (mailboxManager.getSupportedCapabilities().contains(MailboxManager.Capabilities.Move)) {
+            final MoveProcessor moveProcessor = new MoveProcessor(copyProcessor, mailboxManager, statusResponseFactory);
+            authenticateProcessor = new AuthenticateProcessor(moveProcessor, mailboxManager, statusResponseFactory);
+            capabilityProcessor.addProcessor(moveProcessor);
+        } else {
+            authenticateProcessor = new AuthenticateProcessor(copyProcessor, mailboxManager, statusResponseFactory);
+        }
         final ExpungeProcessor expungeProcessor = new ExpungeProcessor(authenticateProcessor, mailboxManager, statusResponseFactory);
         final ExamineProcessor examineProcessor = new ExamineProcessor(expungeProcessor, mailboxManager, statusResponseFactory);
         final AppendProcessor appendProcessor = new AppendProcessor(examineProcessor, mailboxManager, statusResponseFactory);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/DefaultProcessorChain.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/DefaultProcessorChain.java
@@ -57,9 +57,8 @@ public class DefaultProcessorChain {
         final UnsubscribeProcessor unsubscribeProcessor = new UnsubscribeProcessor(closeProcessor, mailboxManager, subscriptionManager, statusResponseFactory);
         final SubscribeProcessor subscribeProcessor = new SubscribeProcessor(unsubscribeProcessor, mailboxManager, subscriptionManager, statusResponseFactory);
         final CopyProcessor copyProcessor = new CopyProcessor(subscribeProcessor, mailboxManager, statusResponseFactory);
-        // TODO Active the MoveProcess when IMAP-370 is solved
-//        final MoveProcessor moveProcessor = new MoveProcessor(copyProcessor, mailboxManager, statusResponseFactory);
-        final AuthenticateProcessor authenticateProcessor = new AuthenticateProcessor(copyProcessor, mailboxManager, statusResponseFactory);
+        final MoveProcessor moveProcessor = new MoveProcessor(copyProcessor, mailboxManager, statusResponseFactory);
+        final AuthenticateProcessor authenticateProcessor = new AuthenticateProcessor(moveProcessor, mailboxManager, statusResponseFactory);
         final ExpungeProcessor expungeProcessor = new ExpungeProcessor(authenticateProcessor, mailboxManager, statusResponseFactory);
         final ExamineProcessor examineProcessor = new ExamineProcessor(expungeProcessor, mailboxManager, statusResponseFactory);
         final AppendProcessor appendProcessor = new AppendProcessor(examineProcessor, mailboxManager, statusResponseFactory);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/MoveProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/MoveProcessor.java
@@ -1,6 +1,5 @@
 package org.apache.james.imap.processor;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -16,22 +15,26 @@ import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageRange;
 
-public class MoveProcessor extends CopyProcessor implements CapabilityImplementingProcessor {
+public class MoveProcessor extends AbstractMessageRangeProcessor<MoveRequest> implements CapabilityImplementingProcessor {
 
-	private static final List<String> CAPS = Collections.unmodifiableList(Arrays.asList(ImapConstants.MOVE_COMMAND_NAME));
+	private static final List<String> CAPS = Collections.unmodifiableList(Collections.singletonList(ImapConstants.MOVE_COMMAND_NAME));
 
-	public MoveProcessor(ImapProcessor next, MailboxManager mailboxManager,
-			StatusResponseFactory factory) {
+	public MoveProcessor(ImapProcessor next, MailboxManager mailboxManager, StatusResponseFactory factory) {
 		super(MoveRequest.class, next, mailboxManager, factory);
 	}
 
-	protected List<MessageRange> process(MailboxPath targetMailbox,
-			final SelectedMailbox currentMailbox,
-			final MailboxSession mailboxSession,
-			final MailboxManager mailboxManager, MessageRange messageSet)
-			throws MailboxException {
+    @Override
+    protected List<MessageRange> process(MailboxPath targetMailbox,
+                                         SelectedMailbox currentMailbox,
+                                         MailboxSession mailboxSession,
+                                         MailboxManager mailboxManager, MessageRange messageSet) throws MailboxException {
 		return mailboxManager.moveMessages(messageSet, currentMailbox.getPath(), targetMailbox, mailboxSession);
 	}
+
+    @Override
+    protected String getOperationName() {
+        return "Move";
+    }
 
     /**
     * @see org.apache.james.imap.processor.CapabilityImplementingProcessor

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/MoveProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/MoveProcessor.java
@@ -1,6 +1,24 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
 package org.apache.james.imap.processor;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.james.imap.api.ImapConstants;
@@ -15,12 +33,15 @@ import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageRange;
 
+import com.google.common.collect.ImmutableList;
+
 public class MoveProcessor extends AbstractMessageRangeProcessor<MoveRequest> implements CapabilityImplementingProcessor {
 
-	private static final List<String> CAPS = Collections.unmodifiableList(Collections.singletonList(ImapConstants.MOVE_COMMAND_NAME));
+	private final boolean moveCapabilitySupported;
 
 	public MoveProcessor(ImapProcessor next, MailboxManager mailboxManager, StatusResponseFactory factory) {
 		super(MoveRequest.class, next, mailboxManager, factory);
+        moveCapabilitySupported = mailboxManager.getSupportedCapabilities().contains(MailboxManager.Capabilities.Move);
 	}
 
     @Override
@@ -36,12 +57,13 @@ public class MoveProcessor extends AbstractMessageRangeProcessor<MoveRequest> im
         return "Move";
     }
 
-    /**
-    * @see org.apache.james.imap.processor.CapabilityImplementingProcessor
-    * #getImplementedCapabilities(org.apache.james.imap.api.process.ImapSession)
-    */
+    @Override
 	public List<String> getImplementedCapabilities(ImapSession session) {
-		return CAPS;
+        if (moveCapabilitySupported) {
+            return ImmutableList.of(ImapConstants.MOVE_COMMAND_NAME);
+        } else {
+            return ImmutableList.of();
+        }
 	}
 
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/MoveProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/MoveProcessor.java
@@ -37,20 +37,19 @@ import com.google.common.collect.ImmutableList;
 
 public class MoveProcessor extends AbstractMessageRangeProcessor<MoveRequest> implements CapabilityImplementingProcessor {
 
-	private final boolean moveCapabilitySupported;
+    private final boolean moveCapabilitySupported;
 
-	public MoveProcessor(ImapProcessor next, MailboxManager mailboxManager, StatusResponseFactory factory) {
-		super(MoveRequest.class, next, mailboxManager, factory);
+    public MoveProcessor(ImapProcessor next, MailboxManager mailboxManager, StatusResponseFactory factory) {
+        super(MoveRequest.class, next, mailboxManager, factory);
         moveCapabilitySupported = mailboxManager.getSupportedCapabilities().contains(MailboxManager.Capabilities.Move);
-	}
+    }
 
     @Override
-    protected List<MessageRange> process(MailboxPath targetMailbox,
-                                         SelectedMailbox currentMailbox,
+    protected List<MessageRange> process(MailboxPath targetMailbox, SelectedMailbox currentMailbox,
                                          MailboxSession mailboxSession,
                                          MailboxManager mailboxManager, MessageRange messageSet) throws MailboxException {
-		return mailboxManager.moveMessages(messageSet, currentMailbox.getPath(), targetMailbox, mailboxSession);
-	}
+        return mailboxManager.moveMessages(messageSet, currentMailbox.getPath(), targetMailbox, mailboxSession);
+    }
 
     @Override
     protected String getOperationName() {
@@ -58,12 +57,12 @@ public class MoveProcessor extends AbstractMessageRangeProcessor<MoveRequest> im
     }
 
     @Override
-	public List<String> getImplementedCapabilities(ImapSession session) {
+    public List<String> getImplementedCapabilities(ImapSession session) {
         if (moveCapabilitySupported) {
             return ImmutableList.of(ImapConstants.MOVE_COMMAND_NAME);
         } else {
             return ImmutableList.of();
         }
-	}
+    }
 
 }

--- a/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/CopyParserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/CopyParserTest.java
@@ -1,0 +1,49 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.imap.decode.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.apache.james.imap.api.ImapCommand;
+import org.apache.james.imap.api.message.IdRange;
+import org.apache.james.imap.decode.ImapRequestStreamLineReader;
+import org.apache.james.imap.message.request.CopyRequest;
+import org.apache.james.protocols.imap.DecodingException;
+import org.junit.Test;
+
+public class CopyParserTest {
+
+    @Test
+    public void testQuotaParsing() throws DecodingException {
+        CopyCommandParser parser = new CopyCommandParser();
+        ImapCommand command = ImapCommand.anyStateCommand("Command");
+        String commandString = " 42:69 foo \n";
+
+        InputStream inputStream = new ByteArrayInputStream(commandString.getBytes());
+        ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, null);
+        CopyRequest request = (CopyRequest) parser.decode(command, lineReader, "A003", null);
+        CopyRequest expected = new CopyRequest(command, new IdRange[] {new IdRange(42, 69)}, "foo", false, "A003");
+
+        assertThat(request).isEqualTo(expected);
+    }
+}

--- a/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/MoveParserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/MoveParserTest.java
@@ -1,0 +1,49 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.imap.decode.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.apache.james.imap.api.ImapCommand;
+import org.apache.james.imap.api.message.IdRange;
+import org.apache.james.imap.decode.ImapRequestStreamLineReader;
+import org.apache.james.imap.message.request.MoveRequest;
+import org.apache.james.protocols.imap.DecodingException;
+import org.junit.Test;
+
+public class MoveParserTest {
+
+    @Test
+    public void testQuotaParsing() throws DecodingException {
+        MoveCommandParser parser = new MoveCommandParser();
+        ImapCommand command = ImapCommand.anyStateCommand("Command");
+        String commandString = " 42:69 foo \n";
+
+        InputStream inputStream = new ByteArrayInputStream(commandString.getBytes());
+        ImapRequestStreamLineReader lineReader = new ImapRequestStreamLineReader(inputStream, null);
+        MoveRequest request = (MoveRequest) parser.decode(command, lineReader, "A003", null);
+        MoveRequest expected = new MoveRequest(command, new IdRange[] {new IdRange(42, 69)}, "foo", false, "A003");
+
+        assertThat(request).isEqualTo(expected);
+    }
+}

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/CopyProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/CopyProcessorTest.java
@@ -1,0 +1,232 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.imap.processor;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.apache.james.imap.api.ImapCommand;
+import org.apache.james.imap.api.ImapConstants;
+import org.apache.james.imap.api.ImapSessionState;
+import org.apache.james.imap.api.ImapSessionUtils;
+import org.apache.james.imap.api.display.HumanReadableText;
+import org.apache.james.imap.api.message.IdRange;
+import org.apache.james.imap.api.message.response.StatusResponse;
+import org.apache.james.imap.api.message.response.StatusResponseFactory;
+import org.apache.james.imap.api.process.ImapProcessor;
+import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.api.process.SelectedMailbox;
+import org.apache.james.imap.message.request.CopyRequest;
+import org.apache.james.imap.message.request.MoveRequest;
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.store.MailboxMetaData;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+
+public class CopyProcessorTest {
+
+    public static final String TAG = "TAG";
+    private static final Logger LOGGER = LoggerFactory.getLogger(CopyProcessorTest.class);
+
+    private CopyProcessor testee;
+    private ImapProcessor mockNextProcessor;
+    private MailboxManager mockMailboxManager;
+    private StatusResponseFactory mockStatusResponseFactory;
+    private ImapProcessor.Responder mockResponder;
+    private ImapSession mockImapSession;
+    private MailboxSession mockMailboxSession;
+
+    @Before
+    public void setUp() {
+        mockNextProcessor = mock(ImapProcessor.class);
+        mockMailboxManager = mock(MailboxManager.class);
+        mockStatusResponseFactory = mock(StatusResponseFactory.class);
+        mockResponder = mock(ImapProcessor.Responder.class);
+        mockImapSession = mock(ImapSession.class);
+        mockMailboxSession = mock(MailboxSession.class);
+
+        testee = new CopyProcessor(mockNextProcessor, mockMailboxManager, mockStatusResponseFactory);
+    }
+
+    @Test
+    public void processShouldWork() throws Exception {
+        CopyRequest copyRequest = new CopyRequest(ImapCommand.anyStateCommand("Name"), new IdRange[] {new IdRange(4, 6)}, ImapConstants.INBOX_NAME, true, TAG);
+
+        MailboxSession.User user = mock(MailboxSession.User.class);
+        when(user.getUserName()).thenReturn("username");
+        when(mockMailboxSession.getPersonalSpace()).thenReturn("");
+        when(mockMailboxSession.getUser()).thenReturn(user);
+        when(mockMailboxSession.getSessionId()).thenReturn(42L);
+        when(mockImapSession.getState()).thenReturn(ImapSessionState.SELECTED);
+        when(mockImapSession.getAttribute(ImapSessionUtils.MAILBOX_SESSION_ATTRIBUTE_SESSION_KEY)).thenReturn(mockMailboxSession);
+        MailboxPath inbox = MailboxPath.inbox(mockMailboxSession);
+        MailboxPath selected = new MailboxPath(inbox, "selected");
+        SelectedMailbox selectedMailbox = mock(SelectedMailbox.class);
+        when(selectedMailbox.getLastUid()).thenReturn(8L);
+        when(selectedMailbox.existsCount()).thenReturn(8L);
+        when(selectedMailbox.getPath()).thenReturn(selected);
+        when(mockImapSession.getSelected()).thenReturn(selectedMailbox);
+        when(mockMailboxManager.mailboxExists(inbox, mockMailboxSession)).thenReturn(true);
+        MessageManager targetMessageManager = mock(MessageManager.class);
+        when(mockMailboxManager.getMailbox(inbox, mockMailboxSession)).thenReturn(targetMessageManager);
+        when(targetMessageManager.getMetaData(false, mockMailboxSession, MessageManager.MetaData.FetchGroup.NO_UNSEEN)).thenReturn(new MailboxMetaData(null, null, 58L, 18L, 8L, 8L, 8L, 8L, true, true, null));
+        StatusResponse okResponse = mock(StatusResponse.class);
+        when(mockStatusResponseFactory.taggedOk(any(String.class), any(ImapCommand.class), any(HumanReadableText.class), any(StatusResponse.ResponseCode.class))).thenReturn(okResponse);
+        when(mockMailboxManager.moveMessages(MessageRange.range(4, 6), selected, inbox, mockMailboxSession)).thenReturn(Lists.<MessageRange>newArrayList(MessageRange.range(4, 6)));
+
+        testee.process(copyRequest, mockResponder, mockImapSession);
+
+        verify(mockMailboxManager).startProcessingRequest(mockMailboxSession);
+        verify(mockMailboxManager).endProcessingRequest(mockMailboxSession);
+        verify(mockMailboxManager).mailboxExists(inbox, mockMailboxSession);
+        verify(mockMailboxManager).getMailbox(inbox, mockMailboxSession);
+        verify(mockMailboxManager).copyMessages(MessageRange.range(4, 6), selected, inbox, mockMailboxSession);
+        verify(targetMessageManager).getMetaData(false, mockMailboxSession, MessageManager.MetaData.FetchGroup.NO_UNSEEN);
+        verify(mockResponder).respond(okResponse);
+        verifyNoMoreInteractions(mockMailboxManager, targetMessageManager, mockResponder, mockNextProcessor);
+    }
+
+
+    @Test
+    public void processShouldWorkWithMultipleRanges() throws Exception {
+        CopyRequest copyRequest = new CopyRequest(ImapCommand.anyStateCommand("Name"), new IdRange[] {new IdRange(5, 6), new IdRange(1, 3)}, ImapConstants.INBOX_NAME, true, TAG);
+
+        MailboxSession.User user = mock(MailboxSession.User.class);
+        when(user.getUserName()).thenReturn("username");
+        when(mockMailboxSession.getPersonalSpace()).thenReturn("");
+        when(mockMailboxSession.getUser()).thenReturn(user);
+        when(mockMailboxSession.getSessionId()).thenReturn(42L);
+        when(mockImapSession.getState()).thenReturn(ImapSessionState.SELECTED);
+        when(mockImapSession.getAttribute(ImapSessionUtils.MAILBOX_SESSION_ATTRIBUTE_SESSION_KEY)).thenReturn(mockMailboxSession);
+        MailboxPath inbox = MailboxPath.inbox(mockMailboxSession);
+        MailboxPath selected = new MailboxPath(inbox, "selected");
+        SelectedMailbox selectedMailbox = mock(SelectedMailbox.class);
+        when(selectedMailbox.getLastUid()).thenReturn(8L);
+        when(selectedMailbox.existsCount()).thenReturn(8L);
+        when(selectedMailbox.getPath()).thenReturn(selected);
+        when(mockImapSession.getSelected()).thenReturn(selectedMailbox);
+        when(mockMailboxManager.mailboxExists(inbox, mockMailboxSession)).thenReturn(true);
+        MessageManager targetMessageManager = mock(MessageManager.class);
+        when(mockMailboxManager.getMailbox(inbox, mockMailboxSession)).thenReturn(targetMessageManager);
+        when(targetMessageManager.getMetaData(false, mockMailboxSession, MessageManager.MetaData.FetchGroup.NO_UNSEEN)).thenReturn(new MailboxMetaData(null, null, 58L, 18L, 8L, 8L, 8L, 8L, true, true, null));
+        StatusResponse okResponse = mock(StatusResponse.class);
+        when(mockStatusResponseFactory.taggedOk(any(String.class), any(ImapCommand.class), any(HumanReadableText.class), any(StatusResponse.ResponseCode.class))).thenReturn(okResponse);
+
+        testee.process(copyRequest, mockResponder, mockImapSession);
+
+        verify(mockMailboxManager).startProcessingRequest(mockMailboxSession);
+        verify(mockMailboxManager).endProcessingRequest(mockMailboxSession);
+        verify(mockMailboxManager).mailboxExists(inbox, mockMailboxSession);
+        verify(mockMailboxManager).getMailbox(inbox, mockMailboxSession);
+        verify(mockMailboxManager).copyMessages(MessageRange.range(5, 6), selected, inbox, mockMailboxSession);
+        verify(mockMailboxManager).copyMessages(MessageRange.range(1, 3), selected, inbox, mockMailboxSession);
+        verify(targetMessageManager).getMetaData(false, mockMailboxSession, MessageManager.MetaData.FetchGroup.NO_UNSEEN);
+        verify(mockResponder).respond(okResponse);
+        verifyNoMoreInteractions(mockMailboxManager, targetMessageManager, mockResponder, mockNextProcessor);
+    }
+
+    @Test
+    public void processShouldRespondNoOnUnExistingTargetMailbox() throws Exception {
+        CopyRequest copyRequest = new CopyRequest(ImapCommand.anyStateCommand("Name"), new IdRange[] {new IdRange(4, 6)}, ImapConstants.INBOX_NAME, true, TAG);
+
+        MailboxSession.User user = mock(MailboxSession.User.class);
+        when(user.getUserName()).thenReturn("username");
+        when(mockMailboxSession.getPersonalSpace()).thenReturn("");
+        when(mockMailboxSession.getUser()).thenReturn(user);
+        when(mockMailboxSession.getSessionId()).thenReturn(42L);
+        when(mockImapSession.getState()).thenReturn(ImapSessionState.SELECTED);
+        when(mockImapSession.getAttribute(ImapSessionUtils.MAILBOX_SESSION_ATTRIBUTE_SESSION_KEY)).thenReturn(mockMailboxSession);
+        MailboxPath inbox = MailboxPath.inbox(mockMailboxSession);
+        MailboxPath selected = new MailboxPath(inbox, "selected");
+        SelectedMailbox selectedMailbox = mock(SelectedMailbox.class);
+        when(selectedMailbox.getLastUid()).thenReturn(8L);
+        when(selectedMailbox.existsCount()).thenReturn(8L);
+        when(selectedMailbox.getPath()).thenReturn(selected);
+        when(mockImapSession.getSelected()).thenReturn(selectedMailbox);
+        when(mockMailboxManager.mailboxExists(inbox, mockMailboxSession)).thenReturn(false);
+
+        StatusResponse noResponse = mock(StatusResponse.class);
+        when(mockStatusResponseFactory.taggedNo(any(String.class), any(ImapCommand.class), any(HumanReadableText.class), any(StatusResponse.ResponseCode.class))).thenReturn(noResponse);
+
+        testee.process(copyRequest, mockResponder, mockImapSession);
+
+        verify(mockMailboxManager).startProcessingRequest(mockMailboxSession);
+        verify(mockMailboxManager).endProcessingRequest(mockMailboxSession);
+        verify(mockMailboxManager).mailboxExists(inbox, mockMailboxSession);
+        verify(mockResponder).respond(noResponse);
+        verifyNoMoreInteractions(mockMailboxManager, mockResponder, mockNextProcessor);
+    }
+
+    @Test
+    public void processShouldRespondNoOnMailboxException() throws Exception {
+        CopyRequest copyRequest = new CopyRequest(ImapCommand.anyStateCommand("Name"), new IdRange[] {new IdRange(4, 6)}, ImapConstants.INBOX_NAME, true, TAG);
+
+        MailboxSession.User user = mock(MailboxSession.User.class);
+        when(user.getUserName()).thenReturn("username");
+        when(mockMailboxSession.getPersonalSpace()).thenReturn("");
+        when(mockMailboxSession.getUser()).thenReturn(user);
+        when(mockImapSession.getLog()).thenReturn(LOGGER);
+        when(mockMailboxSession.getSessionId()).thenReturn(42L);
+        when(mockImapSession.getState()).thenReturn(ImapSessionState.SELECTED);
+        when(mockImapSession.getAttribute(ImapSessionUtils.MAILBOX_SESSION_ATTRIBUTE_SESSION_KEY)).thenReturn(mockMailboxSession);
+        MailboxPath inbox = MailboxPath.inbox(mockMailboxSession);
+        MailboxPath selected = new MailboxPath(inbox, "selected");
+        SelectedMailbox selectedMailbox = mock(SelectedMailbox.class);
+        when(selectedMailbox.getLastUid()).thenReturn(8L);
+        when(selectedMailbox.existsCount()).thenReturn(8L);
+        when(selectedMailbox.getPath()).thenReturn(selected);
+        when(mockImapSession.getSelected()).thenReturn(selectedMailbox);
+        when(mockMailboxManager.mailboxExists(inbox, mockMailboxSession)).thenThrow(new MailboxException());
+
+        StatusResponse noResponse = mock(StatusResponse.class);
+        when(mockStatusResponseFactory.taggedNo(any(String.class), any(ImapCommand.class), any(HumanReadableText.class))).thenReturn(noResponse);
+
+        testee.process(copyRequest, mockResponder, mockImapSession);
+
+        verify(mockMailboxManager).startProcessingRequest(mockMailboxSession);
+        verify(mockMailboxManager).endProcessingRequest(mockMailboxSession);
+        verify(mockMailboxManager).mailboxExists(inbox, mockMailboxSession);
+        verify(mockResponder).respond(noResponse);
+        verifyNoMoreInteractions(mockMailboxManager, mockResponder, mockNextProcessor);
+    }
+
+    @Test
+    public void processShouldNotHandleMoveRequests() throws Exception {
+        MoveRequest moveRequest = new MoveRequest(ImapCommand.anyStateCommand("Name"), new IdRange[] {new IdRange(4, 6)}, ImapConstants.INBOX_NAME, true, TAG);
+
+        testee.process(moveRequest, mockResponder, mockImapSession);
+
+        verify(mockNextProcessor).process(moveRequest, mockResponder, mockImapSession);
+        verifyNoMoreInteractions(mockMailboxManager, mockResponder, mockNextProcessor);
+    }
+
+}

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/MoveProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/MoveProcessorTest.java
@@ -1,0 +1,231 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.imap.processor;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.apache.james.imap.api.ImapCommand;
+import org.apache.james.imap.api.ImapConstants;
+import org.apache.james.imap.api.ImapSessionState;
+import org.apache.james.imap.api.ImapSessionUtils;
+import org.apache.james.imap.api.display.HumanReadableText;
+import org.apache.james.imap.api.message.IdRange;
+import org.apache.james.imap.api.message.response.StatusResponse;
+import org.apache.james.imap.api.message.response.StatusResponseFactory;
+import org.apache.james.imap.api.process.ImapProcessor;
+import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.api.process.SelectedMailbox;
+import org.apache.james.imap.message.request.CopyRequest;
+import org.apache.james.imap.message.request.MoveRequest;
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.store.MailboxMetaData;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+
+public class MoveProcessorTest {
+
+    public static final String TAG = "TAG";
+    private static final Logger LOGGER = LoggerFactory.getLogger(MoveProcessorTest.class);
+
+    private MoveProcessor testee;
+    private ImapProcessor mockNextProcessor;
+    private MailboxManager mockMailboxManager;
+    private StatusResponseFactory mockStatusResponseFactory;
+    private ImapProcessor.Responder mockResponder;
+    private ImapSession mockImapSession;
+    private MailboxSession mockMailboxSession;
+
+    @Before
+    public void setUp() {
+        mockNextProcessor = mock(ImapProcessor.class);
+        mockMailboxManager = mock(MailboxManager.class);
+        mockStatusResponseFactory = mock(StatusResponseFactory.class);
+        mockResponder = mock(ImapProcessor.Responder.class);
+        mockImapSession = mock(ImapSession.class);
+        mockMailboxSession = mock(MailboxSession.class);
+
+        testee = new MoveProcessor(mockNextProcessor, mockMailboxManager, mockStatusResponseFactory);
+    }
+
+    @Test
+    public void processShouldWork() throws Exception {
+        MoveRequest moveRequest = new MoveRequest(ImapCommand.anyStateCommand("Name"), new IdRange[] {new IdRange(4, 6)}, ImapConstants.INBOX_NAME, true, TAG);
+
+        MailboxSession.User user = mock(MailboxSession.User.class);
+        when(user.getUserName()).thenReturn("username");
+        when(mockMailboxSession.getPersonalSpace()).thenReturn("");
+        when(mockMailboxSession.getUser()).thenReturn(user);
+        when(mockMailboxSession.getSessionId()).thenReturn(42L);
+        when(mockImapSession.getState()).thenReturn(ImapSessionState.SELECTED);
+        when(mockImapSession.getAttribute(ImapSessionUtils.MAILBOX_SESSION_ATTRIBUTE_SESSION_KEY)).thenReturn(mockMailboxSession);
+        MailboxPath inbox = MailboxPath.inbox(mockMailboxSession);
+        MailboxPath selected = new MailboxPath(inbox, "selected");
+        SelectedMailbox selectedMailbox = mock(SelectedMailbox.class);
+        when(selectedMailbox.getLastUid()).thenReturn(8L);
+        when(selectedMailbox.existsCount()).thenReturn(8L);
+        when(selectedMailbox.getPath()).thenReturn(selected);
+        when(mockImapSession.getSelected()).thenReturn(selectedMailbox);
+        when(mockMailboxManager.mailboxExists(inbox, mockMailboxSession)).thenReturn(true);
+        MessageManager targetMessageManager = mock(MessageManager.class);
+        when(mockMailboxManager.getMailbox(inbox, mockMailboxSession)).thenReturn(targetMessageManager);
+        when(targetMessageManager.getMetaData(false, mockMailboxSession, MessageManager.MetaData.FetchGroup.NO_UNSEEN)).thenReturn(new MailboxMetaData(null, null, 58L, 18L, 8L, 8L, 8L, 8L, true, true, null));
+        StatusResponse okResponse = mock(StatusResponse.class);
+        when(mockStatusResponseFactory.taggedOk(any(String.class), any(ImapCommand.class), any(HumanReadableText.class), any(StatusResponse.ResponseCode.class))).thenReturn(okResponse);
+        when(mockMailboxManager.moveMessages(MessageRange.range(4, 6), selected, inbox, mockMailboxSession)).thenReturn(Lists.<MessageRange>newArrayList(MessageRange.range(4, 6)));
+
+        testee.process(moveRequest, mockResponder, mockImapSession);
+
+        verify(mockMailboxManager).startProcessingRequest(mockMailboxSession);
+        verify(mockMailboxManager).endProcessingRequest(mockMailboxSession);
+        verify(mockMailboxManager).mailboxExists(inbox, mockMailboxSession);
+        verify(mockMailboxManager).getMailbox(inbox, mockMailboxSession);
+        verify(mockMailboxManager).moveMessages(MessageRange.range(4, 6), selected, inbox, mockMailboxSession);
+        verify(targetMessageManager).getMetaData(false, mockMailboxSession, MessageManager.MetaData.FetchGroup.NO_UNSEEN);
+        verify(mockResponder).respond(okResponse);
+        verifyNoMoreInteractions(mockMailboxManager, targetMessageManager, mockResponder, mockNextProcessor);
+    }
+
+
+    @Test
+    public void processShouldWorkWithMultipleRanges() throws Exception {
+        MoveRequest moveRequest = new MoveRequest(ImapCommand.anyStateCommand("Name"), new IdRange[] {new IdRange(5, 6), new IdRange(1,3)}, ImapConstants.INBOX_NAME, true, TAG);
+
+        MailboxSession.User user = mock(MailboxSession.User.class);
+        when(user.getUserName()).thenReturn("username");
+        when(mockMailboxSession.getPersonalSpace()).thenReturn("");
+        when(mockMailboxSession.getUser()).thenReturn(user);
+        when(mockMailboxSession.getSessionId()).thenReturn(42L);
+        when(mockImapSession.getState()).thenReturn(ImapSessionState.SELECTED);
+        when(mockImapSession.getAttribute(ImapSessionUtils.MAILBOX_SESSION_ATTRIBUTE_SESSION_KEY)).thenReturn(mockMailboxSession);
+        MailboxPath inbox = MailboxPath.inbox(mockMailboxSession);
+        MailboxPath selected = new MailboxPath(inbox, "selected");
+        SelectedMailbox selectedMailbox = mock(SelectedMailbox.class);
+        when(selectedMailbox.getLastUid()).thenReturn(8L);
+        when(selectedMailbox.existsCount()).thenReturn(8L);
+        when(selectedMailbox.getPath()).thenReturn(selected);
+        when(mockImapSession.getSelected()).thenReturn(selectedMailbox);
+        when(mockMailboxManager.mailboxExists(inbox, mockMailboxSession)).thenReturn(true);
+        MessageManager targetMessageManager = mock(MessageManager.class);
+        when(mockMailboxManager.getMailbox(inbox, mockMailboxSession)).thenReturn(targetMessageManager);
+        when(targetMessageManager.getMetaData(false, mockMailboxSession, MessageManager.MetaData.FetchGroup.NO_UNSEEN)).thenReturn(new MailboxMetaData(null, null, 58L, 18L, 8L, 8L, 8L, 8L, true, true, null));
+        StatusResponse okResponse = mock(StatusResponse.class);
+        when(mockStatusResponseFactory.taggedOk(any(String.class), any(ImapCommand.class), any(HumanReadableText.class), any(StatusResponse.ResponseCode.class))).thenReturn(okResponse);
+
+        testee.process(moveRequest, mockResponder, mockImapSession);
+
+        verify(mockMailboxManager).startProcessingRequest(mockMailboxSession);
+        verify(mockMailboxManager).endProcessingRequest(mockMailboxSession);
+        verify(mockMailboxManager).mailboxExists(inbox, mockMailboxSession);
+        verify(mockMailboxManager).getMailbox(inbox, mockMailboxSession);
+        verify(mockMailboxManager).moveMessages(MessageRange.range(5, 6), selected, inbox, mockMailboxSession);
+        verify(mockMailboxManager).moveMessages(MessageRange.range(1, 3), selected, inbox, mockMailboxSession);
+        verify(targetMessageManager).getMetaData(false, mockMailboxSession, MessageManager.MetaData.FetchGroup.NO_UNSEEN);
+        verify(mockResponder).respond(okResponse);
+        verifyNoMoreInteractions(mockMailboxManager, targetMessageManager, mockResponder, mockNextProcessor);
+    }
+
+    @Test
+    public void processShouldRespondNoOnUnExistingTargetMailbox() throws Exception {
+        MoveRequest moveRequest = new MoveRequest(ImapCommand.anyStateCommand("Name"), new IdRange[] {new IdRange(5, 6), new IdRange(1,3)}, ImapConstants.INBOX_NAME, true, TAG);
+
+        MailboxSession.User user = mock(MailboxSession.User.class);
+        when(user.getUserName()).thenReturn("username");
+        when(mockMailboxSession.getPersonalSpace()).thenReturn("");
+        when(mockMailboxSession.getUser()).thenReturn(user);
+        when(mockMailboxSession.getSessionId()).thenReturn(42L);
+        when(mockImapSession.getState()).thenReturn(ImapSessionState.SELECTED);
+        when(mockImapSession.getAttribute(ImapSessionUtils.MAILBOX_SESSION_ATTRIBUTE_SESSION_KEY)).thenReturn(mockMailboxSession);
+        MailboxPath inbox = MailboxPath.inbox(mockMailboxSession);
+        MailboxPath selected = new MailboxPath(inbox, "selected");
+        SelectedMailbox selectedMailbox = mock(SelectedMailbox.class);
+        when(selectedMailbox.getLastUid()).thenReturn(8L);
+        when(selectedMailbox.existsCount()).thenReturn(8L);
+        when(selectedMailbox.getPath()).thenReturn(selected);
+        when(mockImapSession.getSelected()).thenReturn(selectedMailbox);
+        when(mockMailboxManager.mailboxExists(inbox, mockMailboxSession)).thenReturn(false);
+
+        StatusResponse noResponse = mock(StatusResponse.class);
+        when(mockStatusResponseFactory.taggedNo(any(String.class), any(ImapCommand.class), any(HumanReadableText.class), any(StatusResponse.ResponseCode.class))).thenReturn(noResponse);
+
+        testee.process(moveRequest, mockResponder, mockImapSession);
+
+        verify(mockMailboxManager).startProcessingRequest(mockMailboxSession);
+        verify(mockMailboxManager).endProcessingRequest(mockMailboxSession);
+        verify(mockMailboxManager).mailboxExists(inbox, mockMailboxSession);
+        verify(mockResponder).respond(noResponse);
+        verifyNoMoreInteractions(mockMailboxManager, mockResponder, mockNextProcessor);
+    }
+
+    @Test
+    public void processShouldRespondNoOnMailboxException() throws Exception {
+        MoveRequest moveRequest = new MoveRequest(ImapCommand.anyStateCommand("Name"), new IdRange[] {new IdRange(5, 6), new IdRange(1,3)}, ImapConstants.INBOX_NAME, true, TAG);
+
+        MailboxSession.User user = mock(MailboxSession.User.class);
+        when(user.getUserName()).thenReturn("username");
+        when(mockMailboxSession.getPersonalSpace()).thenReturn("");
+        when(mockMailboxSession.getUser()).thenReturn(user);
+        when(mockImapSession.getLog()).thenReturn(LOGGER);
+        when(mockMailboxSession.getSessionId()).thenReturn(42L);
+        when(mockImapSession.getState()).thenReturn(ImapSessionState.SELECTED);
+        when(mockImapSession.getAttribute(ImapSessionUtils.MAILBOX_SESSION_ATTRIBUTE_SESSION_KEY)).thenReturn(mockMailboxSession);
+        MailboxPath inbox = MailboxPath.inbox(mockMailboxSession);
+        MailboxPath selected = new MailboxPath(inbox, "selected");
+        SelectedMailbox selectedMailbox = mock(SelectedMailbox.class);
+        when(selectedMailbox.getLastUid()).thenReturn(8L);
+        when(selectedMailbox.existsCount()).thenReturn(8L);
+        when(selectedMailbox.getPath()).thenReturn(selected);
+        when(mockImapSession.getSelected()).thenReturn(selectedMailbox);
+        when(mockMailboxManager.mailboxExists(inbox, mockMailboxSession)).thenThrow(new MailboxException());
+
+        StatusResponse noResponse = mock(StatusResponse.class);
+        when(mockStatusResponseFactory.taggedNo(any(String.class), any(ImapCommand.class), any(HumanReadableText.class))).thenReturn(noResponse);
+
+        testee.process(moveRequest, mockResponder, mockImapSession);
+
+        verify(mockMailboxManager).startProcessingRequest(mockMailboxSession);
+        verify(mockMailboxManager).endProcessingRequest(mockMailboxSession);
+        verify(mockMailboxManager).mailboxExists(inbox, mockMailboxSession);
+        verify(mockResponder).respond(noResponse);
+        verifyNoMoreInteractions(mockMailboxManager, mockResponder, mockNextProcessor);
+    }
+
+    @Test
+    public void processShouldNotHandleCopyRequests() throws Exception {
+        CopyRequest copyRequest = new CopyRequest(ImapCommand.anyStateCommand("Name"), new IdRange[] {new IdRange(4, 6)}, ImapConstants.INBOX_NAME, true, TAG);
+
+        testee.process(copyRequest, mockResponder, mockImapSession);
+
+        verify(mockNextProcessor).process(copyRequest, mockResponder, mockImapSession);
+        verifyNoMoreInteractions(mockMailboxManager, mockResponder, mockNextProcessor);
+    }
+}

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/MoveProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/MoveProcessorTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.imap.processor;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -74,7 +75,20 @@ public class MoveProcessorTest {
         mockImapSession = mock(ImapSession.class);
         mockMailboxSession = mock(MailboxSession.class);
 
+        when(mockMailboxManager.getSupportedCapabilities()).thenReturn(Lists.newArrayList(MailboxManager.Capabilities.Move, MailboxManager.Capabilities.Basic));
         testee = new MoveProcessor(mockNextProcessor, mockMailboxManager, mockStatusResponseFactory);
+        verify(mockMailboxManager).getSupportedCapabilities();
+    }
+
+    @Test
+    public void getImplementedCapabilitiesShouldContainMoveWhenSupportedByMailboxManager() {
+        assertThat(testee.getImplementedCapabilities(null)).containsExactly(ImapConstants.MOVE_COMMAND_NAME);
+    }
+
+    @Test
+    public void getImplementedCapabilitiesShouldNotContainMoveWhenUnSupportedByMailboxManager() {
+        when(mockMailboxManager.getSupportedCapabilities()).thenReturn(Lists.newArrayList(MailboxManager.Capabilities.Basic));
+        assertThat(new MoveProcessor(mockNextProcessor, mockMailboxManager, mockStatusResponseFactory).getImplementedCapabilities(null)).isEmpty();
     }
 
     @Test

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
@@ -66,6 +66,8 @@ import org.apache.james.mailbox.model.UpdatedFlags;
 import org.junit.Test;
 import org.slf4j.Logger;
 
+import com.google.common.collect.Lists;
+
 public class MailboxEventAnalyserTest {
 
     private static final long BASE_SESSION_ID = 99;
@@ -73,8 +75,12 @@ public class MailboxEventAnalyserTest {
     
     private MailboxPath mailboxPath = new MailboxPath("namespace", "user", "name");
     private final MailboxManager mockManager = new MailboxManager() {
-        
-        
+
+        @Override
+        public List<Capabilities> getSupportedCapabilities() {
+            return Lists.newArrayList(Capabilities.Basic);
+        }
+
         public void removeListener(MailboxPath mailboxPath, MailboxListener listner, MailboxSession session) throws MailboxException {
             
         }

--- a/protocols/src/site/xdoc/imap4.xml
+++ b/protocols/src/site/xdoc/imap4.xml
@@ -14,7 +14,7 @@
   software distributed under the License is distributed on an
   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
   KIND, either express or implied.  See the License for the
-  specific language govaerning permissions and limitations
+  specific language governing permissions and limitations
   under the License.    
 -->
 
@@ -56,10 +56,11 @@
        <li>ENABLE (in release 0.2.1)</li>
        <li>CONDSTORE (RFC 4551 http://www.ietf.org/rfc/rfc4551.txt in release 0.3)</li>
        <li>RESYNCH (RFC 5162 http://www.ietf.org/rfc/rfc5162.txt in trunk)</li>
+       <li>MOVE (RFC 6851 https://tools.ietf.org/html/rfc6851 in trunk). This is enabled only if you use a MailboxManager exposing the Move capability</li>
      </ul>
-     <p>We follow RFC2683 recommandations for our implementations:</p>
+     <p>We follow RFC2683 recommendations for our implementations:</p>
      <ul>
-       <li>IMAP4 Implementation Recommandations (RFC 2683 http://www.ietf.org/rfc/rfc2683.txt)</li>
+       <li>IMAP4 Implementation Recommendations (RFC 2683 http://www.ietf.org/rfc/rfc2683.txt)</li>
      </ul>
      <p>Interesting features:</p>
      <ul>

--- a/server/src/site/xdoc/config-mailbox.xml
+++ b/server/src/site/xdoc/config-mailbox.xml
@@ -35,8 +35,11 @@
 
       <dl>
         <dt><strong>provider</strong></dt>
-        <dd>Supported providers are: jpa (default), jcr, maildir, memory. Be aware that maildir will only work on unix like operation systems!</dd>
+        <dd>Supported providers are: jpa (default), jcr, maildir, cassandra, memory. Be aware that maildir will only work on unix like operation systems!
+        Cassandra mailbox need to be compiled and run using java 8.</dd>
       </dl>
+
+      <p>See <a href="http://james.apache.org/mailbox/index.html">documentation page</a> to learn more about the different back-ends and their capabilities.</p>
 
   </section>
 

--- a/server/src/site/xdoc/feature-protocols.xml
+++ b/server/src/site/xdoc/feature-protocols.xml
@@ -52,7 +52,10 @@
       client/server communication.</p>
       
       <p>More information on configuring the SMTP service can be found <a href="config-smtp-lmtp.html">here</a>.</p>
-    
+
+      <p>You can find further information about supported protocols and RFCs
+        <a href="http://james.apache.org/protocols/smtp.html">on the JAMES-PROTOCOLS project SMTP page</a>
+      </p>
     </subsection>
     
     <subsection name="IMAP4 Protocol">
@@ -66,7 +69,15 @@
       IMAP4 client connecting to the server.</p>
       
       <p>More information on configuring the IMAP4 service can be found <a href="config-imap4.html">here</a>.</p>
-    
+
+      <p>You can find further information about supported protocols and RFCs
+        <a href="http://james.apache.org/protocols/imap4.html">on the JAMES-PROTOCOLS project IMAP4 page</a>
+      </p>
+
+      <p>
+        Note that MOVE extension (RFC-6851) needs a MailboxManager implementing the move function. For now, this is only done with
+        the CassandraMailboxManager
+      </p>
     </subsection>
     
     <subsection name="POP3 Protocol">
@@ -80,7 +91,10 @@
       POP3 client connecting to the server.</p>
       
       <p>More information on configuring the POP3 service can be found <a href="config-pop3.html">here</a>.</p>
-    
+
+      <p>You can find further information about supported protocols and RFCs
+        <a href="http://james.apache.org/protocols/pop3.html">on the JAMES-PROTOCOLS project POP3 page</a>
+      </p>
     </subsection>
     
     <subsection name="FetchMail">


### PR DESCRIPTION
In this PR : 

 - I add the notion of capabilities for Mailbox Managers
 - I solve inheritance bug for MOVE and COPY command
 - I provide unit tests for MOVE and COPY components for IMAP
 - I provide code factorisation between COPY and MOVE commands
 - I provide MPT tests for the MOVE command
 - I announce and enable MOVE command only if supported
 - I provide documentation updates, mostly about mailbox capabilities and MOVE command