### PR TITLE
JAMES-1881 Mark Matcher/Mailet as experimental

### DIFF
--- a/mailet/api/src/main/java/org/apache/mailet/Experimental.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Experimental.java
@@ -1,0 +1,29 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.mailet;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Target;
+
+@Target(TYPE)
+public @interface Experimental {
+
+}

--- a/mailet/mailetdocs-maven-plugin/pom.xml
+++ b/mailet/mailetdocs-maven-plugin/pom.xml
@@ -76,6 +76,21 @@
             <groupId>com.thoughtworks.qdox</groupId>
             <artifactId>qdox</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/mailet/mailetdocs-maven-plugin/src/main/java/org/apache/james/mailet/AbstractMailetdocsReport.java
+++ b/mailet/mailetdocs-maven-plugin/src/main/java/org/apache/james/mailet/AbstractMailetdocsReport.java
@@ -42,6 +42,8 @@ import com.google.common.base.Strings;
  */
 public abstract class AbstractMailetdocsReport extends AbstractMavenReport {
     
+    private static final String EXPERIMENTAL = " (Experimental)";
+
     /**
      * Directory where reports will go.
      */
@@ -89,6 +91,7 @@ public abstract class AbstractMailetdocsReport extends AbstractMavenReport {
         getSink().sectionTitle1();
         getSink().text("Mailets and Matchers Reference");
         getSink().sectionTitle1_();
+        getSink().text("Items marked as Experimental are not yet supported by James; however, you can try them.");
         getSink().section1_();
         
         writeDescriptions();
@@ -177,6 +180,9 @@ public abstract class AbstractMailetdocsReport extends AbstractMavenReport {
             getSink().listItem();
             getSink().link("#" + descriptor.getName());
             getSink().text(descriptor.getName());
+            if (descriptor.isExperimental()) {
+                getSink().text(EXPERIMENTAL);
+            }
             getSink().link_();
             getSink().listItem_();
         }
@@ -199,6 +205,9 @@ public abstract class AbstractMailetdocsReport extends AbstractMavenReport {
             getSink().sectionTitle2();
             getSink().anchor(descriptor.getName());
             getSink().text(descriptor.getName());
+            if (descriptor.isExperimental()) {
+                getSink().text(EXPERIMENTAL);
+            }
             getSink().anchor_();
             getSink().sectionTitle2_();
 

--- a/mailet/mailetdocs-maven-plugin/src/main/java/org/apache/james/mailet/DefaultDescriptorsExtractor.java
+++ b/mailet/mailetdocs-maven-plugin/src/main/java/org/apache/james/mailet/DefaultDescriptorsExtractor.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.james.mailet.MailetMatcherDescriptor.Type;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mailet;
 import org.apache.mailet.Matcher;
 import org.apache.maven.artifact.Artifact;
@@ -38,7 +39,10 @@ import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
 import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.model.Annotation;
 import com.thoughtworks.qdox.model.JavaClass;
 
 /**
@@ -165,6 +169,7 @@ public class DefaultDescriptorsExtractor {
         result.setFullyQualifiedName(nameOfClass);
         result.setClassDocs(nextClass.getComment());
         result.setType(type);
+        result.setExperimental(isExperimental(nextClass));
 
         try {
             final Object instance = klass.newInstance();
@@ -188,6 +193,18 @@ public class DefaultDescriptorsExtractor {
         return result;
     }
 
+
+    private boolean isExperimental(JavaClass javaClass) {
+        return FluentIterable.of(javaClass.getAnnotations())
+            .anyMatch(new Predicate<Annotation>() {
+
+                @Override
+                public boolean apply(Annotation annotation) {
+                    return annotation.getType().getValue()
+                            .equals(Experimental.class.getName());
+                }
+            });
+    }
 
     private void handleInfoLoadFailure(Log log, String nameOfClass,
             final Type type, Exception e) {

--- a/mailet/mailetdocs-maven-plugin/src/main/java/org/apache/james/mailet/MailetMatcherDescriptor.java
+++ b/mailet/mailetdocs-maven-plugin/src/main/java/org/apache/james/mailet/MailetMatcherDescriptor.java
@@ -19,6 +19,9 @@
 
 package org.apache.james.mailet;
 
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+
 /**
  * Simple bean to describe a mailet or a matcher
  */
@@ -65,6 +68,8 @@ public class MailetMatcherDescriptor {
 
     private Type type;
 
+    private boolean experimental;
+
     public String getFullyQualifiedName() {
         return fullyQualifiedClassName;
     }
@@ -105,10 +110,36 @@ public class MailetMatcherDescriptor {
         this.type = type;
     }
 
+    public boolean isExperimental() {
+        return experimental;
+    }
+
+    public void setExperimental(boolean experimental) {
+        this.experimental = experimental;
+    }
+
     @Override
     public String toString() {
-        return "MailetMatcherDescriptor [fullyQualifiedClassName="
-                + fullyQualifiedClassName + ", name=" + name + ", type=" + type
-                + "]";
+        return MoreObjects.toStringHelper(MailetMatcherDescriptor.class)
+                .add("fullyQualifiedClassName", fullyQualifiedClassName)
+                .add("name", name)
+                .add("info", info)
+                .add("type", type)
+                .add("experimental", experimental)
+                .toString();
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof MailetMatcherDescriptor) {
+            MailetMatcherDescriptor other = (MailetMatcherDescriptor) obj;
+            return Objects.equal(this.fullyQualifiedClassName, other.fullyQualifiedClassName)
+                && Objects.equal(this.name, other.name)
+                && Objects.equal(this.info, other.info)
+                && Objects.equal(this.type, other.type)
+                && Objects.equal(this.experimental, other.experimental);
+        }
+        return false;
+    }
+
 }

--- a/mailet/mailetdocs-maven-plugin/src/test/java/org/apache/james/mailet/DefaultDescriptorsExtractorTest.java
+++ b/mailet/mailetdocs-maven-plugin/src/test/java/org/apache/james/mailet/DefaultDescriptorsExtractorTest.java
@@ -1,0 +1,72 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.apache.james.mailet.MailetMatcherDescriptor.Type;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class DefaultDescriptorsExtractorTest {
+
+    private MavenProject mavenProject;
+    private Log log;
+    private DefaultDescriptorsExtractor testee;
+
+    @Before
+    public void setup() {
+        mavenProject = mock(MavenProject.class);
+        log = mock(Log.class);
+        testee = new DefaultDescriptorsExtractor();
+    }
+
+    @Test
+    public void extractShouldSetExperimentalAttributeWhenScanningMailets() {
+        when(mavenProject.getCompileSourceRoots())
+            .thenReturn(ImmutableList.of("src/test/java"));
+
+        List<MailetMatcherDescriptor> descriptors = testee.extract(mavenProject, log)
+            .descriptors();
+
+        MailetMatcherDescriptor experimentalMailet = new MailetMatcherDescriptor();
+        experimentalMailet.setFullyQualifiedName("org.apache.james.mailet.ExperimentalMailet");
+        experimentalMailet.setName("ExperimentalMailet");
+        experimentalMailet.setInfo(null);
+        experimentalMailet.setType(Type.MAILET);
+        experimentalMailet.setExperimental(true);
+        MailetMatcherDescriptor nonExperimentalMailet = new MailetMatcherDescriptor();
+        nonExperimentalMailet.setFullyQualifiedName("org.apache.james.mailet.NonExperimentalMailet");
+        nonExperimentalMailet.setName("NonExperimentalMailet");
+        nonExperimentalMailet.setInfo(null);
+        nonExperimentalMailet.setType(Type.MAILET);
+        nonExperimentalMailet.setExperimental(false);
+
+        assertThat(descriptors).containsOnly(experimentalMailet, nonExperimentalMailet);
+    }
+}

--- a/mailet/mailetdocs-maven-plugin/src/test/java/org/apache/james/mailet/ExperimentalMailet.java
+++ b/mailet/mailetdocs-maven-plugin/src/test/java/org/apache/james/mailet/ExperimentalMailet.java
@@ -1,0 +1,54 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailet;
+
+import javax.mail.MessagingException;
+
+import org.apache.mailet.Experimental;
+import org.apache.mailet.Mail;
+import org.apache.mailet.Mailet;
+import org.apache.mailet.MailetConfig;
+
+@Experimental
+public class ExperimentalMailet implements Mailet {
+
+    @Override
+    public void init(MailetConfig config) throws MessagingException {
+    }
+
+    @Override
+    public void service(Mail mail) throws MessagingException {
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    @Override
+    public MailetConfig getMailetConfig() {
+        return null;
+    }
+
+    @Override
+    public String getMailetInfo() {
+        return null;
+    }
+
+}

--- a/mailet/mailetdocs-maven-plugin/src/test/java/org/apache/james/mailet/NonExperimentalMailet.java
+++ b/mailet/mailetdocs-maven-plugin/src/test/java/org/apache/james/mailet/NonExperimentalMailet.java
@@ -1,0 +1,52 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailet;
+
+import javax.mail.MessagingException;
+
+import org.apache.mailet.Mail;
+import org.apache.mailet.Mailet;
+import org.apache.mailet.MailetConfig;
+
+public class NonExperimentalMailet implements Mailet {
+
+    @Override
+    public void init(MailetConfig config) throws MessagingException {
+    }
+
+    @Override
+    public void service(Mail mail) throws MessagingException {
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    @Override
+    public MailetConfig getMailetConfig() {
+        return null;
+    }
+
+    @Override
+    public String getMailetInfo() {
+        return null;
+    }
+
+}


### PR DESCRIPTION
The matcher/mailet documentation is generated by the mailetdocs-maven-plugin.
The goal of this PR is to mark matchers/mailets not yet supported as experimental.