### PR TITLE
MAILBOX-291 Add JPA support for Quotas

### DIFF
--- a/backends-common/jpa/src/test/java/org/apache/james/backends/jpa/JpaTestCluster.java
+++ b/backends-common/jpa/src/test/java/org/apache/james/backends/jpa/JpaTestCluster.java
@@ -19,8 +19,8 @@
 
 package org.apache.james.backends.jpa;
 
-import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -30,10 +30,15 @@ import org.apache.openjpa.persistence.OpenJPAPersistence;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
 
 public class JpaTestCluster {
 
     public static JpaTestCluster create(Class<?>... clazz) {
+        return create(ImmutableList.copyOf(clazz));
+    }
+
+    public static JpaTestCluster create(List<Class<?>> clazz) {
         HashMap<String, String> properties = new HashMap<String, String>();
         properties.put("openjpa.ConnectionDriverName", org.h2.Driver.class.getName());
         properties.put("openjpa.ConnectionURL", "jdbc:h2:mem:mailboxintegration;DB_CLOSE_DELAY=-1"); // Memory H2 database
@@ -46,7 +51,7 @@ public class JpaTestCluster {
         properties.put("openjpa.ConnectionFactoryProperties", "PrettyPrint=true, PrettyPrintLineLength=72");
         properties.put("openjpa.MetaDataFactory", "jpa(Types=" +
             Joiner.on(";").join(
-                FluentIterable.from(Arrays.asList(clazz))
+                FluentIterable.from(clazz)
                     .transform(toFQDN()))
             + ")");
         return new JpaTestCluster(OpenJPAPersistence.getEntityManagerFactory(properties));
@@ -72,6 +77,10 @@ public class JpaTestCluster {
     }
 
     public void clear(String... tables) {
+        clear(ImmutableList.copyOf(tables));
+    }
+
+    public void clear(List<String> tables) {
         EntityManager entityManager = entityManagerFactory.createEntityManager();
         entityManager.getTransaction().begin();
         for(String tableName: tables) {

--- a/dockerfiles/run/spring/destination/conf/META-INF/persistence.xml
+++ b/dockerfiles/run/spring/destination/conf/META-INF/persistence.xml
@@ -39,6 +39,7 @@
         <class>org.apache.james.mailbox.jpa.quota.model.MaxDefaultStorage</class>
         <class>org.apache.james.mailbox.jpa.quota.model.MaxUserMessageCount</class>
         <class>org.apache.james.mailbox.jpa.quota.model.MaxUserStorage</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.JpaCurrentQuota</class>
 
         <properties>
             <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema(ForeignKeys=true)"/>

--- a/dockerfiles/run/spring/destination/conf/META-INF/persistence.xml
+++ b/dockerfiles/run/spring/destination/conf/META-INF/persistence.xml
@@ -35,6 +35,10 @@
         <class>org.apache.james.domainlist.jpa.model.JPADomain</class>
         <class>org.apache.james.user.jpa.model.JPAUser</class>
         <class>org.apache.james.rrt.jpa.model.JPARecipientRewrite</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.MaxDefaultMessageCount</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.MaxDefaultStorage</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.MaxUserMessageCount</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.MaxUserStorage</class>
 
         <properties>
             <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema(ForeignKeys=true)"/>

--- a/mailbox/jpa/pom.xml
+++ b/mailbox/jpa/pom.xml
@@ -131,7 +131,18 @@
                         <property>
                             <name>metaDataFactory</name>
                             <value>
-                                jpa(Types=org.apache.james.mailbox.jpa.mail.model.JPAUserFlag;org.apache.james.mailbox.jpa.mail.model.JPAMailbox;org.apache.james.mailbox.jpa.mail.model.openjpa.AbstractJPAMessage;org.apache.james.mailbox.jpa.mail.model.openjpa.JPAEncryptedMessage;org.apache.james.mailbox.jpa.mail.model.openjpa.JPAMessage;org.apache.james.mailbox.jpa.mail.model.openjpa.JPAStreamingMessage;org.apache.james.mailbox.jpa.mail.model.JPAProperty;org.apache.james.mailbox.jpa.user.model.JPASubscription)
+                                jpa(Types=org.apache.james.mailbox.jpa.mail.model.JPAUserFlag;
+                                org.apache.james.mailbox.jpa.mail.model.JPAMailbox;
+                                org.apache.james.mailbox.jpa.mail.model.openjpa.AbstractJPAMessage;
+                                org.apache.james.mailbox.jpa.mail.model.openjpa.JPAEncryptedMessage;
+                                org.apache.james.mailbox.jpa.mail.model.openjpa.JPAMessage;
+                                org.apache.james.mailbox.jpa.mail.model.openjpa.JPAStreamingMessage;
+                                org.apache.james.mailbox.jpa.mail.model.JPAProperty;
+                                org.apache.james.mailbox.jpa.user.model.JPASubscription;
+                                org.apache.james.mailbox.jpa.quota.model.MaxDefaultMessageCount;
+                                org.apache.james.mailbox.jpa.quota.model.MaxDefaultStorage
+                                org.apache.james.mailbox.jpa.quota.model.MaxUserMessageCount
+                                org.apache.james.mailbox.jpa.quota.model.MaxUserStorage)
                             </value>
                         </property>
                     </toolProperties>

--- a/mailbox/jpa/pom.xml
+++ b/mailbox/jpa/pom.xml
@@ -142,7 +142,8 @@
                                 org.apache.james.mailbox.jpa.quota.model.MaxDefaultMessageCount;
                                 org.apache.james.mailbox.jpa.quota.model.MaxDefaultStorage
                                 org.apache.james.mailbox.jpa.quota.model.MaxUserMessageCount
-                                org.apache.james.mailbox.jpa.quota.model.MaxUserStorage)
+                                org.apache.james.mailbox.jpa.quota.model.MaxUserStorage
+                                org.apache.james.mailbox.jpa.quota.model.JpaCurrentQuota)
                             </value>
                         </property>
                     </toolProperties>

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/JPAPerUserMaxQuotaManager.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/JPAPerUserMaxQuotaManager.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mailbox.jpa.quota;
 
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 
@@ -38,6 +39,7 @@ public class JPAPerUserMaxQuotaManager implements MaxQuotaManager {
 
     private final EntityManager entityManager;
 
+    @Inject
     public JPAPerUserMaxQuotaManager(EntityManagerFactory entityManagerFactory) {
         entityManager = entityManagerFactory.createEntityManager();
     }

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/JPAPerUserMaxQuotaManager.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/JPAPerUserMaxQuotaManager.java
@@ -1,0 +1,128 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.jpa.quota;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.jpa.quota.model.MaxDefaultMessageCount;
+import org.apache.james.mailbox.jpa.quota.model.MaxDefaultStorage;
+import org.apache.james.mailbox.jpa.quota.model.MaxUserMessageCount;
+import org.apache.james.mailbox.jpa.quota.model.MaxUserStorage;
+import org.apache.james.mailbox.model.Quota;
+import org.apache.james.mailbox.model.QuotaRoot;
+import org.apache.james.mailbox.quota.MaxQuotaManager;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+
+public class JPAPerUserMaxQuotaManager implements MaxQuotaManager {
+
+    private final EntityManager entityManager;
+
+    public JPAPerUserMaxQuotaManager(EntityManagerFactory entityManagerFactory) {
+        entityManager = entityManagerFactory.createEntityManager();
+    }
+
+    @Override
+    public void setMaxStorage(QuotaRoot quotaRoot, long maxStorageQuota) throws MailboxException {
+        entityManager.getTransaction().begin();
+        entityManager.merge(new MaxUserStorage(quotaRoot.getValue(), maxStorageQuota));
+        entityManager.getTransaction().commit();
+    }
+
+    @Override
+    public void setMaxMessage(QuotaRoot quotaRoot, long maxMessageCount) throws MailboxException {
+        entityManager.getTransaction().begin();
+        entityManager.merge(new MaxUserMessageCount(quotaRoot.getValue(), maxMessageCount));
+        entityManager.getTransaction().commit();
+    }
+
+    @Override
+    public void setDefaultMaxStorage(long defaultMaxStorage) throws MailboxException {
+        entityManager.getTransaction().begin();
+        entityManager.merge(new MaxDefaultStorage(defaultMaxStorage));
+        entityManager.getTransaction().commit();
+    }
+
+    @Override
+    public void setDefaultMaxMessage(long defaultMaxMessageCount) throws MailboxException {
+        entityManager.getTransaction().begin();
+        entityManager.merge(new MaxDefaultMessageCount(defaultMaxMessageCount));
+        entityManager.getTransaction().commit();
+    }
+
+    @Override
+    public long getDefaultMaxStorage() throws MailboxException {
+        MaxDefaultStorage storedValue = entityManager.find(MaxDefaultStorage.class, MaxDefaultStorage.DEFAULT_KEY);
+
+        return Optional.fromNullable(storedValue)
+            .transform(new Function<MaxDefaultStorage, Long>() {
+                @Override
+                public Long apply(MaxDefaultStorage input) {
+                    return input.getValue();
+                }
+            })
+            .or(Quota.UNLIMITED);
+    }
+
+    @Override
+    public long getDefaultMaxMessage() throws MailboxException {
+        MaxDefaultMessageCount storedValue = entityManager.find(MaxDefaultMessageCount.class, MaxDefaultMessageCount.DEFAULT_KEY);
+
+        return Optional.fromNullable(storedValue)
+            .transform(new Function<MaxDefaultMessageCount, Long>() {
+                @Override
+                public Long apply(MaxDefaultMessageCount input) {
+                    return input.getValue();
+                }
+            })
+            .or(Quota.UNLIMITED);
+    }
+
+    @Override
+    public long getMaxStorage(QuotaRoot quotaRoot) throws MailboxException {
+        MaxUserStorage storedValue = entityManager.find(MaxUserStorage.class, quotaRoot.getValue());
+
+        return Optional.fromNullable(storedValue)
+            .transform(new Function<MaxUserStorage, Long>() {
+                @Override
+                public Long apply(MaxUserStorage input) {
+                    return input.getValue();
+                }
+            })
+            .or(getDefaultMaxStorage());
+    }
+
+    @Override
+    public long getMaxMessage(QuotaRoot quotaRoot) throws MailboxException {
+        MaxUserMessageCount storedValue = entityManager.find(MaxUserMessageCount.class, quotaRoot.getValue());
+
+        return Optional.fromNullable(storedValue)
+            .transform(new Function<MaxUserMessageCount, Long>() {
+                @Override
+                public Long apply(MaxUserMessageCount input) {
+                    return input.getValue();
+                }
+            })
+            .or(getDefaultMaxMessage());
+    }
+}

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/JPAPerUserMaxQuotaManager.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/JPAPerUserMaxQuotaManager.java
@@ -76,55 +76,39 @@ public class JPAPerUserMaxQuotaManager implements MaxQuotaManager {
     public long getDefaultMaxStorage() throws MailboxException {
         MaxDefaultStorage storedValue = entityManager.find(MaxDefaultStorage.class, MaxDefaultStorage.DEFAULT_KEY);
 
-        return Optional.fromNullable(storedValue)
-            .transform(new Function<MaxDefaultStorage, Long>() {
-                @Override
-                public Long apply(MaxDefaultStorage input) {
-                    return input.getValue();
-                }
-            })
-            .or(Quota.UNLIMITED);
+        if (storedValue == null) {
+            return Quota.UNLIMITED;
+        }
+        return storedValue.getValue();
     }
 
     @Override
     public long getDefaultMaxMessage() throws MailboxException {
         MaxDefaultMessageCount storedValue = entityManager.find(MaxDefaultMessageCount.class, MaxDefaultMessageCount.DEFAULT_KEY);
 
-        return Optional.fromNullable(storedValue)
-            .transform(new Function<MaxDefaultMessageCount, Long>() {
-                @Override
-                public Long apply(MaxDefaultMessageCount input) {
-                    return input.getValue();
-                }
-            })
-            .or(Quota.UNLIMITED);
+        if (storedValue == null) {
+            return Quota.UNLIMITED;
+        }
+        return storedValue.getValue();
     }
 
     @Override
     public long getMaxStorage(QuotaRoot quotaRoot) throws MailboxException {
         MaxUserStorage storedValue = entityManager.find(MaxUserStorage.class, quotaRoot.getValue());
 
-        return Optional.fromNullable(storedValue)
-            .transform(new Function<MaxUserStorage, Long>() {
-                @Override
-                public Long apply(MaxUserStorage input) {
-                    return input.getValue();
-                }
-            })
-            .or(getDefaultMaxStorage());
+        if (storedValue == null) {
+            return getDefaultMaxStorage();
+        }
+        return storedValue.getValue();
     }
 
     @Override
     public long getMaxMessage(QuotaRoot quotaRoot) throws MailboxException {
         MaxUserMessageCount storedValue = entityManager.find(MaxUserMessageCount.class, quotaRoot.getValue());
 
-        return Optional.fromNullable(storedValue)
-            .transform(new Function<MaxUserMessageCount, Long>() {
-                @Override
-                public Long apply(MaxUserMessageCount input) {
-                    return input.getValue();
-                }
-            })
-            .or(getDefaultMaxMessage());
+        if (storedValue == null) {
+            return getDefaultMaxMessage();
+        }
+        return storedValue.getValue();
     }
 }

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/JpaCurrentQuotaManager.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/JpaCurrentQuotaManager.java
@@ -1,0 +1,104 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.jpa.quota;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+
+import org.apache.james.mailbox.MailboxListener;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.jpa.quota.model.JpaCurrentQuota;
+import org.apache.james.mailbox.model.QuotaRoot;
+import org.apache.james.mailbox.store.quota.StoreCurrentQuotaManager;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+
+public class JpaCurrentQuotaManager implements StoreCurrentQuotaManager {
+
+    public static final Function<JpaCurrentQuota, Long> READ_MESSAGE_COUNT = new Function<JpaCurrentQuota, Long>() {
+        @Override
+        public Long apply(JpaCurrentQuota input) {
+            return input.getMessageCount();
+        }
+    };
+    public static final Function<JpaCurrentQuota, Long> READ_STORAGE = new Function<JpaCurrentQuota, Long>() {
+        @Override
+        public Long apply(JpaCurrentQuota input) {
+            return input.getSize();
+        }
+    };
+
+    private final EntityManager entityManager;
+
+    public JpaCurrentQuotaManager(EntityManagerFactory entityManagerFactory) {
+        this.entityManager = entityManagerFactory.createEntityManager();
+    }
+
+    @Override
+    public MailboxListener.ListenerType getAssociatedListenerType() {
+        return MailboxListener.ListenerType.ONCE;
+    }
+
+    @Override
+    public long getCurrentMessageCount(QuotaRoot quotaRoot) throws MailboxException {
+        return Optional.fromNullable(retrieveUserQuota(quotaRoot))
+            .transform(READ_MESSAGE_COUNT)
+            .or(0L);
+    }
+
+    @Override
+    public long getCurrentStorage(QuotaRoot quotaRoot) throws MailboxException {
+        return Optional.fromNullable(retrieveUserQuota(quotaRoot))
+            .transform(READ_STORAGE)
+            .or(0L);
+    }
+
+    @Override
+    public void increase(QuotaRoot quotaRoot, long count, long size) throws MailboxException {
+        Preconditions.checkArgument(count > 0,"Counts should be positive");
+        Preconditions.checkArgument(size > 0, "Size should be positive");
+
+        JpaCurrentQuota jpaCurrentQuota = Optional.fromNullable(retrieveUserQuota(quotaRoot))
+            .or(new JpaCurrentQuota(quotaRoot.getValue(), 0L, 0L));
+
+        entityManager.merge(new JpaCurrentQuota(quotaRoot.getValue(),
+            jpaCurrentQuota.getMessageCount() + count,
+            jpaCurrentQuota.getSize() + size));
+    }
+
+    @Override
+    public void decrease(QuotaRoot quotaRoot, long count, long size) throws MailboxException {
+        Preconditions.checkArgument(count > 0, "Counts should be positive");
+        Preconditions.checkArgument(size > 0, "Counts should be positive");
+
+        JpaCurrentQuota jpaCurrentQuota = Optional.fromNullable(retrieveUserQuota(quotaRoot))
+            .or(new JpaCurrentQuota(quotaRoot.getValue(), 0L, 0L));
+
+        entityManager.merge(new JpaCurrentQuota(quotaRoot.getValue(),
+            jpaCurrentQuota.getMessageCount() - count,
+            jpaCurrentQuota.getSize() - size));
+    }
+
+    private JpaCurrentQuota retrieveUserQuota(QuotaRoot quotaRoot) throws MailboxException {
+        return entityManager.find(JpaCurrentQuota.class, quotaRoot.getValue());
+    }
+}

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/JpaCurrentQuotaManager.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/JpaCurrentQuotaManager.java
@@ -72,7 +72,7 @@ public class JpaCurrentQuotaManager implements StoreCurrentQuotaManager {
 
     @Override
     public void increase(QuotaRoot quotaRoot, long count, long size) throws MailboxException {
-        Preconditions.checkArgument(count > 0,"Counts should be positive");
+        Preconditions.checkArgument(count > 0, "Counts should be positive");
         Preconditions.checkArgument(size > 0, "Size should be positive");
 
         JpaCurrentQuota jpaCurrentQuota = Optional.fromNullable(retrieveUserQuota(quotaRoot))

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/JpaCurrentQuotaManager.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/JpaCurrentQuotaManager.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mailbox.jpa.quota;
 
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 
@@ -49,6 +50,7 @@ public class JpaCurrentQuotaManager implements StoreCurrentQuotaManager {
 
     private final EntityManager entityManager;
 
+    @Inject
     public JpaCurrentQuotaManager(EntityManagerFactory entityManagerFactory) {
         this.entityManager = entityManagerFactory.createEntityManager();
     }

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/JpaCurrentQuota.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/JpaCurrentQuota.java
@@ -17,26 +17,41 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.mailbox.cassandra.quota;
+package org.apache.james.mailbox.jpa.quota.model;
 
-import org.apache.james.backends.cassandra.CassandraCluster;
-import org.apache.james.mailbox.cassandra.modules.CassandraQuotaModule;
-import org.apache.james.mailbox.store.quota.StoreCurrentQuotaManager;
-import org.apache.james.mailbox.store.quota.StoreCurrentQuotaManagerTest;
-import org.junit.After;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
 
-public class CassandraCurrentQuotaManagerTest extends StoreCurrentQuotaManagerTest {
+@Entity(name = "CurrentQuota")
+@Table(name = "JAMES_QUOTA_CURRENTQUOTA")
+public class JpaCurrentQuota {
 
-    private static final CassandraCluster CASSANDRA_CLUSTER = CassandraCluster.create(new CassandraQuotaModule());
+    @Id
+    @Column(name = "CURRENTQUOTA_QUOTAROOT")
+    private String quotaRoot;
 
-    @Override
-    protected StoreCurrentQuotaManager provideTestee() {
-        return new CassandraCurrentQuotaManager(CASSANDRA_CLUSTER.getConf());
+    @Column(name = "CURRENTQUOTA_MESSAGECOUNT")
+    private long messageCount;
+
+    @Column(name = "CURRENTQUOTA_SIZE")
+    private long size;
+
+    public JpaCurrentQuota() {
     }
 
-    @After
-    public void tearDown() {
-        CASSANDRA_CLUSTER.clearAllTables();
+    public JpaCurrentQuota(String quotaRoot, long messageCount, long size) {
+        this.quotaRoot = quotaRoot;
+        this.messageCount = messageCount;
+        this.size = size;
     }
 
+    public long getMessageCount() {
+        return messageCount;
+    }
+
+    public long getSize() {
+        return size;
+    }
 }

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxDefaultMessageCount.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxDefaultMessageCount.java
@@ -1,0 +1,50 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.jpa.quota.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity(name = "MaxDefaultMessageCount")
+@Table(name = "JAMES_MAX_DEFAULT_MESSAGE_COUNT")
+public class MaxDefaultMessageCount {
+    public static final String DEFAULT_KEY = "default_key";
+    
+    @Id
+    @Column(name = "QUOTAROOT_ID")
+    private String quotaRoot = DEFAULT_KEY;
+
+    @Column(name = "VALUE")
+    private long value;
+
+    public MaxDefaultMessageCount(long value) {
+        this.quotaRoot = DEFAULT_KEY;
+        this.value = value;
+    }
+
+    public MaxDefaultMessageCount() {
+    }
+
+    public long getValue() {
+        return value;
+    }
+}

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxDefaultStorage.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxDefaultStorage.java
@@ -1,0 +1,50 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.jpa.quota.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity(name="MaxDefaultStorage")
+@Table(name="JAMES_MAX_DEFAULT_STORAGE")
+public class MaxDefaultStorage {
+    public static final String DEFAULT_KEY = "default_key";
+   
+    @Id
+    @Column(name = "QUOTAROOT_ID")
+    private String quotaRoot = DEFAULT_KEY;
+
+    @Column(name="VALUE")
+    private long value;
+
+    public MaxDefaultStorage(long value) {
+        this.quotaRoot = DEFAULT_KEY;
+        this.value = value;
+    }
+
+    public MaxDefaultStorage() {
+    }
+
+    public long getValue() {
+        return value;
+    }
+}

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxUserMessageCount.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxUserMessageCount.java
@@ -26,12 +26,10 @@ import javax.persistence.Table;
 
 @Entity(name="MaxUserMessageCount")
 @Table(name="JAMES_MAX_USER_MESSAGE_COUNT")
-public class MaxUserMessageCount {  
-    private static final String DEFAULT_KEY = "default_key";
-
+public class MaxUserMessageCount {
     @Id
     @Column(name = "QUOTAROOT_ID")
-    private String quotaRoot = DEFAULT_KEY;
+    private String quotaRoot;
 
     @Column(name = "VALUE")
     private long value;

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxUserMessageCount.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxUserMessageCount.java
@@ -27,10 +27,10 @@ import javax.persistence.Table;
 @Entity(name="MaxUserMessageCount")
 @Table(name="JAMES_MAX_USER_MESSAGE_COUNT")
 public class MaxUserMessageCount {  
-	private static final String DEFAULT_KEY = "default_key";
+    private static final String DEFAULT_KEY = "default_key";
 
-	@Id
-	@Column(name = "QUOTAROOT_ID")
+    @Id
+    @Column(name = "QUOTAROOT_ID")
     private String quotaRoot = DEFAULT_KEY;
 
     @Column(name = "VALUE")

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxUserMessageCount.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxUserMessageCount.java
@@ -1,0 +1,50 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.jpa.quota.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity(name="MaxUserMessageCount")
+@Table(name="JAMES_MAX_USER_MESSAGE_COUNT")
+public class MaxUserMessageCount {  
+	private static final String DEFAULT_KEY = "default_key";
+
+	@Id
+	@Column(name = "QUOTAROOT_ID")
+    private String quotaRoot = DEFAULT_KEY;
+
+    @Column(name = "VALUE")
+    private long value;
+
+    public MaxUserMessageCount(String quotaRoot, long value) {
+        this.quotaRoot = quotaRoot;
+        this.value = value;
+    }
+
+    public MaxUserMessageCount() {
+    }
+
+    public long getValue() {
+        return value;
+    }
+}

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxUserStorage.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxUserStorage.java
@@ -1,0 +1,49 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.jpa.quota.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity(name = "MaxUserStorage")
+@Table(name = "JAMES_MAX_USER_STORAGE")
+public class MaxUserStorage {
+	
+	@Id
+    @Column(name = "QUOTAROOT_ID")
+    private String quotaRoot;
+
+	@Column(name = "VALUE")
+    private long value;
+
+    public MaxUserStorage(String quotaRoot, long value) {
+        this.quotaRoot = quotaRoot;
+        this.value = value;
+    }
+
+    public MaxUserStorage() {
+    }
+
+    public long getValue() {
+        return value;
+    }
+}

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxUserStorage.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxUserStorage.java
@@ -27,12 +27,12 @@ import javax.persistence.Table;
 @Entity(name = "MaxUserStorage")
 @Table(name = "JAMES_MAX_USER_STORAGE")
 public class MaxUserStorage {
-	
-	@Id
+
+    @Id
     @Column(name = "QUOTAROOT_ID")
     private String quotaRoot;
 
-	@Column(name = "VALUE")
+    @Column(name = "VALUE")
     private long value;
 
     public MaxUserStorage(String quotaRoot, long value) {

--- a/mailbox/jpa/src/main/resources/META-INF/persistence.xml
+++ b/mailbox/jpa/src/main/resources/META-INF/persistence.xml
@@ -34,6 +34,7 @@
         <class>org.apache.james.mailbox.jpa.quota.model.MaxDefaultStorage</class>
         <class>org.apache.james.mailbox.jpa.quota.model.MaxUserMessageCount</class>
         <class>org.apache.james.mailbox.jpa.quota.model.MaxUserStorage</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.JpaCurrentQuota</class>
         <properties>
             <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema(ForeignKeys=true)"/>
             <property name="openjpa.jdbc.MappingDefaults" value="ForeignKeyDeleteAction=cascade, JoinForeignKeyDeleteAction=cascade"/>

--- a/mailbox/jpa/src/main/resources/META-INF/persistence.xml
+++ b/mailbox/jpa/src/main/resources/META-INF/persistence.xml
@@ -30,6 +30,10 @@
         <class>org.apache.james.mailbox.jpa.mail.model.openjpa.JPAMailboxMessage</class>
         <class>org.apache.james.mailbox.jpa.mail.model.JPAProperty</class>
         <class>org.apache.james.mailbox.jpa.user.model.JPASubscription</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.MaxDefaultMessageCount</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.MaxDefaultStorage</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.MaxUserMessageCount</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.MaxUserStorage</class>
         <properties>
             <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema(ForeignKeys=true)"/>
             <property name="openjpa.jdbc.MappingDefaults" value="ForeignKeyDeleteAction=cascade, JoinForeignKeyDeleteAction=cascade"/>

--- a/mailbox/jpa/src/main/resources/META-INF/spring/mailbox-jpa.xml
+++ b/mailbox/jpa/src/main/resources/META-INF/spring/mailbox-jpa.xml
@@ -90,5 +90,10 @@
 
     <bean id="jpa-mailbox-id-deserializer" class="org.apache.james.mailbox.jpa.JPAMailboxIdDeserializer"/>
 
-    <bean id="jpaMaxQuotaManager" class="org.apache.james.mailbox.jpa.quota.JPAPerUserMaxQuotaManager"/>
+    <bean id="jpaMaxQuotaManager" class="org.apache.james.mailbox.jpa.quota.JPAPerUserMaxQuotaManager">
+        <constructor-arg index="0" ref="entityManagerFactory"/>
+    </bean>
+    <bean id="jpaCurrentQuotaManager" class="org.apache.james.mailbox.jpa.quota.JpaCurrentQuotaManager">
+        <constructor-arg index="0" ref="entityManagerFactory"/>
+    </bean>
 </beans>

--- a/mailbox/jpa/src/main/resources/META-INF/spring/mailbox-jpa.xml
+++ b/mailbox/jpa/src/main/resources/META-INF/spring/mailbox-jpa.xml
@@ -90,4 +90,5 @@
 
     <bean id="jpa-mailbox-id-deserializer" class="org.apache.james.mailbox.jpa.JPAMailboxIdDeserializer"/>
 
+    <bean id="jpaMaxQuotaManager" class="org.apache.james.mailbox.jpa.quota.JPAPerUserMaxQuotaManager"/>
 </beans>

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxFixture.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxFixture.java
@@ -25,6 +25,10 @@ import org.apache.james.mailbox.jpa.mail.model.JPAProperty;
 import org.apache.james.mailbox.jpa.mail.model.JPAUserFlag;
 import org.apache.james.mailbox.jpa.mail.model.openjpa.AbstractJPAMailboxMessage;
 import org.apache.james.mailbox.jpa.mail.model.openjpa.JPAMailboxMessage;
+import org.apache.james.mailbox.jpa.quota.model.MaxDefaultMessageCount;
+import org.apache.james.mailbox.jpa.quota.model.MaxDefaultStorage;
+import org.apache.james.mailbox.jpa.quota.model.MaxUserMessageCount;
+import org.apache.james.mailbox.jpa.quota.model.MaxUserStorage;
 import org.apache.james.mailbox.jpa.user.model.JPASubscription;
 
 public interface JPAMailboxFixture {
@@ -37,9 +41,23 @@ public interface JPAMailboxFixture {
         JPAMailboxAnnotation.class,
         JPASubscription.class};
 
+    Class<?>[] QUOTA_PERSISTANCE_CLASSES = new Class[] {
+        MaxDefaultMessageCount.class,
+        MaxDefaultStorage.class,
+        MaxUserMessageCount.class,
+        MaxUserStorage.class
+    };
+
     String[] MAILBOX_TABLE_NAMES = new String[] {"JAMES_MAIL_USERFLAG",
         "JAMES_MAIL_PROPERTY",
         "JAMES_MAILBOX_ANNOTATION",
         "JAMES_MAILBOX",
         "JAMES_MAIL"};
+
+    String[] QUOTA_TABLES_NAMES = new String[] {
+        "JAMES_MAX_DEFAULT_MESSAGE_COUNT",
+        "JAMES_MAX_DEFAULT_STORAGE",
+        "JAMES_MAX_USER_MESSAGE_COUNT",
+        "JAMES_MAX_USER_STORAGE"
+    };
 }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxFixture.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxFixture.java
@@ -25,6 +25,7 @@ import org.apache.james.mailbox.jpa.mail.model.JPAProperty;
 import org.apache.james.mailbox.jpa.mail.model.JPAUserFlag;
 import org.apache.james.mailbox.jpa.mail.model.openjpa.AbstractJPAMailboxMessage;
 import org.apache.james.mailbox.jpa.mail.model.openjpa.JPAMailboxMessage;
+import org.apache.james.mailbox.jpa.quota.model.JpaCurrentQuota;
 import org.apache.james.mailbox.jpa.quota.model.MaxDefaultMessageCount;
 import org.apache.james.mailbox.jpa.quota.model.MaxDefaultStorage;
 import org.apache.james.mailbox.jpa.quota.model.MaxUserMessageCount;
@@ -39,13 +40,15 @@ public interface JPAMailboxFixture {
         JPAProperty.class,
         JPAUserFlag.class,
         JPAMailboxAnnotation.class,
-        JPASubscription.class};
+        JPASubscription.class
+    };
 
     Class<?>[] QUOTA_PERSISTANCE_CLASSES = new Class[] {
         MaxDefaultMessageCount.class,
         MaxDefaultStorage.class,
         MaxUserMessageCount.class,
-        MaxUserStorage.class
+        MaxUserStorage.class,
+        JpaCurrentQuota.class
     };
 
     String[] MAILBOX_TABLE_NAMES = new String[] {"JAMES_MAIL_USERFLAG",
@@ -58,6 +61,7 @@ public interface JPAMailboxFixture {
         "JAMES_MAX_DEFAULT_MESSAGE_COUNT",
         "JAMES_MAX_DEFAULT_STORAGE",
         "JAMES_MAX_USER_MESSAGE_COUNT",
-        "JAMES_MAX_USER_STORAGE"
+        "JAMES_MAX_USER_STORAGE",
+        "JAMES_QUOTA_CURRENTQUOTA"
     };
 }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxFixture.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxFixture.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mailbox.jpa;
 
+import java.util.List;
+
 import org.apache.james.mailbox.jpa.mail.model.JPAMailbox;
 import org.apache.james.mailbox.jpa.mail.model.JPAMailboxAnnotation;
 import org.apache.james.mailbox.jpa.mail.model.JPAProperty;
@@ -32,36 +34,38 @@ import org.apache.james.mailbox.jpa.quota.model.MaxUserMessageCount;
 import org.apache.james.mailbox.jpa.quota.model.MaxUserStorage;
 import org.apache.james.mailbox.jpa.user.model.JPASubscription;
 
+import com.google.common.collect.ImmutableList;
+
 public interface JPAMailboxFixture {
 
-    Class<?>[] MAILBOX_PERSISTANCE_CLASSES = new Class[] {JPAMailbox.class,
+    List<Class<?>> MAILBOX_PERSISTANCE_CLASSES = ImmutableList.<Class<?>>of(JPAMailbox.class,
         AbstractJPAMailboxMessage.class,
         JPAMailboxMessage.class,
         JPAProperty.class,
         JPAUserFlag.class,
         JPAMailboxAnnotation.class,
         JPASubscription.class
-    };
+    );
 
-    Class<?>[] QUOTA_PERSISTANCE_CLASSES = new Class[] {
+    List<Class<?>> QUOTA_PERSISTANCE_CLASSES = ImmutableList.<Class<?>>of(
         MaxDefaultMessageCount.class,
         MaxDefaultStorage.class,
         MaxUserMessageCount.class,
         MaxUserStorage.class,
         JpaCurrentQuota.class
-    };
+    );
 
-    String[] MAILBOX_TABLE_NAMES = new String[] {"JAMES_MAIL_USERFLAG",
+    List<String> MAILBOX_TABLE_NAMES = ImmutableList.<String>of("JAMES_MAIL_USERFLAG",
         "JAMES_MAIL_PROPERTY",
         "JAMES_MAILBOX_ANNOTATION",
         "JAMES_MAILBOX",
-        "JAMES_MAIL"};
+        "JAMES_MAIL");
 
-    String[] QUOTA_TABLES_NAMES = new String[] {
+    List<String> QUOTA_TABLES_NAMES = ImmutableList.<String>of(
         "JAMES_MAX_DEFAULT_MESSAGE_COUNT",
         "JAMES_MAX_DEFAULT_STORAGE",
         "JAMES_MAX_USER_MESSAGE_COUNT",
         "JAMES_MAX_USER_STORAGE",
         "JAMES_QUOTA_CURRENTQUOTA"
-    };
+    );
 }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/quota/JPACurrentQuotaManagerTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/quota/JPACurrentQuotaManagerTest.java
@@ -17,26 +17,26 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.mailbox.cassandra.quota;
+package org.apache.james.mailbox.jpa.quota;
 
-import org.apache.james.backends.cassandra.CassandraCluster;
-import org.apache.james.mailbox.cassandra.modules.CassandraQuotaModule;
+import org.apache.james.backends.jpa.JpaTestCluster;
+import org.apache.james.mailbox.jpa.JPAMailboxFixture;
 import org.apache.james.mailbox.store.quota.StoreCurrentQuotaManager;
 import org.apache.james.mailbox.store.quota.StoreCurrentQuotaManagerTest;
 import org.junit.After;
 
-public class CassandraCurrentQuotaManagerTest extends StoreCurrentQuotaManagerTest {
+public class JPACurrentQuotaManagerTest extends StoreCurrentQuotaManagerTest {
 
-    private static final CassandraCluster CASSANDRA_CLUSTER = CassandraCluster.create(new CassandraQuotaModule());
+    private static final JpaTestCluster JPA_TEST_CLUSTER = JpaTestCluster.create(JPAMailboxFixture.QUOTA_PERSISTANCE_CLASSES);
 
     @Override
     protected StoreCurrentQuotaManager provideTestee() {
-        return new CassandraCurrentQuotaManager(CASSANDRA_CLUSTER.getConf());
+        return new JpaCurrentQuotaManager(JPA_TEST_CLUSTER.getEntityManagerFactory());
     }
 
     @After
     public void tearDown() {
-        CASSANDRA_CLUSTER.clearAllTables();
+        JPA_TEST_CLUSTER.clear(JPAMailboxFixture.QUOTA_TABLES_NAMES);
     }
 
 }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/quota/JPAPerUserMaxQuotaTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/quota/JPAPerUserMaxQuotaTest.java
@@ -1,0 +1,41 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.jpa.quota;
+
+import org.apache.james.backends.jpa.JpaTestCluster;
+import org.apache.james.mailbox.jpa.JPAMailboxFixture;
+import org.apache.james.mailbox.quota.MaxQuotaManager;
+import org.apache.james.mailbox.store.quota.GenericMaxQuotaManagerTest;
+import org.junit.After;
+
+public class JPAPerUserMaxQuotaTest extends GenericMaxQuotaManagerTest {
+
+    private static final JpaTestCluster JPA_TEST_CLUSTER = JpaTestCluster.create(JPAMailboxFixture.QUOTA_PERSISTANCE_CLASSES);
+
+    @Override
+    protected MaxQuotaManager provideMaxQuotaManager() {
+        return new JPAPerUserMaxQuotaManager(JPA_TEST_CLUSTER.getEntityManagerFactory());
+    }
+
+    @After
+    public void cleanUp() {
+        JPA_TEST_CLUSTER.clear(JPAMailboxFixture.QUOTA_TABLES_NAMES);
+    }
+}

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/quota/StoreCurrentQuotaManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/quota/StoreCurrentQuotaManagerTest.java
@@ -1,0 +1,108 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.store.quota;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.mailbox.model.QuotaRoot;
+import org.junit.Before;
+import org.junit.Test;
+
+public abstract class StoreCurrentQuotaManagerTest {
+    public static final QuotaRoot QUOTA_ROOT = QuotaRootImpl.quotaRoot("benwa");
+    protected abstract StoreCurrentQuotaManager provideTestee();
+    private StoreCurrentQuotaManager testee;
+
+    @Before
+    public void setUp() throws Exception {
+        testee = provideTestee();
+    }
+
+    @Test
+    public void getCurrentStorageShouldReturnZeroByDefault() throws Exception {
+        assertThat(testee.getCurrentStorage(QUOTA_ROOT)).isEqualTo(0);
+    }
+
+    @Test
+    public void increaseShouldWork() throws Exception {
+        testee.increase(QUOTA_ROOT, 10, 100);
+
+        assertThat(testee.getCurrentMessageCount(QUOTA_ROOT)).isEqualTo(10);
+        assertThat(testee.getCurrentStorage(QUOTA_ROOT)).isEqualTo(100);
+    }
+
+    @Test
+    public void decreaseShouldWork() throws Exception {
+        testee.increase(QUOTA_ROOT, 20, 200);
+
+        testee.decrease(QUOTA_ROOT, 10, 100);
+
+        assertThat(testee.getCurrentMessageCount(QUOTA_ROOT)).isEqualTo(10);
+        assertThat(testee.getCurrentStorage(QUOTA_ROOT)).isEqualTo(100);
+    }
+
+    @Test
+    public void decreaseShouldNotFailWhenItLeadsToNegativeValues() throws Exception {
+        testee.decrease(QUOTA_ROOT, 10, 100);
+
+        assertThat(testee.getCurrentMessageCount(QUOTA_ROOT)).isEqualTo(-10);
+        assertThat(testee.getCurrentStorage(QUOTA_ROOT)).isEqualTo(-100);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void increaseShouldThrowOnZeroCount() throws Exception {
+        testee.increase(QUOTA_ROOT, 0, 5);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void increaseShouldThrowOnNegativeCount() throws Exception {
+        testee.increase(QUOTA_ROOT, -1, 5);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void increaseShouldThrowOnZeroSize() throws Exception {
+        testee.increase(QUOTA_ROOT, 5, 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void increaseShouldThrowOnNegativeSize() throws Exception {
+        testee.increase(QUOTA_ROOT, 5, -1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void decreaseShouldThrowOnZeroCount() throws Exception {
+        testee.decrease(QUOTA_ROOT, 0, 5);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void decreaseShouldThrowOnNegativeCount() throws Exception {
+        testee.decrease(QUOTA_ROOT, -1, 5);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void decreaseShouldThrowOnZeroSize() throws Exception {
+        testee.decrease(QUOTA_ROOT, 5, 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void decreaseShouldThrowOnNegativeSize() throws Exception {
+        testee.decrease(QUOTA_ROOT, 5, -1);
+    }
+}

--- a/mailet/pom.xml
+++ b/mailet/pom.xml
@@ -237,11 +237,6 @@
                 <artifactId>jackson-datatype-jdk8</artifactId>
                 <version>${jackson-data.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.github.steveash.guavate</groupId>
-                <artifactId>guavate</artifactId>
-                <version>${guavate.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/mpt/core/src/main/java/org/apache/james/mpt/api/ImapHostSystem.java
+++ b/mpt/core/src/main/java/org/apache/james/mpt/api/ImapHostSystem.java
@@ -27,4 +27,6 @@ public interface ImapHostSystem extends HostSystem {
     
     void createMailbox(MailboxPath mailboxPath) throws Exception;
 
+    void setQuotaLimits(long maxMessageQuota, long maxStorageQuota) throws Exception;
+
 }

--- a/mpt/core/src/main/java/org/apache/james/mpt/host/ExternalHostSystem.java
+++ b/mpt/core/src/main/java/org/apache/james/mpt/host/ExternalHostSystem.java
@@ -107,5 +107,10 @@ public class ExternalHostSystem extends ExternalSessionFactory implements ImapHo
     public boolean supports(Feature... features) {
         return this.features.supports(features);
     }
+
+    @Override
+    public void setQuotaLimits(long maxMessageQuota, long maxStorageQuota) throws Exception {
+        throw new NotImplementedException();
+    }
     
 }

--- a/mpt/core/src/main/java/org/apache/james/mpt/host/ExternalHostSystem.java
+++ b/mpt/core/src/main/java/org/apache/james/mpt/host/ExternalHostSystem.java
@@ -47,7 +47,7 @@ public class ExternalHostSystem extends ExternalSessionFactory implements ImapHo
     /**
      * Constructs a host system suitable for connection to an open port.
      * 
-     * @param supportedFeatures
+     * @param features
      *            set of features supported by the system
      * @param host
      *            host name that will be connected to, not null

--- a/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/imapmailbox/suite/QuotaTest.java
+++ b/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/imapmailbox/suite/QuotaTest.java
@@ -30,6 +30,9 @@ import java.util.Locale;
 
 public class QuotaTest extends BaseSelectedState {
 
+    private static final int MAX_MESSAGE_QUOTA = 4096;
+    private static final long MAX_STORAGE_QUOTA = 5 * 1024L * 1024L * 1024L;
+
     @Inject
     private static ImapHostSystem system;
 
@@ -40,6 +43,9 @@ public class QuotaTest extends BaseSelectedState {
     @Test
     public void testQuotaScript() throws Exception {
         Assume.assumeTrue(system.supports(ImapFeatures.Feature.QUOTA_SUPPORT));
+
+        system.setQuotaLimits(MAX_MESSAGE_QUOTA, MAX_STORAGE_QUOTA);
+
         scriptTest("Quota", Locale.CANADA);
     }
 }

--- a/mpt/impl/imap-mailbox/cyrus/src/test/java/org/apache/james/mpt/imapmailbox/cyrus/host/CyrusHostSystem.java
+++ b/mpt/impl/imap-mailbox/cyrus/src/test/java/org/apache/james/mpt/imapmailbox/cyrus/host/CyrusHostSystem.java
@@ -20,6 +20,7 @@ package org.apache.james.mpt.imapmailbox.cyrus.host;
 
 import java.net.InetSocketAddress;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.james.mailbox.model.MailboxConstants;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mpt.api.ImapFeatures;
@@ -129,6 +130,9 @@ public class CyrusHostSystem extends ExternalHostSystem implements Provider<Cont
             Throwables.propagate(e);
         }
     }
-    
 
+    @Override
+    public void setQuotaLimits(long maxMessageQuota, long maxStorageQuota) throws Exception {
+        throw new NotImplementedException();
+    }
 }

--- a/mpt/impl/imap-mailbox/elasticsearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/host/ElasticSearchHostSystem.java
+++ b/mpt/impl/imap-mailbox/elasticsearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/host/ElasticSearchHostSystem.java
@@ -25,6 +25,7 @@ import java.time.ZoneId;
 import java.util.concurrent.Executors;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.james.backends.es.DeleteByQueryPerformer;
 import org.apache.james.backends.es.ElasticSearchIndexer;
 import org.apache.james.backends.es.EmbeddedElasticSearch;
@@ -150,4 +151,8 @@ public class ElasticSearchHostSystem extends JamesImapHostSystem {
         return SUPPORTED_FEATURES.supports(features);
     }
 
+    @Override
+    public void setQuotaLimits(long maxMessageQuota, long maxStorageQuota) throws Exception {
+        throw new NotImplementedException();
+    }
 }

--- a/mpt/impl/imap-mailbox/external-james/src/test/java/org/apache/james/mpt/imapmailbox/external/james/host/ExternalJamesHostSystem.java
+++ b/mpt/impl/imap-mailbox/external-james/src/test/java/org/apache/james/mpt/imapmailbox/external/james/host/ExternalJamesHostSystem.java
@@ -74,5 +74,10 @@ public class ExternalJamesHostSystem extends ExternalHostSystem {
     public void createMailbox(MailboxPath mailboxPath) {
         throw new NotImplementedException();
     }
+
+    @Override
+    public void setQuotaLimits(long maxMessageQuota, long maxStorageQuota) throws Exception {
+        throw new NotImplementedException();
+    }
     
 }

--- a/mpt/impl/imap-mailbox/hbase/src/test/java/org/apache/james/mpt/imapmailbox/hbase/host/HBaseHostSystem.java
+++ b/mpt/impl/imap-mailbox/hbase/src/test/java/org/apache/james/mpt/imapmailbox/hbase/host/HBaseHostSystem.java
@@ -21,6 +21,7 @@ package org.apache.james.mpt.imapmailbox.hbase.host;
 import java.io.File;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
@@ -155,5 +156,10 @@ public class HBaseHostSystem extends JamesImapHostSystem {
     @Override
     public boolean supports(Feature... features) {
         return SUPPORTED_FEATURES.supports(features);
+    }
+
+    @Override
+    public void setQuotaLimits(long maxMessageQuota, long maxStorageQuota) throws Exception {
+        throw new NotImplementedException();
     }
 }

--- a/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/host/InMemoryEventAsynchronousHostSystem.java
+++ b/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/host/InMemoryEventAsynchronousHostSystem.java
@@ -55,6 +55,7 @@ public class InMemoryEventAsynchronousHostSystem extends JamesImapHostSystem {
     private static final ImapFeatures SUPPORTED_FEATURES = ImapFeatures.of(Feature.NAMESPACE_SUPPORT);
 
     private StoreMailboxManager mailboxManager;
+    private InMemoryPerUserMaxQuotaManager perUserMaxQuotaManager;
 
     public static JamesImapHostSystem build() throws Exception {
         return new InMemoryEventAsynchronousHostSystem();
@@ -79,9 +80,7 @@ public class InMemoryEventAsynchronousHostSystem extends JamesImapHostSystem {
                 new InMemoryMessageId.Factory(), MailboxConstants.DEFAULT_LIMIT_ANNOTATIONS_ON_MAILBOX, MailboxConstants.DEFAULT_LIMIT_ANNOTATION_SIZE);
         QuotaRootResolver quotaRootResolver = new DefaultQuotaRootResolver(factory);
 
-        InMemoryPerUserMaxQuotaManager perUserMaxQuotaManager = new InMemoryPerUserMaxQuotaManager();
-        perUserMaxQuotaManager.setDefaultMaxMessage(4096);
-        perUserMaxQuotaManager.setDefaultMaxStorage(5L * 1024L * 1024L * 1024L);
+        perUserMaxQuotaManager = new InMemoryPerUserMaxQuotaManager();
 
         InMemoryCurrentQuotaManager currentQuotaManager = new InMemoryCurrentQuotaManager(
             new CurrentQuotaCalculator(factory, quotaRootResolver),
@@ -122,6 +121,12 @@ public class InMemoryEventAsynchronousHostSystem extends JamesImapHostSystem {
     @Override
     public boolean supports(Feature... features) {
         return SUPPORTED_FEATURES.supports(features);
+    }
+
+    @Override
+    public void setQuotaLimits(long maxMessageQuota, long maxStorageQuota) throws MailboxException {
+        perUserMaxQuotaManager.setDefaultMaxMessage(maxMessageQuota);
+        perUserMaxQuotaManager.setDefaultMaxStorage(maxStorageQuota);
     }
     
 }

--- a/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/host/InMemoryHostSystem.java
+++ b/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/host/InMemoryHostSystem.java
@@ -57,6 +57,7 @@ public class InMemoryHostSystem extends JamesImapHostSystem {
         Feature.ANNOTATION_SUPPORT);
 
     private InMemoryMailboxManager mailboxManager;
+    private InMemoryPerUserMaxQuotaManager perUserMaxQuotaManager;
 
     public static JamesImapHostSystem build() throws Exception {
         return new InMemoryHostSystem();
@@ -81,9 +82,7 @@ public class InMemoryHostSystem extends JamesImapHostSystem {
                 new JVMMailboxPathLocker(), aclResolver, groupMembershipResolver, messageParser, new InMemoryMessageId.Factory());
         QuotaRootResolver quotaRootResolver = new DefaultQuotaRootResolver(mailboxManager.getMapperFactory());
 
-        InMemoryPerUserMaxQuotaManager perUserMaxQuotaManager = new InMemoryPerUserMaxQuotaManager();
-        perUserMaxQuotaManager.setDefaultMaxMessage(4096);
-        perUserMaxQuotaManager.setDefaultMaxStorage(5L * 1024L * 1024L * 1024L);
+        perUserMaxQuotaManager = new InMemoryPerUserMaxQuotaManager();
 
         InMemoryCurrentQuotaManager currentQuotaManager = new InMemoryCurrentQuotaManager(
             new CurrentQuotaCalculator(mailboxManager.getMapperFactory(), quotaRootResolver),
@@ -118,5 +117,10 @@ public class InMemoryHostSystem extends JamesImapHostSystem {
     public boolean supports(Feature... features) {
         return SUPPORTED_FEATURES.supports(features);
     }
-    
+
+    @Override
+    public void setQuotaLimits(long maxMessageQuota, long maxStorageQuota) throws MailboxException {
+        perUserMaxQuotaManager.setDefaultMaxMessage(maxMessageQuota);
+        perUserMaxQuotaManager.setDefaultMaxStorage(maxStorageQuota);
+    }
 }

--- a/mpt/impl/imap-mailbox/jcr/src/test/java/org/apache/james/mpt/imapmailbox/jcr/host/JCRHostSystem.java
+++ b/mpt/impl/imap-mailbox/jcr/src/test/java/org/apache/james/mpt/imapmailbox/jcr/host/JCRHostSystem.java
@@ -21,6 +21,7 @@ package org.apache.james.mpt.imapmailbox.jcr.host;
 import java.io.File;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.jackrabbit.core.RepositoryImpl;
 import org.apache.jackrabbit.core.config.RepositoryConfig;
 import org.apache.james.imap.api.process.ImapProcessor;
@@ -165,6 +166,11 @@ public class JCRHostSystem extends JamesImapHostSystem {
     @Override
     public boolean supports(Feature... features) {
         return SUPPORTED_FEATURES.supports(features);
+    }
+
+    @Override
+    public void setQuotaLimits(long maxMessageQuota, long maxStorageQuota) throws Exception {
+        throw new NotImplementedException();
     }
     
 }

--- a/mpt/impl/imap-mailbox/lucenesearch/src/test/java/org/apache/james/mpt/imapmailbox/lucenesearch/host/LuceneSearchHostSystem.java
+++ b/mpt/impl/imap-mailbox/lucenesearch/src/test/java/org/apache/james/mpt/imapmailbox/lucenesearch/host/LuceneSearchHostSystem.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import javax.persistence.EntityManagerFactory;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.james.backends.jpa.JpaTestCluster;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.encode.main.DefaultImapEncoderFactory;
@@ -153,6 +154,11 @@ public class LuceneSearchHostSystem extends JamesImapHostSystem {
     @Override
     public boolean supports(Feature... features) {
         return SUPPORTED_FEATURES.supports(features);
+    }
+
+    @Override
+    public void setQuotaLimits(long maxMessageQuota, long maxStorageQuota) throws Exception {
+        throw new NotImplementedException();
     }
 
 }

--- a/mpt/impl/imap-mailbox/maildir/src/test/java/org/apache/james/mpt/imapmailbox/maildir/host/MaildirHostSystem.java
+++ b/mpt/impl/imap-mailbox/maildir/src/test/java/org/apache/james/mpt/imapmailbox/maildir/host/MaildirHostSystem.java
@@ -21,6 +21,7 @@ package org.apache.james.mpt.imapmailbox.maildir.host;
 import java.io.File;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.encode.main.DefaultImapEncoderFactory;
 import org.apache.james.imap.main.DefaultImapDecoderFactory;
@@ -114,4 +115,8 @@ public class MaildirHostSystem extends JamesImapHostSystem {
         return SUPPORTED_FEATURES.supports(features);
     }
 
+    @Override
+    public void setQuotaLimits(long maxMessageQuota, long maxStorageQuota) throws Exception {
+        throw new NotImplementedException();
+    }
 }

--- a/server/app/src/main/resources/META-INF/persistence.xml
+++ b/server/app/src/main/resources/META-INF/persistence.xml
@@ -39,6 +39,7 @@
         <class>org.apache.james.mailbox.jpa.quota.model.MaxDefaultStorage</class>
         <class>org.apache.james.mailbox.jpa.quota.model.MaxUserMessageCount</class>
         <class>org.apache.james.mailbox.jpa.quota.model.MaxUserStorage</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.JpaCurrentQuota</class>
 
         <properties>
             <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema(ForeignKeys=true)"/>

--- a/server/app/src/main/resources/META-INF/persistence.xml
+++ b/server/app/src/main/resources/META-INF/persistence.xml
@@ -35,6 +35,10 @@
         <class>org.apache.james.domainlist.jpa.model.JPADomain</class>
         <class>org.apache.james.user.jpa.model.JPAUser</class>
         <class>org.apache.james.rrt.jpa.model.JPARecipientRewrite</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.MaxDefaultMessageCount</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.MaxDefaultStorage</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.MaxUserMessageCount</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.MaxUserStorage</class>
 
         <properties>
             <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema(ForeignKeys=true)"/>

--- a/server/app/src/main/resources/quota-template.xml
+++ b/server/app/src/main/resources/quota-template.xml
@@ -36,32 +36,32 @@
 
 <quota>
     <!--
-        Quota implementation is based on several components :
-          - QuotaRootResolver : In regard of quota management, mailboxes forms abstract groups called QUOTA ROOT. This
+        Quota implementation is based on several components:
+          - QuotaRootResolver: In regard of quota management, mailboxes forms abstract groups called QUOTA ROOT. This
           component finds to which QUOTA ROOT a mailbox belongs
-          - Current quota manager : Counters for current values : how many messages belongs to this quota root ? Which
+          - Current quota manager: Counters for current values: how many messages belongs to this quota root ? Which
           size ?
-          - Max Quota manager : Sets a maximum value QUOTA ROOT resources can not exceed.
-          - QuotaManager : assemble Current quota manager and Max quota manager.
-          - Listening quota updater : Event system based quota update. On each APPED / COPY /EXPUNGE command, current
+          - Max Quota manager: Sets a maximum value QUOTA ROOT resources can not exceed.
+          - QuotaManager: assemble Current quota manager and Max quota manager.
+          - Listening quota updater: Event system based quota update. On each APPED / COPY /EXPUNGE command, current
           quotas gets updated.
     -->
 
     <quotaRootResolver>
         <!--
-        Possible value :
+        Possible value:
          - default
         -->
         <provider>default</provider>
     </quotaRootResolver>
     <currentQuotaManager>
         <!--
-        Possible value for provider :
-         - none : when you use fake as a value for quotaManager's provider
+        Possible value for provider:
+         - none: when you use fake as a value for quotaManager's provider
          - inmemory
          - cassandra
 
-        The inmemory implementation :
+        The inmemory implementation:
          - Does not work in a distributed context
         Note that quota need to be (lazy) re-calculated after each starts
 
@@ -75,12 +75,15 @@
         <!--
         This component is exposed to the CLI for quota administration tasks.
 
-        Possible value are :
-         - fake : will always return UNLIMITED. Throws on modifications.
-         - fixed : all QUOTA ROOT get the same upper bound for their quotas.
-         - inmemory : allows you to define QUOTA ROOT specific limits, backed with a fixed policy. It does not
+        Possible value are:
+         - fake: will always return UNLIMITED. Throws on modifications.
+         - fixed: all QUOTA ROOT get the same upper bound for their quotas.
+         - inmemory: allows you to define QUOTA ROOT specific limits, backed with a fixed policy. It does not
          work in a distributed context.
-         - cassandra : Same thing than inmemory but backed on cassandra. Works on a distributed context. Note that using
+         - cassandra: Same thing than inmemory but backed on cassandra. Works on a distributed context. Note that using
+         the default* configuration options and the CLI to set default options is dangerous as server startup might override
+         CLI values.
+         - jpa: Same thing than inmemory but backed on jpa. Works on a distributed context. Note that using
          the default* configuration options and the CLI to set default options is dangerous as server startup might override
          CLI values.
         -->
@@ -110,16 +113,16 @@
         <!--
         The QuotaManager you use.
 
-        Possible values are :
-         - fake : returns only UNKNOWN/UNLIMITED quotas
-         - store : returns quotas using a CurrentQuotaManager and a MaxQuotaManager
+        Possible values are:
+         - fake: returns only UNKNOWN/UNLIMITED quotas
+         - store: returns quotas using a CurrentQuotaManager and a MaxQuotaManager
         -->
         <provider>fake</provider>
     </quotaManager>
     <updates>
         <!--
         This defines the way your quotas gets updated.
-        Possible values are :
+        Possible values are:
          - fake
          - event
         -->

--- a/server/app/src/main/resources/quota-template.xml
+++ b/server/app/src/main/resources/quota-template.xml
@@ -60,6 +60,7 @@
          - none: when you use fake as a value for quotaManager's provider
          - inmemory
          - cassandra
+         - jpa
 
         The inmemory implementation:
          - Does not work in a distributed context

--- a/server/container/guice/jpa-guice/src/main/java/org/apache/james/modules/mailbox/JPAMailboxModule.java
+++ b/server/container/guice/jpa-guice/src/main/java/org/apache/james/modules/mailbox/JPAMailboxModule.java
@@ -71,7 +71,7 @@ public class JPAMailboxModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        install(new DefaultQuotaModule());
+        install(new JpaQuotaModule());
 
         bind(JPAMailboxSessionMapperFactory.class).in(Scopes.SINGLETON);
         bind(OpenJPAMailboxManager.class).in(Scopes.SINGLETON);

--- a/server/container/guice/jpa-guice/src/main/java/org/apache/james/modules/mailbox/JpaQuotaModule.java
+++ b/server/container/guice/jpa-guice/src/main/java/org/apache/james/modules/mailbox/JpaQuotaModule.java
@@ -1,0 +1,50 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.mailbox;
+
+import org.apache.james.mailbox.jpa.quota.JPAPerUserMaxQuotaManager;
+import org.apache.james.mailbox.jpa.quota.JpaCurrentQuotaManager;
+import org.apache.james.mailbox.quota.CurrentQuotaManager;
+import org.apache.james.mailbox.quota.MaxQuotaManager;
+import org.apache.james.mailbox.quota.QuotaManager;
+import org.apache.james.mailbox.quota.QuotaRootResolver;
+import org.apache.james.mailbox.store.quota.DefaultQuotaRootResolver;
+import org.apache.james.mailbox.store.quota.StoreCurrentQuotaManager;
+import org.apache.james.mailbox.store.quota.StoreQuotaManager;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+
+public class JpaQuotaModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(DefaultQuotaRootResolver.class).in(Scopes.SINGLETON);
+        bind(JPAPerUserMaxQuotaManager.class).in(Scopes.SINGLETON);
+        bind(StoreQuotaManager.class).in(Scopes.SINGLETON);
+        bind(JpaCurrentQuotaManager.class).in(Scopes.SINGLETON);
+
+        bind(QuotaRootResolver.class).to(DefaultQuotaRootResolver.class);
+        bind(MaxQuotaManager.class).to(JPAPerUserMaxQuotaManager.class);
+        bind(QuotaManager.class).to(StoreQuotaManager.class);
+        bind(CurrentQuotaManager.class).to(JpaCurrentQuotaManager.class);
+        bind(StoreCurrentQuotaManager.class).to(JpaCurrentQuotaManager.class);
+    }
+}

--- a/server/container/guice/jpa-guice/src/main/resources/META-INF/persistence.xml
+++ b/server/container/guice/jpa-guice/src/main/resources/META-INF/persistence.xml
@@ -30,9 +30,17 @@
         <class>org.apache.james.mailbox.jpa.mail.model.openjpa.JPAMailboxMessage</class>
         <class>org.apache.james.mailbox.jpa.mail.model.JPAProperty</class>
         <class>org.apache.james.mailbox.jpa.user.model.JPASubscription</class>
+
         <class>org.apache.james.domainlist.jpa.model.JPADomain</class>
         <class>org.apache.james.user.jpa.model.JPAUser</class>
         <class>org.apache.james.rrt.jpa.model.JPARecipientRewrite</class>
+
+        <class>org.apache.james.mailbox.jpa.quota.model.MaxDefaultMessageCount</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.MaxDefaultStorage</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.MaxUserMessageCount</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.MaxUserStorage</class>
+        <class>org.apache.james.mailbox.jpa.quota.model.JpaCurrentQuota</class>
+
         <properties>
             <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema(ForeignKeys=true)"/>
             <property name="openjpa.jdbc.MappingDefaults" value="ForeignKeyDeleteAction=cascade, JoinForeignKeyDeleteAction=cascade"/>

--- a/server/container/spring/src/main/java/org/apache/james/container/spring/bean/factorypostprocessor/QuotaBeanFactoryPostProcessor.java
+++ b/server/container/spring/src/main/java/org/apache/james/container/spring/bean/factorypostprocessor/QuotaBeanFactoryPostProcessor.java
@@ -30,19 +30,21 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 
 public class QuotaBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
 
-    private static final String IN_MEMORY = "inmemory";
-    private static final String CASSANDRA = "cassandra";
-    private static final String FAKE = "fake";
+    private static final String IN_MEMORY_IMPLEMENTATION = "inmemory";
+    private static final String CASSANDRA_IMPLEMENTATION = "cassandra";
+    private static final String FAKE_IMPLEMENTATION = "fake";
     private static final String MAX_QUOTA_MANAGER = "maxQuotaManager";
-    private static final String CURRENT_QUOTA_MANAGER = "currentQuotaManager";
-    private static final String QUOTA_MANAGER = "quotaManager";
-    private static final String QUOTA_UPDATER = "quotaUpdater";
+    private static final String JPA_IMPLEMENTATION = "jpa";
+    private static final String DEFAULT_IMPLEMENTATION = "default";
+
+    private static final String QUOTA_MANAGER_BEAN = "quotaManager";
+    private static final String QUOTA_UPDATER_BEAN = "quotaUpdater";
+    private static final String QUOTA_ROOT_RESOLVER_BEAN = "quotaRootResolver";
+    private static final String CURRENT_QUOTA_MANAGER_BEAN = "currentQuotaManager";
+    private static final String UPDATES_BEAN = "updates";
+
     private static final String PROVIDER = "provider";
-    private static final String DEFAULT = "default";
-    private static final String UPDATES = "updates";
-    private static final String QUOTA_ROOT_RESOLVER = "quotaRootResolver";
     private static final String EVENT = "event";
-    public static final String JPA = "jpa";
 
     @Override
     public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
@@ -50,11 +52,11 @@ public class QuotaBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
         try {
             HierarchicalConfiguration config = confProvider.getConfiguration("quota");
 
-            String quotaRootResolver = config.configurationAt(QUOTA_ROOT_RESOLVER).getString(PROVIDER, DEFAULT);
-            String currentQuotaManager = config.configurationAt(CURRENT_QUOTA_MANAGER).getString(PROVIDER, "none");
-            String maxQuotaManager = config.configurationAt(MAX_QUOTA_MANAGER).getString(PROVIDER, FAKE);
-            String quotaManager = config.configurationAt(QUOTA_MANAGER).getString(PROVIDER, FAKE);
-            String quotaUpdater = config.configurationAt(UPDATES).getString(PROVIDER, FAKE);
+            String quotaRootResolver = config.configurationAt(QUOTA_ROOT_RESOLVER_BEAN).getString(PROVIDER, DEFAULT_IMPLEMENTATION);
+            String currentQuotaManager = config.configurationAt(CURRENT_QUOTA_MANAGER_BEAN).getString(PROVIDER, "none");
+            String maxQuotaManager = config.configurationAt(MAX_QUOTA_MANAGER).getString(PROVIDER, FAKE_IMPLEMENTATION);
+            String quotaManager = config.configurationAt(QUOTA_MANAGER_BEAN).getString(PROVIDER, FAKE_IMPLEMENTATION);
+            String quotaUpdater = config.configurationAt(UPDATES_BEAN).getString(PROVIDER, FAKE_IMPLEMENTATION);
 
             BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
 
@@ -70,32 +72,32 @@ public class QuotaBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
 
     private void registerAliasForQuotaUpdater(String quotaUpdater, BeanDefinitionRegistry registry) {
         if (quotaUpdater.equalsIgnoreCase(EVENT)) {
-            registry.registerAlias("eventQuotaUpdater", QUOTA_UPDATER);
-        } else if (quotaUpdater.equalsIgnoreCase(FAKE)) {
-            registry.registerAlias("noQuotaUpdater", QUOTA_UPDATER);
+            registry.registerAlias("eventQuotaUpdater", QUOTA_UPDATER_BEAN);
+        } else if (quotaUpdater.equalsIgnoreCase(FAKE_IMPLEMENTATION)) {
+            registry.registerAlias("noQuotaUpdater", QUOTA_UPDATER_BEAN);
         } else {
             throw new FatalBeanException("Unreadable value for Quota Updater : " + quotaUpdater);
         }
     }
 
     private void registerAliasForQuotaManager(String quotaManager, BeanDefinitionRegistry registry) {
-        if (quotaManager.equalsIgnoreCase(FAKE)) {
-            registry.registerAlias("noQuotaManager", QUOTA_MANAGER);
+        if (quotaManager.equalsIgnoreCase(FAKE_IMPLEMENTATION)) {
+            registry.registerAlias("noQuotaManager", QUOTA_MANAGER_BEAN);
         } else if (quotaManager.equalsIgnoreCase("store")) {
-            registry.registerAlias("storeQuotaManager", QUOTA_MANAGER);
+            registry.registerAlias("storeQuotaManager", QUOTA_MANAGER_BEAN);
         } else {
             throw new FatalBeanException("Unreadable value for Quota Manager : " + quotaManager);
         }
     }
 
     private void registerAliasForMaxQuotaManager(String maxQuotaManager, BeanDefinitionRegistry registry) {
-        if (maxQuotaManager.equalsIgnoreCase(FAKE)) {
+        if (maxQuotaManager.equalsIgnoreCase(FAKE_IMPLEMENTATION)) {
             registry.registerAlias("noMaxQuotaManager", MAX_QUOTA_MANAGER);
-        } else if (maxQuotaManager.equalsIgnoreCase(IN_MEMORY)) {
+        } else if (maxQuotaManager.equalsIgnoreCase(IN_MEMORY_IMPLEMENTATION)) {
             registry.registerAlias("inMemoryMaxQuotaManager", MAX_QUOTA_MANAGER);
-        } else if (maxQuotaManager.equalsIgnoreCase(CASSANDRA)) {
+        } else if (maxQuotaManager.equalsIgnoreCase(CASSANDRA_IMPLEMENTATION)) {
             registry.registerAlias("cassandraMaxQuotaManager", MAX_QUOTA_MANAGER);
-        } else if (maxQuotaManager.equalsIgnoreCase(JPA)) {
+        } else if (maxQuotaManager.equalsIgnoreCase(JPA_IMPLEMENTATION)) {
             registry.registerAlias("jpaMaxQuotaManager", MAX_QUOTA_MANAGER);
         } else {
             throw new FatalBeanException("Unreadable value for Max Quota Manager : " + maxQuotaManager);
@@ -103,20 +105,20 @@ public class QuotaBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
     }
 
     private void registerAliasForCurrentQuotaManager(String currentQuotaManager, BeanDefinitionRegistry registry) {
-        if (currentQuotaManager.equalsIgnoreCase(IN_MEMORY)) {
-            registry.registerAlias("inMemoryCurrentQuotaManager", CURRENT_QUOTA_MANAGER);
-        } else if (currentQuotaManager.equalsIgnoreCase(CASSANDRA)) {
-            registry.registerAlias("cassandraCurrentQuotaManager", CURRENT_QUOTA_MANAGER);
-        }  else if (currentQuotaManager.equalsIgnoreCase(JPA)) {
-            registry.registerAlias("jpaCurrentQuotaManager", CURRENT_QUOTA_MANAGER);
+        if (currentQuotaManager.equalsIgnoreCase(IN_MEMORY_IMPLEMENTATION)) {
+            registry.registerAlias("inMemoryCurrentQuotaManager", CURRENT_QUOTA_MANAGER_BEAN);
+        } else if (currentQuotaManager.equalsIgnoreCase(CASSANDRA_IMPLEMENTATION)) {
+            registry.registerAlias("cassandraCurrentQuotaManager", CURRENT_QUOTA_MANAGER_BEAN);
+        }  else if (currentQuotaManager.equalsIgnoreCase(JPA_IMPLEMENTATION)) {
+            registry.registerAlias("jpaCurrentQuotaManager", CURRENT_QUOTA_MANAGER_BEAN);
         } else if (! currentQuotaManager.equalsIgnoreCase("none")) {
             throw new FatalBeanException("Unreadable value for Current Quota Manager : " + currentQuotaManager);
         }
     }
 
     private void registerAliasForQuotaRootResolver(String quotaRootResolver, BeanDefinitionRegistry registry) {
-        if (quotaRootResolver.equals(DEFAULT)) {
-            registry.registerAlias("defaultQuotaRootResolver", QUOTA_ROOT_RESOLVER);
+        if (quotaRootResolver.equals(DEFAULT_IMPLEMENTATION)) {
+            registry.registerAlias("defaultQuotaRootResolver", QUOTA_ROOT_RESOLVER_BEAN);
         } else {
             throw new FatalBeanException("Unreadable value for QUOTA ROOT resolver : " + quotaRootResolver);
         }

--- a/server/container/spring/src/main/java/org/apache/james/container/spring/bean/factorypostprocessor/QuotaBeanFactoryPostProcessor.java
+++ b/server/container/spring/src/main/java/org/apache/james/container/spring/bean/factorypostprocessor/QuotaBeanFactoryPostProcessor.java
@@ -42,6 +42,7 @@ public class QuotaBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
     private static final String UPDATES = "updates";
     private static final String QUOTA_ROOT_RESOLVER = "quotaRootResolver";
     private static final String EVENT = "event";
+    public static final String JPA = "jpa";
 
     @Override
     public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
@@ -94,6 +95,8 @@ public class QuotaBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
             registry.registerAlias("inMemoryMaxQuotaManager", MAX_QUOTA_MANAGER);
         } else if (maxQuotaManager.equalsIgnoreCase(CASSANDRA)) {
             registry.registerAlias("cassandraMaxQuotaManager", MAX_QUOTA_MANAGER);
+        } else if (maxQuotaManager.equalsIgnoreCase(JPA)) {
+            registry.registerAlias("jpaMaxQuotaManager", MAX_QUOTA_MANAGER);
         } else {
             throw new FatalBeanException("Unreadable value for Max Quota Manager : " + maxQuotaManager);
         }

--- a/server/container/spring/src/main/java/org/apache/james/container/spring/bean/factorypostprocessor/QuotaBeanFactoryPostProcessor.java
+++ b/server/container/spring/src/main/java/org/apache/james/container/spring/bean/factorypostprocessor/QuotaBeanFactoryPostProcessor.java
@@ -107,6 +107,8 @@ public class QuotaBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
             registry.registerAlias("inMemoryCurrentQuotaManager", CURRENT_QUOTA_MANAGER);
         } else if (currentQuotaManager.equalsIgnoreCase(CASSANDRA)) {
             registry.registerAlias("cassandraCurrentQuotaManager", CURRENT_QUOTA_MANAGER);
+        }  else if (currentQuotaManager.equalsIgnoreCase(JPA)) {
+            registry.registerAlias("jpaCurrentQuotaManager", CURRENT_QUOTA_MANAGER);
         } else if (! currentQuotaManager.equalsIgnoreCase("none")) {
             throw new FatalBeanException("Unreadable value for Current Quota Manager : " + currentQuotaManager);
         }

--- a/server/src/site/xdoc/config-quota.xml
+++ b/server/src/site/xdoc/config-quota.xml
@@ -43,23 +43,23 @@
     </p>
 
     <p>
-      James' implementation is split in different components, and each one of them gets its own responsibility :
+      James' implementation is split in different components, and each one of them gets its own responsibility:
 
       <ul>
-        <li>Quota Root Resolver : This component is responsible of the correspondence between mailboxes and QUOTA ROOT. A default implementation is
+        <li>Quota Root Resolver: This component is responsible of the correspondence between mailboxes and QUOTA ROOT. A default implementation is
         available and simply group mailboxes in QUOTA ROOT on the base of the owner name.</li>
-        <li>Quota Manager : This component retrieves quota associated with a QUOTA ROOT. A store implementation is available and relies on other components.
+        <li>Quota Manager: This component retrieves quota associated with a QUOTA ROOT. A store implementation is available and relies on other components.
           A fake implementation is available in order to add no overhead.</li>
-        <li>Max Quota Manager : This component retrieves maximum values associated with quotas and gives a way to potentially
+        <li>Max Quota Manager: This component retrieves maximum values associated with quotas and gives a way to potentially
         (depending on the implementation) update these per QUOTA ROOT maximum values. Four implementations are available for now. A NoQuotaManager implementation
         is read only and returns UNLIMITED maximum values. FixedMaxQuotaManager returns one and only one value for all user. You can configure these maximum values
           threw the configuration files. A InMemoryPerUserMaxQuotaManager allows you to configure quota for each QUOTA ROOT. Note that it needs to be done threw
           configuration to be persistent. We provide some other implementation: A Cassandra implementation allows to store maximum quota values in Cassandra,
           and a JPA implementation.</li>
-        <li>Current Quota Manager : This component can be omitted if you are running a fake QUOTA manager. inmemory implementation is an event updated cache on
+        <li>Current Quota Manager: This component can be omitted if you are running a fake QUOTA manager. inmemory implementation is an event updated cache on
         top of a Quota calculator (that fetches every e-mail metadata of every mailboxes belonging to the QUOTA ROOT: it is expensive). Cassandra and Jpa implementations
         are also available.</li>
-        <li>Quota Updater : This components allows to update current quota values. A fake implementation is available. A real, event base solution also exists.</li>
+        <li>Quota Updater: This components allows to update current quota values. A fake implementation is available. A real, event base solution also exists.</li>
       </ul>
     </p>
 
@@ -68,7 +68,7 @@
     </p>
 
     <p>
-      Quota integration consists of :
+      Quota integration consists of:
 
       <ul>
         <li>Checks in the message manager. An operation that will bring the QUOTA ROOT over quota will be dropped. APPEND and COPY operations are concerned.</li>
@@ -80,13 +80,13 @@
     </p>
 
     <p>
-      The administration of QUOTAs can be done :
+      The administration of QUOTAs can be done:
 
       <ul>
         <li>Threw configuration file. Note that this is required to persist a change made to the inmemory or fixed Max Quota
           Manager. It needs a James reboot to take effect. Finally, using configuration file for setting maximum quota values
           will override CLI set values. Avoid this option this persistent Max Quota Manager (for instance Cassandra)</li>
-        <li>Threw the CLI : offers immediate configuration changes on quota maximum values. Note that if you are using either a
+        <li>Threw the CLI: offers immediate configuration changes on quota maximum values. Note that if you are using either a
         fixed or inmemory Max QUota Manager, your changes need to be done to the XML configuration to be persisted.</li>
       </ul>
     </p>

--- a/server/src/site/xdoc/config-quota.xml
+++ b/server/src/site/xdoc/config-quota.xml
@@ -54,7 +54,8 @@
         (depending on the implementation) update these per QUOTA ROOT maximum values. Four implementations are available for now. A NoQuotaManager implementation
         is read only and returns UNLIMITED maximum values. FixedMaxQuotaManager returns one and only one value for all user. You can configure these maximum values
           threw the configuration files. A InMemoryPerUserMaxQuotaManager allows you to configure quota for each QUOTA ROOT. Note that it needs to be done threw
-          configuration to be persistent. And finally a Cassandra implementation allows to store maximum quota values in Cassandra. We also support a JPA implementation.</li>
+          configuration to be persistent. We provide some other implementation: A Cassandra implementation allows to store maximum quota values in Cassandra,
+          and a JPA implementation.</li>
         <li>Current Quota Manager : This component can be omitted if you are running a fake QUOTA manager. inmemory implementation is an event updated cache on
         top of a Quota calculator (that fetches every e-mail metadata of every mailboxes belonging to the QUOTA ROOT: it is expensive). Cassandra and Jpa implementations
         are also available.</li>

--- a/server/src/site/xdoc/config-quota.xml
+++ b/server/src/site/xdoc/config-quota.xml
@@ -51,10 +51,10 @@
         <li>Quota Manager : This component retrieves quota associated with a QUOTA ROOT. A store implementation is available and relies on other components.
           A fake implementation is available in order to add no overhead.</li>
         <li>Max Quota Manager : This component retrieves maximum values associated with quotas and gives a way to potentially
-        (depending on the implementation) update these per QUOTA ROOT maximum values. Three implementation are available for now. A NoQuotaManager implementation
+        (depending on the implementation) update these per QUOTA ROOT maximum values. Four implementations are available for now. A NoQuotaManager implementation
         is read only and returns UNLIMITED maximum values. FixedMaxQuotaManager returns one and only one value for all user. You can configure these maximum values
           threw the configuration files. A InMemoryPerUserMaxQuotaManager allows you to configure quota for each QUOTA ROOT. Note that it needs to be done threw
-          configuration to be persistent. And finally a Cassandra implementation allows to store maximum quota values in Cassandra.</li>
+          configuration to be persistent. And finally a Cassandra implementation allows to store maximum quota values in Cassandra. We also support a JPA implementation.</li>
         <li>Current Quota Manager : This component can be omitted if you are running a fake QUOTA manager. inmemory implementation is an event updated cache on
         top of a Quota calculator (that fetches every e-mail metadata of every mailboxes belonging to the QUOTA ROOT: it is expensive). A cassandra implementation
         is also available.</li>

--- a/server/src/site/xdoc/config-quota.xml
+++ b/server/src/site/xdoc/config-quota.xml
@@ -56,8 +56,8 @@
           threw the configuration files. A InMemoryPerUserMaxQuotaManager allows you to configure quota for each QUOTA ROOT. Note that it needs to be done threw
           configuration to be persistent. And finally a Cassandra implementation allows to store maximum quota values in Cassandra. We also support a JPA implementation.</li>
         <li>Current Quota Manager : This component can be omitted if you are running a fake QUOTA manager. inmemory implementation is an event updated cache on
-        top of a Quota calculator (that fetches every e-mail metadata of every mailboxes belonging to the QUOTA ROOT: it is expensive). A cassandra implementation
-        is also available.</li>
+        top of a Quota calculator (that fetches every e-mail metadata of every mailboxes belonging to the QUOTA ROOT: it is expensive). Cassandra and Jpa implementations
+        are also available.</li>
         <li>Quota Updater : This components allows to update current quota values. A fake implementation is available. A real, event base solution also exists.</li>
       </ul>
     </p>


### PR DESCRIPTION
This contribution is based on the work of Passerelles Numériques Vietnam students.

They contributed a Hibernate implementation of Quota Storage interfaces, that I then migrated to OpenJPA, and integrate into both Spring and Guice.

Some little refactorings done along the way.

Many thanks to: Lai, Mai, Cuong, Am, Phuc, Vi, Tuan