### PR TITLE
JAMES-1973 LocalDelivery should not compose RRT

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/LocalDelivery.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/LocalDelivery.java
@@ -50,21 +50,18 @@ public class LocalDelivery extends GenericMailet {
     public static final String LOCAL_DELIVERED_MAILS_METRIC_NAME = "localDeliveredMails";
     private final UsersRepository usersRepository;
     private final MailboxManager mailboxManager;
-    private final RecipientRewriteTable recipientRewriteTable;
     private final MetricFactory metricFactory;
     private MailDispatcher mailDispatcher;
 
     @Inject
-    public LocalDelivery(org.apache.james.rrt.api.RecipientRewriteTable rrt, UsersRepository usersRepository,
-                         @Named("mailboxmanager") MailboxManager mailboxManager, DomainList domainList, MetricFactory metricFactory) {
+    public LocalDelivery(UsersRepository usersRepository, @Named("mailboxmanager") MailboxManager mailboxManager,
+                         MetricFactory metricFactory) {
         this.metricFactory = metricFactory;
         this.usersRepository = usersRepository;
         this.mailboxManager = mailboxManager;
-        this.recipientRewriteTable = new RecipientRewriteTable(rrt, domainList);
     }
 
     public void service(Mail mail) throws MessagingException {
-        recipientRewriteTable.service(mail);
         mailDispatcher.dispatch(mail);
     }
 
@@ -73,8 +70,6 @@ public class LocalDelivery extends GenericMailet {
     }
 
     public void init() throws MessagingException {
-        recipientRewriteTable.init(getMailetConfig());
-
         Log log = CommonsLoggingAdapter.builder()
             .wrappedLogger(getMailetContext().getLogger())
             .quiet(getInitParameter("quiet", false))

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/LocalDeliveryTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/LocalDeliveryTest.java
@@ -76,7 +76,7 @@ public class LocalDeliveryTest {
 
         MetricFactory metricFactory = mock(MetricFactory.class);
         when(metricFactory.generate(anyString())).thenReturn(mock(Metric.class));
-        testee = new LocalDelivery(recipientRewriteTable, usersRepository, mailboxManager, domainList, metricFactory);
+        testee = new LocalDelivery(usersRepository, mailboxManager, metricFactory);
 
         user = mock(MailboxSession.User.class);
         MailboxSession session = mock(MailboxSession.class);


### PR DESCRIPTION
No tests on RRT behaviour of LocalDelivery

Default configuration already integrate this.

No integration tests broken.

We can even deploy this without troubbles on OP.LNG.COM