### PR TITLE
JAMES-1879 change target for download 3.0.0-beta5

### DIFF
--- a/src/site/xdoc/download.xml
+++ b/src/site/xdoc/download.xml
@@ -185,8 +185,8 @@ Do not promote snapshots, See JAMES-1558
         <li>Source code <a href="https://github.com/apache/james-project/releases/tag/james-project-3.0-beta5">on GitHub</a></li>
 
         <li>Binary (ZIP Format): <a
-                href="http://www.apache.org/dist/james/server/james-server-app-3.0.0-beta5-SNAPSHOT-app.zip">apache-james-3.0-beta5-app.zip</a> [<a
-                href="http://www.apache.org/dist/james/server/james-server-app-3.0.0-beta5-SNAPSHOT-app.zip.asc">PGP</a>]</li>
+                href="http://www.apache.org/dist/james/server/james-server-app-3.0.0-beta5-app.zip">apache-james-3.0-beta5-app.zip</a> [<a
+                href="http://www.apache.org/dist/james/server/james-server-app-3.0.0-beta5-app.zip.asc">PGP</a>]</li>
 
       </ul>
 


### PR DESCRIPTION
Was pointing on something built before maven-release plugin switch

This one is built on the right commit. (1 commit after)