### PR TITLE
JAMES-1716 Saving to draft should not send message

### DIFF
--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
@@ -59,6 +59,7 @@ import com.google.common.base.Charsets;
 import com.jayway.awaitility.Awaitility;
 import com.jayway.awaitility.Duration;
 import com.jayway.awaitility.core.ConditionFactory;
+import com.jayway.awaitility.core.ConditionTimeoutException;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.builder.ResponseSpecBuilder;
 import com.jayway.restassured.http.ContentType;
@@ -1344,6 +1345,60 @@ public abstract class SetMessagesMethodTest {
         // Then
         calmlyAwait.atMost(10, TimeUnit.SECONDS).until( () -> isHtmlMessageReceived(recipientToken));
     }
+
+
+    @Test(expected = ConditionTimeoutException.class)
+    public void setMessagesWhenSavingToDraftsShouldNotSendMessage() throws Exception {
+        // Sender
+        jmapServer.serverProbe().createMailbox(MailboxConstants.USER_NAMESPACE, username, "sent");
+        jmapServer.serverProbe().createMailbox(MailboxConstants.USER_NAMESPACE, username, "drafts");
+        // Recipient
+        String recipientAddress = "recipient" + "@" + USERS_DOMAIN;
+        String password = "password";
+        jmapServer.serverProbe().addUser(recipientAddress, password);
+        jmapServer.serverProbe().createMailbox(MailboxConstants.USER_NAMESPACE, recipientAddress, "inbox");
+        await();
+        AccessToken recipientToken = JmapAuthentication.authenticateJamesUser(recipientAddress, password);
+
+        String draftsMailboxId = getAllMailboxesIds(accessToken).stream()
+                .filter(x -> x.get("role").equals("drafts"))
+                .map(x -> x.get("id"))
+                .findFirst().get();
+
+        String messageCreationId = "user|inbox|1";
+        String fromAddress = username;
+        String requestBody = "[" +
+                "  [" +
+                "    \"setMessages\","+
+                "    {" +
+                "      \"create\": { \"" + messageCreationId  + "\" : {" +
+                "        \"from\": { \"email\": \"" + fromAddress + "\"}," +
+                "        \"to\": [{ \"name\": \"BOB\", \"email\": \"" + recipientAddress + "\"}]," +
+                "        \"cc\": [{ \"name\": \"ALICE\"}]," +
+                "        \"subject\": \"Thank you for joining example.com!\"," +
+                "        \"textBody\": \"Hello someone, and thank you for joining example.com!\"," +
+                "        \"mailboxIds\": [\"" + draftsMailboxId + "\"]" +
+                "        \"isDraft\": false" +
+                "      }}" +
+                "    }," +
+                "    \"#0\"" +
+                "  ]" +
+                "]";
+
+        // Given
+        given()
+                .accept(ContentType.JSON)
+                .contentType(ContentType.JSON)
+                .header("Authorization", this.accessToken.serialize())
+                .body(requestBody)
+                // When
+                .when()
+                .post("/jmap");
+
+        // Then
+        calmlyAwait.atMost(3, TimeUnit.SECONDS).until( () -> isAnyMessageFoundInRecipientsMailboxes(recipientToken));
+    }
+
 
     private boolean isHtmlMessageReceived(AccessToken recipientToken) {
         try {

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/SetError.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/SetError.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
@@ -98,5 +99,29 @@ public class SetError {
     @JsonSerialize
     public Optional<ImmutableSet<MessageProperty>> getProperties() {
         return properties;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SetError setError = (SetError) o;
+        return Objects.equal(type, setError.type) &&
+                Objects.equal(description, setError.description) &&
+                Objects.equal(properties, setError.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(type, description, properties);
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("type", type)
+                .add("description", description)
+                .add("properties", properties)
+                .toString();
     }
 }

--- a/server/queue/queue-jms/src/test/java/org/apache/james/queue/library/AbstractMailQueueFactoryTest.java
+++ b/server/queue/queue-jms/src/test/java/org/apache/james/queue/library/AbstractMailQueueFactoryTest.java
@@ -19,7 +19,11 @@
 
 package org.apache.james.queue.library;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import org.apache.james.queue.api.MailQueue;
 import org.apache.james.queue.api.ManageableMailQueue;


### PR DESCRIPTION
When saving a message to drafts mailbox, server should not send it to the specified recipients.

providing both an outside integration test (SetMessageMethodTest) and some unit tests (SetMessageCreationProcessorTest) 