### PR TITLE
James 1925 Self healing reads in Cassandra to avoid duplication

### DIFF
--- a/mailbox/cassandra/pom.xml
+++ b/mailbox/cassandra/pom.xml
@@ -201,6 +201,11 @@
                     <type>test-jar</type>
                 </dependency>
                 <dependency>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>james-server-util</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
                     <groupId>com.datastax.cassandra</groupId>
                     <artifactId>cassandra-driver-core</artifactId>
                     <version>${cassandra-driver-core.version}</version>

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxManager.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxManager.java
@@ -123,4 +123,10 @@ public class CassandraMailboxManager extends StoreMailboxManager {
             getMessageIdFactory());
     }
 
+    @Override
+    public void createMailbox(MailboxPath mailboxPath, MailboxSession mailboxSession) throws MailboxException {
+        super.createMailbox(mailboxPath, mailboxSession);
+        // Heal potential mailbox duplication
+        getMailbox(mailboxPath, mailboxSession);
+    }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
@@ -1,0 +1,73 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.init.CassandraModuleComposite;
+import org.apache.james.mailbox.cassandra.modules.CassandraAclModule;
+import org.apache.james.mailbox.cassandra.modules.CassandraMailboxModule;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailbox;
+import org.apache.james.util.concurrency.ConcurrentTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+public class CassandraMailboxMapperConcurrencyTest {
+
+    public static final int MAX_RETRY = 10;
+    public static final int UID_VALIDITY = 52;
+    public static final MailboxPath MAILBOX_PATH = new MailboxPath("#private", "user", "name");
+    private CassandraCluster cassandra;
+    private CassandraMailboxMapper testee;
+
+    @Before
+    public void setUp() {
+        cassandra = CassandraCluster.create(new CassandraModuleComposite(new CassandraMailboxModule(), new CassandraAclModule()));
+        cassandra.ensureAllTables();
+
+        testee = new CassandraMailboxMapper(cassandra.getConf(), cassandra.getTypesProvider(), MAX_RETRY);
+    }
+
+    @Test
+    public void findMailboxByPathShouldAlsoRemoveDuplicatedMailboxes() throws Exception {
+        testee.save(new SimpleMailbox(MAILBOX_PATH, UID_VALIDITY));
+        testee.save(new SimpleMailbox(MAILBOX_PATH, UID_VALIDITY));
+        boolean termination = new ConcurrentTestRunner(10, 1,
+            (a, b) -> {
+                // several writes before self healed read
+                // this maximize probability to mix read and writes
+                testee.save(new SimpleMailbox(MAILBOX_PATH, UID_VALIDITY));
+                testee.save(new SimpleMailbox(MAILBOX_PATH, UID_VALIDITY));
+                testee.save(new SimpleMailbox(MAILBOX_PATH, UID_VALIDITY));
+                testee.save(new SimpleMailbox(MAILBOX_PATH, UID_VALIDITY));
+                testee.save(new SimpleMailbox(MAILBOX_PATH, UID_VALIDITY));
+                testee.findMailboxByPath(MAILBOX_PATH);
+            }).run()
+            .awaitTermination(1, TimeUnit.MINUTES);
+
+        assertThat(termination).isTrue();
+        assertThat(testee.list()).hasSize(1);
+    }
+
+
+}

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/CassandraUserProvisionningConcurrencyTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/CassandraUserProvisionningConcurrencyTest.java
@@ -1,0 +1,36 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ * http://www.apache.org/licenses/LICENSE-2.0                   *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.cassandra;
+
+import org.apache.james.CassandraJmapTestRule;
+import org.apache.james.JmapJamesServer;
+import org.apache.james.jmap.UserProvisionningConcurrencyTest;
+import org.junit.Rule;
+
+public class CassandraUserProvisionningConcurrencyTest extends UserProvisionningConcurrencyTest {
+    @Rule
+    public CassandraJmapTestRule rule = CassandraJmapTestRule.defaultTestRule();
+
+    @Override
+    protected JmapJamesServer createJmapServer() {
+        return rule.jmapServer();
+    }
+
+}

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/UserProvisionningConcurrencyTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/UserProvisionningConcurrencyTest.java
@@ -1,0 +1,108 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ * http://www.apache.org/licenses/LICENSE-2.0                   *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap;
+
+import static com.jayway.restassured.RestAssured.given;
+import static com.jayway.restassured.RestAssured.with;
+import static com.jayway.restassured.config.EncoderConfig.encoderConfig;
+import static com.jayway.restassured.config.RestAssuredConfig.newConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.james.JmapJamesServer;
+import org.apache.james.util.concurrency.ConcurrentTestRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.base.Charsets;
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.builder.RequestSpecBuilder;
+
+public abstract class UserProvisionningConcurrencyTest {
+    private static final String NAME = "[0][0]";
+    private static final String ARGUMENTS = "[0][1]";
+    private static final String DOMAIN = "mydomain.tld";
+    private static final String USER = "myuser@" + DOMAIN;
+    private static final String PASSWORD = "secret";
+    protected abstract JmapJamesServer createJmapServer();
+
+    private JmapJamesServer jmapServer;
+
+    @Before
+    public void setup() throws Throwable {
+        jmapServer = createJmapServer();
+        jmapServer.start();
+        RestAssured.requestSpecification = new RequestSpecBuilder()
+            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+            .setPort(jmapServer.getJmapProbe()
+                .getJmapPort())
+            .build();
+
+        jmapServer.serverProbe().addDomain(DOMAIN);
+        jmapServer.serverProbe().addUser(USER, PASSWORD);
+    }
+
+    @After
+    public void teardown() {
+        jmapServer.stop();
+    }
+
+    @Test
+    public void provisionMailboxesShouldNotDuplicateMailboxByName() throws Exception {
+        String token = HttpJmapAuthentication.authenticateJamesUser(baseUri(), USER, PASSWORD).serialize();
+
+        boolean termination = new ConcurrentTestRunner(10, 1,
+            (a, b) -> with()
+                .header("Authorization", token)
+                .body("[[\"getMailboxes\", {}, \"#0\"]]")
+                .post("/jmap"))
+            .run()
+            .awaitTermination(1, TimeUnit.MINUTES);
+
+        assertThat(termination).isTrue();
+
+        given()
+            .header("Authorization", token)
+            .body("[[\"getMailboxes\", {}, \"#0\"]]")
+        .when()
+            .post("/jmap")
+        .then()
+            .statusCode(200)
+            .body(NAME, equalTo("mailboxes"))
+            .body(ARGUMENTS + ".list", hasSize(5))
+            .body(ARGUMENTS + ".list.name", hasItems(DefaultMailboxes.DEFAULT_MAILBOXES.toArray()));
+
+    }
+
+    private URIBuilder baseUri() {
+        return new URIBuilder()
+            .setScheme("http")
+            .setHost("localhost")
+            .setPort(jmapServer.getJmapProbe()
+                .getJmapPort())
+            .setCharset(Charsets.UTF_8);
+    }
+}

--- a/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/java/org/apache/james/jmap/memory/MemoryUserProvisionningConcurrencyTest.java
+++ b/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/java/org/apache/james/jmap/memory/MemoryUserProvisionningConcurrencyTest.java
@@ -1,0 +1,35 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ * http://www.apache.org/licenses/LICENSE-2.0                   *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.memory;
+
+import org.apache.james.JmapJamesServer;
+import org.apache.james.MemoryJmapTestRule;
+import org.apache.james.jmap.UserProvisionningConcurrencyTest;
+import org.junit.Rule;
+
+public class MemoryUserProvisionningConcurrencyTest extends UserProvisionningConcurrencyTest {
+    @Rule
+    public MemoryJmapTestRule memoryJmap = new MemoryJmapTestRule();
+
+    @Override
+    protected JmapJamesServer createJmapServer() {
+        return memoryJmap.jmapServer();
+    }
+}


### PR DESCRIPTION
I believe this is a "Eventual Consistency" friendly way to handle this.

@quynhn will add integration tests for this on the JMAP layer

Test to be added : details :

 - UserProvisionningConcurrencyTest in jmap-integration-tests, with in-memory and cassandra implems
 - Create a user via serverProbe
 - Issue 10 parrallels "GetMailboxes calls" that will trigger provisionning (ConcurrentTestRunner)
 - Ensure you only have the system mailboxes