### PR TITLE
JAMES-1935 search should be wider in order to prevent further DB reads

### DIFF
--- a/mailbox/hbase/src/main/java/org/apache/james/mailbox/hbase/mail/model/HBaseMailbox.java
+++ b/mailbox/hbase/src/main/java/org/apache/james/mailbox/hbase/mail/model/HBaseMailbox.java
@@ -20,6 +20,7 @@ package org.apache.james.mailbox.hbase.mail.model;
 
 import java.util.UUID;
 
+import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.hbase.HBaseId;
 import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxId;
@@ -214,6 +215,13 @@ public class HBaseMailbox implements Mailbox {
     @Override
     public void setACL(MailboxACL acl) {
         // TODO ACL support
+    }
+
+    @Override
+    public boolean isChildOf(Mailbox potentialParent, MailboxSession mailboxSession) {
+        return namespace.equals(potentialParent.getNamespace())
+            && user.equals(potentialParent.getUser())
+            && name.startsWith(potentialParent.getName() + mailboxSession.getPathDelimiter());
     }
     
 }

--- a/mailbox/jcr/src/main/java/org/apache/james/mailbox/jcr/mail/model/JCRMailbox.java
+++ b/mailbox/jcr/src/main/java/org/apache/james/mailbox/jcr/mail/model/JCRMailbox.java
@@ -23,6 +23,7 @@ import javax.jcr.RepositoryException;
 
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.util.Text;
+import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.jcr.JCRId;
 import org.apache.james.mailbox.jcr.JCRImapConstants;
 import org.apache.james.mailbox.jcr.Persistent;
@@ -323,6 +324,13 @@ public class JCRMailbox implements Mailbox, JCRImapConstants, Persistent{
     @Override
     public void setACL(MailboxACL acl) {
         // TODO ACL support
+    }
+
+    @Override
+    public boolean isChildOf(Mailbox potentialParent, MailboxSession mailboxSession) {
+        return namespace.equals(potentialParent.getNamespace())
+            && user.equals(potentialParent.getUser())
+            && name.startsWith(potentialParent.getName() + mailboxSession.getPathDelimiter());
     }
     
 }

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/JPAMailbox.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/JPAMailbox.java
@@ -27,6 +27,7 @@ import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 
+import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.jpa.JPAId;
 import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxId;
@@ -238,4 +239,10 @@ public class JPAMailbox implements Mailbox {
     public void setACL(MailboxACL acl) {
     }
 
+    @Override
+    public boolean isChildOf(Mailbox potentialParent, MailboxSession mailboxSession) {
+        return namespace.equals(potentialParent.getNamespace())
+            && user.equals(potentialParent.getUser())
+            && name.startsWith(potentialParent.getName() + mailboxSession.getPathDelimiter());
+    }
 }

--- a/mailbox/lucene/src/test/java/org/apache/james/mailbox/lucene/search/LuceneMailboxMessageSearchIndexTest.java
+++ b/mailbox/lucene/src/test/java/org/apache/james/mailbox/lucene/search/LuceneMailboxMessageSearchIndexTest.java
@@ -688,5 +688,11 @@ public class LuceneMailboxMessageSearchIndexTest {
         }
 
 
+        @Override
+        public boolean isChildOf(Mailbox potentialParent, MailboxSession mailboxSession) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+
     }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/Mailbox.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/Mailbox.java
@@ -18,6 +18,7 @@
  ****************************************************************/
 package org.apache.james.mailbox.store.mail.model;
 
+import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxId;
 
@@ -88,5 +89,7 @@ public interface Mailbox {
      * @param acl
      */
     void setACL(MailboxACL acl);
+
+    boolean isChildOf(Mailbox potentialParent, MailboxSession mailboxSession);
     
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailbox.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailbox.java
@@ -18,6 +18,7 @@
  ****************************************************************/
 package org.apache.james.mailbox.store.mail.model.impl;
 
+import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
@@ -160,4 +161,10 @@ public class SimpleMailbox implements Mailbox {
         this.acl = acl;
     }
 
+    @Override
+    public boolean isChildOf(Mailbox potentialParent, MailboxSession mailboxSession) {
+        return namespace.equals(potentialParent.getNamespace())
+            && user.equals(potentialParent.getUser())
+            && name.startsWith(potentialParent.getName() + mailboxSession.getPathDelimiter());
+    }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMailboxAssertTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMailboxAssertTest.java
@@ -24,6 +24,8 @@ import static org.apache.james.mailbox.store.mail.model.ListMailboxAssert.assert
 
 import java.util.List;
 
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
@@ -112,6 +114,11 @@ public class ListMailboxAssertTest {
             @Override
             public MailboxACL getACL() {
                 return null;
+            }
+
+            @Override
+            public boolean isChildOf(Mailbox potentialParent, MailboxSession mailboxSession) {
+                throw new NotImplementedException();
             }
         };
     }


### PR DESCRIPTION
For N mailboxes, with cassandra implementation, previous implementation lead to :
 - A first read returning N mailboxes
 - For these N mailboxes, a new DB call was made to see if we have children

 By doing a wilder query, we can also retrieve children of the mailbox and avoid making these N DB call. Complexity of searching mailboxes is then greatly reduced.