### PR TITLE
JAMES-1950 Add JVM metrics in Grafana

### DIFF
--- a/metrics/metrics-dropwizard/pom.xml
+++ b/metrics/metrics-dropwizard/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>metrics-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jvm</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/metrics/metrics-dropwizard/src/main/java/org/apache/james/metrics/dropwizard/DropWizardJVMMetrics.java
+++ b/metrics/metrics-dropwizard/src/main/java/org/apache/james/metrics/dropwizard/DropWizardJVMMetrics.java
@@ -1,0 +1,47 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.metrics.dropwizard;
+
+import javax.inject.Inject;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jvm.ClassLoadingGaugeSet;
+import com.codahale.metrics.jvm.FileDescriptorRatioGauge;
+import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
+import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
+import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
+
+public class DropWizardJVMMetrics {
+
+    private final MetricRegistry metricRegistry;
+
+    @Inject
+    public DropWizardJVMMetrics(MetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
+    }
+
+    public void start() {
+        metricRegistry.register("jvm.file.descriptor", new FileDescriptorRatioGauge());
+        metricRegistry.register("jvm.gc", new GarbageCollectorMetricSet());
+        metricRegistry.register("jvm.threads", new ThreadStatesGaugeSet());
+        metricRegistry.register("jvm.memory", new MemoryUsageGaugeSet());
+        metricRegistry.register("jvm.class.loading", new ClassLoadingGaugeSet());
+    }
+}

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -45,7 +45,7 @@
         <guava.version>18.0</guava.version>
         <javax.inject.version>1</javax.inject.version>
         <junit.version>4.11</junit.version>
-        <metrics.version>3.1.0</metrics.version>
+        <metrics.version>3.2.1</metrics.version>
         <testcontainers-version>1.1.7</testcontainers-version>
     </properties>
 
@@ -79,6 +79,11 @@
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
+                <version>${metrics.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-jvm</artifactId>
                 <version>${metrics.version}</version>
             </dependency>
             <dependency>

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/modules/server/DropWizardMetricsModule.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/modules/server/DropWizardMetricsModule.java
@@ -25,6 +25,7 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.james.lifecycle.api.Configurable;
 import org.apache.james.metrics.api.MetricFactory;
+import org.apache.james.metrics.dropwizard.DropWizardJVMMetrics;
 import org.apache.james.metrics.dropwizard.DropWizardMetricFactory;
 import org.apache.james.utils.ConfigurationPerformer;
 
@@ -43,6 +44,7 @@ public class DropWizardMetricsModule extends AbstractModule {
     protected void configure() {
         bind(MetricRegistry.class).in(Scopes.SINGLETON);
         bind(DropWizardMetricFactory.class).in(Scopes.SINGLETON);
+        bind(DropWizardJVMMetrics.class).in(Scopes.SINGLETON);
         bind(MetricFactory.class).to(DropWizardMetricFactory.class);
 
         Multibinder.newSetBinder(binder(), ConfigurationPerformer.class).addBinding().to(DropWizardConfigurationPerformer.class);
@@ -76,15 +78,18 @@ public class DropWizardMetricsModule extends AbstractModule {
 
     public static class DropWizardInitializer implements Configurable {
         private final DropWizardMetricFactory dropWizardMetricFactory;
+        private final DropWizardJVMMetrics dropWizardJVMMetrics;
 
         @Inject
-        public DropWizardInitializer(DropWizardMetricFactory dropWizardMetricFactory) {
+        public DropWizardInitializer(DropWizardMetricFactory dropWizardMetricFactory, DropWizardJVMMetrics dropWizardJVMMetrics) {
             this.dropWizardMetricFactory = dropWizardMetricFactory;
+            this.dropWizardJVMMetrics = dropWizardJVMMetrics;
         }
 
         @Override
         public void configure(HierarchicalConfiguration config) throws ConfigurationException {
             dropWizardMetricFactory.start();
+            dropWizardJVMMetrics.start();
         }
     }
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -188,7 +188,7 @@
         <assertj-3.version>3.3.0</assertj-3.version>
         <testcontainers-version>1.1.7</testcontainers-version>
         <guavate.version>1.0.0</guavate.version>
-        <metrics.version>3.1.0</metrics.version>
+        <metrics.version>3.2.1</metrics.version>
         <joda.version>2.9.4</joda.version>
     </properties>
 
@@ -1373,6 +1373,11 @@
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
+                <version>${metrics.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-jvm</artifactId>
                 <version>${metrics.version}</version>
             </dependency>
             <!-- This needed to let the bundle plugin to generate the right import statement -->


### PR DESCRIPTION
List of added metrics (obtained threw inspection) (? might require finding applicable value indexed on ES): 

 - **jvm.file.descriptor** : ratio of open/max file descriptors

-------------------------------------------------------

 - **jvm.gc.?.count** : count of GC
 - **jvm.gc.?.time** : time in GC

-------------------------------------------------------

 - **jvm.threads.count** : Count of threads
 - **jvm.threads.new.count**
 - **jvm.threads.runnable.count**
 - **jvm.threads.blocked.count**
 - **jvm.threads.waiting.count**
 - **jvm.threads.timed_waiting.count**
 - **jvm.threads.terminated.count**
 - **jvm.threads.daemon.count**
 - **jvm.threads.deadlock.count**

-------------------------------------------------------

 - **jvm.memory.total.init**
 - **jvm.memory.total.used**
 - **jvm.memory.total.max**
 - **jvm.memory.total.committed**
 - **jvm.memory.heap.init**
 - **jvm.memory.heap.used**
 - **jvm.memory.heap.max**
 - **jvm.memory.heap.committed**
 - **jvm.memory.heap.usage** (ratio)
 - **jvm.memory.non-heap.init**
 - **jvm.memory.non-heap.used**
 - **jvm.memory.non-heap.max**
 - **jvm.memory.non-heap.committed**
 - **jvm.memory.non-heap.usage** (ratio)
 - **jvm.memory.heap.init**
 - **jvm.memory.total.init**
 - **jvm.memory.total.init**
 - **jvm.memory.total.init**
 - **jvm.memory.total.init**
 - **jvm.memory.pools.?.usage** (Ratio)
 - **jvm.memory.pools.?.max**
 - **jvm.memory.pools.?.used**
 - **jvm.memory.pools.?.committed**
 - **jvm.memory.pools.?.used-after-gc**
 - **jvm.memory.pools.?.init**

-------------------------------------------------------

 - **jvm.class.loading.loaded**
 - **jvm.class.loading.unloaded**
