### PR TITLE
James 1836 Jmap should not break on invalid From in mails

### DIFF
--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/Emailer.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/Emailer.java
@@ -20,7 +20,9 @@
 package org.apache.james.jmap.model;
 
 import java.util.Objects;
+import java.util.Optional;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.common.annotations.VisibleForTesting;
@@ -30,6 +32,8 @@ import com.google.common.base.Strings;
 
 @JsonDeserialize(builder = Emailer.Builder.class)
 public class Emailer {
+
+    public static String INVALID = "invalid";
 
     public static Builder builder() {
         return new Builder();
@@ -55,6 +59,17 @@ public class Emailer {
             Preconditions.checkState(!Strings.isNullOrEmpty(email), "'email' is mandatory");
             Preconditions.checkState(email.contains("@"), "'email' must contain '@' character");
             return new Emailer(name, email);
+        }
+
+        @JsonIgnore
+        public Emailer buildInvalidAllowed() {
+            return new Emailer(replaceIfNeeded(name), replaceIfNeeded(email));
+        }
+
+        private String replaceIfNeeded(String value) {
+            return Optional.ofNullable(value)
+                .filter(s -> !s.equals(""))
+                .orElse(INVALID);
         }
     }
 

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/MessageFactory.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/MessageFactory.java
@@ -146,9 +146,9 @@ public class MessageFactory {
     
     private Emailer fromMailbox(Mailbox mailbox) {
         return Emailer.builder()
-                    .name(getNameOrAddress(mailbox))
-                    .email(mailbox.getAddress())
-                    .build();
+            .name(getNameOrAddress(mailbox))
+            .email(mailbox.getAddress())
+            .buildInvalidAllowed();
     }
 
     private String getNameOrAddress(Mailbox mailbox) {

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/EmailerTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/EmailerTest.java
@@ -59,4 +59,50 @@ public class EmailerTest {
         assertThat(emailer).isEqualToComparingFieldByField(expected);
     }
 
+    @Test
+    public void buildInvalidAllowedShouldConsiderNullValuesAsInvalid() {
+        Emailer expected = new Emailer("invalid", "invalid");
+
+        Emailer actual = Emailer.builder()
+            .buildInvalidAllowed();
+
+        assertThat(actual).isEqualToComparingFieldByField(expected);
+    }
+
+    @Test
+    public void buildInvalidAllowedShouldConsiderEmptyValuesAsInvalid() {
+        Emailer expected = new Emailer("invalid", "invalid");
+
+        Emailer actual = Emailer.builder()
+            .name("")
+            .email("")
+            .buildInvalidAllowed();
+
+        assertThat(actual).isEqualToComparingFieldByField(expected);
+    }
+
+    @Test
+    public void buildInvalidAllowedShouldDeclareInvalidAddressesAsInvalid() {
+        Emailer expected = new Emailer("invalid", "invalidAddress");
+
+        Emailer actual = Emailer.builder()
+            .email("invalidAddress")
+            .buildInvalidAllowed();
+
+        assertThat(actual).isEqualToComparingFieldByField(expected);
+    }
+
+    @Test
+    public void buildInvalidAllowedShouldWork() {
+        String name = "bob";
+        String address = "me@apache.org";
+        Emailer expected = new Emailer(name, address);
+
+        Emailer actual = Emailer.builder()
+            .name(name)
+            .email(address)
+            .buildInvalidAllowed();
+
+        assertThat(actual).isEqualToComparingFieldByField(expected);
+    }
 }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/MessageFactoryTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/MessageFactoryTest.java
@@ -260,4 +260,36 @@ public class MessageFactoryTest {
         assertThat(testee.getAttachments()).hasSize(1);
         assertThat(testee.getAttachments().get(0)).isEqualToComparingFieldByField(expectedAttachment);
     }
+
+    @Test
+    public void invalidAddressesShouldBeAllowed() throws Exception {
+        String headers = "From: user <userdomain>\n"
+            + "To: user1 <user1domain>, user2 <user2domain>\n"
+            + "Cc: usercc <userccdomain>\n"
+            + "Bcc: userbcc <userbccdomain>\n"
+            + "Subject: test subject\n";
+        MetaDataWithContent testMail = MetaDataWithContent.builder()
+            .uid(MessageUid.of(2))
+            .flags(new Flags(Flag.SEEN))
+            .size(headers.length())
+            .internalDate(INTERNAL_DATE)
+            .content(new ByteArrayInputStream(headers.getBytes(Charsets.UTF_8)))
+            .attachments(ImmutableList.of())
+            .mailboxId(MAILBOX_ID)
+            .messageId(MessageId.of("user|box|2"))
+            .build();
+
+        Message testee = messageFactory.fromMetaDataWithContent(testMail);
+
+        Emailer user = Emailer.builder().name("user").email("userdomain").buildInvalidAllowed();
+        Emailer user1 = Emailer.builder().name("user1").email("user1domain").buildInvalidAllowed();
+        Emailer user2 = Emailer.builder().name("user2").email("user2domain").buildInvalidAllowed();
+        Emailer usercc = Emailer.builder().name("usercc").email("userccdomain").buildInvalidAllowed();
+        Emailer userbcc = Emailer.builder().name("userbcc").email("userbccdomain").buildInvalidAllowed();
+
+        assertThat(testee.getFrom()).contains(user);
+        assertThat(testee.getTo()).contains(user1, user2);
+        assertThat(testee.getCc()).contains(usercc);
+        assertThat(testee.getBcc()).contains(userbcc);
+    }
 }


### PR DESCRIPTION
With the following pull request : 
 - JMAP still validate EMailers when specified threw the API
 - When retrieving a message sent by JMAP that have invalid addresses, Emailer generation do not crash, allowing the email to be read.

Note : I choosed not to replace invalid address as it conveys some information, even if not valid...
Note : I extended it and demonstrated it for several addresses : cc bcc, from and to