### PR TITLE
James 1717 Handle HTML in vacation responses

### DIFF
--- a/mailet/base/src/main/java/org/apache/mailet/base/AutomaticallySentMailDetector.java
+++ b/mailet/base/src/main/java/org/apache/mailet/base/AutomaticallySentMailDetector.java
@@ -25,6 +25,9 @@ import org.apache.mailet.Mail;
 
 public interface AutomaticallySentMailDetector {
 
+    String AUTO_SUBMITTED_HEADER = "Auto-Submitted";
+    String AUTO_REPLIED_VALUE = "auto-replied";
+
     boolean isAutomaticallySent(Mail mail) throws MessagingException;
 
     boolean isMailingList(Mail mail) throws MessagingException;

--- a/mailet/base/src/main/java/org/apache/mailet/base/AutomaticallySentMailDetectorImpl.java
+++ b/mailet/base/src/main/java/org/apache/mailet/base/AutomaticallySentMailDetectorImpl.java
@@ -60,10 +60,10 @@ public class AutomaticallySentMailDetectorImpl implements AutomaticallySentMailD
     }
 
     public boolean isAutoSubmitted(Mail mail) throws MessagingException {
-        String[] headers = mail.getMessage().getHeader("Auto-Submitted");
+        String[] headers = mail.getMessage().getHeader(AUTO_SUBMITTED_HEADER);
         if (headers != null) {
             for (String header : headers) {
-                if (header.equalsIgnoreCase("auto-replied")) {
+                if (header.equalsIgnoreCase(AUTO_REPLIED_VALUE)) {
                     return true;
                 }
             }

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/jmap/JMAPModule.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/jmap/JMAPModule.java
@@ -29,6 +29,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.james.filesystem.api.FileSystem;
 import org.apache.james.jmap.mailet.VacationMailet;
 import org.apache.james.jmap.methods.RequestHandler;
+import org.apache.james.jmap.utils.HtmlTextExtractor;
+import org.apache.james.jmap.utils.MailboxBasedHtmlTextExtractor;
 import org.apache.james.lifecycle.api.Configurable;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailetcontainer.impl.MatcherMailetPair;
@@ -57,6 +59,9 @@ public class JMAPModule extends AbstractModule {
         install(new MethodsModule());
         bind(JMAPServer.class).in(Scopes.SINGLETON);
         bind(RequestHandler.class).in(Scopes.SINGLETON);
+        bind(MailboxBasedHtmlTextExtractor.class).in(Scopes.SINGLETON);
+
+        bind(HtmlTextExtractor.class).to(MailboxBasedHtmlTextExtractor.class);
         Multibinder.newSetBinder(binder(), ConfigurationPerformer.class).addBinding().to(MoveCapabilityPrecondition.class);
 
         Multibinder<CamelMailetContainerModule.TransportProcessorCheck> transportProcessorChecks = Multibinder.newSetBinder(binder(), CamelMailetContainerModule.TransportProcessorCheck.class);

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/jmap/MailetPreconditionTest.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/jmap/MailetPreconditionTest.java
@@ -53,7 +53,7 @@ public class MailetPreconditionTest {
 
     @Test(expected = ConfigurationException.class)
     public void vacationMailetCheckShouldThrowOnWrongMatcher() throws Exception {
-        List<MatcherMailetPair> pairs = Lists.newArrayList(new MatcherMailetPair(new All(), new VacationMailet(null, null, null, null)));
+        List<MatcherMailetPair> pairs = Lists.newArrayList(new MatcherMailetPair(new All(), new VacationMailet(null, null, null, null, null)));
         new JMAPModule.VacationMailetCheck().check(pairs);
     }
 
@@ -65,7 +65,7 @@ public class MailetPreconditionTest {
 
     @Test
     public void vacationMailetCheckShouldNotThrowIfValidPairPresent() throws Exception {
-        List<MatcherMailetPair> pairs = Lists.newArrayList(new MatcherMailetPair(new RecipientIsLocal(), new VacationMailet(null, null, null, null)));
+        List<MatcherMailetPair> pairs = Lists.newArrayList(new MatcherMailetPair(new RecipientIsLocal(), new VacationMailet(null, null, null, null, null)));
         new JMAPModule.VacationMailetCheck().check(pairs);
     }
 

--- a/server/container/guice/memory-guice/src/main/java/org/apache/james/modules/data/MemoryDataJmapModule.java
+++ b/server/container/guice/memory-guice/src/main/java/org/apache/james/modules/data/MemoryDataJmapModule.java
@@ -25,6 +25,8 @@ import org.apache.james.jmap.api.vacation.VacationRepository;
 import org.apache.james.jmap.memory.access.MemoryAccessTokenRepository;
 import org.apache.james.jmap.memory.vacation.MemoryNotificationRegistry;
 import org.apache.james.jmap.memory.vacation.MemoryVacationRepository;
+import org.apache.james.mailbox.store.extractor.TextExtractor;
+import org.apache.james.mailbox.tika.extractor.TikaTextExtractor;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
@@ -41,5 +43,8 @@ public class MemoryDataJmapModule extends AbstractModule {
 
         bind(MemoryNotificationRegistry.class).in(Scopes.SINGLETON);
         bind(NotificationRegistry.class).to(MemoryNotificationRegistry.class);
+
+        bind(TikaTextExtractor.class).in(Scopes.SINGLETON);
+        bind(TextExtractor.class).to(TikaTextExtractor.class);
     }
 }

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/vacation/CassandraVacationDAO.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/vacation/CassandraVacationDAO.java
@@ -62,7 +62,8 @@ public class CassandraVacationDAO {
             .value(CassandraVacationTable.FROM_DATE, bindMarker(CassandraVacationTable.FROM_DATE))
             .value(CassandraVacationTable.TO_DATE, bindMarker(CassandraVacationTable.TO_DATE))
             .value(CassandraVacationTable.TEXT, bindMarker(CassandraVacationTable.TEXT))
-            .value(CassandraVacationTable.SUBJECT, bindMarker(CassandraVacationTable.SUBJECT)));
+            .value(CassandraVacationTable.SUBJECT, bindMarker(CassandraVacationTable.SUBJECT))
+            .value(CassandraVacationTable.HTML, bindMarker(CassandraVacationTable.HTML)));
 
         this.readStatement = session.prepare(select()
             .from(CassandraVacationTable.TABLE_NAME)
@@ -77,8 +78,9 @@ public class CassandraVacationDAO {
                 .setBool(CassandraVacationTable.IS_ENABLED, vacation.isEnabled())
                 .setUDTValue(CassandraVacationTable.FROM_DATE, convertToUDTValue(vacation.getFromDate()))
                 .setUDTValue(CassandraVacationTable.TO_DATE, convertToUDTValue(vacation.getToDate()))
-                .setString(CassandraVacationTable.TEXT, vacation.getTextBody())
-                .setString(CassandraVacationTable.SUBJECT, vacation.getSubject().orElse(null)));
+                .setString(CassandraVacationTable.TEXT, vacation.getTextBody().orElse(null))
+                .setString(CassandraVacationTable.SUBJECT, vacation.getSubject().orElse(null))
+                .setString(CassandraVacationTable.HTML, vacation.getHtmlBody().orElse(null)));
     }
 
     public CompletableFuture<Optional<Vacation>> retrieveVacation(AccountId accountId) {
@@ -88,8 +90,9 @@ public class CassandraVacationDAO {
                 .enabled(row.getBool(CassandraVacationTable.IS_ENABLED))
                 .fromDate(retrieveDate(row, CassandraVacationTable.FROM_DATE))
                 .toDate(retrieveDate(row, CassandraVacationTable.TO_DATE))
-                .textBody(row.getString(CassandraVacationTable.TEXT))
                 .subject(Optional.ofNullable(row.getString(CassandraVacationTable.SUBJECT)))
+                .textBody(Optional.ofNullable(row.getString(CassandraVacationTable.TEXT)))
+                .htmlBody(Optional.ofNullable(row.getString(CassandraVacationTable.HTML)))
                 .build()));
     }
 

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/vacation/CassandraVacationModule.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/vacation/CassandraVacationModule.java
@@ -50,7 +50,8 @@ public class CassandraVacationModule implements CassandraModule {
                     .addUDTColumn(CassandraVacationTable.FROM_DATE, SchemaBuilder.frozen(CassandraZonedDateTimeModule.ZONED_DATE_TIME))
                     .addUDTColumn(CassandraVacationTable.TO_DATE, SchemaBuilder.frozen(CassandraZonedDateTimeModule.ZONED_DATE_TIME))
                     .addColumn(CassandraVacationTable.TEXT, text())
-                    .addColumn(CassandraVacationTable.SUBJECT, text())));
+                    .addColumn(CassandraVacationTable.SUBJECT, text())
+                    .addColumn(CassandraVacationTable.HTML, text())));
         index = ImmutableList.of();
         types = ImmutableList.of();
     }

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/vacation/tables/CassandraVacationTable.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/vacation/tables/CassandraVacationTable.java
@@ -28,5 +28,6 @@ public interface CassandraVacationTable {
     String IS_ENABLED = "is_enabled";
     String TEXT = "text";
     String SUBJECT = "subject";
+    String HTML = "html";
 
 }

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/vacation/Vacation.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/vacation/Vacation.java
@@ -38,8 +38,9 @@ public class Vacation {
         private Optional<Boolean> isEnabled = Optional.empty();
         private Optional<ZonedDateTime> fromDate = Optional.empty();
         private Optional<ZonedDateTime> toDate = Optional.empty();
+        private Optional<String> textBody = Optional.empty();
         private Optional<String> subject = Optional.empty();
-        private String textBody = "";
+        private Optional<String> htmlBody = Optional.empty();
 
         public Builder enabled(boolean enabled) {
             isEnabled = Optional.of(enabled);
@@ -58,13 +59,33 @@ public class Vacation {
             return this;
         }
 
-        public Builder textBody(String textBody) {
+        public Builder textBody(Optional<String> textBody) {
+            Preconditions.checkNotNull(textBody);
             this.textBody = textBody;
             return this;
         }
 
+        public Builder textBody(String textBody) {
+            Preconditions.checkNotNull(textBody);
+            this.textBody = Optional.of(textBody);
+            return this;
+        }
+
         public Builder subject(Optional<String> subject) {
+            Preconditions.checkNotNull(subject);
             this.subject = subject;
+            return this;
+        }
+
+        public Builder htmlBody(Optional<String> htmlBody) {
+            Preconditions.checkNotNull(htmlBody);
+            this.htmlBody = htmlBody;
+            return this;
+        }
+
+        public Builder htmlBody(String htmlBody) {
+            Preconditions.checkNotNull(htmlBody);
+            this.htmlBody = Optional.of(htmlBody);
             return this;
         }
 
@@ -78,8 +99,11 @@ public class Vacation {
         }
 
         public Vacation build() {
-            Preconditions.checkNotNull(textBody);
-            return new Vacation(isEnabled.orElse(DEFAULT_DISABLED), fromDate, toDate, textBody, subject);
+            boolean enabled = isEnabled.orElse(DEFAULT_DISABLED);
+            if (enabled) {
+                Preconditions.checkState(textBody.isPresent() || htmlBody.isPresent(), "textBody or htmlBody property of vacationResponse object should not be null when enabled");
+            }
+            return new Vacation(enabled, fromDate, toDate, textBody, subject, htmlBody);
         }
     }
 
@@ -87,14 +111,17 @@ public class Vacation {
     private final Optional<ZonedDateTime> fromDate;
     private final Optional<ZonedDateTime> toDate;
     private final Optional<String> subject;
-    private final String textBody;
+    private final Optional<String> textBody;
+    private final Optional<String> htmlBody;
 
-    private Vacation(boolean isEnabled, Optional<ZonedDateTime> fromDate, Optional<ZonedDateTime> toDate, String textBody, Optional<String> subject) {
+    private Vacation(boolean isEnabled, Optional<ZonedDateTime> fromDate, Optional<ZonedDateTime> toDate,
+                     Optional<String> textBody, Optional<String> subject, Optional<String> htmlBody) {
         this.isEnabled = isEnabled;
         this.fromDate = fromDate;
         this.toDate = toDate;
         this.textBody = textBody;
         this.subject = subject;
+        this.htmlBody = htmlBody;
     }
 
 
@@ -110,12 +137,16 @@ public class Vacation {
         return toDate;
     }
 
-    public String getTextBody() {
+    public Optional<String> getTextBody() {
         return textBody;
     }
 
     public Optional<String> getSubject() {
         return subject;
+    }
+
+    public Optional<String> getHtmlBody() {
+        return htmlBody;
     }
 
     public boolean isActiveAtDate(ZonedDateTime instant) {
@@ -144,12 +175,13 @@ public class Vacation {
             Objects.equals(this.fromDate, vacation.fromDate) &&
             Objects.equals(this.toDate, vacation.toDate) &&
             Objects.equals(this.textBody, vacation.textBody) &&
-            Objects.equals(this.subject, vacation.subject);
+            Objects.equals(this.subject, vacation.subject) &&
+            Objects.equals(this.htmlBody, vacation.htmlBody);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(isEnabled, fromDate, toDate, textBody, subject);
+        return Objects.hash(isEnabled, fromDate, toDate, textBody, subject, htmlBody);
     }
 
 }

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/vacation/AbstractVacationRepositoryTest.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/vacation/AbstractVacationRepositoryTest.java
@@ -33,11 +33,14 @@ public abstract class AbstractVacationRepositoryTest {
     public static final ZonedDateTime ZONED_DATE_TIME = ZonedDateTime.parse("2016-04-03T02:01+07:00[Asia/Vientiane]");
     public static final Vacation VACATION_1 = Vacation.builder()
         .enabled(true)
+        .textBody("other Message")
         .build();
     public static final Vacation VACATION_2 = Vacation.builder()
         .fromDate(Optional.of(ZONED_DATE_TIME))
         .enabled(true)
         .subject(Optional.of("subject"))
+        .textBody("anyMessage")
+        .htmlBody("html Message")
         .build();
 
 

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/vacation/VacationTest.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/vacation/VacationTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.jmap.api.vacation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
@@ -32,6 +33,8 @@ public class VacationTest {
     public static final ZonedDateTime DATE_TIME_2017 = ZonedDateTime.parse("2017-10-09T08:07:06+07:00[Asia/Vientiane]");
     public static final ZonedDateTime DATE_TIME_2017_1MS = ZonedDateTime.parse("2017-10-09T08:07:06.001+07:00[Asia/Vientiane]");
     public static final ZonedDateTime DATE_TIME_2018 = ZonedDateTime.parse("2018-10-09T08:07:06+07:00[Asia/Vientiane]");
+    public static final String TEXT_BODY = "text is required when enabled";
+    public static final String HTML_BODY = "<b>HTML body</b>";
 
     @Test
     public void disabledVacationsAreNotActive() {
@@ -48,6 +51,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .build()
                 .isActiveAtDate(DATE_TIME_2016))
             .isTrue();
@@ -58,6 +62,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .fromDate(Optional.of(DATE_TIME_2016))
                 .build()
                 .isActiveAtDate(DATE_TIME_2016))
@@ -69,6 +74,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .toDate(Optional.of(DATE_TIME_2016))
                 .build()
                 .isActiveAtDate(DATE_TIME_2016))
@@ -80,6 +86,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .fromDate(Optional.of(DATE_TIME_2016))
                 .toDate(Optional.of(DATE_TIME_2018))
                 .build()
@@ -92,6 +99,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .fromDate(Optional.of(DATE_TIME_2016))
                 .toDate(Optional.of(DATE_TIME_2017))
                 .build()
@@ -104,6 +112,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .fromDate(Optional.of(DATE_TIME_2017))
                 .toDate(Optional.of(DATE_TIME_2018))
                 .build()
@@ -115,6 +124,7 @@ public class VacationTest {
     public void isActiveAtDateShouldThrowOnNullValue() {
         Vacation.builder()
             .enabled(true)
+            .textBody(TEXT_BODY)
             .fromDate(Optional.of(DATE_TIME_2016))
             .toDate(Optional.of(DATE_TIME_2016))
             .build()
@@ -126,6 +136,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .fromDate(Optional.of(DATE_TIME_2016))
                 .build()
                 .isActiveAtDate(DATE_TIME_2017))
@@ -137,6 +148,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .fromDate(Optional.of(DATE_TIME_2017))
                 .build()
                 .isActiveAtDate(DATE_TIME_2016))
@@ -148,6 +160,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .toDate(Optional.of(DATE_TIME_2017))
                 .build()
                 .isActiveAtDate(DATE_TIME_2018))
@@ -159,6 +172,7 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .toDate(Optional.of(DATE_TIME_2017))
                 .build()
                 .isActiveAtDate(DATE_TIME_2016))
@@ -170,9 +184,51 @@ public class VacationTest {
         assertThat(
             Vacation.builder()
                 .enabled(true)
+                .textBody(TEXT_BODY)
                 .toDate(Optional.of(DATE_TIME_2017))
                 .build()
                 .isActiveAtDate(DATE_TIME_2017_1MS))
+            .isFalse();
+    }
+
+    @Test
+    public void activeVacationShouldHaveHtmlBodyOrTextBody() {
+        assertThatThrownBy(
+            () -> Vacation.builder()
+                .enabled(true)
+                .build())
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void textBodyShouldBeEnoughToBuildAnActivatedVacation() {
+        assertThat(
+            Vacation.builder()
+                .enabled(true)
+                .textBody(TEXT_BODY)
+                .build()
+                .getTextBody())
+            .contains(TEXT_BODY);
+    }
+
+    @Test
+    public void htmlBodyShouldBeEnoughToBuildAnActivatedVacation() {
+        assertThat(
+            Vacation.builder()
+                .enabled(true)
+                .htmlBody(HTML_BODY)
+                .build()
+                .getHtmlBody())
+            .contains(HTML_BODY);
+    }
+
+    @Test
+    public void textOrHtmlBodyShouldNotBeRequiredOnUnactivatedVacation() {
+        assertThat(
+            Vacation.builder()
+                .enabled(false)
+                .build()
+                .isEnabled())
             .isFalse();
     }
 

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/VacationIntegrationTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/VacationIntegrationTest.java
@@ -47,6 +47,7 @@ import com.jayway.restassured.http.ContentType;
 
 public abstract class VacationIntegrationTest {
 
+    private static final String NAME = "[0][0]";
     private static final String ARGUMENTS = "[0][1]";
     private static final String SECOND_NAME = "[1][0]";
     private static final String SECOND_ARGUMENTS = "[1][1]";
@@ -119,6 +120,24 @@ public abstract class VacationIntegrationTest {
         // User 2 should well receive a notification about user 1 vacation
         calmlyAwait.atMost(10, TimeUnit.SECONDS)
             .until( () -> isTextMessageReceived(user2AccessToken, getInboxId(user2AccessToken), REASON, USER_1, USER_2));
+    }
+
+    @Test
+    public void jmapVacationShouldHaveSupportForHtmlMail() throws Exception {
+        // Given
+        AccessToken user1AccessToken = JmapAuthentication.authenticateJamesUser(USER_1, PASSWORD);
+        AccessToken user2AccessToken = JmapAuthentication.authenticateJamesUser(USER_2, PASSWORD);
+        setHtmlVacationResponse(user1AccessToken);
+
+        // When
+        String user2OutboxId = getOutboxId(user2AccessToken);
+        sendMail(user2AccessToken, user2OutboxId, "user|inbox|1");
+
+        // Then
+        calmlyAwait.atMost(10, TimeUnit.SECONDS)
+            .until(() -> isTextMessageReceived(user1AccessToken, getInboxId(user1AccessToken), ORIGINAL_MESSAGE_TEXT_BODY, USER_2, USER_1));
+        calmlyAwait.atMost(10, TimeUnit.SECONDS)
+            .until( () -> assertNotYetImplemented(user2AccessToken, getInboxId(user2AccessToken)));
     }
 
     @Test
@@ -248,6 +267,30 @@ public abstract class VacationIntegrationTest {
             .statusCode(200);
     }
 
+    private void setHtmlVacationResponse(AccessToken user1AccessToken) {
+        String bodyRequest = "[[" +
+            "\"setVacationResponse\", " +
+            "{" +
+            "  \"update\":{" +
+            "    \"singleton\" : {" +
+            "      \"id\": \"singleton\"," +
+            "      \"isEnabled\": \"true\"," +
+            "      \"htmlBody\": \"<b>" + REASON + "</b>\"" +
+            "    }" +
+            "  }" +
+            "}, \"#0\"" +
+            "]]";
+        given()
+            .accept(ContentType.JSON)
+            .contentType(ContentType.JSON)
+            .header("Authorization", user1AccessToken.serialize())
+            .body(bodyRequest)
+        .when()
+            .post("/jmap")
+        .then()
+            .statusCode(200);
+    }
+
     private void sendMail(AccessToken user2AccessToken, String outboxId, String mailId) {
         String requestBody = "[" +
             "  [" +
@@ -328,6 +371,31 @@ public abstract class VacationIntegrationTest {
             .body(SECOND_ARGUMENTS + ".list[0].from.email", equalTo(expectedFrom))
             .body(SECOND_ARGUMENTS + ".list[0].to.email", hasSize(1))
             .body(SECOND_ARGUMENTS + ".list[0].to.email[0]", equalTo(expectedTo));
+    }
+
+    private boolean assertNotYetImplemented(AccessToken recipientToken, String mailboxId) {
+        try {
+            with()
+                .accept(ContentType.JSON)
+                .contentType(ContentType.JSON)
+                .header("Authorization", recipientToken.serialize())
+                .body("[[\"getMessageList\", " +
+                    "{" +
+                    "  \"fetchMessages\": true, " +
+                    "  \"fetchMessageProperties\": [\"textBody\", \"from\", \"to\", \"mailboxIds\"]," +
+                    "  \"filter\": {" +
+                    "    \"inMailboxes\":[\"" + mailboxId + "\"]" +
+                    "  }" +
+                    "}, \"#0\"]]")
+                .post("/jmap")
+            .then()
+                .statusCode(200)
+                .body(NAME, equalTo("error"))
+                .body(ARGUMENTS + ".type", equalTo("Not yet implemented"));
+            return true;
+        } catch (AssertionError e) {
+            return false;
+        }
     }
 
     private String getOutboxId(AccessToken accessToken) {

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/GetVacationResponseTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/GetVacationResponseTest.java
@@ -99,8 +99,9 @@ public abstract class GetVacationResponseTest {
             .body(ARGUMENTS + ".list[0].fromDate", nullValue())
             .body(ARGUMENTS + ".list[0].toDate", nullValue())
             .body(ARGUMENTS + ".list[0].isEnabled", equalTo(false))
-            .body(ARGUMENTS + ".list[0].textBody", equalTo(""))
-            .body(ARGUMENTS + ".list[0].subject", nullValue());
+            .body(ARGUMENTS + ".list[0].subject", nullValue())
+            .body(ARGUMENTS + ".list[0].textBody", nullValue())
+            .body(ARGUMENTS + ".list[0].htmlBody", nullValue());
     }
 
     @Test
@@ -112,6 +113,7 @@ public abstract class GetVacationResponseTest {
                 .toDate(Optional.of(ZonedDateTime.parse("2014-10-30T14:10:00Z")))
                 .textBody("Test explaining my vacations")
                 .subject(Optional.of(SUBJECT))
+                .htmlBody("<p>Test explaining my vacations</p>")
                 .build());
 
         given()
@@ -135,7 +137,8 @@ public abstract class GetVacationResponseTest {
             .body(ARGUMENTS + ".list[0].toDate", equalTo("2014-10-30T14:10:00Z"))
             .body(ARGUMENTS + ".list[0].isEnabled", equalTo(true))
             .body(ARGUMENTS + ".list[0].textBody", equalTo("Test explaining my vacations"))
-            .body(ARGUMENTS + ".list[0].subject", equalTo(SUBJECT));
+            .body(ARGUMENTS + ".list[0].subject", equalTo(SUBJECT))
+            .body(ARGUMENTS + ".list[0].htmlBody", equalTo("<p>Test explaining my vacations</p>"));
     }
 
     @Test

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetVacationResponseTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetVacationResponseTest.java
@@ -146,6 +146,7 @@ public abstract class SetVacationResponseTest {
                         "\"id\": \"singleton\"," +
                         "\"isEnabled\": \"true\"," +
                         "\"textBody\": \"Message explaining my wonderful vacations\"," +
+                        "\"htmlBody\": \"<p>Here is the HTML version</p>\"," +
                         "\"fromDate\":\"2014-09-30T14:10:00Z[GMT]\"," +
                         "\"toDate\":\"2014-10-30T14:10:00Z[GMT]\"," +
                         "\"subject\":\"" + SUBJECT + "\"" +
@@ -168,7 +169,8 @@ public abstract class SetVacationResponseTest {
             .body(ARGUMENTS + ".updated[0]", equalTo("singleton"));
 
         Vacation vacation = jmapServer.serverProbe().retrieveVacation(AccountId.fromString(USER));
-        assertThat(vacation.getTextBody()).isEqualTo("Message explaining my wonderful vacations");
+        assertThat(vacation.getTextBody()).contains("Message explaining my wonderful vacations");
+        assertThat(vacation.getHtmlBody()).contains("<p>Here is the HTML version</p>");
         assertThat(vacation.isEnabled()).isTrue();
         assertThat(vacation.getFromDate()).contains(ZonedDateTime.parse("2014-09-30T14:10:00Z[GMT]"));
         assertThat(vacation.getToDate()).contains(ZonedDateTime.parse("2014-10-30T14:10:00Z[GMT]"));
@@ -206,7 +208,7 @@ public abstract class SetVacationResponseTest {
             .body(ARGUMENTS + ".updated[0]", equalTo("singleton"));
 
         Vacation vacation = jmapServer.serverProbe().retrieveVacation(AccountId.fromString(USER));
-        assertThat(vacation.getTextBody()).isEqualTo("Message explaining my wonderful vacations");
+        assertThat(vacation.getTextBody()).contains("Message explaining my wonderful vacations");
         assertThat(vacation.isEnabled()).isTrue();
         assertThat(vacation.getFromDate()).contains(ZonedDateTime.parse("2016-04-03T02:01+07:00[Asia/Vientiane]"));
         assertThat(vacation.getToDate()).contains(ZonedDateTime.parse("2016-04-07T02:01+07:00[Asia/Vientiane]"));
@@ -239,7 +241,7 @@ public abstract class SetVacationResponseTest {
             .statusCode(200)
             .body(NAME, equalTo("error"))
             .body(ARGUMENTS + ".type", equalTo("invalidArguments"))
-            .body(ARGUMENTS + ".description", containsString("textBody property of vacationResponse object should not be null"));
+            .body(ARGUMENTS + ".description", containsString("textBody or htmlBody property of vacationResponse object should not be null when enabled"));
     }
 
     @Test
@@ -268,7 +270,7 @@ public abstract class SetVacationResponseTest {
             .statusCode(200)
             .body(NAME, equalTo("error"))
             .body(ARGUMENTS + ".type", equalTo("invalidArguments"))
-            .body(ARGUMENTS + ".description", containsString("textBody property of vacationResponse object should not be null"));
+            .body(ARGUMENTS + ".description", containsString("textBody or htmlBody property of vacationResponse object should not be null when enabled"));
     }
 
     @Test

--- a/server/protocols/jmap/doc/specs/spec/vacationresponse.mdwn
+++ b/server/protocols/jmap/doc/specs/spec/vacationresponse.mdwn
@@ -1,9 +1,5 @@
 ## Vacation Response
 
-<aside class="warning">
-Endpoints and storage implemented but no notifications will be sent.
-</aside>
-
 The **VacationResponse** object represents the state of vacation-response
 related settings for an account. It has the following properties:
 

--- a/server/protocols/jmap/pom.xml
+++ b/server/protocols/jmap/pom.xml
@@ -179,6 +179,11 @@
                 </dependency>
                 <dependency>
                     <groupId>org.apache.james</groupId>
+                    <artifactId>apache-james-mailbox-tika</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.james</groupId>
                     <artifactId>apache-mailet-base</artifactId>
                     <scope>test</scope>
                     <type>test-jar</type>
@@ -272,11 +277,6 @@
                 <dependency>
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcpkix-jdk15on</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>org.jsoup</groupId>
-                    <artifactId>jsoup</artifactId>
-                    <version>1.9.2</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.james</groupId>

--- a/server/protocols/jmap/pom.xml
+++ b/server/protocols/jmap/pom.xml
@@ -274,6 +274,11 @@
                     <artifactId>bcpkix-jdk15on</artifactId>
                 </dependency>
                 <dependency>
+                    <groupId>org.jsoup</groupId>
+                    <artifactId>jsoup</artifactId>
+                    <version>1.9.2</version>
+                </dependency>
+                <dependency>
                     <groupId>org.apache.james</groupId>
                     <artifactId>apache-james-mailbox-store</artifactId>
                     <scope>test</scope>

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationMailet.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationMailet.java
@@ -30,6 +30,7 @@ import org.apache.james.jmap.api.vacation.NotificationRegistry;
 import org.apache.james.jmap.api.vacation.RecipientId;
 import org.apache.james.jmap.api.vacation.Vacation;
 import org.apache.james.jmap.api.vacation.VacationRepository;
+import org.apache.james.jmap.utils.MimeMessageBodyGenerator;
 import org.apache.james.util.date.ZonedDateTimeProvider;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
@@ -46,14 +47,17 @@ public class VacationMailet extends GenericMailet {
     private final ZonedDateTimeProvider zonedDateTimeProvider;
     private final AutomaticallySentMailDetector automaticallySentMailDetector;
     private final NotificationRegistry notificationRegistry;
+    private final MimeMessageBodyGenerator mimeMessageBodyGenerator;
 
     @Inject
     public VacationMailet(VacationRepository vacationRepository, ZonedDateTimeProvider zonedDateTimeProvider,
-                          AutomaticallySentMailDetector automaticallySentMailDetector, NotificationRegistry notificationRegistry) {
+                          AutomaticallySentMailDetector automaticallySentMailDetector, NotificationRegistry notificationRegistry,
+                          MimeMessageBodyGenerator mimeMessageBodyGenerator) {
         this.vacationRepository = vacationRepository;
         this.zonedDateTimeProvider = zonedDateTimeProvider;
         this.automaticallySentMailDetector = automaticallySentMailDetector;
         this.notificationRegistry = notificationRegistry;
+        this.mimeMessageBodyGenerator = mimeMessageBodyGenerator;
     }
 
     @Override
@@ -95,7 +99,7 @@ public class VacationMailet extends GenericMailet {
             VacationReply vacationReply = VacationReply.builder(processedMail)
                 .receivedMailRecipient(recipient)
                 .vacation(vacation)
-                .build();
+                .build(mimeMessageBodyGenerator);
             sendNotification(vacationReply);
             notificationRegistry.register(AccountId.fromString(recipient.toString()),
                 RecipientId.fromMailAddress(processedMail.getSender()),

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationMailet.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationMailet.java
@@ -94,7 +94,7 @@ public class VacationMailet extends GenericMailet {
         try {
             VacationReply vacationReply = VacationReply.builder(processedMail)
                 .receivedMailRecipient(recipient)
-                .reason(vacation.getTextBody())
+                .vacation(vacation)
                 .build();
             sendNotification(vacationReply);
             notificationRegistry.register(AccountId.fromString(recipient.toString()),

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationReply.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationReply.java
@@ -19,23 +19,16 @@
 
 package org.apache.james.jmap.mailet;
 
-import java.io.IOException;
 import java.util.List;
 
-import javax.activation.DataHandler;
 import javax.mail.MessagingException;
-import javax.mail.Multipart;
-import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
-import javax.mail.util.ByteArrayDataSource;
 
 import org.apache.james.jmap.api.vacation.Vacation;
-import org.apache.james.mime4j.dom.field.ContentTypeField;
+import org.apache.james.jmap.utils.MimeMessageBodyGenerator;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.base.AutomaticallySentMailDetector;
-import org.jsoup.Jsoup;
 
 import com.github.fge.lambdas.Throwing;
 import com.google.common.base.Preconditions;
@@ -45,7 +38,6 @@ public class VacationReply {
 
     public static final String FROM_HEADER = "from";
     public static final String TO_HEADER = "to";
-    public static final String MIXED = "mixed";
 
     public static Builder builder(Mail originalMail) {
         return new Builder(originalMail);
@@ -74,60 +66,21 @@ public class VacationReply {
             return this;
         }
 
-        public VacationReply build() throws MessagingException {
+        public VacationReply build(MimeMessageBodyGenerator mimeMessageBodyGenerator) throws MessagingException {
             Preconditions.checkState(mailRecipient != null, "Original recipient address should not be null");
             Preconditions.checkState(originalMail.getSender() != null, "Original sender address should not be null");
 
-            return new VacationReply(mailRecipient, ImmutableList.of(originalMail.getSender()), generateMimeMessage());
+            return new VacationReply(mailRecipient, ImmutableList.of(originalMail.getSender()), generateMimeMessage(mimeMessageBodyGenerator));
         }
 
-        private MimeMessage generateMimeMessage() throws MessagingException {
+        private MimeMessage generateMimeMessage(MimeMessageBodyGenerator mimeMessageBodyGenerator) throws MessagingException {
             MimeMessage reply = (MimeMessage) originalMail.getMessage().reply(NOT_REPLY_TO_ALL);
             vacation.getSubject().ifPresent(Throwing.consumer(subjectString -> reply.setHeader("subject", subjectString)));
             reply.setHeader(FROM_HEADER, mailRecipient.toString());
             reply.setHeader(TO_HEADER, originalMail.getSender().toString());
             reply.setHeader(AutomaticallySentMailDetector.AUTO_SUBMITTED_HEADER, AutomaticallySentMailDetector.AUTO_REPLIED_VALUE);
 
-            return addBody(reply);
-        }
-
-        @SuppressWarnings("OptionalGetWithoutIsPresent")
-        private MimeMessage addBody(MimeMessage reply) throws MessagingException {
-            if (vacation.getHtmlBody().isPresent()) {
-                reply.setContent(generateMultipart());
-            } else {
-                reply.setText(vacation.getTextBody().get());
-            }
-            return reply;
-        }
-
-        @SuppressWarnings("OptionalGetWithoutIsPresent")
-        private Multipart generateMultipart() throws MessagingException {
-            try {
-                Multipart multipart = new MimeMultipart(MIXED);
-                addTextPart(multipart, vacation.getHtmlBody().get(), "text/html");
-                addTextPart(multipart, retrievePlainTextMessage(), ContentTypeField.TYPE_TEXT_PLAIN);
-                return multipart;
-            } catch (IOException e) {
-                throw new MessagingException("Cannot read specified content", e);
-            }
-        }
-
-        @SuppressWarnings("OptionalGetWithoutIsPresent")
-        private String retrievePlainTextMessage() {
-            return vacation.getTextBody()
-                .orElseGet(() -> Jsoup.parse(vacation.getHtmlBody().get()).text());
-        }
-
-        private Multipart addTextPart(Multipart multipart, String text, String contentType) throws MessagingException, IOException {
-            MimeBodyPart textReasonPart = new MimeBodyPart();
-            textReasonPart.setDataHandler(
-                new DataHandler(
-                    new ByteArrayDataSource(
-                        text,
-                        contentType + "; charset=UTF-8")));
-            multipart.addBodyPart(textReasonPart);
-            return multipart;
+            return mimeMessageBodyGenerator.from(reply, vacation.getTextBody(), vacation.getHtmlBody());
         }
     }
 

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationReply.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationReply.java
@@ -19,20 +19,33 @@
 
 package org.apache.james.jmap.mailet;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
+import javax.activation.DataHandler;
 import javax.mail.MessagingException;
+import javax.mail.Multipart;
+import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+import javax.mail.util.ByteArrayDataSource;
 
+import org.apache.james.jmap.api.vacation.Vacation;
+import org.apache.james.mime4j.dom.field.ContentTypeField;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
+import org.apache.mailet.base.AutomaticallySentMailDetector;
 
 import com.github.fge.lambdas.Throwing;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 public class VacationReply {
+
+    public static final String FROM_HEADER = "from";
+    public static final String TO_HEADER = "to";
+    public static final String MIXED = "mixed";
 
     public static Builder builder(Mail originalMail) {
         return new Builder(originalMail);
@@ -43,8 +56,7 @@ public class VacationReply {
         public static final boolean NOT_REPLY_TO_ALL = false;
         private final Mail originalMail;
         private MailAddress mailRecipient;
-        private String reason;
-        private Optional<String> subject = Optional.empty();
+        private Vacation vacation;
 
         private Builder(Mail originalMail) {
             Preconditions.checkNotNull(originalMail, "Origin mail shall not be null");
@@ -57,14 +69,8 @@ public class VacationReply {
             return this;
         }
 
-        public Builder reason(String reason) {
-            Preconditions.checkNotNull(reason);
-            this.reason = reason;
-            return this;
-        }
-
-        public Builder subject(Optional<String> subject) {
-            this.subject = subject;
+        public Builder vacation(Vacation vacation) {
+            this.vacation = vacation;
             return this;
         }
 
@@ -72,17 +78,62 @@ public class VacationReply {
             Preconditions.checkState(mailRecipient != null, "Original recipient address should not be null");
             Preconditions.checkState(originalMail.getSender() != null, "Original sender address should not be null");
 
+            MimeMessage reply = (MimeMessage) originalMail.getMessage().reply(false);
+            reply.setContent(generateMultipart());
+
             return new VacationReply(mailRecipient, ImmutableList.of(originalMail.getSender()), generateMimeMessage());
         }
 
         private MimeMessage generateMimeMessage() throws MessagingException {
             MimeMessage reply = (MimeMessage) originalMail.getMessage().reply(NOT_REPLY_TO_ALL);
-            subject.ifPresent(Throwing.consumer(subjectString -> reply.setHeader("subject", subjectString)));
-            reply.setText(reason);
-            reply.setHeader("from", mailRecipient.toString());
-            reply.setHeader("to", originalMail.getSender().toString());
-            reply.setHeader("Auto-Submitted", "auto-replied");
+            vacation.getSubject().ifPresent(Throwing.consumer(subjectString -> reply.setHeader("subject", subjectString)));
+            reply.setHeader(FROM_HEADER, mailRecipient.toString());
+            reply.setHeader(TO_HEADER, originalMail.getSender().toString());
+            reply.setHeader(AutomaticallySentMailDetector.AUTO_SUBMITTED_HEADER, AutomaticallySentMailDetector.AUTO_REPLIED_VALUE);
+
+            return addBody(reply);
+        }
+
+        private MimeMessage addBody(MimeMessage reply) throws MessagingException {
+            if (! vacation.getHtmlBody().isPresent()) {
+                reply.setText(vacation.getTextBody().get());
+            } else {
+                reply.setContent(generateMultipart());
+            }
             return reply;
+        }
+
+
+        private Multipart generateMultipart() throws MessagingException {
+            try {
+                Multipart multipart = new MimeMultipart(MIXED);
+                addPlainPart(multipart, vacation.getTextBody());
+                addHtmlPart(multipart, vacation.getHtmlBody());
+                return multipart;
+            } catch (IOException e) {
+                throw new MessagingException("Cannot read specified content", e);
+            }
+        }
+
+        private Multipart addPlainPart(Multipart multipart, Optional<String> textBody) throws MessagingException, IOException {
+            textBody.ifPresent(Throwing.consumer(text -> addTextPart(multipart, text, ContentTypeField.TYPE_TEXT_PLAIN)));
+            return multipart;
+        }
+
+        private Multipart addHtmlPart(Multipart multipart, Optional<String> htmlBody) throws MessagingException, IOException {
+            htmlBody.ifPresent(Throwing.consumer(html -> addTextPart(multipart, html, "text/html")));
+            return multipart;
+        }
+
+        private Multipart addTextPart(Multipart multipart, String text, String contentType) throws MessagingException, IOException {
+            MimeBodyPart textReasonPart = new MimeBodyPart();
+            textReasonPart.setDataHandler(
+                new DataHandler(
+                    new ByteArrayDataSource(
+                        text,
+                        contentType + "; charset=UTF-8")));
+            multipart.addBodyPart(textReasonPart);
+            return multipart;
         }
     }
 

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetVacationResponseMethod.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetVacationResponseMethod.java
@@ -123,6 +123,7 @@ public class SetVacationResponseMethod implements Method {
             .toDate(vacationResponse.getToDate())
             .textBody(vacationResponse.getTextBody())
             .subject(vacationResponse.getSubject())
+            .htmlBody(vacationResponse.getHtmlBody())
             .build();
     }
 

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/VacationResponse.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/VacationResponse.java
@@ -37,6 +37,8 @@ import com.google.common.base.Preconditions;
 @JsonDeserialize(builder = VacationResponse.Builder.class)
 public class VacationResponse {
 
+    public static final boolean DEFAULT_DISABLED = false;
+
     public static Builder builder() {
         return new Builder();
     }
@@ -44,11 +46,12 @@ public class VacationResponse {
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
         private String id;
-        private boolean isEnabled;
+        private Optional<Boolean> isEnabled = Optional.empty();
         private Optional<ZonedDateTime> fromDate = Optional.empty();
         private Optional<ZonedDateTime> toDate = Optional.empty();
         private Optional<String> subject = Optional.empty();
-        private String textBody;
+        private Optional<String> textBody = Optional.empty();
+        private Optional<String> htmlBody = Optional.empty();
 
         public Builder id(String id) {
             this.id = id;
@@ -57,45 +60,73 @@ public class VacationResponse {
 
         @JsonProperty("isEnabled")
         public Builder enabled(boolean enabled) {
-            isEnabled = enabled;
+            isEnabled = Optional.of(enabled);
             return this;
         }
 
         @JsonDeserialize(using = OptionalZonedDateTimeDeserializer.class)
         public Builder fromDate(Optional<ZonedDateTime> fromDate) {
+            Preconditions.checkNotNull(fromDate);
             this.fromDate = fromDate;
             return this;
         }
 
         @JsonDeserialize(using = OptionalZonedDateTimeDeserializer.class)
         public Builder toDate(Optional<ZonedDateTime> toDate) {
+            Preconditions.checkNotNull(toDate);
             this.toDate = toDate;
             return this;
         }
 
-        public Builder textBody(String textBody) {
+        public Builder textBody(Optional<String> textBody) {
+            Preconditions.checkNotNull(textBody);
             this.textBody = textBody;
             return this;
         }
 
         public Builder subject(Optional<String> subject) {
+            Preconditions.checkNotNull(subject);
             this.subject = subject;
+            return this;
+        }
+
+        @JsonIgnore
+        public Builder textBody(String textBody) {
+            Preconditions.checkNotNull(textBody);
+            this.textBody = Optional.of(textBody);
+            return this;
+        }
+
+        public Builder htmlBody(Optional<String> htmlBody) {
+            Preconditions.checkNotNull(htmlBody);
+            this.htmlBody = htmlBody;
+            return this;
+        }
+
+        @JsonIgnore
+        public Builder htmlBody(String htmlBody) {
+            Preconditions.checkNotNull(htmlBody);
+            this.htmlBody = Optional.of(htmlBody);
             return this;
         }
 
         public Builder fromVacation(Vacation vacation) {
             this.id = Vacation.ID;
-            this.isEnabled = vacation.isEnabled();
+            this.isEnabled = Optional.of(vacation.isEnabled());
             this.fromDate = vacation.getFromDate();
             this.toDate = vacation.getToDate();
             this.textBody = vacation.getTextBody();
             this.subject = vacation.getSubject();
+            this.htmlBody = vacation.getHtmlBody();
             return this;
         }
 
         public VacationResponse build() {
-            Preconditions.checkState(textBody != null, "textBody property of vacationResponse object should not be null");
-            return new VacationResponse(id, isEnabled, fromDate, toDate, textBody, subject);
+            boolean enabled = isEnabled.orElse(DEFAULT_DISABLED);
+            if (enabled) {
+                Preconditions.checkState(textBody.isPresent() || htmlBody.isPresent(), "textBody or htmlBody property of vacationResponse object should not be null when enabled");
+            }
+            return new VacationResponse(id, enabled, fromDate, toDate, textBody, subject, htmlBody);
         }
     }
 
@@ -104,16 +135,18 @@ public class VacationResponse {
     private final Optional<ZonedDateTime> fromDate;
     private final Optional<ZonedDateTime> toDate;
     private final Optional<String> subject;
-    private final String textBody;
+    private final Optional<String> textBody;
+    private final Optional<String> htmlBody;
 
     private VacationResponse(String id, boolean isEnabled, Optional<ZonedDateTime> fromDate, Optional<ZonedDateTime> toDate,
-                             String textBody, Optional<String> subject) {
+                             Optional<String> textBody, Optional<String> subject, Optional<String> htmlBody) {
         this.id = id;
         this.isEnabled = isEnabled;
         this.fromDate = fromDate;
         this.toDate = toDate;
         this.textBody = textBody;
         this.subject = subject;
+        this.htmlBody = htmlBody;
     }
 
     public String getId() {
@@ -135,12 +168,16 @@ public class VacationResponse {
         return toDate;
     }
 
-    public String getTextBody() {
+    public Optional<String> getTextBody() {
         return textBody;
     }
 
     public Optional<String> getSubject() {
         return subject;
+    }
+
+    public Optional<String> getHtmlBody() {
+        return htmlBody;
     }
 
     @JsonIgnore
@@ -161,11 +198,12 @@ public class VacationResponse {
             && Objects.equals(this.fromDate, that.fromDate)
             && Objects.equals(this.toDate, that.toDate)
             && Objects.equals(this.textBody, that.textBody)
-            && Objects.equals(this.subject, that.subject);
+            && Objects.equals(this.subject, that.subject)
+            && Objects.equals(this.htmlBody, that.htmlBody);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, isEnabled, fromDate, toDate, textBody, subject);
+        return Objects.hash(id, isEnabled, fromDate, toDate, textBody, subject, htmlBody);
     }
 }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/VacationResponse.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/VacationResponse.java
@@ -90,23 +90,9 @@ public class VacationResponse {
             return this;
         }
 
-        @JsonIgnore
-        public Builder textBody(String textBody) {
-            Preconditions.checkNotNull(textBody);
-            this.textBody = Optional.of(textBody);
-            return this;
-        }
-
         public Builder htmlBody(Optional<String> htmlBody) {
             Preconditions.checkNotNull(htmlBody);
             this.htmlBody = htmlBody;
-            return this;
-        }
-
-        @JsonIgnore
-        public Builder htmlBody(String htmlBody) {
-            Preconditions.checkNotNull(htmlBody);
-            this.htmlBody = Optional.of(htmlBody);
             return this;
         }
 

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/HtmlTextExtractor.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/HtmlTextExtractor.java
@@ -1,0 +1,26 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.utils;
+
+public interface HtmlTextExtractor {
+
+    String toPlainText(String html);
+
+}

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/MailboxBasedHtmlTextExtractor.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/MailboxBasedHtmlTextExtractor.java
@@ -1,0 +1,33 @@
+
+
+package org.apache.james.jmap.utils;
+
+import java.io.ByteArrayInputStream;
+
+import javax.inject.Inject;
+
+import org.apache.james.mailbox.store.extractor.TextExtractor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MailboxBasedHtmlTextExtractor implements HtmlTextExtractor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MailboxBasedHtmlTextExtractor.class);
+
+    private final TextExtractor textExtractor;
+
+    @Inject
+    public MailboxBasedHtmlTextExtractor(TextExtractor textExtractor) {
+        this.textExtractor = textExtractor;
+    }
+
+    @Override
+    public String toPlainText(String html) {
+        try {
+            return textExtractor.extractContent(new ByteArrayInputStream(html.getBytes()), "text/html", "").getTextualContent();
+        } catch (Exception e) {
+            LOGGER.warn("Error extracting text from HTML", e);
+            return html;
+        }
+    }
+}

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/MimeMessageBodyGenerator.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/MimeMessageBodyGenerator.java
@@ -1,0 +1,86 @@
+/****************************************************************
+ O * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.utils;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import javax.activation.DataHandler;
+import javax.mail.MessagingException;
+import javax.mail.Multipart;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+import javax.mail.util.ByteArrayDataSource;
+
+import org.apache.james.mime4j.dom.field.ContentTypeField;
+
+import com.github.fge.lambdas.Throwing;
+import com.google.common.base.Preconditions;
+
+public class MimeMessageBodyGenerator {
+    public static final String MIXED = "mixed";
+
+    private final HtmlTextExtractor htmlTextExtractor;
+
+    public MimeMessageBodyGenerator(HtmlTextExtractor htmlTextExtractor) {
+        this.htmlTextExtractor = htmlTextExtractor;
+    }
+
+    public MimeMessage from(MimeMessage messageHoldingHeaders, Optional<String> plainText, Optional<String> htmlText) throws MessagingException {
+        Preconditions.checkNotNull(messageHoldingHeaders);
+        Preconditions.checkNotNull(plainText);
+        Preconditions.checkNotNull(htmlText);
+        Preconditions.checkState(plainText.isPresent() || htmlText.isPresent(), "MimeMessageBodyGenerator needs at least plainText or html text");
+        if (htmlText.isPresent()) {
+            messageHoldingHeaders.setContent(generateMultipart(htmlText.get(), plainText));
+        } else {
+            plainText.ifPresent(Throwing.consumer(messageHoldingHeaders::setText));
+        }
+        return messageHoldingHeaders;
+    }
+
+    private Multipart generateMultipart(String htmlText, Optional<String> plainText) throws MessagingException {
+        try {
+            Multipart multipart = new MimeMultipart(MIXED);
+            addTextPart(multipart, htmlText, "text/html");
+            addTextPart(multipart, retrievePlainTextMessage(plainText, htmlText), ContentTypeField.TYPE_TEXT_PLAIN);
+            return multipart;
+        } catch (IOException e) {
+            throw new MessagingException("Cannot read specified content", e);
+        }
+    }
+
+    private Multipart addTextPart(Multipart multipart, String text, String contentType) throws MessagingException, IOException {
+        MimeBodyPart textReasonPart = new MimeBodyPart();
+        textReasonPart.setDataHandler(
+            new DataHandler(
+                new ByteArrayDataSource(
+                    text,
+                    contentType + "; charset=UTF-8")));
+        multipart.addBodyPart(textReasonPart);
+        return multipart;
+    }
+
+    private String retrievePlainTextMessage(Optional<String> plainText, String htmlText) {
+        return plainText.orElseGet(() -> htmlTextExtractor.toPlainText(htmlText));
+    }
+
+}

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/MimeMessageBodyGenerator.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/MimeMessageBodyGenerator.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Optional;
 
 import javax.activation.DataHandler;
+import javax.inject.Inject;
 import javax.mail.MessagingException;
 import javax.mail.Multipart;
 import javax.mail.internet.MimeBodyPart;
@@ -40,6 +41,7 @@ public class MimeMessageBodyGenerator {
 
     private final HtmlTextExtractor htmlTextExtractor;
 
+    @Inject
     public MimeMessageBodyGenerator(HtmlTextExtractor htmlTextExtractor) {
         this.htmlTextExtractor = htmlTextExtractor;
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/MimeMessageBodyGenerator.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/MimeMessageBodyGenerator.java
@@ -34,6 +34,7 @@ import javax.mail.util.ByteArrayDataSource;
 import org.apache.james.mime4j.dom.field.ContentTypeField;
 
 import com.github.fge.lambdas.Throwing;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 public class MimeMessageBodyGenerator {
@@ -42,7 +43,8 @@ public class MimeMessageBodyGenerator {
     private final HtmlTextExtractor htmlTextExtractor;
 
     @Inject
-    public MimeMessageBodyGenerator(HtmlTextExtractor htmlTextExtractor) {
+    @VisibleForTesting
+    MimeMessageBodyGenerator(HtmlTextExtractor htmlTextExtractor) {
         this.htmlTextExtractor = htmlTextExtractor;
     }
 

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/VacationMailetTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/VacationMailetTest.java
@@ -38,6 +38,7 @@ import org.apache.james.jmap.api.vacation.NotificationRegistry;
 import org.apache.james.jmap.api.vacation.RecipientId;
 import org.apache.james.jmap.api.vacation.Vacation;
 import org.apache.james.jmap.api.vacation.VacationRepository;
+import org.apache.james.jmap.utils.MimeMessageBodyGenerator;
 import org.apache.james.util.date.ZonedDateTimeProvider;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.MailetContext;
@@ -66,6 +67,7 @@ public class VacationMailetTest {
     private VacationMailet testee;
     private VacationRepository vacationRepository;
     private ZonedDateTimeProvider zonedDateTimeProvider;
+    private MimeMessageBodyGenerator mimeMessageBodyGenerator;
     private MailetContext mailetContext;
     private MailAddress originalSender;
     private MailAddress originalRecipient;
@@ -85,11 +87,12 @@ public class VacationMailetTest {
             .sender(originalSender)
             .build();
 
+        mimeMessageBodyGenerator = mock(MimeMessageBodyGenerator.class);
         vacationRepository = mock(VacationRepository.class);
         zonedDateTimeProvider = mock(ZonedDateTimeProvider.class);
         automaticallySentMailDetector = mock(AutomaticallySentMailDetector.class);
         notificationRegistry = mock(NotificationRegistry.class);
-        testee = new VacationMailet(vacationRepository, zonedDateTimeProvider, automaticallySentMailDetector, notificationRegistry);
+        testee = new VacationMailet(vacationRepository, zonedDateTimeProvider, automaticallySentMailDetector, notificationRegistry, mimeMessageBodyGenerator);
         mailetContext = mock(MailetContext.class);
         testee.init(new FakeMailetConfig("vacation", mailetContext));
     }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/VacationReplyTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/VacationReplyTest.java
@@ -28,6 +28,7 @@ import javax.mail.Session;
 import javax.mail.internet.MimeMessage;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.james.jmap.api.vacation.Vacation;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.base.test.FakeMail;
 import org.junit.Before;
@@ -36,7 +37,9 @@ import org.junit.Test;
 public class VacationReplyTest {
 
     public static final String REASON = "I am in vacation dudes !";
-    public static final Optional<String> SUBJECT = Optional.of("Vacation subject specified by the user!");
+    public static final String HTML_REASON = "<p>I am in vacation dudes !</p>";
+    public static final String SUBJECT = "subject";
+
     private MailAddress originalSender;
     private MailAddress originalRecipient;
     private FakeMail mail;
@@ -55,19 +58,42 @@ public class VacationReplyTest {
     public void vacationReplyShouldGenerateASuitableAnswer() throws Exception {
 
         VacationReply vacationReply = VacationReply.builder(mail)
-            .reason(REASON)
+            .vacation(Vacation.builder()
+                .enabled(true)
+                .textBody(REASON)
+                .htmlBody(HTML_REASON)
+                .build())
             .receivedMailRecipient(originalRecipient)
             .build();
 
         assertThat(vacationReply.getRecipients()).containsExactly(originalSender);
         assertThat(vacationReply.getSender()).isEqualTo(originalRecipient);
         assertThat(IOUtils.toString(vacationReply.getMimeMessage().getInputStream())).contains(REASON);
+        assertThat(IOUtils.toString(vacationReply.getMimeMessage().getInputStream())).contains(HTML_REASON);
+    }
+
+    @Test
+    public void vacationReplyShouldNotBeMultipartWhenVacationHaveNoHTML() throws Exception {
+        VacationReply vacationReply = VacationReply.builder(mail)
+            .vacation(Vacation.builder()
+                .enabled(true)
+                .textBody(REASON)
+                .build())
+            .receivedMailRecipient(originalRecipient)
+            .build();
+
+        assertThat(vacationReply.getRecipients()).containsExactly(originalSender);
+        assertThat(vacationReply.getSender()).isEqualTo(originalRecipient);
+        assertThat(IOUtils.toString(vacationReply.getMimeMessage().getInputStream())).isEqualTo(REASON);
     }
 
     @Test
     public void vacationReplyShouldAddReSuffixToSubjectByDefault() throws Exception {
         VacationReply vacationReply = VacationReply.builder(mail)
-            .reason(REASON)
+            .vacation(Vacation.builder()
+                .enabled(true)
+                .textBody(REASON)
+                .build())
             .receivedMailRecipient(originalRecipient)
             .build();
 
@@ -77,12 +103,15 @@ public class VacationReplyTest {
     @Test
     public void aUserShouldBeAbleToSetTheSubjectOfTheGeneratedMimeMessage() throws Exception {
         VacationReply vacationReply = VacationReply.builder(mail)
-            .reason(REASON)
-            .subject(SUBJECT)
+            .vacation(Vacation.builder()
+                .enabled(true)
+                .textBody(REASON)
+                .subject(Optional.of(SUBJECT))
+                .build())
             .receivedMailRecipient(originalRecipient)
             .build();
 
-        assertThat(vacationReply.getMimeMessage().getHeader("subject")).containsExactly(SUBJECT.get());
+        assertThat(vacationReply.getMimeMessage().getHeader("subject")).containsExactly(SUBJECT);
     }
 
     @Test(expected = NullPointerException.class)

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/VacationReplyTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/VacationReplyTest.java
@@ -36,8 +36,9 @@ import org.junit.Test;
 
 public class VacationReplyTest {
 
-    public static final String REASON = "I am in vacation dudes !";
-    public static final String HTML_REASON = "<p>I am in vacation dudes !</p>";
+    public static final String REASON = "I am in vacation dudes ! (plain text)";
+    public static final String HTML_REASON = "<b>I am in vacation dudes !</b> (html text)";
+    public static final String HTML_EXTRACTED_REASON = "I am in vacation dudes ! (html text)";
     public static final String SUBJECT = "subject";
 
     private MailAddress originalSender;
@@ -69,6 +70,22 @@ public class VacationReplyTest {
         assertThat(vacationReply.getRecipients()).containsExactly(originalSender);
         assertThat(vacationReply.getSender()).isEqualTo(originalRecipient);
         assertThat(IOUtils.toString(vacationReply.getMimeMessage().getInputStream())).contains(REASON);
+        assertThat(IOUtils.toString(vacationReply.getMimeMessage().getInputStream())).contains(HTML_REASON);
+    }
+
+    @Test
+    public void vacationReplyShouldExtractPlainTextContentWhenOnlyHtmlBody() throws Exception {
+        VacationReply vacationReply = VacationReply.builder(mail)
+            .vacation(Vacation.builder()
+                .enabled(true)
+                .htmlBody(HTML_REASON)
+                .build())
+            .receivedMailRecipient(originalRecipient)
+            .build();
+
+        assertThat(vacationReply.getRecipients()).containsExactly(originalSender);
+        assertThat(vacationReply.getSender()).isEqualTo(originalRecipient);
+        assertThat(IOUtils.toString(vacationReply.getMimeMessage().getInputStream())).contains(HTML_EXTRACTED_REASON);
         assertThat(IOUtils.toString(vacationReply.getMimeMessage().getInputStream())).contains(HTML_REASON);
     }
 

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/SetVacationResponseMethodTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/SetVacationResponseMethodTest.java
@@ -131,7 +131,7 @@ public class SetVacationResponseMethodTest {
             .update(ImmutableMap.of(WRONG_ID, VacationResponse.builder()
                 .id(Vacation.ID)
                 .enabled(false)
-                .textBody(TEXT_BODY)
+                .textBody(Optional.of(TEXT_BODY))
                 .build()))
             .build();
 
@@ -154,12 +154,12 @@ public class SetVacationResponseMethodTest {
             .update(ImmutableMap.of(Vacation.ID, VacationResponse.builder()
                     .id(Vacation.ID)
                     .enabled(false)
-                    .textBody(TEXT_BODY)
+                    .textBody(Optional.of(TEXT_BODY))
                     .build(),
                 WRONG_ID, VacationResponse.builder()
                     .id(Vacation.ID)
                     .enabled(false)
-                    .textBody(TEXT_BODY)
+                    .textBody(Optional.of(TEXT_BODY))
                     .build()))
             .build();
 
@@ -182,7 +182,7 @@ public class SetVacationResponseMethodTest {
             .update(ImmutableMap.of(Vacation.ID, VacationResponse.builder()
                     .id(Vacation.ID)
                     .enabled(false)
-                    .textBody(TEXT_BODY)
+                    .textBody(Optional.of(TEXT_BODY))
                     .subject(Optional.of(SUBJECT))
                     .build()))
             .build();
@@ -217,7 +217,7 @@ public class SetVacationResponseMethodTest {
         SetVacationRequest setVacationRequest = SetVacationRequest.builder()
             .update(ImmutableMap.of(Vacation.ID, VacationResponse.builder()
                 .id(WRONG_ID)
-                .textBody(TEXT_BODY)
+                .textBody(Optional.of(TEXT_BODY))
                 .enabled(false)
                 .build()))
             .build();

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/GetVacationResponseTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/GetVacationResponseTest.java
@@ -20,6 +20,8 @@ package org.apache.james.jmap.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Optional;
+
 import org.junit.Test;
 
 public class GetVacationResponseTest {
@@ -29,7 +31,7 @@ public class GetVacationResponseTest {
     @Test
     public void getVacationResponseShouldBeConstructedWithTheRightInformation() {
         VacationResponse vacationResponse = VacationResponse.builder()
-            .textBody("Any text")
+            .textBody(Optional.of("Any text"))
             .id("singleton")
             .build();
         GetVacationResponse getVacationResponse = GetVacationResponse.builder()

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/SetVacationRequestTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/SetVacationRequestTest.java
@@ -21,6 +21,7 @@ package org.apache.james.jmap.model;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.AbstractMap;
+import java.util.Optional;
 
 import org.apache.commons.lang.NotImplementedException;
 import org.junit.Test;
@@ -33,7 +34,7 @@ public class SetVacationRequestTest {
 
     @Test
     public void setVacationRequestShouldBeConstructedWithTheRightInformation() {
-        VacationResponse vacationResponse = VacationResponse.builder().id(VACATION_ID).textBody("any message").build();
+        VacationResponse vacationResponse = VacationResponse.builder().id(VACATION_ID).textBody(Optional.of("any message")).build();
         SetVacationRequest setVacationRequest = SetVacationRequest.builder()
             .update(ImmutableMap.of(VACATION_ID, vacationResponse))
             .build();
@@ -43,7 +44,7 @@ public class SetVacationRequestTest {
 
     @Test(expected = NotImplementedException.class)
     public void accountIdIsNotImplemented() {
-        VacationResponse vacationResponse = VacationResponse.builder().id(VACATION_ID).textBody("any message").build();
+        VacationResponse vacationResponse = VacationResponse.builder().id(VACATION_ID).textBody(Optional.of("any message")).build();
         SetVacationRequest.builder()
             .accountId("any")
             .update(ImmutableMap.of(VACATION_ID, vacationResponse))

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/VacationResponseTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/VacationResponseTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.jmap.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
@@ -30,6 +31,7 @@ public class VacationResponseTest {
 
     public static final String IDENTIFIER = "identifier";
     public static final String MESSAGE = "A message explaining I am in vacation";
+    public static final String HTML_MESSAGE = "<p>A message explaining I am in vacation</p>";
     public static final ZonedDateTime FROM_DATE = ZonedDateTime.parse("2016-04-15T11:56:32.224+07:00[Asia/Vientiane]");
     public static final ZonedDateTime TO_DATE = ZonedDateTime.parse("2016-04-16T11:56:32.224+07:00[Asia/Vientiane]");
     public static final String SUBJECT = "subject";
@@ -43,22 +45,67 @@ public class VacationResponseTest {
             .toDate(Optional.of(TO_DATE))
             .textBody(MESSAGE)
             .subject(Optional.of(SUBJECT))
+            .htmlBody(HTML_MESSAGE)
             .build();
 
         assertThat(vacationResponse.getId()).isEqualTo(IDENTIFIER);
         assertThat(vacationResponse.isEnabled()).isEqualTo(true);
-        assertThat(vacationResponse.getTextBody()).isEqualTo(MESSAGE);
+        assertThat(vacationResponse.getTextBody()).contains(MESSAGE);
+        assertThat(vacationResponse.getHtmlBody()).contains(HTML_MESSAGE);
         assertThat(vacationResponse.getFromDate()).contains(FROM_DATE);
         assertThat(vacationResponse.getToDate()).contains(TO_DATE);
         assertThat(vacationResponse.getSubject()).contains(SUBJECT);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void vacationResponseBuilderRequiresABodyText() {
-        VacationResponse.builder()
+    @Test
+    public void vacationResponseBuilderRequiresABodyTextOrHtmlWhenEnabled() {
+        assertThatThrownBy(() ->
+            VacationResponse.builder()
+                .id(IDENTIFIER)
+                .enabled(true)
+                .build())
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void vacationResponseBuilderShouldNotRequiresABodyTextOrHtmlWhenDisabled() {
+        VacationResponse vacationResponse = VacationResponse.builder()
+            .id(IDENTIFIER)
+            .enabled(false)
+            .build();
+
+        assertThat(vacationResponse.getId()).isEqualTo(IDENTIFIER);
+        assertThat(vacationResponse.isEnabled()).isEqualTo(false);
+        assertThat(vacationResponse.getTextBody()).isEmpty();
+        assertThat(vacationResponse.getHtmlBody()).isEmpty();
+    }
+
+    @Test
+    public void bodyTextShouldBeEnoughWhenEnabled() {
+        VacationResponse vacationResponse = VacationResponse.builder()
             .id(IDENTIFIER)
             .enabled(true)
+            .textBody(MESSAGE)
             .build();
+
+        assertThat(vacationResponse.getId()).isEqualTo(IDENTIFIER);
+        assertThat(vacationResponse.isEnabled()).isEqualTo(true);
+        assertThat(vacationResponse.getTextBody()).contains(MESSAGE);
+        assertThat(vacationResponse.getHtmlBody()).isEmpty();
+    }
+
+    @Test
+    public void htmlTextShouldBeEnoughWhenEnabled() {
+        VacationResponse vacationResponse = VacationResponse.builder()
+            .id(IDENTIFIER)
+            .enabled(true)
+            .htmlBody(MESSAGE)
+            .build();
+
+        assertThat(vacationResponse.getId()).isEqualTo(IDENTIFIER);
+        assertThat(vacationResponse.isEnabled()).isEqualTo(true);
+        assertThat(vacationResponse.getTextBody()).isEmpty();
+        assertThat(vacationResponse.getHtmlBody()).contains(MESSAGE);
     }
 
 }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/VacationResponseTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/VacationResponseTest.java
@@ -43,9 +43,9 @@ public class VacationResponseTest {
             .enabled(true)
             .fromDate(Optional.of(FROM_DATE))
             .toDate(Optional.of(TO_DATE))
-            .textBody(MESSAGE)
+            .textBody(Optional.of(MESSAGE))
             .subject(Optional.of(SUBJECT))
-            .htmlBody(HTML_MESSAGE)
+            .htmlBody(Optional.of(HTML_MESSAGE))
             .build();
 
         assertThat(vacationResponse.getId()).isEqualTo(IDENTIFIER);
@@ -85,7 +85,7 @@ public class VacationResponseTest {
         VacationResponse vacationResponse = VacationResponse.builder()
             .id(IDENTIFIER)
             .enabled(true)
-            .textBody(MESSAGE)
+            .textBody(Optional.of(MESSAGE))
             .build();
 
         assertThat(vacationResponse.getId()).isEqualTo(IDENTIFIER);
@@ -99,7 +99,7 @@ public class VacationResponseTest {
         VacationResponse vacationResponse = VacationResponse.builder()
             .id(IDENTIFIER)
             .enabled(true)
-            .htmlBody(MESSAGE)
+            .htmlBody(Optional.of(MESSAGE))
             .build();
 
         assertThat(vacationResponse.getId()).isEqualTo(IDENTIFIER);

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/utils/MailboxBasedHtmlTextExtractorTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/utils/MailboxBasedHtmlTextExtractorTest.java
@@ -1,0 +1,110 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.james.mailbox.tika.extractor.TikaTextExtractor;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MailboxBasedHtmlTextExtractorTest {
+
+    private MailboxBasedHtmlTextExtractor textExtractor;
+
+    @Before
+    public void setUp() {
+        textExtractor = new MailboxBasedHtmlTextExtractor(new TikaTextExtractor());
+    }
+
+    @Test
+    public void toPlainTextShouldNotModifyPlainText() {
+        String textWithoutHtml = "text without html";
+        assertThat(textExtractor.toPlainText(textWithoutHtml)).isEqualTo(textWithoutHtml);
+    }
+
+    @Test
+    public void toPlainTextShouldRemoveSimpleHtmlTag() {
+        String html = "This is an <b>HTML</b> text !";
+        String expectedPlainText = "This is an HTML text !";
+        assertThat(textExtractor.toPlainText(html)).isEqualTo(expectedPlainText);
+    }
+
+    @Test
+    public void toPlainTextShouldReplaceSkipLine() {
+        String html = "<p>This is an<br/>HTML text !</p>";
+        String expectedPlainText = "This is an\nHTML text !\n";
+        assertThat(textExtractor.toPlainText(html)).isEqualTo(expectedPlainText);
+    }
+
+    @Test
+    public void toPlainTextShouldSkipLinesBetweenParagraph() {
+        String html = "<p>para1</p><p>para2</p>";
+        String expectedPlainText = "para1\npara2\n";
+        assertThat(textExtractor.toPlainText(html)).isEqualTo(expectedPlainText);
+    }
+
+    @Test
+    public void nonClosedHtmlShouldBeTranslated() {
+        String html = "This is an <b>HTML text !";
+        String expectedPlainText = "This is an HTML text !";
+        assertThat(textExtractor.toPlainText(html)).isEqualTo(expectedPlainText);
+    }
+
+    @Test
+    public void brokenHtmlShouldBeTranslatedUntilTheBrokenBalise() {
+        String html = "This is an <b>HTML</b missing missing missing !";
+        String expectedPlainText = "This is an HTML";
+        assertThat(textExtractor.toPlainText(html)).isEqualTo(expectedPlainText);
+    }
+
+    @Test
+    public void toPlainTextShouldWorkWithMoreComplexHTML() throws Exception {
+        String html = IOUtils.toString(ClassLoader.getSystemResource("example.html"));
+        String expectedPlainText = "\n" +
+            "    Why a new Logo?\n" +
+            "\n" +
+            "\n" +
+            "\n" +
+            "    We are happy with our current logo, but for the\n" +
+            "        upcoming James Server 3.0 release, we would like to\n" +
+            "        give our community the opportunity to create a new image for James.\n" +
+            "\n" +
+            "\n" +
+            "\n" +
+            "    Don't be shy, take your inkscape and gimp, and send us on\n" +
+            "        the James Server User mailing list\n" +
+            "        your creations. We will publish them on this page.\n" +
+            "\n" +
+            "\n" +
+            "\n" +
+            "    We need an horizontal logo (100p height) to be show displayed on the upper\n" +
+            "        left corner of this page, an avatar (48x48p) to be used on a Twitter stream for example.\n" +
+            "        The used fonts should be redistributable (or commonly available on Windows and Linux).\n" +
+            "        The chosen logo should be delivered in SVG format.\n" +
+            "        We also like the Apache feather.\n" +
+            "\n" +
+            "\n" +
+            "\n";
+        assertThat(textExtractor.toPlainText(html)).isEqualTo(expectedPlainText);
+    }
+
+}

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/utils/MimeMessageBodyGeneratorTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/utils/MimeMessageBodyGeneratorTest.java
@@ -1,0 +1,140 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.Properties;
+
+import javax.mail.Session;
+import javax.mail.internet.MimeMessage;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MimeMessageBodyGeneratorTest {
+
+    private MimeMessageBodyGenerator mimeMessageBodyGenerator;
+    private HtmlTextExtractor htmlTextExtractor;
+    private MimeMessage original;
+
+    @Before
+    public void setUp() {
+        original = new MimeMessage(Session.getDefaultInstance(new Properties()));
+        htmlTextExtractor = mock(HtmlTextExtractor.class);
+        mimeMessageBodyGenerator = new MimeMessageBodyGenerator(htmlTextExtractor);
+    }
+
+    @Test
+    public void fromShouldNotWriteAMultipartWhenOnlyPlainText() throws Exception {
+        assertThat(IOUtils.toString(
+            mimeMessageBodyGenerator.from(original,
+                Optional.of("Plain text"),
+                Optional.empty())
+                .getInputStream()))
+            .isEqualTo("Plain text");
+        verifyZeroInteractions(htmlTextExtractor);
+    }
+
+    @Test
+    public void fromShouldPreservePreviouslySetHeaders() throws Exception {
+        String subject = "Important, I should be kept";
+        original.setHeader("Subject", subject);
+
+        mimeMessageBodyGenerator.from(original,
+            Optional.of("Plain text"),
+            Optional.empty())
+            .getInputStream();
+
+        assertThat(original.getSubject()).isEqualTo(subject);
+        verifyZeroInteractions(htmlTextExtractor);
+    }
+
+    @Test
+    public void fromShouldProvideAPlainTextVersionWhenOnlyHtml() throws Exception {
+        String htmlText = "<p>HTML text</p>";
+        String plainText = "Plain text";
+        when(htmlTextExtractor.toPlainText(htmlText)).thenReturn(plainText);
+
+        String rowContent = IOUtils.toString(
+            mimeMessageBodyGenerator.from(original,
+                Optional.empty(),
+                Optional.of(htmlText))
+                .getInputStream());
+
+        assertThat(rowContent).containsSequence(htmlText);
+        assertThat(rowContent).containsSequence(plainText);
+    }
+
+    @Test
+    public void fromShouldCombinePlainTextAndHtml() throws Exception {
+        String htmlText = "<p>HTML text</p>";
+        String plainText = "Plain text";
+
+        String rowContent = IOUtils.toString(
+            mimeMessageBodyGenerator.from(original,
+                Optional.of(plainText),
+                Optional.of(htmlText))
+                .getInputStream());
+
+        assertThat(rowContent).containsSequence(htmlText);
+        assertThat(rowContent).containsSequence(plainText);
+        verifyZeroInteractions(htmlTextExtractor);
+    }
+
+    @Test
+    public void fromShouldThrowWhenNoPlainTextNorHtmlBody() throws Exception {
+        assertThatThrownBy(() -> mimeMessageBodyGenerator.from(original,
+            Optional.empty(),
+            Optional.empty()))
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void fromShouldThrowOnNullPlainText() throws Exception {
+        assertThatThrownBy(() -> mimeMessageBodyGenerator.from(original,
+            null,
+            Optional.empty()))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void fromShouldThrowOnNullHtml() throws Exception {
+        assertThatThrownBy(() -> mimeMessageBodyGenerator.from(original,
+            Optional.empty(),
+            null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void fromShouldThrowOnNullMimeMessageToDecorate() throws Exception {
+        assertThatThrownBy(() -> mimeMessageBodyGenerator.from(null,
+            Optional.empty(),
+            Optional.empty()))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+}

--- a/server/protocols/jmap/src/test/resources/example.html
+++ b/server/protocols/jmap/src/test/resources/example.html
@@ -1,0 +1,21 @@
+<div class="section">
+    <h3>Why a new Logo?<a name="Why_a_new_Logo"></a></h3>
+
+
+    <p>We are happy with our current logo, but for the
+        upcoming James Server 3.0 release, we would like to
+        give our community the opportunity to create a new image for James.</p>
+
+
+    <p>Don't be shy, take your inkscape and gimp, and send us on
+        the <a href="mail.html">James Server User mailing list</a>
+        your creations. We will publish them on this page.</p>
+
+
+    <p>We need an horizontal logo (100p height) to be show displayed on the upper
+        left corner of this page, an avatar (48x48p) to be used on a Twitter stream for example.
+        The used fonts should be redistributable (or commonly available on Windows and Linux).
+        The chosen logo should be delivered in SVG format.
+        We also like the <a class="externalLink" href="http://www.apache.org/foundation/press/kit/">Apache feather</a>.</p>
+
+</div>


### PR DESCRIPTION
 - Store the htmlBody for vacation
 - Use it to right emails
 - Sent emails should have a plain text version extracted from HTML when no plain text is provided.