### PR TITLE
James 1833 Fallback solution for all-inlined emails

### DIFF
--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/MessageParser.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/MessageParser.java
@@ -183,7 +183,7 @@ public class MessageParser {
                     public Boolean apply(String dispositionType) {
                         return ATTACHMENT_CONTENT_DISPOSITIONS.contains(dispositionType.toLowerCase());
                     }
-                }).isPresent();
+                }).or(false);
     }
 
     private boolean isTextPart(Entity part) {

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/MessageParserTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/MessageParserTest.java
@@ -177,4 +177,11 @@ public class MessageParserTest {
         
         assertThat(attachments).hasSize(6);
     }
+
+    @Test
+    public void getAttachmentsShouldNotConsiderUnknownContentDispositionAsAttachments() throws Exception {
+        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/unknownDisposition.eml"));
+
+        assertThat(attachments).hasSize(0);
+    }
 }

--- a/mailbox/store/src/test/resources/eml/unknownDisposition.eml
+++ b/mailbox/store/src/test/resources/eml/unknownDisposition.eml
@@ -1,0 +1,24 @@
+To: me@linagora.com
+From: Benoit Tellier <me@linagora.com>
+Subject: Mail with text attachment
+Message-ID: <befd8cab-9c9c-5537-4e77-937f32326087@any.com>
+Date: Thu, 13 Oct 2016 10:26:20 +0200
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="------------4FD2D252DB453546C22C25B2"
+
+This is a multi-part message in MIME format.
+--------------4FD2D252DB453546C22C25B2
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+I'm the body!
+
+--------------4FD2D252DB453546C22C25B2
+Content-Type: text/plain; charset=UTF-8;
+ name="attachment.txt"
+Content-Disposition: gabouzomeuh;
+ filename="attachment.txt"
+
+I'm a Schroedinger cat
+--------------4FD2D252DB453546C22C25B2--

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/GetMessagesMethodStepdefs.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/GetMessagesMethodStepdefs.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.mail.Flags;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Request;
@@ -93,6 +94,15 @@ public class GetMessagesMethodStepdefs {
     @Given("^the user has a message in \"([^\"]*)\" mailbox with subject \"([^\"]*)\" and content \"([^\"]*)\" with headers$")
     public void appendMessage(String mailbox, String subject, String content, DataTable headers) throws Throwable {
         appendMessage(mailbox, ContentType.noContentType(), subject, content, Optional.of(headers.asMap(String.class, String.class)));
+    }
+
+    @Given("^the user has a message in \"([^\"]*)\" mailbox, composed of a multipart with inlined text part and inlined html part$")
+    public void appendMessageFromFileInlinedMultipart(String mailbox) throws Throwable {
+        ZonedDateTime dateTime = ZonedDateTime.parse("2014-10-30T14:12:00Z");
+        mainStepdefs.jmapServer.serverProbe().appendMessage(userStepdefs.lastConnectedUser,
+            new MailboxPath(MailboxConstants.USER_NAMESPACE, userStepdefs.lastConnectedUser, mailbox),
+            ClassLoader.getSystemResourceAsStream("eml/inlinedMultipart.eml"),
+            Date.from(dateTime.toInstant()), false, new Flags());
     }
 
     private void appendMessage(String mailbox, ContentType contentType, String subject, String content, Optional<Map<String, String>> headers) throws Exception {

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/GetMessages.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/GetMessages.feature
@@ -199,3 +199,11 @@ Feature: GetMessages method
     And the preview of the message is "multipart/related content"
     And the property "textBody" of the message is null
     And the htmlBody of the message is "<html>multipart/related content</html>\n"
+
+  Scenario: Retrieving message should return textBody and htmlBody when incoming mail have an inlined HTML and text body without Content-ID
+    Given the user has a message in "inbox" mailbox, composed of a multipart with inlined text part and inlined html part
+    When the user ask for messages "["username@domain.tld|inbox|1"]"
+    Then no error is returned
+    And the list should contain 1 message
+    And the textBody of the message is "Hello text body\n"
+    And the htmlBody of the message is "<html>Hello html body</html>\n"

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/eml/inlinedMultipart.eml
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/eml/inlinedMultipart.eml
@@ -1,0 +1,36 @@
+Return-Path: <returnPath>
+Received: from localhost (localhost [127.0.0.1])
+	by localhost (Postfix) with ESMTP id 27358B3A09;
+	Tue, 11 Oct 2016 11:59:12 +0200 (CEST)
+Date: Tue, 11 Oct 2016 02:59:07 -0700
+From: you@apache.org
+To: me@apache.org
+Message-ID: messageId
+Subject: Confirm your email address
+MIME-Version: 1.0
+Content-Type: multipart/mixed; 
+	boundary="----=_Part_5211_53602129.1476179947600"
+Content-Disposition: inline
+
+------=_Part_5211_53602129.1476179947600
+Content-Type: multipart/alternative; 
+	boundary="----=_Part_5210_1271316664.1476179947600"
+
+------=_Part_5210_1271316664.1476179947600
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+Content-Disposition: inline
+
+Hello text body
+
+------=_Part_5210_1271316664.1476179947600
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+Content-Disposition: inline
+
+<html>Hello html body</html>
+
+------=_Part_5210_1271316664.1476179947600--
+
+------=_Part_5211_53602129.1476179947600--
+


### PR DESCRIPTION
@MichaelBailly reported in https://github.com/linagora/james-project/issues/435 a mail that was displayed without body.

The mail was not valid as it contains : 
 - a html part inlined without Content-ID
 - a text plain part inlined without  Content-ID

James was looking for the first html/text part to report that did not have Content-Disposition, hence returned empty bodies.

That being said, [RFC-2183](https://tools.ietf.org/html/rfc2183) states : 

> Inline   bodyparts should be presented in the order in which they occur

Hence, James behaviour did not comply with RFC statements.

James should : 
 - Look first for a body part of specific MIME Type without content-disposition
 - Then have a fallback method for poorly written MIME messages : take first inlined body part with Content-Disposition inlined and without Content-ID

In fallback scenari, rejecting parts with content-id is done to avoid displaying as body mime parts that would have been displayed in an other inlined body which referenced them.

I added integration test based on @MichaelBailly example.