### PR TITLE
JAMES-1716 Saving to draft should not send message

### DIFF
--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/SetError.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/SetError.java
@@ -102,18 +102,26 @@ public class SetError {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof SetError) {
-            SetError other = (SetError) obj;
-            return Objects.equal(this.type, other.type)
-                && Objects.equal(this.description, other.description)
-                && Objects.equal(this.properties, other.properties);
-        }
-        return false;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SetError setError = (SetError) o;
+        return Objects.equal(type, setError.type) &&
+                Objects.equal(description, setError.description) &&
+                Objects.equal(properties, setError.properties);
     }
 
     @Override
     public int hashCode() {
         return Objects.hashCode(type, description, properties);
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("type", type)
+                .add("description", description)
+                .add("properties", properties)
+                .toString();
     }
 }


### PR DESCRIPTION
When saving a message to drafts mailbox, server should not send it to the specified recipients.

providing both an outside integration test (SetMessageMethodTest) and some unit tests (SetMessageCreationProcessorTest)

This implementation is relying on InMemory implementations for unit tests.

Note: previous feedbacks have been applied on this PR.
