### PR TITLE
JAMES-1543 Receive large emails

### DIFF
--- a/protocols/api/src/main/java/org/apache/james/protocols/api/ProtocolSession.java
+++ b/protocols/api/src/main/java/org/apache/james/protocols/api/ProtocolSession.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.protocols.api;
 
+import java.io.Closeable;
 import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 import java.util.Map;
@@ -31,7 +32,7 @@ import org.apache.james.protocols.api.logger.Logger;
  * 
  *
  */
-public interface ProtocolSession {
+public interface ProtocolSession extends Closeable {
    
     enum State {
         Connection,

--- a/protocols/api/src/main/java/org/apache/james/protocols/api/ProtocolSessionImpl.java
+++ b/protocols/api/src/main/java/org/apache/james/protocols/api/ProtocolSessionImpl.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.protocols.api;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 import java.util.HashMap;
@@ -238,6 +240,25 @@ public class ProtocolSessionImpl implements ProtocolSession {
      */
     public <T extends ProtocolSession> void pushLineHandler(LineHandler<T> overrideCommandHandler) {
         transport.pushLineHandler(overrideCommandHandler, this);
+    }
+
+    public void close() {
+        for (Object o: sessionState.values()) {
+            close(o);
+        }
+        for (Object o: connectionState.values()) {
+            close(o);
+        }
+    }
+
+    private void close(Object o) {
+        if (o instanceof Closeable) {
+            try {
+                ((Closeable) o).close();
+            } catch (IOException e) {
+                getLogger().error("Could not close resource", e);
+            }
+        }
     }
 
 }

--- a/protocols/api/src/main/java/org/apache/james/protocols/api/handler/DefaultDisconnectHandler.java
+++ b/protocols/api/src/main/java/org/apache/james/protocols/api/handler/DefaultDisconnectHandler.java
@@ -1,0 +1,48 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.protocols.api.handler;
+
+import java.io.IOException;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.james.protocols.api.ProtocolSession;
+
+public class DefaultDisconnectHandler implements DisconnectHandler<ProtocolSession> {
+
+    @Override
+    public void init(Configuration config) throws ConfigurationException {
+
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+    @Override
+    public void onDisconnect(ProtocolSession session) {
+        try {
+            session.close();
+        } catch (IOException e) {
+            session.getLogger().error("Could not close session " + session.getSessionID(), e);
+        }
+    }
+}

--- a/protocols/lmtp/src/main/java/org/apache/james/protocols/lmtp/LMTPProtocolHandlerChain.java
+++ b/protocols/lmtp/src/main/java/org/apache/james/protocols/lmtp/LMTPProtocolHandlerChain.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.james.protocols.api.handler.CommandDispatcher;
 import org.apache.james.protocols.api.handler.CommandHandlerResultLogger;
+import org.apache.james.protocols.api.handler.DefaultDisconnectHandler;
 import org.apache.james.protocols.api.handler.ProtocolHandler;
 import org.apache.james.protocols.api.handler.WiringException;
 import org.apache.james.protocols.lmtp.core.DataLineMessageHookHandler;
@@ -86,6 +87,7 @@ public class LMTPProtocolHandlerChain extends SMTPProtocolHandlerChain{
         defaultHandlers.add(new StartTlsCmdHandler());
         defaultHandlers.add(new UnknownCmdHandler(new NoopMetricFactory()));
         defaultHandlers.add(new CommandHandlerResultLogger());
+        defaultHandlers.add(new DefaultDisconnectHandler());
 
         return defaultHandlers;
     }

--- a/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/POP3ProtocolHandlerChain.java
+++ b/protocols/pop3/src/main/java/org/apache/james/protocols/pop3/POP3ProtocolHandlerChain.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.apache.james.protocols.api.handler.CommandDispatcher;
 import org.apache.james.protocols.api.handler.CommandHandlerResultLogger;
+import org.apache.james.protocols.api.handler.DefaultDisconnectHandler;
 import org.apache.james.protocols.api.handler.ProtocolHandler;
 import org.apache.james.protocols.api.handler.ProtocolHandlerChainImpl;
 import org.apache.james.protocols.api.handler.WiringException;
@@ -90,6 +91,7 @@ public class POP3ProtocolHandlerChain extends ProtocolHandlerChainImpl{
         handlers.add(new StlsCmdHandler());
         handlers.add(new CommandDispatcher<POP3Session>());
         handlers.add(new CommandHandlerResultLogger());
+        handlers.add(new DefaultDisconnectHandler());
        
         return handlers;
     }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/MailEnvelope.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/MailEnvelope.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.protocols.smtp;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -29,7 +30,7 @@ import java.util.List;
  * 
  * 
  */
-public interface MailEnvelope {
+public interface MailEnvelope extends Closeable {
 
     /**
      * Return the size of the message. If the message is "empty" it will return

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPProtocolHandlerChain.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPProtocolHandlerChain.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.protocols.api.handler.CommandDispatcher;
 import org.apache.james.protocols.api.handler.CommandHandlerResultLogger;
+import org.apache.james.protocols.api.handler.DefaultDisconnectHandler;
 import org.apache.james.protocols.api.handler.ExtensibleHandler;
 import org.apache.james.protocols.api.handler.ProtocolHandler;
 import org.apache.james.protocols.api.handler.ProtocolHandlerChain;
@@ -110,6 +111,7 @@ public class SMTPProtocolHandlerChain extends ProtocolHandlerChainImpl {
         defaultHandlers.add(new StartTlsCmdHandler());
         defaultHandlers.add(new UnknownCmdHandler(metricFactory));
         defaultHandlers.add(new CommandHandlerResultLogger());
+        defaultHandlers.add(new DefaultDisconnectHandler());
         return defaultHandlers;
     }
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPSessionImpl.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/SMTPSessionImpl.java
@@ -24,8 +24,6 @@ import org.apache.james.protocols.api.ProtocolSessionImpl;
 import org.apache.james.protocols.api.ProtocolTransport;
 import org.apache.james.protocols.api.Response;
 import org.apache.james.protocols.api.logger.Logger;
-import org.apache.james.protocols.smtp.SMTPConfiguration;
-import org.apache.james.protocols.smtp.SMTPSession;
 
 /**
  * {@link SMTPSession} implementation

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
@@ -56,6 +56,7 @@ import org.apache.james.util.concurrency.ConcurrentTestRunner;
 import org.junit.Test;
 
 import com.google.common.base.Charsets;
+import com.google.common.base.Throwables;
 import com.google.common.io.CharStreams;
 
 public abstract class AbstractSMTPServerTest {
@@ -1068,6 +1069,11 @@ public abstract class AbstractSMTPServerTest {
 
             public void onDisconnect(SMTPSession session) {
                 called.set(true);
+                try {
+                    session.close();
+                } catch (IOException e) {
+                    throw Throwables.propagate(e);
+                }
             }
         };
         

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/utils/BaseFakeSMTPSession.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/utils/BaseFakeSMTPSession.java
@@ -20,6 +20,7 @@
 
 package org.apache.james.protocols.smtp.utils;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 import java.util.Map;
@@ -203,4 +204,8 @@ public class BaseFakeSMTPSession implements SMTPSession {
         throw new UnsupportedOperationException("Unimplemented Stub Method");
     }
 
+    @Override
+    public void close() throws IOException {
+
+    }
 }

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/DataLineJamesMessageHookHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/DataLineJamesMessageHookHandler.java
@@ -301,5 +301,9 @@ public class DataLineJamesMessageHookHandler implements DataLineFilter, Extensib
             }
         }
 
+        @Override
+        public void close() throws IOException {
+            out.close();
+        }
     }
 }


### PR DESCRIPTION
Food for thoughts...

James failed to receive a mail of more than 40MB with OutOfMemoryException. It could not allocate a ByteArrayOutPutStream (initial capacity at 100 KB but then on growth relocation killed heap, as data size is unknown). The fix relies on a FileBackedOutputStream. However, it needs better resource management to not leak file descriptors.

I'm open to suggestions to better manage resources...

In a general manner, our IOs operations turned out to be bad, with too many, in memory, large copies... This is yet another topic...