### PR TITLE
James 1838 Clarify shared mailbox access

### DIFF
--- a/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/imapmailbox/suite/Security.java
+++ b/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/imapmailbox/suite/Security.java
@@ -37,6 +37,11 @@ public class Security extends BaseImapProtocol {
     }
 
     @Test
+    public void accessingOtherPeopleNamespaceShouldBeDenied() throws Exception {
+        scriptTest("SharedMailbox", Locale.US);
+    }
+
+    @Test
     public void testLoginThreeStrikesUS() throws Exception {
         scriptTest("LoginThreeStrikes", Locale.US);
     }

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/SharedMailbox.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/SharedMailbox.test
@@ -1,0 +1,50 @@
+################################################################
+# Licensed to the Apache Software Foundation (ASF) under one   #
+# or more contributor license agreements.  See the NOTICE file #
+# distributed with this work for additional information        #
+# regarding copyright ownership.  The ASF licenses this file   #
+# to you under the Apache License, Version 2.0 (the            #
+# "License"); you may not use this file except in compliance   #
+# with the License.  You may obtain a copy of the License at   #
+#                                                              #
+#   http://www.apache.org/licenses/LICENSE-2.0                 #
+#                                                              #
+# Unless required by applicable law or agreed to in writing,   #
+# software distributed under the License is distributed on an  #
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       #
+# KIND, either express or implied.  See the License for the    #
+# specific language governing permissions and limitations      #
+# under the License.                                           #
+################################################################
+
+S: \* OK IMAP4rev1 Server ready
+
+C: a001 LOGIN imapuser password
+S: a001 OK LOGIN completed.
+
+C: a002 CREATE test
+S: a002 OK CREATE completed.
+
+C: a003 CREATE #private.test2
+S: a003 OK CREATE completed.
+
+C: a004 CREATE #private.other.test3
+S: a004 OK CREATE completed.
+
+C: a005 CREATE #any.hello
+S: a005 NO CREATE You can not access a mailbox that does not belong to you
+
+C: a006 LIST "" %
+SUB {
+S: \* LIST \(\\HasNoChildren\) \".\" \"INBOX\"
+S: \* LIST \(\\HasChildren\) \".\" \"other\"
+S: \* LIST \(\\HasNoChildren\) \".\" \"test\"
+S: \* LIST \(\\HasNoChildren\) \".\" \"test2\"
+}
+S: a006 OK LIST completed.
+
+C: a006 LIST "" other.%
+SUB {
+S: \* LIST \(\\HasNoChildren\) \".\" \"other.test3\"
+}
+S: a006 OK LIST completed.

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/display/HumanReadableText.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/display/HumanReadableText.java
@@ -158,6 +158,8 @@ public class HumanReadableText {
     public static final HumanReadableText QRESYNC_CLOSED = new HumanReadableText("org.apache.james.imap.QRESYNC_CLOSED", "");
     public static final HumanReadableText QRESYNC_VANISHED_WITHOUT_CHANGEDSINCE = new HumanReadableText("org.apache.james.imap.QRESYNC_VANISHED_WITHOUT_CHANGEDSINCE", "VANISHED used without CHANGEDSINCE");
 
+    public static final HumanReadableText DENIED_SHARED_MAILBOX = new HumanReadableText("org.apache.james.imap.DENIED_SHARED_MAILBOX", "You can not access a mailbox that does not belong to you");
+
     public static final String UNSUFFICIENT_RIGHTS_DEFAULT_VALUE = "You need the {0} right to perform command {1} on mailbox {2}.";
     public static final String UNSUFFICIENT_RIGHTS_KEY = "org.apache.james.imap.UNSUFFICIENT_RIGHTS";
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/main/DeniedAccessOnSharedMailboxException.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/main/DeniedAccessOnSharedMailboxException.java
@@ -1,0 +1,23 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.imap.main;
+
+public class DeniedAccessOnSharedMailboxException extends RuntimeException {
+}

--- a/protocols/imap/src/main/java/org/apache/james/imap/main/PathConverter.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/main/PathConverter.java
@@ -1,0 +1,78 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.imap.main;
+
+import org.apache.james.imap.api.ImapSessionUtils;
+import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.model.MailboxConstants;
+import org.apache.james.mailbox.model.MailboxPath;
+
+public class PathConverter {
+
+    public static PathConverter forSession(ImapSession session) {
+        return new PathConverter(session);
+    }
+
+    private final ImapSession session;
+
+    public PathConverter(ImapSession session) {
+        this.session = session;
+    }
+
+    public MailboxPath buildFullPath(String mailboxName) {
+        String namespace = null;
+        String name = null;
+        final MailboxSession mailboxSession = ImapSessionUtils.getMailboxSession(session);
+
+        if (mailboxName == null || mailboxName.length() == 0) {
+            return new MailboxPath("", "", "");
+        }
+        if (mailboxName.charAt(0) == MailboxConstants.NAMESPACE_PREFIX_CHAR) {
+            int namespaceLength = mailboxName.indexOf(mailboxSession.getPathDelimiter());
+            if (namespaceLength > -1) {
+                namespace = mailboxName.substring(0, namespaceLength);
+                if (mailboxName.length() > namespaceLength)
+                    name = mailboxName.substring(++namespaceLength);
+            } else {
+                namespace = mailboxName;
+            }
+        } else {
+            namespace = MailboxConstants.USER_NAMESPACE;
+            name = mailboxName;
+        }
+        String user = null;
+        // we only use the user as part of the MailboxPath if its a private user
+        // namespace
+        if (namespace.equals(MailboxConstants.USER_NAMESPACE)) {
+            user = ImapSessionUtils.getUserName(session);
+        }
+
+        // use uppercase for INBOX
+        //
+        // See IMAP-349
+        if (name.equalsIgnoreCase(MailboxConstants.INBOX)) {
+            name = MailboxConstants.INBOX;
+        }
+
+        return new MailboxPath(namespace, user, name);
+    }
+
+}

--- a/protocols/imap/src/main/java/org/apache/james/imap/main/PathConverter.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/main/PathConverter.java
@@ -86,6 +86,9 @@ public class PathConverter {
     }
 
     private MailboxPath buildMailboxPath(String namespace, String user, String mailboxName) {
+        if (!namespace.equals(MailboxConstants.USER_NAMESPACE)) {
+            throw new DeniedAccessOnSharedMailboxException();
+        }
         return new MailboxPath(namespace, user, sanitizeMailboxName(mailboxName));
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractAuthProcessor.java
@@ -25,6 +25,7 @@ import org.apache.james.imap.api.message.request.ImapRequest;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.main.PathConverter;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.exception.BadCredentialsException;
@@ -56,7 +57,7 @@ public abstract class AbstractAuthProcessor<M extends ImapRequest> extends Abstr
                     final MailboxSession mailboxSession = mailboxManager.login(userid, passwd, session.getLog());
                     session.authenticated();
                     session.setAttribute(ImapSessionUtils.MAILBOX_SESSION_ATTRIBUTE_SESSION_KEY, mailboxSession);
-                    final MailboxPath inboxPath = buildFullPath(session, MailboxConstants.INBOX);
+                    final MailboxPath inboxPath = PathConverter.forSession(session).buildFullPath(MailboxConstants.INBOX);
                     if (mailboxManager.mailboxExists(inboxPath, mailboxSession)) {
                         if (session.getLog().isDebugEnabled()) {
                             session.getLog().debug("INBOX exists. No need to create it.");

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -351,44 +351,6 @@ abstract public class AbstractMailboxProcessor<M extends ImapRequest> extends Ab
 
     protected abstract void doProcess(M message, ImapSession session, String tag, ImapCommand command, Responder responder);
 
-    public MailboxPath buildFullPath(ImapSession session, String mailboxName) {
-        String namespace = null;
-        String name = null;
-        final MailboxSession mailboxSession = ImapSessionUtils.getMailboxSession(session);
-
-        if (mailboxName == null || mailboxName.length() == 0) {
-            return new MailboxPath("", "", "");
-        }
-        if (mailboxName.charAt(0) == MailboxConstants.NAMESPACE_PREFIX_CHAR) {
-            int namespaceLength = mailboxName.indexOf(mailboxSession.getPathDelimiter());
-            if (namespaceLength > -1) {
-                namespace = mailboxName.substring(0, namespaceLength);
-                if (mailboxName.length() > namespaceLength)
-                    name = mailboxName.substring(++namespaceLength);
-            } else {
-                namespace = mailboxName;
-            }
-        } else {
-            namespace = MailboxConstants.USER_NAMESPACE;
-            name = mailboxName;
-        }
-        String user = null;
-        // we only use the user as part of the MailboxPath if its a private user
-        // namespace
-        if (namespace.equals(MailboxConstants.USER_NAMESPACE)) {
-            user = ImapSessionUtils.getUserName(session);
-        }
-        
-        // use uppercase for INBOX
-        //
-        // See IMAP-349
-        if (name.equalsIgnoreCase(MailboxConstants.INBOX)) {
-            name = MailboxConstants.INBOX;
-        }
-
-        return new MailboxPath(namespace, user, name);
-    }
-
     /**
      * Joins the elements of a mailboxPath together and returns them as a string
      * 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMessageRangeProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMessageRangeProcessor.java
@@ -31,6 +31,7 @@ import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.api.process.SelectedMailbox;
+import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.AbstractMessageRangeRequest;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
@@ -56,7 +57,7 @@ public abstract class AbstractMessageRangeProcessor<M extends AbstractMessageRan
 
     @Override
     protected void doProcess(M request, ImapSession session, String tag, ImapCommand command, Responder responder) {
-        final MailboxPath targetMailbox = buildFullPath(session, request.getMailboxName());
+        final MailboxPath targetMailbox = PathConverter.forSession(session).buildFullPath(request.getMailboxName());
         final IdRange[] idSet = request.getIdSet();
         final boolean useUids = request.isUseUids();
         final SelectedMailbox currentMailbox = session.getSelected();

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
@@ -38,6 +38,7 @@ import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.api.process.SearchResUtil;
 import org.apache.james.imap.api.process.SelectedMailbox;
+import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.AbstractMailboxSelectionRequest;
 import org.apache.james.imap.message.response.ExistsResponse;
 import org.apache.james.imap.message.response.RecentResponse;
@@ -80,7 +81,7 @@ abstract class AbstractSelectionProcessor<M extends AbstractMailboxSelectionRequ
     protected void doProcess(M request, ImapSession session, String tag, ImapCommand command, Responder responder) {
         final String mailboxName = request.getMailboxName();
         try {
-            final MailboxPath fullMailboxPath = buildFullPath(session, mailboxName);
+            final MailboxPath fullMailboxPath = PathConverter.forSession(session).buildFullPath(mailboxName);
 
             respond(tag, command, session, fullMailboxPath, request, responder);
            

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AppendProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AppendProcessor.java
@@ -35,6 +35,7 @@ import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.api.process.SelectedMailbox;
+import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.AppendRequest;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
@@ -64,7 +65,7 @@ public class AppendProcessor extends AbstractMailboxProcessor<AppendRequest> {
         final InputStream messageIn = request.getMessage();
         final Date datetime = request.getDatetime();
         final Flags flags = request.getFlags();
-        final MailboxPath mailboxPath = buildFullPath(session, mailboxName);
+        final MailboxPath mailboxPath = PathConverter.forSession(session).buildFullPath(mailboxName);
 
         try {
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/CreateProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/CreateProcessor.java
@@ -25,6 +25,7 @@ import org.apache.james.imap.api.display.HumanReadableText;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.CreateRequest;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -45,7 +46,7 @@ public class CreateProcessor extends AbstractMailboxProcessor<CreateRequest> {
      * org.apache.james.imap.api.process.ImapProcessor.Responder)
      */
     protected void doProcess(CreateRequest request, ImapSession session, String tag, ImapCommand command, Responder responder) {
-        final MailboxPath mailboxPath = buildFullPath(session, request.getMailboxName());
+        final MailboxPath mailboxPath = PathConverter.forSession(session).buildFullPath(request.getMailboxName());
         try {
             final MailboxManager mailboxManager = getMailboxManager();
             mailboxManager.createMailbox(mailboxPath, ImapSessionUtils.getMailboxSession(session));

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/DeleteACLProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/DeleteACLProcessor.java
@@ -29,6 +29,7 @@ import org.apache.james.imap.api.display.HumanReadableText;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.DeleteACLRequest;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
@@ -65,7 +66,7 @@ public class DeleteACLProcessor extends AbstractMailboxProcessor<DeleteACLReques
         final String identifier = message.getIdentifier();
         try {
 
-            MailboxPath mailboxPath = buildFullPath(session, mailboxName);
+            MailboxPath mailboxPath = PathConverter.forSession(session).buildFullPath(mailboxName);
             // Check that mailbox exists
             mailboxManager.getMailbox(mailboxPath, mailboxSession);
             /*

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/DeleteProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/DeleteProcessor.java
@@ -26,6 +26,7 @@ import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.api.process.SelectedMailbox;
+import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.DeleteRequest;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -46,7 +47,7 @@ public class DeleteProcessor extends AbstractMailboxProcessor<DeleteRequest> {
      * org.apache.james.imap.api.process.ImapProcessor.Responder)
      */
     protected void doProcess(DeleteRequest request, ImapSession session, String tag, ImapCommand command, Responder responder) {
-        final MailboxPath mailboxPath = buildFullPath(session, request.getMailboxName());
+        final MailboxPath mailboxPath = PathConverter.forSession(session).buildFullPath(request.getMailboxName());
         try {
             final SelectedMailbox selected = session.getSelected();
             if (selected != null && selected.getPath().equals(mailboxPath)) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/GetACLProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/GetACLProcessor.java
@@ -29,6 +29,7 @@ import org.apache.james.imap.api.display.HumanReadableText;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.GetACLRequest;
 import org.apache.james.imap.message.response.ACLResponse;
 import org.apache.james.mailbox.MailboxManager;
@@ -62,7 +63,7 @@ public class GetACLProcessor extends AbstractMailboxProcessor<GetACLRequest> imp
         final String mailboxName = message.getMailboxName();
         try {
 
-            MailboxPath mailboxPath = buildFullPath(session, mailboxName);
+            MailboxPath mailboxPath = PathConverter.forSession(session).buildFullPath(mailboxName);
             // Check that mailbox exists
             MessageManager messageManager = mailboxManager.getMailbox(mailboxPath, mailboxSession);
             /*

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/GetAnnotationProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/GetAnnotationProcessor.java
@@ -34,6 +34,7 @@ import org.apache.james.imap.api.display.HumanReadableText;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.GetAnnotationRequest;
 import org.apache.james.imap.message.response.AnnotationResponse;
 import org.apache.james.mailbox.MailboxManager;
@@ -73,7 +74,7 @@ public class GetAnnotationProcessor extends AbstractMailboxProcessor<GetAnnotati
     private void proceed(GetAnnotationRequest message, ImapSession session, String tag, ImapCommand command, Responder responder) throws MailboxException {
         String mailboxName = message.getMailboxName();
         Optional<Integer> maxsize = message.getMaxsize();
-        MailboxPath mailboxPath = buildFullPath(session, mailboxName);
+        MailboxPath mailboxPath = PathConverter.forSession(session).buildFullPath(mailboxName);
 
         List<MailboxAnnotation> mailboxAnnotations = getMailboxAnnotations(session, message.getKeys(), message.getDepth(), mailboxPath);
         Optional<Integer> maximumOversizedSize = getMaxSizeValue(mailboxAnnotations, maxsize);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/GetQuotaRootProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/GetQuotaRootProcessor.java
@@ -26,6 +26,7 @@ import org.apache.james.imap.api.display.HumanReadableText;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.GetQuotaRootRequest;
 import org.apache.james.imap.message.response.QuotaRootResponse;
 import org.apache.james.imap.message.response.QuotaResponse;
@@ -66,7 +67,7 @@ public class GetQuotaRootProcessor extends AbstractMailboxProcessor<GetQuotaRoot
         final MailboxSession mailboxSession = ImapSessionUtils.getMailboxSession(session);
         final MailboxManager mailboxManager = getMailboxManager();
 
-        final MailboxPath mailboxPath = buildFullPath(session, message.getMailboxName());
+        final MailboxPath mailboxPath = PathConverter.forSession(session).buildFullPath(message.getMailboxName());
 
         // First check mailbox exists
         try {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/LSubProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/LSubProcessor.java
@@ -29,6 +29,7 @@ import org.apache.james.imap.api.display.HumanReadableText;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.LsubRequest;
 import org.apache.james.imap.message.response.LSubResponse;
 import org.apache.james.mailbox.MailboxManager;
@@ -62,7 +63,7 @@ public class LSubProcessor extends AbstractSubscriptionProcessor<LsubRequest> {
         if (isRelative) {
             basePath = new MailboxPath(MailboxConstants.USER_NAMESPACE, mailboxSession.getUser().getUserName(), CharsetUtil.decodeModifiedUTF7(finalReferencename));
         } else {
-            basePath = buildFullPath(session, CharsetUtil.decodeModifiedUTF7(finalReferencename));
+            basePath = PathConverter.forSession(session).buildFullPath(CharsetUtil.decodeModifiedUTF7(finalReferencename));
         }
 
         final MailboxQuery expression = new MailboxQuery(basePath, CharsetUtil.decodeModifiedUTF7(mailboxName), mailboxSession.getPathDelimiter());

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/ListProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/ListProcessor.java
@@ -33,6 +33,7 @@ import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.api.process.MailboxType;
 import org.apache.james.imap.api.process.MailboxTyper;
+import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.ListRequest;
 import org.apache.james.imap.message.response.ListResponse;
 import org.apache.james.mailbox.MailboxManager;
@@ -169,7 +170,7 @@ public class ListProcessor extends AbstractMailboxProcessor<ListRequest> {
                 if (isRelative) {
                     basePath = new MailboxPath(MailboxConstants.USER_NAMESPACE, user, finalReferencename);
                 } else {
-                    basePath = buildFullPath(session, finalReferencename);
+                    basePath = PathConverter.forSession(session).buildFullPath(finalReferencename);
                 }
 
                 results = getMailboxManager().search(new MailboxQuery(basePath, CharsetUtil.decodeModifiedUTF7(mailboxName), mailboxSession.getPathDelimiter()), mailboxSession);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/ListRightsProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/ListRightsProcessor.java
@@ -29,6 +29,7 @@ import org.apache.james.imap.api.display.HumanReadableText;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.ListRightsRequest;
 import org.apache.james.imap.message.response.ListRightsResponse;
 import org.apache.james.mailbox.MailboxManager;
@@ -64,7 +65,7 @@ public class ListRightsProcessor extends AbstractMailboxProcessor<ListRightsRequ
         final String identifier = message.getIdentifier();
         try {
 
-            MailboxPath mailboxPath = buildFullPath(session, mailboxName);
+            MailboxPath mailboxPath = PathConverter.forSession(session).buildFullPath(mailboxName);
             // Check that mailbox exists
             mailboxManager.getMailbox(mailboxPath, mailboxSession);
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/MyRightsProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/MyRightsProcessor.java
@@ -29,6 +29,7 @@ import org.apache.james.imap.api.display.HumanReadableText;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.MyRightsRequest;
 import org.apache.james.imap.message.response.MyRightsResponse;
 import org.apache.james.mailbox.MailboxManager;
@@ -61,7 +62,7 @@ public class MyRightsProcessor extends AbstractMailboxProcessor<MyRightsRequest>
         final String mailboxName = message.getMailboxName();
         try {
 
-            MailboxPath mailboxPath = buildFullPath(session, mailboxName);
+            MailboxPath mailboxPath = PathConverter.forSession(session).buildFullPath(mailboxName);
             // Check that mailbox exists
             mailboxManager.getMailbox(mailboxPath, mailboxSession);
             MailboxACLRights myRights = mailboxManager.myRights(mailboxPath, mailboxSession);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/RenameProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/RenameProcessor.java
@@ -26,6 +26,7 @@ import org.apache.james.imap.api.display.HumanReadableText;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.RenameRequest;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
@@ -49,8 +50,9 @@ public class RenameProcessor extends AbstractMailboxProcessor<RenameRequest> {
      * org.apache.james.imap.api.process.ImapProcessor.Responder)
      */
     protected void doProcess(RenameRequest request, ImapSession session, String tag, ImapCommand command, Responder responder) {
-        final MailboxPath existingPath = buildFullPath(session, request.getExistingName());
-        final MailboxPath newPath = buildFullPath(session, request.getNewName());
+        PathConverter pathConverter = PathConverter.forSession(session);
+        MailboxPath existingPath = pathConverter.buildFullPath(request.getExistingName());
+        MailboxPath newPath = pathConverter.buildFullPath(request.getNewName());
         try {
             final MailboxManager mailboxManager = getMailboxManager();
             MailboxSession mailboxsession = ImapSessionUtils.getMailboxSession(session);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SetACLProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SetACLProcessor.java
@@ -29,6 +29,7 @@ import org.apache.james.imap.api.display.HumanReadableText;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.SetACLRequest;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
@@ -84,7 +85,7 @@ public class SetACLProcessor extends AbstractMailboxProcessor<SetACLRequest> imp
             }
             MailboxACLRights mailboxAclRights = new Rfc4314Rights(rights);
 
-            MailboxPath mailboxPath = buildFullPath(session, mailboxName);
+            MailboxPath mailboxPath = PathConverter.forSession(session).buildFullPath(mailboxName);
             // Check that mailbox exists
             mailboxManager.getMailbox(mailboxPath, mailboxSession);
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SetAnnotationProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SetAnnotationProcessor.java
@@ -29,6 +29,7 @@ import org.apache.james.imap.api.message.response.StatusResponse;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.SetAnnotationRequest;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
@@ -54,7 +55,7 @@ public class SetAnnotationProcessor extends AbstractMailboxProcessor<SetAnnotati
         final MailboxSession mailboxSession = ImapSessionUtils.getMailboxSession(session);
         final String mailboxName = message.getMailboxName();
         try {
-            MailboxPath mailboxPath = buildFullPath(session, mailboxName);
+            MailboxPath mailboxPath = PathConverter.forSession(session).buildFullPath(mailboxName);
 
             mailboxManager.updateAnnotations(mailboxPath, mailboxSession, message.getMailboxAnnotations());
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/StatusProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/StatusProcessor.java
@@ -26,6 +26,7 @@ import org.apache.james.imap.api.message.StatusDataItems;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.main.PathConverter;
 import org.apache.james.imap.message.request.StatusRequest;
 import org.apache.james.imap.message.response.MailboxStatusResponse;
 import org.apache.james.mailbox.MailboxManager;
@@ -51,7 +52,7 @@ public class StatusProcessor extends AbstractMailboxProcessor<StatusRequest> {
      * org.apache.james.imap.api.process.ImapProcessor.Responder)
      */
     protected void doProcess(StatusRequest request, ImapSession session, String tag, ImapCommand command, Responder responder) {
-        final MailboxPath mailboxPath = buildFullPath(session, request.getMailboxName());
+        final MailboxPath mailboxPath = PathConverter.forSession(session).buildFullPath(request.getMailboxName());
         final StatusDataItems statusDataItems = request.getStatusDataItems();
         final Logger logger = session.getLog();
         final MailboxSession mailboxSession = ImapSessionUtils.getMailboxSession(session);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/AbstractChainedProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/AbstractChainedProcessor.java
@@ -45,6 +45,7 @@ abstract public class AbstractChainedProcessor<M extends ImapMessage> implements
      * org.apache.james.imap.api.process.ImapProcessor.Responder,
      * org.apache.james.imap.api.process.ImapSession)
      */
+    @Override
     @SuppressWarnings("unchecked")
     public void process(ImapMessage message, Responder responder, ImapSession session) {
         final boolean isAcceptable = isAcceptable(message);

--- a/protocols/imap/src/test/java/org/apache/james/imap/main/PathConverterTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/main/PathConverterTest.java
@@ -1,0 +1,142 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.imap.main;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.james.imap.api.ImapSessionUtils;
+import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.model.MailboxConstants;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PathConverterTest {
+
+    private static final String USERNAME = "username";
+    private static final char PATH_DELIMITER = '.';
+
+    private ImapSession imapSession;
+    private MailboxSession mailboxSession;
+    private PathConverter pathConverter;
+
+    @Before
+    public void setUp() {
+        imapSession = mock(ImapSession.class);
+        mailboxSession = mock(MailboxSession.class);
+        MailboxSession.User user = mock(MailboxSession.User.class);
+        pathConverter = PathConverter.forSession(imapSession);
+        when(imapSession.getAttribute(ImapSessionUtils.MAILBOX_SESSION_ATTRIBUTE_SESSION_KEY)).thenReturn(mailboxSession);
+        when(mailboxSession.getUser()).thenReturn(user);
+        when(mailboxSession.getPathDelimiter()).thenReturn(PATH_DELIMITER);
+        when(user.getUserName()).thenReturn(USERNAME);
+    }
+
+    @Test
+    public void buildFullPathShouldAcceptNull() {
+        assertThat(pathConverter.buildFullPath(null))
+            .isEqualTo(new MailboxPath("", "", ""));
+    }
+
+    @Test
+    public void buildPathShouldAcceptEmpty() {
+        assertThat(pathConverter.buildFullPath(""))
+            .isEqualTo(new MailboxPath("", "", ""));
+    }
+
+    @Test
+    public void buildPathShouldAcceptRelativeMailboxName() {
+        String mailboxName = "mailboxName";
+        assertThat(pathConverter.buildFullPath(mailboxName))
+            .isEqualTo(new MailboxPath(MailboxConstants.USER_NAMESPACE, USERNAME, mailboxName));
+    }
+
+    @Test
+    public void buildFullPathShouldAcceptNamespacePrefix() {
+        assertThat(pathConverter.buildFullPath("#"))
+            .isEqualTo(new MailboxPath("#", null, ""));
+    }
+
+    @Test
+    public void buildFullPathShouldAcceptUserNamespace() {
+        assertThat(pathConverter.buildFullPath(MailboxConstants.USER_NAMESPACE))
+            .isEqualTo(new MailboxPath(MailboxConstants.USER_NAMESPACE, USERNAME, ""));
+    }
+
+    @Test
+    public void buildFullPathShouldAcceptNamespaceAlone() {
+        String namespace = "#any";
+        assertThat(pathConverter.buildFullPath(namespace))
+            .isEqualTo(new MailboxPath(namespace, null, ""));
+    }
+
+    @Test
+    public void buildFullPathShouldAcceptUserNamespaceAndDelimiter() {
+        assertThat(pathConverter.buildFullPath(MailboxConstants.USER_NAMESPACE + PATH_DELIMITER))
+            .isEqualTo(new MailboxPath(MailboxConstants.USER_NAMESPACE, USERNAME, ""));
+    }
+
+    @Test
+    public void buildFullPathShouldAcceptNamespaceAndDelimiter() {
+        String namespace = "#any";
+        assertThat(pathConverter.buildFullPath(namespace + PATH_DELIMITER))
+            .isEqualTo(new MailboxPath(namespace, null, ""));
+    }
+
+    @Test
+    public void buildFullPathShouldAcceptFullAbsoluteUserPath() {
+        String mailboxName = "mailboxName";
+        assertThat(pathConverter.buildFullPath(MailboxConstants.USER_NAMESPACE + PATH_DELIMITER + mailboxName))
+            .isEqualTo(new MailboxPath(MailboxConstants.USER_NAMESPACE, USERNAME, mailboxName));
+    }
+
+    @Test
+    public void buildFullPathShouldAcceptFullAbsolutePath() {
+        String namespace = "#any";
+        String mailboxName = "mailboxName";
+        assertThat(pathConverter.buildFullPath(namespace + PATH_DELIMITER + mailboxName))
+            .isEqualTo(new MailboxPath(namespace, null, mailboxName));
+    }
+
+    @Test
+    public void buildFullPathShouldAcceptRelativePathWithSubFolder() {
+        String mailboxName = "mailboxName" + PATH_DELIMITER + "subFolder";
+        assertThat(pathConverter.buildFullPath(mailboxName))
+            .isEqualTo(new MailboxPath(MailboxConstants.USER_NAMESPACE, USERNAME, mailboxName));
+    }
+
+    @Test
+    public void buildFullPathShouldAcceptAbsoluteUserPathWithSubFolder() {
+        String mailboxName = "mailboxName.subFolder";
+        assertThat(pathConverter.buildFullPath(MailboxConstants.USER_NAMESPACE + PATH_DELIMITER + mailboxName))
+            .isEqualTo(new MailboxPath(MailboxConstants.USER_NAMESPACE, USERNAME, mailboxName));
+    }
+
+    @Test
+    public void buildFullPathShouldAcceptAbsolutePathWithSubFolder() {
+        String namespace = "#any";
+        String mailboxName = "mailboxName.subFolder";
+        assertThat(pathConverter.buildFullPath(namespace + PATH_DELIMITER + mailboxName))
+            .isEqualTo(new MailboxPath(namespace, null, mailboxName));
+    }
+}

--- a/protocols/imap/src/test/java/org/apache/james/imap/main/PathConverterTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/main/PathConverterTest.java
@@ -29,7 +29,10 @@ import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.model.MailboxConstants;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class PathConverterTest {
 
@@ -39,6 +42,7 @@ public class PathConverterTest {
     private ImapSession imapSession;
     private MailboxSession mailboxSession;
     private PathConverter pathConverter;
+    @Rule public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -71,6 +75,7 @@ public class PathConverterTest {
             .isEqualTo(new MailboxPath(MailboxConstants.USER_NAMESPACE, USERNAME, mailboxName));
     }
 
+    @Ignore("Shared mailbox is not supported yet")
     @Test
     public void buildFullPathShouldAcceptNamespacePrefix() {
         assertThat(pathConverter.buildFullPath("#"))
@@ -83,6 +88,7 @@ public class PathConverterTest {
             .isEqualTo(new MailboxPath(MailboxConstants.USER_NAMESPACE, USERNAME, ""));
     }
 
+    @Ignore("Shared mailbox is not supported yet")
     @Test
     public void buildFullPathShouldAcceptNamespaceAlone() {
         String namespace = "#any";
@@ -96,6 +102,7 @@ public class PathConverterTest {
             .isEqualTo(new MailboxPath(MailboxConstants.USER_NAMESPACE, USERNAME, ""));
     }
 
+    @Ignore("Shared mailbox is not supported yet")
     @Test
     public void buildFullPathShouldAcceptNamespaceAndDelimiter() {
         String namespace = "#any";
@@ -110,6 +117,7 @@ public class PathConverterTest {
             .isEqualTo(new MailboxPath(MailboxConstants.USER_NAMESPACE, USERNAME, mailboxName));
     }
 
+    @Ignore("Shared mailbox is not supported yet")
     @Test
     public void buildFullPathShouldAcceptFullAbsolutePath() {
         String namespace = "#any";
@@ -132,11 +140,18 @@ public class PathConverterTest {
             .isEqualTo(new MailboxPath(MailboxConstants.USER_NAMESPACE, USERNAME, mailboxName));
     }
 
+    @Ignore("Shared mailbox is not supported yet")
     @Test
     public void buildFullPathShouldAcceptAbsolutePathWithSubFolder() {
         String namespace = "#any";
         String mailboxName = "mailboxName.subFolder";
         assertThat(pathConverter.buildFullPath(namespace + PATH_DELIMITER + mailboxName))
             .isEqualTo(new MailboxPath(namespace, null, mailboxName));
+    }
+
+    @Test
+    public void buildFullPathShouldDenyMailboxPathNotBelongingToTheUser() {
+        expectedException.expect(DeniedAccessOnSharedMailboxException.class);
+        pathConverter.buildFullPath("#any");
     }
 }


### PR DESCRIPTION
I reworked MailboxPath generation and improved it a bit. Someone can not access any mailbox he do not own.

About paths, if my username is **chibenwa** : 

 - Path *toto* will point to *#private:chibenwa:toto*
 - Path *#private.toto* will also point to *#private:chibenwa:toto* 

With #private username is implied to be yours (previous behaviour)

 - Path *#other.toto* will point to *#other:null:toto*

With shared mailboxes, username component of MailboxPath is implied to be null.

Question : Do we modify MailboxPath to have Optional user ? It is some serious refactoring, so I want to have your opinion before doing it. We may delay it to shared mailbox implementation.

I keep other questions for shared mailbox implementation ;-)