### PR TITLE
James 1784 - Attachment : handle query string on downloadUrl to manage signature (work on filters) 

### DIFF
--- a/server/container/guice/guice-common/src/main/java/org/apache/james/jmap/JMAPCommonModule.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/jmap/JMAPCommonModule.java
@@ -34,6 +34,7 @@ import org.apache.james.jmap.model.MessageFactory;
 import org.apache.james.jmap.model.MessagePreviewGenerator;
 import org.apache.james.jmap.send.MailFactory;
 import org.apache.james.jmap.send.MailSpool;
+import org.apache.james.jmap.utils.HeadersAuthenticationExtractor;
 import org.apache.james.util.date.DefaultZonedDateTimeProvider;
 import org.apache.james.util.date.ZonedDateTimeProvider;
 import org.apache.mailet.base.AutomaticallySentMailDetector;
@@ -60,6 +61,7 @@ public class JMAPCommonModule extends AbstractModule {
         bind(AutomaticallySentMailDetectorImpl.class).in(Scopes.SINGLETON);
         bind(MessageFactory.class).in(Scopes.SINGLETON);
         bind(MessagePreviewGenerator.class).in(Scopes.SINGLETON);
+        bind(HeadersAuthenticationExtractor.class).in(Scopes.SINGLETON);
 
         bind(SignatureHandler.class).to(JamesSignatureHandler.class);
         bind(ZonedDateTimeProvider.class).to(DefaultZonedDateTimeProvider.class);

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/jmap/JMAPCommonModule.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/jmap/JMAPCommonModule.java
@@ -76,10 +76,12 @@ public class JMAPCommonModule extends AbstractModule {
     @Provides
     public List<AuthenticationStrategy> authStrategies(
             AccessTokenAuthenticationStrategy accessTokenAuthenticationStrategy,
-            JWTAuthenticationStrategy jwtAuthenticationStrategy) {
+            JWTAuthenticationStrategy jwtAuthenticationStrategy,
+            QueryParameterAccessTokenAuthenticationStrategy queryParameterAuthenticationStrategy) {
 
         return ImmutableList.of(
                 jwtAuthenticationStrategy,
-                accessTokenAuthenticationStrategy);
+                accessTokenAuthenticationStrategy,
+                queryParameterAuthenticationStrategy);
     }
 }

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/DownloadEndpoint.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/DownloadEndpoint.feature
@@ -17,35 +17,58 @@ Feature: Download endpoint
     When "usera@domain.tld" checks for the availability of the attachment endpoint
     Then the user should be authorized
 
+  Scenario: An unauthenticated user should not have access to the download endpoint
+    When "usera@domain.tld" downloads "a1"
+    Then the user should not be authorized
+
+  Scenario: A user should not have access to the download endpoint without the authentication token
+    When "usera@domain.tld" downloads "a1" without any authentication token
+    Then the user should not be authorized
+
+  Scenario: A user should not have access to the download endpoint with an empty authentication token
+    When "usera@domain.tld" downloads "a1" with an empty authentication token
+    Then the user should not be authorized
+
+  Scenario: A user should not have access to the download endpoint with a bad authentication token
+    When "usera@domain.tld" downloads "a1" with a bad authentication token
+    Then the user should not be authorized
+
+  Scenario: A user should not have access to the download endpoint with an unknown authentication token
+    When "usera@domain.tld" downloads "a1" with an invalid authentication token
+    Then the user should not be authorized
+
+  Scenario: A user should not have access to the download endpoint when an authentication token has expired
+    When "usera@domain.tld" downloads "a1" with an expired token
+    Then the user should not be authorized
+
+  Scenario: A user should not have access to the download endpoint without a blobId
+    Given "usera@domain.tld" is trusted for attachment "a1"
+    When "usera@domain.tld" downloads "a1" without blobId parameter
+    Then the user should not be authorized
+
+  Scenario: A user should not retrieve anything when using wrong blobId
+    Given "usera@domain.tld" is trusted for attachment "a1"
+    When "usera@domain.tld" downloads "a1" with wrong blobId
+    Then the user should not be authorized
+
+  Scenario: A user should have access to the download endpoint when an authentication token is valid
+    Given "usera@domain.tld" is trusted for attachment "a1"
+    When "usera@domain.tld" downloads "a1"
+    Then the user should be authorized
+
   Scenario: An authenticated user should have access to the download endpoint
     Given "usera@domain.tld" is connected
     When "usera@domain.tld" downloads "a1"
     Then the user should be authorized
 
   @Ignore
-  Scenario: An unauthenticated user should not have access to the download endpoint
-    When "usera@domain.tld" downloads "a1"
-    Then the user should not be authorized
-
-  Scenario: A authenticated user should not have access to the download endpoint without a blobId
-    Given "usera@domain.tld" is connected
-    When "usera@domain.tld" asks for an attachment without blobId parameter
-    Then the user should receive a bad request response
-
-
-  Scenario: A user should not retrieve anything when using wrong blobId
-    Given "usera@domain.tld" is connected
-    When "usera@domain.tld" asks for an attachment with wrong blobId
-    Then the user should receive a not found response
-
-  @Ignore
-  Scenario: A user should not have access to someone else attachment
+  Scenario: An authenticated user should not have access to someone else attachment
     Given "userb@domain.tld" is connected
     When "userb@domain.tld" downloads "a1"
     Then the user should receive a not found response
 
   @Ignore
-  Scenario: A user should have access to a shared attachment
+  Scenario: An authenticated user should have access to a shared attachment
     Given "usera@domain.tld" shares its mailbox "INBOX" with "userb@domain.tld"
     And "userb@domain.tld" is connected
     When "userb@domain.tld" downloads "a1"

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/DownloadGet.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/DownloadGet.feature
@@ -13,8 +13,9 @@ Feature: Download GET
     Then the user should receive that attachment
 
   Scenario: Getting an attachment with an unknown blobId
-    When "username@domain.tld" downloads "123"
-    Then the user should receive a not found response
+    Given "username@domain.tld" mailbox "inbox" contains a message "1" with an attachment "2"
+    When "username@domain.tld" downloads "2" with a valid authentication token
+    Then the user should not be authorized
 
   Scenario: Getting an attachment previously stored with a desired name
     Given "username@domain.tld" mailbox "inbox" contains a message "1" with an attachment "2"

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/AccessTokenAuthenticationStrategy.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/AccessTokenAuthenticationStrategy.java
@@ -19,15 +19,16 @@
 package org.apache.james.jmap;
 
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
 
 import org.apache.james.jmap.api.AccessTokenManager;
 import org.apache.james.jmap.api.access.AccessToken;
 import org.apache.james.jmap.api.access.exceptions.NotAnAccessTokenException;
 import org.apache.james.jmap.exceptions.MailboxSessionCreationException;
 import org.apache.james.jmap.exceptions.NoValidAuthHeaderException;
+import org.apache.james.jmap.utils.HeadersAuthenticationExtractor;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -42,18 +43,20 @@ public class AccessTokenAuthenticationStrategy implements AuthenticationStrategy
 
     private final AccessTokenManager accessTokenManager;
     private final MailboxManager mailboxManager;
+    private final HeadersAuthenticationExtractor authenticationExtractor;
 
     @Inject
     @VisibleForTesting
-    AccessTokenAuthenticationStrategy(AccessTokenManager accessTokenManager, MailboxManager mailboxManager) {
+    AccessTokenAuthenticationStrategy(AccessTokenManager accessTokenManager, MailboxManager mailboxManager, HeadersAuthenticationExtractor authenticationExtractor) {
         this.accessTokenManager = accessTokenManager;
         this.mailboxManager = mailboxManager;
+        this.authenticationExtractor = authenticationExtractor;
     }
 
     @Override
-    public MailboxSession createMailboxSession(Stream<String> authHeaders) throws MailboxSessionCreationException, NoValidAuthHeaderException {
+    public MailboxSession createMailboxSession(HttpServletRequest httpRequest) throws MailboxSessionCreationException, NoValidAuthHeaderException {
 
-        Optional<String> username = authHeaders
+        Optional<String> username = authenticationExtractor.authHeaders(httpRequest)
             .map(AccessToken::fromString)
             .map(accessTokenManager::getUsernameFromToken)
             .findFirst();
@@ -69,8 +72,8 @@ public class AccessTokenAuthenticationStrategy implements AuthenticationStrategy
     }
 
     @Override
-    public boolean checkAuthorizationHeader(Stream<String> authHeaders) {
-        return authHeaders
+    public boolean checkAuthorizationHeader(HttpServletRequest httpRequest) {
+        return authenticationExtractor.authHeaders(httpRequest)
                 .map(this::accessTokenFrom)
                 .anyMatch(this::isValid);
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/AuthenticationStrategy.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/AuthenticationStrategy.java
@@ -25,6 +25,4 @@ import org.apache.james.mailbox.MailboxSession;
 public interface AuthenticationStrategy {
 
     MailboxSession createMailboxSession(HttpServletRequest httpRequest);
-
-    boolean checkAuthorizationHeader(HttpServletRequest httpRequest);
 }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPServer.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPServer.java
@@ -58,7 +58,7 @@ public class JMAPServer implements Configurable {
                         .serveAsOneLevelTemplate(JMAPUrls.DOWNLOAD)
                             .with(downloadServlet)
                         .filterAsOneLevelTemplate(JMAPUrls.DOWNLOAD)
-                            .with(new AllowAllCrossOriginRequests(bypass(authenticationFilter).on("GET").and("OPTIONS").only()))
+                            .with(new AllowAllCrossOriginRequests(bypass(authenticationFilter).on("OPTIONS").only()))
                             .only()
                         .serve(JMAPUrls.UPLOAD)
                             .with(uploadServlet)

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/JWTAuthenticationStrategy.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/JWTAuthenticationStrategy.java
@@ -72,12 +72,6 @@ public class JWTAuthenticationStrategy implements AuthenticationStrategy {
                 .orElseThrow(() -> new NoValidAuthHeaderException());
     }
 
-    @Override
-    public boolean checkAuthorizationHeader(HttpServletRequest httpRequest) {
-        return extractTokensFromAuthHeaders(authenticationExtractor.authHeaders(httpRequest))
-                .anyMatch(tokenManager::verify);
-    }
-
     private Stream<String> extractTokensFromAuthHeaders(Stream<String> authHeaders) {
         return authHeaders
                 .filter(h -> h.startsWith(AUTHORIZATION_HEADER_PREFIX))

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/QueryParameterAccessTokenAuthenticationStrategy.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/QueryParameterAccessTokenAuthenticationStrategy.java
@@ -1,0 +1,85 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.jmap;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.james.jmap.api.SimpleTokenManager;
+import org.apache.james.jmap.exceptions.MailboxSessionCreationException;
+import org.apache.james.jmap.exceptions.NoValidAuthHeaderException;
+import org.apache.james.jmap.exceptions.UnauthorizedException;
+import org.apache.james.jmap.model.AttachmentAccessToken;
+import org.apache.james.jmap.utils.DownloadPath;
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class QueryParameterAccessTokenAuthenticationStrategy implements AuthenticationStrategy {
+
+    private static final Logger LOG = LoggerFactory.getLogger(QueryParameterAccessTokenAuthenticationStrategy.class);
+    private static final String AUTHENTICATION_PARAMETER = "access_token";
+
+    private final SimpleTokenManager tokenManager;
+    private final MailboxManager mailboxManager;
+
+    @Inject
+    @VisibleForTesting
+    QueryParameterAccessTokenAuthenticationStrategy(SimpleTokenManager tokenManager, MailboxManager mailboxManager) {
+        this.tokenManager = tokenManager;
+        this.mailboxManager = mailboxManager;
+    }
+
+    @Override
+    public MailboxSession createMailboxSession(HttpServletRequest httpRequest) throws MailboxSessionCreationException, NoValidAuthHeaderException {
+
+        return getAccessToken(httpRequest)
+            .filter(tokenManager::isValid)
+            .map(AttachmentAccessToken::getUsername)
+            .map(this::createSystemSession)
+            .orElseThrow(() -> new UnauthorizedException());
+    }
+
+    private MailboxSession createSystemSession(String username) {
+        try {
+            return mailboxManager.createSystemSession(username, LOG);
+        } catch (MailboxException e) {
+            throw new MailboxSessionCreationException(e);
+        }
+    }
+
+    private Optional<AttachmentAccessToken> getAccessToken(HttpServletRequest httpRequest) {
+        try {
+            return Optional.of(AttachmentAccessToken.from(httpRequest.getParameter(AUTHENTICATION_PARAMETER), getBlobId(httpRequest)));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
+    private String getBlobId(HttpServletRequest httpRequest) {
+        String pathInfo = httpRequest.getPathInfo();
+        return DownloadPath.from(pathInfo).getBlobId();
+    }
+}

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/crypto/SignedTokenFactory.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/crypto/SignedTokenFactory.java
@@ -65,8 +65,8 @@ public class SignedTokenFactory implements SimpleTokenFactory {
                 .blobId(blobId)
                 .expirationDate(expirationTime)
                 .signature(signatureHandler.sign(Joiner.on(AttachmentAccessToken.SEPARATOR)
-                                                    .join(username, 
-                                                            blobId,
+                                                    .join(blobId,
+                                                            username, 
                                                             DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(expirationTime))))
                 .build();
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/AttachmentAccessToken.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/AttachmentAccessToken.java
@@ -21,11 +21,15 @@ package org.apache.james.jmap.model;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Objects;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.Iterables;
 
 public class AttachmentAccessToken implements SignedExpiringToken {
 
@@ -34,7 +38,21 @@ public class AttachmentAccessToken implements SignedExpiringToken {
     public static Builder builder() {
         return new Builder();
     }
-    
+
+    public static AttachmentAccessToken from(String serializedAttachmentAccessToken, String blobId) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(serializedAttachmentAccessToken), "'AttachmentAccessToken' is mandatory");
+        List<String> split = Splitter.on(SEPARATOR).splitToList(serializedAttachmentAccessToken);
+        Preconditions.checkArgument(split.size() == 3, "Wrong 'AttachmentAccessToken'");
+
+        String defaultValue = null;
+        return builder()
+                .blobId(blobId)
+                .username(Iterables.get(split, 0, defaultValue))
+                .expirationDate(ZonedDateTime.parse(Iterables.get(split, 1, defaultValue)))
+                .signature(Iterables.get(split, 2, defaultValue))
+                .build();
+    }
+
     public static class Builder {
         private String username;
         private String blobId;

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/HeadersAuthenticationExtractor.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/HeadersAuthenticationExtractor.java
@@ -16,15 +16,26 @@
  * specific language governing permissions and limitations      *
  * under the License.                                           *
  ****************************************************************/
-package org.apache.james.jmap;
+
+package org.apache.james.jmap.utils;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.stream.Stream;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.james.mailbox.MailboxSession;
+import com.google.common.base.Preconditions;
 
-public interface AuthenticationStrategy {
+public class HeadersAuthenticationExtractor {
 
-    MailboxSession createMailboxSession(HttpServletRequest httpRequest);
+    private static final String AUTHORIZATION_HEADERS = "Authorization";
 
-    boolean checkAuthorizationHeader(HttpServletRequest httpRequest);
+    public Stream<String> authHeaders(HttpServletRequest httpRequest) {
+        Preconditions.checkArgument(httpRequest != null, "'httpRequest' is mandatory");
+        Enumeration<String> authHeaders = httpRequest.getHeaders(AUTHORIZATION_HEADERS);
+
+        return authHeaders != null ? Collections.list(authHeaders).stream() : Stream.of();
+    }
+
 }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/AuthenticationFilterTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/AuthenticationFilterTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletRequest;
@@ -129,12 +128,12 @@ public class AuthenticationFilterTest {
         }
 
         @Override
-        public MailboxSession createMailboxSession(Stream<String> requestHeaders) {
+        public MailboxSession createMailboxSession(HttpServletRequest httpRequest) {
             return null;
         }
 
         @Override
-        public boolean checkAuthorizationHeader(Stream<String> requestHeaders) {
+        public boolean checkAuthorizationHeader(HttpServletRequest httpRequest) {
             return isAuthorized;
         }
     }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/JWTAuthenticationStrategyTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/JWTAuthenticationStrategyTest.java
@@ -27,9 +27,12 @@ import static org.mockito.Mockito.when;
 
 import java.util.stream.Stream;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.james.jmap.crypto.JwtTokenVerifier;
 import org.apache.james.jmap.exceptions.MailboxSessionCreationException;
 import org.apache.james.jmap.exceptions.NoValidAuthHeaderException;
+import org.apache.james.jmap.utils.HeadersAuthenticationExtractor;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -43,26 +46,35 @@ public class JWTAuthenticationStrategyTest {
     private JWTAuthenticationStrategy testee;
     private MailboxManager mockedMailboxManager;
     private JwtTokenVerifier stubTokenVerifier;
+    private HttpServletRequest request;
+    private HeadersAuthenticationExtractor mockAuthenticationExtractor;
 
     @Before
     public void setup() {
-        mockedMailboxManager = mock(MailboxManager.class);
-
         stubTokenVerifier = mock(JwtTokenVerifier.class);
+        mockedMailboxManager = mock(MailboxManager.class);
+        mockAuthenticationExtractor = mock(HeadersAuthenticationExtractor.class);
+        request = mock(HttpServletRequest.class);
 
-        testee = new JWTAuthenticationStrategy(stubTokenVerifier, mockedMailboxManager);
+        testee = new JWTAuthenticationStrategy(stubTokenVerifier, mockedMailboxManager, mockAuthenticationExtractor);
     }
 
 
     @Test
     public void createMailboxSessionShouldThrowWhenAuthHeaderIsEmpty() throws Exception {
-        assertThatThrownBy(() -> testee.createMailboxSession(Stream.empty()))
+        when(mockAuthenticationExtractor.authHeaders(request))
+            .thenReturn(Stream.empty());
+
+        assertThatThrownBy(() -> testee.createMailboxSession(request))
             .isExactlyInstanceOf(NoValidAuthHeaderException.class);
     }
 
     @Test
     public void createMailboxSessionShouldReturnEmptyWhenAuthHeaderIsInvalid() throws Exception {
-        assertThatThrownBy(() -> testee.createMailboxSession(Stream.of("bad")))
+        when(mockAuthenticationExtractor.authHeaders(request))
+            .thenReturn(Stream.of("bad"));
+
+        assertThatThrownBy(() -> testee.createMailboxSession(request))
             .isExactlyInstanceOf(NoValidAuthHeaderException.class);
     }
 
@@ -76,8 +88,10 @@ public class JWTAuthenticationStrategyTest {
         when(stubTokenVerifier.extractLogin(validAuthHeader)).thenReturn(username);
         when(mockedMailboxManager.createSystemSession(eq(username), any(Logger.class)))
                 .thenThrow(new MailboxException());
+        when(mockAuthenticationExtractor.authHeaders(request))
+            .thenReturn(Stream.of(fakeAuthHeaderWithPrefix));
 
-        assertThatThrownBy(() -> testee.createMailboxSession(Stream.of(fakeAuthHeaderWithPrefix)))
+        assertThatThrownBy(() -> testee.createMailboxSession(request))
                 .isExactlyInstanceOf(MailboxSessionCreationException.class);
     }
 
@@ -92,14 +106,20 @@ public class JWTAuthenticationStrategyTest {
         when(stubTokenVerifier.extractLogin(validAuthHeader)).thenReturn(username);
         when(mockedMailboxManager.createSystemSession(eq(username), any(Logger.class)))
                 .thenReturn(fakeMailboxSession);
+        when(mockAuthenticationExtractor.authHeaders(request))
+            .thenReturn(Stream.of(fakeAuthHeaderWithPrefix));
 
-        MailboxSession result = testee.createMailboxSession(Stream.of(fakeAuthHeaderWithPrefix));
+
+        MailboxSession result = testee.createMailboxSession(request);
         assertThat(result).isEqualTo(fakeMailboxSession);
     }
 
     @Test
     public void checkAuthorizationHeaderShouldReturnFalsewWhenAuthHeaderIsEmpty() {
-        assertThat(testee.checkAuthorizationHeader(Stream.empty())).isFalse();
+        when(mockAuthenticationExtractor.authHeaders(request))
+            .thenReturn(Stream.empty());
+
+        assertThat(testee.checkAuthorizationHeader(request)).isFalse();
     }
 
     @Test
@@ -108,8 +128,10 @@ public class JWTAuthenticationStrategyTest {
         String fakeAuthHeaderWithPrefix = JWTAuthenticationStrategy.AUTHORIZATION_HEADER_PREFIX + wrongAuthHeader;
 
         when(stubTokenVerifier.verify(wrongAuthHeader)).thenReturn(false);
+        when(mockAuthenticationExtractor.authHeaders(request))
+            .thenReturn(Stream.of(fakeAuthHeaderWithPrefix));
 
-        assertThat(testee.checkAuthorizationHeader(Stream.of(fakeAuthHeaderWithPrefix))).isFalse();
+        assertThat(testee.checkAuthorizationHeader(request)).isFalse();
     }
 
     @Test
@@ -122,7 +144,10 @@ public class JWTAuthenticationStrategyTest {
 
         Stream<String> authHeadersStream = Stream.of(wrongAuthHeader, invalidAuthHeader)
                 .map(h -> JWTAuthenticationStrategy.AUTHORIZATION_HEADER_PREFIX + h);
-        assertThat(testee.checkAuthorizationHeader(authHeadersStream)).isFalse();
+        when(mockAuthenticationExtractor.authHeaders(request))
+            .thenReturn(authHeadersStream);
+
+        assertThat(testee.checkAuthorizationHeader(request)).isFalse();
     }
 
     @Test
@@ -131,8 +156,10 @@ public class JWTAuthenticationStrategyTest {
         String validAuthHeaderWithPrefix = JWTAuthenticationStrategy.AUTHORIZATION_HEADER_PREFIX + validAuthHeader;
 
         when(stubTokenVerifier.verify(validAuthHeader)).thenReturn(true);
+        when(mockAuthenticationExtractor.authHeaders(request))
+            .thenReturn(Stream.of(validAuthHeaderWithPrefix));
 
-        assertThat(testee.checkAuthorizationHeader(Stream.of(validAuthHeaderWithPrefix))).isTrue();
+        assertThat(testee.checkAuthorizationHeader(request)).isTrue();
     }
 
     @Test
@@ -145,7 +172,10 @@ public class JWTAuthenticationStrategyTest {
 
         Stream<String> authHeadersStream = Stream.of(dummyAuthHeader, validAuthHeader)
                 .map(h -> JWTAuthenticationStrategy.AUTHORIZATION_HEADER_PREFIX + h);
-        assertThat(testee.checkAuthorizationHeader(authHeadersStream)).isTrue();
+        when(mockAuthenticationExtractor.authHeaders(request))
+            .thenReturn(authHeadersStream);
+
+        assertThat(testee.checkAuthorizationHeader(request)).isTrue();
     }
 
 }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/QueryParameterAccessTokenAuthenticationStrategyTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/QueryParameterAccessTokenAuthenticationStrategyTest.java
@@ -1,0 +1,94 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.jmap;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.james.jmap.api.SimpleTokenManager;
+import org.apache.james.jmap.exceptions.MailboxSessionCreationException;
+import org.apache.james.jmap.exceptions.UnauthorizedException;
+import org.apache.james.jmap.model.AttachmentAccessToken;
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+public class QueryParameterAccessTokenAuthenticationStrategyTest {
+
+    private static final String USERNAME = "usera@domain.tld";
+    private static final String VALID_ATTACHMENT_TOKEN = "usera@domain.tld_"
+            + "2016-06-29T13:41:22.124Z_"
+            + "DiZa0O14MjLWrAA8P6MG35Gt5CBp7mt5U1EH/M++rIoZK7nlGJ4dPW0dvZD7h4m3o5b/Yd8DXU5x2x4+s0HOOKzD7X0RMlsU7JHJMNLvTvRGWF/C+MUyC8Zce7DtnRVPEQX2uAZhL2PBABV07Vpa8kH+NxoS9CL955Bc1Obr4G+KN2JorADlocFQA6ElXryF5YS/HPZSvq1MTC6aJIP0ku8WRpRnbwgwJnn26YpcHXcJjbkCBtd9/BhlMV6xNd2hTBkfZmYdoNo+UKBaXWzLxAlbLuxjpxwvDNJfOEyWFPgHDoRvzP+G7KzhVWjanHAHrhF0GilEa/MKpOI1qHBSwA==";
+
+    private SimpleTokenManager mockedSimpleTokenManager;
+    private MailboxManager mockedMailboxManager;
+    private QueryParameterAccessTokenAuthenticationStrategy testee;
+    private HttpServletRequest request;
+
+    @Before
+    public void setup() {
+        mockedSimpleTokenManager = mock(SimpleTokenManager.class);
+        mockedMailboxManager = mock(MailboxManager.class);
+        request = mock(HttpServletRequest.class);
+
+        testee = new QueryParameterAccessTokenAuthenticationStrategy(mockedSimpleTokenManager, mockedMailboxManager);
+    }
+
+    @Test
+    public void createMailboxSessionShouldThrowWhenNoAccessTokenProvided() {
+        when(request.getParameter("access_token"))
+            .thenReturn(null);
+
+        assertThatThrownBy(() -> testee.createMailboxSession(request))
+            .isExactlyInstanceOf(UnauthorizedException.class);
+    }
+
+    @Test
+    public void createMailboxSessionShouldThrowWhenAccessTokenIsNotValid() {
+        when(request.getParameter("access_token"))
+            .thenReturn("bad");
+
+        assertThatThrownBy(() -> testee.createMailboxSession(request))
+                .isExactlyInstanceOf(UnauthorizedException.class);
+    }
+
+    @Test
+    public void createMailboxSessionShouldThrowWhenMailboxExceptionHasOccurred() throws Exception {
+        when(mockedMailboxManager.createSystemSession(eq(USERNAME), any(Logger.class)))
+                .thenThrow(new MailboxException());
+
+        when(request.getParameter("access_token"))
+            .thenReturn(VALID_ATTACHMENT_TOKEN);
+        when(request.getPathInfo())
+            .thenReturn("/blobId");
+
+        when(mockedSimpleTokenManager.isValid(AttachmentAccessToken.from(VALID_ATTACHMENT_TOKEN, "blobId")))
+            .thenReturn(true);
+
+        assertThatThrownBy(() -> testee.createMailboxSession(request))
+                .isExactlyInstanceOf(MailboxSessionCreationException.class);
+    }
+}

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/crypto/SignedTokenFactoryTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/crypto/SignedTokenFactoryTest.java
@@ -73,7 +73,6 @@ public class SignedTokenFactoryTest {
     public void generateAttachmentAccessTokenShouldHaveTheRightOutPut() throws Exception {
         zonedDateTimeProvider.setFixedDateTime(DATE);
         assertThat(toKenFactory.generateAttachmentAccessToken("user", "blobId").serialize())
-            .isEqualTo("user_2011-12-03T10:20:30+01:00_UAmjTzvmmIwvE1Yw54tE7jC1Q2nCJ1l3XX1703kYmLIeOZe7fNSLM6V8CzPFEvZ+Y4H+UD4UTkNHbmgcPbxesITnby+UfT/tIiTppJhXJvtTxSoTy9vuAJrW9/kJh6CruqtSM+BUEkLKuuzJySmvDkaHSaXwot4egGXaJ9yHgjEh2PT3uA0O0JjRNB2x8oa370fFSZsT2QgXrqeqHWWO1j6IrAf4UcyhvjNkJBK9TVNubfqGKuCZ4dz2Rm/CUvp13CpzUoVqBS1nJ1VaIw94L2rX8RkAMTlV7AXKB3kPiBX7MdGp2NBiAUlYlOLjflYl8plnv/QrRCmfGxnsvv4WVQ==");
+            .isEqualTo("user_2011-12-03T10:20:30+01:00_eSg1mVxMpqw5/u6wsTAatP7hoHDoI7blEW0hxGPrRMMj3hECT+YhbUCdhz9Lb4U+jsYPgNLDuAHwxin79xXfLoq0nVsogEE32svRYVvbaDpro+EOtkAHhYnYxWnAGxB/70u7Zyw0oYGmWOwkCkLDFsWKglMp9IUpOJQP50zbzbdW+4dKlAi/8VmN8jFyZx40envRbgEn4Q2QQbnUH/7F9+vdLIl+bAfcj6QlevqFRsUkmTZelkv1rtGUAvnPSBQL4TeBx5Qk/eEiw8IbB2lbCIAoIFZC6Vl8QOO5Y6LFzmqHL9i0BjvuoiZ8FKQS0pGd5CU6pwc7sv0xD82Vx1eFiw==");
     }
-
 }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/crypto/SignedTokenManagerTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/crypto/SignedTokenManagerTest.java
@@ -27,6 +27,7 @@ import java.time.format.DateTimeFormatter;
 
 import org.apache.james.jmap.FixedDateZonedDateTimeProvider;
 import org.apache.james.jmap.api.SimpleTokenManager.TokenStatus;
+import org.apache.james.jmap.model.AttachmentAccessToken;
 import org.apache.james.jmap.model.ContinuationToken;
 import org.junit.Before;
 import org.junit.Test;
@@ -167,5 +168,14 @@ public class SignedTokenManagerTest {
         zonedDateTimeProvider.setFixedDateTime(DATE);
         ContinuationToken pirateContinuationToken = new ContinuationToken("user", DATE.plusMinutes(15), "fake");
         assertThat(tokenManager.getValidity(pirateContinuationToken)).isEqualTo(TokenStatus.INVALID);
+    }
+
+    @Test
+    public void signedAttachmentAccessTokenShouldBeValidated() {
+        String blobId = "blobId";
+        zonedDateTimeProvider.setFixedDateTime(DATE);
+        String serializedToken = tokenFactory.generateAttachmentAccessToken("user", blobId).serialize();
+
+        assertThat(tokenManager.isValid(AttachmentAccessToken.from(serializedToken, blobId))).isTrue();
     }
 }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/utils/HeadersAuthenticationExtractorTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/utils/HeadersAuthenticationExtractorTest.java
@@ -1,0 +1,69 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class HeadersAuthenticationExtractorTest {
+
+    private HeadersAuthenticationExtractor testee;
+
+    @Before
+    public void setup() {
+        testee = new HeadersAuthenticationExtractor();
+    }
+
+    @Test
+    public void authHeadersShouldThrowWhenRequestIsNull() {
+        assertThatThrownBy(() -> testee.authHeaders(null))
+            .isExactlyInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void authHeadersShouldReturnEmptyStreamWhenNoAuthorizationHeader() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeaders("Authorization"))
+            .thenReturn(Collections.emptyEnumeration());
+
+        assertThat(testee.authHeaders(request)).isEmpty();
+    }
+
+    @Test
+    public void authHeadersShouldReturnStreamOfHeadersWhenSome() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        ImmutableList<String> expectedHeaders = ImmutableList.of("header", "otherHeader");
+        when(request.getHeaders("Authorization"))
+            .thenReturn(Collections.enumeration(expectedHeaders));
+
+        assertThat(testee.authHeaders(request)).containsOnlyElementsOf(expectedHeaders);
+    }
+}


### PR DESCRIPTION
Rebase + take care of comment published in #308 
Commit order is wrong on GitHub, real order is:
JAMES-1784 Authentication strategy should be responsible of extracting the authentication part from the request
JAMES-1784 Remove checkAuthorizationHeader in AuthenticationStrategy
JAMES-1784 Add QueryParameterAccessTokenAuthenticationStrategy
JAMES-1784 Add integration tests when downloading attachment with access token
