### PR TITLE
JAMES-1706 delayed dependencies startup should not cause server to hang

### DIFF
--- a/dockerfiles/run/guice/destination/conf/cassandra.properties
+++ b/dockerfiles/run/guice/destination/conf/cassandra.properties
@@ -4,3 +4,5 @@ cassandra.ip=cassandra
 cassandra.port=9042
 cassandra.keyspace=apache_james
 cassandra.replication.factor=1
+cassandra.retryConnection.maxRetries=10
+cassandra.retryConnection.minDelay=5000

--- a/dockerfiles/run/guice/destination/conf/elasticsearch.properties
+++ b/dockerfiles/run/guice/destination/conf/elasticsearch.properties
@@ -24,3 +24,5 @@ elasticsearch.masterHost=elasticsearch
 elasticsearch.port=9300
 elasticsearch.nb.shards=1
 elasticsearch.nb.replica=0
+elasticsearch.retryConnection.maxRetries=7
+elasticsearch.retryConnection.minDelay=3000

--- a/server/container/cassandra-guice/pom.xml
+++ b/server/container/cassandra-guice/pom.xml
@@ -383,6 +383,10 @@
                     <scope>test</scope>
                 </dependency>
                 <dependency>
+                    <groupId>com.nurkiewicz.asyncretry</groupId>
+                    <artifactId>asyncretry</artifactId>
+                </dependency>
+                <dependency>
                     <groupId>commons-daemon</groupId>
                     <artifactId>commons-daemon</artifactId>
                 </dependency>

--- a/server/container/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
+++ b/server/container/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
@@ -89,10 +89,6 @@ public class CassandraSessionModule extends AbstractModule {
 
     @Provides
     private AsyncRetryExecutor provideAsyncRetryExecutor(ScheduledExecutorService scheduler) {
-        return getRetryExecutor(scheduler);
-    }
-
-    private AsyncRetryExecutor getRetryExecutor(ScheduledExecutorService scheduler) {
         return new AsyncRetryExecutor(scheduler);
     }
 

--- a/server/container/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
+++ b/server/container/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
@@ -20,6 +20,8 @@ package org.apache.james.modules.mailbox;
 
 import java.io.FileNotFoundException;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -32,14 +34,20 @@ import org.apache.james.filesystem.api.FileSystem;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.nurkiewicz.asyncretry.AsyncRetryExecutor;
 
 public class CassandraSessionModule extends AbstractModule {
 
+    private static final int DEFAULT_CONNECTION_MAX_RETRIES = 10;
+    private static final int DEFAULT_CONNECTION_MIN_DELAY = 5000;
+
     @Override
     protected void configure() {
+        bind(ScheduledExecutorService.class).toProvider(ScheduledExecutorServiceProvider.class);
     }
     
     @Provides
@@ -59,19 +67,37 @@ public class CassandraSessionModule extends AbstractModule {
 
     @Provides
     @Singleton
-    Cluster provideCluster(FileSystem fileSystem) throws FileNotFoundException, ConfigurationException {
+    Cluster provideCluster(FileSystem fileSystem, AsyncRetryExecutor executor) throws FileNotFoundException, ConfigurationException, ExecutionException, InterruptedException {
         PropertiesConfiguration configuration = getConfiguration(fileSystem);
-        
-        return ClusterWithKeyspaceCreatedFactory.clusterWithInitializedKeyspace(
-            ClusterFactory.createClusterForSingleServerWithoutPassWord(
-                configuration.getString("cassandra.ip"),
-                configuration.getInt("cassandra.port")),
-                configuration.getString("cassandra.keyspace"),
-                configuration.getInt("cassandra.replication.factor"));
+
+        return getRetryer(executor, configuration)
+                .getWithRetry(ctx -> ClusterWithKeyspaceCreatedFactory.clusterWithInitializedKeyspace(
+                        ClusterFactory.createClusterForSingleServerWithoutPassWord(
+                                configuration.getString("cassandra.ip"),
+                                configuration.getInt("cassandra.port")),
+                        configuration.getString("cassandra.keyspace"),
+                        configuration.getInt("cassandra.replication.factor")))
+                .get();
+    }
+
+    private static AsyncRetryExecutor getRetryer(AsyncRetryExecutor executor, PropertiesConfiguration configuration) {
+        return executor.retryOn(NoHostAvailableException.class)
+                .withProportionalJitter()
+                .withMaxRetries(configuration.getInt("cassandra.retryConnection.maxRetries", DEFAULT_CONNECTION_MAX_RETRIES))
+                .withMinDelay(configuration.getInt("cassandra.retryConnection.minDelay", DEFAULT_CONNECTION_MIN_DELAY));
+    }
+
+    @Provides
+    private AsyncRetryExecutor provideAsyncRetryExecutor(ScheduledExecutorService scheduler) {
+        return getRetryExecutor(scheduler);
+    }
+
+    private AsyncRetryExecutor getRetryExecutor(ScheduledExecutorService scheduler) {
+        return new AsyncRetryExecutor(scheduler);
     }
 
     private PropertiesConfiguration getConfiguration(FileSystem fileSystem) throws FileNotFoundException, ConfigurationException {
         return new PropertiesConfiguration(fileSystem.getFile(FileSystem.FILE_PROTOCOL_AND_CONF + "cassandra.properties"));
     }
-    
+
 }

--- a/server/container/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/ScheduledExecutorServiceProvider.java
+++ b/server/container/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/ScheduledExecutorServiceProvider.java
@@ -1,0 +1,49 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.mailbox;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import javax.annotation.PreDestroy;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Provider;
+
+@VisibleForTesting
+class ScheduledExecutorServiceProvider implements Provider<ScheduledExecutorService> {
+
+    private final ScheduledExecutorService scheduler;
+
+    @VisibleForTesting
+    ScheduledExecutorServiceProvider() {
+        scheduler = Executors.newSingleThreadScheduledExecutor();
+    }
+
+    @Override
+    public ScheduledExecutorService get() {
+        return scheduler;
+    }
+
+    @PreDestroy
+    private void stop() {
+        scheduler.shutdown();
+    }
+}

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -1304,6 +1304,11 @@
                 <version>4.0</version>
             </dependency>
             <dependency>
+                <groupId>com.nurkiewicz.asyncretry</groupId>
+                <artifactId>asyncretry</artifactId>
+                <version>0.0.7</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.onami.lifecycle</groupId>
                 <artifactId>org.apache.onami.lifecycle.jsr250</artifactId>
                 <version>0.2.0-SNAPSHOT</version>


### PR DESCRIPTION
starting james before cassandra and elasticsearch are ready is causing server to hang.

This PR is a subset of  https://github.com/linagora/james-project/pull/183.
- Only startup for cassandra and elastic search is using async retry library for now.
- Fixes following review comments from https://github.com/linagora/james-project/pull/183 , on relevant part of the code are included.
