### PR TITLE
JAMES-1716 Saving to draft should not send message

### DIFF
--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailbox.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailbox.java
@@ -31,15 +31,21 @@ public class SimpleMailbox<Id extends MailboxId> implements Mailbox<Id> {
     private String user;
     private String name;
     private final long uidValidity;
+
     private MailboxACL acl = SimpleMailboxACL.EMPTY;
 
-    public SimpleMailbox(MailboxPath path, long uidValidity) {
+    public SimpleMailbox(MailboxPath path, long uidValidity, Id mailboxId) {
+        this.id = mailboxId;
         this.namespace = path.getNamespace();
         this.user = path.getUser();
         this.name = path.getName();
         this.uidValidity = uidValidity;
     }
-    
+
+    public SimpleMailbox(MailboxPath path, long uidValidity) {
+        this(path, uidValidity, null);
+    }
+
     public SimpleMailbox(Mailbox<Id> mailbox) {
         this.id = mailbox.getMailboxId();
         this.namespace = mailbox.getNamespace();
@@ -139,6 +145,7 @@ public class SimpleMailbox<Id extends MailboxId> implements Mailbox<Id> {
         return result;
     }
 
+
     /**
      * @see java.lang.Object#toString()
      */
@@ -146,7 +153,6 @@ public class SimpleMailbox<Id extends MailboxId> implements Mailbox<Id> {
     public String toString() {
         return namespace + ":" + user + ":" + name;
     }
-
 
     public void setMailboxId(Id id) {
         this.id = id;
@@ -167,5 +173,4 @@ public class SimpleMailbox<Id extends MailboxId> implements Mailbox<Id> {
     public void setACL(MailboxACL acl) {
         this.acl = acl;
     }
-
 }

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
@@ -23,6 +23,7 @@ import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.RestAssured.with;
 import static com.jayway.restassured.config.EncoderConfig.encoderConfig;
 import static com.jayway.restassured.config.RestAssuredConfig.newConfig;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.endsWith;
@@ -59,7 +60,6 @@ import com.google.common.base.Charsets;
 import com.jayway.awaitility.Awaitility;
 import com.jayway.awaitility.Duration;
 import com.jayway.awaitility.core.ConditionFactory;
-import com.jayway.awaitility.core.ConditionTimeoutException;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.builder.ResponseSpecBuilder;
 import com.jayway.restassured.http.ContentType;
@@ -1347,7 +1347,7 @@ public abstract class SetMessagesMethodTest {
     }
 
 
-    @Test(expected = ConditionTimeoutException.class)
+    @Test
     public void setMessagesWhenSavingToDraftsShouldNotSendMessage() throws Exception {
         // Sender
         jmapServer.serverProbe().createMailbox(MailboxConstants.USER_NAMESPACE, username, "sent");
@@ -1396,7 +1396,8 @@ public abstract class SetMessagesMethodTest {
                 .post("/jmap");
 
         // Then
-        calmlyAwait.atMost(3, TimeUnit.SECONDS).until( () -> isAnyMessageFoundInRecipientsMailboxes(recipientToken));
+        Thread.sleep(TimeUnit.SECONDS.toMillis(3));
+        assertThat(isAnyMessageFoundInRecipientsMailboxes(recipientToken)).isFalse();
     }
 
 

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMessagesCreationProcessor.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMessagesCreationProcessor.java
@@ -126,7 +126,7 @@ public class SetMessagesCreationProcessor<Id extends MailboxId> implements SetMe
 
     private Mailbox<Id> getOutbox(MailboxSession mailboxSession) {
         Role outbox = Role.OUTBOX;
-        return systemMailboxesProvider.getStreamOfMailboxesFromRole(outbox, mailboxSession).findFirst()
+        return systemMailboxesProvider.listMailboxes(outbox, mailboxSession).findFirst()
                 .orElseThrow(() -> new MailboxRoleNotFoundException(outbox));
     }
 
@@ -145,13 +145,13 @@ public class SetMessagesCreationProcessor<Id extends MailboxId> implements SetMe
     private boolean isRequestForSending(CreationMessage messageWithId, MailboxSession session,
                                         Predicate<CreationMessage> validMessagesTester) {
         Predicate<Mailbox<Id>> isMessageCreatedInOutbox = box -> messageWithId.getMailboxIds().contains(box.getMailboxId().serialize());
-        boolean isMessageSetInOutbox = systemMailboxesProvider.getStreamOfMailboxesFromRole(Role.OUTBOX, session)
+        boolean isMessageSetInOutbox = systemMailboxesProvider.listMailboxes(Role.OUTBOX, session)
                 .anyMatch(isMessageCreatedInOutbox);
         return validMessagesTester.test(messageWithId) && isMessageSetInOutbox;
     }
 
     private Predicate<CreationMessage> getIsMessageSetInDraftPredicate(MailboxSession mailboxSession) {
-        Optional<Id> draftsId = systemMailboxesProvider.getStreamOfMailboxesFromRole(Role.DRAFTS, mailboxSession)
+        Optional<Id> draftsId = systemMailboxesProvider.listMailboxes(Role.DRAFTS, mailboxSession)
                 .map(Mailbox::getMailboxId)
                 .findFirst();
         return creationMessage -> draftsId

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/CreationMessage.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/CreationMessage.java
@@ -22,10 +22,7 @@ package org.apache.james.jmap.model;
 import static org.apache.james.jmap.model.MessageProperties.MessageProperty;
 
 import java.time.ZonedDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import javax.mail.internet.AddressException;
@@ -84,8 +81,12 @@ public class CreationMessage {
             headers = ImmutableMap.builder();
         }
 
-        public Builder mailboxIds(ImmutableList<String> mailboxIds) {
-            this.mailboxIds = mailboxIds;
+        public Builder mailboxId(String mailboxIds) {
+            return mailboxIds(Arrays.asList(mailboxIds));
+        }
+
+        public Builder mailboxIds(List<String> mailboxIds) {
+            this.mailboxIds = ImmutableList.copyOf(mailboxIds);
             return this;
         }
 

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/Message.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/Message.java
@@ -21,6 +21,7 @@ package org.apache.james.jmap.model;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -28,7 +29,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.annotation.JsonFilter;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.james.jmap.methods.GetMessagesMethod;
 import org.apache.james.jmap.methods.JmapResponseWriterImpl;
@@ -36,7 +36,9 @@ import org.apache.james.jmap.model.message.EMailer;
 import org.apache.james.jmap.model.message.IndexableMessage;
 import org.apache.james.mailbox.store.extractor.DefaultTextExtractor;
 import org.apache.james.mailbox.store.mail.model.MailboxId;
+import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 
+import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.common.annotations.VisibleForTesting;
@@ -46,8 +48,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import com.google.common.net.MediaType;
-
-import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 
 @JsonDeserialize(builder = Message.Builder.class)
 @JsonFilter(JmapResponseWriterImpl.PROPERTIES_FILTER)
@@ -234,8 +234,12 @@ public class Message {
             return this;
         }
 
-        public Builder mailboxIds(ImmutableList<String> mailboxIds) {
-            this.mailboxIds = mailboxIds;
+        public Builder mailboxIds(String... mailboxIds) {
+            return mailboxIds(Arrays.asList(mailboxIds));
+        }
+
+        public Builder mailboxIds(List<String> mailboxIds) {
+            this.mailboxIds = ImmutableList.copyOf(mailboxIds);
             return this;
         }
 

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/Message.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/Message.java
@@ -21,7 +21,6 @@ package org.apache.james.jmap.model;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -234,8 +233,8 @@ public class Message {
             return this;
         }
 
-        public Builder mailboxIds(String... mailboxIds) {
-            return mailboxIds(Arrays.asList(mailboxIds));
+        public Builder mailboxId(String mailboxId) {
+            return this.mailboxIds(ImmutableList.of(mailboxId));
         }
 
         public Builder mailboxIds(List<String> mailboxIds) {

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/SetError.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/SetError.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -115,5 +116,14 @@ public class SetError {
     @Override
     public int hashCode() {
         return Objects.hashCode(type, description, properties);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("description", description)
+                .add("type", type)
+                .add("properties", properties)
+                .toString();
     }
 }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/SetMessagesRequest.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/SetMessagesRequest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.james.jmap.methods.JmapRequest;
 import org.apache.james.jmap.methods.UpdateMessagePatchConverter;
 
@@ -34,7 +35,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import org.apache.commons.lang.NotImplementedException;
 
 @JsonDeserialize(builder = SetMessagesRequest.Builder.class)
 public class SetMessagesRequest implements JmapRequest {
@@ -70,6 +70,11 @@ public class SetMessagesRequest implements JmapRequest {
             if (ifInState != null) {
                 throw new NotImplementedException();
             }
+            return this;
+        }
+
+        public Builder create(CreationMessageId creationMessageId, CreationMessage creation) {
+            this.create.put(creationMessageId, creation);
             return this;
         }
 

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/SetMessagesResponse.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/SetMessagesResponse.java
@@ -81,6 +81,11 @@ public class SetMessagesResponse implements Method.Response {
             throw new NotImplementedException();
         }
 
+        public Builder created(CreationMessageId creationMessageId, Message message) {
+            this.created.put(creationMessageId, message);
+            return this;
+        }
+
         public Builder created(Map<CreationMessageId, Message> created) {
             this.created.putAll(created);
             return this;
@@ -119,6 +124,10 @@ public class SetMessagesResponse implements Method.Response {
         public Builder notDestroyed(Map<MessageId, SetError> notDestroyed) {
             this.notDestroyed.putAll(notDestroyed);
             return this;
+        }
+
+        public Builder mergeWith(Builder otherBuilder) {
+            return otherBuilder.build().mergeInto(this);
         }
 
         public SetMessagesResponse build() {

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/SystemMailboxesProvider.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/SystemMailboxesProvider.java
@@ -27,5 +27,5 @@ import org.apache.james.mailbox.store.mail.model.Mailbox;
 import org.apache.james.mailbox.store.mail.model.MailboxId;
 
 public interface SystemMailboxesProvider<Id extends MailboxId> {
-    Stream<Mailbox<Id>> getStreamOfMailboxesFromRole(Role aRole, MailboxSession session);
+    Stream<Mailbox<Id>> listMailboxes(Role aRole, MailboxSession session);
 }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/SystemMailboxesProvider.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/SystemMailboxesProvider.java
@@ -1,0 +1,31 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.utils;
+
+import java.util.stream.Stream;
+
+import org.apache.james.jmap.model.mailbox.Role;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.store.mail.model.Mailbox;
+import org.apache.james.mailbox.store.mail.model.MailboxId;
+
+public interface SystemMailboxesProvider<Id extends MailboxId> {
+    Stream<Mailbox<Id>> getStreamOfMailboxesFromRole(Role aRole, MailboxSession session);
+}

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/SystemMailboxesProviderImpl.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/SystemMailboxesProviderImpl.java
@@ -1,0 +1,71 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.utils;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import javax.inject.Inject;
+
+import org.apache.james.jmap.model.mailbox.Role;
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.model.MailboxMetaData;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.MailboxQuery;
+import org.apache.james.mailbox.store.mail.MailboxMapperFactory;
+import org.apache.james.mailbox.store.mail.model.Mailbox;
+import org.apache.james.mailbox.store.mail.model.MailboxId;
+
+import com.github.fge.lambdas.functions.ThrowingFunction;
+import com.github.fge.lambdas.supplier.ThrowingSupplier;
+import com.google.common.annotations.VisibleForTesting;
+
+public class SystemMailboxesProviderImpl<Id extends MailboxId> implements SystemMailboxesProvider<Id> {
+
+    private final MailboxMapperFactory<Id> mailboxMapperFactory;
+    private final MailboxManager mailboxManager;
+
+    @Inject
+    @VisibleForTesting SystemMailboxesProviderImpl(MailboxMapperFactory<Id> mailboxMapperFactory, MailboxManager mailboxManager) {
+        this.mailboxMapperFactory = mailboxMapperFactory;
+        this.mailboxManager = mailboxManager;
+    }
+
+    private boolean hasRole(Role aRole, MailboxPath mailBoxPath) {
+        return Role.from(mailBoxPath.getName())
+                .map(aRole::equals)
+                .orElse(false);
+    }
+
+    public Stream<Mailbox<Id>> getStreamOfMailboxesFromRole(Role aRole, MailboxSession session) {
+        ThrowingSupplier<List<MailboxMetaData>> getAllMailboxes = () -> mailboxManager.search(MailboxQuery.builder(session).privateUserMailboxes().build(), session);
+        Predicate<MailboxPath> hasSpecifiedRole = path -> hasRole(aRole, path);
+        return getAllMailboxes.get().stream()
+                .map(MailboxMetaData::getPath)
+                .filter(hasSpecifiedRole)
+                .map(loadMailbox(session));
+    }
+
+    private ThrowingFunction<MailboxPath, Mailbox<Id>> loadMailbox(MailboxSession session) {
+        return path -> mailboxMapperFactory.getMailboxMapper(session).findMailboxByPath(path);
+    }
+}

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/SystemMailboxesProviderImpl.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/SystemMailboxesProviderImpl.java
@@ -56,11 +56,11 @@ public class SystemMailboxesProviderImpl<Id extends MailboxId> implements System
                 .orElse(false);
     }
 
-    public Stream<Mailbox<Id>> getStreamOfMailboxesFromRole(Role aRole, MailboxSession session) {
+    public Stream<Mailbox<Id>> listMailboxes(Role aRole, MailboxSession session) {
         ThrowingSupplier<List<MailboxMetaData>> getAllMailboxes = () -> mailboxManager.search(MailboxQuery.builder(session).privateUserMailboxes().build(), session);
         Predicate<MailboxPath> hasSpecifiedRole = path -> hasRole(aRole, path);
         return getAllMailboxes.get().stream()
-                .map(MailboxMetaData::getPath)
+        .map(MailboxMetaData::getPath)
                 .filter(hasSpecifiedRole)
                 .map(loadMailbox(session));
     }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/SetMessagesCreationProcessorTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/SetMessagesCreationProcessorTest.java
@@ -82,7 +82,7 @@ public class SetMessagesCreationProcessorTest {
             .id(MessageId.of(OUTBOX_MESSAGE_ID))
             .blobId("anything")
             .threadId("anything")
-            .mailboxIds(OUTBOX_ID.serialize())
+            .mailboxId(OUTBOX_ID.serialize())
             .headers(ImmutableMap.of())
             .subject("anything")
             .size(0)

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/SetMessagesCreationProcessorTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/SetMessagesCreationProcessorTest.java
@@ -267,7 +267,7 @@ public class SetMessagesCreationProcessorTest {
             this.draftsSupplier = draftsSupplier;
         }
 
-        public Stream<Mailbox<TestId>> getStreamOfMailboxesFromRole(Role aRole, MailboxSession session) {
+        public Stream<Mailbox<TestId>> listMailboxes(Role aRole, MailboxSession session) {
             if (aRole.equals(Role.OUTBOX)) {
                 return outboxSupplier.get().map(o -> Stream.of(o)).orElse(Stream.empty());
             } else if (aRole.equals(Role.DRAFTS)) {

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/SetMessagesCreationProcessorTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/SetMessagesCreationProcessorTest.java
@@ -23,12 +23,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import org.apache.james.jmap.exceptions.MailboxRoleNotFoundException;
 import org.apache.james.jmap.model.CreationMessage;
@@ -36,11 +39,14 @@ import org.apache.james.jmap.model.CreationMessage.DraftEmailer;
 import org.apache.james.jmap.model.CreationMessageId;
 import org.apache.james.jmap.model.Message;
 import org.apache.james.jmap.model.MessageId;
+import org.apache.james.jmap.model.SetError;
 import org.apache.james.jmap.model.SetMessagesRequest;
 import org.apache.james.jmap.model.SetMessagesResponse;
+import org.apache.james.jmap.model.mailbox.Role;
 import org.apache.james.jmap.send.MailFactory;
 import org.apache.james.jmap.send.MailMetadata;
 import org.apache.james.jmap.send.MailSpool;
+import org.apache.james.jmap.utils.SystemMailboxesProvider;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
@@ -49,11 +55,14 @@ import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.mailet.Mail;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 
+@SuppressWarnings("unchecked")
 public class SetMessagesCreationProcessorTest {
 
     private static final Message FAKE_MESSAGE = Message.builder()
@@ -67,18 +76,30 @@ public class SetMessagesCreationProcessorTest {
             .date(ZonedDateTime.now())
             .preview("anything")
             .build();
+    private static final String OUTBOX_ID = "user|outbox|12345";
+
+    private MessageMapper<TestId> mockMapper;
+    private MailboxSessionMapperFactory<TestId> stubSessionMapperFactory;
+    private MailSpool mockedMailSpool;
+    private MailFactory<TestId> mockedMailFactory;
+    private SystemMailboxesProvider<TestId> fakeSystemMailboxesProvider;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setUp() throws MailboxException {
+        mockMapper = mock(MessageMapper.class);
+        stubSessionMapperFactory = mock(MailboxSessionMapperFactory.class);
+        when(stubSessionMapperFactory.createMessageMapper(any(MailboxSession.class)))
+                .thenReturn(mockMapper);
+        mockedMailSpool = mock(MailSpool.class);
+        mockedMailFactory = mock(MailFactory.class);
+
+        fakeSystemMailboxesProvider = new TestSystemMailboxesProvider();
+    }
 
     @Test
     public void processShouldReturnEmptyCreatedWhenRequestHasEmptyCreate() {
-        SetMessagesCreationProcessor<TestId> sut = new SetMessagesCreationProcessor<TestId>(null, null, null, null, null, null) {
-            @Override
-            protected Optional<Mailbox<TestId>> getOutbox(MailboxSession session) throws MailboxException {
-                @SuppressWarnings("unchecked")
-				Mailbox<TestId> fakeOutbox = (Mailbox<TestId>) mock(Mailbox.class);
-                when(fakeOutbox.getName()).thenReturn("outbox");
-                return Optional.of(fakeOutbox);
-            }
-        };
+        SetMessagesCreationProcessor<TestId> sut = new SetMessagesCreationProcessor<>(null, null, null, null, fakeSystemMailboxesProvider);
         SetMessagesRequest requestWithEmptyCreate = SetMessagesRequest.builder().build();
 
         SetMessagesResponse result = sut.process(requestWithEmptyCreate, buildStubbedSession());
@@ -106,16 +127,10 @@ public class SetMessagesCreationProcessorTest {
         when(mockSessionMapperFactory.createMessageMapper(any(MailboxSession.class)))
                 .thenReturn(stubMapper);
 
-        SetMessagesCreationProcessor<TestId> sut = new SetMessagesCreationProcessor<TestId>(null, null, mockSessionMapperFactory, null, null, null) {
+        SetMessagesCreationProcessor<TestId> sut = new SetMessagesCreationProcessor<TestId>(mockSessionMapperFactory, null, null, null, fakeSystemMailboxesProvider) {
             @Override
             protected MessageWithId<Message> createMessageInOutboxAndSend(MessageWithId.CreationMessageEntry createdEntry, MailboxSession session, Mailbox<TestId> outbox, Function<Long, MessageId> buildMessageIdFromUid) {
                 return new MessageWithId<>(createdEntry.getCreationId(), FAKE_MESSAGE);
-            }
-            @Override
-            protected Optional<Mailbox<TestId>> getOutbox(MailboxSession session) throws MailboxException {
-                Mailbox<TestId> fakeOutbox = mock(Mailbox.class);
-                when(fakeOutbox.getName()).thenReturn("outbox");
-                return Optional.of(fakeOutbox);
             }
         };
         // When
@@ -129,39 +144,20 @@ public class SetMessagesCreationProcessorTest {
     @Test(expected = MailboxRoleNotFoundException.class)
     public void processShouldThrowWhenOutboxNotFound() {
         // Given
-        SetMessagesCreationProcessor<TestId> sut = new SetMessagesCreationProcessor<TestId>(null, null, null, null, null, null) {
-            @Override
-            protected Optional<Mailbox<TestId>> getOutbox(MailboxSession session) throws MailboxException {
-                return Optional.empty();
-            }
-        };
+        TestSystemMailboxesProvider doNotProvideOutbox = TestSystemMailboxesProvider.fakeOutbox(Optional::empty);
+        SetMessagesCreationProcessor<TestId> sut = new SetMessagesCreationProcessor<>(null, null, null, null, doNotProvideOutbox);
         // When
         sut.process(buildFakeCreationRequest(), null);
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void processShouldCallMessageMapperWhenRequestHasNonEmptyCreate() throws MailboxException {
         // Given
-        Mailbox<TestId> fakeOutbox = mock(Mailbox.class);
-        MessageMapper<TestId> mockMapper = mock(MessageMapper.class);
-        MailboxSessionMapperFactory<TestId> stubSessionMapperFactory = mock(MailboxSessionMapperFactory.class);
-        when(stubSessionMapperFactory.createMessageMapper(any(MailboxSession.class)))
-                .thenReturn(mockMapper);
-        MailSpool mockedMailSpool = mock(MailSpool.class);
-        MailFactory<TestId> mockedMailFactory = mock(MailFactory.class);
+        Mailbox<TestId> fakeOutbox = buildAndConfigureFakeMailbox("outbox", OUTBOX_ID);
 
-        SetMessagesCreationProcessor<TestId> sut = new SetMessagesCreationProcessor<TestId>(null, null,
-                stubSessionMapperFactory, new MIMEMessageConverter(), mockedMailSpool, mockedMailFactory) {
-            @Override
-            protected Optional<Mailbox<TestId>> getOutbox(MailboxSession session) throws MailboxException {
-                TestId stubMailboxId = mock(TestId.class);
-                when(stubMailboxId.serialize()).thenReturn("user|outbox|12345");
-                when(fakeOutbox.getMailboxId()).thenReturn(stubMailboxId);
-                when(fakeOutbox.getName()).thenReturn("outbox");
-                return Optional.of(fakeOutbox);
-            }
-        };
+        TestSystemMailboxesProvider stubbedMailboxes = TestSystemMailboxesProvider.fakeOutbox(() -> Optional.of(fakeOutbox));
+        SetMessagesCreationProcessor<TestId> sut = new SetMessagesCreationProcessor<>(
+                stubSessionMapperFactory, new MIMEMessageConverter(), mockedMailSpool, mockedMailFactory, stubbedMailboxes);
         // When
         sut.process(buildFakeCreationRequest(), buildStubbedSession());
 
@@ -169,29 +165,20 @@ public class SetMessagesCreationProcessorTest {
         verify(mockMapper).add(eq(fakeOutbox), any(MailboxMessage.class));
     }
 
+    private Mailbox<TestId> buildAndConfigureFakeMailbox(String mailboxName, String mailboxId) {
+        Mailbox<TestId> fakeOutbox = mock(Mailbox.class);
+        TestId stubMailboxId = mock(TestId.class);
+        when(fakeOutbox.getName()).thenReturn(mailboxName);
+        when(stubMailboxId.serialize()).thenReturn(mailboxId);
+        when(fakeOutbox.getMailboxId()).thenReturn(stubMailboxId);
+        return fakeOutbox;
+    }
+
     @Test
-    @SuppressWarnings("unchecked")
     public void processShouldSendMailWhenRequestHasNonEmptyCreate() throws Exception {
         // Given
-        Mailbox<TestId> fakeOutbox = mock(Mailbox.class);
-        MessageMapper<TestId> mockMapper = mock(MessageMapper.class);
-        MailboxSessionMapperFactory<TestId> stubSessionMapperFactory = mock(MailboxSessionMapperFactory.class);
-        when(stubSessionMapperFactory.createMessageMapper(any(MailboxSession.class)))
-                .thenReturn(mockMapper);
-        MailSpool mockedMailSpool = mock(MailSpool.class);
-        MailFactory<TestId> mockedMailFactory = mock(MailFactory.class);
-
-        SetMessagesCreationProcessor<TestId> sut = new SetMessagesCreationProcessor<TestId>(null, null,
-                stubSessionMapperFactory, new MIMEMessageConverter(), mockedMailSpool, mockedMailFactory) {
-            @Override
-            protected Optional<Mailbox<TestId>> getOutbox(MailboxSession session) throws MailboxException {
-                TestId stubMailboxId = mock(TestId.class);
-                when(stubMailboxId.serialize()).thenReturn("user|outbox|12345");
-                when(fakeOutbox.getMailboxId()).thenReturn(stubMailboxId);
-                when(fakeOutbox.getName()).thenReturn("outbox");
-                return Optional.of(fakeOutbox);
-            }
-        };
+        SetMessagesCreationProcessor<TestId> sut = new SetMessagesCreationProcessor<>(
+                stubSessionMapperFactory, new MIMEMessageConverter(), mockedMailSpool, mockedMailFactory, fakeSystemMailboxesProvider);
         // When
         sut.process(buildFakeCreationRequest(), buildStubbedSession());
 
@@ -205,9 +192,134 @@ public class SetMessagesCreationProcessorTest {
                     .from(DraftEmailer.builder().name("alice").email("alice@example.com").build())
                     .to(ImmutableList.of(DraftEmailer.builder().name("bob").email("bob@example.com").build()))
                     .subject("Hey! ")
-                    .mailboxIds(ImmutableList.of("mailboxId"))
+                    .mailboxIds(ImmutableList.of(OUTBOX_ID))
                     .build()
                 ))
                 .build();
     }
+
+    @Test
+    public void processShouldNotSpoolMailWhenNotSavingToOutbox() throws Exception {
+        // Given
+        SetMessagesCreationProcessor<TestId> sut = new SetMessagesCreationProcessor<>(
+                stubSessionMapperFactory, new MIMEMessageConverter(), mockedMailSpool, mockedMailFactory, fakeSystemMailboxesProvider);
+        // When
+        sut.process(buildCreationRequestNotForSending(), buildStubbedSession());
+
+        // Then
+        verify(mockedMailSpool, never()).send(any(Mail.class), any(MailMetadata.class));
+    }
+
+    private SetMessagesRequest buildCreationRequestNotForSending() {
+        return SetMessagesRequest.builder()
+                .create(ImmutableMap.of(CreationMessageId.of("anything-really"), CreationMessage.builder()
+                        .from(DraftEmailer.builder().name("alice").email("alice@example.com").build())
+                        .to(ImmutableList.of(DraftEmailer.builder().name("bob").email("bob@example.com").build()))
+                        .subject("Hey! ")
+                        .mailboxIds(ImmutableList.of("any-id-but-outbox-id"))
+                        .build()
+                ))
+                .build();
+    }
+
+    @Test
+    public void processShouldReturnNotImplementedErrorWhenSavingToDrafts() {
+        // Given
+        TestId draftsId = TestId.of(17L);
+        Mailbox<TestId> fakeDrafts = buildAndConfigureFakeMailbox("drafts", draftsId.serialize());
+        TestSystemMailboxesProvider fakeSystemMailboxesProvider = TestSystemMailboxesProvider.fakeDrafts(() -> Optional.of(fakeDrafts));
+
+        SetMessagesCreationProcessor<TestId> sut = new SetMessagesCreationProcessor<>(
+                stubSessionMapperFactory, new MIMEMessageConverter(), mockedMailSpool, mockedMailFactory, fakeSystemMailboxesProvider);
+        // When
+        CreationMessageId creationMessageId = CreationMessageId.of("anything-really");
+        SetMessagesResponse actual = sut.process(buildSaveToDraftsRequest(draftsId, creationMessageId), buildStubbedSession());
+
+        // Then
+        assertThat(actual.getNotCreated()).containsExactly(Maps.immutableEntry(creationMessageId, SetError.builder()
+                .type("error")
+                .description("Not yet implemented")
+                .build()));
+    }
+
+    private SetMessagesRequest buildSaveToDraftsRequest(TestId draftsId, CreationMessageId creationMessageId) {
+        return SetMessagesRequest.builder()
+                .create(ImmutableMap.of(creationMessageId, CreationMessage.builder()
+                        .from(DraftEmailer.builder().name("alice").email("alice@example.com").build())
+                        .to(ImmutableList.of(DraftEmailer.builder().name("bob").email("bob@example.com").build()))
+                        .subject("Hey! ")
+                        .mailboxIds(ImmutableList.of(draftsId.serialize()))
+                        .build()
+                )).build();
+    }
+
+    @Test
+    public void processShouldNotSendWhenSavingToDrafts() throws Exception {
+        // Given
+        TestId draftsId = TestId.of(17L);
+        Mailbox<TestId> fakeDrafts = buildAndConfigureFakeMailbox("drafts", draftsId.serialize());
+        TestSystemMailboxesProvider fakeSystemMailboxesProvider = TestSystemMailboxesProvider.fakeDrafts(() -> Optional.of(fakeDrafts));
+
+        SetMessagesCreationProcessor<TestId> sut = new SetMessagesCreationProcessor<>(
+                stubSessionMapperFactory, new MIMEMessageConverter(), mockedMailSpool, mockedMailFactory, fakeSystemMailboxesProvider);
+        // When
+        CreationMessageId creationMessageId = CreationMessageId.of("anything-really");
+        sut.process(buildSaveToDraftsRequest(draftsId, creationMessageId), buildStubbedSession());
+
+        // Then
+        verify(mockedMailSpool, never()).send(any(Mail.class), any(MailMetadata.class));
+    }
+
+
+    public static class TestSystemMailboxesProvider implements SystemMailboxesProvider<TestId> {
+
+        public static final long BOGUS_TEST_ID = 12L;
+
+        private final Supplier<Optional<Mailbox<TestId>>> outboxSupplier;
+        private final Supplier<Optional<Mailbox<TestId>>> draftsSupplier;
+
+        public TestSystemMailboxesProvider() {
+            this.outboxSupplier = () -> getFakeOutbox();
+            this.draftsSupplier= () -> getFakeDrafts(BOGUS_TEST_ID);
+        }
+
+        private TestSystemMailboxesProvider(Supplier<Optional<Mailbox<TestId>>> outboxSupplier,
+                                            Supplier<Optional<Mailbox<TestId>>> draftsSupplier) {
+            this.outboxSupplier = outboxSupplier;
+            this.draftsSupplier = draftsSupplier;
+        }
+
+        public static TestSystemMailboxesProvider fakeOutbox(Supplier<Optional<Mailbox<TestId>>> outboxSupplier) {
+            return new TestSystemMailboxesProvider(outboxSupplier, () -> getFakeDrafts(BOGUS_TEST_ID));
+        }
+
+        public static TestSystemMailboxesProvider fakeDrafts(Supplier<Optional<Mailbox<TestId>>> draftsSupplier) {
+            return new TestSystemMailboxesProvider(() -> getFakeOutbox(), draftsSupplier);
+        }
+
+        public Stream<Mailbox<TestId>> getStreamOfMailboxesFromRole(Role aRole, MailboxSession session) {
+            if (aRole.equals(Role.OUTBOX)) {
+                return outboxSupplier.get().map(o -> Stream.of(o)).orElse(Stream.empty());
+            } else if (aRole.equals(Role.DRAFTS)) {
+                return draftsSupplier.get().map(d -> Stream.of(d)).orElse(Stream.empty());
+            }
+            return Stream.empty();
+        }
+
+        private static Optional<Mailbox<TestId>> getFakeOutbox() {
+            Mailbox<TestId> fakeOutbox = mock(Mailbox.class);
+            TestId stubMailboxId = mock(TestId.class);
+            when(fakeOutbox.getName()).thenReturn("outbox");
+            when(stubMailboxId.serialize()).thenReturn(OUTBOX_ID);
+            when(fakeOutbox.getMailboxId()).thenReturn(stubMailboxId);
+            return Optional.of(fakeOutbox);
+        }
+
+        private static Optional<Mailbox<TestId>> getFakeDrafts(long testId) {
+            Mailbox<TestId> fakeDrafts = mock(Mailbox.class);
+            when(fakeDrafts.getMailboxId()).thenReturn(TestId.of(testId));
+            return Optional.of(fakeDrafts);
+        }
+    }
+
 }


### PR DESCRIPTION
When saving a message to drafts mailbox, server should not send it to the specified recipients.

SetMessageCreationProcessor is getting mailboxes through an adapter (SystemMailboxesProvider) which makes stubbing for unit testing easier than when coupled with MailboxManager.

providing both an outside integration test (SetMessageMethodTest) and some unit tests (SetMessageCreationProcessorTest)

Note: previous feedbacks (from https://github.com/linagora/james-project/pull/203) have been applied on this PR