### PR TITLE
JAMES-1950 Add time metrics on Remote Mail delivering

### DIFF
--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailSpooler.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailSpooler.java
@@ -155,13 +155,13 @@ public class JamesMailSpooler implements Runnable, Disposable, Configurable, Log
         while (active.get()) {
 
             final MailQueueItem queueItem;
-            TimeMetric timeMetric = metricFactory.timer(SPOOL_PROCESSING);
             try {
                 queueItem = queue.deQueue();
                 workerService.execute(new Runnable() {
 
                     @Override
                     public void run() {
+                        TimeMetric timeMetric = metricFactory.timer(SPOOL_PROCESSING);
                         try {
                             numActive.incrementAndGet();
 
@@ -195,6 +195,7 @@ public class JamesMailSpooler implements Runnable, Disposable, Configurable, Log
                         } finally {
                             processingActive.decrementAndGet();
                             numActive.decrementAndGet();
+                            timeMetric.stopAndPublish();
                         }
 
                     }
@@ -206,8 +207,6 @@ public class JamesMailSpooler implements Runnable, Disposable, Configurable, Log
                 }
             } catch (InterruptedException interrupted) {
                 //MailSpooler is stopping
-            } finally {
-                timeMetric.stopAndPublish();
             }
         }
         logger.info("Stop {} : {}", getClass().getName(), Thread.currentThread().getName());

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RemoteDelivery.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RemoteDelivery.java
@@ -126,13 +126,12 @@ public class RemoteDelivery extends GenericMailet {
         DO_NOT_START_THREADS
     }
 
-    private static final String OUTGOING_MAILS = "outgoingMails";
     public static final String NAME_JUNCTION = "-to-";
 
     private final DNSService dnsServer;
     private final DomainList domainList;
     private final MailQueueFactory queueFactory;
-    private final Metric outgoingMailsMetric;
+    private final MetricFactory metricFactory;
     private final AtomicBoolean isDestroyed;
     private final THREAD_STATE startThreads;
 
@@ -150,7 +149,7 @@ public class RemoteDelivery extends GenericMailet {
         this.dnsServer = dnsServer;
         this.domainList = domainList;
         this.queueFactory = queueFactory;
-        this.outgoingMailsMetric = metricFactory.generate(OUTGOING_MAILS);
+        this.metricFactory = metricFactory;
         this.isDestroyed = new AtomicBoolean(false);
         this.startThreads = startThreads;
     }
@@ -177,7 +176,7 @@ public class RemoteDelivery extends GenericMailet {
                 new DeliveryRunnable(queue,
                     configuration,
                     dnsServer,
-                    outgoingMailsMetric,
+                    metricFactory,
                     logger,
                     getMailetContext(),
                     new Bouncer(configuration, getMailetContext(), logger),

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remoteDelivery/DeliveryRunnableTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remoteDelivery/DeliveryRunnableTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.transport.mailets.remoteDelivery;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -31,6 +32,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.james.domainlist.api.DomainList;
 import org.apache.james.metrics.api.Metric;
+import org.apache.james.metrics.api.MetricFactory;
+import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.james.queue.api.MailQueue;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.test.FakeMail;
@@ -74,10 +77,13 @@ public class DeliveryRunnableTest {
 
         RemoteDeliveryConfiguration configuration = new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class));
         outgoingMailsMetric = mock(Metric.class);
+        MetricFactory mockMetricFactory = mock(MetricFactory.class);
+        when(mockMetricFactory.generate(anyString())).thenReturn(outgoingMailsMetric);
+        when(mockMetricFactory.timer(anyString())).thenReturn(new NoopMetricFactory.NoopTimeMetric());
         bouncer = mock(Bouncer.class);
         mailDelivrer = mock(MailDelivrer.class);
         mailQueue = mock(MailQueue.class);
-        testee = new DeliveryRunnable(mailQueue, configuration, outgoingMailsMetric, LOGGER, bouncer, mailDelivrer, DeliveryRunnable.DEFAULT_NOT_STARTED, FIXED_DATE_SUPPLIER);
+        testee = new DeliveryRunnable(mailQueue, configuration, mockMetricFactory, LOGGER, bouncer, mailDelivrer, DeliveryRunnable.DEFAULT_NOT_STARTED, FIXED_DATE_SUPPLIER);
     }
 
     @Test

--- a/server/queue/queue-activemq/src/main/java/org/apache/james/queue/activemq/ActiveMQMailQueue.java
+++ b/server/queue/queue-activemq/src/main/java/org/apache/james/queue/activemq/ActiveMQMailQueue.java
@@ -43,7 +43,7 @@ import org.apache.activemq.util.JMSExceptionSupport;
 import org.apache.james.core.MimeMessageCopyOnWriteProxy;
 import org.apache.james.core.MimeMessageInputStream;
 import org.apache.james.core.MimeMessageSource;
-import org.apache.james.metrics.api.Metric;
+import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.queue.api.MailQueue;
 import org.apache.james.queue.api.MailQueueItemDecoratorFactory;
 import org.apache.james.queue.jms.JMSMailQueue;
@@ -93,8 +93,8 @@ public class ActiveMQMailQueue extends JMSMailQueue implements ActiveMQSupport {
      * Construct a {@link ActiveMQMailQueue} which only use {@link BlobMessage}
      * 
      */
-    public ActiveMQMailQueue(ConnectionFactory connectionFactory, MailQueueItemDecoratorFactory mailQueueItemDecoratorFactory, String queuename, Metric enqueuedMailsMetric, Logger logger) {
-        this(connectionFactory, mailQueueItemDecoratorFactory, queuename, true, enqueuedMailsMetric, logger);
+    public ActiveMQMailQueue(ConnectionFactory connectionFactory, MailQueueItemDecoratorFactory mailQueueItemDecoratorFactory, String queuename, MetricFactory metricFactory, Logger logger) {
+        this(connectionFactory, mailQueueItemDecoratorFactory, queuename, true, metricFactory, logger);
     }
 
     /**
@@ -105,8 +105,8 @@ public class ActiveMQMailQueue extends JMSMailQueue implements ActiveMQSupport {
      * @param useBlob
      * @param logger
      */
-    public ActiveMQMailQueue(ConnectionFactory connectionFactory, MailQueueItemDecoratorFactory mailQueueItemDecoratorFactory, String queuename, boolean useBlob, Metric enqueuedMailsMetric, Logger logger) {
-        super(connectionFactory, mailQueueItemDecoratorFactory, queuename, enqueuedMailsMetric, logger);
+    public ActiveMQMailQueue(ConnectionFactory connectionFactory, MailQueueItemDecoratorFactory mailQueueItemDecoratorFactory, String queuename, boolean useBlob, MetricFactory metricFactory, Logger logger) {
+        super(connectionFactory, mailQueueItemDecoratorFactory, queuename, metricFactory, logger);
         this.useBlob = useBlob;
     }
 

--- a/server/queue/queue-activemq/src/main/java/org/apache/james/queue/activemq/ActiveMQMailQueueFactory.java
+++ b/server/queue/queue-activemq/src/main/java/org/apache/james/queue/activemq/ActiveMQMailQueueFactory.java
@@ -50,6 +50,6 @@ public class ActiveMQMailQueueFactory extends JMSMailQueueFactory {
 
     @Override
     protected MailQueue createMailQueue(String name) {
-        return new ActiveMQMailQueue(connectionFactory, mailQueueItemDecoratorFactory, name, useBlob, metricFactory.generate("enqueuedMails:" + name), log);
+        return new ActiveMQMailQueue(connectionFactory, mailQueueItemDecoratorFactory, name, useBlob, metricFactory, log);
     }
 }

--- a/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueTest.java
+++ b/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueTest.java
@@ -18,8 +18,6 @@
  ****************************************************************/
 package org.apache.james.queue.activemq;
 
-import static org.mockito.Mockito.mock;
-
 import java.util.Arrays;
 
 import javax.jms.ConnectionFactory;
@@ -29,7 +27,7 @@ import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.region.policy.PolicyEntry;
 import org.apache.activemq.broker.region.policy.PolicyMap;
 import org.apache.activemq.plugin.StatisticsBrokerPlugin;
-import org.apache.james.metrics.api.Metric;
+import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.james.queue.api.MailQueueItemDecoratorFactory;
 import org.apache.james.queue.jms.AbstractJMSMailQueueTest;
 import org.apache.james.queue.jms.JMSMailQueue;
@@ -79,7 +77,7 @@ public abstract class ActiveMQMailQueueTest extends AbstractJMSMailQueueTest {
     protected JMSMailQueue createQueue(ConnectionFactory factory, MailQueueItemDecoratorFactory mailQueueItemDecoratorFactory, String queueName) {
         Logger log = LoggerFactory.getLogger(ActiveMQMailQueueTest.class);
 
-        return new ActiveMQMailQueue(factory, mailQueueItemDecoratorFactory, queueName, useBlobMessages(), mock(Metric.class), log);
+        return new ActiveMQMailQueue(factory, mailQueueItemDecoratorFactory, queueName, useBlobMessages(), new NoopMetricFactory(), log);
     }
 
     protected boolean useBlobMessages() {

--- a/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueueFactory.java
+++ b/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueueFactory.java
@@ -45,7 +45,7 @@ public class JMSMailQueueFactory extends AbstractMailQueueFactory {
 
     @Override
     protected MailQueue createMailQueue(String name) {
-        return new JMSMailQueue(connectionFactory, mailQueueItemDecoratorFactory, name, metricFactory.generate("enqueuedMail:" + name), log);
+        return new JMSMailQueue(connectionFactory, mailQueueItemDecoratorFactory, name, metricFactory, log);
     }
     
 }

--- a/server/queue/queue-jms/src/test/java/org/apache/james/queue/jms/AbstractJMSMailQueueTest.java
+++ b/server/queue/queue-jms/src/test/java/org/apache/james/queue/jms/AbstractJMSMailQueueTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -40,7 +39,7 @@ import javax.mail.internet.MimeMessage;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.james.core.MailImpl;
-import org.apache.james.metrics.api.Metric;
+import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.james.protocols.smtp.MailAddressException;
 import org.apache.james.queue.api.MailQueue.MailQueueItem;
 import org.apache.james.queue.api.MailQueueItemDecoratorFactory;
@@ -72,7 +71,7 @@ public abstract class AbstractJMSMailQueueTest {
     
     protected JMSMailQueue createQueue(ConnectionFactory factory, MailQueueItemDecoratorFactory mailQueueItemDecoratorFactory, String queueName) {
         Logger log = LoggerFactory.getLogger(AbstractJMSMailQueueTest.class);
-        return new JMSMailQueue(factory, mailQueueItemDecoratorFactory, queueName, mock(Metric.class), log);
+        return new JMSMailQueue(factory, mailQueueItemDecoratorFactory, queueName, new NoopMetricFactory(), log);
     }
 
     @Before


### PR DESCRIPTION
Because we are missing this important metric now.

(RemoteDelivery only enqueue the mail on the mail queue for planning delivery)