### PR TITLE
James 1901 - Report metrics in ElasticSearch

### DIFF
--- a/dockerfiles/run/guice/cassandra/destination/conf/elasticsearch.properties
+++ b/dockerfiles/run/guice/cassandra/destination/conf/elasticsearch.properties
@@ -28,3 +28,9 @@ elasticsearch.retryConnection.maxRetries=7
 elasticsearch.retryConnection.minDelay=3000
 # Index or not attachments (default value: true)
 elasticsearch.indexAttachments=true
+
+# Reports for metrics into ElasticSearch
+elasticsearch.http.port=9200
+elasticsearch.metrics.reports.enabled=true
+elasticsearch.metrics.reports.period=30
+elasticsearch.metrics.reports.index=james-metrics

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/CassandraJamesServerMain.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/CassandraJamesServerMain.java
@@ -29,6 +29,7 @@ import org.apache.james.modules.mailbox.CassandraSessionModule;
 import org.apache.james.modules.mailbox.ElasticSearchMailboxModule;
 import org.apache.james.modules.protocols.JMAPServerModule;
 import org.apache.james.modules.server.ActiveMQQueueModule;
+import org.apache.james.modules.server.ESMetricReporterModule;
 import org.apache.james.modules.server.JMXServerModule;
 import org.apache.james.modules.server.QuotaModule;
 
@@ -48,7 +49,8 @@ public class CassandraJamesServerMain {
         new CassandraSessionModule(),
         new ElasticSearchMailboxModule(),
         new QuotaModule(),
-        new ActiveMQQueueModule());
+        new ActiveMQQueueModule(),
+        new ESMetricReporterModule());
 
 
     public static void main(String[] args) throws Exception {

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/ElasticSearchMailboxModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/ElasticSearchMailboxModule.java
@@ -50,6 +50,9 @@ public class ElasticSearchMailboxModule extends AbstractModule {
     private static final int DEFAULT_CONNECTION_MAX_RETRIES = 7;
     private static final int DEFAULT_CONNECTION_MIN_DELAY = 3000;
     private static final boolean DEFAULT_INDEX_ATTACHMENTS = true;
+    public static final String ES_CONFIG_FILE = FileSystem.FILE_PROTOCOL_AND_CONF + "elasticsearch.properties";
+    public static final String ELASTICSEARCH_MASTER_HOST = "elasticsearch.masterHost";
+    public static final String ELASTICSEARCH_PORT = "elasticsearch.port";
 
     @Override
     protected void configure() {
@@ -66,8 +69,8 @@ public class ElasticSearchMailboxModule extends AbstractModule {
     protected Client provideClientProvider(FileSystem fileSystem, AsyncRetryExecutor executor) throws ConfigurationException, FileNotFoundException, ExecutionException, InterruptedException {
         PropertiesConfiguration propertiesReader = new PropertiesConfiguration(fileSystem.getFile(FileSystem.FILE_PROTOCOL_AND_CONF + "elasticsearch.properties"));
 
-        ClientProvider clientProvider = new ClientProviderImpl(propertiesReader.getString("elasticsearch.masterHost"),
-                propertiesReader.getInt("elasticsearch.port"));
+        ClientProvider clientProvider = new ClientProviderImpl(propertiesReader.getString(ELASTICSEARCH_MASTER_HOST),
+                propertiesReader.getInt(ELASTICSEARCH_PORT));
         Client client = getRetryer(executor, propertiesReader)
                 .getWithRetry(ctx -> clientProvider.get()).get();
         IndexCreationFactory.createIndex(client,

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/server/ESMetricReporterModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/server/ESMetricReporterModule.java
@@ -1,0 +1,114 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.server;
+
+import java.io.FileNotFoundException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.james.filesystem.api.FileSystem;
+import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.metrics.dropwizard.DropWizardMetricFactory;
+import org.apache.james.metrics.dropwizard.ESMetricReporter;
+import org.apache.james.metrics.dropwizard.ESReporterConfiguration;
+import org.apache.james.modules.mailbox.ElasticSearchMailboxModule;
+import org.apache.james.utils.ConfigurationPerformer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.Multibinder;
+import com.nurkiewicz.asyncretry.AsyncRetryExecutor;
+
+public class ESMetricReporterModule extends AbstractModule {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ESMetricReporterModule.class);
+    public static final boolean DEFAULT_DISABLE = false;
+    public static final int DEFAULT_ES_HTTP_PORT = 9200;
+
+    @Override
+    protected void configure() {
+        Multibinder.newSetBinder(binder(), ConfigurationPerformer.class).addBinding().to(ESMetricReporterStarter.class);
+    }
+
+    @Provides
+    public ESReporterConfiguration provideConfiguration(FileSystem fileSystem) throws ConfigurationException {
+        try {
+            PropertiesConfiguration propertiesReader = getPropertiesConfiguration(fileSystem);
+
+            if (propertiesReader.getBoolean("elasticsearch.metrics.reports.enabled", DEFAULT_DISABLE)) {
+                return ESReporterConfiguration.enabled(
+                    propertiesReader.getString(ElasticSearchMailboxModule.ELASTICSEARCH_MASTER_HOST),
+                    propertiesReader.getInt("elasticsearch.http.port", DEFAULT_ES_HTTP_PORT),
+                    Optional.fromNullable(propertiesReader.getString("elasticsearch.metrics.reports.index", null)),
+                    Optional.fromNullable(propertiesReader.getLong("elasticsearch.metrics.reports.period", null)));
+            }
+        } catch (FileNotFoundException e) {
+            LOGGER.info("Can not locate " + ElasticSearchMailboxModule.ES_CONFIG_FILE);
+        }
+        return ESReporterConfiguration.disabled();
+    }
+
+    private PropertiesConfiguration getPropertiesConfiguration(FileSystem fileSystem) throws ConfigurationException, FileNotFoundException {
+        return new PropertiesConfiguration(
+                    fileSystem.getFile(ElasticSearchMailboxModule.ES_CONFIG_FILE));
+    }
+
+    @Provides
+    public ESMetricReporter provideReporter(DropWizardMetricFactory metricFactory, ESReporterConfiguration configuration) throws ConfigurationException, ExecutionException, InterruptedException {
+        return metricFactory.provideEsReporter(configuration);
+    }
+
+    @Singleton
+    public static class ESMetricReporterStarter implements ConfigurationPerformer, Configurable {
+
+        private final ESMetricReporter esMetricReporter;
+
+        @Inject
+        public ESMetricReporterStarter(ESMetricReporter esMetricReporter) {
+            this.esMetricReporter = esMetricReporter;
+        }
+
+        @Override
+        public void initModule() {
+            esMetricReporter.start();
+        }
+
+        @Override
+        public List<Class<? extends Configurable>> forClasses() {
+            return ImmutableList.of(ESMetricReporterStarter.class);
+        }
+
+        @Override
+        public void configure(HierarchicalConfiguration config) throws ConfigurationException {
+            throw new NotImplementedException();
+        }
+    }
+
+}

--- a/server/container/metrics/metrics-dropwizard/pom.xml
+++ b/server/container/metrics/metrics-dropwizard/pom.xml
@@ -57,6 +57,10 @@
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>metrics-elasticsearch-reporter</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/server/container/metrics/metrics-dropwizard/src/main/java/org/apache/james/metrics/dropwizard/ESReporterConfiguration.java
+++ b/server/container/metrics/metrics-dropwizard/src/main/java/org/apache/james/metrics/dropwizard/ESReporterConfiguration.java
@@ -1,0 +1,81 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.metrics.dropwizard;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+
+public class ESReporterConfiguration {
+
+    public static final boolean ENABLED = true;
+    public static final boolean DISABLED = !ENABLED;
+    public static final String DEFAULT_INDEX = "james-metrics";
+    public static final long DEFAULT_period_in_second = 60L;
+
+    public static ESReporterConfiguration disabled() {
+        return new ESReporterConfiguration(
+            Optional.<String>absent(),
+            Optional.<Integer>absent(),
+            DISABLED,
+            Optional.<String>absent(),
+            Optional.<Long>absent());
+    }
+
+    public static ESReporterConfiguration enabled(String host, int port, Optional<String> index, Optional<Long> periodInSecond) {
+        return new ESReporterConfiguration(
+            Optional.of(host),
+            Optional.of(port),
+            ENABLED,
+            index,
+            periodInSecond);
+    }
+
+    private final Optional<String> host;
+    private final Optional<Integer> port;
+    private final boolean enabled;
+    private final Optional<String> index;
+    private final Optional<Long> periodInSecond;
+
+    public ESReporterConfiguration(Optional<String> host, Optional<Integer> port, boolean enabled, Optional<String> index, Optional<Long> periodInSecond) {
+        this.host = host;
+        this.port = port;
+        this.enabled = enabled;
+        this.index = index;
+        this.periodInSecond = periodInSecond;
+    }
+
+    public String getHostWithPort() {
+        Preconditions.checkState(host.isPresent());
+        Preconditions.checkState(port.isPresent());
+        return host.get() + ":" + port.get();
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getIndex() {
+        return index.or(DEFAULT_INDEX);
+    }
+
+    public long getPeriodInSecond() {
+        return periodInSecond.or(DEFAULT_period_in_second);
+    }
+}

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -1551,6 +1551,11 @@
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.elasticsearch</groupId>
+                <artifactId>metrics-elasticsearch-reporter</artifactId>
+                <version>2.2.0</version>
+            </dependency>
+            <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>
                 <version>${testcontainers-version}</version>


### PR DESCRIPTION
No tests yet. It's thought to not chrash if config file is absent.

Also as it uses http, the dependency added is super light. Also as it uses HTTP, james still start without ES (reports just fails, error log).

The report are done in james-metrics-2016-12

![screenshot from 2016-12-30 18-57-02](https://cloud.githubusercontent.com/assets/6928740/21564599/d57ccf74-cec1-11e6-9ca3-2497682981a5.png)
