### PR TITLE
Vn barcamp : enable HTTPS

### DIFF
--- a/dockerfiles/run/guice/cassandra-ldap/destination/conf/webadmin.properties
+++ b/dockerfiles/run/guice/cassandra-ldap/destination/conf/webadmin.properties
@@ -20,3 +20,14 @@
 
 enabled=true
 port=8000
+
+# Defaults to false
+https.enabled=false
+
+# Compulsory when enabling HTTPS
+#https.keystore=/path/to/keystore
+#https.password=password
+
+# Optional when enabling HTTPS (self signed)
+#https.trust.keystore
+#https.trust.password

--- a/dockerfiles/run/guice/cassandra/destination/conf/webadmin.properties
+++ b/dockerfiles/run/guice/cassandra/destination/conf/webadmin.properties
@@ -20,3 +20,14 @@
 
 enabled=true
 port=8000
+
+# Defaults to false
+https.enabled=false
+
+# Compulsory when enabling HTTPS
+#https.keystore=/path/to/keystore
+#https.password=password
+
+# Optional when enabling HTTPS (self signed)
+#https.trust.keystore
+#https.trust.password

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/modules/server/WebAdminServerModule.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/modules/server/WebAdminServerModule.java
@@ -32,6 +32,7 @@ import org.apache.james.utils.GuiceProbe;
 import org.apache.james.utils.PropertiesProvider;
 import org.apache.james.utils.WebAdminGuiceProbe;
 import org.apache.james.webadmin.FixedPort;
+import org.apache.james.webadmin.HttpsConfiguration;
 import org.apache.james.webadmin.Routes;
 import org.apache.james.webadmin.WebAdminConfiguration;
 import org.apache.james.webadmin.WebAdminServer;
@@ -72,12 +73,33 @@ public class WebAdminServerModule extends AbstractModule {
             return WebAdminConfiguration.builder()
                 .enable(configurationFile.getBoolean("enabled", false))
                 .port(new FixedPort(configurationFile.getInt("port", WebAdminServer.DEFAULT_PORT)))
+                .https(readHttpsConfiguration(configurationFile))
                 .build();
         } catch (FileNotFoundException e) {
             return WebAdminConfiguration.builder()
                 .disabled()
                 .build();
         }
+    }
+
+    private HttpsConfiguration readHttpsConfiguration(PropertiesConfiguration configurationFile) {
+        boolean enabled = configurationFile.getBoolean("https.enabled", DEFAULT_HTTPS_DISABLED());
+        if (enabled) {
+            return HttpsConfiguration.builder()
+                .enabled()
+                .raw(configurationFile.getString("https.keystore", null),
+                    configurationFile.getString("https.password", null),
+                    configurationFile.getString("https.trust.keystore", null),
+                    configurationFile.getString("https.trust.password", null))
+                .build();
+        }
+        return HttpsConfiguration.builder()
+            .disabled()
+            .build();
+    }
+
+    private boolean DEFAULT_HTTPS_DISABLED() {
+        return false;
     }
 
     @Singleton

--- a/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/WebAdminConfigurationModule.java
+++ b/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/WebAdminConfigurationModule.java
@@ -19,15 +19,11 @@
 
 package org.apache.james.webadmin.integration;
 
-import static org.apache.james.webadmin.WebAdminServer.WEBADMIN_ENABLED;
-import static org.apache.james.webadmin.WebAdminServer.WEBADMIN_PORT;
-
-import org.apache.james.webadmin.Port;
 import org.apache.james.webadmin.RandomPort;
+import org.apache.james.webadmin.WebAdminConfiguration;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
-import com.google.inject.name.Named;
 
 public class WebAdminConfigurationModule extends AbstractModule {
 
@@ -37,14 +33,11 @@ public class WebAdminConfigurationModule extends AbstractModule {
     }
 
     @Provides
-    @Named(WEBADMIN_PORT)
-    public Port provideWebAdminPort() throws Exception {
-        return new RandomPort();
+    public WebAdminConfiguration provideWebAdminConfiguration() throws Exception {
+        return WebAdminConfiguration.builder()
+            .enabled()
+            .port(new RandomPort())
+            .build();
     }
 
-    @Provides
-    @Named(WEBADMIN_ENABLED)
-    public boolean provideWebAdminEnabled() throws Exception {
-        return true;
-    }
 }

--- a/server/protocols/webadmin/pom.xml
+++ b/server/protocols/webadmin/pom.xml
@@ -231,6 +231,11 @@
                     <artifactId>slf4j-api</artifactId>
                 </dependency>
                 <dependency>
+                    <groupId>nl.jqno.equalsverifier</groupId>
+                    <artifactId>equalsverifier</artifactId>
+                    <version>1.7.6</version>
+                </dependency>
+                <dependency>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-simple</artifactId>
                     <scope>test</scope>

--- a/server/protocols/webadmin/src/main/java/org/apache/james/webadmin/FixedPort.java
+++ b/server/protocols/webadmin/src/main/java/org/apache/james/webadmin/FixedPort.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.webadmin;
 
+import java.util.Objects;
+
 import com.google.common.base.Preconditions;
 
 public class FixedPort implements Port {
@@ -35,4 +37,18 @@ public class FixedPort implements Port {
         return port;
     }
 
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof FixedPort) {
+            FixedPort that = (FixedPort) o;
+
+            return Objects.equals(this.port, that.port);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(port);
+    }
 }

--- a/server/protocols/webadmin/src/main/java/org/apache/james/webadmin/HttpsConfiguration.java
+++ b/server/protocols/webadmin/src/main/java/org/apache/james/webadmin/HttpsConfiguration.java
@@ -1,0 +1,148 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
+public class HttpsConfiguration {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Optional<Boolean> enabled = Optional.empty();
+        private String keystoreFilePath;
+        private String keystorePassword;
+        private String truststoreFilePath;
+        private String truststorePassword;
+
+        public Builder enable(boolean isEnabled) {
+            this.enabled = Optional.of(isEnabled);
+            return this;
+        }
+
+        public Builder enabled() {
+            return enable(true);
+        }
+
+        public Builder disabled() {
+            return enable(false);
+        }
+
+        public Builder raw(String keystoreFilePath,
+                           String keystorePassword,
+                           String truststoreFilePath,
+                           String truststorePassword){
+            Preconditions.checkNotNull(keystoreFilePath);
+            Preconditions.checkNotNull(keystorePassword);
+
+            this.keystoreFilePath = keystoreFilePath;
+            this.keystorePassword = keystorePassword;
+            this.truststoreFilePath = truststoreFilePath;
+            this.truststorePassword = truststorePassword;
+            return this;
+        }
+
+        public Builder selfSigned(String keystoreFilePath, String keystorePassword){
+            Preconditions.checkNotNull(keystoreFilePath);
+            Preconditions.checkNotNull(keystorePassword);
+
+            this.enabled = Optional.of(true);
+            this.keystoreFilePath = keystoreFilePath;
+            this.keystorePassword = keystorePassword;
+            return this;
+        }
+
+        public HttpsConfiguration build() {
+            Preconditions.checkState(enabled.isPresent(), "You need to specify if https is enabled");
+            Preconditions.checkState(!enabled.get() || hasKeystoreInformation(), "If enabled, you need to provide keystore information");
+            Preconditions.checkState(optionalHasTrustStoreInformation(), "You need to provide both information about trustStore");
+            return new HttpsConfiguration(enabled.get(), keystoreFilePath, keystorePassword, truststoreFilePath, truststorePassword);
+        }
+
+        private boolean optionalHasTrustStoreInformation() {
+            return (truststoreFilePath == null) == (truststorePassword == null);
+        }
+
+        private boolean hasKeystoreInformation() {
+            return keystorePassword != null && keystoreFilePath != null;
+        }
+
+    }
+
+    private final boolean enabled;
+    private final String keystoreFilePath;
+    private final String keystorePassword;
+    private final String truststoreFilePath;
+    private final String truststorePassword;
+
+    @VisibleForTesting
+    HttpsConfiguration(boolean enabled, String keystoreFilePath, String keystorePassword, String truststoreFilePath, String truststorePassword) {
+        this.enabled = enabled;
+        this.keystoreFilePath = keystoreFilePath;
+        this.keystorePassword = keystorePassword;
+        this.truststoreFilePath = truststoreFilePath;
+        this.truststorePassword = truststorePassword;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getKeystoreFilePath() {
+        return keystoreFilePath;
+    }
+
+    public String getKeystorePassword() {
+        return keystorePassword;
+    }
+
+    public String getTruststoreFilePath() {
+        return truststoreFilePath;
+    }
+
+    public String getTruststorePassword() {
+        return truststorePassword;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+       if (o instanceof HttpsConfiguration) {
+           HttpsConfiguration that = (HttpsConfiguration) o;
+
+           return Objects.equals(this.enabled, that.enabled)
+               && Objects.equals(this.keystoreFilePath, that.keystoreFilePath)
+               && Objects.equals(this.keystorePassword, that.keystorePassword)
+               && Objects.equals(this.truststoreFilePath, that.truststoreFilePath)
+               && Objects.equals(this.truststorePassword, that.truststorePassword);
+       }
+       return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(enabled, keystoreFilePath, keystorePassword, truststoreFilePath, truststorePassword);
+    }
+}

--- a/server/protocols/webadmin/src/main/java/org/apache/james/webadmin/WebAdminConfiguration.java
+++ b/server/protocols/webadmin/src/main/java/org/apache/james/webadmin/WebAdminConfiguration.java
@@ -1,0 +1,96 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+
+package org.apache.james.webadmin;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
+public class WebAdminConfiguration {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Optional<Boolean> enabled = Optional.empty();
+        private Port port;
+
+        public Builder port(Port port) {
+            this.port = port;
+            return this;
+        }
+
+        public Builder enable(boolean isEnabled) {
+            this.enabled = Optional.of(isEnabled);
+            return this;
+        }
+
+        public Builder enabled() {
+            return enable(true);
+        }
+
+        public Builder disabled() {
+            return enable(false);
+        }
+
+        public WebAdminConfiguration build() {
+            Preconditions.checkState(enabled.isPresent(), "You need to explicitly enable or disable WebAdmin server");
+            Preconditions.checkState(!enabled.get() || port != null, "You need to specify a port for WebAdminConfiguration");
+            return new WebAdminConfiguration(enabled.get(), port);
+        }
+    }
+
+    private final boolean enabled;
+    private final Port port;
+
+    @VisibleForTesting
+    WebAdminConfiguration(boolean enabled, Port port) {
+        this.enabled = enabled;
+        this.port = port;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public Port getPort() {
+        return port;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof WebAdminConfiguration) {
+            WebAdminConfiguration that = (WebAdminConfiguration) o;
+
+            return Objects.equals(this.enabled, that.enabled)
+                && Objects.equals(this.port, that.port);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(enabled, port);
+    }
+}

--- a/server/protocols/webadmin/src/main/java/org/apache/james/webadmin/WebAdminConfiguration.java
+++ b/server/protocols/webadmin/src/main/java/org/apache/james/webadmin/WebAdminConfiguration.java
@@ -35,6 +35,12 @@ public class WebAdminConfiguration {
     public static class Builder {
         private Optional<Boolean> enabled = Optional.empty();
         private Port port;
+        private Optional<HttpsConfiguration> httpsConfiguration = Optional.empty();
+
+        public Builder https(HttpsConfiguration httpsConfiguration) {
+            this.httpsConfiguration = Optional.of(httpsConfiguration);
+            return this;
+        }
 
         public Builder port(Port port) {
             this.port = port;
@@ -57,17 +63,24 @@ public class WebAdminConfiguration {
         public WebAdminConfiguration build() {
             Preconditions.checkState(enabled.isPresent(), "You need to explicitly enable or disable WebAdmin server");
             Preconditions.checkState(!enabled.get() || port != null, "You need to specify a port for WebAdminConfiguration");
-            return new WebAdminConfiguration(enabled.get(), port);
+            return new WebAdminConfiguration(enabled.get(),
+                port,
+                httpsConfiguration.orElse(
+                    HttpsConfiguration.builder()
+                        .disabled()
+                        .build()));
         }
     }
 
     private final boolean enabled;
     private final Port port;
+    private final HttpsConfiguration httpsConfiguration;
 
     @VisibleForTesting
-    WebAdminConfiguration(boolean enabled, Port port) {
+    WebAdminConfiguration(boolean enabled, Port port, HttpsConfiguration httpsConfiguration) {
         this.enabled = enabled;
         this.port = port;
+        this.httpsConfiguration = httpsConfiguration;
     }
 
     public boolean isEnabled() {
@@ -76,6 +89,10 @@ public class WebAdminConfiguration {
 
     public Port getPort() {
         return port;
+    }
+
+    public HttpsConfiguration getHttpsConfiguration() {
+        return httpsConfiguration;
     }
 
     @Override

--- a/server/protocols/webadmin/src/main/java/org/apache/james/webadmin/WebAdminServer.java
+++ b/server/protocols/webadmin/src/main/java/org/apache/james/webadmin/WebAdminServer.java
@@ -67,6 +67,14 @@ public class WebAdminServer implements Configurable {
     public void configure(HierarchicalConfiguration config) throws ConfigurationException {
         if (configuration.isEnabled()) {
             service.port(configuration.getPort().toInt());
+            HttpsConfiguration httpsConfiguration = configuration.getHttpsConfiguration();
+            if (httpsConfiguration.isEnabled()) {
+                service.secure(httpsConfiguration.getKeystoreFilePath(),
+                    httpsConfiguration.getKeystorePassword(),
+                    httpsConfiguration.getTruststoreFilePath(),
+                    httpsConfiguration.getTruststorePassword());
+                LOGGER.info("Web admin set up to use HTTPS");
+            }
             routesList.forEach(routes -> routes.define(service));
             LOGGER.info("Web admin server started");
         }

--- a/server/protocols/webadmin/src/test/java/org/apache/james/webadmin/WebAdminConfigurationTest.java
+++ b/server/protocols/webadmin/src/test/java/org/apache/james/webadmin/WebAdminConfigurationTest.java
@@ -20,38 +20,55 @@
 package org.apache.james.webadmin;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class FixedPortTest {
+public class WebAdminConfigurationTest {
+
+    public static final FixedPort PORT = new FixedPort(80);
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
-    public void toIntShouldThrowOnNegativePort() {
-        assertThatThrownBy(() -> new FixedPort(-1)).isInstanceOf(IllegalArgumentException.class);
+    public void buildShouldThrowWhenNoPortButEnabled() {
+        expectedException.expect(IllegalStateException.class);
+
+        WebAdminConfiguration.builder().enabled().build();
     }
 
     @Test
-    public void toIntShouldThrowOnNullPort() {
-        assertThatThrownBy(() -> new FixedPort(0)).isInstanceOf(IllegalArgumentException.class);
+    public void buildShouldWorkWithoutPortWhenDisabled() {
+        assertThat(WebAdminConfiguration.builder()
+            .disabled()
+            .build())
+            .isEqualTo(new WebAdminConfiguration(false, null));
     }
 
     @Test
-    public void toIntShouldThrowOnTooBigNumbers() {
-        assertThatThrownBy(() -> new FixedPort(65536)).isInstanceOf(IllegalArgumentException.class);
+    public void buildShouldFailOnNoEnable() {
+        expectedException.expect(IllegalStateException.class);
+
+        WebAdminConfiguration.builder().port(PORT).build();
     }
 
     @Test
-    public void toIntShouldReturnedDesiredPort() {
-        int expectedPort = 452;
-        assertThat(new FixedPort(expectedPort).toInt()).isEqualTo(expectedPort);
+    public void builderShouldBuildRightObject() {
+        assertThat(
+            WebAdminConfiguration.builder()
+                .enabled()
+                .port(PORT)
+                .build())
+            .isEqualTo(new WebAdminConfiguration(true, PORT));
     }
 
     @Test
     public void shouldMatchBeanContract() {
-        EqualsVerifier.forClass(FixedPort.class).verify();
+        EqualsVerifier.forClass(WebAdminConfiguration.class).verify();
     }
 
 }


### PR DESCRIPTION
Crafted with love with Dung !

 - Class for encapsultating web admin configuration
 - Class for HTTPS configuration
 - Enable HTTPS

Unable to write an integration test with RestAssured. But manual checks works fine : 

```
% curl -XGET -k https://127.0.0.1:34895/domains                                                                                        
["horizon","localhost.","127.0.0.1"]
```