### PR TITLE
Correct versions in Spring dockerfile

### DIFF
--- a/dockerfiles/run/spring/Dockerfile
+++ b/dockerfiles/run/spring/Dockerfile
@@ -18,18 +18,18 @@ EXPOSE 25 110 143 465 587 993
 WORKDIR /root
 
 # Get data we need to run James : build results and configuration
-ADD destination/james-server-app-3.0.0-beta6-SNAPSHOT-app.zip /root/james-server-app-3.0.0-beta6-SNAPSHOT-app.zip
+ADD destination/james-server-app-3.0.0-RC2-SNAPSHOT-app.zip /root/james-server-app-3.0.0-RC2-SNAPSHOT-app.zip
 ADD destination/conf /root/conf
 
 # Unzip build result
-RUN unzip james-server-app-3.0.0-beta6-SNAPSHOT-app.zip
+RUN unzip james-server-app-3.0.0-RC2-SNAPSHOT-app.zip
 
 # Copy configuration.
 # Warning : we want to use the wrapper.conf file we just compiled.
-RUN cp james-server-app-3.0.0-beta6-SNAPSHOT/conf/wrapper.conf .
-RUN rm -r james-server-app-3.0.0-beta6-SNAPSHOT/conf/*
-RUN cp -r conf/* james-server-app-3.0.0-beta6-SNAPSHOT/conf
-RUN cp wrapper.conf james-server-app-3.0.0-beta6-SNAPSHOT/conf
+RUN cp james-server-app-3.0.0-RC2-SNAPSHOT/conf/wrapper.conf .
+RUN rm -r james-server-app-3.0.0-RC2-SNAPSHOT/conf/*
+RUN cp -r conf/* james-server-app-3.0.0-RC2-SNAPSHOT/conf
+RUN cp wrapper.conf james-server-app-3.0.0-RC2-SNAPSHOT/conf
 
-WORKDIR /root/james-server-app-3.0.0-beta6-SNAPSHOT/bin
+WORKDIR /root/james-server-app-3.0.0-RC2-SNAPSHOT/bin
 ENTRYPOINT ["./wrapper-linux-x86-64","../conf/wrapper.conf", "wrapper.syslog.ident=james", "wrapper.pidfile=../var/james.pid", "wrapper.daemonize=FALSE"]


### PR DESCRIPTION
A better alternative would be to pass current build version as a parameter to the dockerfile.

Hence we can set this as part of our CI script.

Note: I do not know how to remove version from appassembler...