### PR TITLE
MAILBOX-279: make the JPAMapperTests should work when enable MAILBOX and MESSAGE

### DIFF
--- a/mailbox/hbase/src/main/java/org/apache/james/mailbox/hbase/mail/model/HBaseMailbox.java
+++ b/mailbox/hbase/src/main/java/org/apache/james/mailbox/hbase/mail/model/HBaseMailbox.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 
 import org.apache.james.mailbox.hbase.HBaseId;
 import org.apache.james.mailbox.model.MailboxACL;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.SimpleMailboxACL;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
@@ -64,8 +65,9 @@ public class HBaseMailbox implements Mailbox {
         return mailboxId;
     }
 
-    public void setMailboxId(HBaseId mailboxId) {
-        this.mailboxId = mailboxId;
+    @Override
+    public void setMailboxId(MailboxId mailboxId) {
+        this.mailboxId = (HBaseId)mailboxId;
     }
     /*
      * (non-Javadoc)

--- a/mailbox/jcr/src/main/java/org/apache/james/mailbox/jcr/mail/model/JCRMailbox.java
+++ b/mailbox/jcr/src/main/java/org/apache/james/mailbox/jcr/mail/model/JCRMailbox.java
@@ -27,6 +27,7 @@ import org.apache.james.mailbox.jcr.JCRId;
 import org.apache.james.mailbox.jcr.JCRImapConstants;
 import org.apache.james.mailbox.jcr.Persistent;
 import org.apache.james.mailbox.model.MailboxACL;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.SimpleMailboxACL;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
@@ -198,10 +199,7 @@ public class JCRMailbox implements Mailbox, JCRImapConstants, Persistent{
         return true;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.apache.james.mailbox.store.mail.model.Mailbox#getMailboxId()
-     */
+    @Override
     public JCRId getMailboxId() {
         if (isPersistent()) {
             try {
@@ -213,6 +211,10 @@ public class JCRMailbox implements Mailbox, JCRImapConstants, Persistent{
         return null;      
     }
 
+    @Override
+    public void setMailboxId(MailboxId mailboxId) {
+        
+    }
     /*
      * (non-Javadoc)
      * @see org.apache.james.mailbox.store.mail.model.Mailbox#getNamespace()

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAAnnotationMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAAnnotationMapper.java
@@ -27,6 +27,7 @@ import javax.persistence.NoResultException;
 import javax.persistence.PersistenceException;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import org.apache.james.mailbox.jpa.JPAId;
 import org.apache.james.mailbox.jpa.JPATransactionalMapper;
@@ -169,6 +170,7 @@ public class JPAAnnotationMapper extends JPATransactionalMapper implements Annot
 
     @Override
     public void insertAnnotation(MailboxId mailboxId, MailboxAnnotation mailboxAnnotation) {
+        Preconditions.checkArgument(!mailboxAnnotation.isNil());
         JPAId jpaId = (JPAId) mailboxId;
         if (getAnnotationsByKeys(mailboxId, ImmutableSet.of(mailboxAnnotation.getKey())).isEmpty()) {
             getEntityManager().persist(

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/JPAMailbox.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/JPAMailbox.java
@@ -38,7 +38,7 @@ import org.apache.james.mailbox.store.mail.model.Mailbox;
 @Table(name="JAMES_MAILBOX")
 @NamedQueries({
     @NamedQuery(name="findMailboxById",
-        query="SELECT mailbox FROM Mailbox mailbox WHERE mailbox.mailbox.mailboxId = :idParam"),
+        query="SELECT mailbox FROM Mailbox mailbox WHERE mailbox.mailboxId = :idParam"),
     @NamedQuery(name="findMailboxByName",
         query="SELECT mailbox FROM Mailbox mailbox WHERE mailbox.name = :nameParam and mailbox.user is NULL and mailbox.namespace= :namespaceParam"),
     @NamedQuery(name="findMailboxByNameWithUser",
@@ -80,8 +80,8 @@ public class JPAMailbox implements Mailbox {
     @Column(name = "MAILBOX_UID_VALIDITY", nullable = false)
     private long uidValidity;
 
-    @Basic(optional = false)
-    @Column(name = "USER_NAME", nullable = false, length = 200)
+    @Basic(optional = true)
+    @Column(name = "USER_NAME", nullable = true, length = 200)
     private String user;
     
     @Basic(optional = false)
@@ -89,11 +89,11 @@ public class JPAMailbox implements Mailbox {
     private String namespace;
 
     @Basic(optional = false)
-    @Column(name = "MAILBOX_LAST_UID", nullable = false)
+    @Column(name = "MAILBOX_LAST_UID", nullable = true)
     private long lastUid;
     
     @Basic(optional = false)
-    @Column(name = "MAILBOX_HIGHEST_MODSEQ", nullable = false)
+    @Column(name = "MAILBOX_HIGHEST_MODSEQ", nullable = true)
     private long highestModSeq;
     
     /**
@@ -101,15 +101,17 @@ public class JPAMailbox implements Mailbox {
      */
     @Deprecated
     public JPAMailbox() {
-        super();
     }
     
-    public JPAMailbox(MailboxPath path, int uidValidity) {
-        this();
+    public JPAMailbox(MailboxPath path, long uidValidity) {
         this.name = path.getName();
         this.user = path.getUser();
         this.namespace = path.getNamespace();
         this.uidValidity = uidValidity;
+    }
+
+    public JPAMailbox(Mailbox mailbox) {
+        this(new MailboxPath(mailbox.getNamespace(), mailbox.getUser(), mailbox.getName()), mailbox.getUidValidity());
     }
 
     /**
@@ -220,21 +222,13 @@ public class JPAMailbox implements Mailbox {
         return ++highestModSeq;
     }
     
-    /* (non-Javadoc)
-     * @see org.apache.james.mailbox.store.mail.model.Mailbox#getACL()
-     */
     @Override
     public MailboxACL getACL() {
-        // TODO ACL support
-        return SimpleMailboxACL.OWNER_FULL_ACL;
+        return SimpleMailboxACL.EMPTY;
     }
 
-    /* (non-Javadoc)
-     * @see org.apache.james.mailbox.store.mail.model.Mailbox#setACL(org.apache.james.mailbox.MailboxACL)
-     */
     @Override
     public void setACL(MailboxACL acl) {
-        // TODO ACL support
     }
     
 }

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/JPAMailbox.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/JPAMailbox.java
@@ -29,6 +29,7 @@ import javax.persistence.Table;
 
 import org.apache.james.mailbox.jpa.JPAId;
 import org.apache.james.mailbox.model.MailboxACL;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.SimpleMailboxACL;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
@@ -118,6 +119,10 @@ public class JPAMailbox implements Mailbox {
         return JPAId.of(mailboxId);
     }
 
+    @Override
+    public void setMailboxId(MailboxId mailboxId) {
+        this.mailboxId = ((JPAId)mailboxId).getRawId();
+    }
     /**
      * @see org.apache.james.mailbox.store.mail.model.Mailbox#getName()
      */

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/AbstractJPAMailboxMessage.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/AbstractJPAMailboxMessage.java
@@ -228,6 +228,10 @@ public abstract class AbstractJPAMailboxMessage implements MailboxMessage {
             @ElementJoinColumn(name = "MAIL_UID", referencedColumnName = "MAIL_UID") })
     private List<JPAUserFlag> userFlags;
 
+    public AbstractJPAMailboxMessage() {
+        
+    }
+
     public AbstractJPAMailboxMessage(JPAMailbox mailbox, Date internalDate, Flags flags, long contentOctets,
             int bodyStartOctet, PropertyBuilder propertyBuilder) {
         this.mailbox = mailbox;

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/JPAMailboxMessage.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/JPAMailboxMessage.java
@@ -56,6 +56,11 @@ public class JPAMailboxMessage extends AbstractJPAMailboxMessage {
     @Column(name = "HEADER_BYTES", length = 10485760, nullable = false)
     @Lob private byte[] header;
     
+
+    public JPAMailboxMessage() {
+        
+    }
+
     public JPAMailboxMessage(JPAMailbox mailbox, Date internalDate, int size, Flags flags, SharedInputStream content, int bodyStartOctet, PropertyBuilder propertyBuilder) throws MailboxException {
         super(mailbox, internalDate, flags, size ,bodyStartOctet, propertyBuilder);
         try {

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAMapperProvider.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAMapperProvider.java
@@ -124,6 +124,6 @@ public class JPAMapperProvider implements MapperProvider {
 
     @Override
     public List<Capabilities> getNotImplemented() {
-        return ImmutableList.of(Capabilities.MESSAGE, Capabilities.ATTACHMENT);
+        return ImmutableList.of(Capabilities.MESSAGE, Capabilities.ATTACHMENT, Capabilities.MOVE);
     }
 }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAMapperProvider.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAMapperProvider.java
@@ -52,7 +52,7 @@ public class JPAMapperProvider implements MapperProvider {
 
     @Override
     public MailboxMapper createMailboxMapper() throws MailboxException {
-        throw new NotImplementedException();
+        return new TransactionalMailboxMapper(new JPAMailboxMapper(createEntityManagerFactory()));
     }
 
     @Override
@@ -84,11 +84,11 @@ public class JPAMapperProvider implements MapperProvider {
     public void clearMapper() throws MailboxException {
         EntityManager entityManager = createEntityManagerFactory().createEntityManager();
         entityManager.getTransaction().begin();
-        entityManager.createNativeQuery("TRUNCATE table JAMES_MAIL_USERFLAG;");
-        entityManager.createNativeQuery("TRUNCATE table JAMES_MAIL_PROPERTY;");
-        entityManager.createNativeQuery("TRUNCATE table JAMES_MAILBOX_ANNOTATION;");
-        entityManager.createNativeQuery("TRUNCATE table JAMES_MAILBOX;");
-        entityManager.createNativeQuery("TRUNCATE table JAMES_MAIL;");
+        entityManager.createNativeQuery("TRUNCATE table JAMES_MAIL_USERFLAG;").executeUpdate();
+        entityManager.createNativeQuery("TRUNCATE table JAMES_MAIL_PROPERTY;").executeUpdate();
+        entityManager.createNativeQuery("TRUNCATE table JAMES_MAILBOX_ANNOTATION;").executeUpdate();
+        entityManager.createNativeQuery("TRUNCATE table JAMES_MAILBOX;").executeUpdate();
+        entityManager.createNativeQuery("TRUNCATE table JAMES_MAIL;").executeUpdate();
         entityManager.getTransaction().commit();
         entityManager.close();
     }
@@ -124,6 +124,6 @@ public class JPAMapperProvider implements MapperProvider {
 
     @Override
     public List<Capabilities> getNotImplemented() {
-        return ImmutableList.of(Capabilities.MAILBOX, Capabilities.MESSAGE, Capabilities.ATTACHMENT);
+        return ImmutableList.of(Capabilities.MESSAGE, Capabilities.ATTACHMENT);
     }
 }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMailboxMapper.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMailboxMapper.java
@@ -1,0 +1,111 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.jpa.mail;
+
+import java.util.List;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.exception.MailboxNotFoundException;
+import org.apache.james.mailbox.model.MailboxACL.MailboxACLCommand;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.store.mail.MailboxMapper;
+import org.apache.james.mailbox.store.mail.model.Mailbox;
+import org.apache.james.mailbox.store.transaction.Mapper.VoidTransaction;
+
+import com.google.common.base.Throwables;
+
+public class TransactionalMailboxMapper implements MailboxMapper {
+    private final JPAMailboxMapper wrapped;
+
+    public TransactionalMailboxMapper(JPAMailboxMapper wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public void endRequest() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public <T> T execute(Transaction<T> transaction) throws MailboxException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void save(final Mailbox mailbox) throws MailboxException {
+        try {
+            wrapped.execute(new VoidTransaction() {
+                @Override
+                public void runVoid() throws MailboxException {
+                    wrapped.save(mailbox);
+                }
+            });
+        } catch (MailboxException e) {
+            Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public void delete(final Mailbox mailbox) throws MailboxException {
+        try {
+            wrapped.execute(new VoidTransaction() {
+                @Override
+                public void runVoid() throws MailboxException {
+                    wrapped.delete(mailbox);
+                }
+            });
+        } catch (MailboxException e) {
+            Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public Mailbox findMailboxByPath(MailboxPath mailboxPath) throws MailboxException, MailboxNotFoundException {
+        return wrapped.findMailboxByPath(mailboxPath);
+    }
+
+    @Override
+    public Mailbox findMailboxById(MailboxId mailboxId) throws MailboxException, MailboxNotFoundException {
+        return wrapped.findMailboxById(mailboxId);
+    }
+
+    @Override
+    public List<Mailbox> findMailboxWithPathLike(MailboxPath mailboxPath) throws MailboxException {
+        return wrapped.findMailboxWithPathLike(mailboxPath);
+    }
+
+    @Override
+    public boolean hasChildren(Mailbox mailbox, char delimiter) throws MailboxException, MailboxNotFoundException {
+        return wrapped.hasChildren(mailbox, delimiter);
+    }
+
+    @Override
+    public void updateACL(Mailbox mailbox, MailboxACLCommand mailboxACLCommand) throws MailboxException {
+        wrapped.updateACL(mailbox, mailboxACLCommand);
+    }
+
+    @Override
+    public List<Mailbox> list() throws MailboxException {
+        return wrapped.list();
+    }
+
+}

--- a/mailbox/lucene/src/test/java/org/apache/james/mailbox/lucene/search/LuceneMailboxMessageSearchIndexTest.java
+++ b/mailbox/lucene/src/test/java/org/apache/james/mailbox/lucene/search/LuceneMailboxMessageSearchIndexTest.java
@@ -606,10 +606,14 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     private final class SimpleMailbox implements Mailbox {
-        private final TestId id;
+        private TestId id;
 
         public SimpleMailbox(long id) {
         	this.id = TestId.of(id);
+        }
+
+        public void setMailboxId(MailboxId id) {
+            this.id = (TestId)id;
         }
 
         public TestId getMailboxId() {

--- a/mailbox/lucene/src/test/java/org/apache/james/mailbox/lucene/search/LuceneMailboxMessageSearchIndexTest.java
+++ b/mailbox/lucene/src/test/java/org/apache/james/mailbox/lucene/search/LuceneMailboxMessageSearchIndexTest.java
@@ -606,14 +606,13 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     private final class SimpleMailbox implements Mailbox {
-        private TestId id;
+        private final TestId id;
 
         public SimpleMailbox(long id) {
         	this.id = TestId.of(id);
         }
 
         public void setMailboxId(MailboxId id) {
-            this.id = (TestId)id;
         }
 
         public TestId getMailboxId() {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/Mailbox.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/Mailbox.java
@@ -25,7 +25,7 @@ import org.apache.james.mailbox.model.MailboxId;
  * Models long term mailbox data.
  */
 public interface Mailbox {
-
+    void setMailboxId(MailboxId id);
     /**
      * Gets the unique mailbox ID.
      * @return mailbox id

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailbox.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailbox.java
@@ -138,7 +138,9 @@ public class SimpleMailbox implements Mailbox {
         final int PRIME = 31;
         int result = 1;
         result = PRIME * result + namespace.hashCode();
-        result = PRIME * result + user.hashCode();
+        if (user != null) {
+            result = PRIME * result + user.hashCode();
+        }
         result = PRIME * result + name.hashCode();
         return result;
     }
@@ -151,7 +153,7 @@ public class SimpleMailbox implements Mailbox {
         return namespace + ":" + user + ":" + name;
     }
 
-
+    @Override
     public void setMailboxId(MailboxId id) {
         this.id = id;
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailbox.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailbox.java
@@ -24,6 +24,9 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.SimpleMailboxACL;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
 
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+
 public class SimpleMailbox implements Mailbox {
 
     private MailboxId id = null;
@@ -115,17 +118,9 @@ public class SimpleMailbox implements Mailbox {
      * @see java.lang.Object#equals(java.lang.Object)
      */
     public boolean equals(Object obj) {
-        if (obj == this) {
-            return true;
-        }
         if (obj instanceof SimpleMailbox) {
-            if (id != null) {
-                if (id.equals(((SimpleMailbox) obj).getMailboxId()))
-                    return true;
-            } else {
-                if (((SimpleMailbox) obj).getMailboxId() == null)
-                    return true;
-            }
+            SimpleMailbox o = (SimpleMailbox)obj;
+            return Objects.equal(id, o.getMailboxId());
         }
         return false;
     }
@@ -135,14 +130,7 @@ public class SimpleMailbox implements Mailbox {
      */
     @Override
     public int hashCode() {
-        final int PRIME = 31;
-        int result = 1;
-        result = PRIME * result + namespace.hashCode();
-        if (user != null) {
-            result = PRIME * result + user.hashCode();
-        }
-        result = PRIME * result + name.hashCode();
-        return result;
+        return Objects.hashCode(namespace, user, name);
     }
 
     /**
@@ -150,7 +138,11 @@ public class SimpleMailbox implements Mailbox {
      */
     @Override
     public String toString() {
-        return namespace + ":" + user + ":" + name;
+        return MoreObjects.toStringHelper(this)
+            .add("namespace", namespace)
+            .add("user", user)
+            .add("name", name)
+            .toString();
     }
 
     @Override
@@ -158,17 +150,11 @@ public class SimpleMailbox implements Mailbox {
         this.id = id;
     }
 
-    /* (non-Javadoc)
-     * @see org.apache.james.mailbox.store.mail.model.Mailbox#getACL()
-     */
     @Override
     public MailboxACL getACL() {
         return acl;
     }
 
-    /* (non-Javadoc)
-     * @see org.apache.james.mailbox.store.mail.model.Mailbox#setACL(org.apache.james.mailbox.MailboxACL)
-     */
     @Override
     public void setACL(MailboxACL acl) {
         this.acl = acl;

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/MailboxEventDispatcherTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/MailboxEventDispatcherTest.java
@@ -37,6 +37,7 @@ import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.mock.MockMailboxSession;
 import org.apache.james.mailbox.model.MailboxACL;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageResult;
 import org.apache.james.mailbox.model.SimpleMailboxACL;
 import org.apache.james.mailbox.model.UpdatedFlags;
@@ -111,6 +112,10 @@ public class MailboxEventDispatcherTest {
 
         @Override
         public void setACL(MailboxACL acl) {
+        }
+
+        @Override
+        public void setMailboxId(MailboxId id) {
         }
 
     };

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/MailboxEventDispatcherTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/MailboxEventDispatcherTest.java
@@ -19,13 +19,12 @@
 
 package org.apache.james.mailbox.store;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -36,10 +35,7 @@ import org.apache.james.mailbox.MailboxListener;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.mock.MockMailboxSession;
-import org.apache.james.mailbox.model.MailboxACL;
-import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageResult;
-import org.apache.james.mailbox.model.SimpleMailboxACL;
 import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.store.event.MailboxEventDispatcher;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
@@ -48,85 +44,35 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class MailboxEventDispatcherTest {
+    private static final int sessionId = 10;
 
-    MailboxEventDispatcher dispatcher;
+    private MailboxEventDispatcher dispatcher;
 
-    EventCollector collector;
+    private EventCollector collector;
 
-    MessageResult result;
-    int sessionId = 10;
+    private MessageResult result;
+
+    private Mailbox mailbox;
 
     private MailboxSession session = new MockMailboxSession("test") {
-
         @Override
         public long getSessionId() {
             return sessionId;
         }
-        
     };
 
-    private Mailbox mailbox = new Mailbox() {
-
-        @Override
-        public TestId getMailboxId() {
-            return TestId.of(1L);
-        }
-
-        @Override
-        public String getNamespace() {
-            return null;
-        }
-
-        @Override
-        public void setNamespace(String namespace) {            
-        }
-
-        @Override
-        public String getUser() {
-            return null;
-        }
-
-        @Override
-        public void setUser(String user) {
-            
-        }
-
-        @Override
-        public String getName() {
-            return "test";
-        }
-
-        @Override
-        public void setName(String name) {
-        }
-
-        @Override
-        public long getUidValidity() {
-            return 0;
-        }
-        
-        @Override
-        public MailboxACL getACL() {
-            return SimpleMailboxACL.EMPTY;
-        }
-
-        @Override
-        public void setACL(MailboxACL acl) {
-        }
-
-        @Override
-        public void setMailboxId(MailboxId id) {
-        }
-
-    };
-    
     @Before
     public void setUp() throws Exception {
         collector = new EventCollector();
 
         dispatcher = new MailboxEventDispatcher(collector);
         result = mock(MessageResult.class);
+        mailbox = mock(Mailbox.class);
+
         when(result.getUid()).thenReturn(MessageUid.of(23));
+        when(mailbox.getNamespace()).thenReturn("namespace");
+        when(mailbox.getUser()).thenReturn("user");
+        when(mailbox.getName()).thenReturn("name");
     }
 
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMailboxAssert.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMailboxAssert.java
@@ -1,0 +1,106 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.store.mail.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.james.mailbox.model.MailboxId;
+
+import com.google.common.base.Function;
+import com.google.common.base.Objects;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.Lists;
+
+public class ListMailboxAssert {
+
+    private final List<Mailbox> actual;
+
+    private final List<InnerMailbox> mailboxtoInnerMailbox(List<Mailbox> mailboxes) {
+        return FluentIterable.from(mailboxes).transform(new Function<Mailbox, InnerMailbox>() {
+            @Override
+            public InnerMailbox apply(Mailbox input) {
+                return new InnerMailbox(input.getMailboxId(), input.getUser(), input.getName(), input.getNamespace());
+            }
+            
+        }).toList();
+    }
+
+    private ListMailboxAssert(List<Mailbox> actual) {
+        this.actual = actual;
+    }
+
+    public static ListMailboxAssert assertMailboxes(List<Mailbox> actual) {
+        return new ListMailboxAssert(actual);
+    }
+
+    public void containOnly(Mailbox... expecteds) {
+        assertThat(mailboxtoInnerMailbox(actual)).containsOnlyElementsOf(mailboxtoInnerMailbox(Lists.newArrayList(expecteds)));
+    }
+
+    private final class InnerMailbox {
+        private final MailboxId id;
+        private final String user;
+        private final String name;
+        private final String namespace;
+
+        public InnerMailbox(MailboxId id, String user, String name, String namespace) {
+            this.id = id;
+            this.user = user;
+            this.name = name;
+            this.namespace = namespace;
+        }
+
+        public MailboxId getId() {
+            return id;
+        }
+
+        public String getUser() {
+            return user;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getNamespace() {
+            return namespace;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(id, user, name, namespace);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof InnerMailbox) {
+                InnerMailbox o = (InnerMailbox)obj;
+                return Objects.equal(id, o.getId()) 
+                    && Objects.equal(name, o.getName()) 
+                    && Objects.equal(namespace, o.getNamespace()) 
+                    && Objects.equal(user, o.getUser());
+            }
+            return false;
+        }
+        
+    }
+}

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMailboxAssertTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMailboxAssertTest.java
@@ -1,0 +1,118 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.store.mail.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.apache.james.mailbox.store.mail.model.ListMailboxAssert.assertMailboxes;
+
+import java.util.List;
+
+import org.apache.james.mailbox.model.MailboxACL;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailbox;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class ListMailboxAssertTest {
+    private static final String OTHER_NAMESPACE = "other_namespace";
+    private static final String NAME = "name";
+    private static final String USER = "user";
+    private static final String NAMESPACE = "namespace";
+    private static final long UID_VALIDITY = 42;
+    private static final Mailbox mailbox1 = new SimpleMailbox(new MailboxPath(NAMESPACE, USER, NAME), UID_VALIDITY);
+    private static final Mailbox mailbox2 = new SimpleMailbox(new MailboxPath(OTHER_NAMESPACE, USER, NAME), UID_VALIDITY);
+
+    private ListMailboxAssert listMaiboxAssert;
+    private List<Mailbox> actualMailbox;
+
+    @Before
+    public void setUp() {
+        actualMailbox = ImmutableList.of(mailbox1, mailbox2);
+        listMaiboxAssert = ListMailboxAssert.assertMailboxes(actualMailbox);
+    }
+
+    @Test
+    public void initListMailboxAssertShouldWork() throws Exception {
+        assertThat(listMaiboxAssert).isNotNull();
+    }
+
+    @Test
+    public void assertListMailboxShouldWork() throws Exception {
+        assertMailboxes(actualMailbox).containOnly(createMailbox(NAMESPACE, USER, NAME, UID_VALIDITY), 
+            createMailbox(OTHER_NAMESPACE, USER, NAME, UID_VALIDITY));
+    }
+    
+    private Mailbox createMailbox(final String namespace, final String user, final String name, final long uid_validity) {
+        return new Mailbox() {
+            @Override
+            public void setUser(String user) {
+            }
+            
+            @Override
+            public void setNamespace(String namespace) {
+            }
+            
+            @Override
+            public void setName(String name) {
+            }
+            
+            @Override
+            public void setMailboxId(MailboxId id) {
+            }
+            
+            @Override
+            public void setACL(MailboxACL acl) {
+            }
+            
+            @Override
+            public String getUser() {
+                return user;
+            }
+            
+            @Override
+            public long getUidValidity() {
+                return uid_validity;
+            }
+            
+            @Override
+            public String getNamespace() {
+                return namespace;
+            }
+            
+            @Override
+            public String getName() {
+                return name;
+            }
+            
+            @Override
+            public MailboxId getMailboxId() {
+                return null;
+            }
+            
+            @Override
+            public MailboxACL getACL() {
+                return null;
+            }
+        };
+    }
+}

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMapperTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mailbox.store.mail.model;
 
+import static org.apache.james.mailbox.store.mail.model.ListMailboxAssert.assertMailboxes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -50,80 +51,50 @@ public class MailboxMapperTest<T extends MapperProvider> {
     private final static char WILDCARD = '%';
     private final static long UID_VALIDITY = 42;
 
-    private IProducer<T> producer;
-    private MailboxMapper mailboxMapper;
-
     private MailboxPath benwaInboxPath;
-    private SimpleMailbox benwaInboxMailbox;
+    private Mailbox benwaInboxMailbox;
     private MailboxPath benwaWorkPath;
-    private SimpleMailbox benwaWorkMailbox;
+    private Mailbox benwaWorkMailbox;
     private MailboxPath benwaWorkTodoPath;
-    private SimpleMailbox benwaWorkTodoMailbox;
+    private Mailbox benwaWorkTodoMailbox;
     private MailboxPath benwaPersoPath;
-    private SimpleMailbox benwaPersoMailbox;
+    private Mailbox benwaPersoMailbox;
     private MailboxPath benwaWorkDonePath;
-    private SimpleMailbox benwaWorkDoneMailbox;
+    private Mailbox benwaWorkDoneMailbox;
     private MailboxPath bobInboxPath;
-    private SimpleMailbox bobyMailbox;
+    private Mailbox bobyMailbox;
     private MailboxPath bobyMailboxPath;
-    private SimpleMailbox bobInboxMailbox;
+    private Mailbox bobInboxMailbox;
     private MailboxPath esnDevGroupInboxPath;
-    private SimpleMailbox esnDevGroupInboxMailbox;
+    private Mailbox esnDevGroupInboxMailbox;
     private MailboxPath esnDevGroupHublinPath;
-    private SimpleMailbox esnDevGroupHublinMailbox;
+    private Mailbox esnDevGroupHublinMailbox;
     private MailboxPath esnDevGroupJamesPath;
-    private SimpleMailbox esnDevGroupJamesMailbox;
+    private Mailbox esnDevGroupJamesMailbox;
     private MailboxPath obmTeamGroupInboxPath;
-    private SimpleMailbox obmTeamGroupInboxMailbox;
+    private Mailbox obmTeamGroupInboxMailbox;
     private MailboxPath obmTeamGroupOPushPath;
-    private SimpleMailbox obmTeamGroupOPushMailbox;
+    private Mailbox obmTeamGroupOPushMailbox;
     private MailboxPath obmTeamGroupRoundCubePath;
-    private SimpleMailbox obmTeamGroupRoundCubeMailbox;
+    private Mailbox obmTeamGroupRoundCubeMailbox;
     private MailboxPath bobDifferentNamespacePath;
-    private SimpleMailbox bobDifferentNamespaceMailbox;
+    private Mailbox bobDifferentNamespaceMailbox;
 
     @Rule
     public ExpectedException expected = ExpectedException.none();
+    private IProducer<T> producer;
+    private MailboxMapper mailboxMapper;
     private T mapperProvider;
 
     @Contract.Inject
     public final void setProducer(IProducer<T> producer) throws MailboxException {
-        this.producer = producer;
         this.mapperProvider = producer.newInstance();
         Assume.assumeFalse(mapperProvider.getNotImplemented().contains(MapperProvider.Capabilities.MAILBOX));
 
-        this.mapperProvider.ensureMapperPrepared();
+        this.producer = producer;
         this.mailboxMapper = mapperProvider.createMailboxMapper();
-
-        benwaInboxPath = new MailboxPath("#private", "benwa", "INBOX");
-        benwaWorkPath = new MailboxPath("#private", "benwa", "INBOX"+DELIMITER+"work");
-        benwaWorkTodoPath = new MailboxPath("#private", "benwa", "INBOX"+DELIMITER+"work"+DELIMITER+"todo");
-        benwaPersoPath = new MailboxPath("#private", "benwa", "INBOX"+DELIMITER+"perso");
-        benwaWorkDonePath = new MailboxPath("#private", "benwa", "INBOX"+DELIMITER+"work"+DELIMITER+"done");
-        bobInboxPath = new MailboxPath("#private", "bob", "INBOX");
-        bobyMailboxPath = new MailboxPath("#private", "boby", "INBOX.that.is.a.trick");
-        bobDifferentNamespacePath = new MailboxPath("#private_bob", "bob", "INBOX.bob");
-        esnDevGroupInboxPath = new MailboxPath("#community_ESN_DEV", null, "INBOX");
-        esnDevGroupHublinPath = new MailboxPath("#community_ESN_DEV", null, "INBOX"+DELIMITER+"hublin");
-        esnDevGroupJamesPath = new MailboxPath("#community_ESN_DEV", null, "INBOX"+DELIMITER+"james");
-        obmTeamGroupInboxPath = new MailboxPath("#community_OBM_Core_Team", null, "INBOX");
-        obmTeamGroupOPushPath = new MailboxPath("#community_OBM_Core_Team", null, "INBOX"+DELIMITER+"OPush");
-        obmTeamGroupRoundCubePath = new MailboxPath("#community_OBM_Core_Team", null, "INBOX"+DELIMITER+"roundCube");
-
-        benwaInboxMailbox = createMailbox(benwaInboxPath);
-        benwaWorkMailbox = createMailbox(benwaWorkPath);
-        benwaWorkTodoMailbox = createMailbox(benwaWorkTodoPath);
-        benwaPersoMailbox = createMailbox(benwaPersoPath);
-        benwaWorkDoneMailbox = createMailbox(benwaWorkDonePath);
-        bobInboxMailbox = createMailbox(bobInboxPath);
-        esnDevGroupInboxMailbox = createMailbox(esnDevGroupInboxPath);
-        esnDevGroupHublinMailbox = createMailbox(esnDevGroupHublinPath);
-        esnDevGroupJamesMailbox = createMailbox(esnDevGroupJamesPath);
-        obmTeamGroupInboxMailbox = createMailbox(obmTeamGroupInboxPath);
-        obmTeamGroupOPushMailbox = createMailbox(obmTeamGroupOPushPath);
-        obmTeamGroupRoundCubeMailbox = createMailbox(obmTeamGroupRoundCubePath);
-        bobyMailbox = createMailbox(bobyMailboxPath);
-        bobDifferentNamespaceMailbox = createMailbox(bobDifferentNamespacePath);
+        
+        initData();
     }
 
     @After
@@ -153,10 +124,14 @@ public class MailboxMapperTest<T extends MapperProvider> {
     public void listShouldRetrieveAllMailbox() throws MailboxException {
         saveAll();
         List<Mailbox> mailboxes = mailboxMapper.list();
-        assertThat(mailboxes).contains(benwaInboxMailbox, benwaWorkMailbox, benwaWorkTodoMailbox, benwaPersoMailbox, benwaWorkDoneMailbox, bobInboxMailbox, esnDevGroupInboxMailbox, esnDevGroupHublinMailbox,
-            esnDevGroupJamesMailbox, obmTeamGroupInboxMailbox, obmTeamGroupOPushMailbox, obmTeamGroupRoundCubeMailbox);
-    }
 
+        assertMailboxes(mailboxes)
+            .containOnly(benwaInboxMailbox, benwaWorkMailbox, benwaWorkTodoMailbox, benwaPersoMailbox, benwaWorkDoneMailbox, 
+                esnDevGroupInboxMailbox, esnDevGroupHublinMailbox, esnDevGroupJamesMailbox, 
+                obmTeamGroupInboxMailbox, obmTeamGroupOPushMailbox, obmTeamGroupRoundCubeMailbox, 
+                bobyMailbox, bobDifferentNamespaceMailbox, bobInboxMailbox);
+    }
+    
     @ContractTest
     public void hasChildrenShouldReturnFalseWhenNoChildrenExists() throws MailboxException {
         saveAll();
@@ -191,9 +166,11 @@ public class MailboxMapperTest<T extends MapperProvider> {
     public void findMailboxWithPathLikeShouldBeLimitedToUserAndNamespace() throws MailboxException {
         saveAll();
         MailboxPath mailboxPathQuery = new MailboxPath(bobInboxMailbox.getNamespace(), bobInboxMailbox.getUser(), "IN" + WILDCARD);
-        assertThat(mailboxMapper.findMailboxWithPathLike(mailboxPathQuery)).containsOnly(bobInboxMailbox);
-    }
+        List<Mailbox> mailboxes = mailboxMapper.findMailboxWithPathLike(mailboxPathQuery);
 
+        assertMailboxes(mailboxes).containOnly(bobInboxMailbox);
+    }
+    
     @ContractTest
     public void deleteShouldEraseTheGivenMailbox() throws MailboxException {
         expected.expect(MailboxNotFoundException.class);
@@ -222,28 +199,39 @@ public class MailboxMapperTest<T extends MapperProvider> {
     public void findMailboxWithPathLikeWithChildRegexShouldRetrieveChildren() throws MailboxException {
         saveAll();
         MailboxPath regexPath = new MailboxPath(benwaWorkPath.getNamespace(), benwaWorkPath.getUser(), benwaWorkPath.getName() + WILDCARD);
-        assertThat(mailboxMapper.findMailboxWithPathLike(regexPath)).containsOnly(benwaWorkMailbox, benwaWorkTodoMailbox, benwaWorkDoneMailbox);
+        List<Mailbox> mailboxes = mailboxMapper.findMailboxWithPathLike(regexPath);
+
+        assertMailboxes(mailboxes).containOnly(benwaWorkMailbox, benwaWorkDoneMailbox, benwaWorkTodoMailbox);
     }
 
     @ContractTest
     public void findMailboxWithPathLikeWithNullUserWithChildRegexShouldRetrieveChildren() throws MailboxException {
         saveAll();
         MailboxPath regexPath = new MailboxPath(obmTeamGroupInboxPath.getNamespace(), obmTeamGroupInboxPath.getUser(), obmTeamGroupInboxPath.getName() + WILDCARD);
-        assertThat(mailboxMapper.findMailboxWithPathLike(regexPath)).contains(obmTeamGroupInboxMailbox, obmTeamGroupOPushMailbox, obmTeamGroupRoundCubeMailbox);
-    }
 
+        List<Mailbox> mailboxes = mailboxMapper.findMailboxWithPathLike(regexPath);
+
+        assertMailboxes(mailboxes).containOnly(obmTeamGroupInboxMailbox, obmTeamGroupOPushMailbox, obmTeamGroupRoundCubeMailbox);
+    }
+    
     @ContractTest
     public void findMailboxWithPathLikeWithRegexShouldRetrieveCorrespondingMailbox() throws MailboxException {
         saveAll();
         MailboxPath regexPath = new MailboxPath(benwaInboxPath.getNamespace(), benwaInboxPath.getUser(), WILDCARD + "X");
-        assertThat(mailboxMapper.findMailboxWithPathLike(regexPath)).containsOnly(benwaInboxMailbox);
+
+        List<Mailbox> mailboxes = mailboxMapper.findMailboxWithPathLike(regexPath);
+
+        assertMailboxes(mailboxes).containOnly(benwaInboxMailbox);
     }
 
     @ContractTest
     public void findMailboxWithPathLikeWithNullUserWithRegexShouldRetrieveCorrespondingMailbox() throws MailboxException {
         saveAll();
         MailboxPath regexPath = new MailboxPath(esnDevGroupInboxPath.getNamespace(), esnDevGroupInboxPath.getUser(), WILDCARD + "X");
-        assertThat(mailboxMapper.findMailboxWithPathLike(regexPath)).contains(esnDevGroupInboxMailbox);
+
+        List<Mailbox> mailboxes = mailboxMapper.findMailboxWithPathLike(regexPath);
+
+        assertMailboxes(mailboxes).containOnly(esnDevGroupInboxMailbox);
     }
 
     @ContractTest
@@ -257,7 +245,7 @@ public class MailboxMapperTest<T extends MapperProvider> {
     public void findMailboxByIdShouldReturnExistingMailbox() throws MailboxException {
         saveAll();
         Mailbox actual = mailboxMapper.findMailboxById(benwaInboxMailbox.getMailboxId());
-        assertThat(actual).isEqualTo(benwaInboxMailbox);
+        MailboxAssert.assertThat(actual).isEqualTo(benwaInboxMailbox);
     }
     
     @ContractTest
@@ -267,6 +255,38 @@ public class MailboxMapperTest<T extends MapperProvider> {
         MailboxId removed = benwaInboxMailbox.getMailboxId();
         mailboxMapper.delete(benwaInboxMailbox);
         mailboxMapper.findMailboxById(removed);
+    }
+
+    private void initData() {
+        benwaInboxPath = new MailboxPath("#private", "benwa", "INBOX");
+        benwaWorkPath = new MailboxPath("#private", "benwa", "INBOX"+DELIMITER+"work");
+        benwaWorkTodoPath = new MailboxPath("#private", "benwa", "INBOX"+DELIMITER+"work"+DELIMITER+"todo");
+        benwaPersoPath = new MailboxPath("#private", "benwa", "INBOX"+DELIMITER+"perso");
+        benwaWorkDonePath = new MailboxPath("#private", "benwa", "INBOX"+DELIMITER+"work"+DELIMITER+"done");
+        bobInboxPath = new MailboxPath("#private", "bob", "INBOX");
+        bobyMailboxPath = new MailboxPath("#private", "boby", "INBOX.that.is.a.trick");
+        bobDifferentNamespacePath = new MailboxPath("#private_bob", "bob", "INBOX.bob");
+        esnDevGroupInboxPath = new MailboxPath("#community_ESN_DEV", null, "INBOX");
+        esnDevGroupHublinPath = new MailboxPath("#community_ESN_DEV", null, "INBOX"+DELIMITER+"hublin");
+        esnDevGroupJamesPath = new MailboxPath("#community_ESN_DEV", null, "INBOX"+DELIMITER+"james");
+        obmTeamGroupInboxPath = new MailboxPath("#community_OBM_Core_Team", null, "INBOX");
+        obmTeamGroupOPushPath = new MailboxPath("#community_OBM_Core_Team", null, "INBOX"+DELIMITER+"OPush");
+        obmTeamGroupRoundCubePath = new MailboxPath("#community_OBM_Core_Team", null, "INBOX"+DELIMITER+"roundCube");
+
+        benwaInboxMailbox = createMailbox(benwaInboxPath);
+        benwaWorkMailbox = createMailbox(benwaWorkPath);
+        benwaWorkTodoMailbox = createMailbox(benwaWorkTodoPath);
+        benwaPersoMailbox = createMailbox(benwaPersoPath);
+        benwaWorkDoneMailbox = createMailbox(benwaWorkDonePath);
+        bobInboxMailbox = createMailbox(bobInboxPath);
+        esnDevGroupInboxMailbox = createMailbox(esnDevGroupInboxPath);
+        esnDevGroupHublinMailbox = createMailbox(esnDevGroupHublinPath);
+        esnDevGroupJamesMailbox = createMailbox(esnDevGroupJamesPath);
+        obmTeamGroupInboxMailbox = createMailbox(obmTeamGroupInboxPath);
+        obmTeamGroupOPushMailbox = createMailbox(obmTeamGroupOPushPath);
+        obmTeamGroupRoundCubeMailbox = createMailbox(obmTeamGroupRoundCubePath);
+        bobyMailbox = createMailbox(bobyMailboxPath);
+        bobDifferentNamespaceMailbox = createMailbox(bobDifferentNamespacePath);
     }
 
     private void saveAll() throws MailboxException{

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MapperProvider.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MapperProvider.java
@@ -34,7 +34,8 @@ public interface MapperProvider {
         MESSAGE,
         MAILBOX,
         ATTACHMENT,
-        ANNOTATION
+        ANNOTATION,
+        MOVE
     }
 
     List<Capabilities> getNotImplemented();

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMoveTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMoveTest.java
@@ -70,6 +70,7 @@ public class MessageMoveTest<T extends MapperProvider> {
         this.producer = producer;
         this.mapperProvider = producer.newInstance();
         this.mapperProvider.ensureMapperPrepared();
+        Assume.assumeFalse(mapperProvider.getNotImplemented().contains(MapperProvider.Capabilities.MOVE));
         this.messageMapper = mapperProvider.createMessageMapper();
         Assume.assumeNotNull(messageMapper);
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageWithAttachmentMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageWithAttachmentMapperTest.java
@@ -53,7 +53,7 @@ import org.xenei.junit.contract.IProducer;
 
 import com.google.common.collect.ImmutableList;
 
-//@Contract(MapperProvider.class)
+@Contract(MapperProvider.class)
 public class MessageWithAttachmentMapperTest<T extends MapperProvider> {
 
     private static final int LIMIT = 10;

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageWithAttachmentMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageWithAttachmentMapperTest.java
@@ -1,0 +1,204 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.store.mail.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.mail.Flags;
+import javax.mail.util.SharedByteArrayInputStream;
+
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.Attachment;
+import org.apache.james.mailbox.model.AttachmentId;
+import org.apache.james.mailbox.model.Cid;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.MessageAttachment;
+import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.store.mail.AttachmentMapper;
+import org.apache.james.mailbox.store.mail.MessageMapper;
+import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailbox;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.xenei.junit.contract.Contract;
+import org.xenei.junit.contract.ContractTest;
+import org.xenei.junit.contract.IProducer;
+
+import com.google.common.collect.ImmutableList;
+
+//@Contract(MapperProvider.class)
+public class MessageWithAttachmentMapperTest<T extends MapperProvider> {
+
+    private static final int LIMIT = 10;
+    private static final int BODY_START = 16;
+    public static final int UID_VALIDITY = 42;
+    public static final String USER_FLAG = "userFlag";
+
+    private IProducer<T> producer;
+    private MapperProvider mapperProvider;
+    private MessageMapper messageMapper;
+    private AttachmentMapper attachmentMapper;
+
+    private SimpleMailbox attachmentsMailbox;
+    
+    private SimpleMailboxMessage messageWithoutAttachment;
+    private SimpleMailboxMessage message7With1Attachment;
+    private SimpleMailboxMessage message8With2Attachments;
+
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
+
+    @Contract.Inject
+    public final void setProducer(IProducer<T> producer) throws MailboxException {
+        this.producer = producer;
+        this.mapperProvider = producer.newInstance();
+        this.mapperProvider.ensureMapperPrepared();
+
+        Assume.assumeFalse(mapperProvider.getNotImplemented().contains(MapperProvider.Capabilities.MESSAGE));
+        Assume.assumeFalse(mapperProvider.getNotImplemented().contains(MapperProvider.Capabilities.ATTACHMENT));
+
+        this.messageMapper = mapperProvider.createMessageMapper();
+        this.attachmentMapper = mapperProvider.createAttachmentMapper();
+
+        attachmentsMailbox = createMailbox( new MailboxPath("#private", "benwa", "Attachments"));
+
+        Attachment attachment = Attachment.builder()
+                .attachmentId(AttachmentId.from("123"))
+                .bytes("attachment".getBytes())
+                .type("content")
+                .build();
+        attachmentMapper.storeAttachment(attachment);
+        Attachment attachment2 = Attachment.builder()
+                .attachmentId(AttachmentId.from("456"))
+                .bytes("attachment2".getBytes())
+                .type("content")
+                .build();
+        attachmentMapper.storeAttachment(attachment2);
+        message7With1Attachment = createMessage(attachmentsMailbox, mapperProvider.generateMessageId(), "Subject: Test7 \n\nBody7\n.\n", BODY_START, new PropertyBuilder(), 
+                ImmutableList.of(MessageAttachment.builder()
+                        .attachment(attachment)
+                        .cid(Cid.from("cid"))
+                        .isInline(true)
+                        .build()));
+        message8With2Attachments = createMessage(attachmentsMailbox, mapperProvider.generateMessageId(), "Subject: Test8 \n\nBody8\n.\n", BODY_START, new PropertyBuilder(),
+                ImmutableList.of(
+                        MessageAttachment.builder()
+                            .attachment(attachment)
+                            .cid(Cid.from("cid"))
+                            .isInline(true)
+                            .build(),
+                        MessageAttachment.builder()
+                            .attachment(attachment2)
+                            .cid(Cid.from("cid2"))
+                            .isInline(false)
+                            .build()));
+        messageWithoutAttachment = createMessage(attachmentsMailbox, mapperProvider.generateMessageId(), "Subject: Test1 \n\nBody1\n.\n", BODY_START, new PropertyBuilder());
+
+    }
+
+    @After
+    public void tearDown() throws MailboxException {
+        producer.cleanUp();
+    }
+
+    @ContractTest
+    public void messagesRetrievedUsingFetchTypeFullShouldHaveAttachmentsLoadedWhenOneAttachment() throws MailboxException, IOException{
+        saveMessages();
+        MessageMapper.FetchType fetchType = MessageMapper.FetchType.Full;
+        Iterator<MailboxMessage> retrievedMessageIterator = messageMapper.findInMailbox(attachmentsMailbox, MessageRange.one(message7With1Attachment.getUid()), fetchType, LIMIT);
+        assertThat(retrievedMessageIterator.next().getAttachments()).isEqualTo(message7With1Attachment.getAttachments());
+    }
+
+    @ContractTest
+    public void messagesRetrievedUsingFetchTypeFullShouldHaveAttachmentsLoadedWhenTwoAttachments() throws MailboxException, IOException{
+        saveMessages();
+        MessageMapper.FetchType fetchType = MessageMapper.FetchType.Full;
+        Iterator<MailboxMessage> retrievedMessageIterator = messageMapper.findInMailbox(attachmentsMailbox, MessageRange.one(message8With2Attachments.getUid()), fetchType, LIMIT);
+        assertThat(retrievedMessageIterator.next().getAttachments()).isEqualTo(message8With2Attachments.getAttachments());
+    }
+
+    @ContractTest
+    public void messagesRetrievedUsingFetchTypeBodyShouldHaveAttachmentsLoadedWhenOneAttachment() throws MailboxException, IOException{
+        saveMessages();
+        MessageMapper.FetchType fetchType = MessageMapper.FetchType.Body;
+        Iterator<MailboxMessage> retrievedMessageIterator = messageMapper.findInMailbox(attachmentsMailbox, MessageRange.one(message7With1Attachment.getUid()), fetchType, LIMIT);
+        assertThat(retrievedMessageIterator.next().getAttachments()).isEqualTo(message7With1Attachment.getAttachments());
+    }
+
+    @ContractTest
+    public void messagesRetrievedUsingFetchTypeHeadersShouldHaveAttachmentsEmptyWhenOneAttachment() throws MailboxException, IOException{
+        Assume.assumeTrue(mapperProvider.supportPartialAttachmentFetch());
+        saveMessages();
+        MessageMapper.FetchType fetchType = MessageMapper.FetchType.Headers;
+        Iterator<MailboxMessage> retrievedMessageIterator = messageMapper.findInMailbox(attachmentsMailbox, MessageRange.one(message7With1Attachment.getUid()), fetchType, LIMIT);
+        assertThat(retrievedMessageIterator.next().getAttachments()).isEmpty();
+    }
+
+    @ContractTest
+    public void messagesRetrievedUsingFetchTypeMetadataShouldHaveAttachmentsEmptyWhenOneAttachment() throws MailboxException, IOException{
+        Assume.assumeTrue(mapperProvider.supportPartialAttachmentFetch());
+        saveMessages();
+        MessageMapper.FetchType fetchType = MessageMapper.FetchType.Metadata;
+        Iterator<MailboxMessage> retrievedMessageIterator = messageMapper.findInMailbox(attachmentsMailbox, MessageRange.one(message7With1Attachment.getUid()), fetchType, LIMIT);
+        assertThat(retrievedMessageIterator.next().getAttachments()).isEmpty();
+    }
+
+    @ContractTest
+    public void messagesRetrievedUsingFetchTypeFullShouldHaveAttachmentsEmptyWhenNoAttachment() throws MailboxException, IOException{
+        saveMessages();
+        MessageMapper.FetchType fetchType = MessageMapper.FetchType.Full;
+        Iterator<MailboxMessage> retrievedMessageIterator = messageMapper.findInMailbox(attachmentsMailbox, MessageRange.one(messageWithoutAttachment.getUid()), fetchType, LIMIT);
+        assertThat(retrievedMessageIterator.next().getAttachments()).isEmpty();
+    }
+    
+    private SimpleMailbox createMailbox(MailboxPath mailboxPath) {
+        SimpleMailbox mailbox = new SimpleMailbox(mailboxPath, UID_VALIDITY);
+        MailboxId id = mapperProvider.generateId();
+        mailbox.setMailboxId(id);
+        return mailbox;
+    }
+    
+    private void saveMessages() throws MailboxException {
+        messageMapper.add(attachmentsMailbox, messageWithoutAttachment);
+        messageWithoutAttachment.setModSeq(messageMapper.getHighestModSeq(attachmentsMailbox));
+        messageMapper.add(attachmentsMailbox, message7With1Attachment);
+        message7With1Attachment.setModSeq(messageMapper.getHighestModSeq(attachmentsMailbox));
+        messageMapper.add(attachmentsMailbox, message8With2Attachments);
+        message8With2Attachments.setModSeq(messageMapper.getHighestModSeq(attachmentsMailbox));
+    }
+
+    private SimpleMailboxMessage createMessage(Mailbox mailbox, MessageId messageId, String content, int bodyStart, PropertyBuilder propertyBuilder, List<MessageAttachment> attachments) {
+        return new SimpleMailboxMessage(messageId, new Date(), content.length(), bodyStart, new SharedByteArrayInputStream(content.getBytes()), new Flags(), propertyBuilder, mailbox.getMailboxId(), attachments);
+    }
+
+    private SimpleMailboxMessage createMessage(Mailbox mailbox, MessageId messageId, String content, int bodyStart, PropertyBuilder propertyBuilder) {
+        return new SimpleMailboxMessage(messageId, new Date(), content.length(), bodyStart, new SharedByteArrayInputStream(content.getBytes()), new Flags(), propertyBuilder, mailbox.getMailboxId());
+    }
+}


### PR DESCRIPTION
which are:
- Split MessageMapperTest into 2 parts: one with attachment and the another without attachment which should be work with JPA
- Make JPAMapperTests should be fine when enable MAILBOX