### PR TITLE
JAMES-1846 Improve IMAP logging

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/main/DefaultImapDecoder.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/main/DefaultImapDecoder.java
@@ -18,6 +18,7 @@
  ****************************************************************/
 package org.apache.james.imap.decode.main;
 
+import org.apache.james.imap.api.ImapConstants;
 import org.apache.james.imap.api.ImapMessage;
 import org.apache.james.imap.api.ImapSessionState;
 import org.apache.james.imap.api.display.HumanReadableText;

--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/UidCommandParser.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/UidCommandParser.java
@@ -73,6 +73,9 @@ public class UidCommandParser extends AbstractImapCommandParser implements Deleg
         if (helperCommand == null || !(helperCommand instanceof AbstractUidCommandParser)) {
             throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Invalid UID command: '" + commandName + "'");
         }
+        if (session.getLog().isDebugEnabled()) {
+            session.getLog().debug("Got <command>: UID " + commandName);
+        }
         final AbstractUidCommandParser uidEnabled = (AbstractUidCommandParser) helperCommand;
         return uidEnabled.decode(request, tag, true, session);
     }


### PR DESCRIPTION
We should be able to know wich command is being used after UID command

It might help us to better understand  some IMAP bugs as Thunderbird exclusively relies on UIDs
