### PR TITLE
Fixing compilation warnings related to deprecated usages of guava

### DIFF
--- a/server/karaf/integration/src/test/java/org/apache/james/karaf/features/KarafLiveTestSupport.java
+++ b/server/karaf/integration/src/test/java/org/apache/james/karaf/features/KarafLiveTestSupport.java
@@ -120,7 +120,7 @@ public class KarafLiveTestSupport {
         final ServiceTracker tracker = new ServiceTracker(bundleContext, clazz, null);
         tracker.open(true);
         try {
-            final Stopwatch stopwatch = new Stopwatch().start();
+            final Stopwatch stopwatch = Stopwatch.createStarted();
             final int expectedCount = 1;
 
             while (true) {

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/MessageId.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/MessageId.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Splitter;
 
 public class MessageId {
@@ -93,8 +94,8 @@ public class MessageId {
     
     @Override
     public String toString() {
-        return com.google.common.base.Objects
-                .toStringHelper(getClass())
+        return MoreObjects
+                .toStringHelper(this)
                 .add("username", username)
                 .add("mailboxPath", mailboxPath)
                 .add("uid", uid)


### PR DESCRIPTION
recent changes have introduced updated versions of guava libs in some modules, leading to obsolete signature (aka deprecated).
patch is removing deprecated usages, as reported during compilation to make the build pass.