### PR TITLE
JAMES-1881 Mark mailets that require it as experimental

### DIFF
--- a/mailet/ai/src/main/java/org/apache/james/ai/classic/BayesianAnalysis.java
+++ b/mailet/ai/src/main/java/org/apache/james/ai/classic/BayesianAnalysis.java
@@ -32,6 +32,7 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import javax.sql.DataSource;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.base.GenericMailet;
@@ -119,7 +120,7 @@ import org.apache.mailet.base.RFC2822Headers;
  * @see JDBCBayesianAnalyzer
  * @since 2.3.0
  */
-
+@Experimental
 public class BayesianAnalysis extends GenericMailet implements Log {
     /**
      * The JDBCUtil helper class

--- a/mailet/ai/src/main/java/org/apache/james/ai/classic/BayesianAnalysisFeeder.java
+++ b/mailet/ai/src/main/java/org/apache/james/ai/classic/BayesianAnalysisFeeder.java
@@ -31,6 +31,7 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import javax.sql.DataSource;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
 
@@ -123,7 +124,7 @@ import org.apache.mailet.base.GenericMailet;
  * @see JDBCBayesianAnalyzer
  * @since 2.3.0
  */
-
+@Experimental
 public class BayesianAnalysisFeeder extends GenericMailet implements Log {
     /**
      * The JDBCUtil helper class

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/AddHabeasWarrantMark.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/AddHabeasWarrantMark.java
@@ -22,6 +22,7 @@
 package org.apache.james.transport.mailets;
 
 import org.apache.james.transport.matchers.HasHabeasWarrantMark;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.base.GenericMailet ;
 import org.apache.mailet.Mail ;
 
@@ -81,7 +82,7 @@ import org.apache.mailet.Mail ;
  * -----------------------------------
  * </pre>
  */
-
+@Experimental
 public class AddHabeasWarrantMark extends GenericMailet
 {
     /**

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/ClamAVScan.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/ClamAVScan.java
@@ -20,6 +20,7 @@
 
 package org.apache.james.transport.mailets;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.base.GenericMailet;
@@ -179,6 +180,7 @@ import java.util.Set;
  * @see <a href="http://www.sosdg.org/clamav-win32/">ClamAV For Windows</a>
  * @since 2.2.1
  */
+@Experimental
 public class ClamAVScan extends GenericMailet {
 
     private static final int DEFAULT_PORT = 3310;

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/ClassifyBounce.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/ClassifyBounce.java
@@ -18,6 +18,7 @@
  ****************************************************************/
 package org.apache.james.transport.mailets;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
 
@@ -42,6 +43,7 @@ import java.util.regex.Pattern;
  * <headerName>X-MailetHeader</headerName>
  * </mailet>
  */
+@Experimental
 public class ClassifyBounce extends GenericMailet {
 
     /**

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/HeadersToHTTP.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/HeadersToHTTP.java
@@ -36,6 +36,7 @@ import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
 
@@ -53,6 +54,7 @@ import org.apache.mailet.base.GenericMailet;
 
  * 
  */
+@Experimental
 public class HeadersToHTTP extends GenericMailet {
 
     /**

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/OnlyText.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/OnlyText.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.transport.mailets;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailetException;
 import org.apache.mailet.base.GenericMailet;
@@ -39,6 +40,7 @@ import java.util.HashMap;
  * - text/html => with a conversion to text only<br>
  * - text/* as is.</p>
  */
+@Experimental
 public class OnlyText extends GenericMailet {
     private static final String PARAMETER_NAME_NOTEXT_PROCESSOR = "NoTextProcessor";
 

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/RecoverAttachment.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/RecoverAttachment.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.transport.mailets;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.base.GenericMailet;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailetException;
@@ -55,6 +56,7 @@ import java.util.Map;
  * 
  * </p>
  */
+@Experimental
 public class RecoverAttachment extends GenericMailet {
 
     public static final String ATTRIBUTE_PARAMETER_NAME = "attribute";

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/SerialiseToHTTP.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/SerialiseToHTTP.java
@@ -36,6 +36,7 @@ import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
 
@@ -53,6 +54,7 @@ import org.apache.mailet.base.GenericMailet;
  * </mailet>
  * 
  */
+@Experimental
 public class SerialiseToHTTP extends GenericMailet {
 
     /**

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/ServerTime.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/ServerTime.java
@@ -21,6 +21,7 @@
 
 package org.apache.james.transport.mailets;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.base.GenericMailet;
 import org.apache.mailet.Mail;
 
@@ -34,6 +35,7 @@ import javax.mail.internet.MimeMessage;
  * </code></pre>
  *
  */
+@Experimental
 public class ServerTime extends GenericMailet {
     /**
      * Sends a message back to the sender indicating what time the server thinks it is.

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/UnwrapText.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/UnwrapText.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.transport.mailets;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.base.FlowedMessageUtils;
 import org.apache.mailet.base.GenericMailet;
 import org.apache.mailet.Mail;
@@ -52,6 +53,7 @@ import java.util.regex.Pattern;
  *  <code>quotewidth = -10</code>
  * </p>
  */
+@Experimental
 public class UnwrapText extends GenericMailet {
     public final static String PARAMETER_NAME_QUOTEWIDTH = "quotewidth";
     

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/UseHeaderRecipients.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/UseHeaderRecipients.java
@@ -34,6 +34,7 @@ import org.apache.james.mime4j.dom.address.Group;
 import org.apache.james.mime4j.dom.address.Mailbox;
 import org.apache.james.mime4j.field.address.LenientAddressParser;
 import org.apache.james.mime4j.util.MimeUtil;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.base.GenericMailet;
@@ -66,6 +67,7 @@ import com.google.common.collect.ImmutableList;
  *
  * @version 1.0.0, 24/11/2000
  */
+@Experimental
 public class UseHeaderRecipients extends GenericMailet {
 
     public static final Function<Mailbox, MailAddress> TO_MAIL_ADDRESS = new Function<Mailbox, MailAddress>() {

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/WrapText.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/WrapText.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.transport.mailets;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.base.FlowedMessageUtils;
 import org.apache.mailet.base.GenericMailet;
 import org.apache.mailet.Mail;
@@ -31,6 +32,7 @@ import java.io.IOException;
 /**
  * Convert a message to format=flowed
  */
+@Experimental
 public class WrapText extends GenericMailet {
     private static final String PARAMETER_NAME_FLOWED_DELSP = "delsp";
     private static final String PARAMETER_NAME_WIDTH = "width";

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/AbstractQuotaMatcher.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/AbstractQuotaMatcher.java
@@ -24,6 +24,8 @@ package org.apache.james.transport.matchers;
 import java.util.Collection;
 import java.util.ArrayList;
 import javax.mail.MessagingException;
+
+import org.apache.mailet.Experimental;
 import org.apache.mailet.base.GenericMatcher;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.Mail;
@@ -37,6 +39,7 @@ import org.apache.mailet.Mail;
  * @version CVS $Revision$ $Date$
  * @since 2.2.0
  */
+@Experimental
 abstract public class AbstractQuotaMatcher extends GenericMatcher { 
 
     /**

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/AttachmentFileNameIs.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/AttachmentFileNameIs.java
@@ -21,6 +21,7 @@
  
 package org.apache.james.transport.matchers;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.base.GenericMatcher;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
@@ -53,6 +54,7 @@ import java.io.UnsupportedEncodingException;
  * @version CVS $Revision$ $Date$
  * @since 2.2.0
  */
+@Experimental
 public class AttachmentFileNameIs extends GenericMatcher {
     
     /** Unzip request parameter. */

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/CommandForListserv.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/CommandForListserv.java
@@ -21,6 +21,7 @@
 
 package org.apache.james.transport.matchers;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.base.GenericRecipientMatcher;
 import org.apache.mailet.MailAddress;
 
@@ -32,6 +33,7 @@ import javax.mail.MessagingException;
  * for james-on@list.working-dogs.com and james-off@list.working-dogs.com.
  *
  */
+@Experimental
 public class CommandForListserv extends GenericRecipientMatcher {
 
     private MailAddress listservAddress;

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/CommandListservMatcher.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/CommandListservMatcher.java
@@ -21,6 +21,7 @@
 
 package org.apache.james.transport.matchers;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.base.GenericRecipientMatcher;
 import org.apache.mailet.MailAddress;
 
@@ -40,6 +41,7 @@ import javax.mail.MessagingException;
  * @version CVS $Revision$ $Date$
  * @since 2.2.0
  */
+@Experimental
 public class CommandListservMatcher extends GenericRecipientMatcher {
 
     private MailAddress listservAddress;

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/CompareNumericHeaderValue.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/CompareNumericHeaderValue.java
@@ -21,6 +21,7 @@
 
 package org.apache.james.transport.matchers;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.base.GenericMatcher;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
@@ -51,6 +52,7 @@ import java.util.StringTokenizer;
  * @version CVS $Revision$ $Date$
  * @since 2.2.0
  */
+@Experimental
 public class CompareNumericHeaderValue extends GenericMatcher {
 
     private String headerName = null;

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/FileRegexMatcher.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/FileRegexMatcher.java
@@ -26,10 +26,13 @@ import java.util.regex.PatternSyntaxException;
 
 import javax.mail.MessagingException;
 
+import org.apache.mailet.Experimental;
+
 /**
  * Initializes RegexMatcher with regular expressions from a file.
  *
  */
+@Experimental
 public class FileRegexMatcher extends GenericRegexMatcher {
     
     /**

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/HasHabeasWarrantMark.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/HasHabeasWarrantMark.java
@@ -21,6 +21,7 @@
 
 package org.apache.james.transport.matchers;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.base.GenericMatcher;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
@@ -66,7 +67,7 @@ import java.util.Collection;
  * -----------------------------------
  * </pre>
  */
-
+@Experimental
 public class HasHabeasWarrantMark extends GenericMatcher
 {
     public static final String[][] warrantMark =

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/NESSpamCheck.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/NESSpamCheck.java
@@ -25,6 +25,7 @@ import java.util.regex.PatternSyntaxException;
 
 import javax.mail.MessagingException;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.base.RFC2822Headers;
 
 /**
@@ -32,6 +33,7 @@ import org.apache.mailet.base.RFC2822Headers;
  * spam.
  *
  */
+@Experimental
 public class NESSpamCheck extends GenericRegexMatcher {
     protected Object NESPatterns[][] = {{RFC2822Headers.RECEIVED, "GAA.*-0600.*EST"},
     {RFC2822Headers.RECEIVED, "XAA.*-0700.*EDT"},

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/SMTPIsAuthNetwork.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/SMTPIsAuthNetwork.java
@@ -21,6 +21,7 @@
 
 package org.apache.james.transport.matchers;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.base.GenericMatcher;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
@@ -36,6 +37,7 @@ import java.util.Collection;
  * class=&quot;&lt;any-class&gt;&quot;&gt; </CODE></PRE>
  * 
  */
+@Experimental
 public class SMTPIsAuthNetwork extends GenericMatcher {
 
     /**

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/AbstractRecipientRewriteTable.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/AbstractRecipientRewriteTable.java
@@ -37,6 +37,7 @@ import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.domainlist.api.DomainList;
 import org.apache.james.domainlist.api.DomainListException;
 import org.apache.james.rrt.lib.RecipientRewriteTableUtil;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.base.GenericMailet;
@@ -49,6 +50,7 @@ import org.apache.mailet.base.GenericMailet;
  * @deprecated use the definitions in virtualusertable-store.xml instead
  */
 @Deprecated
+@Experimental
 public abstract class AbstractRecipientRewriteTable extends GenericMailet {
     static private final String MARKER = "org.apache.james.transport.mailets.AbstractRecipientRewriteTable.mapped";
     private DNSService dns;

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/BayesianAnalysis.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/BayesianAnalysis.java
@@ -35,6 +35,7 @@ import javax.sql.DataSource;
 import org.apache.james.filesystem.api.FileSystem;
 import org.apache.james.util.bayesian.JDBCBayesianAnalyzer;
 import org.apache.james.util.sql.JDBCUtil;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.base.GenericMailet;
@@ -122,7 +123,7 @@ import org.apache.mailet.base.RFC2822Headers;
  * @see org.apache.james.util.bayesian.JDBCBayesianAnalyzer
  * @since 2.3.0
  */
-
+@Experimental
 public class BayesianAnalysis extends GenericMailet {
     /**
      * The JDBCUtil helper class

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/BayesianAnalysisFeeder.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/BayesianAnalysisFeeder.java
@@ -34,6 +34,7 @@ import javax.sql.DataSource;
 import org.apache.james.filesystem.api.FileSystem;
 import org.apache.james.util.bayesian.JDBCBayesianAnalyzer;
 import org.apache.james.util.sql.JDBCUtil;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
 
@@ -126,7 +127,7 @@ import org.apache.mailet.base.GenericMailet;
  * @see org.apache.james.util.bayesian.JDBCBayesianAnalyzer
  * @since 2.3.0
  */
-
+@Experimental
 public class BayesianAnalysisFeeder extends GenericMailet {
     /**
      * The JDBCUtil helper class

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/FromRepository.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/FromRepository.java
@@ -29,6 +29,7 @@ import javax.mail.MessagingException;
 import org.apache.james.lifecycle.api.LifecycleUtil;
 import org.apache.james.mailrepository.api.MailRepository;
 import org.apache.james.mailrepository.api.MailRepositoryStore;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
 
@@ -43,6 +44,7 @@ import org.apache.mailet.base.GenericMailet;
  * &lt;/mailet&gt;
  * </pre>
  */
+@Experimental
 public class FromRepository extends GenericMailet {
 
     /** The repository from where this mailet spools mail. */

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/JDBCAlias.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/JDBCAlias.java
@@ -33,6 +33,7 @@ import javax.mail.internet.ParseException;
 import javax.sql.DataSource;
 
 import org.apache.james.util.sql.JDBCUtil;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.MailetException;
@@ -52,6 +53,7 @@ import org.apache.mailet.base.GenericMailet;
  * &lt;/mailet&gt;
  * </pre>
  */
+@Experimental
 public class JDBCAlias extends GenericMailet {
 
     protected DataSource datasource;

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/JDBCRecipientRewriteTable.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/JDBCRecipientRewriteTable.java
@@ -33,6 +33,7 @@ import javax.sql.DataSource;
 
 import org.apache.james.rrt.lib.RecipientRewriteTableUtil;
 import org.apache.james.util.sql.JDBCUtil;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.MailetException;
 
@@ -107,6 +108,7 @@ import org.apache.mailet.MailetException;
  * 
  * @deprecated use the definitions in virtualusertable-store.xml instead
  */
+@Experimental
 @Deprecated
 public class JDBCRecipientRewriteTable extends AbstractRecipientRewriteTable {
     protected DataSource datasource;

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/SPF.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/SPF.java
@@ -25,6 +25,7 @@ import javax.mail.internet.MimeMessage;
 import org.apache.james.jspf.core.Logger;
 import org.apache.james.jspf.executor.SPFResult;
 import org.apache.james.jspf.impl.DefaultSPF;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.base.GenericMailet;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
@@ -49,6 +50,7 @@ import org.apache.mailet.MailAddress;
  * &lt;/mailet&gt;
  * </pre>
  */
+@Experimental
 public class SPF extends GenericMailet {
     private boolean addHeader = false;
     private org.apache.james.jspf.impl.SPF spf;

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/SpamAssassin.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/SpamAssassin.java
@@ -20,6 +20,7 @@
 package org.apache.james.transport.mailets;
 
 import org.apache.james.util.scanner.SpamAssassinInvoker;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.base.GenericMailet;
 import org.apache.mailet.Mail;
 
@@ -50,6 +51,7 @@ import javax.mail.internet.MimeMessage;
  * &lt;spamdPort&gt;783&lt;/spamdPort&gt;
  * </pre>
  */
+@Experimental
 public class SpamAssassin extends GenericMailet {
 
     String spamdHost;

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/ToSenderFolder.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/ToSenderFolder.java
@@ -26,6 +26,7 @@ import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.transport.mailets.delivery.MailboxAppender;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.UsersRepositoryException;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.base.GenericMailet;
@@ -46,6 +47,7 @@ import org.apache.mailet.base.GenericMailet;
  * </pre>
  * 
  */
+@Experimental
 public class ToSenderFolder extends GenericMailet {
 
     private final UsersRepository usersRepository;

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/UsersRepositoryAliasingForwarding.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/UsersRepositoryAliasingForwarding.java
@@ -25,6 +25,7 @@ import javax.mail.MessagingException;
 import org.apache.james.domainlist.api.DomainList;
 import org.apache.james.rrt.api.RecipientRewriteTable;
 import org.apache.james.user.api.UsersRepository;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
 
@@ -45,6 +46,7 @@ import com.google.common.base.Preconditions;
  * 
  * @deprecated use org.apache.james.transport.mailets.RecipientRewriteTable
  */
+@Experimental
 @Deprecated
 public class UsersRepositoryAliasingForwarding extends GenericMailet {
     private final UsersRepository usersRepository;

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/WhiteListManager.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/WhiteListManager.java
@@ -50,6 +50,7 @@ import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.model.JamesUser;
 import org.apache.james.util.sql.JDBCUtil;
 import org.apache.james.util.sql.SqlResources;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.base.GenericMailet;
@@ -118,6 +119,7 @@ import org.apache.mailet.base.DateFormats;
  * @see org.apache.james.transport.matchers.IsInWhiteList
  * @since 2.3.0
  */
+@Experimental
 @SuppressWarnings("deprecation")
 public class WhiteListManager extends GenericMailet {
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/XMLRecipientRewriteTable.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/XMLRecipientRewriteTable.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import javax.mail.MessagingException;
 
 import org.apache.james.rrt.lib.RecipientRewriteTableUtil;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.MailAddress;
 
 /**
@@ -72,6 +73,7 @@ import org.apache.mailet.MailAddress;
  * @deprecated use the definitions in virtualusertable-store.xml instead
  * 
  */
+@Experimental
 @Deprecated
 public class XMLRecipientRewriteTable extends AbstractRecipientRewriteTable {
     /**

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/managesieve/ManageSieveMailet.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/managesieve/ManageSieveMailet.java
@@ -39,6 +39,7 @@ import org.apache.james.managesieve.util.SettableSession;
 import org.apache.james.sieverepository.api.SieveRepository;
 import org.apache.james.transport.mailets.managesieve.transcode.MessageToCoreToMessage;
 import org.apache.james.user.api.UsersRepository;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailetContext;
 import org.apache.mailet.MailetContext.LogLevel;
@@ -87,6 +88,7 @@ import com.google.common.collect.Lists;
  * Sieve provides powerful email processing capabilities that if hijacked can
  * expose the mail of individuals and organisations to intruders.
  */
+@Experimental
 public class ManageSieveMailet extends GenericMailet implements MessageToCoreToMessage.HelpProvider {
 
     public final static String SMTP_AUTH_USER_ATTRIBUTE_NAME = "org.apache.james.SMTPAuthUser";

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/AbstractSQLWhitelistMatcher.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/AbstractSQLWhitelistMatcher.java
@@ -40,11 +40,13 @@ import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.model.JamesUser;
 import org.apache.james.util.sql.JDBCUtil;
 import org.apache.james.util.sql.SqlResources;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.base.GenericMatcher;
 
 @SuppressWarnings("deprecation")
+@Experimental
 public abstract class AbstractSQLWhitelistMatcher extends GenericMatcher {
 
     /**

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/AbstractStorageQuota.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/AbstractStorageQuota.java
@@ -40,6 +40,7 @@ import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.MessageResult;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.UsersRepositoryException;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.MailetContext;
@@ -62,6 +63,7 @@ import org.apache.mailet.MailetContext;
  * 
  * @since 2.2.0
  */
+@Experimental
 abstract public class AbstractStorageQuota extends AbstractQuotaMatcher {
 
     private MailboxManager manager;

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/InSpammerBlacklist.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/InSpammerBlacklist.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 import javax.mail.MessagingException;
 
 import org.apache.james.dnsservice.api.DNSService;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.base.GenericMatcher;
@@ -51,6 +52,7 @@ import org.apache.mailet.base.GenericMatcher;
  * &lt;/mailet&gt;
  * </pre>
  */
+@Experimental
 public class InSpammerBlacklist extends GenericMatcher {
     private String network = null;
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/IsInWhiteList.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/IsInWhiteList.java
@@ -27,6 +27,7 @@ import java.util.Locale;
 
 import javax.mail.MessagingException;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
 
@@ -56,6 +57,7 @@ import org.apache.mailet.MailAddress;
  * @see org.apache.james.transport.mailets.WhiteListManager
  * @since 2.3.0
  */
+@Experimental
 public class IsInWhiteList extends AbstractSQLWhitelistMatcher {
 
     private String selectByPK;

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/MailboxQuotaFixed.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/MailboxQuotaFixed.java
@@ -18,6 +18,7 @@
  ****************************************************************/
 package org.apache.james.transport.matchers;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
 import org.apache.mailet.Matcher;
@@ -29,6 +30,7 @@ import javax.mail.MessagingException;
  * {@link Matcher} need to recalculate the used space of users mailbox on every
  * call. So use it with caution!
  */
+@Experimental
 public class MailboxQuotaFixed extends AbstractStorageQuota {
 
     /**

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/NetworkIsInWhitelist.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/NetworkIsInWhitelist.java
@@ -31,6 +31,7 @@ import javax.mail.MessagingException;
 
 import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.dnsservice.library.netmatcher.NetMatcher;
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
 
@@ -46,6 +47,7 @@ import org.apache.mailet.MailAddress;
  * Th whitelisting is done per recipient
  * </p>
  */
+@Experimental
 public class NetworkIsInWhitelist extends AbstractSQLWhitelistMatcher {
 
     private DNSService dns;

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/SenderInFakeDomain.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/SenderInFakeDomain.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.transport.matchers;
 
+import org.apache.mailet.Experimental;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailAddress;
 
@@ -28,6 +29,7 @@ import java.util.Collection;
  * Does a DNS lookup (MX and A/CNAME records) on the sender's domain. If there
  * are no entries, the domain is considered fake and the match is successful.
  */
+@Experimental
 public class SenderInFakeDomain extends AbstractNetworkMatcher {
 
     public Collection<MailAddress> match(Mail mail) {


### PR DESCRIPTION
What makes a mailet as experimental:

 - No tests
 - Tests are not trust worthy
 - Implementation is not generic
 - Implementation have been replaced with better tested mailets/matcher
 - The current team is not confident with the code
 - The mailet/matcher have been declared as "Experimental" for the 3.0 release