### PR TITLE
Add logs of http JMAP requests on /jmap endpoint

### DIFF
--- a/server/protocols/jmap/pom.xml
+++ b/server/protocols/jmap/pom.xml
@@ -372,6 +372,16 @@
                     <artifactId>slf4j-simple</artifactId>
                     <scope>test</scope>
                 </dependency>
+                <dependency>
+                    <groupId>org.zalando</groupId>
+                    <artifactId>logbook-core</artifactId>
+                    <version>1.2.1</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.zalando</groupId>
+                    <artifactId>logbook-servlet</artifactId>
+                    <version>1.2.1</version>
+                </dependency>
             </dependencies>
             <build>
                 <plugins>


### PR DESCRIPTION
Just add this logger in your logback configuration:
```
<logger name="http.jmap" level="DEBUG"/>
```
and then, we will have such logs:
```
2017-05-11 15:23:37,743 DEBUG [qtp1057468716-30] - [http.jmap]- Incoming Request: 797afde3-93fe-485c-bcf1-004e086fea3b
POST http://localhost:33030/jmap HTTP/1.1
Authorization: XXX
Accept: application/json, application/javascript, text/javascript
User-Agent: Apache-HttpClient/4.5.1 (Java/1.8.0_121)
Connection: keep-alive
Host: localhost:33030
Accept-Encoding: gzip,deflate
Content-Length: 69
Content-Type: application/json; charset=UTF-8

[["setMessages", {"update": {"1" : { "isUnread" : false } } }, "#0"]]
2017-05-11 15:23:37,964 DEBUG [qtp1057468716-30] - [http.jmap]- Outgoing Response: 797afde3-93fe-485c-bcf1-004e086fea3b
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: GET, POST, DELETE, PUT
Date: Thu, 11 May 2017 13:23:37 GMT
Access-Control-Allow-Headers: Content-Type, Authorization, Accept
Content-Type: application/json

[["messagesSet",{"accountId":null,"oldState":null,"newState":null,"created":{},"updated":["1"],"destroyed":[],"notCreated":{},"notUpdated":{},"notDestroyed":{}},"#0"]]
```