### PR TITLE
JAMES-1950 Track execution time in the mailets

### DIFF
--- a/server/container/guice/guice-common/src/test/java/org/apache/james/jmap/MailetPreconditionTest.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/jmap/MailetPreconditionTest.java
@@ -54,7 +54,7 @@ public class MailetPreconditionTest {
 
     @Test(expected = ConfigurationException.class)
     public void vacationMailetCheckShouldThrowOnWrongMatcher() throws Exception {
-        List<MatcherMailetPair> pairs = Lists.newArrayList(new MatcherMailetPair(new All(), new VacationMailet(null, null, null, null, null)));
+        List<MatcherMailetPair> pairs = Lists.newArrayList(new MatcherMailetPair(new All(), new VacationMailet(null, null, null, null, null, null)));
         new JMAPModule.VacationMailetCheck().check(pairs);
     }
 
@@ -66,7 +66,7 @@ public class MailetPreconditionTest {
 
     @Test
     public void vacationMailetCheckShouldNotThrowIfValidPairPresent() throws Exception {
-        List<MatcherMailetPair> pairs = Lists.newArrayList(new MatcherMailetPair(new RecipientIsLocal(), new VacationMailet(null, null, null, null, null)));
+        List<MatcherMailetPair> pairs = Lists.newArrayList(new MatcherMailetPair(new RecipientIsLocal(), new VacationMailet(null, null, null, null, null, null)));
         new JMAPModule.VacationMailetCheck().check(pairs);
     }
 

--- a/server/mailet/mailetcontainer-camel/pom.xml
+++ b/server/mailet/mailetcontainer-camel/pom.xml
@@ -69,6 +69,10 @@
             <groupId>org.apache.james</groupId>
             <artifactId>apache-mailet-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.james</groupId>
+            <artifactId>metrics-api</artifactId>
+        </dependency>
         <!--
             <dependency>
             <groupId>org.apache.james</groupId>

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailSpooler.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailSpooler.java
@@ -35,6 +35,8 @@ import org.apache.james.lifecycle.api.LifecycleUtil;
 import org.apache.james.lifecycle.api.LogEnabled;
 import org.apache.james.mailetcontainer.api.MailProcessor;
 import org.apache.james.mailetcontainer.api.jmx.MailSpoolerMBean;
+import org.apache.james.metrics.api.MetricFactory;
+import org.apache.james.metrics.api.TimeMetric;
 import org.apache.james.queue.api.MailQueue;
 import org.apache.james.queue.api.MailQueue.MailQueueException;
 import org.apache.james.queue.api.MailQueue.MailQueueItem;
@@ -50,6 +52,7 @@ import org.slf4j.Logger;
  */
 public class JamesMailSpooler implements Runnable, Disposable, Configurable, LogEnabled, MailSpoolerMBean {
 
+    public static final String SPOOL_PROCESSING = "spoolProcessing";
     private MailQueue queue;
 
     /**
@@ -69,6 +72,8 @@ public class JamesMailSpooler implements Runnable, Disposable, Configurable, Log
      */
     private final AtomicBoolean active = new AtomicBoolean(false);
 
+    private final MetricFactory metricFactory;
+
     /**
      * Spool threads
      */
@@ -86,6 +91,11 @@ public class JamesMailSpooler implements Runnable, Disposable, Configurable, Log
     private MailQueueFactory queueFactory;
 
     private int numDequeueThreads;
+
+    @Inject
+    public JamesMailSpooler(MetricFactory metricFactory) {
+        this.metricFactory = metricFactory;
+    }
 
     @Inject
     public void setMailQueueFactory(MailQueueFactory queueFactory) {
@@ -145,6 +155,7 @@ public class JamesMailSpooler implements Runnable, Disposable, Configurable, Log
         while (active.get()) {
 
             final MailQueueItem queueItem;
+            TimeMetric timeMetric = metricFactory.timer(SPOOL_PROCESSING);
             try {
                 queueItem = queue.deQueue();
                 workerService.execute(new Runnable() {
@@ -195,6 +206,8 @@ public class JamesMailSpooler implements Runnable, Disposable, Configurable, Log
                 }
             } catch (InterruptedException interrupted) {
                 //MailSpooler is stopping
+            } finally {
+                timeMetric.stopAndPublish();
             }
         }
         logger.info("Stop {} : {}", getClass().getName(), Thread.currentThread().getName());

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/LocalDelivery.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/LocalDelivery.java
@@ -62,7 +62,7 @@ public class LocalDelivery extends GenericMailet {
         this.metricFactory = metricFactory;
         this.usersRepository = usersRepository;
         this.mailboxManager = mailboxManager;
-        this.recipientRewriteTable = new RecipientRewriteTable(rrt, domainList);
+        this.recipientRewriteTable = new RecipientRewriteTable(rrt, domainList, metricFactory);
     }
 
     public void service(Mail mail) throws MessagingException {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/LocalDelivery.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/LocalDelivery.java
@@ -29,6 +29,7 @@ import org.apache.james.mailbox.MailboxManager;
 
 import org.apache.james.mailbox.model.MailboxConstants;
 import org.apache.james.metrics.api.MetricFactory;
+import org.apache.james.metrics.api.TimeMetric;
 import org.apache.james.transport.mailets.delivery.MailDispatcher;
 import org.apache.james.transport.mailets.delivery.MailboxAppender;
 import org.apache.james.transport.mailets.delivery.SimpleMailStore;
@@ -48,6 +49,7 @@ import org.apache.mailet.base.GenericMailet;
 public class LocalDelivery extends GenericMailet {
 
     public static final String LOCAL_DELIVERED_MAILS_METRIC_NAME = "localDeliveredMails";
+    public static final String LOCAL_DELIVERY_TIME_METRIC = "localDeliveryTimeMetric";
     private final UsersRepository usersRepository;
     private final MailboxManager mailboxManager;
     private final RecipientRewriteTable recipientRewriteTable;
@@ -64,8 +66,13 @@ public class LocalDelivery extends GenericMailet {
     }
 
     public void service(Mail mail) throws MessagingException {
-        recipientRewriteTable.service(mail);
-        mailDispatcher.dispatch(mail);
+        TimeMetric timeMetric = metricFactory.timer(LOCAL_DELIVERY_TIME_METRIC);
+        try {
+            recipientRewriteTable.service(mail);
+            mailDispatcher.dispatch(mail);
+        } finally {
+            timeMetric.stopAndPublish();
+        }
     }
 
     public String getMailetInfo() {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTable.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTable.java
@@ -24,6 +24,8 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
 import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.metrics.api.MetricFactory;
+import org.apache.james.metrics.api.TimeMetric;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
 
@@ -34,20 +36,24 @@ import com.google.common.base.Preconditions;
  * implementations for mappings of forwards and aliases.
  */
 public class RecipientRewriteTable extends GenericMailet {
+    public static final String RRT_EXECUTION = "rrtExecution";
     private final org.apache.james.rrt.api.RecipientRewriteTable virtualTableStore;
     private final DomainList domainList;
+    private final MetricFactory metricFactory;
     private RecipientRewriteTableProcessor processor;
 
     /**
      * Sets the virtual table store.
-     * 
+     *
      * @param vut
      *            the vutStore to set, possibly null
+     * @param metricFactory
      */
     @Inject
-    public RecipientRewriteTable(org.apache.james.rrt.api.RecipientRewriteTable virtualTableStore, DomainList domainList) {
+    public RecipientRewriteTable(org.apache.james.rrt.api.RecipientRewriteTable virtualTableStore, DomainList domainList, MetricFactory metricFactory) {
         this.virtualTableStore = virtualTableStore;
         this.domainList = domainList;
+        this.metricFactory = metricFactory;
     }
 
     @Override
@@ -67,12 +73,15 @@ public class RecipientRewriteTable extends GenericMailet {
     @Override
     public void service(Mail mail) throws MessagingException {
         Preconditions.checkNotNull(mail);
-        MimeMessage message = mail.getMessage();
-
-        if (message != null) {
-            processor.processMail(mail);
+        TimeMetric timeMetric = metricFactory.timer(RRT_EXECUTION);
+        try {
+            MimeMessage message = mail.getMessage();
+            if (message != null) {
+                processor.processMail(mail);
+            }
+        } finally {
+            timeMetric.stopAndPublish();
         }
-
     }
 
     @Override

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RemoteDelivery.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RemoteDelivery.java
@@ -132,6 +132,7 @@ public class RemoteDelivery extends GenericMailet {
     private final DNSService dnsServer;
     private final DomainList domainList;
     private final MailQueueFactory queueFactory;
+    private final MetricFactory metricFactory;
     private final Metric outgoingMailsMetric;
     private final AtomicBoolean isDestroyed;
     private final THREAD_STATE startThreads;
@@ -151,6 +152,7 @@ public class RemoteDelivery extends GenericMailet {
         this.domainList = domainList;
         this.queueFactory = queueFactory;
         this.outgoingMailsMetric = metricFactory.generate(OUTGOING_MAILS);
+        this.metricFactory = metricFactory;
         this.isDestroyed = new AtomicBoolean(false);
         this.startThreads = startThreads;
     }
@@ -181,7 +183,7 @@ public class RemoteDelivery extends GenericMailet {
                     logger,
                     getMailetContext(),
                     new Bouncer(configuration, getMailetContext(), logger),
-                    isDestroyed));
+                    isDestroyed, metricFactory));
         }
     }
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/Sieve.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/Sieve.java
@@ -27,6 +27,8 @@ import javax.mail.MessagingException;
 
 import org.apache.commons.logging.Log;
 import org.apache.james.mailbox.model.MailboxConstants;
+import org.apache.james.metrics.api.MetricFactory;
+import org.apache.james.metrics.api.TimeMetric;
 import org.apache.james.sieverepository.api.SieveRepository;
 import org.apache.james.transport.mailets.delivery.MailStore;
 import org.apache.james.transport.mailets.jsieve.CommonsLoggingAdapter;
@@ -48,18 +50,21 @@ import com.google.common.collect.ImmutableList;
  */
 public class Sieve extends GenericMailet {
 
+    public static final String SIEVE_EXECUTION = "sieveExecution";
     private final UsersRepository usersRepository;
     private final ResourceLocator resourceLocator;
+    private final MetricFactory metricFactory;
     private SieveExecutor sieveExecutor;
 
     @Inject
-    public Sieve(UsersRepository usersRepository, SieveRepository sieveRepository) throws MessagingException {
-        this(usersRepository, new ResourceLocator(sieveRepository, usersRepository));
+    public Sieve(UsersRepository usersRepository, SieveRepository sieveRepository, MetricFactory metricFactory) throws MessagingException {
+        this(usersRepository, new ResourceLocator(sieveRepository, usersRepository), metricFactory);
     }
 
-    public Sieve(UsersRepository usersRepository, ResourceLocator resourceLocator) throws MessagingException {
+    public Sieve(UsersRepository usersRepository, ResourceLocator resourceLocator, MetricFactory metricFactory) throws MessagingException {
         this.usersRepository = usersRepository;
         this.resourceLocator = resourceLocator;
+        this.metricFactory = metricFactory;
     }
 
     @Override
@@ -84,8 +89,13 @@ public class Sieve extends GenericMailet {
 
     @Override
     public void service(Mail mail) throws MessagingException {
-        List<MailAddress> recipientsWithSuccessfulSieveExecution = executeRetrieveSuccess(mail);
-        mail.setRecipients(keepNonDiscardedRecipients(mail, recipientsWithSuccessfulSieveExecution));
+        TimeMetric timeMetric = metricFactory.timer(SIEVE_EXECUTION);
+        try {
+            List<MailAddress> recipientsWithSuccessfulSieveExecution = executeRetrieveSuccess(mail);
+            mail.setRecipients(keepNonDiscardedRecipients(mail, recipientsWithSuccessfulSieveExecution));
+        } finally {
+            timeMetric.stopAndPublish();
+        }
     }
 
     private List<MailAddress> executeRetrieveSuccess(Mail mail) throws MessagingException {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remoteDelivery/DeliveryRunnable.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remoteDelivery/DeliveryRunnable.java
@@ -26,6 +26,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.lifecycle.api.LifecycleUtil;
 import org.apache.james.metrics.api.Metric;
+import org.apache.james.metrics.api.MetricFactory;
+import org.apache.james.metrics.api.TimeMetric;
 import org.apache.james.queue.api.MailPrioritySupport;
 import org.apache.james.queue.api.MailQueue;
 import org.apache.mailet.Mail;
@@ -44,6 +46,7 @@ public class DeliveryRunnable implements Runnable {
         }
     };
     public static final AtomicBoolean DEFAULT_NOT_STARTED = new AtomicBoolean(false);
+    public static final String REMOTE_DELIVERY_ATTEMPT = "remoteDeliveryAttempt";
 
     private final MailQueue queue;
     private final RemoteDeliveryConfiguration configuration;
@@ -53,17 +56,18 @@ public class DeliveryRunnable implements Runnable {
     private final MailDelivrer mailDelivrer;
     private final AtomicBoolean isDestroyed;
     private final Supplier<Date> dateSupplier;
+    private final MetricFactory metricFactory;
 
     public DeliveryRunnable(MailQueue queue, RemoteDeliveryConfiguration configuration, DNSService dnsServer, Metric outgoingMailsMetric,
-                            Logger logger, MailetContext mailetContext, Bouncer bouncer, AtomicBoolean isDestroyed) {
+                            Logger logger, MailetContext mailetContext, Bouncer bouncer, AtomicBoolean isDestroyed, MetricFactory metricFactory) {
         this(queue, configuration, outgoingMailsMetric, logger, bouncer,
             new MailDelivrer(configuration, new MailDelivrerToHost(configuration, mailetContext, logger), dnsServer, bouncer, logger),
-            isDestroyed, CURRENT_DATE_SUPPLIER);
+            isDestroyed, CURRENT_DATE_SUPPLIER, metricFactory);
     }
 
     @VisibleForTesting
     DeliveryRunnable(MailQueue queue, RemoteDeliveryConfiguration configuration, Metric outgoingMailsMetric, Logger logger, Bouncer bouncer,
-                     MailDelivrer mailDelivrer, AtomicBoolean isDestroyeds, Supplier<Date> dateSupplier) {
+                     MailDelivrer mailDelivrer, AtomicBoolean isDestroyeds, Supplier<Date> dateSupplier, MetricFactory metricFactory) {
         this.queue = queue;
         this.configuration = configuration;
         this.outgoingMailsMetric = outgoingMailsMetric;
@@ -72,15 +76,18 @@ public class DeliveryRunnable implements Runnable {
         this.mailDelivrer = mailDelivrer;
         this.isDestroyed = isDestroyeds;
         this.dateSupplier = dateSupplier;
+        this.metricFactory = metricFactory;
     }
 
     @Override
     public void run() {
+        TimeMetric timeMetric = metricFactory.timer(REMOTE_DELIVERY_ATTEMPT);
         try {
             while (!Thread.interrupted() && !isDestroyed.get()) {
                 runStep();
             }
         } finally {
+            timeMetric.stopAndPublish();
             // Restore the thread state to non-interrupted.
             Thread.interrupted();
         }

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/RecipientRewriteTableTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/RecipientRewriteTableTest.java
@@ -26,6 +26,7 @@ import javax.mail.Session;
 import javax.mail.internet.MimeMessage;
 
 import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.mailet.MailetContext;
 import org.apache.mailet.base.MailAddressFixture;
 import org.apache.mailet.base.test.FakeMail;
@@ -52,7 +53,7 @@ public class RecipientRewriteTableTest {
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         
-        mailet = new RecipientRewriteTable(virtualTableStore, domainList);
+        mailet = new RecipientRewriteTable(virtualTableStore, domainList, new NoopMetricFactory());
 
         message = new MimeMessage(Session.getDefaultInstance(new Properties()));
 

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/SieveIntegrationTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/SieveIntegrationTest.java
@@ -29,6 +29,7 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeBodyPart;
 
 import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.james.sieverepository.api.exception.ScriptNotFoundException;
 import org.apache.james.transport.mailets.Sieve;
 import org.apache.james.transport.mailets.jsieve.ResourceLocator;
@@ -72,7 +73,7 @@ public class SieveIntegrationTest {
         usersRepository = mock(UsersRepository.class);
         fakeMailContext = FakeMailContext.builder().logger(mock(Logger.class)).build();
 
-        testee = new Sieve(usersRepository, resourceLocator);
+        testee = new Sieve(usersRepository, resourceLocator, new NoopMetricFactory());
         testee.init(FakeMailetConfig.builder().mailetName("Sieve").mailetContext(fakeMailContext).build());
     }
 

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remoteDelivery/DeliveryRunnableTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remoteDelivery/DeliveryRunnableTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.james.domainlist.api.DomainList;
 import org.apache.james.metrics.api.Metric;
+import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.james.queue.api.MailQueue;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.test.FakeMail;
@@ -77,7 +78,8 @@ public class DeliveryRunnableTest {
         bouncer = mock(Bouncer.class);
         mailDelivrer = mock(MailDelivrer.class);
         mailQueue = mock(MailQueue.class);
-        testee = new DeliveryRunnable(mailQueue, configuration, outgoingMailsMetric, LOGGER, bouncer, mailDelivrer, DeliveryRunnable.DEFAULT_NOT_STARTED, FIXED_DATE_SUPPLIER);
+        testee = new DeliveryRunnable(mailQueue, configuration, outgoingMailsMetric, LOGGER, bouncer, mailDelivrer,
+            DeliveryRunnable.DEFAULT_NOT_STARTED, FIXED_DATE_SUPPLIER, new NoopMetricFactory());
     }
 
     @Test

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationMailet.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationMailet.java
@@ -31,6 +31,8 @@ import org.apache.james.jmap.api.vacation.RecipientId;
 import org.apache.james.jmap.api.vacation.Vacation;
 import org.apache.james.jmap.api.vacation.VacationRepository;
 import org.apache.james.jmap.utils.MimeMessageBodyGenerator;
+import org.apache.james.metrics.api.MetricFactory;
+import org.apache.james.metrics.api.TimeMetric;
 import org.apache.james.util.date.ZonedDateTimeProvider;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
@@ -42,26 +44,30 @@ import org.slf4j.LoggerFactory;
 public class VacationMailet extends GenericMailet {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(VacationMailet.class);
+    public static final String VACATION_MAILET_EXECUTION = "vacationMailetExecution";
 
     private final VacationRepository vacationRepository;
     private final ZonedDateTimeProvider zonedDateTimeProvider;
     private final AutomaticallySentMailDetector automaticallySentMailDetector;
     private final NotificationRegistry notificationRegistry;
     private final MimeMessageBodyGenerator mimeMessageBodyGenerator;
+    private final MetricFactory metricFactory;
 
     @Inject
     public VacationMailet(VacationRepository vacationRepository, ZonedDateTimeProvider zonedDateTimeProvider,
                           AutomaticallySentMailDetector automaticallySentMailDetector, NotificationRegistry notificationRegistry,
-                          MimeMessageBodyGenerator mimeMessageBodyGenerator) {
+                          MimeMessageBodyGenerator mimeMessageBodyGenerator, MetricFactory metricFactory) {
         this.vacationRepository = vacationRepository;
         this.zonedDateTimeProvider = zonedDateTimeProvider;
         this.automaticallySentMailDetector = automaticallySentMailDetector;
         this.notificationRegistry = notificationRegistry;
         this.mimeMessageBodyGenerator = mimeMessageBodyGenerator;
+        this.metricFactory = metricFactory;
     }
 
     @Override
     public void service(Mail mail) {
+        TimeMetric timeMetric = metricFactory.timer(VACATION_MAILET_EXECUTION);
         try {
             if (! automaticallySentMailDetector.isAutomaticallySent(mail)) {
                 ZonedDateTime processingDate = zonedDateTimeProvider.get();
@@ -72,6 +78,8 @@ public class VacationMailet extends GenericMailet {
             }
         } catch (Throwable e) {
             LOGGER.warn("Can not process vacation for one or more recipients in {}", mail.getRecipients(), e);
+        } finally {
+            timeMetric.stopAndPublish();
         }
     }
 

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/VacationMailetTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/VacationMailetTest.java
@@ -39,6 +39,7 @@ import org.apache.james.jmap.api.vacation.RecipientId;
 import org.apache.james.jmap.api.vacation.Vacation;
 import org.apache.james.jmap.api.vacation.VacationRepository;
 import org.apache.james.jmap.utils.MimeMessageBodyGenerator;
+import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.james.util.date.ZonedDateTimeProvider;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.MailetContext;
@@ -92,7 +93,7 @@ public class VacationMailetTest {
         zonedDateTimeProvider = mock(ZonedDateTimeProvider.class);
         automaticallySentMailDetector = mock(AutomaticallySentMailDetector.class);
         notificationRegistry = mock(NotificationRegistry.class);
-        testee = new VacationMailet(vacationRepository, zonedDateTimeProvider, automaticallySentMailDetector, notificationRegistry, mimeMessageBodyGenerator);
+        testee = new VacationMailet(vacationRepository, zonedDateTimeProvider, automaticallySentMailDetector, notificationRegistry, mimeMessageBodyGenerator, new NoopMetricFactory());
         mailetContext = mock(MailetContext.class);
         testee.init(FakeMailetConfig.builder()
                 .mailetName("vacation")


### PR DESCRIPTION
Because we are blind with the mailets, and I believe we would gain much knowledge on our application from this... I added time tracking on the mailet pipeline, and on what I believe are the more time consuming mailets. 

I added the following metrics : 
 - "spoolProcessing" tracking the execution times for the mailet pipeline
 - "localDeliveryTimeMetric" for LocalDelivery
 - "rrtExecution" for recipient rewriting
 - "sieveExecution" for tracking Sieve execution time
 - "remoteDeliveryAttempt" for tracking remoteDelivery time
 - "vacationMailetExecution" for tracking vacation mailet execution time