### PR TITLE
JAMES-1739 Review default log levels in order to have readable logs 

### DIFF
--- a/server/container/guice/cassandra-guice/src/main/resources/logback.xml
+++ b/server/container/guice/cassandra-guice/src/main/resources/logback.xml
@@ -12,8 +12,11 @@
                 </encoder>
         </appender>
 
-        <root level="INFO">
+        <root level="WARN">
                 <appender-ref ref="CONSOLE" />
         </root>
+
+        <logger name="org.apache.james" level="INFO"/>
+
 
 </configuration>


### PR DESCRIPTION
Because I am tired of damaging my eyes reading James log !!!

Keep INFO as default log level for James
Third party logs should be set to ERROR

Too verbose third party logs includes :
 - Cassandra unit
 - Cassandra driver
 - Apache camel
 - Apache ActiveMQ
 - ElasticSearch embedded server