### PR TITLE
James 1751 Do not list all mailboxes

### DIFF
--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/MailboxUtils.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/MailboxUtils.java
@@ -46,6 +46,7 @@ public class MailboxUtils {
 
     private static final boolean DONT_RESET_RECENT = false;
     private static final Logger LOGGER = LoggerFactory.getLogger(MailboxUtils.class);
+    private static final String WILDCARD = "%";
 
     private final MailboxManager mailboxManager;
     private final MailboxMapperFactory mailboxMapperFactory;
@@ -105,7 +106,8 @@ public class MailboxUtils {
 
     private Optional<org.apache.james.mailbox.store.mail.model.Mailbox> getMailboxFromId(String mailboxId, MailboxSession mailboxSession) throws MailboxException {
         return mailboxMapperFactory.getMailboxMapper(mailboxSession)
-                .list().stream()
+                .findMailboxWithPathLike(new MailboxPath(mailboxSession.getPersonalSpace(), mailboxSession.getUser().getUserName(), WILDCARD))
+                .stream()
                 .filter(mailbox -> mailbox.getMailboxId().serialize().equals(mailboxId))
                 .findFirst();
     }


### PR DESCRIPTION
Temporary workaround that let a chance to scalability. 

JMAP utils should not list all mailboxes to retrieve mailbox ID

Current implementation do not support shared mailboxes and retrieves only user mailboxes. It is not optimal though...

/!\ As many other mart of the JMAP implementation, this behaviour is not compatible with delegated mailboxes.