### PR TITLE
James 1874 Various optimisation for JMAP

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
@@ -42,6 +42,8 @@ import org.apache.james.mailbox.model.MultimailboxesSearchQuery;
 import org.apache.james.mailbox.model.SimpleMailboxACL;
 import org.slf4j.Logger;
 
+import com.google.common.base.Optional;
+
 /**
  * <p>
  * Central MailboxManager which creates, lists, provides, renames and deletes
@@ -152,8 +154,10 @@ public interface MailboxManager extends RequestAware, MailboxListenerSupport {
      *            the context for this call, not null
      * @throws MailboxException
      *             when creation fails
+     * @return Empty optional when the name is empty. If mailbox is created, the id of the mailboxPath specified as
+     *  parameter is returned (and not potential mailboxIds of parent mailboxes created in the process will be omitted)
      */
-    void createMailbox(MailboxPath mailboxPath, MailboxSession mailboxSession) throws MailboxException;
+    Optional<MailboxId> createMailbox(MailboxPath mailboxPath, MailboxSession mailboxSession) throws MailboxException;
 
     /**
      * Delete the mailbox with the name

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
@@ -154,8 +154,8 @@ public interface MailboxManager extends RequestAware, MailboxListenerSupport {
      *            the context for this call, not null
      * @throws MailboxException
      *             when creation fails
-     * @return Empty optional when the name is empty. If mailbox is created, the id of the mailboxPath specified as
-     *  parameter is returned (and not potential mailboxIds of parent mailboxes created in the process will be omitted)
+     * @return Empty optional when the mailbox name is empty. If mailbox is created, the id of the mailboxPath specified as
+     *  parameter is returned (and potential mailboxIds of parent mailboxes created in the process will be omitted)
      */
     Optional<MailboxId> createMailbox(MailboxPath mailboxPath, MailboxSession mailboxSession) throws MailboxException;
 

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
@@ -31,6 +31,7 @@ import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.UnsupportedCriteriaException;
 import org.apache.james.mailbox.model.ComposedMessageId;
 import org.apache.james.mailbox.model.MailboxACL;
+import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageRange;
@@ -38,6 +39,8 @@ import org.apache.james.mailbox.model.MessageResult;
 import org.apache.james.mailbox.model.MessageResult.FetchGroup;
 import org.apache.james.mailbox.model.MessageResultIterator;
 import org.apache.james.mailbox.model.SearchQuery;
+
+import com.google.common.base.Objects;
 
 /**
  * Interface which represent a Mailbox
@@ -60,7 +63,7 @@ public interface MessageManager {
     /**
      * Return the count of unseen messages in the mailbox
      */
-    long getUnseenMessageCount(MailboxSession mailboxSession) throws MailboxException;
+    MailboxCounters getMailboxCounters(MailboxSession mailboxSession) throws MailboxException;
 
     /**
      * Return if the Mailbox is writable

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxCounters.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxCounters.java
@@ -1,0 +1,84 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.model;
+
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+
+public class MailboxCounters {
+
+    public static class Builder {
+        private Optional<Long> count = Optional.absent();
+        private Optional<Long> unseen = Optional.absent();
+
+        public Builder count(long count) {
+            this.count = Optional.of(count);
+            return this;
+        }
+
+        public Builder unseen(long unseen) {
+            this.unseen = Optional.of(unseen);
+            return this;
+        }
+
+        public MailboxCounters build() {
+            Preconditions.checkState(count.isPresent(), "count is compulsory");
+            Preconditions.checkState(unseen.isPresent(), "unseen is compulsory");
+            return new MailboxCounters(count.get(), unseen.get());
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private final long count;
+    private final long unseen;
+
+    private MailboxCounters(long count, long unseen) {
+        this.count = count;
+        this.unseen = unseen;
+    }
+
+    public long getCount() {
+        return count;
+    }
+
+    public long getUnseen() {
+        return unseen;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof MailboxCounters) {
+            MailboxCounters that = (MailboxCounters) o;
+
+            return Objects.equal(this.count, that.count)
+                && Objects.equal(this.unseen, that.unseen);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hashCode(count, unseen);
+    }
+}

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxPath.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxPath.java
@@ -24,6 +24,8 @@ import java.util.List;
 
 import org.apache.james.mailbox.MailboxSession;
 
+import com.google.common.collect.ImmutableList;
+
 /**
  * The path to a mailbox.
  */
@@ -116,6 +118,9 @@ public class MailboxPath {
      * @return list of hierarchy levels
      */
     public List<MailboxPath> getHierarchyLevels(char delimiter) {
+        if (name == null) {
+            return ImmutableList.of(this);
+        }
         ArrayList<MailboxPath> levels = new ArrayList<MailboxPath>();
         int index = name.indexOf(delimiter);
         while (index >= 0) {

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -35,6 +35,7 @@ import org.apache.james.mailbox.mock.MockMailboxManager;
 import org.apache.james.mailbox.model.MailboxAnnotation;
 import org.apache.james.mailbox.model.MailboxAnnotationKey;
 import org.apache.james.mailbox.model.MailboxConstants;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxMetaData;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MailboxQuery;
@@ -47,6 +48,7 @@ import org.xenei.junit.contract.Contract;
 import org.xenei.junit.contract.ContractTest;
 import org.xenei.junit.contract.IProducer;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -114,7 +116,20 @@ public class MailboxManagerTest<T extends MailboxManager> {
         MailboxPath inbox = MailboxPath.inbox(session);
         assertThat(mailboxManager.mailboxExists(inbox, session)).isFalse();
     }
-    
+
+    @ContractTest
+    public void createMailboxShouldReturnRightId() throws MailboxException, UnsupportedEncodingException {
+        session = mailboxManager.createSystemSession(USER_1, LoggerFactory.getLogger("Mock"));
+        mailboxManager.startProcessingRequest(session);
+
+        MailboxPath mailboxPath = new MailboxPath(MailboxConstants.USER_NAMESPACE, USER_1, "name.subfolder");
+        Optional<MailboxId> mailboxId = mailboxManager.createMailbox(mailboxPath, session);
+        MessageManager retrievedMailbox = mailboxManager.getMailbox(mailboxPath, session);
+
+        assertThat(mailboxId.isPresent()).isTrue();
+        assertThat(mailboxId.get()).isEqualTo(retrievedMailbox.getId());
+    }
+
     @ContractTest
     public void user1ShouldBeAbleToCreateInbox() throws MailboxException, UnsupportedEncodingException {
         session = mailboxManager.createSystemSession(USER_1, LoggerFactory.getLogger("Mock"));

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxCountersTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxCountersTest.java
@@ -1,0 +1,33 @@
+/*
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+
+package org.apache.james.mailbox.model;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class MailboxCountersTest {
+
+    @Test
+    public void mailboxCountersShouldRespectBeanContract() {
+        EqualsVerifier.forClass(MailboxCounters.class).verify();
+    }
+}

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxPathTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxPathTest.java
@@ -1,0 +1,62 @@
+/*
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+
+package org.apache.james.mailbox.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class MailboxPathTest {
+
+    @Test
+    public void getHierarchyLevelsShouldBeOrdered() {
+        assertThat(new MailboxPath("#private", "user", "inbox.folder.subfolder")
+            .getHierarchyLevels('.'))
+            .containsExactly(
+                new MailboxPath("#private", "user", "inbox"),
+                new MailboxPath("#private", "user", "inbox.folder"),
+                new MailboxPath("#private", "user", "inbox.folder.subfolder"));
+    }
+
+    @Test
+    public void getHierarchyLevelsShouldReturnPathWhenOneLevel() {
+        assertThat(new MailboxPath("#private", "user", "inbox")
+            .getHierarchyLevels('.'))
+            .containsExactly(
+                new MailboxPath("#private", "user", "inbox"));
+    }
+
+    @Test
+    public void getHierarchyLevelsShouldReturnPathWhenEmptyName() {
+        assertThat(new MailboxPath("#private", "user", "")
+            .getHierarchyLevels('.'))
+            .containsExactly(
+                new MailboxPath("#private", "user", ""));
+    }
+
+    @Test
+    public void getHierarchyLevelsShouldReturnPathWhenNullName() {
+        assertThat(new MailboxPath("#private", "user", null)
+            .getHierarchyLevels('.'))
+            .containsExactly(
+                new MailboxPath("#private", "user", null));
+    }
+}

--- a/mailbox/caching/src/main/java/org/apache/james/mailbox/caching/CachingMailboxMapper.java
+++ b/mailbox/caching/src/main/java/org/apache/james/mailbox/caching/CachingMailboxMapper.java
@@ -55,9 +55,9 @@ public class CachingMailboxMapper implements MailboxMapper {
 	}
 
 	@Override
-	public void save(Mailbox mailbox) throws MailboxException {
+	public MailboxId save(Mailbox mailbox) throws MailboxException {
 		invalidate(mailbox);
-		underlying.save(mailbox);
+		return underlying.save(mailbox);
 	}
 
 	@Override

--- a/mailbox/caching/src/main/java/org/apache/james/mailbox/caching/CachingMessageMapper.java
+++ b/mailbox/caching/src/main/java/org/apache/james/mailbox/caching/CachingMessageMapper.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.UpdatedFlags;
@@ -65,6 +66,14 @@ public class CachingMessageMapper implements MessageMapper {
     public long countUnseenMessagesInMailbox(Mailbox mailbox)
             throws MailboxException {
         return cache.countUnseenMessagesInMailbox(mailbox, underlying);
+    }
+
+    @Override
+    public MailboxCounters getMailboxCounters(Mailbox mailbox) throws MailboxException {
+        return MailboxCounters.builder()
+            .count(countMessagesInMailbox(mailbox))
+            .unseen(countUnseenMessagesInMailbox(mailbox))
+            .build();
     }
 
     @Override

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapper.java
@@ -122,7 +122,7 @@ public class CassandraMailboxMapper implements MailboxMapper {
     }
 
     @Override
-    public void save(Mailbox mailbox) throws MailboxException {
+    public MailboxId save(Mailbox mailbox) throws MailboxException {
         Preconditions.checkArgument(mailbox instanceof SimpleMailbox);
         SimpleMailbox cassandraMailbox = (SimpleMailbox) mailbox;
 
@@ -164,6 +164,7 @@ public class CassandraMailboxMapper implements MailboxMapper {
             }
             throw e;
         }
+        return cassandraId;
     }
 
     private CassandraId retrieveId(SimpleMailbox cassandraMailbox) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -42,6 +42,7 @@ import org.apache.james.mailbox.cassandra.mail.utils.MessageDeletedDuringFlagsUp
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.ComposedMessageId;
 import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
+import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
@@ -65,6 +66,10 @@ import com.google.common.collect.ImmutableList;
 
 public class CassandraMessageMapper implements MessageMapper {
     private static final Logger LOGGER = LoggerFactory.getLogger(CassandraMessageMapper.class);
+    public static final MailboxCounters INITIAL_COUNTERS =  MailboxCounters.builder()
+        .count(0L)
+        .unseen(0L)
+        .build();
 
     private final ModSeqProvider modSeqProvider;
     private final MailboxSession mailboxSession;
@@ -107,6 +112,13 @@ public class CassandraMessageMapper implements MessageMapper {
         return mailboxCounterDAO.countUnseenMessagesInMailbox(mailbox)
             .join()
             .orElse(0L);
+    }
+
+    @Override
+    public MailboxCounters getMailboxCounters(Mailbox mailbox) throws MailboxException {
+        return mailboxCounterDAO.retrieveMailboxCounters(mailbox)
+            .join()
+            .orElse(INITIAL_COUNTERS);
     }
 
     @Override

--- a/mailbox/hbase/src/main/java/org/apache/james/mailbox/hbase/mail/HBaseMailboxMapper.java
+++ b/mailbox/hbase/src/main/java/org/apache/james/mailbox/hbase/mail/HBaseMailboxMapper.java
@@ -252,7 +252,7 @@ public class HBaseMailboxMapper extends HBaseNonTransactionalMapper implements M
     }
     
     @Override
-    public void save(Mailbox mlbx) throws MailboxException {
+    public MailboxId save(Mailbox mlbx) throws MailboxException {
         //TODO: maybe switch to checkAndPut for transactions
         HTable mailboxes = null;
         try {
@@ -262,6 +262,7 @@ public class HBaseMailboxMapper extends HBaseNonTransactionalMapper implements M
              */
             Put put = toPut((HBaseMailbox) mlbx);
             mailboxes.put(put);
+            return mlbx.getMailboxId();
         } catch (IOException ex) {
             throw new MailboxException("IOExeption", ex);
         } finally {

--- a/mailbox/hbase/src/main/java/org/apache/james/mailbox/hbase/mail/HBaseMessageMapper.java
+++ b/mailbox/hbase/src/main/java/org/apache/james/mailbox/hbase/mail/HBaseMessageMapper.java
@@ -68,6 +68,7 @@ import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.hbase.HBaseId;
 import org.apache.james.mailbox.hbase.io.ChunkOutputStream;
+import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.MessageId.Factory;
 import org.apache.james.mailbox.model.MessageMetaData;
@@ -109,6 +110,14 @@ public class HBaseMessageMapper extends NonTransactionalMapper implements Messag
         this.uidProvider = uidProvider;
         this.messageIdFactory = messageIdFactory;
         this.conf = conf;
+    }
+
+    @Override
+    public MailboxCounters getMailboxCounters(Mailbox mailbox) throws MailboxException {
+        return MailboxCounters.builder()
+            .count(countMessagesInMailbox(mailbox))
+            .unseen(countUnseenMessagesInMailbox(mailbox))
+            .build();
     }
 
     @Override

--- a/mailbox/jcr/src/main/java/org/apache/james/mailbox/jcr/mail/JCRMailboxMapper.java
+++ b/mailbox/jcr/src/main/java/org/apache/james/mailbox/jcr/mail/JCRMailboxMapper.java
@@ -159,7 +159,7 @@ public class JCRMailboxMapper extends AbstractJCRScalingMapper implements Mailbo
      * org.apache.james.mailbox.store.mail.MailboxMapper#save(org.apache.james.
      * imap.store.mail.model.Mailbox)
      */
-    public void save(Mailbox mailbox) throws MailboxException {
+    public MailboxId save(Mailbox mailbox) throws MailboxException {
         
         try {
             final JCRMailbox jcrMailbox = (JCRMailbox)mailbox;
@@ -191,6 +191,7 @@ public class JCRMailboxMapper extends AbstractJCRScalingMapper implements Mailbo
            } else {
                jcrMailbox.merge(node);
            }
+           return jcrMailbox.getMailboxId();
             
         } catch (RepositoryException e) {
             throw new MailboxException("Unable to save mailbox " + mailbox, e);

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMailboxMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMailboxMapper.java
@@ -74,7 +74,7 @@ public class JPAMailboxMapper extends JPATransactionalMapper implements MailboxM
     /**
      * @see org.apache.james.mailbox.store.mail.MailboxMapper#save(Mailbox)
      */
-    public void save(Mailbox mailbox) throws MailboxException {
+    public MailboxId save(Mailbox mailbox) throws MailboxException {
         try {
             this.lastMailboxName = mailbox.getName();
             JPAMailbox persistedMailbox = JPAMailbox.from(mailbox);
@@ -82,6 +82,7 @@ public class JPAMailboxMapper extends JPATransactionalMapper implements MailboxM
             if (!(mailbox instanceof JPAMailbox)) {
                 mailbox.setMailboxId(persistedMailbox.getMailboxId());
             }
+            return mailbox.getMailboxId();
         } catch (PersistenceException e) {
             throw new MailboxException("Save of mailbox " + mailbox.getName() +" failed", e);
         } 

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMessageMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMessageMapper.java
@@ -38,6 +38,7 @@ import org.apache.james.mailbox.jpa.mail.model.openjpa.AbstractJPAMailboxMessage
 import org.apache.james.mailbox.jpa.mail.model.openjpa.JPAEncryptedMailboxMessage;
 import org.apache.james.mailbox.jpa.mail.model.openjpa.JPAMailboxMessage;
 import org.apache.james.mailbox.jpa.mail.model.openjpa.JPAStreamingMailboxMessage;
+import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.MessageRange.Type;
@@ -66,6 +67,14 @@ public class JPAMessageMapper extends JPATransactionalMapper implements MessageM
     public JPAMessageMapper(MailboxSession mailboxSession, UidProvider uidProvider, ModSeqProvider modSeqProvider, EntityManagerFactory entityManagerFactory) {
         super(entityManagerFactory);
         this.messageMetadataMapper = new MessageUtils(mailboxSession, uidProvider, modSeqProvider);
+    }
+
+    @Override
+    public MailboxCounters getMailboxCounters(Mailbox mailbox) throws MailboxException {
+        return MailboxCounters.builder()
+            .count(countMessagesInMailbox(mailbox))
+            .unseen(countUnseenMessagesInMailbox(mailbox))
+            .build();
     }
 
     /**

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMailboxMapper.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMailboxMapper.java
@@ -50,16 +50,16 @@ public class TransactionalMailboxMapper implements MailboxMapper {
     }
 
     @Override
-    public void save(final Mailbox mailbox) throws MailboxException {
+    public MailboxId save(final Mailbox mailbox) throws MailboxException {
         try {
-            wrapped.execute(new VoidTransaction() {
+            return wrapped.execute(new Transaction<MailboxId>() {
                 @Override
-                public void runVoid() throws MailboxException {
-                    wrapped.save(mailbox);
+                public MailboxId run() throws MailboxException {
+                    return wrapped.save(mailbox);
                 }
             });
         } catch (MailboxException e) {
-            Throwables.propagate(e);
+            throw Throwables.propagate(e);
         }
     }
 

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMessageMapper.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMessageMapper.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.UpdatedFlags;
@@ -46,6 +47,14 @@ public class TransactionalMessageMapper implements MessageMapper {
     @Override
     public void endRequest() {
         throw new NotImplementedException();
+    }
+
+    @Override
+    public MailboxCounters getMailboxCounters(Mailbox mailbox) throws MailboxException {
+        return MailboxCounters.builder()
+            .count(countMessagesInMailbox(mailbox))
+            .unseen(countUnseenMessagesInMailbox(mailbox))
+            .build();
     }
 
     @Override

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMailboxMapper.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMailboxMapper.java
@@ -160,7 +160,7 @@ public class MaildirMailboxMapper extends NonTransactionalMapper implements Mail
      * @see org.apache.james.mailbox.store.mail.MailboxMapper#save(org.apache.james.mailbox.store.mail.model.Mailbox)
      */
     @Override
-    public void save(Mailbox mailbox) throws MailboxException {
+    public MailboxId save(Mailbox mailbox) throws MailboxException {
         try {
             Mailbox originalMailbox = getCachedMailbox((MaildirId) mailbox.getMailboxId());
             MaildirFolder folder = maildirStore.createMaildirFolder(mailbox);
@@ -229,7 +229,8 @@ public class MaildirMailboxMapper extends NonTransactionalMapper implements Mail
             }
             folder.setACL(session, mailbox.getACL());
         }
-        
+        cacheMailbox(mailbox);
+        return mailbox.getMailboxId();
     }
 
     /**

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMailboxMapper.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMailboxMapper.java
@@ -109,13 +109,14 @@ public class InMemoryMailboxMapper implements MailboxMapper {
     /**
      * @see org.apache.james.mailbox.store.mail.MailboxMapper#save(org.apache.james.mailbox.store.mail.model.Mailbox)
      */
-    public void save(Mailbox mailbox) throws MailboxException {
+    public MailboxId save(Mailbox mailbox) throws MailboxException {
         InMemoryId id = (InMemoryId) mailbox.getMailboxId();
         if (id == null) {
             id = InMemoryId.of(mailboxIdGenerator.incrementAndGet());
             ((SimpleMailbox) mailbox).setMailboxId(id);
         }
         mailboxesById.put(id, mailbox);
+        return mailbox.getMailboxId();
     }
 
     /**

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -54,6 +54,7 @@ import org.apache.james.mailbox.model.Attachment;
 import org.apache.james.mailbox.model.ComposedMessageId;
 import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxACL.MailboxACLRights;
+import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageAttachment;
@@ -232,10 +233,10 @@ public class StoreMessageManager implements org.apache.james.mailbox.MessageMana
         return new Flags(MINIMAL_PERMANET_FLAGS);
     }
 
+
     @Override
-    public long getUnseenMessageCount(MailboxSession mailboxSession) throws MailboxException {
-        return mapperFactory.createMessageMapper(mailboxSession)
-            .countUnseenMessagesInMailbox(mailbox);
+    public MailboxCounters getMailboxCounters(MailboxSession mailboxSession) throws MailboxException {
+        return mapperFactory.createMessageMapper(mailboxSession).getMailboxCounters(mailbox);
     }
 
     /**

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AbstractMessageMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AbstractMessageMapper.java
@@ -27,6 +27,7 @@ import javax.mail.Flags;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.UpdatedFlags;
@@ -61,6 +62,14 @@ public abstract class AbstractMessageMapper extends TransactionalMapper implemen
     @Override
     public Optional<MessageUid> getLastUid(Mailbox mailbox) throws MailboxException {
         return uidProvider.lastUid(mailboxSession, mailbox);
+    }
+
+    @Override
+    public MailboxCounters getMailboxCounters(Mailbox mailbox) throws MailboxException {
+        return MailboxCounters.builder()
+            .count(countMessagesInMailbox(mailbox))
+            .unseen(countUnseenMessagesInMailbox(mailbox))
+            .build();
     }
     
     @Override

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MailboxMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MailboxMapper.java
@@ -41,7 +41,7 @@ public interface MailboxMapper extends Mapper {
      * @param mailbox
      * @throws MailboxException
      */
-    void save(Mailbox mailbox) throws MailboxException;
+    MailboxId save(Mailbox mailbox) throws MailboxException;
     
     /**
      * Delete the given {@link Mailbox} from the underlying storage

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.UpdatedFlags;
@@ -83,6 +84,7 @@ public interface MessageMapper extends Mapper {
     long countUnseenMessagesInMailbox(Mailbox mailbox)
             throws MailboxException;
 
+    MailboxCounters getMailboxCounters(Mailbox mailbox) throws MailboxException;
 
     /**
      * Delete the given {@link MailboxMessage}

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxMessageResultIteratorTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxMessageResultIteratorTest.java
@@ -34,6 +34,7 @@ import javax.mail.util.SharedByteArrayInputStream;
 
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.MessageResult;
@@ -83,6 +84,14 @@ public class StoreMailboxMessageResultIteratorTest {
         @Override
         public <T> T execute(Transaction<T> transaction) throws MailboxException {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public MailboxCounters getMailboxCounters(Mailbox mailbox) throws MailboxException {
+            return MailboxCounters.builder()
+                .count(countMessagesInMailbox(mailbox))
+                .unseen(countUnseenMessagesInMailbox(mailbox))
+                .build();
         }
 
         @Override

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/TestMailboxSessionMapperFactory.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/TestMailboxSessionMapperFactory.java
@@ -86,7 +86,7 @@ public class TestMailboxSessionMapperFactory extends MailboxSessionMapperFactory
 
         mailboxMapper = new MailboxMapper() {
             @Override
-            public void save(Mailbox mailbox) throws MailboxException {
+            public MailboxId save(Mailbox mailbox) throws MailboxException {
                 throw new NotImplementedException();
             }
 

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
@@ -58,6 +58,7 @@ import org.apache.james.mailbox.model.MailboxACL.MailboxACLRight;
 import org.apache.james.mailbox.model.MailboxACL.MailboxACLRights;
 import org.apache.james.mailbox.model.MailboxAnnotation;
 import org.apache.james.mailbox.model.MailboxAnnotationKey;
+import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxMetaData;
 import org.apache.james.mailbox.model.MailboxPath;
@@ -174,15 +175,15 @@ public class MailboxEventAnalyserTest {
         public MessageManager getMailbox(MailboxPath mailboxPath, MailboxSession session) throws MailboxException {
             return new MessageManager() {
 
-                @Override
-                public long getUnseenMessageCount(MailboxSession mailboxSession) throws MailboxException {
-                    return 0;
-                }
-
                 public long getMessageCount(MailboxSession mailboxSession) throws MailboxException {
                     return 1;
                 }
-                
+
+                @Override
+                public MailboxCounters getMailboxCounters(MailboxSession mailboxSession) throws MailboxException {
+                    throw new UnsupportedOperationException("Not implemented");
+                }
+
                 public boolean isWriteable(MailboxSession session) {
                     return false;
                 }

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
@@ -78,6 +78,7 @@ import org.apache.james.mailbox.store.mail.model.DefaultMessageId;
 import org.junit.Test;
 import org.slf4j.Logger;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 
 public class MailboxEventAnalyserTest {
@@ -340,7 +341,7 @@ public class MailboxEventAnalyserTest {
             throw new UnsupportedOperationException("Not implemented");
         }
         
-        public void createMailbox(MailboxPath mailboxPath, MailboxSession mailboxSession) throws MailboxException {
+        public Optional<MailboxId> createMailbox(MailboxPath mailboxPath, MailboxSession mailboxSession) throws MailboxException {
             throw new UnsupportedOperationException("Not implemented");
         }
         

--- a/server/container/util-java8/src/test/java/org/apache/james/util/OptionalConverterTest.java
+++ b/server/container/util-java8/src/test/java/org/apache/james/util/OptionalConverterTest.java
@@ -21,6 +21,7 @@ package org.apache.james.util;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/GetMailboxesMethod.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/GetMailboxesMethod.java
@@ -104,7 +104,10 @@ public class GetMailboxesMethod implements Method {
         if (mailboxIds.isPresent()) {
             return mailboxIds.get()
                 .stream()
-                .map(mailboxId -> mailboxFactory.fromMailboxId(mailboxId, mailboxSession))
+                .map(mailboxId -> mailboxFactory.builder()
+                        .id(mailboxId)
+                        .session(mailboxSession)
+                        .build())
                 .flatMap(OptionalConverter::toStream);
         } else {
             List<MailboxMetaData> userMailboxes = mailboxManager.search(
@@ -113,7 +116,11 @@ public class GetMailboxesMethod implements Method {
             return userMailboxes
                 .stream()
                 .map(MailboxMetaData::getId)
-                .map(mailboxId -> mailboxFactory.fromMailboxId(mailboxId, userMailboxes, mailboxSession))
+                .map(mailboxId -> mailboxFactory.builder()
+                        .id(mailboxId)
+                        .session(mailboxSession)
+                        .usingPreloadedMailboxesMetadata(userMailboxes)
+                        .build())
                 .flatMap(OptionalConverter::toStream);
         }
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMailboxesCreationProcessor.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMailboxesCreationProcessor.java
@@ -106,7 +106,10 @@ public class SetMailboxesCreationProcessor implements SetMailboxesProcessor {
             ensureValidMailboxName(mailboxRequest, mailboxSession);
             MailboxPath mailboxPath = getMailboxPath(mailboxRequest, creationIdsToCreatedMailboxId, mailboxSession);
             Optional<MailboxId> mailboxId = OptionalConverter.fromGuava(mailboxManager.createMailbox(mailboxPath, mailboxSession));
-            Optional<Mailbox> mailbox = mailboxId.flatMap(id -> mailboxFactory.fromMailboxId(id, mailboxSession));
+            Optional<Mailbox> mailbox = mailboxId.flatMap(id -> mailboxFactory.builder()
+                    .id(id)
+                    .session(mailboxSession)
+                    .build());
             if (mailbox.isPresent()) {
                 subscriptionManager.subscribe(mailboxSession, mailboxPath.getName());
                 builder.created(mailboxCreationId, mailbox.get());

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMailboxesCreationProcessor.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMailboxesCreationProcessor.java
@@ -46,6 +46,7 @@ import org.apache.james.mailbox.exception.TooLongMailboxNameException;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxId.Factory;
 import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.util.OptionalConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,10 +105,11 @@ public class SetMailboxesCreationProcessor implements SetMailboxesProcessor {
         try {
             ensureValidMailboxName(mailboxRequest, mailboxSession);
             MailboxPath mailboxPath = getMailboxPath(mailboxRequest, creationIdsToCreatedMailboxId, mailboxSession);
-            mailboxManager.createMailbox(mailboxPath, mailboxSession);
-            subscriptionManager.subscribe(mailboxSession, mailboxPath.getName());
-            Optional<Mailbox> mailbox = mailboxFactory.fromMailboxPath(mailboxPath, mailboxSession);
+            Optional<MailboxId> mailboxId = OptionalConverter.fromGuava(mailboxManager.createMailbox(mailboxPath, mailboxSession));
+            Optional<Mailbox> mailbox = mailboxId.map(id -> mailboxFactory.fromMailboxId(id, mailboxSession))
+                .orElseGet(Optional::empty);
             if (mailbox.isPresent()) {
+                subscriptionManager.subscribe(mailboxSession, mailboxPath.getName());
                 builder.created(mailboxCreationId, mailbox.get());
                 creationIdsToCreatedMailboxId.put(mailboxCreationId, mailbox.get().getId());
             } else {

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMailboxesCreationProcessor.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMailboxesCreationProcessor.java
@@ -106,8 +106,7 @@ public class SetMailboxesCreationProcessor implements SetMailboxesProcessor {
             ensureValidMailboxName(mailboxRequest, mailboxSession);
             MailboxPath mailboxPath = getMailboxPath(mailboxRequest, creationIdsToCreatedMailboxId, mailboxSession);
             Optional<MailboxId> mailboxId = OptionalConverter.fromGuava(mailboxManager.createMailbox(mailboxPath, mailboxSession));
-            Optional<Mailbox> mailbox = mailboxId.map(id -> mailboxFactory.fromMailboxId(id, mailboxSession))
-                .orElseGet(Optional::empty);
+            Optional<Mailbox> mailbox = mailboxId.flatMap(id -> mailboxFactory.fromMailboxId(id, mailboxSession));
             if (mailbox.isPresent()) {
                 subscriptionManager.subscribe(mailboxSession, mailboxPath.getName());
                 builder.created(mailboxCreationId, mailbox.get());

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMailboxesDestructionProcessor.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMailboxesDestructionProcessor.java
@@ -86,7 +86,10 @@ public class SetMailboxesDestructionProcessor implements SetMailboxesProcessor {
     private ImmutableMap<MailboxId, Mailbox> mapDestroyRequests(SetMailboxesRequest request, MailboxSession mailboxSession) {
         ImmutableMap.Builder<MailboxId, Mailbox> idToMailboxBuilder = ImmutableMap.builder(); 
         request.getDestroy().stream()
-            .map(id -> mailboxFactory.fromMailboxId(id, mailboxSession))
+            .map(id -> mailboxFactory.builder()
+                    .id(id)
+                    .session(mailboxSession)
+                    .build())
             .filter(Optional::isPresent)
             .map(Optional::get)
             .forEach(mailbox -> idToMailboxBuilder.put(mailbox.getId(), mailbox));

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMailboxesUpdateProcessor.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMailboxesUpdateProcessor.java
@@ -138,7 +138,10 @@ public class SetMailboxesUpdateProcessor implements SetMailboxesProcessor {
     }
 
     private Mailbox getMailbox(MailboxId mailboxId, MailboxSession mailboxSession) throws MailboxNotFoundException {
-        return mailboxFactory.fromMailboxId(mailboxId, mailboxSession)
+        return mailboxFactory.builder()
+                .id(mailboxId)
+                .session(mailboxSession)
+                .build()
                 .orElseThrow(() -> new MailboxNotFoundException(mailboxId.serialize()));
     }
 

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/MailboxFactory.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/MailboxFactory.java
@@ -30,7 +30,9 @@ import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MailboxMetaData;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,13 +72,14 @@ public class MailboxFactory {
     private Optional<Mailbox> fromMessageManager(MessageManager messageManager, MailboxSession mailboxSession) throws MailboxException {
         MailboxPath mailboxPath = messageManager.getMailboxPath();
         Optional<Role> role = Role.from(mailboxPath.getName());
+        MailboxCounters mailboxCounters = messageManager.getMailboxCounters(mailboxSession);
         return Optional.ofNullable(Mailbox.builder()
                 .id(messageManager.getId())
                 .name(getName(mailboxPath, mailboxSession))
                 .parentId(getParentIdFromMailboxPath(mailboxPath, mailboxSession).orElse(null))
                 .role(role)
-                .unreadMessages(messageManager.getUnseenMessageCount(mailboxSession))
-                .totalMessages(messageManager.getMessageCount(mailboxSession))
+                .unreadMessages(mailboxCounters.getUnseen())
+                .totalMessages(mailboxCounters.getCount())
                 .sortOrder(SortOrder.getSortOrder(role))
                 .build());
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/MailboxFactory.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/MailboxFactory.java
@@ -34,30 +34,16 @@ import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxMetaData;
 import org.apache.james.mailbox.model.MailboxPath;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 
 public class MailboxFactory {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MailboxFactory.class);
-
     private final MailboxManager mailboxManager;
 
     @Inject
     public MailboxFactory(MailboxManager mailboxManager) {
         this.mailboxManager = mailboxManager;
-    }
-    
-    public Optional<Mailbox> fromMailboxPath(MailboxPath mailboxPath, MailboxSession mailboxSession) {
-        try {
-            MessageManager mailbox = mailboxManager.getMailbox(mailboxPath, mailboxSession);
-            return fromMessageManager(mailbox, Optional.empty(), mailboxSession);
-        } catch (MailboxException e) {
-            LOGGER.warn("Cannot find mailbox for: " + mailboxPath.getName(), e);
-            return Optional.empty();
-        }
     }
 
     public Optional<Mailbox> fromMailboxId(MailboxId mailboxId, MailboxSession mailboxSession) {

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/DefaultMailboxesProvisioningFilterThreadTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/DefaultMailboxesProvisioningFilterThreadTest.java
@@ -22,6 +22,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.james.mailbox.MailboxListener;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
@@ -42,9 +43,11 @@ import org.apache.james.mailbox.model.MailboxQuery;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.MultimailboxesSearchQuery;
+import org.apache.james.mailbox.model.TestId;
 import org.junit.Test;
 import org.slf4j.Logger;
 
+import com.google.common.base.Optional;
 import com.google.testing.threadtester.AnnotatedTestRunner;
 import com.google.testing.threadtester.ThreadedAfter;
 import com.google.testing.threadtester.ThreadedBefore;
@@ -137,7 +140,8 @@ public class DefaultMailboxesProvisioningFilterThreadTest {
         }
 
         @Override
-        public void createMailbox(MailboxPath mailboxPath, MailboxSession mailboxSession) throws MailboxException {
+        public Optional<MailboxId> createMailbox(MailboxPath mailboxPath, MailboxSession mailboxSession) throws MailboxException {
+            return Optional.of(TestId.of(18L));
         }
 
         @Override

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/SetMailboxesUpdateProcessorTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/methods/SetMailboxesUpdateProcessorTest.java
@@ -20,7 +20,10 @@
 package org.apache.james.jmap.methods;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.mockito.Mockito;
 

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/MailboxFactoryTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/MailboxFactoryTest.java
@@ -75,24 +75,6 @@ public class MailboxFactoryTest {
     }
 
     @Test
-    public void mailboxFromMailboxPathShouldReturnNotEmptyWhenMailboxExists() throws Exception {
-        MailboxPath mailboxPath = new MailboxPath("#private", user, "mailbox");
-        mailboxManager.createMailbox(mailboxPath, mailboxSession);
-
-        Optional<Mailbox> optionalMailbox = sut.fromMailboxPath(mailboxPath, mailboxSession);
-        assertThat(optionalMailbox).isPresent();
-    }
-
-    @Test
-    public void mailboxFromMailboxPathShouldReturnEmptyWhenMailboxDoesntExist() throws Exception {
-        MailboxPath mailboxPath = new MailboxPath("#private", user, "mailbox");
-
-        Optional<Mailbox> optionalMailbox = sut.fromMailboxPath(mailboxPath, mailboxSession);
-        assertThat(optionalMailbox).isEmpty();
-    }
-
-
-    @Test
     public void getNameShouldReturnMailboxNameWhenRootMailbox() throws Exception {
         String expected = "mailbox";
         MailboxPath mailboxPath = new MailboxPath("#private", user, expected);

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/MailboxFactoryTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/MailboxFactoryTest.java
@@ -59,7 +59,11 @@ public class MailboxFactoryTest {
 
     @Test
     public void mailboxFromMailboxIdShouldReturnAbsentWhenDoesntExist() throws Exception {
-        Optional<Mailbox> mailbox = sut.fromMailboxId(InMemoryId.of(123), mailboxSession);
+        Optional<Mailbox> mailbox = sut.builder()
+                .id(InMemoryId.of(123))
+                .session(mailboxSession)
+                .build();
+
         assertThat(mailbox).isEmpty();
     }
 
@@ -69,7 +73,11 @@ public class MailboxFactoryTest {
         mailboxManager.createMailbox(mailboxPath, mailboxSession);
         MailboxId mailboxId = mailboxManager.getMailbox(mailboxPath, mailboxSession).getId();
 
-        Optional<Mailbox> mailbox = sut.fromMailboxId(mailboxId, mailboxSession);
+        Optional<Mailbox> mailbox = sut.builder()
+                .id(mailboxId)
+                .session(mailboxSession)
+                .build();
+
         assertThat(mailbox).isPresent();
         assertThat(mailbox.get().getId()).isEqualTo(mailboxId);
     }


### PR DESCRIPTION
This PR aims at minimising the number of calls to an external DB. Thus : 
 - We can retrieve all mailboxCounters once as they are collocated on the same row
 - We can avoid a read per mailboxes for GetMailboxes as we can retrieve parentId from context

Then (not related to @ddolcimascolo complains bu still cool IMO ) : 
 - Avoid a read on an index by making MailboxManager::save return the MailboxId. This cleans the code of MailboxFactory btw. I provide more tests to be confident with the code of MailboxPath.