### PR TITLE
James 1891 Update ActiveMQ + use inMemory for testing

### DIFF
--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/JamesCapabilitiesServerTest.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/JamesCapabilitiesServerTest.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.EnumSet;
 
+import org.apache.activemq.store.PersistenceAdapter;
+import org.apache.activemq.store.memory.MemoryPersistenceAdapter;
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.es.EmbeddedElasticSearch;
@@ -64,6 +66,7 @@ public class JamesCapabilitiesServerTest {
         
         return new GuiceJamesServerImpl()
             .combineWith(CassandraJamesServerMain.cassandraServerModule)
+            .overrideWith((binder) -> binder.bind(PersistenceAdapter.class).to(MemoryPersistenceAdapter.class))
             .overrideWith(new TestElasticSearchModule(embeddedElasticSearch),
                 new TestFilesystemModule(temporaryFolder),
                 new TestJMAPServerModule(GetMessageListMethod.DEFAULT_MAXIMUM_LIMIT),

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/modules/server/ActiveMQQueueModule.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/modules/server/ActiveMQQueueModule.java
@@ -21,7 +21,10 @@ package org.apache.james.modules.server;
 
 import javax.jms.ConnectionFactory;
 
+import org.apache.activemq.store.PersistenceAdapter;
+import org.apache.activemq.store.kahadb.KahaDBPersistenceAdapter;
 import org.apache.james.queue.activemq.ActiveMQMailQueueFactory;
+import org.apache.james.queue.activemq.EmbeddedActiveMQ;
 import org.apache.james.queue.api.MailQueueFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +40,8 @@ public class ActiveMQQueueModule extends AbstractModule {
     
     @Override
     protected void configure() {
+        bind(PersistenceAdapter.class).to(KahaDBPersistenceAdapter.class);
+        bind(KahaDBPersistenceAdapter.class).in(Scopes.SINGLETON);
         bind(EmbeddedActiveMQ.class).in(Scopes.SINGLETON);
     }
     

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/modules/server/EmbeddedActiveMQ.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/modules/server/EmbeddedActiveMQ.java
@@ -29,7 +29,7 @@ import org.apache.activemq.broker.BrokerPlugin;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.jmx.ManagementContext;
 import org.apache.activemq.plugin.StatisticsBrokerPlugin;
-import org.apache.activemq.store.amq.AMQPersistenceAdapter;
+import org.apache.activemq.store.kahadb.KahaDBPersistenceAdapter;
 import org.apache.james.filesystem.api.FileSystem;
 import org.apache.james.queue.activemq.FileSystemBlobTransferPolicy;
 
@@ -94,7 +94,7 @@ public class EmbeddedActiveMQ {
         ManagementContext managementContext = new ManagementContext();
         managementContext.setCreateConnector(false);
         brokerService.setManagementContext(managementContext);
-        brokerService.setPersistenceAdapter(new AMQPersistenceAdapter());
+        brokerService.setPersistenceAdapter(new KahaDBPersistenceAdapter());
         BrokerPlugin[] brokerPlugins = {new StatisticsBrokerPlugin()};
         brokerService.setPlugins(brokerPlugins);
         String[] transportConnectorsURIs = {"tcp://localhost:0"};

--- a/server/container/guice/memory-guice/src/test/java/org/apache/james/MemoryJmapTestRule.java
+++ b/server/container/guice/memory-guice/src/test/java/org/apache/james/MemoryJmapTestRule.java
@@ -19,6 +19,8 @@
 
 package org.apache.james;
 
+import org.apache.activemq.store.PersistenceAdapter;
+import org.apache.activemq.store.memory.MemoryPersistenceAdapter;
 import org.apache.james.modules.TestFilesystemModule;
 import org.apache.james.modules.TestJMAPServerModule;
 import org.junit.rules.TemporaryFolder;
@@ -36,7 +38,8 @@ public class MemoryJmapTestRule implements TestRule {
         return new JmapJamesServer()
                 .combineWith(MemoryJamesServerMain.inMemoryServerModule)
                 .overrideWith(new TestFilesystemModule(temporaryFolder),
-                        new TestJMAPServerModule(LIMIT_TO_3_MESSAGES));
+                        new TestJMAPServerModule(LIMIT_TO_3_MESSAGES))
+                .overrideWith((binder) -> binder.bind(PersistenceAdapter.class).to(MemoryPersistenceAdapter.class));
     }
 
     @Override

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/TemporaryJamesServer.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/TemporaryJamesServer.java
@@ -26,6 +26,8 @@ import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
+import org.apache.activemq.store.PersistenceAdapter;
+import org.apache.activemq.store.memory.MemoryPersistenceAdapter;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.IOUtils;
 import org.apache.james.JmapJamesServer;
@@ -52,6 +54,7 @@ public class TemporaryJamesServer {
 
         jamesServer = new JmapJamesServer()
             .combineWith(MemoryJamesServerMain.inMemoryServerModule)
+            .overrideWith((binder) -> binder.bind(PersistenceAdapter.class).to(MemoryPersistenceAdapter.class))
             .overrideWith(ImmutableList.<Module>builder().addAll(Arrays.asList(additionalModules))
                 .add(new TestJMAPServerModule(LIMIT_TO_3_MESSAGES))
                 .add(new TemporaryFilesystemModule(temporaryFolder))

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -123,7 +123,7 @@
     <properties>
         <productName>Apache-James Mail Server</productName>
 
-        <activemq.version>5.7.0</activemq.version>
+        <activemq.version>5.10.2</activemq.version>
         <apache-mime4j.version>0.8.0</apache-mime4j.version>
         <camel.version>2.13.4</camel.version>
         <derby.version>10.9.1.0</derby.version>
@@ -1304,7 +1304,7 @@
 
             <dependency>
                 <groupId>org.apache.activemq</groupId>
-                <artifactId>activemq-core</artifactId>
+                <artifactId>activemq-broker</artifactId>
                 <version>${activemq.version}</version>
                 <exclusions>
                     <exclusion>

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraStepdefs.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraStepdefs.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 
 import javax.inject.Inject;
 
+import org.apache.activemq.store.PersistenceAdapter;
+import org.apache.activemq.store.memory.MemoryPersistenceAdapter;
 import org.apache.james.CassandraJamesServerMain;
 import org.apache.james.JmapJamesServer;
 import org.apache.james.backends.cassandra.EmbeddedCassandra;
@@ -59,7 +61,8 @@ public class CassandraStepdefs {
         mainStepdefs.messageIdFactory = new CassandraMessageId.Factory();
         mainStepdefs.jmapServer = new JmapJamesServer()
                 .combineWith(CassandraJamesServerMain.cassandraServerModule)
-                .overrideWith(new CassandraJmapServerModule(temporaryFolder, embeddedElasticSearch, cassandra));
+                .overrideWith(new CassandraJmapServerModule(temporaryFolder, embeddedElasticSearch, cassandra))
+                .overrideWith((binder) -> binder.bind(PersistenceAdapter.class).to(MemoryPersistenceAdapter.class));
         mainStepdefs.awaitMethod = () -> embeddedElasticSearch.awaitForElasticSearch();
         mainStepdefs.init();
     }

--- a/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/java/org/apache/james/jmap/memory/cucumber/MemoryStepdefs.java
+++ b/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/java/org/apache/james/jmap/memory/cucumber/MemoryStepdefs.java
@@ -21,6 +21,8 @@ package org.apache.james.jmap.memory.cucumber;
 
 import javax.inject.Inject;
 
+import org.apache.activemq.store.PersistenceAdapter;
+import org.apache.activemq.store.memory.MemoryPersistenceAdapter;
 import org.apache.james.JmapJamesServer;
 import org.apache.james.MemoryJamesServerMain;
 import org.apache.james.jmap.methods.integration.cucumber.MainStepdefs;
@@ -52,7 +54,8 @@ public class MemoryStepdefs {
         mainStepdefs.jmapServer = new JmapJamesServer()
                 .combineWith(MemoryJamesServerMain.inMemoryServerModule)
                 .overrideWith(new MemoryJmapServerModule(temporaryFolder),
-                		(binder) -> binder.bind(MessageId.Factory.class).toInstance(mainStepdefs.messageIdFactory));
+                		(binder) -> binder.bind(MessageId.Factory.class).toInstance(mainStepdefs.messageIdFactory))
+                .overrideWith((binder) -> binder.bind(PersistenceAdapter.class).to(MemoryPersistenceAdapter.class));
         mainStepdefs.init();
     }
 

--- a/server/queue/queue-activemq/pom.xml
+++ b/server/queue/queue-activemq/pom.xml
@@ -55,8 +55,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
-            <artifactId>activemq-core</artifactId>
+            <artifactId>activemq-broker</artifactId>
         </dependency>
+        <dependency>
+          <groupId>org.apache.activemq</groupId>
+          <artifactId>activemq-kahadb-store</artifactId>
+          <version>${activemq.version}</version>
+	</dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jms</artifactId>

--- a/server/queue/queue-activemq/pom.xml
+++ b/server/queue/queue-activemq/pom.xml
@@ -61,7 +61,12 @@
           <groupId>org.apache.activemq</groupId>
           <artifactId>activemq-kahadb-store</artifactId>
           <version>${activemq.version}</version>
-	</dependency>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.activemq</groupId>
+          <artifactId>activemq-spring</artifactId>
+          <version>${activemq.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jms</artifactId>

--- a/server/queue/queue-activemq/src/main/java/org/apache/james/queue/activemq/ActiveMQMailQueueFactory.java
+++ b/server/queue/queue-activemq/src/main/java/org/apache/james/queue/activemq/ActiveMQMailQueueFactory.java
@@ -35,9 +35,13 @@ public class ActiveMQMailQueueFactory extends JMSMailQueueFactory {
 
     private boolean useBlob = true;
 
-    @Inject
     public ActiveMQMailQueueFactory(ConnectionFactory connectionFactory, MailQueueItemDecoratorFactory mailQueueItemDecoratorFactory, MetricFactory metricFactory) {
         super(connectionFactory, mailQueueItemDecoratorFactory, metricFactory);
+    }
+
+    @Inject
+    public ActiveMQMailQueueFactory(EmbeddedActiveMQ embeddedActiveMQ, MailQueueItemDecoratorFactory mailQueueItemDecoratorFactory, MetricFactory metricFactory) {
+        this(embeddedActiveMQ.getConnectionFactory(), mailQueueItemDecoratorFactory, metricFactory);
     }
 
     public void setUseBlobMessages(boolean useBlob) {

--- a/server/queue/queue-activemq/src/main/java/org/apache/james/queue/activemq/EmbeddedActiveMQ.java
+++ b/server/queue/queue-activemq/src/main/java/org/apache/james/queue/activemq/EmbeddedActiveMQ.java
@@ -17,9 +17,10 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.modules.server;
+package org.apache.james.queue.activemq;
 
 import javax.annotation.PreDestroy;
+import javax.inject.Inject;
 import javax.jms.ConnectionFactory;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
@@ -29,19 +30,20 @@ import org.apache.activemq.broker.BrokerPlugin;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.jmx.ManagementContext;
 import org.apache.activemq.plugin.StatisticsBrokerPlugin;
-import org.apache.activemq.store.kahadb.KahaDBPersistenceAdapter;
+import org.apache.activemq.store.PersistenceAdapter;
 import org.apache.james.filesystem.api.FileSystem;
-import org.apache.james.queue.activemq.FileSystemBlobTransferPolicy;
 
 import com.google.common.base.Throwables;
-import com.google.inject.Inject;
 
 public class EmbeddedActiveMQ {
 
     private final ActiveMQConnectionFactory activeMQConnectionFactory;
+    private final PersistenceAdapter persistenceAdapter;
     private BrokerService brokerService;
 
-    @Inject private EmbeddedActiveMQ(FileSystem fileSystem) {
+    @Inject
+        private EmbeddedActiveMQ(FileSystem fileSystem, PersistenceAdapter persistenceAdapter) {
+        this.persistenceAdapter = persistenceAdapter;
         try {
             launchEmbeddedBroker(fileSystem);
         } catch (Exception e) {
@@ -94,7 +96,7 @@ public class EmbeddedActiveMQ {
         ManagementContext managementContext = new ManagementContext();
         managementContext.setCreateConnector(false);
         brokerService.setManagementContext(managementContext);
-        brokerService.setPersistenceAdapter(new KahaDBPersistenceAdapter());
+        brokerService.setPersistenceAdapter(persistenceAdapter);
         BrokerPlugin[] brokerPlugins = {new StatisticsBrokerPlugin()};
         brokerService.setPlugins(brokerPlugins);
         String[] transportConnectorsURIs = {"tcp://localhost:0"};

--- a/server/queue/queue-activemq/src/main/resources/META-INF/spring/activemq-queue-context.xml
+++ b/server/queue/queue-activemq/src/main/resources/META-INF/spring/activemq-queue-context.xml
@@ -52,7 +52,7 @@
             <amq:managementContext createConnector="false"/>
         </amq:managementContext>
         <amq:persistenceAdapter>
-            <amq:amqPersistenceAdapter/>
+            <amq:kahaDB/>
         </amq:persistenceAdapter>
         <amq:plugins>
             <amq:statisticsBrokerPlugin/>

--- a/server/queue/queue-activemq/src/main/resources/META-INF/spring/activemq-queue-context.xml
+++ b/server/queue/queue-activemq/src/main/resources/META-INF/spring/activemq-queue-context.xml
@@ -17,77 +17,22 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:amq="http://activemq.apache.org/schema/core"
-       xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-         http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-         http://activemq.apache.org/schema/core
-         http://activemq.apache.org/schema/core/activemq-core.xsd
-         http://www.springframework.org/schema/util
-         http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+         http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
     <!-- James Mail Queue Factory -->
-    <bean id="mailqueuefactory" class="org.apache.james.queue.activemq.ActiveMQMailQueueFactory" depends-on="broker">
-        <constructor-arg index="0" ref="jmsConnectionFactory"/>
+    <bean id="mailqueuefactory" class="org.apache.james.queue.activemq.ActiveMQMailQueueFactory">
+        <constructor-arg index="0" ref="embeddedActiveMQ"/>
         <constructor-arg index="1" ref="rawMailQueueItemDecoratorFactory"/>
         <constructor-arg index="2" ref="metricFactory"/>
     </bean>
 
-    <!-- 
-      ActiveMQ Broker, Connections, Blob
-     -->
-    <amq:broker useJmx="true" persistent="true" brokerName="james"
-                dataDirectory="filesystem=file://var/store/activemq/brokers"
-                useShutdownHook="false" schedulerSupport="false" id="broker">
-        <amq:destinationPolicy>
-            <amq:policyMap>
-                <amq:policyEntries>
-                    <!-- Support priority handling of messages -->
-                    <!-- http://activemq.apache.org/how-can-i-support-priority-queues.html -->
-                    <amq:policyEntry queue=">" prioritizedMessages="true"/>
-                </amq:policyEntries>
-            </amq:policyMap>
-        </amq:destinationPolicy>
-        <amq:managementContext>
-            <amq:managementContext createConnector="false"/>
-        </amq:managementContext>
-        <amq:persistenceAdapter>
-            <amq:kahaDB/>
-        </amq:persistenceAdapter>
-        <amq:plugins>
-            <amq:statisticsBrokerPlugin/>
-        </amq:plugins>
-        <amq:transportConnectors>
-            <amq:transportConnector uri="tcp://localhost:0"/>
-        </amq:transportConnectors>
-    </amq:broker>
+    <bean id="rawMailQueueItemDecoratorFactory" class="org.apache.james.queue.api.RawMailQueueItemDecoratorFactory"/>
 
-    <amq:connectionFactory id="amqConnectionFactory" brokerURL="vm://james?create=false">
-        <amq:prefetchPolicy>
-            <!-- Disable prefetch so slow consuming can not block other threads -->
-            <!-- See JAMES-1253 -->
-            <amq:prefetchPolicy queuePrefetch="0" topicPrefetch="0"/>
-        </amq:prefetchPolicy>
-        <property name="blobTransferPolicy" ref="blobTransferPolicy"/>
-    </amq:connectionFactory>
-
-    <bean id="blobTransferPolicy" class="org.apache.james.queue.activemq.FileSystemBlobTransferPolicy"
-          autowire="byName">
-        <property name="defaultUploadUrl" value="file://var/store/activemq/blob-transfer"/>
+    <bean id="embeddedActiveMQ" class="org.apache.james.queue.activemq.EmbeddedActiveMQ">
+        <constructor-arg index="0" ref="filesystem"/>
+        <constructor-arg index="1" ref="persistenceAdapter"/>
     </bean>
 
-    <bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
-        <property name="targetConnectionFactory" ref="amqConnectionFactory"/>
-        <property name="sessionCacheSize" value="10"/>
-        <property name="cacheConsumers" value="false"/>
-        <property name="cacheProducers" value="true"/>
-    </bean>
-
-    <bean id="jmsTransactionManager" class="org.springframework.jms.connection.JmsTransactionManager">
-        <property name="connectionFactory" ref="jmsConnectionFactory"/>
-    </bean>
-
-    <bean id="rawMailQueueItemDecoratorFactory" class="org.apache.james.queue.api.RawMailQueueItemDecoratorFactory">
-    </bean>
-
+    <bean id="persistenceAdapter" class="org.apache.activemq.store.kahadb.KahaDBPersistenceAdapter"/>
 </beans>

--- a/server/queue/queue-jms/pom.xml
+++ b/server/queue/queue-jms/pom.xml
@@ -95,7 +95,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
-            <artifactId>activemq-core</artifactId>
+            <artifactId>activemq-broker</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Maximal version working with Java-6 is 5.10

I also thinkit's time to drop the dark magic in Spring xml files and rely on things we can maintain. (I gave it 2 times a one day try, today, and straight after @mbaechler open the inital PRs)

I also experimented issues with Spring injections. Hence I used EmbeddedActiveMQ as default injection (no impact on Guice behaviour).

https://github.com/linagora/james-project/pull/514
https://github.com/linagora/james-project/pull/515
