### PR TITLE
James 1945 chunker to overcome cassandra limitation

### DIFF
--- a/server/container/util-java8/src/main/java/org/apache/james/util/streams/JamesCollectors.java
+++ b/server/container/util-java8/src/main/java/org/apache/james/util/streams/JamesCollectors.java
@@ -1,0 +1,36 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.util.streams;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+import com.google.common.base.Preconditions;
+
+public class JamesCollectors {
+    public static <D> Collector<D, ?, Map<Integer, List<D>>> chunker(int chunkSize) {
+        Preconditions.checkArgument(chunkSize > 0, "ChunkSize should be strictly positive");
+        AtomicInteger counter = new AtomicInteger(-1);
+        return Collectors.groupingBy(x -> counter.incrementAndGet() / chunkSize);
+    }
+}

--- a/server/container/util-java8/src/test/java/org/apache/james/util/streams/JamesCollectorsTest.java
+++ b/server/container/util-java8/src/test/java/org/apache/james/util/streams/JamesCollectorsTest.java
@@ -1,0 +1,130 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.util.streams;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+
+public class JamesCollectorsTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void chunkerShouldAcceptEmptyStrem() {
+        Stream<Integer> emptyStream = Stream.of();
+
+        assertThat(emptyStream.collect(JamesCollectors.chunker(10)))
+            .isEmpty();
+    }
+
+    @Test
+    public void chunkerShouldThrowOnZeroChunkSize() {
+        expectedException.expect(IllegalArgumentException.class);
+
+        JamesCollectors.chunker(0);
+    }
+
+    @Test
+    public void chunkerShouldThrowOnNegativeChunkSize() {
+        expectedException.expect(IllegalArgumentException.class);
+
+        JamesCollectors.chunker(-1);
+    }
+
+    @Test
+    public void chunkerShouldChunkMonoValueStreams() {
+        Stream<Integer> emptyStream = Stream.of(1);
+
+        List<List<Integer>> values = emptyStream.collect(JamesCollectors.chunker(10))
+            .values()
+            .stream()
+            .map(ImmutableList::copyOf)
+            .collect(Guavate.toImmutableList());
+        assertThat(values)
+            .isEqualTo(ImmutableList.of(ImmutableList.of(1)));
+    }
+
+    @Test
+    public void chunkerShouldChunkStreamsSmallerThanChunkSize() {
+        Stream<Integer> emptyStream = Stream.of(1, 2);
+
+        List<List<Integer>> values = emptyStream.collect(JamesCollectors.chunker(3))
+            .values()
+            .stream()
+            .map(ImmutableList::copyOf)
+            .collect(Guavate.toImmutableList());
+        assertThat(values)
+            .isEqualTo(ImmutableList.of(ImmutableList.of(1, 2)));
+    }
+
+    @Test
+    public void chunkerShouldChunkStreamsAsBigAsChunkSize() {
+        Stream<Integer> emptyStream = Stream.of(1, 2, 3);
+
+        List<List<Integer>> values = emptyStream.collect(JamesCollectors.chunker(3))
+            .values()
+            .stream()
+            .map(ImmutableList::copyOf)
+            .collect(Guavate.toImmutableList());
+        assertThat(values)
+            .isEqualTo(ImmutableList.of(ImmutableList.of(1, 2, 3)));
+    }
+
+    @Test
+    public void chunkerShouldChunkStreamsBiggerThanChunkSize() {
+        Stream<Integer> emptyStream = Stream.of(1, 2, 3, 4);
+
+        List<List<Integer>> values = emptyStream.collect(JamesCollectors.chunker(3))
+            .values()
+            .stream()
+            .map(ImmutableList::copyOf)
+            .collect(Guavate.toImmutableList());
+        assertThat(values)
+            .isEqualTo(ImmutableList.of(
+                ImmutableList.of(1, 2, 3),
+                ImmutableList.of(4)));
+    }
+
+    @Test
+    public void chunkerShouldChunkInSeveralBuckets() {
+        Stream<Integer> emptyStream = Stream.of(1, 2, 3, 4, 5, 6, 7);
+
+        List<List<Integer>> values = emptyStream.collect(JamesCollectors.chunker(3))
+            .values()
+            .stream()
+            .map(ImmutableList::copyOf)
+            .collect(Guavate.toImmutableList());
+        assertThat(values)
+            .isEqualTo(ImmutableList.of(
+                ImmutableList.of(1, 2, 3),
+                ImmutableList.of(4, 5, 6),
+                ImmutableList.of(7)));
+    }
+}

--- a/server/container/util-java8/src/test/java/org/apache/james/util/streams/JamesCollectorsTest.java
+++ b/server/container/util-java8/src/test/java/org/apache/james/util/streams/JamesCollectorsTest.java
@@ -60,9 +60,9 @@ public class JamesCollectorsTest {
 
     @Test
     public void chunkerShouldChunkMonoValueStreams() {
-        Stream<Integer> emptyStream = Stream.of(1);
+        Stream<Integer> monoValueStream = Stream.of(1);
 
-        List<List<Integer>> values = emptyStream.collect(JamesCollectors.chunker(10))
+        List<List<Integer>> values = monoValueStream.collect(JamesCollectors.chunker(10))
             .values()
             .stream()
             .map(ImmutableList::copyOf)

--- a/server/container/util-java8/src/test/java/org/apache/james/util/streams/JamesCollectorsTest.java
+++ b/server/container/util-java8/src/test/java/org/apache/james/util/streams/JamesCollectorsTest.java
@@ -73,9 +73,9 @@ public class JamesCollectorsTest {
 
     @Test
     public void chunkerShouldChunkStreamsSmallerThanChunkSize() {
-        Stream<Integer> emptyStream = Stream.of(1, 2);
+        Stream<Integer> stream = Stream.of(1, 2);
 
-        List<List<Integer>> values = emptyStream.collect(JamesCollectors.chunker(3))
+        List<List<Integer>> values = stream.collect(JamesCollectors.chunker(3))
             .values()
             .stream()
             .map(ImmutableList::copyOf)
@@ -86,9 +86,9 @@ public class JamesCollectorsTest {
 
     @Test
     public void chunkerShouldChunkStreamsAsBigAsChunkSize() {
-        Stream<Integer> emptyStream = Stream.of(1, 2, 3);
+        Stream<Integer> stream = Stream.of(1, 2, 3);
 
-        List<List<Integer>> values = emptyStream.collect(JamesCollectors.chunker(3))
+        List<List<Integer>> values = stream.collect(JamesCollectors.chunker(3))
             .values()
             .stream()
             .map(ImmutableList::copyOf)
@@ -99,9 +99,9 @@ public class JamesCollectorsTest {
 
     @Test
     public void chunkerShouldChunkStreamsBiggerThanChunkSize() {
-        Stream<Integer> emptyStream = Stream.of(1, 2, 3, 4);
+        Stream<Integer> stream = Stream.of(1, 2, 3, 4);
 
-        List<List<Integer>> values = emptyStream.collect(JamesCollectors.chunker(3))
+        List<List<Integer>> values = stream.collect(JamesCollectors.chunker(3))
             .values()
             .stream()
             .map(ImmutableList::copyOf)
@@ -114,9 +114,9 @@ public class JamesCollectorsTest {
 
     @Test
     public void chunkerShouldChunkInSeveralBuckets() {
-        Stream<Integer> emptyStream = Stream.of(1, 2, 3, 4, 5, 6, 7);
+        Stream<Integer> stream = Stream.of(1, 2, 3, 4, 5, 6, 7);
 
-        List<List<Integer>> values = emptyStream.collect(JamesCollectors.chunker(3))
+        List<List<Integer>> values = stream.collect(JamesCollectors.chunker(3))
             .values()
             .stream()
             .map(ImmutableList::copyOf)


### PR DESCRIPTION
As mentionned in the chat : 

```
    @Test
    public void tooLargeInClauseAreFailing() {
        ImmutableList<Integer> clusterings = IntStream.range(0, 66000)
            .boxed().collect(Guavate.toImmutableList());

        select().from(TABLE_NAME)
            .where(eq(ID, UUID))
            .and(in(CLUSTERING, clusterings));
    }
```
Is raising : 
```
java.lang.IllegalArgumentException: Too many values for IN clause, the maximum allowed is 65535
```