### PR TITLE
JAMES-1817 Maven 3.3.1 can not be downloaded anymore - reported by Alan Cabrera

### DIFF
--- a/dockerfiles/compilation/java-8/Dockerfile
+++ b/dockerfiles/compilation/java-8/Dockerfile
@@ -8,9 +8,9 @@ ENV GIT_VERSION 1:2.1.4-2.1
 
 # Install Maven
 WORKDIR /root
-RUN wget http://mirrors.ircam.fr/pub/apache/maven/maven-3/3.3.1/binaries/apache-maven-3.3.1-bin.tar.gz
-RUN tar -xvf apache-maven-3.3.1-bin.tar.gz
-RUN ln -s /root/apache-maven-3.3.1/bin/mvn /usr/bin/mvn
+RUN wget http://mirrors.ircam.fr/pub/apache/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
+RUN tar -xvf apache-maven-3.3.9-bin.tar.gz
+RUN ln -s /root/apache-maven-3.3.9/bin/mvn /usr/bin/mvn
 
 # Install git
 RUN apt-get update


### PR DESCRIPTION
Unit testing for https://github.com/apache/james-project/pull/51