### PR TITLE
Mailbox 270: Entry names can have any number of components starting at 2, unless they fall under the vendor namespaces

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxAnnotationKey.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxAnnotationKey.java
@@ -31,16 +31,20 @@ public class MailboxAnnotationKey {
 
     private static final CharMatcher NAME_ANNOTATION_PATTERN = CharMatcher.JAVA_LETTER_OR_DIGIT
         .or(CharMatcher.is('/'));
+    public static final int MINIMUM_COMPONENTS = 2;
+    public static final int MINIMUM_COMPONENTS_OF_VENDOR = 4;
+    public static final int SECOND_COMPONENT_INDEX = 1;
+    public static final String VENDOR_COMPONENT = "vendor";
 
     private final String key;
 
     public MailboxAnnotationKey(String key) {
-        Preconditions.checkArgument(isValid(key),
-            "Key must start with '/' and not end with '/' and does not contain charater with hex from '\u0000' to '\u00019' or {'*', '%', two consecutive '/'} ");
         this.key = key;
+        Preconditions.checkArgument(isValid(),
+            "Key must start with '/' and not end with '/' and does not contain charater with hex from '\u0000' to '\u00019' or {'*', '%', two consecutive '/'} ");
     }
 
-    private boolean isValid(String key) {
+    private boolean isValid() {
         if (StringUtils.isBlank(key)) {
             return false;
         }
@@ -59,7 +63,24 @@ public class MailboxAnnotationKey {
         if (!NAME_ANNOTATION_PATTERN.matchesAllOf(key)) {
             return false;
         }
+        int componentsNo = countComponents();
+        if (isVendorKey() && componentsNo < MINIMUM_COMPONENTS_OF_VENDOR) {
+            return false;
+        }
+        if (componentsNo < MINIMUM_COMPONENTS) {
+            return false;
+        }
         return true;
+    }
+
+    private boolean isVendorKey() {
+        String[] components = StringUtils.split(key, SLASH_CHARACTER);
+
+        if (components.length >= MINIMUM_COMPONENTS &&
+            VENDOR_COMPONENT.equalsIgnoreCase(components[SECOND_COMPONENT_INDEX])) {
+            return true;
+        }
+        return false;
     }
 
     public int countComponents() {

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxAnnotationKeyTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxAnnotationKeyTest.java
@@ -93,4 +93,24 @@ public class MailboxAnnotationKeyTest {
         MailboxAnnotationKey annotationKey = new MailboxAnnotationKey("/private/comment/user/name");
         assertThat(annotationKey.countComponents()).isEqualTo(4);
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void keyMustContainAtLeastTwoComponents() throws Exception {
+        MailboxAnnotationKey annotationKey = new MailboxAnnotationKey("/private");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void keyVendorShouldThrowsExceptionWithTwoComponents() throws Exception {
+        MailboxAnnotationKey annotationKey = new MailboxAnnotationKey("/private/vendor");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void keyVendorShouldThrowsExceptionWithThreeComponents() throws Exception {
+        MailboxAnnotationKey annotationKey = new MailboxAnnotationKey("/shared/vendor/token");
+    }
+
+    @Test
+    public void keyVendorShouldOKWithFourComponents() throws Exception {
+        MailboxAnnotationKey annotationKey = new MailboxAnnotationKey("/shared/vendor/token/comment");
+    }
 }

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Annotation.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/Annotation.test
@@ -142,3 +142,18 @@ S: g18 BAD GETMETADATA failed. Illegal arguments.
 
 C: g19 GETMETADATA "INBOX" (MAXSIZE 0) (/private/comment)
 S: g19 BAD GETMETADATA failed. Illegal arguments.
+
+########################End of get annotation############
+
+C: a21 SETMETADATA INBOX (/private "My new comment")
+S: a21 BAD SETMETADATA failed. Illegal arguments.
+
+C: a22 SETMETADATA INBOX (/private/vendor "My new comment")
+S: a22 BAD SETMETADATA failed. Illegal arguments.
+
+C: a23 SETMETADATA INBOX (/private/vendor/token "My new comment")
+S: a23 BAD SETMETADATA failed. Illegal arguments.
+
+C: a24 SETMETADATA INBOX (/shared/vendor/token/comment "My token comment")
+S: a24 OK SETMETADATA completed.
+


### PR DESCRIPTION
On RFC: https://www.ietf.org/rfc/rfc5464.txt
At the end of session "3.2.  Namespace of Entries" it said:
Entry names can have any number of components starting at 2, unless they fall under the vendor namespaces (i.e., have a /shared/vendor/   <vendor-token> or /private/vendor/<vendor-token> prefix as described  below), in which case they have at least 4 components.