### PR TITLE
James 1738 -- Remove dependancy to ONAMI

### DIFF
--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraMailboxTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraMailboxTest.java
@@ -20,7 +20,7 @@
 package org.apache.james.mpt.imapmailbox.cassandra;
 
 import org.apache.james.mpt.imapmailbox.AbstractMailboxTest;
-import org.apache.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
 
 @GuiceModules({ CassandraMailboxTestModule.class })
 public class CassandraMailboxTest extends AbstractMailboxTest {

--- a/mpt/impl/imap-mailbox/core/pom.xml
+++ b/mpt/impl/imap-mailbox/core/pom.xml
@@ -57,8 +57,8 @@
             <type>test-jar</type>
         </dependency>
         <dependency>
-            <groupId>org.apache.onami</groupId>
-            <artifactId>org.apache.onami.test</artifactId>
+            <groupId>org.apache.james</groupId>
+            <artifactId>apache-james-mpt-onami-test</artifactId>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/imapmailbox/AbstractMailboxTest.java
+++ b/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/imapmailbox/AbstractMailboxTest.java
@@ -40,7 +40,7 @@ import org.apache.james.mpt.imapmailbox.suite.SelectedInbox;
 import org.apache.james.mpt.imapmailbox.suite.SelectedState;
 import org.apache.james.mpt.imapmailbox.suite.UidSearch;
 import org.apache.james.mpt.imapmailbox.suite.UserFlagsSupport;
-import org.apache.onami.test.OnamiSuite;
+import org.apache.james.mpt.onami.test.OnamiSuite;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite.SuiteClasses;
 

--- a/mpt/impl/imap-mailbox/cyrus/src/test/java/org/apache/james/mpt/imapmailbox/cyrus/CyrusMailboxTest.java
+++ b/mpt/impl/imap-mailbox/cyrus/src/test/java/org/apache/james/mpt/imapmailbox/cyrus/CyrusMailboxTest.java
@@ -21,8 +21,8 @@ package org.apache.james.mpt.imapmailbox.cyrus;
 
 import org.apache.james.mpt.imapmailbox.suite.ACLCommands;
 import org.apache.james.mpt.imapmailbox.suite.ACLIntegration;
-import org.apache.onami.test.OnamiSuite;
-import org.apache.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.OnamiSuite;
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite.SuiteClasses;
 

--- a/mpt/impl/imap-mailbox/elasticsearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/ElasticSearchMailboxTest.java
+++ b/mpt/impl/imap-mailbox/elasticsearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/ElasticSearchMailboxTest.java
@@ -20,8 +20,8 @@
 package org.apache.james.mpt.imapmailbox.elasticsearch;
 
 import org.apache.james.mpt.imapmailbox.suite.UidSearchOnIndex;
-import org.apache.onami.test.OnamiSuite;
-import org.apache.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.OnamiSuite;
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 

--- a/mpt/impl/imap-mailbox/external-james/src/test/java/org/apache/james/mpt/imapmailbox/external/james/ExternalJamesTest.java
+++ b/mpt/impl/imap-mailbox/external-james/src/test/java/org/apache/james/mpt/imapmailbox/external/james/ExternalJamesTest.java
@@ -21,8 +21,8 @@ package org.apache.james.mpt.imapmailbox.external.james;
 
 import org.apache.james.mpt.imapmailbox.suite.DeploymentValidation;
 
-import org.apache.onami.test.OnamiSuite;
-import org.apache.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.OnamiSuite;
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 

--- a/mpt/impl/imap-mailbox/hbase/src/test/java/org/apache/james/mpt/imapmailbox/hbase/HBaseMailboxTest.java
+++ b/mpt/impl/imap-mailbox/hbase/src/test/java/org/apache/james/mpt/imapmailbox/hbase/HBaseMailboxTest.java
@@ -1,7 +1,7 @@
 package org.apache.james.mpt.imapmailbox.hbase;
 
 import org.apache.james.mpt.imapmailbox.AbstractMailboxTest;
-import org.apache.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
 
 @GuiceModules({ HBaseMailboxTestModule.class })
 public class HBaseMailboxTest extends AbstractMailboxTest {

--- a/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/InMemoryMailboxEventAsynchronousTest.java
+++ b/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/InMemoryMailboxEventAsynchronousTest.java
@@ -37,8 +37,8 @@ import org.apache.james.mpt.imapmailbox.suite.Select;
 import org.apache.james.mpt.imapmailbox.suite.SelectedInbox;
 import org.apache.james.mpt.imapmailbox.suite.SelectedState;
 import org.apache.james.mpt.imapmailbox.suite.UidSearch;
-import org.apache.onami.test.OnamiSuite;
-import org.apache.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.OnamiSuite;
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 

--- a/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/InMemoryMailboxTest.java
+++ b/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/InMemoryMailboxTest.java
@@ -19,7 +19,7 @@
 package org.apache.james.mpt.imapmailbox.inmemory;
 
 import org.apache.james.mpt.imapmailbox.AbstractMailboxTest;
-import org.apache.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
 
 @GuiceModules({ InMemoryMailboxTestModule.class })
 public class InMemoryMailboxTest extends AbstractMailboxTest {

--- a/mpt/impl/imap-mailbox/jcr/src/test/java/org/apache/james/mpt/imapmailbox/jcr/JcrMailboxTest.java
+++ b/mpt/impl/imap-mailbox/jcr/src/test/java/org/apache/james/mpt/imapmailbox/jcr/JcrMailboxTest.java
@@ -19,7 +19,7 @@
 package org.apache.james.mpt.imapmailbox.jcr;
 
 import org.apache.james.mpt.imapmailbox.AbstractMailboxTest;
-import org.apache.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
 import org.junit.Ignore;
 
 @Ignore("JWC-130 : JCR mailbox does not correctly release resources + append problems")

--- a/mpt/impl/imap-mailbox/jpa/src/test/java/org/apache/james/mpt/imapmailbox/jpa/JpaMailboxTest.java
+++ b/mpt/impl/imap-mailbox/jpa/src/test/java/org/apache/james/mpt/imapmailbox/jpa/JpaMailboxTest.java
@@ -19,7 +19,7 @@
 package org.apache.james.mpt.imapmailbox.jpa;
 
 import org.apache.james.mpt.imapmailbox.AbstractMailboxTest;
-import org.apache.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
 
 @GuiceModules({ JpaMailboxTestModule.class })
 public class JpaMailboxTest extends AbstractMailboxTest {

--- a/mpt/impl/imap-mailbox/maildir/src/test/java/org/apache/james/mpt/imapmailbox/maildir/MaildirMailboxTest.java
+++ b/mpt/impl/imap-mailbox/maildir/src/test/java/org/apache/james/mpt/imapmailbox/maildir/MaildirMailboxTest.java
@@ -19,7 +19,7 @@
 package org.apache.james.mpt.imapmailbox.maildir;
 
 import org.apache.james.mpt.imapmailbox.AbstractMailboxTest;
-import org.apache.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
 
 @GuiceModules({ MaildirMailboxTestModule.class })
 public class MaildirMailboxTest extends AbstractMailboxTest {

--- a/mpt/impl/managesieve/cassandra/src/test/java/org/apache/james/mpt/managesieve/cassandra/ManageSieveCassandraTest.java
+++ b/mpt/impl/managesieve/cassandra/src/test/java/org/apache/james/mpt/managesieve/cassandra/ManageSieveCassandraTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mpt.managesieve.cassandra;
 
+import org.apache.james.mpt.onami.test.OnamiSuite;
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
 import org.apache.james.mpt.testsuite.AuthenticateTest;
 import org.apache.james.mpt.testsuite.CapabilityTest;
 import org.apache.james.mpt.testsuite.CheckScriptTest;
@@ -33,8 +35,6 @@ import org.apache.james.mpt.testsuite.RenameScriptTest;
 import org.apache.james.mpt.testsuite.SetActiveTest;
 import org.apache.james.mpt.testsuite.StartTlsTest;
 import org.apache.james.mpt.testsuite.UnauthenticatedTest;
-import org.apache.onami.test.OnamiSuite;
-import org.apache.onami.test.annotation.GuiceModules;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 

--- a/mpt/impl/managesieve/core/pom.xml
+++ b/mpt/impl/managesieve/core/pom.xml
@@ -55,8 +55,8 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.onami</groupId>
-            <artifactId>org.apache.onami.test</artifactId>
+            <groupId>org.apache.james</groupId>
+            <artifactId>apache-james-mpt-onami-test</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/mpt/impl/managesieve/file/src/test/java/org/apache/james/mpt/managesieve/file/ManageSieveFileTest.java
+++ b/mpt/impl/managesieve/file/src/test/java/org/apache/james/mpt/managesieve/file/ManageSieveFileTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mpt.managesieve.file;
 
+import org.apache.james.mpt.onami.test.OnamiSuite;
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
 import org.apache.james.mpt.testsuite.AuthenticateTest;
 import org.apache.james.mpt.testsuite.CapabilityTest;
 import org.apache.james.mpt.testsuite.CheckScriptTest;
@@ -33,8 +35,6 @@ import org.apache.james.mpt.testsuite.RenameScriptTest;
 import org.apache.james.mpt.testsuite.SetActiveTest;
 import org.apache.james.mpt.testsuite.StartTlsTest;
 import org.apache.james.mpt.testsuite.UnauthenticatedTest;
-import org.apache.onami.test.OnamiSuite;
-import org.apache.onami.test.annotation.GuiceModules;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 

--- a/mpt/impl/smtp/cassandra/pom.xml
+++ b/mpt/impl/smtp/cassandra/pom.xml
@@ -195,8 +195,8 @@
                     <version>18.0</version>
                 </dependency>
                 <dependency>
-                    <groupId>org.apache.onami</groupId>
-                    <artifactId>org.apache.onami.test</artifactId>
+                    <groupId>org.apache.james</groupId>
+                    <artifactId>apache-james-mpt-onami-test</artifactId>
                 </dependency>
                 <dependency>
                     <groupId>org.cassandraunit</groupId>
@@ -270,6 +270,10 @@
                 </dependency>
                 <dependency>
                     <groupId>org.apache.james</groupId>
+                    <artifactId>apache-james-mpt-onami-test</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.james</groupId>
                     <artifactId>james-server-cassandra-guice</artifactId>
                 </dependency>
                 <dependency>
@@ -288,10 +292,6 @@
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
                     <version>18.0</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.onami</groupId>
-                    <artifactId>org.apache.onami.test</artifactId>
                 </dependency>
                 <dependency>
                     <groupId>org.cassandraunit</groupId>

--- a/mpt/impl/smtp/cassandra/src/test/java/org/apache/james/mpt/smtp/SmtpTest.java
+++ b/mpt/impl/smtp/cassandra/src/test/java/org/apache/james/mpt/smtp/SmtpTest.java
@@ -18,8 +18,8 @@
  ****************************************************************/
 package org.apache.james.mpt.smtp;
 
-import org.apache.onami.test.OnamiSuite;
-import org.apache.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.OnamiSuite;
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 

--- a/mpt/onami-test/pom.xml
+++ b/mpt/onami-test/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>apache-james-mpt</artifactId>
+        <groupId>org.apache.james</groupId>
+        <version>3.0.0-beta5-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>apache-james-mpt-onami-test</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Apache James :: MPT :: Onami-test</name>
+    <description>MPT tooling from Onami project</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <version>3.2</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>16.0.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.9.5</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/GuiceMockModule.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/GuiceMockModule.java
@@ -1,0 +1,182 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.james.mpt.onami.test.annotation.Mock;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.inject.AbstractModule;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
+
+/**
+ * <p>
+ * This class creates the binding for all mock objects found.
+ * </p>
+ * <p>
+ * Method {@link GuiceMockModule#configure()} creates a binding for each {@link Mock} annotation found. The binding will
+ * be created <b>if and only if</b> there is no types conflict between {@link Mock} caught.
+ * <p>
+ * <p>
+ * <b>A type conflict</b> is detected if two or more field are annotated with the same {@link Mock} and no different
+ * {@link Mock#annotatedWith} parameter are specified, or two o more equals {@link Mock#annotatedWith} parameter are
+ * specified for the same type field.
+ * </p>
+ * <p>
+ * If a conflict is detected the binding will not create for the conflicted type, moreover the field will be injected
+ * into the test class.
+ * </p>
+ */
+public class GuiceMockModule
+    extends AbstractModule
+{
+
+    private static final Logger LOGGER = Logger.getLogger( GuiceMockModule.class.getName() );
+
+    final Map<Field, Object> mockedFields;
+
+    /**
+     * Costructor.
+     *
+     * @param mockedFields the map of mock fileds.
+     */
+
+    public GuiceMockModule( final Map<Field, Object> mockedFields )
+    {
+        this.mockedFields = mockedFields;
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @Override
+    protected void configure()
+    {
+        final Multimap<Type, Field> fieldsByType = HashMultimap.create();
+
+        for ( final Entry<Field, Object> entry : this.mockedFields.entrySet() )
+        {
+            fieldsByType.put( entry.getKey().getGenericType(), entry.getKey() );
+        }
+
+        for ( final Type type : fieldsByType.keySet() )
+        {
+            final Collection<Field> fields = fieldsByType.get( type );
+
+            boolean isTypeConflicts = false;
+            if ( fields.size() != 1 )
+            {
+                isTypeConflicts = checkTypeConflict( fields );
+            }
+
+            checkState( !isTypeConflicts, "   Found multiple annotation @%s for type: %s; binding skipped!.",
+                        Mock.class.getSimpleName(), type );
+            for ( final Field field : fields )
+            {
+                final TypeLiteral literal = TypeLiteral.get( type );
+                final Mock annoBy = field.getAnnotation( Mock.class );
+                final Object mock = this.mockedFields.get( field );
+                if ( annoBy.annotatedWith() != Mock.NoAnnotation.class )
+                {
+                    bind( literal ).annotatedWith( annoBy.annotatedWith() ).toInstance( mock );
+                }
+                else if ( !"".equals( annoBy.namedWith() ) )
+                {
+                    bind( literal ).annotatedWith( Names.named( annoBy.namedWith() ) ).toInstance( mock );
+                }
+                else
+                {
+                    bind( literal ).toInstance( mock );
+                }
+                if ( LOGGER.isLoggable( Level.FINER ) )
+                {
+                    LOGGER.finer( "    Created binding for: " + type + " " + annoBy );
+                }
+            }
+        }
+    }
+
+    /**
+     * @param fields
+     * @return
+     */
+    private boolean checkTypeConflict( Collection<Field> fields )
+    {
+        final List<Class<?>> listAnnotatedType = new ArrayList<Class<?>>();
+        final List<String> listNamedType = new ArrayList<String>();
+        int numOfSimpleType = 0;
+
+        for ( Field field : fields )
+        {
+            final Mock annoBy = field.getAnnotation( Mock.class );
+
+            if ( annoBy.annotatedWith() == Mock.NoAnnotation.class && "".equals( annoBy.namedWith() ) )
+            {
+                numOfSimpleType++;
+            }
+            if ( numOfSimpleType > 1 )
+            {
+                LOGGER.finer( "Found multiple simple type" );
+                return true;
+            }
+
+            if ( annoBy.annotatedWith() != Mock.NoAnnotation.class )
+            {
+                if ( !listAnnotatedType.contains( annoBy.annotatedWith() ) )
+                {
+                    listAnnotatedType.add( annoBy.annotatedWith() );
+                }
+                else
+                {
+                    // found two fields with same annotation
+                    LOGGER.finer( "Found multiple annotatedBy type" );
+                    return true;
+                }
+            }
+
+            if ( !"".equals( annoBy.namedWith() ) )
+            {
+                if ( !listNamedType.contains( annoBy.namedWith() ) )
+                {
+                    listNamedType.add( annoBy.namedWith() );
+                }
+                else
+                {
+                    // found two fields with same named annotation
+                    LOGGER.finer( "Found multiple namedWith type" );
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/GuiceMockModule.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/GuiceMockModule.java
@@ -57,11 +57,9 @@ import com.google.inject.name.Names;
  * into the test class.
  * </p>
  */
-public class GuiceMockModule
-    extends AbstractModule
-{
+public class GuiceMockModule extends AbstractModule {
 
-    private static final Logger LOGGER = Logger.getLogger( GuiceMockModule.class.getName() );
+    private static final Logger LOGGER = Logger.getLogger(GuiceMockModule.class.getName());
 
     final Map<Field, Object> mockedFields;
 
@@ -71,54 +69,42 @@ public class GuiceMockModule
      * @param mockedFields the map of mock fileds.
      */
 
-    public GuiceMockModule( final Map<Field, Object> mockedFields )
-    {
+    public GuiceMockModule(final Map<Field, Object> mockedFields) {
         this.mockedFields = mockedFields;
     }
 
-    @SuppressWarnings( "unchecked" )
+    @SuppressWarnings("unchecked")
     @Override
-    protected void configure()
-    {
+    protected void configure() {
         final Multimap<Type, Field> fieldsByType = HashMultimap.create();
 
-        for ( final Entry<Field, Object> entry : this.mockedFields.entrySet() )
-        {
-            fieldsByType.put( entry.getKey().getGenericType(), entry.getKey() );
+        for (final Entry<Field, Object> entry : this.mockedFields.entrySet()) {
+            fieldsByType.put(entry.getKey().getGenericType(), entry.getKey());
         }
 
-        for ( final Type type : fieldsByType.keySet() )
-        {
-            final Collection<Field> fields = fieldsByType.get( type );
+        for (final Type type : fieldsByType.keySet()) {
+            final Collection<Field> fields = fieldsByType.get(type);
 
             boolean isTypeConflicts = false;
-            if ( fields.size() != 1 )
-            {
-                isTypeConflicts = checkTypeConflict( fields );
+            if (fields.size() != 1) {
+                isTypeConflicts = checkTypeConflict(fields);
             }
 
-            checkState( !isTypeConflicts, "   Found multiple annotation @%s for type: %s; binding skipped!.",
-                        Mock.class.getSimpleName(), type );
-            for ( final Field field : fields )
-            {
-                final TypeLiteral literal = TypeLiteral.get( type );
-                final Mock annoBy = field.getAnnotation( Mock.class );
-                final Object mock = this.mockedFields.get( field );
-                if ( annoBy.annotatedWith() != Mock.NoAnnotation.class )
-                {
-                    bind( literal ).annotatedWith( annoBy.annotatedWith() ).toInstance( mock );
+            checkState(!isTypeConflicts, "   Found multiple annotation @%s for type: %s; binding skipped!.",
+                Mock.class.getSimpleName(), type);
+            for (final Field field : fields) {
+                final TypeLiteral literal = TypeLiteral.get(type);
+                final Mock annoBy = field.getAnnotation(Mock.class);
+                final Object mock = this.mockedFields.get(field);
+                if (annoBy.annotatedWith() != Mock.NoAnnotation.class) {
+                    bind(literal).annotatedWith(annoBy.annotatedWith()).toInstance(mock);
+                } else if (!"".equals(annoBy.namedWith())) {
+                    bind(literal).annotatedWith(Names.named(annoBy.namedWith())).toInstance(mock);
+                } else {
+                    bind(literal).toInstance(mock);
                 }
-                else if ( !"".equals( annoBy.namedWith() ) )
-                {
-                    bind( literal ).annotatedWith( Names.named( annoBy.namedWith() ) ).toInstance( mock );
-                }
-                else
-                {
-                    bind( literal ).toInstance( mock );
-                }
-                if ( LOGGER.isLoggable( Level.FINER ) )
-                {
-                    LOGGER.finer( "    Created binding for: " + type + " " + annoBy );
+                if (LOGGER.isLoggable(Level.FINER)) {
+                    LOGGER.finer("    Created binding for: " + type + " " + annoBy);
                 }
             }
         }
@@ -128,50 +114,38 @@ public class GuiceMockModule
      * @param fields
      * @return
      */
-    private boolean checkTypeConflict( Collection<Field> fields )
-    {
+    private boolean checkTypeConflict(Collection<Field> fields) {
         final List<Class<?>> listAnnotatedType = new ArrayList<Class<?>>();
         final List<String> listNamedType = new ArrayList<String>();
         int numOfSimpleType = 0;
 
-        for ( Field field : fields )
-        {
-            final Mock annoBy = field.getAnnotation( Mock.class );
+        for (Field field : fields) {
+            final Mock annoBy = field.getAnnotation(Mock.class);
 
-            if ( annoBy.annotatedWith() == Mock.NoAnnotation.class && "".equals( annoBy.namedWith() ) )
-            {
+            if (annoBy.annotatedWith() == Mock.NoAnnotation.class && "".equals(annoBy.namedWith())) {
                 numOfSimpleType++;
             }
-            if ( numOfSimpleType > 1 )
-            {
-                LOGGER.finer( "Found multiple simple type" );
+            if (numOfSimpleType > 1) {
+                LOGGER.finer("Found multiple simple type");
                 return true;
             }
 
-            if ( annoBy.annotatedWith() != Mock.NoAnnotation.class )
-            {
-                if ( !listAnnotatedType.contains( annoBy.annotatedWith() ) )
-                {
-                    listAnnotatedType.add( annoBy.annotatedWith() );
-                }
-                else
-                {
+            if (annoBy.annotatedWith() != Mock.NoAnnotation.class) {
+                if (!listAnnotatedType.contains(annoBy.annotatedWith())) {
+                    listAnnotatedType.add(annoBy.annotatedWith());
+                } else {
                     // found two fields with same annotation
-                    LOGGER.finer( "Found multiple annotatedBy type" );
+                    LOGGER.finer("Found multiple annotatedBy type");
                     return true;
                 }
             }
 
-            if ( !"".equals( annoBy.namedWith() ) )
-            {
-                if ( !listNamedType.contains( annoBy.namedWith() ) )
-                {
-                    listNamedType.add( annoBy.namedWith() );
-                }
-                else
-                {
+            if (!"".equals(annoBy.namedWith())) {
+                if (!listNamedType.contains(annoBy.namedWith())) {
+                    listNamedType.add(annoBy.namedWith());
+                } else {
                     // found two fields with same named annotation
-                    LOGGER.finer( "Found multiple namedWith type" );
+                    LOGGER.finer("Found multiple namedWith type");
                     return true;
                 }
             }

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/MockEngineFactory.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/MockEngineFactory.java
@@ -26,17 +26,15 @@ import org.apache.james.mpt.onami.test.mock.framework.MockitoFramework;
 
 /**
  * Factory class to create the mock framework.
- * 
+ *
  * @see org.apache.onami.test.annotation.MockFramework
  */
-final class MockEngineFactory
-{
+final class MockEngineFactory {
 
     /**
      * Hidden constructor, this class must not be instantiated directly.
      */
-    private MockEngineFactory()
-    {
+    private MockEngineFactory() {
         // do nothing
     }
 
@@ -44,14 +42,12 @@ final class MockEngineFactory
      * Mock factory constructor. <br>
      * Supported framewors: <li> {@link MockType}.EASY_MOCK <li> {@link MockType}.MOCKITO <br>
      *
-     * @see MockType
      * @param type of mock framework to create.
      * @return An instance of mock framework.
+     * @see MockType
      */
-    public static MockEngine getMockEngine(MockType type )
-    {
-        switch ( type )
-        {
+    public static MockEngine getMockEngine(MockType type) {
+        switch (type) {
             case EASY_MOCK:
                 return new EasyMockFramework();
 
@@ -59,7 +55,7 @@ final class MockEngineFactory
                 return new MockitoFramework();
 
             default:
-                throw new IllegalArgumentException( "Unrecognized MockType '" + type.name() + "'" );
+                throw new IllegalArgumentException("Unrecognized MockType '" + type.name() + "'");
         }
     }
 

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/MockEngineFactory.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/MockEngineFactory.java
@@ -1,0 +1,66 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+import org.apache.james.mpt.onami.test.annotation.MockType;
+import org.apache.james.mpt.onami.test.mock.MockEngine;
+import org.apache.james.mpt.onami.test.mock.framework.EasyMockFramework;
+import org.apache.james.mpt.onami.test.mock.framework.MockitoFramework;
+
+/**
+ * Factory class to create the mock framework.
+ * 
+ * @see org.apache.onami.test.annotation.MockFramework
+ */
+final class MockEngineFactory
+{
+
+    /**
+     * Hidden constructor, this class must not be instantiated directly.
+     */
+    private MockEngineFactory()
+    {
+        // do nothing
+    }
+
+    /**
+     * Mock factory constructor. <br>
+     * Supported framewors: <li> {@link MockType}.EASY_MOCK <li> {@link MockType}.MOCKITO <br>
+     *
+     * @see MockType
+     * @param type of mock framework to create.
+     * @return An instance of mock framework.
+     */
+    public static MockEngine getMockEngine(MockType type )
+    {
+        switch ( type )
+        {
+            case EASY_MOCK:
+                return new EasyMockFramework();
+
+            case MOCKITO:
+                return new MockitoFramework();
+
+            default:
+                throw new IllegalArgumentException( "Unrecognized MockType '" + type.name() + "'" );
+        }
+    }
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/OnamiRunner.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/OnamiRunner.java
@@ -1,0 +1,510 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.annotation.GuiceProvidedModules;
+import org.apache.james.mpt.onami.test.annotation.Mock;
+import org.apache.james.mpt.onami.test.annotation.MockFramework;
+import org.apache.james.mpt.onami.test.annotation.MockType;
+import org.apache.james.mpt.onami.test.guice.MockTypeListener;
+import org.apache.james.mpt.onami.test.handler.GuiceInjectableClassHandler;
+import org.apache.james.mpt.onami.test.handler.GuiceModuleHandler;
+import org.apache.james.mpt.onami.test.handler.GuiceProvidedModuleHandler;
+import org.apache.james.mpt.onami.test.handler.MockFrameworkHandler;
+import org.apache.james.mpt.onami.test.handler.MockHandler;
+import org.apache.james.mpt.onami.test.mock.MockEngine;
+import org.apache.james.mpt.onami.test.reflection.ClassVisitor;
+import org.apache.james.mpt.onami.test.reflection.HandleException;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.matcher.Matchers;
+import com.google.inject.util.Modules;
+
+/**
+ * <p>
+ * It's a {@link BlockJUnit4ClassRunner} runner.
+ * </p>
+ * <p>
+ * This class creates a Google Guice {@link Injector} configured by {@link GuiceModules} annotation (only fr modules
+ * with default constructor) and {@link GuiceProvidedModules} annotation and {@link Mock}.
+ * </p>
+ * <p>
+ * <b>Example #1:</b> <br>
+ * 
+ * <pre>
+ * 
+ * &#064;org.junit.runner.RunWith( OnamiRunner.class )
+ * &#064;GuiceModules( SimpleModule.class )
+ * public class AcmeTestCase
+ * {
+ * 
+ *     &#064;GuiceProvidedModules
+ *     static public Module getProperties()
+ *     {
+
+import org.apache.onami.test.reflection.AnnotationHandler;
+import org.apache.onami.test.reflection.HandleException;
+ *         ...
+ *         return Modules.combine(new ComplexModule( loadProperies() ), ...  );
+ *     }
+ * 
+ * </pre>
+ * 
+ * </p>
+ * <p>
+ * <b>Example #2:</b> <br>
+ * 
+ * <pre>
+ * 
+ * &#064;org.junit.runner.RunWith( OnamiRunner.class )
+ * public class AcmeTestCase
+ *     extends com.google.inject.AbstractModule
+ * {
+ * 
+ *     public void configure()
+ *     {
+ *         // Configure your proper modules
+ *         ...
+ *         bind( Service.class ).annotatedWith( TestAnnotation.class ).to( ServiceTestImpl.class );
+ *         ...
+ *     }
+ * 
+ *     &#064;Mock
+ *     private AnotherService serviceMock;
+ * 
+ *     &#064;Inject
+ *     private Service serviceTest;
+ * 
+ *     &#064;org.junit.Test
+ *     public void test()
+ *     {
+ *         assertNotNull( serviceMock );
+ *         assertNotNull( serviceTest );
+ *     }
+ * </pre>
+ * 
+ * </p>
+ * 
+ * @see GuiceMockModule
+ */
+public class OnamiRunner
+    extends BlockJUnit4ClassRunner
+{
+
+    private static final Logger LOGGER = Logger.getLogger( OnamiRunner.class.getName() );
+
+    private Injector injector;
+
+    private final List<Module> allModules;
+
+    private final Map<Field, Object> mocked = new HashMap<Field, Object>( 1 );
+
+    private MockType mockFramework = MockType.EASY_MOCK;
+
+    /**
+     * OnamiRunner constructor to create the core JUnice class.
+     * 
+     * @see org.junit.runner.RunWith
+     * @param klass The test case class to run.
+     * @throws org.junit.runners.model.InitializationError if any error occurs.
+     */
+    public OnamiRunner( Class<?> klass )
+        throws InitializationError
+    {
+        super( klass );
+
+        try
+        {
+            if ( LOGGER.isLoggable( Level.FINER ) )
+            {
+                LOGGER.finer( "Inizializing injector for test class: " + klass.getName() );
+            }
+
+            this.allModules = inizializeInjector( klass );
+
+            if ( LOGGER.isLoggable( Level.FINER ) )
+            {
+                LOGGER.finer( "done..." );
+            }
+        }
+        catch ( Exception e )
+        {
+            final List<Throwable> throwables = new LinkedList<Throwable>();
+            throwables.add( e );
+            throw new InitializationError( throwables );
+        }
+    }
+
+    /**
+     * OnamiRunner constructor to create the runner needed
+     * by the OnamiSuite class.
+     * 
+     * @see org.junit.runner.RunWith
+     * @param suite The suite test case class to run.
+     * @param test The test case class to run.
+     * @throws org.junit.runners.model.InitializationError if any error occurs.
+     */
+    public OnamiRunner( Class<?> suite, Class<?> test )
+        throws InitializationError
+    {
+        super( test );
+
+        try
+        {
+            if ( LOGGER.isLoggable( Level.FINER ) )
+            {
+                LOGGER.finer( "Inizializing injector for test class: " + test.getName() );
+            }
+
+            this.allModules = inizializeInjector( suite, test );
+
+            if ( LOGGER.isLoggable( Level.FINER ) )
+            {
+                LOGGER.finer( "done..." );
+            }
+        }
+        catch ( Exception e )
+        {
+            final List<Throwable> throwables = new LinkedList<Throwable>();
+            throwables.add( e );
+            throw new InitializationError( throwables );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void run( final RunNotifier notifier )
+    {
+        if ( LOGGER.isLoggable( Level.FINER ) )
+        {
+            LOGGER.finer( " ### Run test case: " + getTestClass().getJavaClass() + " ### " );
+            LOGGER.finer( " #### Creating injector ####" );
+        }
+
+        this.injector = createInjector( allModules );
+        super.run( notifier );
+        this.flush();
+
+        if ( LOGGER.isLoggable( Level.FINER ) )
+        {
+            LOGGER.finer( " ### End test case: " + getTestClass().getJavaClass().getName() + " ### " );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    private void flush()
+    {
+        this.injector = null;
+        this.allModules.clear();
+        this.mocked.clear();
+    }
+
+    @Override
+    protected void runChild( FrameworkMethod method, RunNotifier notifier )
+    {
+        if ( LOGGER.isLoggable( Level.FINER ) )
+        {
+            LOGGER.finer( " +++ invoke test method: " + method.getName() + " +++ " );
+        }
+
+        super.runChild( method, notifier );
+        resetAllResetAfterMocks();
+
+        if ( LOGGER.isLoggable( Level.FINER ) )
+        {
+            LOGGER.finer( " --- end test method: " + method.getName() + " --- " );
+        }
+    }
+
+    /**
+     * Creates test instance via Google-Guice to inject all not-static dependencies.
+     * @return The instance of the test case.
+     * @throws Exception when an error occurs.
+     */
+    @Override
+    protected Object createTest()
+        throws Exception
+    {
+        if ( LOGGER.isLoggable( Level.FINER ) )
+        {
+            LOGGER.finer( " Create and inject test class: " + getTestClass().getJavaClass() );
+        }
+        return this.injector.getInstance( getTestClass().getJavaClass() );
+    }
+
+    /**
+     * Shortcut to create the Injector given a list of Modules.
+     *
+     * @param modules the list of modules have to be load
+     * @return an Injector instance built using the input Module list
+     */
+    protected Injector createInjector( List<Module> modules )
+    {
+        return Guice.createInjector( modules );
+    }
+
+    /**
+     * This method collects modules from {@link GuiceModules}, {@link GuiceProvidedModules}, {@link Mock}
+     * and {@ OnamiSuite}.
+     *
+     * @param <T> whatever input type is accepted
+     * @param suite the input suite to be analyzed
+     * @param test the input class has to be analyzed
+     * @return a List of Guice Modules built after input class analysis.
+     * @throws IllegalAccessException when a n error occurs.
+     * @throws InstantiationException when a n error occurs.
+     * @throws HandleException when a n error occurs.
+     */
+    protected <T> List<Module> inizializeInjector( Class<?> suite, Class<T> test)
+        throws HandleException, InstantiationException, IllegalAccessException
+    {
+        final List<Module> modules = inizializeInjector(test);
+        Module m = visitClass( suite );
+        if ( m != null )
+        {
+            modules.add( m );
+        }
+        return modules;
+    }
+
+    /**
+     * This method collects modules from {@link GuiceModules}, {@link GuiceProvidedModules}, {@link Mock}.
+     *
+     * @param <T> whatever input type is accepted
+     * @param clazz the input class has to be analyzed
+     * @return a List of Guice Modules built after input class analysis.
+     * @throws IllegalAccessException when a n error occurs.
+     * @throws InstantiationException when a n error occurs.
+     * @throws HandleException when a n error occurs.
+     */
+    protected <T> List<Module> inizializeInjector( Class<T> clazz )
+        throws HandleException, InstantiationException, IllegalAccessException
+    {
+        final List<Module> modules = new ArrayList<Module>();
+        Module m = visitClass( clazz );
+        if ( m != null )
+        {
+            modules.add( m );
+        }
+        return modules;
+    }
+
+    private void resetAllResetAfterMocks()
+    {
+        for ( Entry<Field, Object> entry : mocked.entrySet() )
+        {
+            final Mock mockAnnotation = entry.getKey().getAnnotation( Mock.class );
+            if ( mockAnnotation.resetAfter() )
+            {
+                MockEngine mockEngine = MockEngineFactory.getMockEngine( mockFramework );
+                mockEngine.resetMock( entry.getValue() );
+            }
+        }
+    }
+
+    /**
+     * @throws HandleException
+     * @throws IllegalAccessException
+     * @throws InstantiationException
+     */
+    private <T> Module visitClass( final Class<T> clazz )
+        throws HandleException, InstantiationException, IllegalAccessException
+    {
+        try
+        {
+            if ( LOGGER.isLoggable( Level.FINER ) )
+            {
+                LOGGER.finer( "  Start introspecting class: " + clazz.getName() );
+            }
+            final List<Module> allModules = new ArrayList<Module>();
+
+            // Setup the handlers
+            final GuiceProvidedModuleHandler guiceProvidedModuleHandler = new GuiceProvidedModuleHandler();
+            final GuiceModuleHandler guiceModuleHandler = new GuiceModuleHandler();
+            final GuiceInjectableClassHandler<Inject> guiceInjectableClassHandler = new GuiceInjectableClassHandler<com.google.inject.Inject>();
+            final GuiceInjectableClassHandler<javax.inject.Inject> jsr330InjectableClassHandler = new GuiceInjectableClassHandler<javax.inject.Inject>();
+
+            final MockHandler mockHandler = new MockHandler();
+            final MockFrameworkHandler mockFrameworkHandler = new MockFrameworkHandler();
+
+            // Visit class and super-classes
+            new ClassVisitor()
+            .registerHandler( GuiceProvidedModules.class, guiceProvidedModuleHandler )
+            .registerHandler( GuiceModules.class, guiceModuleHandler )
+            .registerHandler( Mock.class, mockHandler )
+            .registerHandler( MockFramework.class, mockFrameworkHandler )
+            .registerHandler( com.google.inject.Inject.class, guiceInjectableClassHandler )
+            .registerHandler( javax.inject.Inject.class, jsr330InjectableClassHandler )
+            .visit( clazz );
+
+            // Retrieve mock framework
+            if ( mockFrameworkHandler.getMockType() != null )
+            {
+                this.mockFramework = mockFrameworkHandler.getMockType();
+            }
+
+            // retrieve the modules founded
+            allModules.addAll( guiceProvidedModuleHandler.getModules() );
+            allModules.addAll( guiceModuleHandler.getModules() );
+            MockEngine engine = MockEngineFactory.getMockEngine( this.mockFramework );
+            this.mocked.putAll( mockHandler.getMockedObject( engine ) );
+            if ( !this.mocked.isEmpty() )
+            {
+                // Replace all real module binding with Mocked moduled.
+                Module m = Modules.override( allModules ).with( new GuiceMockModule( this.mocked ) );
+                allModules.clear();
+                allModules.add( m );
+            }
+
+            // Add only clasess that have got the Inject annotation
+             final Class<?>[] guiceInjectableClasses = guiceInjectableClassHandler.getClasses();
+             final Class<?>[] jsr330InjectableClasses = jsr330InjectableClassHandler.getClasses();
+
+            final AbstractModule statcInjector = new AbstractModule()
+            {
+                @Override
+                protected void configure()
+                {
+                    // inject all STATIC dependencies
+                    if ( guiceInjectableClasses.length != 0 )
+                    {
+                        requestStaticInjection( guiceInjectableClasses );
+                    }
+                    
+                    if ( jsr330InjectableClasses.length != 0 )
+                    {
+                        requestStaticInjection( jsr330InjectableClasses );
+                    }
+
+                    
+                }
+            };
+            if ( guiceInjectableClasses.length != 0 || jsr330InjectableClasses.length != 0 )
+            {
+                allModules.add( statcInjector );
+            }
+
+            // Check if the class is itself a Google Module.
+            if ( Module.class.isAssignableFrom( getTestClass().getJavaClass() ) )
+            {
+                if ( LOGGER.isLoggable( Level.FINER ) )
+                {
+                    LOGGER.finer( "   creating module from test class " + getTestClass().getJavaClass() );
+                }
+                final Module classModule = (Module) getTestClass().getJavaClass().newInstance();
+                allModules.add( classModule );
+            }
+
+            // create MockTypeListenerModule
+            if ( this.mocked.size() != 0 )
+            {
+                final AbstractModule mockTypeListenerModule = new AbstractModule()
+                {
+                    @Override
+                    protected void configure()
+                    {
+                        bindListener( Matchers.any(), new MockTypeListener( mocked ) );
+                    }
+                };
+
+                // BEGIN patch for issue: google-guice: #452
+                for ( Entry<Field, Object> entry : mocked.entrySet() )
+                {
+                    final Field field = entry.getKey();
+                    final Object mock = entry.getValue();
+                    if ( Modifier.isStatic( field.getModifiers() ) )
+                    {
+                        if ( LOGGER.isLoggable( Level.FINER ) )
+                        {
+                            LOGGER.finer( "   inject static mock field: " + field.getName() );
+                        }
+
+                        AccessController.doPrivileged( new PrivilegedAction<Void>()
+                        {
+
+                            public Void run()
+                            {
+                                field.setAccessible( true );
+                                return null;
+                            }
+
+                        } );
+                        field.set( field.getDeclaringClass(), mock );
+                    }
+                }
+                // END patch for issue: google-guice: #452
+
+                allModules.add( mockTypeListenerModule );
+            }
+
+            if ( allModules.size() != 0 )
+            {
+                if ( LOGGER.isLoggable( Level.FINER ) )
+                {
+                    StringBuilder builder = new StringBuilder();
+                    builder.append( " Collected modules: " );
+                    builder.append( "\n" );
+                    for ( Module module : allModules )
+                    {
+                        builder.append( "    " ).append( module );
+                        builder.append( "\n" );
+                    }
+                    LOGGER.finer( builder.toString() );
+                }
+                return Modules.combine( allModules );
+            }
+            return null;
+        }
+        finally
+        {
+            if ( LOGGER.isLoggable( Level.FINER ) )
+            {
+                LOGGER.finer( " ...done" );
+            }
+        }
+    }
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/OnamiRunner.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/OnamiRunner.java
@@ -69,37 +69,34 @@ import com.google.inject.util.Modules;
  * </p>
  * <p>
  * <b>Example #1:</b> <br>
- * 
+ * <p>
  * <pre>
- * 
+ *
  * &#064;org.junit.runner.RunWith( OnamiRunner.class )
  * &#064;GuiceModules( SimpleModule.class )
  * public class AcmeTestCase
  * {
- * 
+ *
  *     &#064;GuiceProvidedModules
  *     static public Module getProperties()
  *     {
-
-import org.apache.onami.test.reflection.AnnotationHandler;
-import org.apache.onami.test.reflection.HandleException;
  *         ...
  *         return Modules.combine(new ComplexModule( loadProperies() ), ...  );
  *     }
- * 
+ *
  * </pre>
- * 
+ * <p>
  * </p>
  * <p>
  * <b>Example #2:</b> <br>
- * 
+ * <p>
  * <pre>
- * 
+ *
  * &#064;org.junit.runner.RunWith( OnamiRunner.class )
  * public class AcmeTestCase
  *     extends com.google.inject.AbstractModule
  * {
- * 
+ *
  *     public void configure()
  *     {
  *         // Configure your proper modules
@@ -107,13 +104,13 @@ import org.apache.onami.test.reflection.HandleException;
  *         bind( Service.class ).annotatedWith( TestAnnotation.class ).to( ServiceTestImpl.class );
  *         ...
  *     }
- * 
+ *
  *     &#064;Mock
  *     private AnotherService serviceMock;
- * 
+ *
  *     &#064;Inject
  *     private Service serviceTest;
- * 
+ *
  *     &#064;org.junit.Test
  *     public void test()
  *     {
@@ -121,92 +118,78 @@ import org.apache.onami.test.reflection.HandleException;
  *         assertNotNull( serviceTest );
  *     }
  * </pre>
- * 
+ * <p>
  * </p>
- * 
+ *
  * @see GuiceMockModule
  */
-public class OnamiRunner
-    extends BlockJUnit4ClassRunner
-{
+public class OnamiRunner extends BlockJUnit4ClassRunner {
 
-    private static final Logger LOGGER = Logger.getLogger( OnamiRunner.class.getName() );
+    private static final Logger LOGGER = Logger.getLogger(OnamiRunner.class.getName());
 
     private Injector injector;
 
     private final List<Module> allModules;
 
-    private final Map<Field, Object> mocked = new HashMap<Field, Object>( 1 );
+    private final Map<Field, Object> mocked = new HashMap<Field, Object>(1);
 
     private MockType mockFramework = MockType.EASY_MOCK;
 
     /**
      * OnamiRunner constructor to create the core JUnice class.
-     * 
-     * @see org.junit.runner.RunWith
+     *
      * @param klass The test case class to run.
      * @throws org.junit.runners.model.InitializationError if any error occurs.
+     * @see org.junit.runner.RunWith
      */
-    public OnamiRunner( Class<?> klass )
-        throws InitializationError
-    {
-        super( klass );
+    public OnamiRunner(Class<?> klass)
+        throws InitializationError {
+        super(klass);
 
-        try
-        {
-            if ( LOGGER.isLoggable( Level.FINER ) )
-            {
-                LOGGER.finer( "Inizializing injector for test class: " + klass.getName() );
+        try {
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.finer("Inizializing injector for test class: " + klass.getName());
             }
 
-            this.allModules = inizializeInjector( klass );
+            this.allModules = inizializeInjector(klass);
 
-            if ( LOGGER.isLoggable( Level.FINER ) )
-            {
-                LOGGER.finer( "done..." );
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.finer("done...");
             }
-        }
-        catch ( Exception e )
-        {
+        } catch (Exception e) {
             final List<Throwable> throwables = new LinkedList<Throwable>();
-            throwables.add( e );
-            throw new InitializationError( throwables );
+            throwables.add(e);
+            throw new InitializationError(throwables);
         }
     }
 
     /**
      * OnamiRunner constructor to create the runner needed
      * by the OnamiSuite class.
-     * 
-     * @see org.junit.runner.RunWith
+     *
      * @param suite The suite test case class to run.
-     * @param test The test case class to run.
+     * @param test  The test case class to run.
      * @throws org.junit.runners.model.InitializationError if any error occurs.
+     * @see org.junit.runner.RunWith
      */
-    public OnamiRunner( Class<?> suite, Class<?> test )
-        throws InitializationError
-    {
-        super( test );
+    public OnamiRunner(Class<?> suite, Class<?> test)
+        throws InitializationError {
+        super(test);
 
-        try
-        {
-            if ( LOGGER.isLoggable( Level.FINER ) )
-            {
-                LOGGER.finer( "Inizializing injector for test class: " + test.getName() );
+        try {
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.finer("Inizializing injector for test class: " + test.getName());
             }
 
-            this.allModules = inizializeInjector( suite, test );
+            this.allModules = inizializeInjector(suite, test);
 
-            if ( LOGGER.isLoggable( Level.FINER ) )
-            {
-                LOGGER.finer( "done..." );
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.finer("done...");
             }
-        }
-        catch ( Exception e )
-        {
+        } catch (Exception e) {
             final List<Throwable> throwables = new LinkedList<Throwable>();
-            throwables.add( e );
-            throw new InitializationError( throwables );
+            throwables.add(e);
+            throw new InitializationError(throwables);
         }
     }
 
@@ -214,65 +197,57 @@ public class OnamiRunner
      * {@inheritDoc}
      */
     @Override
-    public void run( final RunNotifier notifier )
-    {
-        if ( LOGGER.isLoggable( Level.FINER ) )
-        {
-            LOGGER.finer( " ### Run test case: " + getTestClass().getJavaClass() + " ### " );
-            LOGGER.finer( " #### Creating injector ####" );
+    public void run(final RunNotifier notifier) {
+        if (LOGGER.isLoggable(Level.FINER)) {
+            LOGGER.finer(" ### Run test case: " + getTestClass().getJavaClass() + " ### ");
+            LOGGER.finer(" #### Creating injector ####");
         }
 
-        this.injector = createInjector( allModules );
-        super.run( notifier );
+        this.injector = createInjector(allModules);
+        super.run(notifier);
         this.flush();
 
-        if ( LOGGER.isLoggable( Level.FINER ) )
-        {
-            LOGGER.finer( " ### End test case: " + getTestClass().getJavaClass().getName() + " ### " );
+        if (LOGGER.isLoggable(Level.FINER)) {
+            LOGGER.finer(" ### End test case: " + getTestClass().getJavaClass().getName() + " ### ");
         }
     }
 
     /**
      * {@inheritDoc}
      */
-    private void flush()
-    {
+    private void flush() {
         this.injector = null;
         this.allModules.clear();
         this.mocked.clear();
     }
 
     @Override
-    protected void runChild( FrameworkMethod method, RunNotifier notifier )
-    {
-        if ( LOGGER.isLoggable( Level.FINER ) )
-        {
-            LOGGER.finer( " +++ invoke test method: " + method.getName() + " +++ " );
+    protected void runChild(FrameworkMethod method, RunNotifier notifier) {
+        if (LOGGER.isLoggable(Level.FINER)) {
+            LOGGER.finer(" +++ invoke test method: " + method.getName() + " +++ ");
         }
 
-        super.runChild( method, notifier );
+        super.runChild(method, notifier);
         resetAllResetAfterMocks();
 
-        if ( LOGGER.isLoggable( Level.FINER ) )
-        {
-            LOGGER.finer( " --- end test method: " + method.getName() + " --- " );
+        if (LOGGER.isLoggable(Level.FINER)) {
+            LOGGER.finer(" --- end test method: " + method.getName() + " --- ");
         }
     }
 
     /**
      * Creates test instance via Google-Guice to inject all not-static dependencies.
+     *
      * @return The instance of the test case.
      * @throws Exception when an error occurs.
      */
     @Override
     protected Object createTest()
-        throws Exception
-    {
-        if ( LOGGER.isLoggable( Level.FINER ) )
-        {
-            LOGGER.finer( " Create and inject test class: " + getTestClass().getJavaClass() );
+        throws Exception {
+        if (LOGGER.isLoggable(Level.FINER)) {
+            LOGGER.finer(" Create and inject test class: " + getTestClass().getJavaClass());
         }
-        return this.injector.getInstance( getTestClass().getJavaClass() );
+        return this.injector.getInstance(getTestClass().getJavaClass());
     }
 
     /**
@@ -281,31 +256,28 @@ public class OnamiRunner
      * @param modules the list of modules have to be load
      * @return an Injector instance built using the input Module list
      */
-    protected Injector createInjector( List<Module> modules )
-    {
-        return Guice.createInjector( modules );
+    protected Injector createInjector(List<Module> modules) {
+        return Guice.createInjector(modules);
     }
 
     /**
      * This method collects modules from {@link GuiceModules}, {@link GuiceProvidedModules}, {@link Mock}
      * and {@ OnamiSuite}.
      *
-     * @param <T> whatever input type is accepted
+     * @param <T>   whatever input type is accepted
      * @param suite the input suite to be analyzed
-     * @param test the input class has to be analyzed
+     * @param test  the input class has to be analyzed
      * @return a List of Guice Modules built after input class analysis.
      * @throws IllegalAccessException when a n error occurs.
      * @throws InstantiationException when a n error occurs.
-     * @throws HandleException when a n error occurs.
+     * @throws HandleException        when a n error occurs.
      */
-    protected <T> List<Module> inizializeInjector( Class<?> suite, Class<T> test)
-        throws HandleException, InstantiationException, IllegalAccessException
-    {
+    protected <T> List<Module> inizializeInjector(Class<?> suite, Class<T> test)
+        throws HandleException, InstantiationException, IllegalAccessException {
         final List<Module> modules = inizializeInjector(test);
-        Module m = visitClass( suite );
-        if ( m != null )
-        {
-            modules.add( m );
+        Module m = visitClass(suite);
+        if (m != null) {
+            modules.add(m);
         }
         return modules;
     }
@@ -313,34 +285,29 @@ public class OnamiRunner
     /**
      * This method collects modules from {@link GuiceModules}, {@link GuiceProvidedModules}, {@link Mock}.
      *
-     * @param <T> whatever input type is accepted
+     * @param <T>   whatever input type is accepted
      * @param clazz the input class has to be analyzed
      * @return a List of Guice Modules built after input class analysis.
      * @throws IllegalAccessException when a n error occurs.
      * @throws InstantiationException when a n error occurs.
-     * @throws HandleException when a n error occurs.
+     * @throws HandleException        when a n error occurs.
      */
-    protected <T> List<Module> inizializeInjector( Class<T> clazz )
-        throws HandleException, InstantiationException, IllegalAccessException
-    {
+    protected <T> List<Module> inizializeInjector(Class<T> clazz)
+        throws HandleException, InstantiationException, IllegalAccessException {
         final List<Module> modules = new ArrayList<Module>();
-        Module m = visitClass( clazz );
-        if ( m != null )
-        {
-            modules.add( m );
+        Module m = visitClass(clazz);
+        if (m != null) {
+            modules.add(m);
         }
         return modules;
     }
 
-    private void resetAllResetAfterMocks()
-    {
-        for ( Entry<Field, Object> entry : mocked.entrySet() )
-        {
-            final Mock mockAnnotation = entry.getKey().getAnnotation( Mock.class );
-            if ( mockAnnotation.resetAfter() )
-            {
-                MockEngine mockEngine = MockEngineFactory.getMockEngine( mockFramework );
-                mockEngine.resetMock( entry.getValue() );
+    private void resetAllResetAfterMocks() {
+        for (Entry<Field, Object> entry : mocked.entrySet()) {
+            final Mock mockAnnotation = entry.getKey().getAnnotation(Mock.class);
+            if (mockAnnotation.resetAfter()) {
+                MockEngine mockEngine = MockEngineFactory.getMockEngine(mockFramework);
+                mockEngine.resetMock(entry.getValue());
             }
         }
     }
@@ -350,14 +317,11 @@ public class OnamiRunner
      * @throws IllegalAccessException
      * @throws InstantiationException
      */
-    private <T> Module visitClass( final Class<T> clazz )
-        throws HandleException, InstantiationException, IllegalAccessException
-    {
-        try
-        {
-            if ( LOGGER.isLoggable( Level.FINER ) )
-            {
-                LOGGER.finer( "  Start introspecting class: " + clazz.getName() );
+    private <T> Module visitClass(final Class<T> clazz)
+        throws HandleException, InstantiationException, IllegalAccessException {
+        try {
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.finer("  Start introspecting class: " + clazz.getName());
             }
             final List<Module> allModules = new ArrayList<Module>();
 
@@ -372,137 +336,114 @@ public class OnamiRunner
 
             // Visit class and super-classes
             new ClassVisitor()
-            .registerHandler( GuiceProvidedModules.class, guiceProvidedModuleHandler )
-            .registerHandler( GuiceModules.class, guiceModuleHandler )
-            .registerHandler( Mock.class, mockHandler )
-            .registerHandler( MockFramework.class, mockFrameworkHandler )
-            .registerHandler( com.google.inject.Inject.class, guiceInjectableClassHandler )
-            .registerHandler( javax.inject.Inject.class, jsr330InjectableClassHandler )
-            .visit( clazz );
+                .registerHandler(GuiceProvidedModules.class, guiceProvidedModuleHandler)
+                .registerHandler(GuiceModules.class, guiceModuleHandler)
+                .registerHandler(Mock.class, mockHandler)
+                .registerHandler(MockFramework.class, mockFrameworkHandler)
+                .registerHandler(com.google.inject.Inject.class, guiceInjectableClassHandler)
+                .registerHandler(javax.inject.Inject.class, jsr330InjectableClassHandler)
+                .visit(clazz);
 
             // Retrieve mock framework
-            if ( mockFrameworkHandler.getMockType() != null )
-            {
+            if (mockFrameworkHandler.getMockType() != null) {
                 this.mockFramework = mockFrameworkHandler.getMockType();
             }
 
             // retrieve the modules founded
-            allModules.addAll( guiceProvidedModuleHandler.getModules() );
-            allModules.addAll( guiceModuleHandler.getModules() );
-            MockEngine engine = MockEngineFactory.getMockEngine( this.mockFramework );
-            this.mocked.putAll( mockHandler.getMockedObject( engine ) );
-            if ( !this.mocked.isEmpty() )
-            {
+            allModules.addAll(guiceProvidedModuleHandler.getModules());
+            allModules.addAll(guiceModuleHandler.getModules());
+            MockEngine engine = MockEngineFactory.getMockEngine(this.mockFramework);
+            this.mocked.putAll(mockHandler.getMockedObject(engine));
+            if (!this.mocked.isEmpty()) {
                 // Replace all real module binding with Mocked moduled.
-                Module m = Modules.override( allModules ).with( new GuiceMockModule( this.mocked ) );
+                Module m = Modules.override(allModules).with(new GuiceMockModule(this.mocked));
                 allModules.clear();
-                allModules.add( m );
+                allModules.add(m);
             }
 
             // Add only clasess that have got the Inject annotation
-             final Class<?>[] guiceInjectableClasses = guiceInjectableClassHandler.getClasses();
-             final Class<?>[] jsr330InjectableClasses = jsr330InjectableClassHandler.getClasses();
+            final Class<?>[] guiceInjectableClasses = guiceInjectableClassHandler.getClasses();
+            final Class<?>[] jsr330InjectableClasses = jsr330InjectableClassHandler.getClasses();
 
-            final AbstractModule statcInjector = new AbstractModule()
-            {
+            final AbstractModule statcInjector = new AbstractModule() {
                 @Override
-                protected void configure()
-                {
+                protected void configure() {
                     // inject all STATIC dependencies
-                    if ( guiceInjectableClasses.length != 0 )
-                    {
-                        requestStaticInjection( guiceInjectableClasses );
-                    }
-                    
-                    if ( jsr330InjectableClasses.length != 0 )
-                    {
-                        requestStaticInjection( jsr330InjectableClasses );
+                    if (guiceInjectableClasses.length != 0) {
+                        requestStaticInjection(guiceInjectableClasses);
                     }
 
-                    
+                    if (jsr330InjectableClasses.length != 0) {
+                        requestStaticInjection(jsr330InjectableClasses);
+                    }
+
+
                 }
             };
-            if ( guiceInjectableClasses.length != 0 || jsr330InjectableClasses.length != 0 )
-            {
-                allModules.add( statcInjector );
+            if (guiceInjectableClasses.length != 0 || jsr330InjectableClasses.length != 0) {
+                allModules.add(statcInjector);
             }
 
             // Check if the class is itself a Google Module.
-            if ( Module.class.isAssignableFrom( getTestClass().getJavaClass() ) )
-            {
-                if ( LOGGER.isLoggable( Level.FINER ) )
-                {
-                    LOGGER.finer( "   creating module from test class " + getTestClass().getJavaClass() );
+            if (Module.class.isAssignableFrom(getTestClass().getJavaClass())) {
+                if (LOGGER.isLoggable(Level.FINER)) {
+                    LOGGER.finer("   creating module from test class " + getTestClass().getJavaClass());
                 }
                 final Module classModule = (Module) getTestClass().getJavaClass().newInstance();
-                allModules.add( classModule );
+                allModules.add(classModule);
             }
 
             // create MockTypeListenerModule
-            if ( this.mocked.size() != 0 )
-            {
-                final AbstractModule mockTypeListenerModule = new AbstractModule()
-                {
+            if (this.mocked.size() != 0) {
+                final AbstractModule mockTypeListenerModule = new AbstractModule() {
                     @Override
-                    protected void configure()
-                    {
-                        bindListener( Matchers.any(), new MockTypeListener( mocked ) );
+                    protected void configure() {
+                        bindListener(Matchers.any(), new MockTypeListener(mocked));
                     }
                 };
 
                 // BEGIN patch for issue: google-guice: #452
-                for ( Entry<Field, Object> entry : mocked.entrySet() )
-                {
+                for (Entry<Field, Object> entry : mocked.entrySet()) {
                     final Field field = entry.getKey();
                     final Object mock = entry.getValue();
-                    if ( Modifier.isStatic( field.getModifiers() ) )
-                    {
-                        if ( LOGGER.isLoggable( Level.FINER ) )
-                        {
-                            LOGGER.finer( "   inject static mock field: " + field.getName() );
+                    if (Modifier.isStatic(field.getModifiers())) {
+                        if (LOGGER.isLoggable(Level.FINER)) {
+                            LOGGER.finer("   inject static mock field: " + field.getName());
                         }
 
-                        AccessController.doPrivileged( new PrivilegedAction<Void>()
-                        {
+                        AccessController.doPrivileged(new PrivilegedAction<Void>() {
 
-                            public Void run()
-                            {
-                                field.setAccessible( true );
+                            public Void run() {
+                                field.setAccessible(true);
                                 return null;
                             }
 
-                        } );
-                        field.set( field.getDeclaringClass(), mock );
+                        });
+                        field.set(field.getDeclaringClass(), mock);
                     }
                 }
                 // END patch for issue: google-guice: #452
 
-                allModules.add( mockTypeListenerModule );
+                allModules.add(mockTypeListenerModule);
             }
 
-            if ( allModules.size() != 0 )
-            {
-                if ( LOGGER.isLoggable( Level.FINER ) )
-                {
+            if (allModules.size() != 0) {
+                if (LOGGER.isLoggable(Level.FINER)) {
                     StringBuilder builder = new StringBuilder();
-                    builder.append( " Collected modules: " );
-                    builder.append( "\n" );
-                    for ( Module module : allModules )
-                    {
-                        builder.append( "    " ).append( module );
-                        builder.append( "\n" );
+                    builder.append(" Collected modules: ");
+                    builder.append("\n");
+                    for (Module module : allModules) {
+                        builder.append("    ").append(module);
+                        builder.append("\n");
                     }
-                    LOGGER.finer( builder.toString() );
+                    LOGGER.finer(builder.toString());
                 }
-                return Modules.combine( allModules );
+                return Modules.combine(allModules);
             }
             return null;
-        }
-        finally
-        {
-            if ( LOGGER.isLoggable( Level.FINER ) )
-            {
-                LOGGER.finer( " ...done" );
+        } finally {
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.finer(" ...done");
             }
         }
     }

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/OnamiSuite.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/OnamiSuite.java
@@ -70,35 +70,35 @@ import com.google.inject.util.Modules;
  * </p>
  * <p>
  * <b>Example #1:</b> <br>
- * 
+ * <p>
  * <pre>
- * 
+ *
  * &#064;org.junit.runner.RunWith( OnamiSuite.class )
  * &#064;GuiceModules( SimpleModule.class )
  * &#064;SuiteClasses({ .class })
  * public class AcmeTestCase
  * {
- * 
+ *
  *     &#064;GuiceProvidedModules
  *     static public Module getProperties()
  *     {
  *         ...
  *         return Modules.combine(new ComplexModule( loadProperies() ), ...  );
  *     }
- * 
+ *
  * </pre>
- * 
+ * <p>
  * </p>
  * <p>
  * <b>Example #2:</b> <br>
- * 
+ * <p>
  * <pre>
- * 
+ *
  * &#064;org.junit.runner.RunWith( OnamiSuite.class )
  * public class AcmeTestCase
  *     extends com.google.inject.AbstractModule
  * {
- * 
+ *
  *     public void configure()
  *     {
  *         // Configure your proper modules
@@ -106,13 +106,13 @@ import com.google.inject.util.Modules;
  *         bind( Service.class ).annotatedWith( TestAnnotation.class ).to( ServiceTestImpl.class );
  *         ...
  *     }
- * 
+ *
  *     &#064;Mock
  *     private AnotherService serviceMock;
- * 
+ *
  *     &#064;Inject
  *     private Service serviceTest;
- * 
+ *
  *     &#064;org.junit.Test
  *     public void test()
  *     {
@@ -120,27 +120,25 @@ import com.google.inject.util.Modules;
  *         assertNotNull( serviceTest );
  *     }
  * </pre>
- * 
+ * <p>
  * </p>
- * 
+ *
  * @see GuiceMockModule
  */
-public class OnamiSuite
-    extends Suite
-{
+public class OnamiSuite extends Suite {
 
-    private static final Logger LOGGER = Logger.getLogger( OnamiSuite.class.getName() );
+    private static final Logger LOGGER = Logger.getLogger(OnamiSuite.class.getName());
 
     private Injector injector;
 
     private final List<Module> allModules;
 
-    private final Map<Field, Object> mocked = new HashMap<Field, Object>( 1 );
+    private final Map<Field, Object> mocked = new HashMap<Field, Object>(1);
 
     private MockType mockFramework = MockType.EASY_MOCK;
 
     private static Class<?>[] getAnnotatedClasses(Class<?> klass) throws InitializationError {
-        SuiteClasses annotation= klass.getAnnotation(SuiteClasses.class);
+        SuiteClasses annotation = klass.getAnnotation(SuiteClasses.class);
         if (annotation == null)
             throw new InitializationError(String.format("class '%s' must have a SuiteClasses annotation", klass.getName()));
         return annotation.value();
@@ -148,78 +146,68 @@ public class OnamiSuite
 
     /**
      * OnamiRunner constructor to create the core JUnice class.
-     * 
-     * @see org.junit.runner.RunWith
+     *
      * @param klass The test case class to run.
      * @throws org.junit.runners.model.InitializationError if any error occurs.
+     * @see org.junit.runner.RunWith
      */
-    public OnamiSuite( Class<?> klass, RunnerBuilder builder )
-        throws InitializationError
-    {
+    public OnamiSuite(Class<?> klass, RunnerBuilder builder)
+        throws InitializationError {
         this(builder, klass, getAnnotatedClasses(klass));
 
     }
 
     /**
      * Called by this class and subclasses once the classes making up the suite have been determined
-     * 
-     * @param builder builds runners for classes in the suite
-     * @param klass the root of the suite
+     *
+     * @param builder      builds runners for classes in the suite
+     * @param klass        the root of the suite
      * @param suiteClasses the classes in the suite
      * @throws InitializationError
      */
-    protected OnamiSuite( RunnerBuilder builder, Class<?> suite, Class<?>[] suiteClasses ) 
-        throws InitializationError 
-    {
-        super( suite, runners( suite, suiteClasses ) );
-        try
-        {
-            if ( LOGGER.isLoggable( Level.FINER ) )
-            {
-                LOGGER.finer( "Inizializing injector for siote class: " + suite.getName() );
+    protected OnamiSuite(RunnerBuilder builder, Class<?> suite, Class<?>[] suiteClasses)
+        throws InitializationError {
+        super(suite, runners(suite, suiteClasses));
+        try {
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.finer("Inizializing injector for siote class: " + suite.getName());
             }
 
-            this.allModules = inizializeInjector( suite );
+            this.allModules = inizializeInjector(suite);
 
-            if ( LOGGER.isLoggable( Level.FINER ) )
-            {
-                LOGGER.finer( "done..." );
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.finer("done...");
             }
-        }
-        catch ( Exception e )
-        {
+        } catch (Exception e) {
             final List<Throwable> throwables = new LinkedList<Throwable>();
-            throwables.add( e );
-            throw new InitializationError( throwables );
+            throwables.add(e);
+            throw new InitializationError(throwables);
         }
     }
-    
+
     /**
      * {@inheritDoc}
      */
     @Override
-    public void run( final RunNotifier notifier )
-    {
-        if ( LOGGER.isLoggable( Level.FINER ) )
-        {
-            LOGGER.finer( " ### Run test case: " + getTestClass().getJavaClass() + " ### " );
-            LOGGER.finer( " #### Creating injector ####" );
+    public void run(final RunNotifier notifier) {
+        if (LOGGER.isLoggable(Level.FINER)) {
+            LOGGER.finer(" ### Run test case: " + getTestClass().getJavaClass() + " ### ");
+            LOGGER.finer(" #### Creating injector ####");
         }
 
-        this.injector = createInjector( allModules );
-        super.run( notifier );
+        this.injector = createInjector(allModules);
+        super.run(notifier);
         this.flush();
 
-        if ( LOGGER.isLoggable( Level.FINER ) )
-        {
-            LOGGER.finer( " ### End test case: " + getTestClass().getJavaClass().getName() + " ### " );
+        if (LOGGER.isLoggable(Level.FINER)) {
+            LOGGER.finer(" ### End test case: " + getTestClass().getJavaClass().getName() + " ### ");
         }
     }
 
-    private static List<Runner> runners( Class<?> suite, Class<?>[] children ) throws InitializationError {
-        ArrayList<Runner> runners= new ArrayList<Runner>();
+    private static List<Runner> runners(Class<?> suite, Class<?>[] children) throws InitializationError {
+        ArrayList<Runner> runners = new ArrayList<Runner>();
         for (Class<?> each : children) {
-            Runner childRunner= new OnamiRunner( suite, each );
+            Runner childRunner = new OnamiRunner(suite, each);
             if (childRunner != null)
                 runners.add(childRunner);
         }
@@ -229,27 +217,23 @@ public class OnamiSuite
     /**
      * {@inheritDoc}
      */
-    private void flush()
-    {
+    private void flush() {
         this.injector = null;
         this.allModules.clear();
         this.mocked.clear();
     }
 
     @Override
-    protected void runChild( Runner runner, RunNotifier notifier )
-    {
-        if ( LOGGER.isLoggable( Level.FINER ) )
-        {
-            LOGGER.finer( " +++ invoke runner: " + runner + " +++ " );
+    protected void runChild(Runner runner, RunNotifier notifier) {
+        if (LOGGER.isLoggable(Level.FINER)) {
+            LOGGER.finer(" +++ invoke runner: " + runner + " +++ ");
         }
 
-        super.runChild( runner, notifier );
+        super.runChild(runner, notifier);
         resetAllResetAfterMocks();
 
-        if ( LOGGER.isLoggable( Level.FINER ) )
-        {
-            LOGGER.finer( " --- end runner: " + runner + " --- " );
+        if (LOGGER.isLoggable(Level.FINER)) {
+            LOGGER.finer(" --- end runner: " + runner + " --- ");
         }
     }
 
@@ -259,42 +243,36 @@ public class OnamiSuite
      * @param modules the list of modules have to be load
      * @return an Injector instance built using the input Module list
      */
-    protected Injector createInjector( List<Module> modules )
-    {
-        return Guice.createInjector( modules );
+    protected Injector createInjector(List<Module> modules) {
+        return Guice.createInjector(modules);
     }
 
     /**
      * This method collects modules from {@link GuiceModules}, {@link GuiceProvidedModules}, {@link Mock}.
      *
-     * @param <T> whatever input type is accepted
+     * @param <T>   whatever input type is accepted
      * @param clazz the input class has to be analyzed
      * @return a List of Guice Modules built after input class analysis.
      * @throws IllegalAccessException when a n error occurs.
      * @throws InstantiationException when a n error occurs.
-     * @throws HandleException when a n error occurs.
+     * @throws HandleException        when a n error occurs.
      */
-    protected <T> List<Module> inizializeInjector( Class<T> clazz )
-        throws HandleException, InstantiationException, IllegalAccessException
-    {
+    protected <T> List<Module> inizializeInjector(Class<T> clazz)
+        throws HandleException, InstantiationException, IllegalAccessException {
         final List<Module> modules = new ArrayList<Module>();
-        Module m = visitClass( clazz );
-        if ( m != null )
-        {
-            modules.add( m );
+        Module m = visitClass(clazz);
+        if (m != null) {
+            modules.add(m);
         }
         return modules;
     }
 
-    private void resetAllResetAfterMocks()
-    {
-        for ( Entry<Field, Object> entry : mocked.entrySet() )
-        {
-            final Mock mockAnnotation = entry.getKey().getAnnotation( Mock.class );
-            if ( mockAnnotation.resetAfter() )
-            {
-                MockEngine mockEngine = MockEngineFactory.getMockEngine( mockFramework );
-                mockEngine.resetMock( entry.getValue() );
+    private void resetAllResetAfterMocks() {
+        for (Entry<Field, Object> entry : mocked.entrySet()) {
+            final Mock mockAnnotation = entry.getKey().getAnnotation(Mock.class);
+            if (mockAnnotation.resetAfter()) {
+                MockEngine mockEngine = MockEngineFactory.getMockEngine(mockFramework);
+                mockEngine.resetMock(entry.getValue());
             }
         }
     }
@@ -304,14 +282,11 @@ public class OnamiSuite
      * @throws IllegalAccessException
      * @throws InstantiationException
      */
-    private <T> Module visitClass( final Class<T> clazz )
-        throws HandleException, InstantiationException, IllegalAccessException
-    {
-        try
-        {
-            if ( LOGGER.isLoggable( Level.FINER ) )
-            {
-                LOGGER.finer( "  Start introspecting class: " + clazz.getName() );
+    private <T> Module visitClass(final Class<T> clazz)
+        throws HandleException, InstantiationException, IllegalAccessException {
+        try {
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.finer("  Start introspecting class: " + clazz.getName());
             }
             final List<Module> allModules = new ArrayList<Module>();
 
@@ -326,137 +301,110 @@ public class OnamiSuite
 
             // Visit class and super-classes
             new ClassVisitor()
-            .registerHandler( GuiceProvidedModules.class, guiceProvidedModuleHandler )
-            .registerHandler( GuiceModules.class, guiceModuleHandler )
-            .registerHandler( Mock.class, mockHandler )
-            .registerHandler( MockFramework.class, mockFrameworkHandler )
-            .registerHandler( Inject.class, guiceInjectableClassHandler )
-            .registerHandler( javax.inject.Inject.class, jsr330InjectableClassHandler )
-            .visit( clazz );
+                .registerHandler(GuiceProvidedModules.class, guiceProvidedModuleHandler)
+                .registerHandler(GuiceModules.class, guiceModuleHandler)
+                .registerHandler(Mock.class, mockHandler)
+                .registerHandler(MockFramework.class, mockFrameworkHandler)
+                .registerHandler(Inject.class, guiceInjectableClassHandler)
+                .registerHandler(javax.inject.Inject.class, jsr330InjectableClassHandler)
+                .visit(clazz);
 
             // Retrieve mock framework
-            if ( mockFrameworkHandler.getMockType() != null )
-            {
+            if (mockFrameworkHandler.getMockType() != null) {
                 this.mockFramework = mockFrameworkHandler.getMockType();
             }
 
             // retrieve the modules founded
-            allModules.addAll( guiceProvidedModuleHandler.getModules() );
-            allModules.addAll( guiceModuleHandler.getModules() );
-            MockEngine engine = MockEngineFactory.getMockEngine( this.mockFramework );
-            this.mocked.putAll( mockHandler.getMockedObject( engine ) );
-            if ( !this.mocked.isEmpty() )
-            {
+            allModules.addAll(guiceProvidedModuleHandler.getModules());
+            allModules.addAll(guiceModuleHandler.getModules());
+            MockEngine engine = MockEngineFactory.getMockEngine(this.mockFramework);
+            this.mocked.putAll(mockHandler.getMockedObject(engine));
+            if (!this.mocked.isEmpty()) {
                 // Replace all real module binding with Mocked moduled.
-                Module m = Modules.override( allModules ).with( new GuiceMockModule( this.mocked ) );
+                Module m = Modules.override(allModules).with(new GuiceMockModule(this.mocked));
                 allModules.clear();
-                allModules.add( m );
+                allModules.add(m);
             }
 
             // Add only clasess that have got the Inject annotation
-             final Class<?>[] guiceInjectableClasses = guiceInjectableClassHandler.getClasses();
-             final Class<?>[] jsr330InjectableClasses = jsr330InjectableClassHandler.getClasses();
+            final Class<?>[] guiceInjectableClasses = guiceInjectableClassHandler.getClasses();
+            final Class<?>[] jsr330InjectableClasses = jsr330InjectableClassHandler.getClasses();
 
-            final AbstractModule statcInjector = new AbstractModule()
-            {
+            final AbstractModule statcInjector = new AbstractModule() {
                 @Override
-                protected void configure()
-                {
+                protected void configure() {
                     // inject all STATIC dependencies
-                    if ( guiceInjectableClasses.length != 0 )
-                    {
-                        requestStaticInjection( guiceInjectableClasses );
-                    }
-                    
-                    if ( jsr330InjectableClasses.length != 0 )
-                    {
-                        requestStaticInjection( jsr330InjectableClasses );
+                    if (guiceInjectableClasses.length != 0) {
+                        requestStaticInjection(guiceInjectableClasses);
                     }
 
-                    
+                    if (jsr330InjectableClasses.length != 0) {
+                        requestStaticInjection(jsr330InjectableClasses);
+                    }
                 }
             };
-            if ( guiceInjectableClasses.length != 0 || jsr330InjectableClasses.length != 0 )
-            {
-                allModules.add( statcInjector );
+            if (guiceInjectableClasses.length != 0 || jsr330InjectableClasses.length != 0) {
+                allModules.add(statcInjector);
             }
 
             // Check if the class is itself a Google Module.
-            if ( Module.class.isAssignableFrom( getTestClass().getJavaClass() ) )
-            {
-                if ( LOGGER.isLoggable( Level.FINER ) )
-                {
-                    LOGGER.finer( "   creating module from test class " + getTestClass().getJavaClass() );
+            if (Module.class.isAssignableFrom(getTestClass().getJavaClass())) {
+                if (LOGGER.isLoggable(Level.FINER)) {
+                    LOGGER.finer("   creating module from test class " + getTestClass().getJavaClass());
                 }
                 final Module classModule = (Module) getTestClass().getJavaClass().newInstance();
-                allModules.add( classModule );
+                allModules.add(classModule);
             }
 
             // create MockTypeListenerModule
-            if ( this.mocked.size() != 0 )
-            {
-                final AbstractModule mockTypeListenerModule = new AbstractModule()
-                {
+            if (this.mocked.size() != 0) {
+                final AbstractModule mockTypeListenerModule = new AbstractModule() {
                     @Override
-                    protected void configure()
-                    {
-                        bindListener( Matchers.any(), new MockTypeListener( mocked ) );
+                    protected void configure() {
+                        bindListener(Matchers.any(), new MockTypeListener(mocked));
                     }
                 };
 
                 // BEGIN patch for issue: google-guice: #452
-                for ( Entry<Field, Object> entry : mocked.entrySet() )
-                {
+                for (Entry<Field, Object> entry : mocked.entrySet()) {
                     final Field field = entry.getKey();
                     final Object mock = entry.getValue();
-                    if ( Modifier.isStatic( field.getModifiers() ) )
-                    {
-                        if ( LOGGER.isLoggable( Level.FINER ) )
-                        {
-                            LOGGER.finer( "   inject static mock field: " + field.getName() );
+                    if (Modifier.isStatic(field.getModifiers())) {
+                        if (LOGGER.isLoggable(Level.FINER)) {
+                            LOGGER.finer("   inject static mock field: " + field.getName());
                         }
+                        AccessController.doPrivileged(new PrivilegedAction<Void>() {
 
-                        AccessController.doPrivileged( new PrivilegedAction<Void>()
-                        {
-
-                            public Void run()
-                            {
-                                field.setAccessible( true );
+                            public Void run() {
+                                field.setAccessible(true);
                                 return null;
                             }
 
-                        } );
-                        field.set( field.getDeclaringClass(), mock );
+                        });
+                        field.set(field.getDeclaringClass(), mock);
                     }
                 }
                 // END patch for issue: google-guice: #452
-
-                allModules.add( mockTypeListenerModule );
+                allModules.add(mockTypeListenerModule);
             }
 
-            if ( allModules.size() != 0 )
-            {
-                if ( LOGGER.isLoggable( Level.FINER ) )
-                {
+            if (allModules.size() != 0) {
+                if (LOGGER.isLoggable(Level.FINER)) {
                     StringBuilder builder = new StringBuilder();
-                    builder.append( " Collected modules: " );
-                    builder.append( "\n" );
-                    for ( Module module : allModules )
-                    {
-                        builder.append( "    " ).append( module );
-                        builder.append( "\n" );
+                    builder.append(" Collected modules: ");
+                    builder.append("\n");
+                    for (Module module : allModules) {
+                        builder.append("    ").append(module);
+                        builder.append("\n");
                     }
-                    LOGGER.finer( builder.toString() );
+                    LOGGER.finer(builder.toString());
                 }
-                return Modules.combine( allModules );
+                return Modules.combine(allModules);
             }
             return null;
-        }
-        finally
-        {
-            if ( LOGGER.isLoggable( Level.FINER ) )
-            {
-                LOGGER.finer( " ...done" );
+        } finally {
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.finer(" ...done");
             }
         }
     }

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/OnamiSuite.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/OnamiSuite.java
@@ -1,0 +1,464 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.annotation.GuiceProvidedModules;
+import org.apache.james.mpt.onami.test.annotation.Mock;
+import org.apache.james.mpt.onami.test.annotation.MockFramework;
+import org.apache.james.mpt.onami.test.annotation.MockType;
+import org.apache.james.mpt.onami.test.guice.MockTypeListener;
+import org.apache.james.mpt.onami.test.handler.GuiceInjectableClassHandler;
+import org.apache.james.mpt.onami.test.handler.GuiceModuleHandler;
+import org.apache.james.mpt.onami.test.handler.GuiceProvidedModuleHandler;
+import org.apache.james.mpt.onami.test.handler.MockFrameworkHandler;
+import org.apache.james.mpt.onami.test.handler.MockHandler;
+import org.apache.james.mpt.onami.test.mock.MockEngine;
+import org.apache.james.mpt.onami.test.reflection.ClassVisitor;
+import org.apache.james.mpt.onami.test.reflection.HandleException;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.Suite;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.RunnerBuilder;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.matcher.Matchers;
+import com.google.inject.util.Modules;
+
+/**
+ * <p>
+ * It's a {@link Suite} runner.
+ * </p>
+ * <p>
+ * This class creates a Google Guice {@link Injector} configured by {@link GuiceModules} annotation (only fr modules
+ * with default constructor) and {@link GuiceProvidedModules} annotation and {@link Mock}.
+ * </p>
+ * <p>
+ * <b>Example #1:</b> <br>
+ * 
+ * <pre>
+ * 
+ * &#064;org.junit.runner.RunWith( OnamiSuite.class )
+ * &#064;GuiceModules( SimpleModule.class )
+ * &#064;SuiteClasses({ .class })
+ * public class AcmeTestCase
+ * {
+ * 
+ *     &#064;GuiceProvidedModules
+ *     static public Module getProperties()
+ *     {
+ *         ...
+ *         return Modules.combine(new ComplexModule( loadProperies() ), ...  );
+ *     }
+ * 
+ * </pre>
+ * 
+ * </p>
+ * <p>
+ * <b>Example #2:</b> <br>
+ * 
+ * <pre>
+ * 
+ * &#064;org.junit.runner.RunWith( OnamiSuite.class )
+ * public class AcmeTestCase
+ *     extends com.google.inject.AbstractModule
+ * {
+ * 
+ *     public void configure()
+ *     {
+ *         // Configure your proper modules
+ *         ...
+ *         bind( Service.class ).annotatedWith( TestAnnotation.class ).to( ServiceTestImpl.class );
+ *         ...
+ *     }
+ * 
+ *     &#064;Mock
+ *     private AnotherService serviceMock;
+ * 
+ *     &#064;Inject
+ *     private Service serviceTest;
+ * 
+ *     &#064;org.junit.Test
+ *     public void test()
+ *     {
+ *         assertNotNull( serviceMock );
+ *         assertNotNull( serviceTest );
+ *     }
+ * </pre>
+ * 
+ * </p>
+ * 
+ * @see GuiceMockModule
+ */
+public class OnamiSuite
+    extends Suite
+{
+
+    private static final Logger LOGGER = Logger.getLogger( OnamiSuite.class.getName() );
+
+    private Injector injector;
+
+    private final List<Module> allModules;
+
+    private final Map<Field, Object> mocked = new HashMap<Field, Object>( 1 );
+
+    private MockType mockFramework = MockType.EASY_MOCK;
+
+    private static Class<?>[] getAnnotatedClasses(Class<?> klass) throws InitializationError {
+        SuiteClasses annotation= klass.getAnnotation(SuiteClasses.class);
+        if (annotation == null)
+            throw new InitializationError(String.format("class '%s' must have a SuiteClasses annotation", klass.getName()));
+        return annotation.value();
+    }
+
+    /**
+     * OnamiRunner constructor to create the core JUnice class.
+     * 
+     * @see org.junit.runner.RunWith
+     * @param klass The test case class to run.
+     * @throws org.junit.runners.model.InitializationError if any error occurs.
+     */
+    public OnamiSuite( Class<?> klass, RunnerBuilder builder )
+        throws InitializationError
+    {
+        this(builder, klass, getAnnotatedClasses(klass));
+
+    }
+
+    /**
+     * Called by this class and subclasses once the classes making up the suite have been determined
+     * 
+     * @param builder builds runners for classes in the suite
+     * @param klass the root of the suite
+     * @param suiteClasses the classes in the suite
+     * @throws InitializationError
+     */
+    protected OnamiSuite( RunnerBuilder builder, Class<?> suite, Class<?>[] suiteClasses ) 
+        throws InitializationError 
+    {
+        super( suite, runners( suite, suiteClasses ) );
+        try
+        {
+            if ( LOGGER.isLoggable( Level.FINER ) )
+            {
+                LOGGER.finer( "Inizializing injector for siote class: " + suite.getName() );
+            }
+
+            this.allModules = inizializeInjector( suite );
+
+            if ( LOGGER.isLoggable( Level.FINER ) )
+            {
+                LOGGER.finer( "done..." );
+            }
+        }
+        catch ( Exception e )
+        {
+            final List<Throwable> throwables = new LinkedList<Throwable>();
+            throwables.add( e );
+            throw new InitializationError( throwables );
+        }
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void run( final RunNotifier notifier )
+    {
+        if ( LOGGER.isLoggable( Level.FINER ) )
+        {
+            LOGGER.finer( " ### Run test case: " + getTestClass().getJavaClass() + " ### " );
+            LOGGER.finer( " #### Creating injector ####" );
+        }
+
+        this.injector = createInjector( allModules );
+        super.run( notifier );
+        this.flush();
+
+        if ( LOGGER.isLoggable( Level.FINER ) )
+        {
+            LOGGER.finer( " ### End test case: " + getTestClass().getJavaClass().getName() + " ### " );
+        }
+    }
+
+    private static List<Runner> runners( Class<?> suite, Class<?>[] children ) throws InitializationError {
+        ArrayList<Runner> runners= new ArrayList<Runner>();
+        for (Class<?> each : children) {
+            Runner childRunner= new OnamiRunner( suite, each );
+            if (childRunner != null)
+                runners.add(childRunner);
+        }
+        return runners;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    private void flush()
+    {
+        this.injector = null;
+        this.allModules.clear();
+        this.mocked.clear();
+    }
+
+    @Override
+    protected void runChild( Runner runner, RunNotifier notifier )
+    {
+        if ( LOGGER.isLoggable( Level.FINER ) )
+        {
+            LOGGER.finer( " +++ invoke runner: " + runner + " +++ " );
+        }
+
+        super.runChild( runner, notifier );
+        resetAllResetAfterMocks();
+
+        if ( LOGGER.isLoggable( Level.FINER ) )
+        {
+            LOGGER.finer( " --- end runner: " + runner + " --- " );
+        }
+    }
+
+    /**
+     * Shortcut to create the Injector given a list of Modules.
+     *
+     * @param modules the list of modules have to be load
+     * @return an Injector instance built using the input Module list
+     */
+    protected Injector createInjector( List<Module> modules )
+    {
+        return Guice.createInjector( modules );
+    }
+
+    /**
+     * This method collects modules from {@link GuiceModules}, {@link GuiceProvidedModules}, {@link Mock}.
+     *
+     * @param <T> whatever input type is accepted
+     * @param clazz the input class has to be analyzed
+     * @return a List of Guice Modules built after input class analysis.
+     * @throws IllegalAccessException when a n error occurs.
+     * @throws InstantiationException when a n error occurs.
+     * @throws HandleException when a n error occurs.
+     */
+    protected <T> List<Module> inizializeInjector( Class<T> clazz )
+        throws HandleException, InstantiationException, IllegalAccessException
+    {
+        final List<Module> modules = new ArrayList<Module>();
+        Module m = visitClass( clazz );
+        if ( m != null )
+        {
+            modules.add( m );
+        }
+        return modules;
+    }
+
+    private void resetAllResetAfterMocks()
+    {
+        for ( Entry<Field, Object> entry : mocked.entrySet() )
+        {
+            final Mock mockAnnotation = entry.getKey().getAnnotation( Mock.class );
+            if ( mockAnnotation.resetAfter() )
+            {
+                MockEngine mockEngine = MockEngineFactory.getMockEngine( mockFramework );
+                mockEngine.resetMock( entry.getValue() );
+            }
+        }
+    }
+
+    /**
+     * @throws HandleException
+     * @throws IllegalAccessException
+     * @throws InstantiationException
+     */
+    private <T> Module visitClass( final Class<T> clazz )
+        throws HandleException, InstantiationException, IllegalAccessException
+    {
+        try
+        {
+            if ( LOGGER.isLoggable( Level.FINER ) )
+            {
+                LOGGER.finer( "  Start introspecting class: " + clazz.getName() );
+            }
+            final List<Module> allModules = new ArrayList<Module>();
+
+            // Setup the handlers
+            final GuiceProvidedModuleHandler guiceProvidedModuleHandler = new GuiceProvidedModuleHandler();
+            final GuiceModuleHandler guiceModuleHandler = new GuiceModuleHandler();
+            final GuiceInjectableClassHandler<Inject> guiceInjectableClassHandler = new GuiceInjectableClassHandler<Inject>();
+            final GuiceInjectableClassHandler<javax.inject.Inject> jsr330InjectableClassHandler = new GuiceInjectableClassHandler<javax.inject.Inject>();
+
+            final MockHandler mockHandler = new MockHandler();
+            final MockFrameworkHandler mockFrameworkHandler = new MockFrameworkHandler();
+
+            // Visit class and super-classes
+            new ClassVisitor()
+            .registerHandler( GuiceProvidedModules.class, guiceProvidedModuleHandler )
+            .registerHandler( GuiceModules.class, guiceModuleHandler )
+            .registerHandler( Mock.class, mockHandler )
+            .registerHandler( MockFramework.class, mockFrameworkHandler )
+            .registerHandler( Inject.class, guiceInjectableClassHandler )
+            .registerHandler( javax.inject.Inject.class, jsr330InjectableClassHandler )
+            .visit( clazz );
+
+            // Retrieve mock framework
+            if ( mockFrameworkHandler.getMockType() != null )
+            {
+                this.mockFramework = mockFrameworkHandler.getMockType();
+            }
+
+            // retrieve the modules founded
+            allModules.addAll( guiceProvidedModuleHandler.getModules() );
+            allModules.addAll( guiceModuleHandler.getModules() );
+            MockEngine engine = MockEngineFactory.getMockEngine( this.mockFramework );
+            this.mocked.putAll( mockHandler.getMockedObject( engine ) );
+            if ( !this.mocked.isEmpty() )
+            {
+                // Replace all real module binding with Mocked moduled.
+                Module m = Modules.override( allModules ).with( new GuiceMockModule( this.mocked ) );
+                allModules.clear();
+                allModules.add( m );
+            }
+
+            // Add only clasess that have got the Inject annotation
+             final Class<?>[] guiceInjectableClasses = guiceInjectableClassHandler.getClasses();
+             final Class<?>[] jsr330InjectableClasses = jsr330InjectableClassHandler.getClasses();
+
+            final AbstractModule statcInjector = new AbstractModule()
+            {
+                @Override
+                protected void configure()
+                {
+                    // inject all STATIC dependencies
+                    if ( guiceInjectableClasses.length != 0 )
+                    {
+                        requestStaticInjection( guiceInjectableClasses );
+                    }
+                    
+                    if ( jsr330InjectableClasses.length != 0 )
+                    {
+                        requestStaticInjection( jsr330InjectableClasses );
+                    }
+
+                    
+                }
+            };
+            if ( guiceInjectableClasses.length != 0 || jsr330InjectableClasses.length != 0 )
+            {
+                allModules.add( statcInjector );
+            }
+
+            // Check if the class is itself a Google Module.
+            if ( Module.class.isAssignableFrom( getTestClass().getJavaClass() ) )
+            {
+                if ( LOGGER.isLoggable( Level.FINER ) )
+                {
+                    LOGGER.finer( "   creating module from test class " + getTestClass().getJavaClass() );
+                }
+                final Module classModule = (Module) getTestClass().getJavaClass().newInstance();
+                allModules.add( classModule );
+            }
+
+            // create MockTypeListenerModule
+            if ( this.mocked.size() != 0 )
+            {
+                final AbstractModule mockTypeListenerModule = new AbstractModule()
+                {
+                    @Override
+                    protected void configure()
+                    {
+                        bindListener( Matchers.any(), new MockTypeListener( mocked ) );
+                    }
+                };
+
+                // BEGIN patch for issue: google-guice: #452
+                for ( Entry<Field, Object> entry : mocked.entrySet() )
+                {
+                    final Field field = entry.getKey();
+                    final Object mock = entry.getValue();
+                    if ( Modifier.isStatic( field.getModifiers() ) )
+                    {
+                        if ( LOGGER.isLoggable( Level.FINER ) )
+                        {
+                            LOGGER.finer( "   inject static mock field: " + field.getName() );
+                        }
+
+                        AccessController.doPrivileged( new PrivilegedAction<Void>()
+                        {
+
+                            public Void run()
+                            {
+                                field.setAccessible( true );
+                                return null;
+                            }
+
+                        } );
+                        field.set( field.getDeclaringClass(), mock );
+                    }
+                }
+                // END patch for issue: google-guice: #452
+
+                allModules.add( mockTypeListenerModule );
+            }
+
+            if ( allModules.size() != 0 )
+            {
+                if ( LOGGER.isLoggable( Level.FINER ) )
+                {
+                    StringBuilder builder = new StringBuilder();
+                    builder.append( " Collected modules: " );
+                    builder.append( "\n" );
+                    for ( Module module : allModules )
+                    {
+                        builder.append( "    " ).append( module );
+                        builder.append( "\n" );
+                    }
+                    LOGGER.finer( builder.toString() );
+                }
+                return Modules.combine( allModules );
+            }
+            return null;
+        }
+        finally
+        {
+            if ( LOGGER.isLoggable( Level.FINER ) )
+            {
+                LOGGER.finer( " ...done" );
+            }
+        }
+    }
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/GuiceModules.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/GuiceModules.java
@@ -1,0 +1,42 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.google.inject.Module;
+
+/**
+ * Annotate your class to define a list of Google Guice {@link Module} whit default constructor.
+ */
+@Retention( RetentionPolicy.RUNTIME )
+@Target( ElementType.TYPE )
+public @interface GuiceModules
+{
+
+    /**
+     * List of Google Guice {@link Module}.
+     */
+    Class<? extends Module>[] value();
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/GuiceModules.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/GuiceModules.java
@@ -29,10 +29,9 @@ import com.google.inject.Module;
 /**
  * Annotate your class to define a list of Google Guice {@link Module} whit default constructor.
  */
-@Retention( RetentionPolicy.RUNTIME )
-@Target( ElementType.TYPE )
-public @interface GuiceModules
-{
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface GuiceModules {
 
     /**
      * List of Google Guice {@link Module}.

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/GuiceProvidedModules.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/GuiceProvidedModules.java
@@ -36,9 +36,8 @@ import java.lang.annotation.Target;
  * <li>com.google.inject.Module[]</li>
  * </p>
  */
-@Retention( RetentionPolicy.RUNTIME )
-@Target( ElementType.METHOD )
-public @interface GuiceProvidedModules
-{
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface GuiceProvidedModules {
 
 }

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/GuiceProvidedModules.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/GuiceProvidedModules.java
@@ -1,0 +1,44 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>
+ * Annotate a <b>public static</b> method to create a Google Guice {@link com.google.inject.Module} provider.
+ * </p>
+ * <p>
+ * The method return type must be one of:
+ * <ul>
+ * <li>com.google.inject.Module</li>
+ * <li>Iterable&lt;com.google.inject.Module&gt;</li>
+ * <li>com.google.inject.Module[]</li>
+ * </p>
+ */
+@Retention( RetentionPolicy.RUNTIME )
+@Target( ElementType.METHOD )
+public @interface GuiceProvidedModules
+{
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/Mock.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/Mock.java
@@ -1,0 +1,77 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.annotation;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotate your filed into which {@link org.apache.onami.test.GuiceMockModule} will create and inject the mock object.
+ */
+@Retention( RetentionPolicy.RUNTIME )
+@Target( ElementType.FIELD )
+@Inherited
+public @interface Mock
+{
+
+    /**
+     * Annotation class used to mark that no annotation binding is defined.
+     */
+    public static @interface NoAnnotation
+    {
+    }
+
+    /**
+     * Indicates if this mock object has to be resetted after each test method Default: true
+     */
+    boolean resetAfter() default true;
+
+    /**
+     * The name of the method that provides to mock creation.
+     */
+    String providedBy() default "";
+
+    /**
+     * The {@link Class} that contains the method {@link Mock#providedBy()}. By default: the filed declaring class.
+     */
+    Class<?> providerClass() default Object.class;
+
+    /**
+     * Specifies an annotation {@link Class} that will be used in the <em>Google Guice</em> binder to execute the literal
+     * annotating binding.
+     */
+    Class<? extends Annotation> annotatedWith() default NoAnnotation.class;
+
+    /**
+     * Specifies an {@link String} annotation that will be used in the <em>Google Guice</em> binder to execute the
+     * literal annotating binding via {@link com.google.inject.name.Named} class.
+     */
+    String namedWith() default "";
+
+    /**
+     * Specifies TODO
+     */
+    MockObjType type() default MockObjType.DEFAULT;
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/Mock.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/Mock.java
@@ -29,17 +29,15 @@ import java.lang.annotation.Target;
 /**
  * Annotate your filed into which {@link org.apache.onami.test.GuiceMockModule} will create and inject the mock object.
  */
-@Retention( RetentionPolicy.RUNTIME )
-@Target( ElementType.FIELD )
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
 @Inherited
-public @interface Mock
-{
+public @interface Mock {
 
     /**
      * Annotation class used to mark that no annotation binding is defined.
      */
-    public static @interface NoAnnotation
-    {
+    public static @interface NoAnnotation {
     }
 
     /**

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/MockFramework.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/MockFramework.java
@@ -27,10 +27,9 @@ import java.lang.annotation.Target;
 /**
  * Annotate test class to specify you favorite mock framework.
  */
-@Retention( RetentionPolicy.RUNTIME )
-@Target( ElementType.TYPE )
-public @interface MockFramework
-{
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface MockFramework {
 
     /**
      * Type of mock that JUnice has to create.

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/MockFramework.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/MockFramework.java
@@ -1,0 +1,40 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotate test class to specify you favorite mock framework.
+ */
+@Retention( RetentionPolicy.RUNTIME )
+@Target( ElementType.TYPE )
+public @interface MockFramework
+{
+
+    /**
+     * Type of mock that JUnice has to create.
+     */
+    MockType value();
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/MockObjType.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/MockObjType.java
@@ -22,25 +22,24 @@ package org.apache.james.mpt.onami.test.annotation;
 /**
  * Enumeration class to specifies the preferred mock object.
  */
-public enum MockObjType
-{
+public enum MockObjType {
 
-    /** 
+    /**
      * @see EasyMock.createMock
      */
     EASY_MOCK_NORMAL,
-    
-    /** 
+
+    /**
      * @see EasyMock.createStrictMock
      */
     EASY_MOCK_STRICT,
-    
-    /** 
+
+    /**
      * @see EasyMock.createNiceMock
      */
     EASY_MOCK_NICE,
-    
-    /** 
+
+    /**
      * Use default mock creation mode
      */
     DEFAULT

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/MockObjType.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/MockObjType.java
@@ -1,0 +1,48 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.annotation;
+
+/**
+ * Enumeration class to specifies the preferred mock object.
+ */
+public enum MockObjType
+{
+
+    /** 
+     * @see EasyMock.createMock
+     */
+    EASY_MOCK_NORMAL,
+    
+    /** 
+     * @see EasyMock.createStrictMock
+     */
+    EASY_MOCK_STRICT,
+    
+    /** 
+     * @see EasyMock.createNiceMock
+     */
+    EASY_MOCK_NICE,
+    
+    /** 
+     * Use default mock creation mode
+     */
+    DEFAULT
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/MockType.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/MockType.java
@@ -1,0 +1,39 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.annotation;
+
+/**
+ * Enumeration class to specifies your preferred mock framework.
+ *
+ * @see MockFramework
+ */
+public enum MockType
+{
+    /**
+     * Identify the Easy Mock framework
+     */
+    EASY_MOCK, 
+    
+    /**
+     * Identify the Mockito framework
+     */
+    MOCKITO
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/MockType.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/annotation/MockType.java
@@ -24,13 +24,12 @@ package org.apache.james.mpt.onami.test.annotation;
  *
  * @see MockFramework
  */
-public enum MockType
-{
+public enum MockType {
     /**
      * Identify the Easy Mock framework
      */
-    EASY_MOCK, 
-    
+    EASY_MOCK,
+
     /**
      * Identify the Mockito framework
      */

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/guice/MockMembersInjector.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/guice/MockMembersInjector.java
@@ -1,0 +1,79 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.guice;
+
+import java.lang.reflect.Field;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Map;
+
+import com.google.inject.MembersInjector;
+
+/**
+ * Class to inject via google-guice mock members into test cases classes.
+ *
+ * @param <T> type to inject members of
+ */
+public class MockMembersInjector<T>
+    implements MembersInjector<T>
+{
+
+    private final Field field;
+
+    private final Map<Field, Object> mockedObjects;
+
+    /**
+     * Create a new instance.
+     * 
+     * @param field the field that has to be injected.
+     * @param mockedObjects  the map of mocked object.
+     */
+    public MockMembersInjector( final Field field, Map<Field, Object> mockedObjects )
+    {
+        this.field = field;
+        this.mockedObjects = mockedObjects;
+        AccessController.doPrivileged( new PrivilegedAction<Void>()
+        {
+
+            public Void run()
+            {
+                field.setAccessible( true );
+                return null;
+            }
+
+        } );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void injectMembers( T t )
+    {
+        try
+        {
+            field.set( t, mockedObjects.get( field ) );
+        }
+        catch ( IllegalAccessException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/guice/MockMembersInjector.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/guice/MockMembersInjector.java
@@ -31,9 +31,7 @@ import com.google.inject.MembersInjector;
  *
  * @param <T> type to inject members of
  */
-public class MockMembersInjector<T>
-    implements MembersInjector<T>
-{
+public class MockMembersInjector<T> implements MembersInjector<T> {
 
     private final Field field;
 
@@ -41,38 +39,31 @@ public class MockMembersInjector<T>
 
     /**
      * Create a new instance.
-     * 
-     * @param field the field that has to be injected.
-     * @param mockedObjects  the map of mocked object.
+     *
+     * @param field         the field that has to be injected.
+     * @param mockedObjects the map of mocked object.
      */
-    public MockMembersInjector( final Field field, Map<Field, Object> mockedObjects )
-    {
+    public MockMembersInjector(final Field field, Map<Field, Object> mockedObjects) {
         this.field = field;
         this.mockedObjects = mockedObjects;
-        AccessController.doPrivileged( new PrivilegedAction<Void>()
-        {
+        AccessController.doPrivileged(new PrivilegedAction<Void>() {
 
-            public Void run()
-            {
-                field.setAccessible( true );
+            public Void run() {
+                field.setAccessible(true);
                 return null;
             }
 
-        } );
+        });
     }
 
     /**
      * {@inheritDoc}
      */
-    public void injectMembers( T t )
-    {
-        try
-        {
-            field.set( t, mockedObjects.get( field ) );
-        }
-        catch ( IllegalAccessException e )
-        {
-            throw new RuntimeException( e );
+    public void injectMembers(T t) {
+        try {
+            field.set(t, mockedObjects.get(field));
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/guice/MockTypeListener.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/guice/MockTypeListener.java
@@ -1,0 +1,87 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.guice;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import org.apache.james.mpt.onami.test.annotation.Mock;
+import org.apache.james.mpt.onami.test.reflection.AnnotationHandler;
+import org.apache.james.mpt.onami.test.reflection.ClassVisitor;
+import org.apache.james.mpt.onami.test.reflection.HandleException;
+
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.TypeEncounter;
+import com.google.inject.spi.TypeListener;
+
+/**
+ * <p>
+ * {@link TypeListener} implementation.
+ * </p>
+ * <p>
+ * Creates a specific {@link MockMembersInjector} for each {@link Mock} annotation found.
+ * </p>
+ *
+ * @see MockMembersInjector
+ * @see Mock
+ */
+public class MockTypeListener
+    implements TypeListener
+{
+
+    private final Map<Field, Object> mockedObjects;
+
+    /**
+     * Creates a new {@code MockTypeListener} instance given a map of mocked objects.
+     *
+     * @param mockedObjects a map of mocked objects
+     */
+    public MockTypeListener( Map<Field, Object> mockedObjects )
+    {
+        this.mockedObjects = mockedObjects;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public <I> void hear( final TypeLiteral<I> typeLiteral, final TypeEncounter<I> typeEncounter )
+    {
+        try
+        {
+            new ClassVisitor()
+            .registerHandler( Mock.class, new AnnotationHandler<Mock, Field>()
+            {
+
+                public void handle( Mock annotation, Field field )
+                    throws HandleException
+                {
+                    typeEncounter.register( new MockMembersInjector<I>( field, mockedObjects ) );
+                }
+
+            } )
+            .visit( typeLiteral.getRawType() );
+        }
+        catch ( HandleException e )
+        {
+            typeEncounter.addError( e );
+        }
+    }
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/guice/MockTypeListener.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/guice/MockTypeListener.java
@@ -42,9 +42,7 @@ import com.google.inject.spi.TypeListener;
  * @see MockMembersInjector
  * @see Mock
  */
-public class MockTypeListener
-    implements TypeListener
-{
+public class MockTypeListener implements TypeListener {
 
     private final Map<Field, Object> mockedObjects;
 
@@ -53,34 +51,27 @@ public class MockTypeListener
      *
      * @param mockedObjects a map of mocked objects
      */
-    public MockTypeListener( Map<Field, Object> mockedObjects )
-    {
+    public MockTypeListener(Map<Field, Object> mockedObjects) {
         this.mockedObjects = mockedObjects;
     }
 
     /**
      * {@inheritDoc}
      */
-    public <I> void hear( final TypeLiteral<I> typeLiteral, final TypeEncounter<I> typeEncounter )
-    {
-        try
-        {
+    public <I> void hear(final TypeLiteral<I> typeLiteral, final TypeEncounter<I> typeEncounter) {
+        try {
             new ClassVisitor()
-            .registerHandler( Mock.class, new AnnotationHandler<Mock, Field>()
-            {
+                .registerHandler(Mock.class, new AnnotationHandler<Mock, Field>() {
 
-                public void handle( Mock annotation, Field field )
-                    throws HandleException
-                {
-                    typeEncounter.register( new MockMembersInjector<I>( field, mockedObjects ) );
-                }
+                    public void handle(Mock annotation, Field field)
+                        throws HandleException {
+                        typeEncounter.register(new MockMembersInjector<I>(field, mockedObjects));
+                    }
 
-            } )
-            .visit( typeLiteral.getRawType() );
-        }
-        catch ( HandleException e )
-        {
-            typeEncounter.addError( e );
+                })
+                .visit(typeLiteral.getRawType());
+        } catch (HandleException e) {
+            typeEncounter.addError(e);
         }
     }
 

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/GuiceInjectableClassHandler.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/GuiceInjectableClassHandler.java
@@ -36,11 +36,9 @@ import org.apache.james.mpt.onami.test.reflection.HandleException;
  * @param <A> whatever annotation type
  * @see org.apache.onami.test.reflection.ClassVisitor
  */
-public final class GuiceInjectableClassHandler<A extends Annotation>
-    implements AnnotationHandler<A, AccessibleObject>
-{
+public final class GuiceInjectableClassHandler<A extends Annotation> implements AnnotationHandler<A, AccessibleObject> {
 
-    private static final Logger LOGGER = Logger.getLogger( GuiceInjectableClassHandler.class.getName() );
+    private static final Logger LOGGER = Logger.getLogger(GuiceInjectableClassHandler.class.getName());
 
     /**
      * Contains the guice injectable classes founded, after inspection.
@@ -53,31 +51,26 @@ public final class GuiceInjectableClassHandler<A extends Annotation>
      *
      * @return {@link Class} array.
      */
-    public Class<?>[] getClasses()
-    {
-        return classes.toArray( new Class<?>[classes.size()] );
+    public Class<?>[] getClasses() {
+        return classes.toArray(new Class<?>[classes.size()]);
     }
 
     /**
      * {@inheritDoc}
      */
-    public void handle( A annotation, AccessibleObject element )
-        throws HandleException
-    {
+    public void handle(A annotation, AccessibleObject element)
+        throws HandleException {
         Class<?> type = null;
 
-        if ( element instanceof Member )
-        {
-            type = ( (Member) element ).getDeclaringClass();
+        if (element instanceof Member) {
+            type = ((Member) element).getDeclaringClass();
         }
 
-        if ( type != null && !classes.contains( type ) )
-        {
-            if ( LOGGER.isLoggable( Level.FINER ) )
-            {
-                LOGGER.finer( "   Found injectable type: " + type );
+        if (type != null && !classes.contains(type)) {
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.finer("   Found injectable type: " + type);
             }
-            classes.add( type );
+            classes.add(type);
         }
     }
 

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/GuiceInjectableClassHandler.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/GuiceInjectableClassHandler.java
@@ -1,0 +1,84 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.handler;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Member;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.james.mpt.onami.test.reflection.AnnotationHandler;
+import org.apache.james.mpt.onami.test.reflection.HandleException;
+
+/**
+ * Handler class to handle all {@link com.google.inject.Inject} and {@link javax.inject.Inject} annotations.
+ *
+ * @param <A> whatever annotation type
+ * @see org.apache.onami.test.reflection.ClassVisitor
+ */
+public final class GuiceInjectableClassHandler<A extends Annotation>
+    implements AnnotationHandler<A, AccessibleObject>
+{
+
+    private static final Logger LOGGER = Logger.getLogger( GuiceInjectableClassHandler.class.getName() );
+
+    /**
+     * Contains the guice injectable classes founded, after inspection.
+     */
+    protected final Set<Class<?>> classes = new HashSet<Class<?>>();
+
+    /**
+     * Return all {@link Class} that contains at last one {@link com.google.inject.Inject} or
+     * {@link javax.inject.Inject} annotation.
+     *
+     * @return {@link Class} array.
+     */
+    public Class<?>[] getClasses()
+    {
+        return classes.toArray( new Class<?>[classes.size()] );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void handle( A annotation, AccessibleObject element )
+        throws HandleException
+    {
+        Class<?> type = null;
+
+        if ( element instanceof Member )
+        {
+            type = ( (Member) element ).getDeclaringClass();
+        }
+
+        if ( type != null && !classes.contains( type ) )
+        {
+            if ( LOGGER.isLoggable( Level.FINER ) )
+            {
+                LOGGER.finer( "   Found injectable type: " + type );
+            }
+            classes.add( type );
+        }
+    }
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/GuiceModuleHandler.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/GuiceModuleHandler.java
@@ -1,0 +1,77 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.reflection.ClassHandler;
+import org.apache.james.mpt.onami.test.reflection.HandleException;
+
+import com.google.inject.Module;
+
+/**
+ * Handler class to handle all {@link GuiceModules} annotations.
+ *
+ * @see org.apache.onami.test.reflection.ClassVisitor
+ */
+public final class GuiceModuleHandler
+    implements ClassHandler<GuiceModules>
+{
+
+    private static final Logger LOGGER = Logger.getLogger( GuiceModuleHandler.class.getName() );
+
+    private final List<Module> modules = new ArrayList<Module>();
+
+    /**
+     * @return the modules
+     */
+    public List<Module> getModules()
+    {
+        return modules;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void handle( GuiceModules annotation, Class<?> element )
+        throws HandleException
+    {
+        for ( Class<? extends Module> module : annotation.value() )
+        {
+            if ( LOGGER.isLoggable( Level.FINER ) )
+            {
+                LOGGER.finer( "   Try to create module: " + module );
+            }
+            try
+            {
+                modules.add( module.newInstance() );
+            }
+            catch ( Exception e )
+            {
+                throw new HandleException( e );
+            }
+        }
+    }
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/GuiceModuleHandler.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/GuiceModuleHandler.java
@@ -35,41 +35,32 @@ import com.google.inject.Module;
  *
  * @see org.apache.onami.test.reflection.ClassVisitor
  */
-public final class GuiceModuleHandler
-    implements ClassHandler<GuiceModules>
-{
+public final class GuiceModuleHandler implements ClassHandler<GuiceModules> {
 
-    private static final Logger LOGGER = Logger.getLogger( GuiceModuleHandler.class.getName() );
+    private static final Logger LOGGER = Logger.getLogger(GuiceModuleHandler.class.getName());
 
     private final List<Module> modules = new ArrayList<Module>();
 
     /**
      * @return the modules
      */
-    public List<Module> getModules()
-    {
+    public List<Module> getModules() {
         return modules;
     }
 
     /**
      * {@inheritDoc}
      */
-    public void handle( GuiceModules annotation, Class<?> element )
-        throws HandleException
-    {
-        for ( Class<? extends Module> module : annotation.value() )
-        {
-            if ( LOGGER.isLoggable( Level.FINER ) )
-            {
-                LOGGER.finer( "   Try to create module: " + module );
+    public void handle(GuiceModules annotation, Class<?> element)
+        throws HandleException {
+        for (Class<? extends Module> module : annotation.value()) {
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.finer("   Try to create module: " + module);
             }
-            try
-            {
-                modules.add( module.newInstance() );
-            }
-            catch ( Exception e )
-            {
-                throw new HandleException( e );
+            try {
+                modules.add(module.newInstance());
+            } catch (Exception e) {
+                throw new HandleException(e);
             }
         }
     }

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/GuiceProvidedModuleHandler.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/GuiceProvidedModuleHandler.java
@@ -1,0 +1,137 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.handler;
+
+import static java.lang.String.format;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.james.mpt.onami.test.annotation.GuiceProvidedModules;
+import org.apache.james.mpt.onami.test.reflection.HandleException;
+import org.apache.james.mpt.onami.test.reflection.MethodHandler;
+
+import com.google.inject.Module;
+import com.google.inject.TypeLiteral;
+
+/**
+ * Handler class to handle all {@link GuiceProvidedModules} annotations.
+ *
+ * @see org.apache.onami.test.reflection.ClassVisitor
+ * @see GuiceProvidedModules
+ */
+public final class GuiceProvidedModuleHandler
+    implements MethodHandler<GuiceProvidedModules>
+{
+
+    private static final Logger LOGGER = Logger.getLogger( GuiceProvidedModuleHandler.class.getName() );
+
+    private final List<Module> modules = new ArrayList<Module>();
+
+    /**
+     * @return the guiceProviderModuleRegistry
+     */
+    public List<Module> getModules()
+    {
+        return modules;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings( "unchecked" )
+    public void handle( GuiceProvidedModules annotation, Method method )
+        throws HandleException
+    {
+        final Class<?> returnType = method.getReturnType();
+
+        if ( LOGGER.isLoggable( Level.FINER ) )
+        {
+            LOGGER.finer( format( "  Found %s annotated method, checking if return type '%s' is one of ( %s | Iterable<%s> | %s[] )",
+                                  GuiceProvidedModules.class.getSimpleName(),
+                                  returnType.getName(),
+                                  Module.class.getName(),
+                                  Module.class.getName(),
+                                  Module.class.getName() ) );
+        }
+
+        if ( !Modifier.isPublic( method.getModifiers() ) || !Modifier.isStatic( method.getModifiers() ) )
+        {
+            throw new HandleException( "Impossible to invoke method: " + method + ", it has to be static and public" );
+        }
+
+        final Class<?> type = method.getDeclaringClass();
+
+        try
+        {
+            if ( Module.class.isAssignableFrom( returnType ) )
+            {
+                modules.add( (Module) method.invoke( type ) );
+            }
+            else if ( new TypeLiteral<Iterable<Module>>()
+            {
+            }.getRawType().isAssignableFrom( returnType ) )
+            {
+                addModules( (Iterable<Module>) method.invoke( type ) );
+            }
+            else if ( new TypeLiteral<Module[]>()
+            {
+            }.getRawType().isAssignableFrom( returnType ) )
+            {
+                addModules( (Module[]) method.invoke( type ) );
+            }
+            else
+            {
+                throw new ClassCastException( format( "  Incompatible return type: %s.\nThe return type must be one of ( %s | Iterable<%s> | %s[] )",
+                                                      returnType.getName(),
+                                                      Module.class.getName(),
+                                                      Module.class.getName(),
+                                                      Module.class.getName() ) );
+            }
+
+            if ( LOGGER.isLoggable( Level.FINER ) )
+            {
+                LOGGER.finer( "  Invoked method: " + method.toGenericString() );
+            }
+        }
+        catch ( Exception e )
+        {
+            throw new HandleException( e );
+        }
+    }
+
+    private void addModules( Iterable<Module> modules )
+    {
+        for ( Module module : modules )
+        {
+            this.modules.add( module );
+        }
+    }
+
+    private void addModules( Module... modules )
+    {
+        Collections.addAll( this.modules, modules );
+    }
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/GuiceProvidedModuleHandler.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/GuiceProvidedModuleHandler.java
@@ -42,96 +42,74 @@ import com.google.inject.TypeLiteral;
  * @see org.apache.onami.test.reflection.ClassVisitor
  * @see GuiceProvidedModules
  */
-public final class GuiceProvidedModuleHandler
-    implements MethodHandler<GuiceProvidedModules>
-{
+public final class GuiceProvidedModuleHandler implements MethodHandler<GuiceProvidedModules> {
 
-    private static final Logger LOGGER = Logger.getLogger( GuiceProvidedModuleHandler.class.getName() );
+    private static final Logger LOGGER = Logger.getLogger(GuiceProvidedModuleHandler.class.getName());
 
     private final List<Module> modules = new ArrayList<Module>();
 
     /**
      * @return the guiceProviderModuleRegistry
      */
-    public List<Module> getModules()
-    {
+    public List<Module> getModules() {
         return modules;
     }
 
     /**
      * {@inheritDoc}
      */
-    @SuppressWarnings( "unchecked" )
-    public void handle( GuiceProvidedModules annotation, Method method )
-        throws HandleException
-    {
+    @SuppressWarnings("unchecked")
+    public void handle(GuiceProvidedModules annotation, Method method)
+        throws HandleException {
         final Class<?> returnType = method.getReturnType();
 
-        if ( LOGGER.isLoggable( Level.FINER ) )
-        {
-            LOGGER.finer( format( "  Found %s annotated method, checking if return type '%s' is one of ( %s | Iterable<%s> | %s[] )",
-                                  GuiceProvidedModules.class.getSimpleName(),
-                                  returnType.getName(),
-                                  Module.class.getName(),
-                                  Module.class.getName(),
-                                  Module.class.getName() ) );
+        if (LOGGER.isLoggable(Level.FINER)) {
+            LOGGER.finer(format("  Found %s annotated method, checking if return type '%s' is one of ( %s | Iterable<%s> | %s[] )",
+                GuiceProvidedModules.class.getSimpleName(),
+                returnType.getName(),
+                Module.class.getName(),
+                Module.class.getName(),
+                Module.class.getName()));
         }
 
-        if ( !Modifier.isPublic( method.getModifiers() ) || !Modifier.isStatic( method.getModifiers() ) )
-        {
-            throw new HandleException( "Impossible to invoke method: " + method + ", it has to be static and public" );
+        if (!Modifier.isPublic(method.getModifiers()) || !Modifier.isStatic(method.getModifiers())) {
+            throw new HandleException("Impossible to invoke method: " + method + ", it has to be static and public");
         }
 
         final Class<?> type = method.getDeclaringClass();
 
-        try
-        {
-            if ( Module.class.isAssignableFrom( returnType ) )
-            {
-                modules.add( (Module) method.invoke( type ) );
-            }
-            else if ( new TypeLiteral<Iterable<Module>>()
-            {
-            }.getRawType().isAssignableFrom( returnType ) )
-            {
-                addModules( (Iterable<Module>) method.invoke( type ) );
-            }
-            else if ( new TypeLiteral<Module[]>()
-            {
-            }.getRawType().isAssignableFrom( returnType ) )
-            {
-                addModules( (Module[]) method.invoke( type ) );
-            }
-            else
-            {
-                throw new ClassCastException( format( "  Incompatible return type: %s.\nThe return type must be one of ( %s | Iterable<%s> | %s[] )",
-                                                      returnType.getName(),
-                                                      Module.class.getName(),
-                                                      Module.class.getName(),
-                                                      Module.class.getName() ) );
+        try {
+            if (Module.class.isAssignableFrom(returnType)) {
+                modules.add((Module) method.invoke(type));
+            } else if (new TypeLiteral<Iterable<Module>>() {
+            }.getRawType().isAssignableFrom(returnType)) {
+                addModules((Iterable<Module>) method.invoke(type));
+            } else if (new TypeLiteral<Module[]>() {
+            }.getRawType().isAssignableFrom(returnType)) {
+                addModules((Module[]) method.invoke(type));
+            } else {
+                throw new ClassCastException(format("  Incompatible return type: %s.\nThe return type must be one of ( %s | Iterable<%s> | %s[] )",
+                    returnType.getName(),
+                    Module.class.getName(),
+                    Module.class.getName(),
+                    Module.class.getName()));
             }
 
-            if ( LOGGER.isLoggable( Level.FINER ) )
-            {
-                LOGGER.finer( "  Invoked method: " + method.toGenericString() );
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.finer("  Invoked method: " + method.toGenericString());
             }
-        }
-        catch ( Exception e )
-        {
-            throw new HandleException( e );
+        } catch (Exception e) {
+            throw new HandleException(e);
         }
     }
 
-    private void addModules( Iterable<Module> modules )
-    {
-        for ( Module module : modules )
-        {
-            this.modules.add( module );
+    private void addModules(Iterable<Module> modules) {
+        for (Module module : modules) {
+            this.modules.add(module);
         }
     }
 
-    private void addModules( Module... modules )
-    {
-        Collections.addAll( this.modules, modules );
+    private void addModules(Module... modules) {
+        Collections.addAll(this.modules, modules);
     }
 }

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/MockFrameworkHandler.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/MockFrameworkHandler.java
@@ -33,37 +33,31 @@ import org.apache.james.mpt.onami.test.reflection.HandleException;
  * @see org.apache.onami.test.reflection.ClassVisitor
  * @see MockFramework
  */
-public final class MockFrameworkHandler
-    implements ClassHandler<MockFramework>
-{
+public final class MockFrameworkHandler implements ClassHandler<MockFramework> {
 
-    private static final Logger LOGGER = Logger.getLogger( MockFrameworkHandler.class.getName() );
+    private static final Logger LOGGER = Logger.getLogger(MockFrameworkHandler.class.getName());
 
     private MockType mockType;
 
     /**
      * @return the mockType
      */
-    public MockType getMockType()
-    {
+    public MockType getMockType() {
         return mockType;
     }
 
     /**
      * {@inheritDoc}
      */
-    public void handle( MockFramework annotation, Class<?> element )
-        throws HandleException
-    {
-        if ( mockType != null && mockType != annotation.value() )
-        {
-            throw new HandleException( "Inconsistent mock framework found. " + "Mock framework already set [set: "
-                + mockType + " now found: " + annotation.value() + "]" );
+    public void handle(MockFramework annotation, Class<?> element)
+        throws HandleException {
+        if (mockType != null && mockType != annotation.value()) {
+            throw new HandleException("Inconsistent mock framework found. " + "Mock framework already set [set: "
+                + mockType + " now found: " + annotation.value() + "]");
         }
 
-        if ( LOGGER.isLoggable( Level.FINER ) )
-        {
-            LOGGER.finer( "  Found MockFramework: " + annotation.value() );
+        if (LOGGER.isLoggable(Level.FINER)) {
+            LOGGER.finer("  Found MockFramework: " + annotation.value());
         }
 
         mockType = annotation.value();

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/MockFrameworkHandler.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/MockFrameworkHandler.java
@@ -1,0 +1,72 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.handler;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.james.mpt.onami.test.annotation.MockFramework;
+import org.apache.james.mpt.onami.test.annotation.MockType;
+import org.apache.james.mpt.onami.test.reflection.ClassHandler;
+import org.apache.james.mpt.onami.test.reflection.HandleException;
+
+/**
+ * Handler class to handle all {@link MockFramework} annotations.
+ *
+ * @see org.apache.onami.test.reflection.ClassVisitor
+ * @see MockFramework
+ */
+public final class MockFrameworkHandler
+    implements ClassHandler<MockFramework>
+{
+
+    private static final Logger LOGGER = Logger.getLogger( MockFrameworkHandler.class.getName() );
+
+    private MockType mockType;
+
+    /**
+     * @return the mockType
+     */
+    public MockType getMockType()
+    {
+        return mockType;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void handle( MockFramework annotation, Class<?> element )
+        throws HandleException
+    {
+        if ( mockType != null && mockType != annotation.value() )
+        {
+            throw new HandleException( "Inconsistent mock framework found. " + "Mock framework already set [set: "
+                + mockType + " now found: " + annotation.value() + "]" );
+        }
+
+        if ( LOGGER.isLoggable( Level.FINER ) )
+        {
+            LOGGER.finer( "  Found MockFramework: " + annotation.value() );
+        }
+
+        mockType = annotation.value();
+    }
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/MockHandler.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/MockHandler.java
@@ -1,0 +1,178 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.handler;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.james.mpt.onami.test.annotation.Mock;
+import org.apache.james.mpt.onami.test.mock.MockEngine;
+import org.apache.james.mpt.onami.test.reflection.FieldHandler;
+import org.apache.james.mpt.onami.test.reflection.HandleException;
+
+
+/**
+ * Handler class to handle all {@link Mock} annotations.
+ *
+ * @see org.apache.onami.test.reflection.ClassVisitor
+ * @see Mock
+ */
+public final class MockHandler
+    implements FieldHandler<Mock>
+{
+
+    private static final Logger LOGGER = Logger.getLogger( MockHandler.class.getName() );
+
+    private final HashMap<Field, Object> mockedObjects = new HashMap<Field, Object>( 1 );
+
+    /**
+     * Return the mocked objects.
+     * 
+     * @param engine the {@link MockEngine}
+     * @return the map of mocked objects
+     */
+    public HashMap<Field, Object> getMockedObject( MockEngine engine )
+    {
+        createMockedObjectBymockFramekork( engine );
+        return mockedObjects;
+    }
+
+    private void createMockedObjectBymockFramekork( MockEngine engine )
+    {
+        for ( Entry<Field, Object> entry : mockedObjects.entrySet() )
+        {
+            if ( entry.getValue() instanceof Class<?> )
+            {
+                Field field = entry.getKey();
+                Mock mock = field.getAnnotation( Mock.class );
+                mockedObjects.put( entry.getKey(), engine.createMock( (Class<?>) entry.getValue(), mock.type() ) );
+            }
+        }
+    }
+
+    
+    /**
+     * Invoked when the visitor founds an element with a {@link Mock} annotation.
+     * @param annotation The {@link Mock} annotation type
+     * @param element the {@link Mock} annotated fiels 
+     * @throws HandleException when an error occurs.    
+     */
+    @SuppressWarnings( "unchecked" )
+    public void handle( final Mock annotation, final Field element )
+        throws HandleException
+    {
+        final Class<? super Object> type = (Class<? super Object>) element.getDeclaringClass();
+
+        if ( LOGGER.isLoggable( Level.FINER ) )
+        {
+            LOGGER.finer( "      Found annotated field: " + element );
+        }
+        if ( annotation.providedBy().length() > 0 )
+        {
+            Class<?> providedClass = type;
+            if ( annotation.providerClass() != Object.class )
+            {
+                providedClass = annotation.providerClass();
+            }
+            try
+            {
+                Method method = providedClass.getMethod( annotation.providedBy() );
+
+                if ( !element.getType().isAssignableFrom( method.getReturnType() ) )
+                {
+                    throw new HandleException( "Impossible to mock %s due to compatibility type, method provider %s#%s returns %s",
+                                               element.getDeclaringClass().getName(),
+                                               providedClass.getName(),
+                                               annotation.providedBy(),
+                                               method.getReturnType().getName() );
+                }
+                try
+                {
+                    Object mocked = getMockProviderForType( element.getType(), method, type );
+                    mockedObjects.put( element, mocked );
+                }
+                catch ( Throwable t )
+                {
+                    throw new HandleException( "Impossible to mock %s, method provider %s#%s raised an error: %s",
+                                               element.getDeclaringClass().getName(),
+                                               providedClass.getName(),
+                                               annotation.providedBy(),
+                                               t );
+                }
+            }
+            catch ( SecurityException e )
+            {
+                throw new HandleException( "Impossible to mock %s, impossible to access to method provider %s#%s: %s",
+                                           element.getDeclaringClass().getName(),
+                                           providedClass.getName(),
+                                           annotation.providedBy(),
+                                           e );
+            }
+            catch ( NoSuchMethodException e )
+            {
+                throw new HandleException( "Impossible to mock %s, the method provider %s#%s doesn't exist.",
+                                           element.getDeclaringClass().getName(),
+                                           providedClass.getName(),
+                                           annotation.providedBy() );
+            }
+        }
+        else
+        {
+            mockedObjects.put( element, element.getType() );
+        }
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private <T> T getMockProviderForType( T t, Method method, Class<?> cls )
+        throws HandleException
+    {
+        if ( method.getReturnType() == t )
+        {
+            try
+            {
+                if ( LOGGER.isLoggable( Level.FINER ) )
+                {
+                    LOGGER.finer( "        ...invoke Provider method for Mock: " + method.getName() );
+                }
+                if ( !Modifier.isPublic( method.getModifiers() ) || !Modifier.isStatic( method.getModifiers() ) )
+                {
+                    throw new HandleException( "Impossible to invoke method %s#%s. The method shuld be 'static public %s %s()",
+                                               cls.getName(),
+                                               method.getName(),
+                                               method.getReturnType().getName(),
+                                               method.getName() );
+                }
+
+                return (T) method.invoke( cls );
+            }
+            catch ( Exception e )
+            {
+                throw new RuntimeException( e );
+            }
+        }
+        throw new HandleException( "The method: %s should return type %s", method, t );
+    }
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/MockHandler.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/handler/MockHandler.java
@@ -39,140 +39,113 @@ import org.apache.james.mpt.onami.test.reflection.HandleException;
  * @see org.apache.onami.test.reflection.ClassVisitor
  * @see Mock
  */
-public final class MockHandler
-    implements FieldHandler<Mock>
-{
+public final class MockHandler implements FieldHandler<Mock> {
 
-    private static final Logger LOGGER = Logger.getLogger( MockHandler.class.getName() );
+    private static final Logger LOGGER = Logger.getLogger(MockHandler.class.getName());
 
-    private final HashMap<Field, Object> mockedObjects = new HashMap<Field, Object>( 1 );
+    private final HashMap<Field, Object> mockedObjects = new HashMap<Field, Object>(1);
 
     /**
      * Return the mocked objects.
-     * 
+     *
      * @param engine the {@link MockEngine}
      * @return the map of mocked objects
      */
-    public HashMap<Field, Object> getMockedObject( MockEngine engine )
-    {
-        createMockedObjectBymockFramekork( engine );
+    public HashMap<Field, Object> getMockedObject(MockEngine engine) {
+        createMockedObjectBymockFramekork(engine);
         return mockedObjects;
     }
 
-    private void createMockedObjectBymockFramekork( MockEngine engine )
-    {
-        for ( Entry<Field, Object> entry : mockedObjects.entrySet() )
-        {
-            if ( entry.getValue() instanceof Class<?> )
-            {
+    private void createMockedObjectBymockFramekork(MockEngine engine) {
+        for (Entry<Field, Object> entry : mockedObjects.entrySet()) {
+            if (entry.getValue() instanceof Class<?>) {
                 Field field = entry.getKey();
-                Mock mock = field.getAnnotation( Mock.class );
-                mockedObjects.put( entry.getKey(), engine.createMock( (Class<?>) entry.getValue(), mock.type() ) );
+                Mock mock = field.getAnnotation(Mock.class);
+                mockedObjects.put(entry.getKey(), engine.createMock((Class<?>) entry.getValue(), mock.type()));
             }
         }
     }
 
-    
+
     /**
      * Invoked when the visitor founds an element with a {@link Mock} annotation.
+     *
      * @param annotation The {@link Mock} annotation type
-     * @param element the {@link Mock} annotated fiels 
-     * @throws HandleException when an error occurs.    
+     * @param element    the {@link Mock} annotated fiels
+     * @throws HandleException when an error occurs.
      */
-    @SuppressWarnings( "unchecked" )
-    public void handle( final Mock annotation, final Field element )
-        throws HandleException
-    {
+    @SuppressWarnings("unchecked")
+    public void handle(final Mock annotation, final Field element)
+        throws HandleException {
         final Class<? super Object> type = (Class<? super Object>) element.getDeclaringClass();
 
-        if ( LOGGER.isLoggable( Level.FINER ) )
-        {
-            LOGGER.finer( "      Found annotated field: " + element );
+        if (LOGGER.isLoggable(Level.FINER)) {
+            LOGGER.finer("      Found annotated field: " + element);
         }
-        if ( annotation.providedBy().length() > 0 )
-        {
+        if (annotation.providedBy().length() > 0) {
             Class<?> providedClass = type;
-            if ( annotation.providerClass() != Object.class )
-            {
+            if (annotation.providerClass() != Object.class) {
                 providedClass = annotation.providerClass();
             }
-            try
-            {
-                Method method = providedClass.getMethod( annotation.providedBy() );
+            try {
+                Method method = providedClass.getMethod(annotation.providedBy());
 
-                if ( !element.getType().isAssignableFrom( method.getReturnType() ) )
-                {
-                    throw new HandleException( "Impossible to mock %s due to compatibility type, method provider %s#%s returns %s",
-                                               element.getDeclaringClass().getName(),
-                                               providedClass.getName(),
-                                               annotation.providedBy(),
-                                               method.getReturnType().getName() );
+                if (!element.getType().isAssignableFrom(method.getReturnType())) {
+                    throw new HandleException("Impossible to mock %s due to compatibility type, method provider %s#%s returns %s",
+                        element.getDeclaringClass().getName(),
+                        providedClass.getName(),
+                        annotation.providedBy(),
+                        method.getReturnType().getName());
                 }
-                try
-                {
-                    Object mocked = getMockProviderForType( element.getType(), method, type );
-                    mockedObjects.put( element, mocked );
+                try {
+                    Object mocked = getMockProviderForType(element.getType(), method, type);
+                    mockedObjects.put(element, mocked);
+                } catch (Throwable t) {
+                    throw new HandleException("Impossible to mock %s, method provider %s#%s raised an error: %s",
+                        element.getDeclaringClass().getName(),
+                        providedClass.getName(),
+                        annotation.providedBy(),
+                        t);
                 }
-                catch ( Throwable t )
-                {
-                    throw new HandleException( "Impossible to mock %s, method provider %s#%s raised an error: %s",
-                                               element.getDeclaringClass().getName(),
-                                               providedClass.getName(),
-                                               annotation.providedBy(),
-                                               t );
-                }
+            } catch (SecurityException e) {
+                throw new HandleException("Impossible to mock %s, impossible to access to method provider %s#%s: %s",
+                    element.getDeclaringClass().getName(),
+                    providedClass.getName(),
+                    annotation.providedBy(),
+                    e);
+            } catch (NoSuchMethodException e) {
+                throw new HandleException("Impossible to mock %s, the method provider %s#%s doesn't exist.",
+                    element.getDeclaringClass().getName(),
+                    providedClass.getName(),
+                    annotation.providedBy());
             }
-            catch ( SecurityException e )
-            {
-                throw new HandleException( "Impossible to mock %s, impossible to access to method provider %s#%s: %s",
-                                           element.getDeclaringClass().getName(),
-                                           providedClass.getName(),
-                                           annotation.providedBy(),
-                                           e );
-            }
-            catch ( NoSuchMethodException e )
-            {
-                throw new HandleException( "Impossible to mock %s, the method provider %s#%s doesn't exist.",
-                                           element.getDeclaringClass().getName(),
-                                           providedClass.getName(),
-                                           annotation.providedBy() );
-            }
-        }
-        else
-        {
-            mockedObjects.put( element, element.getType() );
+        } else {
+            mockedObjects.put(element, element.getType());
         }
     }
 
-    @SuppressWarnings( "unchecked" )
-    private <T> T getMockProviderForType( T t, Method method, Class<?> cls )
-        throws HandleException
-    {
-        if ( method.getReturnType() == t )
-        {
-            try
-            {
-                if ( LOGGER.isLoggable( Level.FINER ) )
-                {
-                    LOGGER.finer( "        ...invoke Provider method for Mock: " + method.getName() );
+    @SuppressWarnings("unchecked")
+    private <T> T getMockProviderForType(T t, Method method, Class<?> cls)
+        throws HandleException {
+        if (method.getReturnType() == t) {
+            try {
+                if (LOGGER.isLoggable(Level.FINER)) {
+                    LOGGER.finer("        ...invoke Provider method for Mock: " + method.getName());
                 }
-                if ( !Modifier.isPublic( method.getModifiers() ) || !Modifier.isStatic( method.getModifiers() ) )
-                {
-                    throw new HandleException( "Impossible to invoke method %s#%s. The method shuld be 'static public %s %s()",
-                                               cls.getName(),
-                                               method.getName(),
-                                               method.getReturnType().getName(),
-                                               method.getName() );
+                if (!Modifier.isPublic(method.getModifiers()) || !Modifier.isStatic(method.getModifiers())) {
+                    throw new HandleException("Impossible to invoke method %s#%s. The method shuld be 'static public %s %s()",
+                        cls.getName(),
+                        method.getName(),
+                        method.getReturnType().getName(),
+                        method.getName());
                 }
 
-                return (T) method.invoke( cls );
-            }
-            catch ( Exception e )
-            {
-                throw new RuntimeException( e );
+                return (T) method.invoke(cls);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
             }
         }
-        throw new HandleException( "The method: %s should return type %s", method, t );
+        throw new HandleException("The method: %s should return type %s", method, t);
     }
 
 }

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/mock/MockEngine.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/mock/MockEngine.java
@@ -1,0 +1,50 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.mock;
+
+import org.apache.james.mpt.onami.test.annotation.MockObjType;
+
+/**
+ * Interface to specify mock framework class engine.
+ *
+ * @see org.apache.onami.test.mock.framework.EasyMockFramework
+ * @see org.apache.onami.test.mock.framework.MockitoFramework
+ */
+public interface MockEngine
+{
+
+    /**
+     * Reset the mock objects
+     *
+     * @param objects to reset.
+     */
+    void resetMock( Object... objects );
+
+    /**
+     * Create a typed mock
+     *
+     * @param <T> Class to mock
+     * @param cls Class to mock
+     * @param type the {@link MockObjType}
+     * @return the mock object
+     */
+    <T> T createMock( Class<T> cls, MockObjType type );
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/mock/MockEngine.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/mock/MockEngine.java
@@ -27,24 +27,23 @@ import org.apache.james.mpt.onami.test.annotation.MockObjType;
  * @see org.apache.onami.test.mock.framework.EasyMockFramework
  * @see org.apache.onami.test.mock.framework.MockitoFramework
  */
-public interface MockEngine
-{
+public interface MockEngine {
 
     /**
      * Reset the mock objects
      *
      * @param objects to reset.
      */
-    void resetMock( Object... objects );
+    void resetMock(Object... objects);
 
     /**
      * Create a typed mock
      *
-     * @param <T> Class to mock
-     * @param cls Class to mock
+     * @param <T>  Class to mock
+     * @param cls  Class to mock
      * @param type the {@link MockObjType}
      * @return the mock object
      */
-    <T> T createMock( Class<T> cls, MockObjType type );
+    <T> T createMock(Class<T> cls, MockObjType type);
 
 }

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/mock/framework/EasyMockFramework.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/mock/framework/EasyMockFramework.java
@@ -1,0 +1,65 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.mock.framework;
+
+import org.apache.james.mpt.onami.test.annotation.MockObjType;
+import org.apache.james.mpt.onami.test.mock.MockEngine;
+import org.easymock.EasyMock;
+
+/**
+ * Specifies the Easy-Mock Framework.
+ *
+ * @see MockEngine
+ */
+public class EasyMockFramework
+    implements MockEngine
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public void resetMock( Object... objects )
+    {
+        EasyMock.reset( objects );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public <T> T createMock( Class<T> cls, MockObjType type )
+    {
+        switch ( type )
+        {
+            case EASY_MOCK_NICE:
+                return EasyMock.createNiceMock( cls );
+
+            case EASY_MOCK_STRICT:
+                return EasyMock.createStrictMock( cls );
+
+            case EASY_MOCK_NORMAL:
+            case DEFAULT:
+                return EasyMock.createMock( cls );
+
+            default:
+                throw new IllegalArgumentException( "Unsupported mock type '" + type + "' for Easy-Mock Framework." );
+        }
+    }
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/mock/framework/EasyMockFramework.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/mock/framework/EasyMockFramework.java
@@ -28,37 +28,32 @@ import org.easymock.EasyMock;
  *
  * @see MockEngine
  */
-public class EasyMockFramework
-    implements MockEngine
-{
+public class EasyMockFramework implements MockEngine {
 
     /**
      * {@inheritDoc}
      */
-    public void resetMock( Object... objects )
-    {
-        EasyMock.reset( objects );
+    public void resetMock(Object... objects) {
+        EasyMock.reset(objects);
     }
 
     /**
      * {@inheritDoc}
      */
-    public <T> T createMock( Class<T> cls, MockObjType type )
-    {
-        switch ( type )
-        {
+    public <T> T createMock(Class<T> cls, MockObjType type) {
+        switch (type) {
             case EASY_MOCK_NICE:
-                return EasyMock.createNiceMock( cls );
+                return EasyMock.createNiceMock(cls);
 
             case EASY_MOCK_STRICT:
-                return EasyMock.createStrictMock( cls );
+                return EasyMock.createStrictMock(cls);
 
             case EASY_MOCK_NORMAL:
             case DEFAULT:
-                return EasyMock.createMock( cls );
+                return EasyMock.createMock(cls);
 
             default:
-                throw new IllegalArgumentException( "Unsupported mock type '" + type + "' for Easy-Mock Framework." );
+                throw new IllegalArgumentException("Unsupported mock type '" + type + "' for Easy-Mock Framework.");
         }
     }
 

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/mock/framework/MockitoFramework.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/mock/framework/MockitoFramework.java
@@ -1,0 +1,55 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.mock.framework;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.james.mpt.onami.test.annotation.MockObjType.DEFAULT;
+
+import org.apache.james.mpt.onami.test.annotation.MockObjType;
+import org.apache.james.mpt.onami.test.mock.MockEngine;
+import org.mockito.Mockito;
+
+/**
+ * Specifies the Mockito Framework.
+ *
+ * @see MockEngine
+ */
+public class MockitoFramework
+    implements MockEngine
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public void resetMock( Object... objects )
+    {
+        Mockito.reset( objects );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public <T> T createMock( Class<T> cls, MockObjType type )
+    {
+        checkArgument( DEFAULT == type, "Unsupported mock type '%s' for Mockito Framework.", type );
+        return Mockito.mock( cls );
+    }
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/mock/framework/MockitoFramework.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/mock/framework/MockitoFramework.java
@@ -32,24 +32,21 @@ import org.mockito.Mockito;
  * @see MockEngine
  */
 public class MockitoFramework
-    implements MockEngine
-{
+    implements MockEngine {
 
     /**
      * {@inheritDoc}
      */
-    public void resetMock( Object... objects )
-    {
-        Mockito.reset( objects );
+    public void resetMock(Object... objects) {
+        Mockito.reset(objects);
     }
 
     /**
      * {@inheritDoc}
      */
-    public <T> T createMock( Class<T> cls, MockObjType type )
-    {
-        checkArgument( DEFAULT == type, "Unsupported mock type '%s' for Mockito Framework.", type );
-        return Mockito.mock( cls );
+    public <T> T createMock(Class<T> cls, MockObjType type) {
+        checkArgument(DEFAULT == type, "Unsupported mock type '%s' for Mockito Framework.", type);
+        return Mockito.mock(cls);
     }
 
 }

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/AnnotationHandler.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/AnnotationHandler.java
@@ -1,0 +1,45 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.reflection;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+
+/**
+ * Interface to specify a generic annotation handler.
+ *
+ * @param <A> whatever annotation type
+ * @param <E> the element annotated with an annotation type
+ */
+public interface AnnotationHandler<A extends Annotation, E extends AnnotatedElement>
+{
+
+    /**
+     * Invoked when {@link ClassVisitor} found an annotation into a class.
+     *
+     * @param annotation handled annotation
+     * @param element the element annotated with input annotation
+     * @throws HandleException if an error occurs while processing the annotated element
+     *         and the related annotation
+     */
+    void handle( A annotation, E element )
+        throws HandleException;
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/AnnotationHandler.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/AnnotationHandler.java
@@ -28,18 +28,17 @@ import java.lang.reflect.AnnotatedElement;
  * @param <A> whatever annotation type
  * @param <E> the element annotated with an annotation type
  */
-public interface AnnotationHandler<A extends Annotation, E extends AnnotatedElement>
-{
+public interface AnnotationHandler<A extends Annotation, E extends AnnotatedElement> {
 
     /**
      * Invoked when {@link ClassVisitor} found an annotation into a class.
      *
      * @param annotation handled annotation
-     * @param element the element annotated with input annotation
+     * @param element    the element annotated with input annotation
      * @throws HandleException if an error occurs while processing the annotated element
-     *         and the related annotation
+     *                         and the related annotation
      */
-    void handle( A annotation, E element )
+    void handle(A annotation, E element)
         throws HandleException;
 
 }

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/ClassHandler.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/ClassHandler.java
@@ -1,0 +1,33 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.reflection;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * Interface to specify a generic class handler.
+ *
+ * @param <A> whatever annotation type
+ */
+public interface ClassHandler<A extends Annotation>
+    extends AnnotationHandler<A, Class<?>>
+{
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/ClassHandler.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/ClassHandler.java
@@ -26,8 +26,6 @@ import java.lang.annotation.Annotation;
  *
  * @param <A> whatever annotation type
  */
-public interface ClassHandler<A extends Annotation>
-    extends AnnotationHandler<A, Class<?>>
-{
+public interface ClassHandler<A extends Annotation> extends AnnotationHandler<A, Class<?>> {
 
 }

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/ClassVisitor.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/ClassVisitor.java
@@ -37,12 +37,11 @@ import com.google.common.collect.Multimap;
  * Visit the input class and all super classes and invokes handler to register annotations.
  * </p>
  */
-public final class ClassVisitor
-{
+public final class ClassVisitor {
 
     private static final String JAVA_PACKAGE = "java";
 
-    private static final Logger LOGGER = Logger.getLogger( ClassVisitor.class.getName() );
+    private static final Logger LOGGER = Logger.getLogger(ClassVisitor.class.getName());
 
     private final Multimap<Class<? extends Annotation>, AnnotationHandler<? extends Annotation, ? extends AnnotatedElement>> handlers =
         ArrayListMultimap.create();
@@ -50,58 +49,50 @@ public final class ClassVisitor
     /**
      * Registers an annotation handler.
      *
-     * @param <A> whatever annotation type
+     * @param <A>            whatever annotation type
      * @param annotationType the annotation class to handle
-     * @param handler the related annotation handler
+     * @param handler        the related annotation handler
      * @return the current {@code ClassVisitor} instance
      */
-    public <A extends Annotation> ClassVisitor registerHandler( Class<A> annotationType,
-                                                                AnnotationHandler<A, ? extends AnnotatedElement> handler )
-    {
-        handlers.put( annotationType, handler );
+    public <A extends Annotation> ClassVisitor registerHandler(Class<A> annotationType,
+                                                               AnnotationHandler<A, ? extends AnnotatedElement> handler) {
+        handlers.put(annotationType, handler);
         return this;
     }
 
     /**
      * Visits all fields, methods and super classes of the input class.
      *
-     * @param <T> any type
-     * @param type The type 
+     * @param <T>  any type
+     * @param type The type
      * @throws HandleException when an error occurs.
      */
-    public <T> void visit( final Class<? super T> type )
-        throws HandleException
-    {
-        checkArgument( type != null, "Type to be visited cannot be null" );
+    public <T> void visit(final Class<? super T> type)
+        throws HandleException {
+        checkArgument(type != null, "Type to be visited cannot be null");
 
-        if ( LOGGER.isLoggable( Level.FINER ) )
-        {
-            LOGGER.finer( "  Visit class: " + type );
+        if (LOGGER.isLoggable(Level.FINER)) {
+            LOGGER.finer("  Visit class: " + type);
         }
 
-        if ( type.getPackage() != null && type.getPackage().getName().startsWith( JAVA_PACKAGE ) )
-        {
+        if (type.getPackage() != null && type.getPackage().getName().startsWith(JAVA_PACKAGE)) {
             return;
         }
 
-        handle( type );
-        handle( type.getDeclaredFields() );
-        handle( type.getDeclaredMethods() );
+        handle(type);
+        handle(type.getDeclaredFields());
+        handle(type.getDeclaredMethods());
 
-        visit( (Class<? super T>) type.getSuperclass() );
+        visit((Class<? super T>) type.getSuperclass());
     }
 
-    @SuppressWarnings( "unchecked" )
-    private void handle( AnnotatedElement... elements )
-        throws HandleException
-    {
-        for ( AnnotatedElement element : elements )
-        {
-            for ( Annotation annotation : element.getAnnotations() )
-            {
-                for ( AnnotationHandler<? extends Annotation, ? extends AnnotatedElement> handler : handlers.get( annotation.annotationType() ) )
-                {
-                    ( (AnnotationHandler<Annotation, AnnotatedElement>) handler ).handle( annotation, element );
+    @SuppressWarnings("unchecked")
+    private void handle(AnnotatedElement... elements)
+        throws HandleException {
+        for (AnnotatedElement element : elements) {
+            for (Annotation annotation : element.getAnnotations()) {
+                for (AnnotationHandler<? extends Annotation, ? extends AnnotatedElement> handler : handlers.get(annotation.annotationType())) {
+                    ((AnnotationHandler<Annotation, AnnotatedElement>) handler).handle(annotation, element);
                 }
             }
         }

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/ClassVisitor.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/ClassVisitor.java
@@ -1,0 +1,110 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.reflection;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
+/**
+ * <p>
+ * Class visitor engine.
+ * </p>
+ * <p>
+ * Visit the input class and all super classes and invokes handler to register annotations.
+ * </p>
+ */
+public final class ClassVisitor
+{
+
+    private static final String JAVA_PACKAGE = "java";
+
+    private static final Logger LOGGER = Logger.getLogger( ClassVisitor.class.getName() );
+
+    private final Multimap<Class<? extends Annotation>, AnnotationHandler<? extends Annotation, ? extends AnnotatedElement>> handlers =
+        ArrayListMultimap.create();
+
+    /**
+     * Registers an annotation handler.
+     *
+     * @param <A> whatever annotation type
+     * @param annotationType the annotation class to handle
+     * @param handler the related annotation handler
+     * @return the current {@code ClassVisitor} instance
+     */
+    public <A extends Annotation> ClassVisitor registerHandler( Class<A> annotationType,
+                                                                AnnotationHandler<A, ? extends AnnotatedElement> handler )
+    {
+        handlers.put( annotationType, handler );
+        return this;
+    }
+
+    /**
+     * Visits all fields, methods and super classes of the input class.
+     *
+     * @param <T> any type
+     * @param type The type 
+     * @throws HandleException when an error occurs.
+     */
+    public <T> void visit( final Class<? super T> type )
+        throws HandleException
+    {
+        checkArgument( type != null, "Type to be visited cannot be null" );
+
+        if ( LOGGER.isLoggable( Level.FINER ) )
+        {
+            LOGGER.finer( "  Visit class: " + type );
+        }
+
+        if ( type.getPackage() != null && type.getPackage().getName().startsWith( JAVA_PACKAGE ) )
+        {
+            return;
+        }
+
+        handle( type );
+        handle( type.getDeclaredFields() );
+        handle( type.getDeclaredMethods() );
+
+        visit( (Class<? super T>) type.getSuperclass() );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private void handle( AnnotatedElement... elements )
+        throws HandleException
+    {
+        for ( AnnotatedElement element : elements )
+        {
+            for ( Annotation annotation : element.getAnnotations() )
+            {
+                for ( AnnotationHandler<? extends Annotation, ? extends AnnotatedElement> handler : handlers.get( annotation.annotationType() ) )
+                {
+                    ( (AnnotationHandler<Annotation, AnnotatedElement>) handler ).handle( annotation, element );
+                }
+            }
+        }
+    }
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/FieldHandler.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/FieldHandler.java
@@ -27,8 +27,6 @@ import java.lang.reflect.Field;
  *
  * @param <A> whatever annotation type
  */
-public interface FieldHandler<A extends Annotation>
-    extends AnnotationHandler<A, Field>
-{
+public interface FieldHandler<A extends Annotation> extends AnnotationHandler<A, Field> {
 
 }

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/FieldHandler.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/FieldHandler.java
@@ -1,0 +1,34 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.reflection;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+
+/**
+ * Interface to specify a generic field handler.
+ *
+ * @param <A> whatever annotation type
+ */
+public interface FieldHandler<A extends Annotation>
+    extends AnnotationHandler<A, Field>
+{
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/HandleException.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/HandleException.java
@@ -24,33 +24,29 @@ import static java.lang.String.format;
 /**
  * Exception thrown by a {@link ClassVisitor} when a error occurs.
  */
-public final class HandleException
-    extends Exception
-{
+public final class HandleException extends Exception {
 
     private static final long serialVersionUID = 1L;
 
     /**
      * Constructs a new HandleException with the specified detail message and cause.
      *
-     * @param message  detail message
-     * @param cause the cause
+     * @param message detail message
+     * @param cause   the cause
      */
-    public HandleException( String message, Throwable cause )
-    {
-        super( message, cause );
+    public HandleException(String message, Throwable cause) {
+        super(message, cause);
     }
 
     /**
      * Constructs a new HandleException with the specified detail message.
      *
      * @param message a format string
-     * @param args arguments referenced by the format specifiers in the format string
+     * @param args    arguments referenced by the format specifiers in the format string
      * @see String#format(String, Object...)
      */
-    public HandleException( String message, Object...args )
-    {
-        super( format( message, args ) );
+    public HandleException(String message, Object... args) {
+        super(format(message, args));
     }
 
     /**
@@ -58,9 +54,8 @@ public final class HandleException
      *
      * @param cause the cause
      */
-    public HandleException( Throwable cause )
-    {
-        super( cause );
+    public HandleException(Throwable cause) {
+        super(cause);
     }
 
 }

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/HandleException.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/HandleException.java
@@ -1,0 +1,66 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.reflection;
+
+import static java.lang.String.format;
+
+/**
+ * Exception thrown by a {@link ClassVisitor} when a error occurs.
+ */
+public final class HandleException
+    extends Exception
+{
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new HandleException with the specified detail message and cause.
+     *
+     * @param message  detail message
+     * @param cause the cause
+     */
+    public HandleException( String message, Throwable cause )
+    {
+        super( message, cause );
+    }
+
+    /**
+     * Constructs a new HandleException with the specified detail message.
+     *
+     * @param message a format string
+     * @param args arguments referenced by the format specifiers in the format string
+     * @see String#format(String, Object...)
+     */
+    public HandleException( String message, Object...args )
+    {
+        super( format( message, args ) );
+    }
+
+    /**
+     * Constructs a new HandleException with the specified cause.
+     *
+     * @param cause the cause
+     */
+    public HandleException( Throwable cause )
+    {
+        super( cause );
+    }
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/MethodHandler.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/MethodHandler.java
@@ -1,0 +1,34 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.reflection;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+/**
+ * Interface to specify a generic method handler.
+ *
+ * @param <A> whatever annotation type
+ */
+public interface MethodHandler<A extends Annotation>
+    extends AnnotationHandler<A, Method>
+{
+
+}

--- a/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/MethodHandler.java
+++ b/mpt/onami-test/src/main/java/org/apache/james/mpt/onami/test/reflection/MethodHandler.java
@@ -27,8 +27,6 @@ import java.lang.reflect.Method;
  *
  * @param <A> whatever annotation type
  */
-public interface MethodHandler<A extends Annotation>
-    extends AnnotationHandler<A, Method>
-{
+public interface MethodHandler<A extends Annotation> extends AnnotationHandler<A, Method> {
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/AbstractEmptyTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/AbstractEmptyTestCase.java
@@ -28,15 +28,13 @@ import org.junit.BeforeClass;
 /**
  * Utility class. Just for logging initialization.
  */
-abstract public class AbstractEmptyTestCase
-{
+abstract public class AbstractEmptyTestCase {
 
     @BeforeClass
     public static void initLogging()
-        throws Exception
-    {
-        LogManager.getLogManager().readConfiguration( new FileInputStream(
-                                                                           new File(
-                                                                                     "src/test/resources/log4j.properties" ) ) );
+        throws Exception {
+        LogManager.getLogManager().readConfiguration(new FileInputStream(
+            new File(
+                "src/test/resources/log4j.properties")));
     }
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/AbstractEmptyTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/AbstractEmptyTestCase.java
@@ -1,0 +1,42 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.logging.LogManager;
+
+import org.junit.BeforeClass;
+
+/**
+ * Utility class. Just for logging initialization.
+ */
+abstract public class AbstractEmptyTestCase
+{
+
+    @BeforeClass
+    public static void initLogging()
+        throws Exception
+    {
+        LogManager.getLogManager().readConfiguration( new FileInputStream(
+                                                                           new File(
+                                                                                     "src/test/resources/log4j.properties" ) ) );
+    }
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/AbstractMockTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/AbstractMockTestCase.java
@@ -23,18 +23,15 @@ import org.apache.james.mpt.onami.test.annotation.Mock;
 import org.apache.james.mpt.onami.test.data.Service;
 import org.easymock.EasyMock;
 
-abstract public class AbstractMockTestCase
-    extends AbstractEmptyTestCase
-{
+abstract public class AbstractMockTestCase extends AbstractEmptyTestCase {
 
     // Create and inject a Provided EasyMock
-    @Mock( providedBy = "getMock" )
+    @Mock(providedBy = "getMock")
     protected Service providedMock;
 
-    public static Service getMock()
-    {
+    public static Service getMock() {
         // Create the mock object and inject the dependency via Google-guice into HelloWorld
-        return EasyMock.createNiceMock( Service.class );
+        return EasyMock.createNiceMock(Service.class);
     }
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/AbstractMockTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/AbstractMockTestCase.java
@@ -1,0 +1,40 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+import org.apache.james.mpt.onami.test.annotation.Mock;
+import org.apache.james.mpt.onami.test.data.Service;
+import org.easymock.EasyMock;
+
+abstract public class AbstractMockTestCase
+    extends AbstractEmptyTestCase
+{
+
+    // Create and inject a Provided EasyMock
+    @Mock( providedBy = "getMock" )
+    protected Service providedMock;
+
+    public static Service getMock()
+    {
+        // Create the mock object and inject the dependency via Google-guice into HelloWorld
+        return EasyMock.createNiceMock( Service.class );
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/AbstractMockitoTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/AbstractMockitoTestCase.java
@@ -1,0 +1,45 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+
+import org.apache.james.mpt.onami.test.annotation.Mock;
+import org.apache.james.mpt.onami.test.annotation.MockFramework;
+import org.apache.james.mpt.onami.test.annotation.MockType;
+import org.apache.james.mpt.onami.test.data.Service;
+import org.mockito.Mockito;
+
+@MockFramework( MockType.MOCKITO )
+abstract public class AbstractMockitoTestCase
+    extends AbstractEmptyTestCase
+{
+
+    // Create and inject a Provided EasyMock
+    @Mock( providedBy = "getMock" )
+    protected Service providedMock;
+
+    // @MockProvider
+    public static Service getMock()
+    {
+        // Create the mock object and inject the dependency via Google-guice into HelloWorld
+        return Mockito.mock( Service.class );
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/AbstractMockitoTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/AbstractMockitoTestCase.java
@@ -26,20 +26,17 @@ import org.apache.james.mpt.onami.test.annotation.MockType;
 import org.apache.james.mpt.onami.test.data.Service;
 import org.mockito.Mockito;
 
-@MockFramework( MockType.MOCKITO )
-abstract public class AbstractMockitoTestCase
-    extends AbstractEmptyTestCase
-{
+@MockFramework(MockType.MOCKITO)
+abstract public class AbstractMockitoTestCase extends AbstractEmptyTestCase {
 
     // Create and inject a Provided EasyMock
-    @Mock( providedBy = "getMock" )
+    @Mock(providedBy = "getMock")
     protected Service providedMock;
 
     // @MockProvider
-    public static Service getMock()
-    {
+    public static Service getMock() {
         // Create the mock object and inject the dependency via Google-guice into HelloWorld
-        return Mockito.mock( Service.class );
+        return Mockito.mock(Service.class);
     }
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/AbstractTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/AbstractTestCase.java
@@ -1,0 +1,83 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+import java.util.ArrayList;
+
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.annotation.GuiceProvidedModules;
+import org.apache.james.mpt.onami.test.data.SimpleModule;
+import org.junit.runner.RunWith;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+import com.google.inject.name.Names;
+
+@RunWith( OnamiRunner.class )
+@GuiceModules( SimpleModule.class )
+abstract public class AbstractTestCase
+    extends AbstractEmptyTestCase
+{
+
+    @GuiceProvidedModules
+    public static Module genericModule()
+    {
+        return new AbstractModule()
+        {
+            @Override
+            protected void configure()
+            {
+                bind( String.class ).annotatedWith( Names.named( "test.info.inject" ) ).toInstance( "JUnice = JUnit + Guice" );
+            }
+        };
+    }
+
+    @GuiceProvidedModules
+    public static Iterable<Module> genericModule2()
+    {
+        AbstractModule a = new AbstractModule()
+        {
+            @Override
+            protected void configure()
+            {
+                bind( String.class ).annotatedWith( Names.named( "test.info.inject2" ) ).toInstance( "JUnice = JUnit + Guice Iterable" );
+            }
+        };
+
+        ArrayList<Module> al = new ArrayList<Module>();
+        al.add( a );
+        return al;
+    }
+
+    @GuiceProvidedModules
+    public static Module[] genericModule3()
+    {
+        AbstractModule a = new AbstractModule()
+        {
+            @Override
+            protected void configure()
+            {
+                bind( String.class ).annotatedWith( Names.named( "test.info.inject3" ) ).toInstance( "JUnice = JUnit + Guice Array" );
+            }
+        };
+        return new Module[] { a };
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/AbstractTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/AbstractTestCase.java
@@ -30,54 +30,43 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.google.inject.name.Names;
 
-@RunWith( OnamiRunner.class )
-@GuiceModules( SimpleModule.class )
-abstract public class AbstractTestCase
-    extends AbstractEmptyTestCase
-{
+@RunWith(OnamiRunner.class)
+@GuiceModules(SimpleModule.class)
+abstract public class AbstractTestCase extends AbstractEmptyTestCase {
 
     @GuiceProvidedModules
-    public static Module genericModule()
-    {
-        return new AbstractModule()
-        {
+    public static Module genericModule() {
+        return new AbstractModule() {
             @Override
-            protected void configure()
-            {
-                bind( String.class ).annotatedWith( Names.named( "test.info.inject" ) ).toInstance( "JUnice = JUnit + Guice" );
+            protected void configure() {
+                bind(String.class).annotatedWith(Names.named("test.info.inject")).toInstance("JUnice = JUnit + Guice");
             }
         };
     }
 
     @GuiceProvidedModules
-    public static Iterable<Module> genericModule2()
-    {
-        AbstractModule a = new AbstractModule()
-        {
+    public static Iterable<Module> genericModule2() {
+        AbstractModule a = new AbstractModule() {
             @Override
-            protected void configure()
-            {
-                bind( String.class ).annotatedWith( Names.named( "test.info.inject2" ) ).toInstance( "JUnice = JUnit + Guice Iterable" );
+            protected void configure() {
+                bind(String.class).annotatedWith(Names.named("test.info.inject2")).toInstance("JUnice = JUnit + Guice Iterable");
             }
         };
 
         ArrayList<Module> al = new ArrayList<Module>();
-        al.add( a );
+        al.add(a);
         return al;
     }
 
     @GuiceProvidedModules
-    public static Module[] genericModule3()
-    {
-        AbstractModule a = new AbstractModule()
-        {
+    public static Module[] genericModule3() {
+        AbstractModule a = new AbstractModule() {
             @Override
-            protected void configure()
-            {
-                bind( String.class ).annotatedWith( Names.named( "test.info.inject3" ) ).toInstance( "JUnice = JUnit + Guice Array" );
+            protected void configure() {
+                bind(String.class).annotatedWith(Names.named("test.info.inject3")).toInstance("JUnice = JUnit + Guice Array");
             }
         };
-        return new Module[] { a };
+        return new Module[]{a};
     }
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectDependingMockObjectTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectDependingMockObjectTestCase.java
@@ -22,6 +22,8 @@ package org.apache.james.mpt.onami.test;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.inject.Inject;
+
 import org.apache.james.mpt.onami.test.annotation.Mock;
 import org.apache.james.mpt.onami.test.data.HelloWorld;
 import org.apache.james.mpt.onami.test.data.Service;
@@ -32,13 +34,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.google.inject.AbstractModule;
-import javax.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.TypeLiteral;
 
-@RunWith( OnamiRunner.class )
-public class InjectDependingMockObjectTestCase
-{
+@RunWith(OnamiRunner.class)
+public class InjectDependingMockObjectTestCase {
 
     @Mock
     static private Service service;
@@ -49,39 +49,34 @@ public class InjectDependingMockObjectTestCase
     private HelloWorld helloWorld;
 
     @Before
-    public void setUp()
-    {
+    public void setUp() {
         final List<Service> list = new ArrayList<Service>();
-        list.add( service );
+        list.add(service);
 
-        AbstractModule listAbstractModule = new AbstractModule()
-        {
+        AbstractModule listAbstractModule = new AbstractModule() {
             @Override
-            protected void configure()
-            {
-                bind( new TypeLiteral<List<Service>>()
-                {
-                } ).toInstance( list );
+            protected void configure() {
+                bind(new TypeLiteral<List<Service>>() {
+                }).toInstance(list);
             }
         };
 
-        Injector cInjector = injector.createChildInjector( listAbstractModule );
-        helloWorld = cInjector.getInstance( HelloWorld.class );
+        Injector cInjector = injector.createChildInjector(listAbstractModule);
+        helloWorld = cInjector.getInstance(HelloWorld.class);
         // required for optional dependencies
-        cInjector.injectMembers( helloWorld );
+        cInjector.injectMembers(helloWorld);
     }
 
     @Test
-    public void testMock()
-    {
-        Assert.assertNotNull( helloWorld );
-        Assert.assertNotNull( service );
-        EasyMock.expect( service.go() ).andReturn( "Ciao" );
+    public void testMock() {
+        Assert.assertNotNull(helloWorld);
+        Assert.assertNotNull(service);
+        EasyMock.expect(service.go()).andReturn("Ciao");
         EasyMock.expectLastCall().once();
 
-        EasyMock.replay( service );
+        EasyMock.replay(service);
         helloWorld.sayHalloByServiceLists();
-        EasyMock.verify( service );
+        EasyMock.verify(service);
     }
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectDependingMockObjectTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectDependingMockObjectTestCase.java
@@ -1,0 +1,87 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.james.mpt.onami.test.annotation.Mock;
+import org.apache.james.mpt.onami.test.data.HelloWorld;
+import org.apache.james.mpt.onami.test.data.Service;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.google.inject.AbstractModule;
+import javax.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
+
+@RunWith( OnamiRunner.class )
+public class InjectDependingMockObjectTestCase
+{
+
+    @Mock
+    static private Service service;
+
+    @Inject
+    Injector injector;
+
+    private HelloWorld helloWorld;
+
+    @Before
+    public void setUp()
+    {
+        final List<Service> list = new ArrayList<Service>();
+        list.add( service );
+
+        AbstractModule listAbstractModule = new AbstractModule()
+        {
+            @Override
+            protected void configure()
+            {
+                bind( new TypeLiteral<List<Service>>()
+                {
+                } ).toInstance( list );
+            }
+        };
+
+        Injector cInjector = injector.createChildInjector( listAbstractModule );
+        helloWorld = cInjector.getInstance( HelloWorld.class );
+        // required for optional dependencies
+        cInjector.injectMembers( helloWorld );
+    }
+
+    @Test
+    public void testMock()
+    {
+        Assert.assertNotNull( helloWorld );
+        Assert.assertNotNull( service );
+        EasyMock.expect( service.go() ).andReturn( "Ciao" );
+        EasyMock.expectLastCall().once();
+
+        EasyMock.replay( service );
+        helloWorld.sayHalloByServiceLists();
+        EasyMock.verify( service );
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectFromSuperClassTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectFromSuperClassTestCase.java
@@ -19,39 +19,37 @@
 
 package org.apache.james.mpt.onami.test;
 
+import javax.inject.Inject;
+
 import org.junit.Assert;
 import org.junit.Test;
 
-import javax.inject.Inject;
 import com.google.inject.name.Named;
 
-public class InjectFromSuperClassTestCase
-    extends AbstractTestCase
-{
+public class InjectFromSuperClassTestCase extends AbstractTestCase {
 
     @Inject
-    @Named( "test.info.inject" )
+    @Named("test.info.inject")
     private String info;
 
     @Inject
-    @Named( "test.info.inject2" )
+    @Named("test.info.inject2")
     private String infoFromIterable;
 
     @Inject
-    @Named( "test.info.inject3" )
+    @Named("test.info.inject3")
     private String infoFromArray;
 
     @Test
-    public void testInjectFromSuperClass()
-    {
-        Assert.assertNotNull( info );
-        Assert.assertEquals( "JUnice = JUnit + Guice", info );
+    public void testInjectFromSuperClass() {
+        Assert.assertNotNull(info);
+        Assert.assertEquals("JUnice = JUnit + Guice", info);
 
-        Assert.assertNotNull( infoFromIterable );
-        Assert.assertEquals( "JUnice = JUnit + Guice Iterable", infoFromIterable );
+        Assert.assertNotNull(infoFromIterable);
+        Assert.assertEquals("JUnice = JUnit + Guice Iterable", infoFromIterable);
 
-        Assert.assertNotNull( infoFromArray );
-        Assert.assertEquals( "JUnice = JUnit + Guice Array", infoFromArray );
+        Assert.assertNotNull(infoFromArray);
+        Assert.assertEquals("JUnice = JUnit + Guice Array", infoFromArray);
     }
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectFromSuperClassTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectFromSuperClassTestCase.java
@@ -1,0 +1,57 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.inject.Inject;
+import com.google.inject.name.Named;
+
+public class InjectFromSuperClassTestCase
+    extends AbstractTestCase
+{
+
+    @Inject
+    @Named( "test.info.inject" )
+    private String info;
+
+    @Inject
+    @Named( "test.info.inject2" )
+    private String infoFromIterable;
+
+    @Inject
+    @Named( "test.info.inject3" )
+    private String infoFromArray;
+
+    @Test
+    public void testInjectFromSuperClass()
+    {
+        Assert.assertNotNull( info );
+        Assert.assertEquals( "JUnice = JUnit + Guice", info );
+
+        Assert.assertNotNull( infoFromIterable );
+        Assert.assertEquals( "JUnice = JUnit + Guice Iterable", infoFromIterable );
+
+        Assert.assertNotNull( infoFromArray );
+        Assert.assertEquals( "JUnice = JUnit + Guice Array", infoFromArray );
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectJSR330ModuleClassTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectJSR330ModuleClassTestCase.java
@@ -29,26 +29,22 @@ import org.junit.runner.RunWith;
 import com.google.inject.AbstractModule;
 import com.google.inject.name.Names;
 
-@RunWith( OnamiRunner.class )
-public class InjectJSR330ModuleClassTestCase
-    extends AbstractModule
-{
+@RunWith(OnamiRunner.class)
+public class InjectJSR330ModuleClassTestCase extends AbstractModule {
 
     @Override
-    public void configure()
-    {
-        bind( Integer.class ).annotatedWith( Names.named( "numeber.version" ) ).toInstance( 10 );
+    public void configure() {
+        bind(Integer.class).annotatedWith(Names.named("numeber.version")).toInstance(10);
     }
 
     @Inject
-    @Named( "numeber.version" )
+    @Named("numeber.version")
     private Integer version;
 
     @Test
-    public void testInjectModuleClass()
-    {
-        Assert.assertNotNull( version );
-        Assert.assertEquals( 10, version.intValue() );
+    public void testInjectModuleClass() {
+        Assert.assertNotNull(version);
+        Assert.assertEquals(10, version.intValue());
     }
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectJSR330ModuleClassTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectJSR330ModuleClassTestCase.java
@@ -1,0 +1,54 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
+
+@RunWith( OnamiRunner.class )
+public class InjectJSR330ModuleClassTestCase
+    extends AbstractModule
+{
+
+    @Override
+    public void configure()
+    {
+        bind( Integer.class ).annotatedWith( Names.named( "numeber.version" ) ).toInstance( 10 );
+    }
+
+    @Inject
+    @Named( "numeber.version" )
+    private Integer version;
+
+    @Test
+    public void testInjectModuleClass()
+    {
+        Assert.assertNotNull( version );
+        Assert.assertEquals( 10, version.intValue() );
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectMockObjectTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectMockObjectTestCase.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mpt.onami.test;
 
+import javax.inject.Inject;
+
 import org.apache.james.mpt.onami.test.annotation.GuiceModules;
 import org.apache.james.mpt.onami.test.annotation.Mock;
 import org.apache.james.mpt.onami.test.data.HelloWorld;
@@ -29,14 +31,11 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import javax.inject.Inject;
 import com.google.inject.Injector;
 
-@RunWith( OnamiRunner.class )
-@GuiceModules( SimpleModule.class )
-public class InjectMockObjectTestCase
-    extends AbstractMockTestCase
-{
+@RunWith(OnamiRunner.class)
+@GuiceModules(SimpleModule.class)
+public class InjectMockObjectTestCase extends AbstractMockTestCase {
 
     // Create and inject a simple EasyMock Strict mock
     @Mock
@@ -49,49 +48,45 @@ public class InjectMockObjectTestCase
     private HelloWorld helloWorld;
 
     @Test
-    public void testMock()
-    {
-        EasyMock.expect( providedMock.go() ).andReturn( "Ciao" );
-        EasyMock.replay( providedMock );
+    public void testMock() {
+        EasyMock.expect(providedMock.go()).andReturn("Ciao");
+        EasyMock.replay(providedMock);
 
-        Assert.assertNotNull( this.providedMock );
-        Assert.assertEquals( "Ciao", helloWorld.sayHalloByService() );
-        EasyMock.verify( providedMock );
+        Assert.assertNotNull(this.providedMock);
+        Assert.assertEquals("Ciao", helloWorld.sayHalloByService());
+        EasyMock.verify(providedMock);
     }
 
     @Test
-    public void testMock2()
-    {
-        EasyMock.expect( providedMock.go() ).andReturn( "Ciao" );
-        EasyMock.replay( providedMock );
+    public void testMock2() {
+        EasyMock.expect(providedMock.go()).andReturn("Ciao");
+        EasyMock.replay(providedMock);
 
-        Assert.assertNotNull( this.providedMock );
-        Assert.assertEquals( "Ciao", helloWorld.sayHalloByService() );
-        EasyMock.verify( providedMock );
+        Assert.assertNotNull(this.providedMock);
+        Assert.assertEquals("Ciao", helloWorld.sayHalloByService());
+        EasyMock.verify(providedMock);
     }
 
     @Test
-    public void testStrickMock()
-    {
-        EasyMock.expect( telephonServiceMock.getTelephonNumber() ).andReturn( "1234567890" );
-        providedMock.call( "1234567890" );
+    public void testStrickMock() {
+        EasyMock.expect(telephonServiceMock.getTelephonNumber()).andReturn("1234567890");
+        providedMock.call("1234567890");
         EasyMock.expectLastCall().once();
-        EasyMock.replay( telephonServiceMock );
-        EasyMock.replay( providedMock );
+        EasyMock.replay(telephonServiceMock);
+        EasyMock.replay(providedMock);
 
         helloWorld.callHelloWorldTelephon();
 
-        EasyMock.verify( telephonServiceMock );
-        EasyMock.verify( providedMock );
+        EasyMock.verify(telephonServiceMock);
+        EasyMock.verify(providedMock);
 
         // reset manually the mock object. Flag resettable is false!!!
-        EasyMock.reset( telephonServiceMock );
+        EasyMock.reset(telephonServiceMock);
     }
 
     @Test
-    public void testStrickMock2()
-    {
-        Assert.assertNotNull( telephonServiceMock );
+    public void testStrickMock2() {
+        Assert.assertNotNull(telephonServiceMock);
     }
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectMockObjectTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectMockObjectTestCase.java
@@ -1,0 +1,97 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.annotation.Mock;
+import org.apache.james.mpt.onami.test.data.HelloWorld;
+import org.apache.james.mpt.onami.test.data.SimpleModule;
+import org.apache.james.mpt.onami.test.data.TelephonService;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import com.google.inject.Injector;
+
+@RunWith( OnamiRunner.class )
+@GuiceModules( SimpleModule.class )
+public class InjectMockObjectTestCase
+    extends AbstractMockTestCase
+{
+
+    // Create and inject a simple EasyMock Strict mock
+    @Mock
+    private TelephonService telephonServiceMock;
+
+    @Inject
+    Injector injector;
+
+    @Inject
+    private HelloWorld helloWorld;
+
+    @Test
+    public void testMock()
+    {
+        EasyMock.expect( providedMock.go() ).andReturn( "Ciao" );
+        EasyMock.replay( providedMock );
+
+        Assert.assertNotNull( this.providedMock );
+        Assert.assertEquals( "Ciao", helloWorld.sayHalloByService() );
+        EasyMock.verify( providedMock );
+    }
+
+    @Test
+    public void testMock2()
+    {
+        EasyMock.expect( providedMock.go() ).andReturn( "Ciao" );
+        EasyMock.replay( providedMock );
+
+        Assert.assertNotNull( this.providedMock );
+        Assert.assertEquals( "Ciao", helloWorld.sayHalloByService() );
+        EasyMock.verify( providedMock );
+    }
+
+    @Test
+    public void testStrickMock()
+    {
+        EasyMock.expect( telephonServiceMock.getTelephonNumber() ).andReturn( "1234567890" );
+        providedMock.call( "1234567890" );
+        EasyMock.expectLastCall().once();
+        EasyMock.replay( telephonServiceMock );
+        EasyMock.replay( providedMock );
+
+        helloWorld.callHelloWorldTelephon();
+
+        EasyMock.verify( telephonServiceMock );
+        EasyMock.verify( providedMock );
+
+        // reset manually the mock object. Flag resettable is false!!!
+        EasyMock.reset( telephonServiceMock );
+    }
+
+    @Test
+    public void testStrickMock2()
+    {
+        Assert.assertNotNull( telephonServiceMock );
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectModuleClassTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectModuleClassTestCase.java
@@ -19,35 +19,32 @@
 
 package org.apache.james.mpt.onami.test;
 
+import javax.inject.Inject;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.google.inject.AbstractModule;
-import javax.inject.Inject;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 
-@RunWith( OnamiRunner.class )
-public class InjectModuleClassTestCase
-    extends AbstractModule
-{
+@RunWith(OnamiRunner.class)
+public class InjectModuleClassTestCase extends AbstractModule {
 
     @Override
-    public void configure()
-    {
-        bind( Integer.class ).annotatedWith( Names.named( "numeber.version" ) ).toInstance( 10 );
+    public void configure() {
+        bind(Integer.class).annotatedWith(Names.named("numeber.version")).toInstance(10);
     }
 
     @Inject
-    @Named( "numeber.version" )
+    @Named("numeber.version")
     private Integer version;
 
     @Test
-    public void testInjectModuleClass()
-    {
-        Assert.assertNotNull( version );
-        Assert.assertEquals( 10, version.intValue() );
+    public void testInjectModuleClass() {
+        Assert.assertNotNull(version);
+        Assert.assertEquals(10, version.intValue());
     }
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectModuleClassTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectModuleClassTestCase.java
@@ -1,0 +1,53 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.google.inject.AbstractModule;
+import javax.inject.Inject;
+import com.google.inject.name.Named;
+import com.google.inject.name.Names;
+
+@RunWith( OnamiRunner.class )
+public class InjectModuleClassTestCase
+    extends AbstractModule
+{
+
+    @Override
+    public void configure()
+    {
+        bind( Integer.class ).annotatedWith( Names.named( "numeber.version" ) ).toInstance( 10 );
+    }
+
+    @Inject
+    @Named( "numeber.version" )
+    private Integer version;
+
+    @Test
+    public void testInjectModuleClass()
+    {
+        Assert.assertNotNull( version );
+        Assert.assertEquals( 10, version.intValue() );
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectStaticSimpleTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectStaticSimpleTestCase.java
@@ -20,6 +20,8 @@
 package org.apache.james.mpt.onami.test;
 
 
+import javax.inject.Inject;
+
 import org.apache.james.mpt.onami.test.annotation.GuiceModules;
 import org.apache.james.mpt.onami.test.annotation.GuiceProvidedModules;
 import org.apache.james.mpt.onami.test.data.ComplexModule;
@@ -30,13 +32,11 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import javax.inject.Inject;
 import com.google.inject.Module;
 
-@RunWith( OnamiRunner.class )
-@GuiceModules( SimpleModule.class )
-public class InjectStaticSimpleTestCase
-{
+@RunWith(OnamiRunner.class)
+@GuiceModules(SimpleModule.class)
+public class InjectStaticSimpleTestCase {
 
     /*
      * Any static filed will be injecteded once before creation of SimpleTest Class
@@ -48,23 +48,20 @@ public class InjectStaticSimpleTestCase
     public static WhoIm whoIm;
 
     @GuiceProvidedModules
-    public static Module createComplexModule()
-    {
-        return new ComplexModule( "Marco Speranza" );
+    public static Module createComplexModule() {
+        return new ComplexModule("Marco Speranza");
     }
 
     @Test
-    public void testHelloWorld()
-    {
-        Assert.assertNotNull( helloWorld );
-        Assert.assertEquals( "Hello World!!!!", helloWorld.sayHallo() );
+    public void testHelloWorld() {
+        Assert.assertNotNull(helloWorld);
+        Assert.assertEquals("Hello World!!!!", helloWorld.sayHallo());
     }
 
     @Test
-    public void testWhoIm()
-    {
-        Assert.assertNotNull( whoIm );
-        Assert.assertEquals( "Marco Speranza", whoIm.sayWhoIm() );
+    public void testWhoIm() {
+        Assert.assertNotNull(whoIm);
+        Assert.assertEquals("Marco Speranza", whoIm.sayWhoIm());
     }
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectStaticSimpleTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/InjectStaticSimpleTestCase.java
@@ -1,0 +1,70 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.annotation.GuiceProvidedModules;
+import org.apache.james.mpt.onami.test.data.ComplexModule;
+import org.apache.james.mpt.onami.test.data.HelloWorld;
+import org.apache.james.mpt.onami.test.data.SimpleModule;
+import org.apache.james.mpt.onami.test.data.WhoIm;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import com.google.inject.Module;
+
+@RunWith( OnamiRunner.class )
+@GuiceModules( SimpleModule.class )
+public class InjectStaticSimpleTestCase
+{
+
+    /*
+     * Any static filed will be injecteded once before creation of SimpleTest Class
+     */
+    @Inject
+    public static HelloWorld helloWorld;
+
+    @Inject
+    public static WhoIm whoIm;
+
+    @GuiceProvidedModules
+    public static Module createComplexModule()
+    {
+        return new ComplexModule( "Marco Speranza" );
+    }
+
+    @Test
+    public void testHelloWorld()
+    {
+        Assert.assertNotNull( helloWorld );
+        Assert.assertEquals( "Hello World!!!!", helloWorld.sayHallo() );
+    }
+
+    @Test
+    public void testWhoIm()
+    {
+        Assert.assertNotNull( whoIm );
+        Assert.assertEquals( "Marco Speranza", whoIm.sayWhoIm() );
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/MockTypeTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/MockTypeTestCase.java
@@ -27,17 +27,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 
-@RunWith( OnamiRunner.class )
-public class MockTypeTestCase
-{
+@RunWith(OnamiRunner.class)
+public class MockTypeTestCase {
 
-    @Mock( type = MockObjType.EASY_MOCK_STRICT )
+    @Mock(type = MockObjType.EASY_MOCK_STRICT)
     Service service;
 
     @Test
-    public void test()
-    {
-        Assert.assertNotNull( service );
+    public void test() {
+        Assert.assertNotNull(service);
     }
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/MockTypeTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/MockTypeTestCase.java
@@ -1,0 +1,43 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+import org.apache.james.mpt.onami.test.annotation.Mock;
+import org.apache.james.mpt.onami.test.annotation.MockObjType;
+import org.apache.james.mpt.onami.test.data.Service;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith( OnamiRunner.class )
+public class MockTypeTestCase
+{
+
+    @Mock( type = MockObjType.EASY_MOCK_STRICT )
+    Service service;
+
+    @Test
+    public void test()
+    {
+        Assert.assertNotNull( service );
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/MockitoFrameworkTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/MockitoFrameworkTestCase.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mpt.onami.test;
 
+import javax.inject.Inject;
+
 import org.apache.james.mpt.onami.test.annotation.Mock;
 import org.apache.james.mpt.onami.test.data.HelloWorld;
 import org.apache.james.mpt.onami.test.data.TelephonService;
@@ -27,12 +29,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import javax.inject.Inject;
-
-@RunWith( OnamiRunner.class )
-public class MockitoFrameworkTestCase
-    extends AbstractMockitoTestCase
-{
+@RunWith(OnamiRunner.class)
+public class MockitoFrameworkTestCase extends AbstractMockitoTestCase {
 
     /*
      * Any NON-static filed will be injected before run each tests.
@@ -44,17 +42,15 @@ public class MockitoFrameworkTestCase
     private TelephonService service;
 
     @BeforeClass
-    public static void setUpClass()
-    {
+    public static void setUpClass() {
     }
 
     @Test
-    public void testInjectNotStatic()
-    {
-        Assert.assertNotNull( helloWorldNotStatic );
-        Assert.assertEquals( "Hello World!!!!", helloWorldNotStatic.sayHallo() );
-        Assert.assertNotNull( service );
-        Assert.assertNotNull( providedMock );
+    public void testInjectNotStatic() {
+        Assert.assertNotNull(helloWorldNotStatic);
+        Assert.assertEquals("Hello World!!!!", helloWorldNotStatic.sayHallo());
+        Assert.assertNotNull(service);
+        Assert.assertNotNull(providedMock);
     }
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/MockitoFrameworkTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/MockitoFrameworkTestCase.java
@@ -1,0 +1,60 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+import org.apache.james.mpt.onami.test.annotation.Mock;
+import org.apache.james.mpt.onami.test.data.HelloWorld;
+import org.apache.james.mpt.onami.test.data.TelephonService;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+@RunWith( OnamiRunner.class )
+public class MockitoFrameworkTestCase
+    extends AbstractMockitoTestCase
+{
+
+    /*
+     * Any NON-static filed will be injected before run each tests.
+     */
+    @Inject
+    private HelloWorld helloWorldNotStatic;
+
+    @Mock
+    private TelephonService service;
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+    }
+
+    @Test
+    public void testInjectNotStatic()
+    {
+        Assert.assertNotNull( helloWorldNotStatic );
+        Assert.assertEquals( "Hello World!!!!", helloWorldNotStatic.sayHallo() );
+        Assert.assertNotNull( service );
+        Assert.assertNotNull( providedMock );
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/OnamiSuiteTest.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/OnamiSuiteTest.java
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(OnamiSuite.class)
-@SuiteClasses({ InjectDependingMockObjectTestCase.class, InjectFromSuperClassTestCase.class })
+@SuiteClasses({InjectDependingMockObjectTestCase.class, InjectFromSuperClassTestCase.class})
 public class OnamiSuiteTest {
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/OnamiSuiteTest.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/OnamiSuiteTest.java
@@ -1,0 +1,29 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(OnamiSuite.class)
+@SuiteClasses({ InjectDependingMockObjectTestCase.class, InjectFromSuperClassTestCase.class })
+public class OnamiSuiteTest {
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/ServiceMockProviderTest.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/ServiceMockProviderTest.java
@@ -1,0 +1,43 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+import org.apache.james.mpt.onami.test.annotation.Mock;
+import org.apache.james.mpt.onami.test.data.Service;
+import org.apache.james.mpt.onami.test.data.ServiceMockProvider;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith( OnamiRunner.class )
+public class ServiceMockProviderTest
+{
+
+    @Mock( providedBy = "providerMethod", providerClass = ServiceMockProvider.class )
+    private Service service;
+
+    @Test
+    public void test()
+    {
+        Assert.assertNotNull( service );
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/ServiceMockProviderTest.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/ServiceMockProviderTest.java
@@ -27,17 +27,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 
-@RunWith( OnamiRunner.class )
-public class ServiceMockProviderTest
-{
+@RunWith(OnamiRunner.class)
+public class ServiceMockProviderTest {
 
-    @Mock( providedBy = "providerMethod", providerClass = ServiceMockProvider.class )
+    @Mock(providedBy = "providerMethod", providerClass = ServiceMockProvider.class)
     private Service service;
 
     @Test
-    public void test()
-    {
-        Assert.assertNotNull( service );
+    public void test() {
+        Assert.assertNotNull(service);
     }
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/SimpleTest.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/SimpleTest.java
@@ -1,0 +1,56 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test;
+
+
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.data.HelloWorld;
+import org.apache.james.mpt.onami.test.data.SimpleModule;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+@RunWith( OnamiRunner.class )
+@GuiceModules( SimpleModule.class )
+public class SimpleTest
+{
+
+    /*
+     * Any NON-static filed will be injecteded before run each tests.
+     */
+    @Inject
+    private HelloWorld helloWorldNotStatic;
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+    }
+
+    @Test
+    public void testInjectNotStatic()
+    {
+        Assert.assertNotNull( helloWorldNotStatic );
+        Assert.assertEquals( "Hello World!!!!", helloWorldNotStatic.sayHallo() );
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/SimpleTest.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/SimpleTest.java
@@ -20,6 +20,8 @@
 package org.apache.james.mpt.onami.test;
 
 
+import javax.inject.Inject;
+
 import org.apache.james.mpt.onami.test.annotation.GuiceModules;
 import org.apache.james.mpt.onami.test.data.HelloWorld;
 import org.apache.james.mpt.onami.test.data.SimpleModule;
@@ -28,12 +30,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import javax.inject.Inject;
-
-@RunWith( OnamiRunner.class )
-@GuiceModules( SimpleModule.class )
-public class SimpleTest
-{
+@RunWith(OnamiRunner.class)
+@GuiceModules(SimpleModule.class)
+public class SimpleTest {
 
     /*
      * Any NON-static filed will be injecteded before run each tests.
@@ -42,15 +41,13 @@ public class SimpleTest
     private HelloWorld helloWorldNotStatic;
 
     @BeforeClass
-    public static void setUpClass()
-    {
+    public static void setUpClass() {
     }
 
     @Test
-    public void testInjectNotStatic()
-    {
-        Assert.assertNotNull( helloWorldNotStatic );
-        Assert.assertEquals( "Hello World!!!!", helloWorldNotStatic.sayHallo() );
+    public void testInjectNotStatic() {
+        Assert.assertNotNull(helloWorldNotStatic);
+        Assert.assertEquals("Hello World!!!!", helloWorldNotStatic.sayHallo());
     }
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/ComplexModule.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/ComplexModule.java
@@ -1,0 +1,41 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.data;
+
+import com.google.inject.AbstractModule;
+
+public class ComplexModule
+    extends AbstractModule
+{
+
+    private final String name;
+
+    public ComplexModule( String name )
+    {
+        this.name = name;
+    }
+
+    @Override
+    protected void configure()
+    {
+        bind( WhoIm.class ).toInstance( new WhoIm( name ) );
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/ComplexModule.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/ComplexModule.java
@@ -21,21 +21,17 @@ package org.apache.james.mpt.onami.test.data;
 
 import com.google.inject.AbstractModule;
 
-public class ComplexModule
-    extends AbstractModule
-{
+public class ComplexModule extends AbstractModule {
 
     private final String name;
 
-    public ComplexModule( String name )
-    {
+    public ComplexModule(String name) {
         this.name = name;
     }
 
     @Override
-    protected void configure()
-    {
-        bind( WhoIm.class ).toInstance( new WhoIm( name ) );
+    protected void configure() {
+        bind(WhoIm.class).toInstance(new WhoIm(name));
     }
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/HelloWordAnnotated.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/HelloWordAnnotated.java
@@ -1,0 +1,46 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.data;
+
+import javax.inject.Inject;
+import com.google.inject.name.Named;
+
+public class HelloWordAnnotated
+{
+
+    @Inject
+    @TestAnnotation
+    Service service;
+
+    @Inject
+    @Named( "test.named" )
+    Service named;
+
+    public String go()
+    {
+        return service.go();
+    }
+
+    public String getNamed()
+    {
+        return named.go();
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/HelloWordAnnotated.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/HelloWordAnnotated.java
@@ -20,26 +20,24 @@
 package org.apache.james.mpt.onami.test.data;
 
 import javax.inject.Inject;
+
 import com.google.inject.name.Named;
 
-public class HelloWordAnnotated
-{
+public class HelloWordAnnotated {
 
     @Inject
     @TestAnnotation
     Service service;
 
     @Inject
-    @Named( "test.named" )
+    @Named("test.named")
     Service named;
 
-    public String go()
-    {
+    public String go() {
         return service.go();
     }
 
-    public String getNamed()
-    {
+    public String getNamed() {
         return named.go();
     }
 

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/HelloWorld.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/HelloWorld.java
@@ -21,43 +21,37 @@ package org.apache.james.mpt.onami.test.data;
 
 import java.util.List;
 
-import com.google.inject.Inject;
-
 import javax.inject.Singleton;
 
-@Singleton
-public class HelloWorld
-{
+import com.google.inject.Inject;
 
-    @Inject( optional = true )
+@Singleton
+public class HelloWorld {
+
+    @Inject(optional = true)
     private Service service;
 
-    @Inject( optional = true )
+    @Inject(optional = true)
     private TelephonService telephon;
 
-    @Inject( optional = true )
+    @Inject(optional = true)
     private List<Service> services;
 
-    public String sayHallo()
-    {
+    public String sayHallo() {
         return "Hello World!!!!";
     }
 
-    public String sayHalloByService()
-    {
+    public String sayHalloByService() {
         return service.go();
     }
 
-    public void callHelloWorldTelephon()
-    {
+    public void callHelloWorldTelephon() {
         String number = telephon.getTelephonNumber();
-        service.call( number );
+        service.call(number);
     }
 
-    public void sayHalloByServiceLists()
-    {
-        for ( Service service : services )
-        {
+    public void sayHalloByServiceLists() {
+        for (Service service : services) {
             service.go();
         }
     }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/HelloWorld.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/HelloWorld.java
@@ -1,0 +1,65 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.data;
+
+import java.util.List;
+
+import com.google.inject.Inject;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class HelloWorld
+{
+
+    @Inject( optional = true )
+    private Service service;
+
+    @Inject( optional = true )
+    private TelephonService telephon;
+
+    @Inject( optional = true )
+    private List<Service> services;
+
+    public String sayHallo()
+    {
+        return "Hello World!!!!";
+    }
+
+    public String sayHalloByService()
+    {
+        return service.go();
+    }
+
+    public void callHelloWorldTelephon()
+    {
+        String number = telephon.getTelephonNumber();
+        service.call( number );
+    }
+
+    public void sayHalloByServiceLists()
+    {
+        for ( Service service : services )
+        {
+            service.go();
+        }
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/Service.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/Service.java
@@ -1,0 +1,29 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.data;
+
+public interface Service
+{
+
+    String go();
+
+    void call( String value );
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/Service.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/Service.java
@@ -19,11 +19,10 @@
 
 package org.apache.james.mpt.onami.test.data;
 
-public interface Service
-{
+public interface Service {
 
     String go();
 
-    void call( String value );
+    void call(String value);
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/ServiceImpl.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/ServiceImpl.java
@@ -19,17 +19,13 @@
 
 package org.apache.james.mpt.onami.test.data;
 
-public class ServiceImpl
-    implements Service
-{
+public class ServiceImpl implements Service {
 
-    public void call( String value )
-    {
+    public void call(String value) {
         // do nothing
     }
 
-    public String go()
-    {
+    public String go() {
         return "It's real class";
     }
 

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/ServiceImpl.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/ServiceImpl.java
@@ -1,0 +1,36 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.data;
+
+public class ServiceImpl
+    implements Service
+{
+
+    public void call( String value )
+    {
+        // do nothing
+    }
+
+    public String go()
+    {
+        return "It's real class";
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/ServiceMockProvider.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/ServiceMockProvider.java
@@ -21,12 +21,10 @@ package org.apache.james.mpt.onami.test.data;
 
 import org.easymock.EasyMock;
 
-public class ServiceMockProvider
-{
+public class ServiceMockProvider {
 
-    public static Service providerMethod()
-    {
-        Service mockedService = EasyMock.createNiceMock( Service.class );
+    public static Service providerMethod() {
+        Service mockedService = EasyMock.createNiceMock(Service.class);
         return mockedService;
     }
 

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/ServiceMockProvider.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/ServiceMockProvider.java
@@ -1,0 +1,33 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.data;
+
+import org.easymock.EasyMock;
+
+public class ServiceMockProvider
+{
+
+    public static Service providerMethod()
+    {
+        Service mockedService = EasyMock.createNiceMock( Service.class );
+        return mockedService;
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/ServiceModule.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/ServiceModule.java
@@ -1,0 +1,35 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.data;
+
+import com.google.inject.AbstractModule;
+
+public class ServiceModule
+    extends AbstractModule
+{
+
+    @Override
+    protected void configure()
+    {
+        bind( Service.class ).to( ServiceImpl.class ).asEagerSingleton();
+        bind( TelephonService.class ).to( TelephonServiceImpl.class ).asEagerSingleton();
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/ServiceModule.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/ServiceModule.java
@@ -21,15 +21,12 @@ package org.apache.james.mpt.onami.test.data;
 
 import com.google.inject.AbstractModule;
 
-public class ServiceModule
-    extends AbstractModule
-{
+public class ServiceModule extends AbstractModule {
 
     @Override
-    protected void configure()
-    {
-        bind( Service.class ).to( ServiceImpl.class ).asEagerSingleton();
-        bind( TelephonService.class ).to( TelephonServiceImpl.class ).asEagerSingleton();
+    protected void configure() {
+        bind(Service.class).to(ServiceImpl.class).asEagerSingleton();
+        bind(TelephonService.class).to(TelephonServiceImpl.class).asEagerSingleton();
     }
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/SimpleModule.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/SimpleModule.java
@@ -21,14 +21,11 @@ package org.apache.james.mpt.onami.test.data;
 
 import com.google.inject.AbstractModule;
 
-public class SimpleModule
-    extends AbstractModule
-{
+public class SimpleModule extends AbstractModule {
 
     @Override
-    protected void configure()
-    {
-        bind( HelloWorld.class );
+    protected void configure() {
+        bind(HelloWorld.class);
     }
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/SimpleModule.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/SimpleModule.java
@@ -1,0 +1,34 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.data;
+
+import com.google.inject.AbstractModule;
+
+public class SimpleModule
+    extends AbstractModule
+{
+
+    @Override
+    protected void configure()
+    {
+        bind( HelloWorld.class );
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/TelephonService.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/TelephonService.java
@@ -1,0 +1,27 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.data;
+
+public interface TelephonService
+{
+
+    String getTelephonNumber();
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/TelephonService.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/TelephonService.java
@@ -19,8 +19,7 @@
 
 package org.apache.james.mpt.onami.test.data;
 
-public interface TelephonService
-{
+public interface TelephonService {
 
     String getTelephonNumber();
 

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/TelephonServiceImpl.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/TelephonServiceImpl.java
@@ -20,11 +20,9 @@
 package org.apache.james.mpt.onami.test.data;
 
 public class TelephonServiceImpl
-    implements TelephonService
-{
+    implements TelephonService {
 
-    public String getTelephonNumber()
-    {
+    public String getTelephonNumber() {
         return "It's real class";
     }
 

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/TelephonServiceImpl.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/TelephonServiceImpl.java
@@ -1,0 +1,31 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.data;
+
+public class TelephonServiceImpl
+    implements TelephonService
+{
+
+    public String getTelephonNumber()
+    {
+        return "It's real class";
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/TestAnnotation.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/TestAnnotation.java
@@ -25,8 +25,7 @@ import java.lang.annotation.RetentionPolicy;
 import javax.inject.Qualifier;
 
 @Qualifier
-@Retention( RetentionPolicy.RUNTIME )
-public @interface TestAnnotation
-{
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestAnnotation {
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/TestAnnotation.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/TestAnnotation.java
@@ -1,0 +1,32 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.data;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.inject.Qualifier;
+
+@Qualifier
+@Retention( RetentionPolicy.RUNTIME )
+public @interface TestAnnotation
+{
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/TestAnnotation2.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/TestAnnotation2.java
@@ -1,0 +1,32 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.data;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.inject.Qualifier;
+
+@Qualifier
+@Retention( RetentionPolicy.RUNTIME )
+public @interface TestAnnotation2
+{
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/TestAnnotation2.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/TestAnnotation2.java
@@ -25,8 +25,7 @@ import java.lang.annotation.RetentionPolicy;
 import javax.inject.Qualifier;
 
 @Qualifier
-@Retention( RetentionPolicy.RUNTIME )
-public @interface TestAnnotation2
-{
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestAnnotation2 {
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/WhoIm.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/WhoIm.java
@@ -1,0 +1,37 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.data;
+
+public class WhoIm
+{
+
+    private final String name;
+
+    public WhoIm( String name )
+    {
+        this.name = name;
+    }
+
+    public String sayWhoIm()
+    {
+        return name;
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/WhoIm.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/data/WhoIm.java
@@ -19,18 +19,15 @@
 
 package org.apache.james.mpt.onami.test.data;
 
-public class WhoIm
-{
+public class WhoIm {
 
     private final String name;
 
-    public WhoIm( String name )
-    {
+    public WhoIm(String name) {
         this.name = name;
     }
 
-    public String sayWhoIm()
-    {
+    public String sayWhoIm() {
         return name;
     }
 

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/guice/MockAnnotatedWithTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/guice/MockAnnotatedWithTestCase.java
@@ -1,0 +1,76 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.guice;
+
+import org.apache.james.mpt.onami.test.OnamiRunner;
+import org.apache.james.mpt.onami.test.annotation.Mock;
+import org.apache.james.mpt.onami.test.data.HelloWordAnnotated;
+import org.apache.james.mpt.onami.test.data.Service;
+import org.apache.james.mpt.onami.test.data.TestAnnotation;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+@RunWith( OnamiRunner.class )
+public class MockAnnotatedWithTestCase
+{
+
+    @Mock( annotatedWith = TestAnnotation.class )
+    private Service service2;
+
+    @Mock
+    private Service service;
+
+    @Mock( namedWith = "test.named" )
+    private Service serviceNamed;
+
+    @Inject
+    private HelloWordAnnotated seviceImplAnnotated;
+
+    @Test
+    public void test()
+        throws Exception
+    {
+        Assert.assertNotNull( service2 );
+        Assert.assertNotNull( service );
+        Assert.assertNotNull( serviceNamed );
+    }
+
+    @Test
+    public void test3()
+        throws Exception
+    {
+        Assert.assertNotNull( service2 );
+        Assert.assertNotNull( serviceNamed );
+
+        EasyMock.expect( service2.go() ).andReturn( "Mocked injected class annotated" ).anyTimes();
+        EasyMock.expect( serviceNamed.go() ).andReturn( "Mocked injected class named" ).anyTimes();
+        EasyMock.replay( service2, serviceNamed );
+
+        Assert.assertEquals( "Mocked injected class annotated", service2.go() );
+        Assert.assertEquals( "Mocked injected class annotated", seviceImplAnnotated.go() );
+        Assert.assertEquals( "Mocked injected class named", seviceImplAnnotated.getNamed() );
+        EasyMock.verify( service2 );
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/guice/MockAnnotatedWithTestCase.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/guice/MockAnnotatedWithTestCase.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mpt.onami.test.guice;
 
+import javax.inject.Inject;
+
 import org.apache.james.mpt.onami.test.OnamiRunner;
 import org.apache.james.mpt.onami.test.annotation.Mock;
 import org.apache.james.mpt.onami.test.data.HelloWordAnnotated;
@@ -29,19 +31,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import javax.inject.Inject;
+@RunWith(OnamiRunner.class)
+public class MockAnnotatedWithTestCase {
 
-@RunWith( OnamiRunner.class )
-public class MockAnnotatedWithTestCase
-{
-
-    @Mock( annotatedWith = TestAnnotation.class )
+    @Mock(annotatedWith = TestAnnotation.class)
     private Service service2;
 
     @Mock
     private Service service;
 
-    @Mock( namedWith = "test.named" )
+    @Mock(namedWith = "test.named")
     private Service serviceNamed;
 
     @Inject
@@ -49,28 +48,26 @@ public class MockAnnotatedWithTestCase
 
     @Test
     public void test()
-        throws Exception
-    {
-        Assert.assertNotNull( service2 );
-        Assert.assertNotNull( service );
-        Assert.assertNotNull( serviceNamed );
+        throws Exception {
+        Assert.assertNotNull(service2);
+        Assert.assertNotNull(service);
+        Assert.assertNotNull(serviceNamed);
     }
 
     @Test
     public void test3()
-        throws Exception
-    {
-        Assert.assertNotNull( service2 );
-        Assert.assertNotNull( serviceNamed );
+        throws Exception {
+        Assert.assertNotNull(service2);
+        Assert.assertNotNull(serviceNamed);
 
-        EasyMock.expect( service2.go() ).andReturn( "Mocked injected class annotated" ).anyTimes();
-        EasyMock.expect( serviceNamed.go() ).andReturn( "Mocked injected class named" ).anyTimes();
-        EasyMock.replay( service2, serviceNamed );
+        EasyMock.expect(service2.go()).andReturn("Mocked injected class annotated").anyTimes();
+        EasyMock.expect(serviceNamed.go()).andReturn("Mocked injected class named").anyTimes();
+        EasyMock.replay(service2, serviceNamed);
 
-        Assert.assertEquals( "Mocked injected class annotated", service2.go() );
-        Assert.assertEquals( "Mocked injected class annotated", seviceImplAnnotated.go() );
-        Assert.assertEquals( "Mocked injected class named", seviceImplAnnotated.getNamed() );
-        EasyMock.verify( service2 );
+        Assert.assertEquals("Mocked injected class annotated", service2.go());
+        Assert.assertEquals("Mocked injected class annotated", seviceImplAnnotated.go());
+        Assert.assertEquals("Mocked injected class named", seviceImplAnnotated.getNamed());
+        EasyMock.verify(service2);
     }
 
 }

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/guice/TestCustomInjectionTest.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/guice/TestCustomInjectionTest.java
@@ -1,0 +1,82 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mpt.onami.test.guice;
+
+import org.apache.james.mpt.onami.test.OnamiRunner;
+import org.apache.james.mpt.onami.test.annotation.GuiceModules;
+import org.apache.james.mpt.onami.test.annotation.Mock;
+import org.apache.james.mpt.onami.test.data.HelloWorld;
+import org.apache.james.mpt.onami.test.data.Service;
+import org.apache.james.mpt.onami.test.data.ServiceModule;
+import org.apache.james.mpt.onami.test.data.TelephonService;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+@RunWith( OnamiRunner.class )
+@GuiceModules( ServiceModule.class )
+public class TestCustomInjectionTest
+{
+
+    @Mock
+    private static Service service;
+
+    @Inject
+    private TelephonService telephonService;
+
+    @Inject
+    private HelloWorld helloWorld;
+
+    @BeforeClass
+    public static void setUp()
+    {
+        Assert.assertNotNull( service );
+        // service.go();
+    }
+
+    @Test
+    public void test()
+        throws Exception
+    {
+        Assert.assertNotNull( service );
+        Assert.assertNotNull( telephonService );
+        Assert.assertNotNull( helloWorld );
+    }
+
+    @Test
+    public void testOverideModule()
+        throws Exception
+    {
+        Assert.assertNotNull( service );
+        Assert.assertNotNull( telephonService );
+        Assert.assertEquals( "It's real class", telephonService.getTelephonNumber() );
+
+        EasyMock.expect( service.go() ).andReturn( "Mocked injected class" );
+        EasyMock.replay( service );
+
+        Assert.assertEquals( "Mocked injected class", helloWorld.sayHalloByService() );
+        EasyMock.verify( service );
+    }
+
+}

--- a/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/guice/TestCustomInjectionTest.java
+++ b/mpt/onami-test/src/test/java/org/apache/james/mpt/onami/test/guice/TestCustomInjectionTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mpt.onami.test.guice;
 
+import javax.inject.Inject;
+
 import org.apache.james.mpt.onami.test.OnamiRunner;
 import org.apache.james.mpt.onami.test.annotation.GuiceModules;
 import org.apache.james.mpt.onami.test.annotation.Mock;
@@ -32,12 +34,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import javax.inject.Inject;
-
-@RunWith( OnamiRunner.class )
-@GuiceModules( ServiceModule.class )
-public class TestCustomInjectionTest
-{
+@RunWith(OnamiRunner.class)
+@GuiceModules(ServiceModule.class)
+public class TestCustomInjectionTest {
 
     @Mock
     private static Service service;
@@ -49,34 +48,31 @@ public class TestCustomInjectionTest
     private HelloWorld helloWorld;
 
     @BeforeClass
-    public static void setUp()
-    {
-        Assert.assertNotNull( service );
+    public static void setUp() {
+        Assert.assertNotNull(service);
         // service.go();
     }
 
     @Test
     public void test()
-        throws Exception
-    {
-        Assert.assertNotNull( service );
-        Assert.assertNotNull( telephonService );
-        Assert.assertNotNull( helloWorld );
+        throws Exception {
+        Assert.assertNotNull(service);
+        Assert.assertNotNull(telephonService);
+        Assert.assertNotNull(helloWorld);
     }
 
     @Test
     public void testOverideModule()
-        throws Exception
-    {
-        Assert.assertNotNull( service );
-        Assert.assertNotNull( telephonService );
-        Assert.assertEquals( "It's real class", telephonService.getTelephonNumber() );
+        throws Exception {
+        Assert.assertNotNull(service);
+        Assert.assertNotNull(telephonService);
+        Assert.assertEquals("It's real class", telephonService.getTelephonNumber());
 
-        EasyMock.expect( service.go() ).andReturn( "Mocked injected class" );
-        EasyMock.replay( service );
+        EasyMock.expect(service.go()).andReturn("Mocked injected class");
+        EasyMock.replay(service);
 
-        Assert.assertEquals( "Mocked injected class", helloWorld.sayHalloByService() );
-        EasyMock.verify( service );
+        Assert.assertEquals("Mocked injected class", helloWorld.sayHalloByService());
+        EasyMock.verify(service);
     }
 
 }

--- a/mpt/onami-test/src/test/resources/log4j.properties
+++ b/mpt/onami-test/src/test/resources/log4j.properties
@@ -1,0 +1,46 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Set root category priority to INFO and its only appender to CONSOLE.
+#log4j.rootCategory=DEBUG, CONSOLE
+
+# Set the enterprise logger category to FATAL and its only appender to CONSOLE.
+#log4j.logger.org.apache.onami=CONSOLE
+
+# CONSOLE is set to be a ConsoleAppender using a PatternLayout.
+#log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+#log4j.appender.CONSOLE.Threshold=DEBUG
+#log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+#log4j.appender.CONSOLE.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+
+
+
+# Specify the handlers to create in the root logger
+# (all loggers are children of the root logger)
+# The following creates two handlers
+handlers = java.util.logging.ConsoleHandler
+
+# Set the default logging level for the root logger
+.level = ALL
+
+# Set the default logging level for new ConsoleHandler instances
+java.util.logging.ConsoleHandler.level = ALL
+
+# Set the default formatter for new ConsoleHandler instances
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter

--- a/mpt/pom.xml
+++ b/mpt/pom.xml
@@ -47,6 +47,7 @@
         <module>impl/managesieve</module>
         <module>impl/smtp</module>
         <module>mavenplugin</module>
+        <module>onami-test</module>
     </modules>
 
     <issueManagement>

--- a/mpt/pom.xml
+++ b/mpt/pom.xml
@@ -101,7 +101,6 @@
         <junit.version>4.11</junit.version>
         <log4j.version>1.2.16</log4j.version>
         <lucene-core.version>3.6.0</lucene-core.version>
-        <onami.version>1.4.1-incubating-SNAPSHOT</onami.version>
         <slf4j.version>1.6.6</slf4j.version>
         <assertj-1.version>1.7.1</assertj-1.version>
         <assertj-3.version>3.2.0</assertj-3.version>
@@ -153,6 +152,11 @@
                 <artifactId>apache-james-mpt-core</artifactId>
                 <version>${project.version}</version>
                 <type>test-jar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.james</groupId>
+                <artifactId>apache-james-mpt-onami-test</artifactId>
+                <version>${project.version}</version>
             </dependency>
             <!-- Other Apache James sub projects -->
             <dependency>
@@ -435,11 +439,6 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.onami</groupId>
-                <artifactId>org.apache.onami.test</artifactId>
-                <version>${onami.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.cassandraunit</groupId>

--- a/server/container/guice/guice-common/pom.xml
+++ b/server/container/guice/guice-common/pom.xml
@@ -226,6 +226,10 @@
                     <artifactId>james-server-queue-activemq</artifactId>
                 </dependency>
                 <dependency>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>james-server-onami</artifactId>
+                </dependency>
+                <dependency>
                     <groupId>org.apache.james</groupId>
                     <artifactId>james-server-webadmin</artifactId>
                 </dependency>
@@ -253,10 +257,6 @@
                     <groupId>com.jayway.restassured</groupId>
                     <artifactId>rest-assured</artifactId>
                     <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.onami.lifecycle</groupId>
-                    <artifactId>org.apache.onami.lifecycle.jsr250</artifactId>
                 </dependency>
                 <dependency>
                     <groupId>org.assertj</groupId>

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/GuiceJamesServer.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/GuiceJamesServer.java
@@ -27,12 +27,12 @@ import org.apache.james.jmap.JMAPServer;
 import org.apache.james.modules.CommonServicesModule;
 import org.apache.james.modules.MailetProcessingModule;
 import org.apache.james.modules.ProtocolsModule;
+import org.apache.james.onami.lifecycle.Stager;
 import org.apache.james.utils.ConfigurationsPerformer;
 import org.apache.james.utils.ExtendedServerProbe;
 import org.apache.james.utils.GuiceServerProbe;
 import org.apache.james.webadmin.Port;
 import org.apache.james.webadmin.WebAdminServer;
-import org.apache.onami.lifecycle.core.Stager;
 
 import com.google.common.collect.Iterables;
 import com.google.inject.Guice;

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/modules/CommonServicesModule.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/modules/CommonServicesModule.java
@@ -32,8 +32,8 @@ import org.apache.james.filesystem.api.JamesDirectoriesProvider;
 import org.apache.james.modules.server.AsyncTasksExecutorModule;
 import org.apache.james.modules.server.ConfigurationProviderModule;
 import org.apache.james.modules.server.DNSServiceModule;
+import org.apache.james.onami.lifecycle.PreDestroyModule;
 import org.apache.james.utils.GuiceServerProbe;
-import org.apache.onami.lifecycle.jsr250.PreDestroyModule;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;

--- a/server/container/guice/onami/pom.xml
+++ b/server/container/guice/onami/pom.xml
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>james-server-guice</artifactId>
+        <groupId>org.apache.james</groupId>
+        <version>3.0.0-beta5-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>james-server-onami</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Apache James :: Server :: Onami</name>
+    <description>Guice tooling from Onami project</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>disable-build-for-older-jdk</id>
+            <activation>
+                <jdk>(,1.8)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-jar</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>jar</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>test-jar</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-compile</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-testCompile</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-install-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-install</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-resources</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-testResources</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-site-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-descriptor</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>build-for-jdk-8</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <source>1.8</source>
+                            <target>1.8</target>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build><dependencies>
+            <dependency>
+                <groupId>com.google.inject</groupId>
+                <artifactId>guice</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+        </profile>
+        <profile>
+            <id>animal-sniffer-java-8</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>animal-sniffer-maven-plugin</artifactId>
+                        <configuration>
+                            <signature>
+                                <groupId>org.codehaus.mojo.signature</groupId>
+                                <artifactId>java18</artifactId>
+                                <version>1.0</version>
+                            </signature>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>check_java_8</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/AbstractBasicStageable.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/AbstractBasicStageable.java
@@ -1,0 +1,50 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+/**
+ * Base implementation for stageables.
+ *
+ * @author Mikhail Mazursky
+ */
+public abstract class AbstractBasicStageable<S>
+    implements Stageable
+{
+
+    /**
+     * Object to stage.
+     */
+    protected final S object;
+
+    protected AbstractBasicStageable( S object )
+    {
+        this.object = object;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final String toString()
+    {
+        return object.toString();
+    }
+
+}

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/AbstractBasicStageable.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/AbstractBasicStageable.java
@@ -24,17 +24,14 @@ package org.apache.james.onami.lifecycle;
  *
  * @author Mikhail Mazursky
  */
-public abstract class AbstractBasicStageable<S>
-    implements Stageable
-{
+public abstract class AbstractBasicStageable<S> implements Stageable {
 
     /**
      * Object to stage.
      */
     protected final S object;
 
-    protected AbstractBasicStageable( S object )
-    {
+    protected AbstractBasicStageable(S object) {
         this.object = object;
     }
 
@@ -42,8 +39,7 @@ public abstract class AbstractBasicStageable<S>
      * {@inheritDoc}
      */
     @Override
-    public final String toString()
-    {
+    public final String toString() {
         return object.toString();
     }
 

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/AbstractMethodTypeListener.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/AbstractMethodTypeListener.java
@@ -19,20 +19,18 @@
 
 package org.apache.james.onami.lifecycle;
 
-import com.google.inject.TypeLiteral;
-import com.google.inject.spi.TypeEncounter;
-import com.google.inject.spi.TypeListener;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
 
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.TypeEncounter;
+import com.google.inject.spi.TypeListener;
+
 /**
  * A Guice {@code TypeListener} to hear annotated methods with lifecycle annotations.
  */
-abstract class AbstractMethodTypeListener
-    implements TypeListener
-{
+abstract class AbstractMethodTypeListener implements TypeListener {
 
     /**
      * The {@code java} package constants.
@@ -49,8 +47,7 @@ abstract class AbstractMethodTypeListener
      *
      * @param annotationTypes the lifecycle annotations to search on methods in the order to be searched.
      */
-    public AbstractMethodTypeListener( List<? extends Class<? extends Annotation>> annotationTypes )
-    {
+    public AbstractMethodTypeListener(List<? extends Class<? extends Annotation>> annotationTypes) {
         this.annotationTypes = annotationTypes;
     }
 
@@ -58,9 +55,8 @@ abstract class AbstractMethodTypeListener
      * {@inheritDoc}
      */
     @Override
-    public final <I> void hear( TypeLiteral<I> type, TypeEncounter<I> encounter )
-    {
-        hear( type, type.getRawType(), encounter );
+    public final <I> void hear(TypeLiteral<I> type, TypeEncounter<I> encounter) {
+        hear(type, type.getRawType(), encounter);
     }
 
     /**
@@ -70,32 +66,26 @@ abstract class AbstractMethodTypeListener
      * @param klass      encountered by Guice.
      * @param encounter  the injection context.
      */
-    private <I> void hear( final TypeLiteral<I> parentType, Class<? super I> klass, TypeEncounter<I> encounter )
-    {
+    private <I> void hear(final TypeLiteral<I> parentType, Class<? super I> klass, TypeEncounter<I> encounter) {
         Package pkg;
-        if ( klass == null || ( ( pkg = klass.getPackage() ) != null && pkg.getName().startsWith( JAVA_PACKAGE ) ) )
-        {
+        if (klass == null || ((pkg = klass.getPackage()) != null && pkg.getName().startsWith(JAVA_PACKAGE))) {
             return;
         }
 
-        for ( Class<? extends Annotation> annotationType : annotationTypes )
-        {
-            for ( Method method : klass.getDeclaredMethods() )
-            {
-                if ( method.isAnnotationPresent( annotationType ) )
-                {
-                    if ( method.getParameterTypes().length != 0 )
-                    {
-                        encounter.addError( "Annotated methods with @%s must not accept any argument, found %s",
-                                            annotationType.getName(), method );
+        for (Class<? extends Annotation> annotationType : annotationTypes) {
+            for (Method method : klass.getDeclaredMethods()) {
+                if (method.isAnnotationPresent(annotationType)) {
+                    if (method.getParameterTypes().length != 0) {
+                        encounter.addError("Annotated methods with @%s must not accept any argument, found %s",
+                            annotationType.getName(), method);
                     }
 
-                    hear( method, parentType, encounter, annotationType );
+                    hear(method, parentType, encounter, annotationType);
                 }
             }
         }
 
-        hear( parentType, klass.getSuperclass(), encounter );
+        hear(parentType, klass.getSuperclass(), encounter);
     }
 
     /**
@@ -106,7 +96,6 @@ abstract class AbstractMethodTypeListener
      * @param encounter      the injection context.
      * @param annotationType the annotation type that was specified.
      */
-    protected abstract <I> void hear( Method method, TypeLiteral<I> parentType, TypeEncounter<I> encounter,
-                                      Class<? extends Annotation> annotationType );
+    protected abstract <I> void hear(Method method, TypeLiteral<I> parentType, TypeEncounter<I> encounter, Class<? extends Annotation> annotationType);
 
 }

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/AbstractMethodTypeListener.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/AbstractMethodTypeListener.java
@@ -1,0 +1,112 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.TypeEncounter;
+import com.google.inject.spi.TypeListener;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * A Guice {@code TypeListener} to hear annotated methods with lifecycle annotations.
+ */
+abstract class AbstractMethodTypeListener
+    implements TypeListener
+{
+
+    /**
+     * The {@code java} package constants.
+     */
+    private static final String JAVA_PACKAGE = "java";
+
+    /**
+     * The lifecycle annotations to search on methods in the order to be searched.
+     */
+    protected final List<? extends Class<? extends Annotation>> annotationTypes;
+
+    /**
+     * Creates a new methods listener instance.
+     *
+     * @param annotationTypes the lifecycle annotations to search on methods in the order to be searched.
+     */
+    public AbstractMethodTypeListener( List<? extends Class<? extends Annotation>> annotationTypes )
+    {
+        this.annotationTypes = annotationTypes;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final <I> void hear( TypeLiteral<I> type, TypeEncounter<I> encounter )
+    {
+        hear( type, type.getRawType(), encounter );
+    }
+
+    /**
+     * Allows traverse the input klass hierarchy.
+     *
+     * @param parentType the owning type being heard
+     * @param klass      encountered by Guice.
+     * @param encounter  the injection context.
+     */
+    private <I> void hear( final TypeLiteral<I> parentType, Class<? super I> klass, TypeEncounter<I> encounter )
+    {
+        Package pkg;
+        if ( klass == null || ( ( pkg = klass.getPackage() ) != null && pkg.getName().startsWith( JAVA_PACKAGE ) ) )
+        {
+            return;
+        }
+
+        for ( Class<? extends Annotation> annotationType : annotationTypes )
+        {
+            for ( Method method : klass.getDeclaredMethods() )
+            {
+                if ( method.isAnnotationPresent( annotationType ) )
+                {
+                    if ( method.getParameterTypes().length != 0 )
+                    {
+                        encounter.addError( "Annotated methods with @%s must not accept any argument, found %s",
+                                            annotationType.getName(), method );
+                    }
+
+                    hear( method, parentType, encounter, annotationType );
+                }
+            }
+        }
+
+        hear( parentType, klass.getSuperclass(), encounter );
+    }
+
+    /**
+     * Allows implementations to define the behavior when lifecycle annotation is found on the method.
+     *
+     * @param method         encountered by this type handler.
+     * @param parentType     the owning type being heard
+     * @param encounter      the injection context.
+     * @param annotationType the annotation type that was specified.
+     */
+    protected abstract <I> void hear( Method method, TypeLiteral<I> parentType, TypeEncounter<I> encounter,
+                                      Class<? extends Annotation> annotationType );
+
+}

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/AbstractStageable.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/AbstractStageable.java
@@ -1,0 +1,60 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+/**
+ * Base implementation for stageables.
+ *
+ * @author Mikhail Mazursky
+ */
+public abstract class AbstractStageable<S>
+    extends AbstractBasicStageable<S>
+{
+
+    protected AbstractStageable( S object )
+    {
+        super( object );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void stage( StageHandler stageHandler )
+    {
+        try
+        {
+            doStage();
+        }
+        catch ( Throwable e )
+        {
+            stageHandler.onError( object, e );
+            return;
+        }
+        stageHandler.onSuccess( object );
+    }
+
+    /**
+     * Does actual object staging.
+     *
+     * @throws Exception
+     */
+    protected abstract void doStage() throws Exception;
+}

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/AbstractStageable.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/AbstractStageable.java
@@ -24,31 +24,24 @@ package org.apache.james.onami.lifecycle;
  *
  * @author Mikhail Mazursky
  */
-public abstract class AbstractStageable<S>
-    extends AbstractBasicStageable<S>
-{
+public abstract class AbstractStageable<S> extends AbstractBasicStageable<S> {
 
-    protected AbstractStageable( S object )
-    {
-        super( object );
+    protected AbstractStageable(S object) {
+        super(object);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public final void stage( StageHandler stageHandler )
-    {
-        try
-        {
+    public final void stage(StageHandler stageHandler) {
+        try {
             doStage();
-        }
-        catch ( Throwable e )
-        {
-            stageHandler.onError( object, e );
+        } catch (Throwable e) {
+            stageHandler.onError(object, e);
             return;
         }
-        stageHandler.onSuccess( object );
+        stageHandler.onSuccess(object);
     }
 
     /**

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/DefaultStager.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/DefaultStager.java
@@ -1,0 +1,218 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import java.io.Closeable;
+import java.lang.annotation.Annotation;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Queue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Default {@link Stager} implementation.
+ */
+public class DefaultStager<A extends Annotation>
+    implements DisposingStager<A>
+{
+    private final Class<A> stage;
+
+    /**
+     * Stack of elements have to be disposed.
+     */
+    private final Queue<Stageable> stageables;
+
+    /**
+     * @param stage the annotation that specifies this stage
+     */
+    public DefaultStager( Class<A> stage )
+    {
+        this( stage, Order.FIRST_IN_FIRST_OUT );
+    }
+
+	/**
+     * @param stage the annotation that specifies this stage
+     * @param mode  execution order
+     */
+    public DefaultStager( Class<A> stage, Order mode )
+    {
+        this.stage = stage;
+
+        Queue<Stageable> localStageables;
+        switch ( mode )
+        {
+            case FIRST_IN_FIRST_OUT:
+            {
+                localStageables = new ArrayDeque<Stageable>();
+                break;
+            }
+
+            case FIRST_IN_LAST_OUT:
+            {
+                localStageables = Collections.asLifoQueue( new ArrayDeque<Stageable>() );
+                break;
+            }
+
+            default:
+            {
+                throw new IllegalArgumentException( "Unknown mode: " + mode );
+            }
+        }
+        stageables = localStageables;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void register( Stageable stageable )
+    {
+        synchronized ( stageables )
+        {
+            stageables.add( stageable );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T extends ExecutorService> T register( T executorService )
+    {
+        register( new ExecutorServiceStageable( executorService ) );
+        return executorService;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T extends Closeable> T register( T closeable )
+    {
+        register( new CloseableStageable( closeable ) );
+        return closeable;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void stage()
+    {
+        stage( null );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void stage( StageHandler stageHandler )
+    {
+        if ( stageHandler == null )
+        {
+            stageHandler = new NoOpStageHandler();
+        }
+
+        while ( true )
+        {
+            Stageable stageable;
+            synchronized ( stageables )
+            {
+                stageable = stageables.poll();
+            }
+            if ( stageable == null )
+            {
+                break;
+            }
+            stageable.stage( stageHandler );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Class<A> getStage()
+    {
+        return stage;
+    }
+
+    /**
+     * specifies ordering for a {@link DefaultStager}
+     */
+    public static enum Order
+    {
+        /**
+         * FIFO
+         */
+        FIRST_IN_FIRST_OUT,
+
+        /**
+         * FILO/LIFO
+         */
+        FIRST_IN_LAST_OUT
+    }
+
+    private static class CloseableStageable extends AbstractStageable<Closeable>
+    {
+
+        public CloseableStageable( Closeable closeable )
+        {
+            super( closeable );
+        }
+
+        @Override
+        protected void doStage() throws Exception
+        {
+            object.close();
+        }
+
+    }
+
+    private static class ExecutorServiceStageable extends AbstractStageable<ExecutorService>
+    {
+
+        public ExecutorServiceStageable( ExecutorService executor )
+        {
+            super( executor );
+        }
+
+        @Override
+        protected void doStage() throws Exception
+        {
+            object.shutdown();
+            try
+            {
+                if ( !object.awaitTermination( 1, TimeUnit.MINUTES ) )
+                {
+                    object.shutdownNow();
+                }
+            }
+            catch ( InterruptedException e )
+            {
+                object.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+
+    }
+
+}

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/DisposingStager.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/DisposingStager.java
@@ -1,0 +1,50 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import java.io.Closeable;
+import java.lang.annotation.Annotation;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * {@link org.apache.onami.lifecycle.core.Stager} that disposes resources.
+ *
+ * @author Mikhail Mazursky
+ */
+public interface DisposingStager<A extends Annotation> extends Stager<A>
+{
+
+    /**
+     * Register an {@link java.util.concurrent.ExecutorService} to be staged.
+     *
+     * @param executorService object to be staged to dispose resources.
+     * @return Staged object
+     */
+    <T extends ExecutorService> T register( T executorService );
+
+    /**
+     * Register a {@link java.io.Closeable} to be staged.
+     *
+     * @param closeable object to be staged to dispose resources.
+     * @return Staged object
+     */
+    <T extends Closeable> T register( T closeable );
+
+}

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/DisposingStager.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/DisposingStager.java
@@ -28,8 +28,7 @@ import java.util.concurrent.ExecutorService;
  *
  * @author Mikhail Mazursky
  */
-public interface DisposingStager<A extends Annotation> extends Stager<A>
-{
+public interface DisposingStager<A extends Annotation> extends Stager<A> {
 
     /**
      * Register an {@link java.util.concurrent.ExecutorService} to be staged.
@@ -37,7 +36,7 @@ public interface DisposingStager<A extends Annotation> extends Stager<A>
      * @param executorService object to be staged to dispose resources.
      * @return Staged object
      */
-    <T extends ExecutorService> T register( T executorService );
+    <T extends ExecutorService> T register(T executorService);
 
     /**
      * Register a {@link java.io.Closeable} to be staged.
@@ -45,6 +44,6 @@ public interface DisposingStager<A extends Annotation> extends Stager<A>
      * @param closeable object to be staged to dispose resources.
      * @return Staged object
      */
-    <T extends Closeable> T register( T closeable );
+    <T extends Closeable> T register(T closeable);
 
 }

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/LifeCycleModule.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/LifeCycleModule.java
@@ -1,0 +1,117 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.ProvisionException;
+import com.google.inject.TypeLiteral;
+import com.google.inject.matcher.Matcher;
+import com.google.inject.spi.InjectionListener;
+import com.google.inject.spi.TypeEncounter;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static com.google.inject.matcher.Matchers.any;
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+
+/**
+ * Guice module to register methods to be invoked after injection is complete.
+ */
+public abstract class LifeCycleModule
+    extends AbstractModule
+{
+
+    /**
+     * Binds lifecycle listener.
+     *
+     * @param annotation the lifecycle annotation to be searched.
+     */
+    protected final void bindLifeCycle( Class<? extends Annotation> annotation )
+    {
+        bindLifeCycle( annotation, any() );
+    }
+
+    /**
+     * Binds lifecycle listener.
+     *
+     * @param annotation  the lifecycle annotation to be searched.
+     * @param typeMatcher the filter for injectee types.
+     */
+    protected final void bindLifeCycle( Class<? extends Annotation> annotation, Matcher<? super TypeLiteral<?>> typeMatcher )
+    {
+        bindLifeCycle( asList( annotation ), typeMatcher );
+    }
+
+    /**
+     * Binds lifecycle listener.
+     *
+     * @param annotations  the lifecycle annotations to be searched in the order to be searched.
+     * @param typeMatcher the filter for injectee types.
+     */
+    protected final void bindLifeCycle( List<? extends Class<? extends Annotation>> annotations, Matcher<? super TypeLiteral<?>> typeMatcher )
+    {
+        bindListener( typeMatcher, new AbstractMethodTypeListener( annotations )
+        {
+
+            @Override
+            protected <I> void hear( final Method method, TypeLiteral<I> parentType, TypeEncounter<I> encounter,
+                                     final Class<? extends Annotation> annotationType )
+            {
+                encounter.register( new InjectionListener<I>()
+                {
+
+                    @Override
+                    public void afterInjection( I injectee )
+                    {
+                        try
+                        {
+                            method.invoke( injectee );
+                        }
+                        catch ( IllegalArgumentException e )
+                        {
+                            // should not happen, anyway...
+                            throw new ProvisionException(
+                                format( "Method @%s %s requires arguments", annotationType.getName(), method ), e );
+                        }
+                        catch ( IllegalAccessException e )
+                        {
+                            throw new ProvisionException(
+                                format( "Impossible to access to @%s %s on %s", annotationType.getName(), method,
+                                        injectee ), e );
+                        }
+                        catch ( InvocationTargetException e )
+                        {
+                            throw new ProvisionException(
+                                format( "An error occurred while invoking @%s %s on %s", annotationType.getName(),
+                                        method, injectee ), e.getCause() );
+                        }
+                    }
+
+                } );
+            }
+
+        } );
+    }
+
+}

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/LifeCycleStageModule.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/LifeCycleStageModule.java
@@ -19,12 +19,8 @@
 
 package org.apache.james.onami.lifecycle;
 
-import com.google.inject.Key;
-import com.google.inject.TypeLiteral;
-import com.google.inject.matcher.Matcher;
-import com.google.inject.spi.InjectionListener;
-import com.google.inject.spi.TypeEncounter;
-import com.google.inject.util.Types;
+import static com.google.inject.matcher.Matchers.any;
+import static java.util.Arrays.asList;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -32,17 +28,19 @@ import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.inject.matcher.Matchers.any;
-import static java.util.Arrays.asList;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import com.google.inject.matcher.Matcher;
+import com.google.inject.spi.InjectionListener;
+import com.google.inject.spi.TypeEncounter;
+import com.google.inject.util.Types;
 
 /**
  * Guice module to register methods to be invoked when {@link Stager#stage()} is invoked.
  * <p/>
  * Module instance have has so it must not be used to construct more than one {@link com.google.inject.Injector}.
  */
-public abstract class LifeCycleStageModule
-    extends LifeCycleModule
-{
+public abstract class LifeCycleStageModule extends LifeCycleModule {
 
     private List<BindingBuilder<?>> bindings;
 
@@ -58,17 +56,15 @@ public abstract class LifeCycleStageModule
      * @param <A>   the Annotation type
      * @return the Guice key to use for accessing the stager for the input stage
      */
-    public static <A extends Annotation> Key<Stager<A>> key( Class<A> stage )
-    {
-        return Key.get( type( stage ) );
+    public static <A extends Annotation> Key<Stager<A>> key(Class<A> stage) {
+        return Key.get(type(stage));
     }
 
-    private static <A extends Annotation> TypeLiteral<Stager<A>> type( Class<A> stage )
-    {
-        ParameterizedType parameterizedType = Types.newParameterizedTypeWithOwner( null, Stager.class, stage );
+    private static <A extends Annotation> TypeLiteral<Stager<A>> type(Class<A> stage) {
+        ParameterizedType parameterizedType = Types.newParameterizedTypeWithOwner(null, Stager.class, stage);
         //noinspection unchecked
-        @SuppressWarnings( "unchecked" ) // TODO
-        TypeLiteral<Stager<A>> stagerType = (TypeLiteral<Stager<A>>) TypeLiteral.get( parameterizedType );
+        @SuppressWarnings("unchecked") // TODO
+            TypeLiteral<Stager<A>> stagerType = (TypeLiteral<Stager<A>>) TypeLiteral.get(parameterizedType);
         return stagerType;
     }
 
@@ -76,92 +72,72 @@ public abstract class LifeCycleStageModule
      * {@inheritDoc}
      */
     @Override
-    protected final void configure()
-    {
-        if ( bindings != null )
-        {
-            throw new IllegalStateException( "Re-entry is not allowed" );
+    protected final void configure() {
+        if (bindings != null) {
+            throw new IllegalStateException("Re-entry is not allowed");
         }
-        bindings = new ArrayList<BindingBuilder<?>>();
-        try
-        {
+        bindings = new ArrayList<>();
+        try {
             configureBindings();
-            for ( BindingBuilder<?> binding : bindings )
-            {
-                bind( binding );
+            for (BindingBuilder<?> binding : bindings) {
+                bind(binding);
             }
-        }
-        finally
-        {
+        } finally {
             bindings = null;
         }
     }
 
-    private <A extends Annotation> void bind( BindingBuilder<A> binding )
-    {
+    private <A extends Annotation> void bind(BindingBuilder<A> binding) {
         final Stager<A> stager = binding.stager;
         final StageableTypeMapper typeMapper = binding.typeMapper;
-        bind( type( stager.getStage() ) ).toInstance( stager );
+        bind(type(stager.getStage())).toInstance(stager);
 
-        bindListener( binding.typeMatcher, new AbstractMethodTypeListener( asList( stager.getStage() ) )
-        {
-
+        bindListener(binding.typeMatcher, new AbstractMethodTypeListener(asList(stager.getStage())) {
             @Override
-            protected <I> void hear( final Method stageMethod, final TypeLiteral<I> parentType,
-                                     final TypeEncounter<I> encounter,
-                                     final Class<? extends Annotation> annotationType )
-            {
-                encounter.register( new InjectionListener<I>()
-                {
-
+            protected <I> void hear(final Method stageMethod, final TypeLiteral<I> parentType,
+                                    final TypeEncounter<I> encounter, final Class<? extends Annotation> annotationType) {
+                encounter.register(new InjectionListener<I>() {
                     @Override
-                    public void afterInjection( I injectee )
-                    {
-                        Stageable stageable = new StageableMethod( stageMethod, injectee );
-                        stager.register( stageable );
-                        typeMapper.registerType( stageable, parentType );
+                    public void afterInjection(I injectee) {
+                        Stageable stageable = new StageableMethod(stageMethod, injectee);
+                        stager.register(stageable);
+                        typeMapper.registerType(stageable, parentType);
                     }
-
-                } );
+                });
             }
-
-        } );
+        });
     }
 
     protected abstract void configureBindings();
 
-    protected final <A extends Annotation> MapperBinding bindStager( Stager<A> stager )
-    {
-        BindingBuilder<A> builder = new BindingBuilder<A>( checkNotNull( stager, "Argument 'stager' must be not null" ) );
-        bindings.add( builder );
+    protected final <A extends Annotation> MapperBinding bindStager(Stager<A> stager) {
+        BindingBuilder<A> builder = new BindingBuilder<>(checkNotNull(stager, "Argument 'stager' must be not null"));
+        bindings.add(builder);
         return builder;
     }
 
-    protected interface MatcherBinding
-    {
+    protected interface MatcherBinding {
         /**
          * Sets the filter for injectee types.
          *
          * @param typeMatcher the filter for injectee types.
          */
-        void matching( Matcher<? super TypeLiteral<?>> typeMatcher );
+        void matching(Matcher<? super TypeLiteral<?>> typeMatcher);
     }
 
-    protected interface MapperBinding extends MatcherBinding
-    {
+    protected interface MapperBinding extends MatcherBinding {
         /**
          * Sets the container to register mappings from {@link Stageable}s to the types that created them.
          *
          * @param typeMapper container to map {@link Stageable}s to types.
          */
-        MatcherBinding mappingWith( StageableTypeMapper typeMapper );
+        MatcherBinding mappingWith(StageableTypeMapper typeMapper);
     }
 
     /**
      * Builder pattern helper.
      */
-    private static class BindingBuilder<A extends Annotation> implements MapperBinding
-    {
+    private static class BindingBuilder<A extends Annotation> implements MapperBinding {
 
         private Matcher<? super TypeLiteral<?>> typeMatcher = any();
 
@@ -169,31 +145,26 @@ public abstract class LifeCycleStageModule
 
         private StageableTypeMapper typeMapper = new NoOpStageableTypeMapper();
 
-        public BindingBuilder( Stager<A> stager )
-        {
+        public BindingBuilder(Stager<A> stager) {
             this.stager = stager;
         }
 
         @Override
-        public MatcherBinding mappingWith( StageableTypeMapper typeMapper )
-        {
-            this.typeMapper = checkNotNull( typeMapper, "Argument 'typeMapper' must be not null." );
+        public MatcherBinding mappingWith(StageableTypeMapper typeMapper) {
+            this.typeMapper = checkNotNull(typeMapper, "Argument 'typeMapper' must be not null.");
             return this;
         }
 
         @Override
-        public void matching( Matcher<? super TypeLiteral<?>> typeMatcher )
-        {
-            this.typeMatcher = checkNotNull( typeMatcher, "Argument 'typeMatcher' must be not null" );
+        public void matching(Matcher<? super TypeLiteral<?>> typeMatcher) {
+            this.typeMatcher = checkNotNull(typeMatcher, "Argument 'typeMatcher' must be not null");
         }
 
     }
 
-    private static <T> T checkNotNull( T object, String message )
-    {
-        if ( object == null )
-        {
-            throw new IllegalArgumentException( message );
+    private static <T> T checkNotNull(T object, String message) {
+        if (object == null) {
+            throw new IllegalArgumentException(message);
         }
         return object;
     }

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/LifeCycleStageModule.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/LifeCycleStageModule.java
@@ -1,0 +1,200 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import com.google.inject.matcher.Matcher;
+import com.google.inject.spi.InjectionListener;
+import com.google.inject.spi.TypeEncounter;
+import com.google.inject.util.Types;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.inject.matcher.Matchers.any;
+import static java.util.Arrays.asList;
+
+/**
+ * Guice module to register methods to be invoked when {@link Stager#stage()} is invoked.
+ * <p/>
+ * Module instance have has so it must not be used to construct more than one {@link com.google.inject.Injector}.
+ */
+public abstract class LifeCycleStageModule
+    extends LifeCycleModule
+{
+
+    private List<BindingBuilder<?>> bindings;
+
+    /**
+     * Convenience to generate the correct key for retrieving stagers from an injector.
+     * E.g.
+     * <p/>
+     * <code><pre>
+     * Stager&lt;MyAnnotation&gt; stager = injector.getInstance( LifeCycleStageModule.key( MyAnnotation.class ) );
+     * </pre></code>
+     *
+     * @param stage the annotation that represents this stage and the methods with this annotation
+     * @param <A>   the Annotation type
+     * @return the Guice key to use for accessing the stager for the input stage
+     */
+    public static <A extends Annotation> Key<Stager<A>> key( Class<A> stage )
+    {
+        return Key.get( type( stage ) );
+    }
+
+    private static <A extends Annotation> TypeLiteral<Stager<A>> type( Class<A> stage )
+    {
+        ParameterizedType parameterizedType = Types.newParameterizedTypeWithOwner( null, Stager.class, stage );
+        //noinspection unchecked
+        @SuppressWarnings( "unchecked" ) // TODO
+        TypeLiteral<Stager<A>> stagerType = (TypeLiteral<Stager<A>>) TypeLiteral.get( parameterizedType );
+        return stagerType;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected final void configure()
+    {
+        if ( bindings != null )
+        {
+            throw new IllegalStateException( "Re-entry is not allowed" );
+        }
+        bindings = new ArrayList<BindingBuilder<?>>();
+        try
+        {
+            configureBindings();
+            for ( BindingBuilder<?> binding : bindings )
+            {
+                bind( binding );
+            }
+        }
+        finally
+        {
+            bindings = null;
+        }
+    }
+
+    private <A extends Annotation> void bind( BindingBuilder<A> binding )
+    {
+        final Stager<A> stager = binding.stager;
+        final StageableTypeMapper typeMapper = binding.typeMapper;
+        bind( type( stager.getStage() ) ).toInstance( stager );
+
+        bindListener( binding.typeMatcher, new AbstractMethodTypeListener( asList( stager.getStage() ) )
+        {
+
+            @Override
+            protected <I> void hear( final Method stageMethod, final TypeLiteral<I> parentType,
+                                     final TypeEncounter<I> encounter,
+                                     final Class<? extends Annotation> annotationType )
+            {
+                encounter.register( new InjectionListener<I>()
+                {
+
+                    @Override
+                    public void afterInjection( I injectee )
+                    {
+                        Stageable stageable = new StageableMethod( stageMethod, injectee );
+                        stager.register( stageable );
+                        typeMapper.registerType( stageable, parentType );
+                    }
+
+                } );
+            }
+
+        } );
+    }
+
+    protected abstract void configureBindings();
+
+    protected final <A extends Annotation> MapperBinding bindStager( Stager<A> stager )
+    {
+        BindingBuilder<A> builder = new BindingBuilder<A>( checkNotNull( stager, "Argument 'stager' must be not null" ) );
+        bindings.add( builder );
+        return builder;
+    }
+
+    protected interface MatcherBinding
+    {
+        /**
+         * Sets the filter for injectee types.
+         *
+         * @param typeMatcher the filter for injectee types.
+         */
+        void matching( Matcher<? super TypeLiteral<?>> typeMatcher );
+    }
+
+    protected interface MapperBinding extends MatcherBinding
+    {
+        /**
+         * Sets the container to register mappings from {@link Stageable}s to the types that created them.
+         *
+         * @param typeMapper container to map {@link Stageable}s to types.
+         */
+        MatcherBinding mappingWith( StageableTypeMapper typeMapper );
+    }
+
+    /**
+     * Builder pattern helper.
+     */
+    private static class BindingBuilder<A extends Annotation> implements MapperBinding
+    {
+
+        private Matcher<? super TypeLiteral<?>> typeMatcher = any();
+
+        private final Stager<A> stager;
+
+        private StageableTypeMapper typeMapper = new NoOpStageableTypeMapper();
+
+        public BindingBuilder( Stager<A> stager )
+        {
+            this.stager = stager;
+        }
+
+        @Override
+        public MatcherBinding mappingWith( StageableTypeMapper typeMapper )
+        {
+            this.typeMapper = checkNotNull( typeMapper, "Argument 'typeMapper' must be not null." );
+            return this;
+        }
+
+        @Override
+        public void matching( Matcher<? super TypeLiteral<?>> typeMatcher )
+        {
+            this.typeMatcher = checkNotNull( typeMatcher, "Argument 'typeMatcher' must be not null" );
+        }
+
+    }
+
+    private static <T> T checkNotNull( T object, String message )
+    {
+        if ( object == null )
+        {
+            throw new IllegalArgumentException( message );
+        }
+        return object;
+    }
+}

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/NoOpStageHandler.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/NoOpStageHandler.java
@@ -22,16 +22,13 @@ package org.apache.james.onami.lifecycle;
 /**
  * NOP {@code StageHandler} implementation.
  */
-public final class NoOpStageHandler
-    implements StageHandler
-{
+public final class NoOpStageHandler implements StageHandler {
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public <I, E extends Throwable> void onError( I injectee, E error )
-    {
+    public <I, E extends Throwable> void onError(I injectee, E error) {
         // do nothing
     }
 
@@ -39,8 +36,7 @@ public final class NoOpStageHandler
      * {@inheritDoc}
      */
     @Override
-    public <I> void onSuccess( I injectee )
-    {
+    public <I> void onSuccess(I injectee) {
         // do nothing
     }
 

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/NoOpStageHandler.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/NoOpStageHandler.java
@@ -1,0 +1,47 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+/**
+ * NOP {@code StageHandler} implementation.
+ */
+public final class NoOpStageHandler
+    implements StageHandler
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <I, E extends Throwable> void onError( I injectee, E error )
+    {
+        // do nothing
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <I> void onSuccess( I injectee )
+    {
+        // do nothing
+    }
+
+}

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/NoOpStageableTypeMapper.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/NoOpStageableTypeMapper.java
@@ -21,13 +21,10 @@ package org.apache.james.onami.lifecycle;
 
 import com.google.inject.TypeLiteral;
 
-class NoOpStageableTypeMapper
-    implements StageableTypeMapper
-{
+class NoOpStageableTypeMapper implements StageableTypeMapper {
 
     @Override
-    public <I> void registerType( Stageable stageable, TypeLiteral<I> parentType )
-    {
+    public <I> void registerType(Stageable stageable, TypeLiteral<I> parentType) {
         // NOP
     }
 

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/NoOpStageableTypeMapper.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/NoOpStageableTypeMapper.java
@@ -1,0 +1,34 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import com.google.inject.TypeLiteral;
+
+class NoOpStageableTypeMapper
+    implements StageableTypeMapper
+{
+
+    @Override
+    public <I> void registerType( Stageable stageable, TypeLiteral<I> parentType )
+    {
+        // NOP
+    }
+
+}

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/PreDestroyModule.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/PreDestroyModule.java
@@ -19,9 +19,9 @@
 
 package org.apache.james.onami.lifecycle;
 
-import com.google.inject.TypeLiteral;
-
 import javax.annotation.PreDestroy;
+
+import com.google.inject.TypeLiteral;
 
 /**
  * Guice module to register methods to be invoked when {@link org.apache.onami.lifecycle.core.Stager#stage()} is invoked.
@@ -30,22 +30,17 @@ import javax.annotation.PreDestroy;
  *
  * @author Mikhail Mazursky
  */
-public class PreDestroyModule
-    extends LifeCycleStageModule
-{
+public class PreDestroyModule extends LifeCycleStageModule {
 
-    private final DisposingStager<PreDestroy> stager = new DefaultStager<PreDestroy>(
-        PreDestroy.class, DefaultStager.Order.FIRST_IN_LAST_OUT );
+    private final DisposingStager<PreDestroy> stager = new DefaultStager<PreDestroy>(PreDestroy.class, DefaultStager.Order.FIRST_IN_LAST_OUT);
 
     @Override
-    protected void configureBindings()
-    {
-        bindStager( stager );
-        bind( new TypeLiteral<DisposingStager<PreDestroy>>() {} ).toInstance( stager );
+    protected void configureBindings() {
+        bindStager(stager);
+        bind(new TypeLiteral<DisposingStager<PreDestroy>>() {}).toInstance(stager);
     }
 
-    public DisposingStager<PreDestroy> getStager()
-    {
+    public DisposingStager<PreDestroy> getStager() {
         return stager;
     }
 

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/PreDestroyModule.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/PreDestroyModule.java
@@ -1,0 +1,52 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import com.google.inject.TypeLiteral;
+
+import javax.annotation.PreDestroy;
+
+/**
+ * Guice module to register methods to be invoked when {@link org.apache.onami.lifecycle.core.Stager#stage()} is invoked.
+ * <p/>
+ * Module instance have state so it must not be used to construct more than one {@link com.google.inject.Injector}.
+ *
+ * @author Mikhail Mazursky
+ */
+public class PreDestroyModule
+    extends LifeCycleStageModule
+{
+
+    private final DisposingStager<PreDestroy> stager = new DefaultStager<PreDestroy>(
+        PreDestroy.class, DefaultStager.Order.FIRST_IN_LAST_OUT );
+
+    @Override
+    protected void configureBindings()
+    {
+        bindStager( stager );
+        bind( new TypeLiteral<DisposingStager<PreDestroy>>() {} ).toInstance( stager );
+    }
+
+    public DisposingStager<PreDestroy> getStager()
+    {
+        return stager;
+    }
+
+}

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/StageHandler.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/StageHandler.java
@@ -1,0 +1,43 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+/**
+ * A {@link StageHandler} instance is used to track staging progresses.
+ */
+public interface StageHandler
+{
+
+    /**
+     * Tracks the input injectee successfully staged the resources.
+     *
+     * @param injectee the injectee to be staged
+     */
+    <I> void onSuccess( I injectee );
+
+    /**
+     * Tracks an error occurred while the input injectee staged the resources.
+     *
+     * @param injectee the injectee to be staged
+     * @param error    the exception occurred
+     */
+    <I, E extends Throwable> void onError( I injectee, E error );
+
+}

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/StageHandler.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/StageHandler.java
@@ -22,15 +22,14 @@ package org.apache.james.onami.lifecycle;
 /**
  * A {@link StageHandler} instance is used to track staging progresses.
  */
-public interface StageHandler
-{
+public interface StageHandler {
 
     /**
      * Tracks the input injectee successfully staged the resources.
      *
      * @param injectee the injectee to be staged
      */
-    <I> void onSuccess( I injectee );
+    <I> void onSuccess(I injectee);
 
     /**
      * Tracks an error occurred while the input injectee staged the resources.
@@ -38,6 +37,6 @@ public interface StageHandler
      * @param injectee the injectee to be staged
      * @param error    the exception occurred
      */
-    <I, E extends Throwable> void onError( I injectee, E error );
+    <I, E extends Throwable> void onError(I injectee, E error);
 
 }

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/Stageable.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/Stageable.java
@@ -22,8 +22,7 @@ package org.apache.james.onami.lifecycle;
 /**
  * Object that knows how to stage some resources.
  */
-public interface Stageable
-{
+public interface Stageable {
 
     /**
      * Stage allocated resources, tracking progresses in the
@@ -31,7 +30,7 @@ public interface Stageable
      *
      * @param stageHandler the handler to track progresses.
      */
-    void stage( StageHandler stageHandler );
+    void stage(StageHandler stageHandler);
 
     /**
      * @return Description of a stageable resource.

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/Stageable.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/Stageable.java
@@ -1,0 +1,41 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+/**
+ * Object that knows how to stage some resources.
+ */
+public interface Stageable
+{
+
+    /**
+     * Stage allocated resources, tracking progresses in the
+     * input {@code StageHandler}.
+     *
+     * @param stageHandler the handler to track progresses.
+     */
+    void stage( StageHandler stageHandler );
+
+    /**
+     * @return Description of a stageable resource.
+     */
+    @Override
+    String toString();
+}

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/StageableMethod.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/StageableMethod.java
@@ -1,0 +1,86 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+/**
+ * A {@link StageableMethod} is a reference to a stageable injectee
+ * and related method to release resources.
+ */
+final class StageableMethod
+    extends AbstractBasicStageable<Object>
+{
+
+    /**
+     * The method to be invoked to stage resources.
+     */
+    private final Method stageMethod;
+
+    /**
+     * Creates a new {@link StageableMethod} reference.
+     *
+     * @param stageMethod the method to be invoked to stage resources.
+     * @param injectee    the target injectee has to stage the resources.
+     */
+    StageableMethod( Method stageMethod, Object injectee )
+    {
+        super( injectee );
+        this.stageMethod = stageMethod;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void stage( StageHandler stageHandler )
+    {
+        try
+        {
+            AccessController.doPrivileged( new PrivilegedAction<Void>()
+            {
+
+                @Override
+                public Void run()
+                {
+                    stageMethod.setAccessible( true );
+                    return null;
+                }
+
+            } );
+            stageMethod.invoke( object );
+        }
+        catch ( InvocationTargetException e )
+        {
+            stageHandler.onError( object, e.getCause() );
+            return;
+        }
+        catch ( Throwable e )
+        {
+            stageHandler.onError( object, e );
+            return;
+        }
+        stageHandler.onSuccess( object );
+    }
+
+}

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/StageableMethod.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/StageableMethod.java
@@ -28,9 +28,7 @@ import java.security.PrivilegedAction;
  * A {@link StageableMethod} is a reference to a stageable injectee
  * and related method to release resources.
  */
-final class StageableMethod
-    extends AbstractBasicStageable<Object>
-{
+final class StageableMethod extends AbstractBasicStageable<Object> {
 
     /**
      * The method to be invoked to stage resources.
@@ -43,9 +41,8 @@ final class StageableMethod
      * @param stageMethod the method to be invoked to stage resources.
      * @param injectee    the target injectee has to stage the resources.
      */
-    StageableMethod( Method stageMethod, Object injectee )
-    {
-        super( injectee );
+    StageableMethod(Method stageMethod, Object injectee) {
+        super(injectee);
         this.stageMethod = stageMethod;
     }
 
@@ -53,34 +50,24 @@ final class StageableMethod
      * {@inheritDoc}
      */
     @Override
-    public final void stage( StageHandler stageHandler )
-    {
-        try
-        {
-            AccessController.doPrivileged( new PrivilegedAction<Void>()
-            {
-
+    public final void stage(StageHandler stageHandler) {
+        try {
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
                 @Override
-                public Void run()
-                {
-                    stageMethod.setAccessible( true );
+                public Void run() {
+                    stageMethod.setAccessible(true);
                     return null;
                 }
-
-            } );
-            stageMethod.invoke( object );
-        }
-        catch ( InvocationTargetException e )
-        {
-            stageHandler.onError( object, e.getCause() );
+            });
+            stageMethod.invoke(object);
+        } catch (InvocationTargetException e) {
+            stageHandler.onError(object, e.getCause());
+            return;
+        } catch (Throwable e) {
+            stageHandler.onError(object, e);
             return;
         }
-        catch ( Throwable e )
-        {
-            stageHandler.onError( object, e );
-            return;
-        }
-        stageHandler.onSuccess( object );
+        stageHandler.onSuccess(object);
     }
 
 }

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/StageableTypeMapper.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/StageableTypeMapper.java
@@ -1,0 +1,39 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import com.google.inject.TypeLiteral;
+
+/**
+ * Container for mapping a {@link Stageable} to the parent type
+ * that created it. Useful in specialty Stage containers.
+ */
+public interface StageableTypeMapper
+{
+
+    /**
+     * Register a new {@link Stageable} with the type that created it
+     *
+     * @param stageable stageable
+     * @param parentType     the owning type being heard
+     */
+    <I> void registerType( Stageable stageable, TypeLiteral<I> parentType );
+
+}

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/StageableTypeMapper.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/StageableTypeMapper.java
@@ -25,15 +25,14 @@ import com.google.inject.TypeLiteral;
  * Container for mapping a {@link Stageable} to the parent type
  * that created it. Useful in specialty Stage containers.
  */
-public interface StageableTypeMapper
-{
+public interface StageableTypeMapper {
 
     /**
      * Register a new {@link Stageable} with the type that created it
      *
-     * @param stageable stageable
-     * @param parentType     the owning type being heard
+     * @param stageable  stageable
+     * @param parentType the owning type being heard
      */
-    <I> void registerType( Stageable stageable, TypeLiteral<I> parentType );
+    <I> void registerType(Stageable stageable, TypeLiteral<I> parentType);
 
 }

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/Stager.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/Stager.java
@@ -31,15 +31,14 @@ import java.lang.annotation.Annotation;
  * Implementations must be thread-safe because registration can be done from
  * any thread.
  */
-public interface Stager<A extends Annotation>
-{
+public interface Stager<A extends Annotation> {
 
     /**
      * Register a {@link Stageable} to stage resources.
      *
      * @param stageable object to be invoked to stage resources.
      */
-    void register( Stageable stageable );
+    void register(Stageable stageable);
 
     /**
      * Stages resources invoking {@link Stageable#stage(StageHandler)}.
@@ -52,7 +51,7 @@ public interface Stager<A extends Annotation>
      * @param stageHandler the {@link StageHandler} instance that tracks progresses.
      * @since 0.2.0
      */
-    void stage( StageHandler stageHandler );
+    void stage(StageHandler stageHandler);
 
     /**
      * Returns the annotation that represents this stage.

--- a/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/Stager.java
+++ b/server/container/guice/onami/src/main/java/org/apache/james/onami/lifecycle/Stager.java
@@ -1,0 +1,64 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * A Stager is a mini-container that stages resources
+ * invoking {@link Stageable#stage(StageHandler)}.
+ * <p/>
+ * Order of disposal is specified by the concrete implementation of this
+ * interface via {@link org.apache.onami.lifecycle.core.DefaultStager.Order}.
+ * <p/>
+ * Implementations must be thread-safe because registration can be done from
+ * any thread.
+ */
+public interface Stager<A extends Annotation>
+{
+
+    /**
+     * Register a {@link Stageable} to stage resources.
+     *
+     * @param stageable object to be invoked to stage resources.
+     */
+    void register( Stageable stageable );
+
+    /**
+     * Stages resources invoking {@link Stageable#stage(StageHandler)}.
+     */
+    void stage();
+
+    /**
+     * Stages resources invoking {@link Stageable#stage(StageHandler)}.
+     *
+     * @param stageHandler the {@link StageHandler} instance that tracks progresses.
+     * @since 0.2.0
+     */
+    void stage( StageHandler stageHandler );
+
+    /**
+     * Returns the annotation that represents this stage.
+     *
+     * @return stage annotation.
+     */
+    Class<A> getStage();
+
+}

--- a/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/DefaultStagerTestCase.java
+++ b/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/DefaultStagerTestCase.java
@@ -1,0 +1,105 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DefaultStagerTestCase
+{
+
+    @Test
+    public void stagerShouldStageObjectsRegisteredWhileStaging()
+    {
+        final Stager<TestAnnotationA> stager =
+                new DefaultStager<TestAnnotationA>( TestAnnotationA.class );
+        final AtomicBoolean staged = new AtomicBoolean();
+        stager.register( new Stageable()
+        {
+            @Override
+            public void stage( StageHandler stageHandler )
+            {
+                stager.register( new Stageable()
+                {
+                    @Override
+                    public void stage( StageHandler stageHandler )
+                    {
+                        staged.set( true );
+                    }
+                } );
+            }
+        } );
+
+        stager.stage();
+
+        Assert.assertTrue( staged.get() );
+    }
+
+    /*
+     * Deadlock scenario:
+     * 1. DefaultStager holds lock while calling Stageable.stage();
+     * 2. Stageable.stage() blocks on some thread
+     * 3. the thread blocks on the lock in DefaultStager.register()
+     */
+    @Test
+    public void stagerShouldNotDeadlockWhileStagingObjectChains()
+    {
+        final AtomicBoolean staged = new AtomicBoolean();
+        final Stager<TestAnnotationA> stager =
+                new DefaultStager<TestAnnotationA>( TestAnnotationA.class );
+        stager.register( new Stageable()
+        {
+            @Override
+            public void stage( StageHandler stageHandler )
+            {
+                Thread thread = new Thread( new Runnable()
+                {
+                    @Override
+                    public void run()
+                    {
+                        stager.register( new Stageable()
+                        {
+                            @Override
+                            public void stage( StageHandler stageHandler )
+                            {
+                                staged.set( true );
+                            }
+                        } );
+                    }
+                } );
+                thread.start();
+                try
+                {
+                    thread.join();
+                }
+                catch ( InterruptedException e )
+                {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        } );
+
+        stager.stage();
+
+        Assert.assertTrue( staged.get() );
+    }
+}

--- a/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/DefaultStagerTestCase.java
+++ b/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/DefaultStagerTestCase.java
@@ -24,34 +24,27 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class DefaultStagerTestCase
-{
+public class DefaultStagerTestCase {
 
     @Test
-    public void stagerShouldStageObjectsRegisteredWhileStaging()
-    {
-        final Stager<TestAnnotationA> stager =
-                new DefaultStager<TestAnnotationA>( TestAnnotationA.class );
+    public void stagerShouldStageObjectsRegisteredWhileStaging() {
+        final Stager<TestAnnotationA> stager = new DefaultStager<TestAnnotationA>(TestAnnotationA.class);
         final AtomicBoolean staged = new AtomicBoolean();
-        stager.register( new Stageable()
-        {
+        stager.register(new Stageable() {
             @Override
-            public void stage( StageHandler stageHandler )
-            {
-                stager.register( new Stageable()
-                {
+            public void stage(StageHandler stageHandler) {
+                stager.register(new Stageable() {
                     @Override
-                    public void stage( StageHandler stageHandler )
-                    {
-                        staged.set( true );
+                    public void stage(StageHandler stageHandler) {
+                        staged.set(true);
                     }
-                } );
+                });
             }
-        } );
+        });
 
         stager.stage();
 
-        Assert.assertTrue( staged.get() );
+        Assert.assertTrue(staged.get());
     }
 
     /*
@@ -61,45 +54,34 @@ public class DefaultStagerTestCase
      * 3. the thread blocks on the lock in DefaultStager.register()
      */
     @Test
-    public void stagerShouldNotDeadlockWhileStagingObjectChains()
-    {
+    public void stagerShouldNotDeadlockWhileStagingObjectChains() {
         final AtomicBoolean staged = new AtomicBoolean();
-        final Stager<TestAnnotationA> stager =
-                new DefaultStager<TestAnnotationA>( TestAnnotationA.class );
-        stager.register( new Stageable()
-        {
+        final Stager<TestAnnotationA> stager = new DefaultStager<TestAnnotationA>(TestAnnotationA.class);
+        stager.register(new Stageable() {
             @Override
-            public void stage( StageHandler stageHandler )
-            {
-                Thread thread = new Thread( new Runnable()
-                {
+            public void stage(StageHandler stageHandler) {
+                Thread thread = new Thread(new Runnable() {
                     @Override
-                    public void run()
-                    {
-                        stager.register( new Stageable()
-                        {
+                    public void run() {
+                        stager.register(new Stageable() {
                             @Override
-                            public void stage( StageHandler stageHandler )
-                            {
-                                staged.set( true );
+                            public void stage(StageHandler stageHandler) {
+                                staged.set(true);
                             }
-                        } );
+                        });
                     }
-                } );
+                });
                 thread.start();
-                try
-                {
+                try {
                     thread.join();
-                }
-                catch ( InterruptedException e )
-                {
+                } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }
             }
-        } );
+        });
 
         stager.stage();
 
-        Assert.assertTrue( staged.get() );
+        Assert.assertTrue(staged.get());
     }
 }

--- a/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/MultiLifeCycleObject.java
+++ b/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/MultiLifeCycleObject.java
@@ -1,0 +1,76 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class MultiLifeCycleObject
+{
+    private final StringBuilder str = new StringBuilder();
+
+    @TestAnnotationC
+    public void foo()
+    {
+        str.append( "c" );
+    }
+
+    @TestAnnotationA
+    public void aaa()
+    {
+        str.append( "a" );
+    }
+
+    @TestAnnotationB
+    public void bbb()
+    {
+        str.append( "b" );
+    }
+
+    @TestAnnotationA
+    public void mmm()
+    {
+        str.append( "a" );
+    }
+
+    @TestAnnotationB
+    public void nnn()
+    {
+        str.append( "b" );
+    }
+
+    @TestAnnotationB
+    public void qqq()
+    {
+        str.append( "b" );
+    }
+
+    @TestAnnotationA
+    public void zzz()
+    {
+        str.append( "a" );
+    }
+
+    @Override
+    public String toString()
+    {
+        return str.toString();
+    }
+}

--- a/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/MultiLifeCycleObject.java
+++ b/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/MultiLifeCycleObject.java
@@ -22,55 +22,46 @@ package org.apache.james.onami.lifecycle;
 import javax.inject.Singleton;
 
 @Singleton
-public class MultiLifeCycleObject
-{
+public class MultiLifeCycleObject {
     private final StringBuilder str = new StringBuilder();
 
     @TestAnnotationC
-    public void foo()
-    {
-        str.append( "c" );
+    public void foo() {
+        str.append("c");
     }
 
     @TestAnnotationA
-    public void aaa()
-    {
-        str.append( "a" );
+    public void aaa() {
+        str.append("a");
     }
 
     @TestAnnotationB
-    public void bbb()
-    {
-        str.append( "b" );
+    public void bbb() {
+        str.append("b");
     }
 
     @TestAnnotationA
-    public void mmm()
-    {
-        str.append( "a" );
+    public void mmm() {
+        str.append("a");
     }
 
     @TestAnnotationB
-    public void nnn()
-    {
-        str.append( "b" );
+    public void nnn() {
+        str.append("b");
     }
 
     @TestAnnotationB
-    public void qqq()
-    {
-        str.append( "b" );
+    public void qqq() {
+        str.append("b");
     }
 
     @TestAnnotationA
-    public void zzz()
-    {
-        str.append( "a" );
+    public void zzz() {
+        str.append("a");
     }
 
     @Override
-    public String toString()
-    {
+    public String toString() {
         return str.toString();
     }
 }

--- a/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/MultiLifeCycleTestCase.java
+++ b/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/MultiLifeCycleTestCase.java
@@ -1,0 +1,144 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import static com.google.inject.matcher.Matchers.any;
+import static java.util.Arrays.asList;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import javax.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+public class MultiLifeCycleTestCase
+{
+    @Test
+    public void testOrdering()
+    {
+        Module lifeCycleModule = new TestLifeCycleModule(
+            asList( TestAnnotationA.class, TestAnnotationB.class, TestAnnotationC.class ) );
+        MultiLifeCycleObject obj = Guice.createInjector( lifeCycleModule ).getInstance( MultiLifeCycleObject.class );
+        Assert.assertEquals( "aaabbbc", obj.toString() );
+    }
+
+    public static class Foo
+    {
+        @Inject
+        public Foo( Stager<TestAnnotationA> stager )
+        {
+            System.out.println( stager.getStage() );
+        }
+    }
+
+    @Test
+    public void testStaging()
+    {
+        Module moduleA =
+            new TestLifeCycleStageModule( new DefaultStager<TestAnnotationA>( TestAnnotationA.class ) );
+        Module moduleB =
+            new TestLifeCycleStageModule( new DefaultStager<TestAnnotationB>( TestAnnotationB.class ) );
+        Module moduleC =
+            new TestLifeCycleStageModule( new DefaultStager<TestAnnotationC>( TestAnnotationC.class ) );
+
+        Injector injector = Guice.createInjector( moduleA, moduleB, moduleC );
+        MultiLifeCycleObject obj = injector.getInstance( MultiLifeCycleObject.class );
+
+        Assert.assertEquals( obj.toString(), "" );
+
+        injector.getInstance( LifeCycleStageModule.key( TestAnnotationA.class ) ).stage();
+        Assert.assertEquals( "aaa", obj.toString() );
+        injector.getInstance( LifeCycleStageModule.key( TestAnnotationB.class ) ).stage();
+        Assert.assertEquals( "aaabbb", obj.toString() );
+        injector.getInstance( LifeCycleStageModule.key( TestAnnotationC.class ) ).stage();
+        Assert.assertEquals( "aaabbbc", obj.toString() );
+
+        injector.getInstance( Foo.class );
+    }
+
+    @Test
+    public void testStagingOrdering()
+    {
+        Module moduleA =
+            new TestLifeCycleStageModule( new DefaultStager<TestAnnotationA>( TestAnnotationA.class, DefaultStager.Order.FIRST_IN_FIRST_OUT ) );
+        Module moduleB =
+            new TestLifeCycleStageModule( new DefaultStager<TestAnnotationB>( TestAnnotationB.class, DefaultStager.Order.FIRST_IN_LAST_OUT ) );
+
+        final StringBuilder str = new StringBuilder();
+        Module m = new AbstractModule()
+        {
+            @Override
+            protected void configure()
+            {
+                binder().bind( StringBuilder.class ).toInstance( str );
+            }
+        };
+
+        Injector injector = Guice.createInjector( moduleA, moduleB, m );
+        injector.getInstance( StageObject1.class );
+        injector.getInstance( StageObject2.class );
+
+        injector.getInstance( LifeCycleStageModule.key( TestAnnotationA.class ) ).stage();
+        Assert.assertEquals( "1a2a", str.toString() );
+        str.setLength( 0 );
+
+        injector.getInstance( LifeCycleStageModule.key( TestAnnotationB.class ) ).stage();
+        Assert.assertEquals( "2b1b", str.toString() );
+    }
+
+    private static class TestLifeCycleModule extends LifeCycleModule
+    {
+
+        private final List<? extends Class<? extends Annotation>> annotations;
+
+        public TestLifeCycleModule( List<? extends Class<? extends Annotation>> annotations )
+        {
+            this.annotations = annotations;
+        }
+
+        @Override
+        protected void configure()
+        {
+            bindLifeCycle( annotations, any() );
+        }
+    }
+
+    private static class TestLifeCycleStageModule extends LifeCycleStageModule
+    {
+
+        private final Stager<?> stager;
+
+        public TestLifeCycleStageModule( Stager<?> stager )
+        {
+            this.stager = stager;
+        }
+
+        @Override
+        protected void configureBindings()
+        {
+            bindStager( stager );
+        }
+    }
+}

--- a/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/MultiLifeCycleTestCase.java
+++ b/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/MultiLifeCycleTestCase.java
@@ -22,123 +22,105 @@ package org.apache.james.onami.lifecycle;
 import static com.google.inject.matcher.Matchers.any;
 import static java.util.Arrays.asList;
 
-import com.google.inject.AbstractModule;
-import com.google.inject.Guice;
-import javax.inject.Inject;
-import com.google.inject.Injector;
-import com.google.inject.Module;
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.lang.annotation.Annotation;
 import java.util.List;
 
-public class MultiLifeCycleTestCase
-{
+import javax.inject.Inject;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+
+public class MultiLifeCycleTestCase {
     @Test
-    public void testOrdering()
-    {
-        Module lifeCycleModule = new TestLifeCycleModule(
-            asList( TestAnnotationA.class, TestAnnotationB.class, TestAnnotationC.class ) );
-        MultiLifeCycleObject obj = Guice.createInjector( lifeCycleModule ).getInstance( MultiLifeCycleObject.class );
-        Assert.assertEquals( "aaabbbc", obj.toString() );
+    public void testOrdering() {
+        Module lifeCycleModule = new TestLifeCycleModule(asList(TestAnnotationA.class, TestAnnotationB.class, TestAnnotationC.class));
+        MultiLifeCycleObject obj = Guice.createInjector(lifeCycleModule).getInstance(MultiLifeCycleObject.class);
+        Assert.assertEquals("aaabbbc", obj.toString());
     }
 
-    public static class Foo
-    {
+    public static class Foo {
         @Inject
-        public Foo( Stager<TestAnnotationA> stager )
-        {
-            System.out.println( stager.getStage() );
+        public Foo(Stager<TestAnnotationA> stager) {
+            System.out.println(stager.getStage());
         }
     }
 
     @Test
-    public void testStaging()
-    {
-        Module moduleA =
-            new TestLifeCycleStageModule( new DefaultStager<TestAnnotationA>( TestAnnotationA.class ) );
-        Module moduleB =
-            new TestLifeCycleStageModule( new DefaultStager<TestAnnotationB>( TestAnnotationB.class ) );
-        Module moduleC =
-            new TestLifeCycleStageModule( new DefaultStager<TestAnnotationC>( TestAnnotationC.class ) );
+    public void testStaging() {
+        Module moduleA = new TestLifeCycleStageModule(new DefaultStager<>(TestAnnotationA.class));
+        Module moduleB = new TestLifeCycleStageModule(new DefaultStager<>(TestAnnotationB.class));
+        Module moduleC = new TestLifeCycleStageModule(new DefaultStager<>(TestAnnotationC.class));
 
-        Injector injector = Guice.createInjector( moduleA, moduleB, moduleC );
-        MultiLifeCycleObject obj = injector.getInstance( MultiLifeCycleObject.class );
+        Injector injector = Guice.createInjector(moduleA, moduleB, moduleC);
+        MultiLifeCycleObject obj = injector.getInstance(MultiLifeCycleObject.class);
 
-        Assert.assertEquals( obj.toString(), "" );
+        Assert.assertEquals(obj.toString(), "");
 
-        injector.getInstance( LifeCycleStageModule.key( TestAnnotationA.class ) ).stage();
-        Assert.assertEquals( "aaa", obj.toString() );
-        injector.getInstance( LifeCycleStageModule.key( TestAnnotationB.class ) ).stage();
-        Assert.assertEquals( "aaabbb", obj.toString() );
-        injector.getInstance( LifeCycleStageModule.key( TestAnnotationC.class ) ).stage();
-        Assert.assertEquals( "aaabbbc", obj.toString() );
+        injector.getInstance(LifeCycleStageModule.key(TestAnnotationA.class)).stage();
+        Assert.assertEquals("aaa", obj.toString());
+        injector.getInstance(LifeCycleStageModule.key(TestAnnotationB.class)).stage();
+        Assert.assertEquals("aaabbb", obj.toString());
+        injector.getInstance(LifeCycleStageModule.key(TestAnnotationC.class)).stage();
+        Assert.assertEquals("aaabbbc", obj.toString());
 
-        injector.getInstance( Foo.class );
+        injector.getInstance(Foo.class);
     }
 
     @Test
-    public void testStagingOrdering()
-    {
-        Module moduleA =
-            new TestLifeCycleStageModule( new DefaultStager<TestAnnotationA>( TestAnnotationA.class, DefaultStager.Order.FIRST_IN_FIRST_OUT ) );
-        Module moduleB =
-            new TestLifeCycleStageModule( new DefaultStager<TestAnnotationB>( TestAnnotationB.class, DefaultStager.Order.FIRST_IN_LAST_OUT ) );
+    public void testStagingOrdering() {
+        Module moduleA = new TestLifeCycleStageModule(new DefaultStager<>(TestAnnotationA.class, DefaultStager.Order.FIRST_IN_FIRST_OUT));
+        Module moduleB = new TestLifeCycleStageModule(new DefaultStager<>(TestAnnotationB.class, DefaultStager.Order.FIRST_IN_LAST_OUT));
 
         final StringBuilder str = new StringBuilder();
-        Module m = new AbstractModule()
-        {
+        Module m = new AbstractModule() {
             @Override
-            protected void configure()
-            {
-                binder().bind( StringBuilder.class ).toInstance( str );
+            protected void configure() {
+                binder().bind(StringBuilder.class).toInstance(str);
             }
         };
 
-        Injector injector = Guice.createInjector( moduleA, moduleB, m );
-        injector.getInstance( StageObject1.class );
-        injector.getInstance( StageObject2.class );
+        Injector injector = Guice.createInjector(moduleA, moduleB, m);
+        injector.getInstance(StageObject1.class);
+        injector.getInstance(StageObject2.class);
 
-        injector.getInstance( LifeCycleStageModule.key( TestAnnotationA.class ) ).stage();
-        Assert.assertEquals( "1a2a", str.toString() );
-        str.setLength( 0 );
+        injector.getInstance(LifeCycleStageModule.key(TestAnnotationA.class)).stage();
+        Assert.assertEquals("1a2a", str.toString());
+        str.setLength(0);
 
-        injector.getInstance( LifeCycleStageModule.key( TestAnnotationB.class ) ).stage();
-        Assert.assertEquals( "2b1b", str.toString() );
+        injector.getInstance(LifeCycleStageModule.key(TestAnnotationB.class)).stage();
+        Assert.assertEquals("2b1b", str.toString());
     }
 
-    private static class TestLifeCycleModule extends LifeCycleModule
-    {
+    private static class TestLifeCycleModule extends LifeCycleModule {
 
         private final List<? extends Class<? extends Annotation>> annotations;
 
-        public TestLifeCycleModule( List<? extends Class<? extends Annotation>> annotations )
-        {
+        public TestLifeCycleModule(List<? extends Class<? extends Annotation>> annotations) {
             this.annotations = annotations;
         }
 
         @Override
-        protected void configure()
-        {
-            bindLifeCycle( annotations, any() );
+        protected void configure() {
+            bindLifeCycle(annotations, any());
         }
     }
 
-    private static class TestLifeCycleStageModule extends LifeCycleStageModule
-    {
+    private static class TestLifeCycleStageModule extends LifeCycleStageModule {
 
         private final Stager<?> stager;
 
-        public TestLifeCycleStageModule( Stager<?> stager )
-        {
+        public TestLifeCycleStageModule(Stager<?> stager) {
             this.stager = stager;
         }
 
         @Override
-        protected void configureBindings()
-        {
-            bindStager( stager );
+        protected void configureBindings() {
+            bindStager(stager);
         }
     }
 }

--- a/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/StageObject1.java
+++ b/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/StageObject1.java
@@ -1,0 +1,45 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import javax.inject.Inject;
+
+public class StageObject1
+{
+    private final StringBuilder str;
+
+    @Inject
+    public StageObject1( StringBuilder str )
+    {
+        this.str = str;
+    }
+
+    @TestAnnotationA
+    public void stageA()
+    {
+        str.append( "1a" );
+    }
+
+    @TestAnnotationB
+    public void stageB()
+    {
+        str.append( "1b" );
+    }
+}

--- a/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/StageObject1.java
+++ b/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/StageObject1.java
@@ -21,25 +21,21 @@ package org.apache.james.onami.lifecycle;
 
 import javax.inject.Inject;
 
-public class StageObject1
-{
+public class StageObject1 {
     private final StringBuilder str;
 
     @Inject
-    public StageObject1( StringBuilder str )
-    {
+    public StageObject1(StringBuilder str) {
         this.str = str;
     }
 
     @TestAnnotationA
-    public void stageA()
-    {
-        str.append( "1a" );
+    public void stageA() {
+        str.append("1a");
     }
 
     @TestAnnotationB
-    public void stageB()
-    {
-        str.append( "1b" );
+    public void stageB() {
+        str.append("1b");
     }
 }

--- a/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/StageObject2.java
+++ b/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/StageObject2.java
@@ -21,25 +21,21 @@ package org.apache.james.onami.lifecycle;
 
 import javax.inject.Inject;
 
-public class StageObject2
-{
+public class StageObject2 {
     private final StringBuilder str;
 
     @Inject
-    public StageObject2( StringBuilder str )
-    {
+    public StageObject2(StringBuilder str) {
         this.str = str;
     }
 
     @TestAnnotationA
-    public void stageA()
-    {
-        str.append( "2a" );
+    public void stageA() {
+        str.append("2a");
     }
 
     @TestAnnotationB
-    public void stageB()
-    {
-        str.append( "2b" );
+    public void stageB() {
+        str.append("2b");
     }
 }

--- a/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/StageObject2.java
+++ b/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/StageObject2.java
@@ -1,0 +1,45 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import javax.inject.Inject;
+
+public class StageObject2
+{
+    private final StringBuilder str;
+
+    @Inject
+    public StageObject2( StringBuilder str )
+    {
+        this.str = str;
+    }
+
+    @TestAnnotationA
+    public void stageA()
+    {
+        str.append( "2a" );
+    }
+
+    @TestAnnotationB
+    public void stageB()
+    {
+        str.append( "2b" );
+    }
+}

--- a/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/StagingOrderTestCase.java
+++ b/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/StagingOrderTestCase.java
@@ -19,67 +19,41 @@
 
 package org.apache.james.onami.lifecycle;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class StagingOrderTestCase
-{
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StagingOrderTestCase {
     @Test
-    public void testFifo()
-    {
-        List<Integer> order = new ArrayList<Integer>();
-        DefaultStager<TestAnnotationA> stager = makeStager( order, DefaultStager.Order.FIRST_IN_FIRST_OUT );
+    public void testFifo() {
+        List<Integer> order = new ArrayList<>();
+        DefaultStager<TestAnnotationA> stager = makeStager(order, DefaultStager.Order.FIRST_IN_FIRST_OUT);
         stager.stage();
 
-        Assert.assertEquals( Arrays.asList( 1, 2, 3 ), order );
+        Assert.assertEquals(Arrays.asList(1, 2, 3), order);
     }
 
     @Test
-    public void testFilo()
-    {
-        List<Integer> order = new ArrayList<Integer>();
-        DefaultStager<TestAnnotationA> stager = makeStager( order, DefaultStager.Order.FIRST_IN_LAST_OUT );
+    public void testFilo() {
+        List<Integer> order = new ArrayList<>();
+        DefaultStager<TestAnnotationA> stager = makeStager(order, DefaultStager.Order.FIRST_IN_LAST_OUT);
         stager.stage();
 
-        Assert.assertEquals( Arrays.asList( 3, 2, 1 ), order );
+        Assert.assertEquals(Arrays.asList(3, 2, 1), order);
     }
 
-    private DefaultStager<TestAnnotationA> makeStager( final List<Integer> order, DefaultStager.Order stagingOrder )
-    {
-        Stageable stageable1 = new Stageable()
-        {
-            @Override
-            public void stage( StageHandler stageHandler )
-            {
-                order.add( 1 );
-            }
-        };
-        Stageable stageable2 = new Stageable()
-        {
-            @Override
-            public void stage( StageHandler stageHandler )
-            {
-                order.add( 2 );
-            }
-        };
-        Stageable stageable3 = new Stageable()
-        {
-            @Override
-            public void stage( StageHandler stageHandler )
-            {
-                order.add( 3 );
-            }
-        };
+    private DefaultStager<TestAnnotationA> makeStager(final List<Integer> order, DefaultStager.Order stagingOrder) {
+        Stageable stageable1 = stageHandler -> order.add(1);
+        Stageable stageable2 = stageHandler -> order.add(2);
+        Stageable stageable3 = stageHandler -> order.add(3);
 
-        DefaultStager<TestAnnotationA> stager =
-            new DefaultStager<TestAnnotationA>( TestAnnotationA.class, stagingOrder );
-        stager.register( stageable1 );
-        stager.register( stageable2 );
-        stager.register( stageable3 );
+        DefaultStager<TestAnnotationA> stager = new DefaultStager<TestAnnotationA>(TestAnnotationA.class, stagingOrder);
+        stager.register(stageable1);
+        stager.register(stageable2);
+        stager.register(stageable3);
         return stager;
     }
 }

--- a/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/StagingOrderTestCase.java
+++ b/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/StagingOrderTestCase.java
@@ -1,0 +1,85 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class StagingOrderTestCase
+{
+    @Test
+    public void testFifo()
+    {
+        List<Integer> order = new ArrayList<Integer>();
+        DefaultStager<TestAnnotationA> stager = makeStager( order, DefaultStager.Order.FIRST_IN_FIRST_OUT );
+        stager.stage();
+
+        Assert.assertEquals( Arrays.asList( 1, 2, 3 ), order );
+    }
+
+    @Test
+    public void testFilo()
+    {
+        List<Integer> order = new ArrayList<Integer>();
+        DefaultStager<TestAnnotationA> stager = makeStager( order, DefaultStager.Order.FIRST_IN_LAST_OUT );
+        stager.stage();
+
+        Assert.assertEquals( Arrays.asList( 3, 2, 1 ), order );
+    }
+
+    private DefaultStager<TestAnnotationA> makeStager( final List<Integer> order, DefaultStager.Order stagingOrder )
+    {
+        Stageable stageable1 = new Stageable()
+        {
+            @Override
+            public void stage( StageHandler stageHandler )
+            {
+                order.add( 1 );
+            }
+        };
+        Stageable stageable2 = new Stageable()
+        {
+            @Override
+            public void stage( StageHandler stageHandler )
+            {
+                order.add( 2 );
+            }
+        };
+        Stageable stageable3 = new Stageable()
+        {
+            @Override
+            public void stage( StageHandler stageHandler )
+            {
+                order.add( 3 );
+            }
+        };
+
+        DefaultStager<TestAnnotationA> stager =
+            new DefaultStager<TestAnnotationA>( TestAnnotationA.class, stagingOrder );
+        stager.register( stageable1 );
+        stager.register( stageable2 );
+        stager.register( stageable3 );
+        return stager;
+    }
+}

--- a/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/TestAnnotationA.java
+++ b/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/TestAnnotationA.java
@@ -1,0 +1,33 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface TestAnnotationA
+{
+
+}

--- a/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/TestAnnotationA.java
+++ b/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/TestAnnotationA.java
@@ -19,15 +19,14 @@
 
 package org.apache.james.onami.lifecycle;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
 @Retention(RUNTIME)
 @Target(METHOD)
-public @interface TestAnnotationA
-{
+public @interface TestAnnotationA {
 
 }

--- a/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/TestAnnotationB.java
+++ b/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/TestAnnotationB.java
@@ -19,15 +19,14 @@
 
 package org.apache.james.onami.lifecycle;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-@Retention( RUNTIME )
-@Target( METHOD )
-public @interface TestAnnotationB
-{
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface TestAnnotationB {
 
 }

--- a/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/TestAnnotationB.java
+++ b/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/TestAnnotationB.java
@@ -1,0 +1,33 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention( RUNTIME )
+@Target( METHOD )
+public @interface TestAnnotationB
+{
+
+}

--- a/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/TestAnnotationC.java
+++ b/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/TestAnnotationC.java
@@ -1,0 +1,33 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.onami.lifecycle;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention( RUNTIME )
+@Target( METHOD )
+public @interface TestAnnotationC
+{
+
+}

--- a/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/TestAnnotationC.java
+++ b/server/container/guice/onami/src/test/java/org/apache/james/onami/lifecycle/TestAnnotationC.java
@@ -19,15 +19,14 @@
 
 package org.apache.james.onami.lifecycle;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-@Retention( RUNTIME )
-@Target( METHOD )
-public @interface TestAnnotationC
-{
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface TestAnnotationC {
 
 }

--- a/server/container/guice/pom.xml
+++ b/server/container/guice/pom.xml
@@ -39,6 +39,7 @@
         <module>guice-common</module>
         <module>cassandra-guice</module>
         <module>memory-guice</module>
+        <module>onami</module>
     </modules>
 </project>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -226,6 +226,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.james</groupId>
+                <artifactId>james-server-onami</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.james</groupId>
                 <artifactId>james-server-guice-common</artifactId>
                 <version>${project.version}</version>
                 <type>test-jar</type>
@@ -1389,11 +1394,6 @@
                 <groupId>com.nurkiewicz.asyncretry</groupId>
                 <artifactId>asyncretry</artifactId>
                 <version>0.0.7</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.onami.lifecycle</groupId>
-                <artifactId>org.apache.onami.lifecycle.jsr250</artifactId>
-                <version>0.2.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Apache Felix Karaf integration -->


### PR DESCRIPTION
We use ONAMI in two places : 

 - Guice server for @PreDestroy. 
 - MPT testing with injection in test suite based on a Guice module

My policy  was : 

 - locate code near where it is used
 - Import only what was needed
 - Keep tests
 - Reformat code to respect James standards defined on main project page
 - Solve obvious IntelliJ warnings