### PR TITLE
JAMES-1957 Camel upgrade to 2.18.2

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -123,7 +123,7 @@
 
         <activemq.version>5.10.2</activemq.version>
         <apache-mime4j.version>0.8.0</apache-mime4j.version>
-        <camel.version>2.13.4</camel.version>
+        <camel.version>2.18.2</camel.version>
         <derby.version>10.9.1.0</derby.version>
         <hadoop.version>1.1.1</hadoop.version>
         <hbase.version>0.94.27</hbase.version>


### PR DESCRIPTION
With Memory mail queue and Camel 2.18.2 : 

![camel_18_1](https://cloud.githubusercontent.com/assets/6928740/23642027/ab0d6986-032a-11e7-8dc9-063cc8b2e272.png)

![camel_18_2](https://cloud.githubusercontent.com/assets/6928740/23642029/aef2ae12-032a-11e7-8690-745082bba22d.png)

But with memory mailqueue and Camel 2.13.4 : 

![camel_13_1](https://cloud.githubusercontent.com/assets/6928740/23642038/bf17c2a0-032a-11e7-812f-bfe23fcd8826.png)

![camel_13_2](https://cloud.githubusercontent.com/assets/6928740/23642041/c1a609be-032a-11e7-8d16-a0d8d4cae3e4.png)

This little changeset propose a 1s latency gain while sending messages, as well as a 10% improvment in throughput.
