### PR TITLE
JAMES-2022 Add ES logback appender as a guice-cassandra dependency

### DIFF
--- a/server/container/guice/cassandra-guice/pom.xml
+++ b/server/container/guice/cassandra-guice/pom.xml
@@ -323,6 +323,17 @@
                     <version>1.1.7</version>
                 </dependency>
                 <dependency>
+                    <groupId>com.internetitem</groupId>
+                    <artifactId>logback-elasticsearch-appender</artifactId>
+                    <version>1.5</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.fasterxml.jackson.core</groupId>
+                            <artifactId>jackson-core</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
                     <groupId>com.jayway.awaitility</groupId>
                     <artifactId>awaitility</artifactId>
                 </dependency>


### PR DESCRIPTION
![screenshot from 2017-05-11 11-04-48](https://cloud.githubusercontent.com/assets/6928740/25932040/f84e30d0-3639-11e7-963e-38dad1aeb55f.png)

ES searchable logs with rotating indexes <3

Will try to plug Kibana...

The configuration used for ES APPENDER:

```
    <appender name="ELASTIC" class="com.internetitem.logback.elasticsearch.ElasticsearchAppender">
        <url>http://172.17.0.4:9200/_bulk</url>
        <index>logs-%date{yyyy-MM-dd}</index>
        <type>tester</type>
        <properties>
            <property>
                <name>host</name>
                <value>${HOSTNAME}</value>
                <allowEmpty>false</allowEmpty>
            </property>
            <property>
                <name>severity</name>
                <value>%level</value>
            </property>
            <property>
                <name>thread</name>
                <value>%thread</value>
            </property>
            <property>
                <name>stacktrace</name>
                <value>%ex</value>
            </property>
            <property>
                <name>logger</name>
                <value>%logger</value>
            </property>
        </properties>
        <headers>
            <header>
                <name>Content-Type</name>
                <value>text/plain</value>
            </header>
        </headers>
    </appender>
```
