### PR TITLE
Improving select perf : Play with fetchType (do not retrieve Attachments when not needed)

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
@@ -94,6 +94,9 @@ public class CassandraAttachmentMapper implements AttachmentMapper {
     @Override
     public List<Attachment> getAttachments(Collection<AttachmentId> attachmentIds) {
         Preconditions.checkArgument(attachmentIds != null);
+        if (attachmentIds.isEmpty()) {
+            return ImmutableList.of();
+        }
         List<String> ids = attachmentIds.stream()
                 .map(AttachmentId::getId)
                 .collect(Guavate.toImmutableList());

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -150,14 +150,20 @@ public class CassandraMessageMapper implements MessageMapper {
     }
 
     private Stream<SimpleMailboxMessage> retrieveMessages(List<ComposedMessageIdWithMetaData> messageIds, FetchType fetchType, Optional<Integer> limit) {
-        return messageDAO.retrieveMessages(messageIds, fetchType, limit).join()
-            .map(pair -> Pair.of(pair.getLeft(), new AttachmentLoader(attachmentMapper)
-                .getAttachments(pair.getRight()
-                    .collect(Guavate.toImmutableList()))))
-            .map(Throwing.function(pair -> pair.getLeft()
-                .toMailboxMessage(pair.getRight()
-                    .stream()
-                    .collect(Guavate.toImmutableList()))));
+        Stream<Pair<CassandraMessageDAO.MessageWithoutAttachment, Stream<CassandraMessageDAO.MessageAttachmentRepresentation>>>
+            messageRepresentions = messageDAO.retrieveMessages(messageIds, fetchType, limit).join();
+        if (fetchType == FetchType.Body || fetchType == FetchType.Full) {
+            return messageRepresentions
+                .map(pair -> Pair.of(pair.getLeft(), new AttachmentLoader(attachmentMapper)
+                    .getAttachments(pair.getRight()
+                        .collect(Guavate.toImmutableList()))))
+                .map(Throwing.function(pair -> pair.getLeft()
+                    .toMailboxMessage(pair.getRight()
+                        .stream()
+                        .collect(Guavate.toImmutableList()))));
+        } else {
+            return messageRepresentions.map(pair -> pair.getLeft().toMailboxMessage(ImmutableList.of()));
+        }
     }
 
     @Override


### PR DESCRIPTION
On Raphael dirty test, with 1.000 messages, reduce select time from 8.3 sec to 7.3 sec.

Improvement is stable and blattant enough to be fast validated.

(Avoid 1 query per attachment when no attachment, avoid fetching attachments upon select)