### PR TITLE
MAILBOX-296 EXPUNGE command should succeed over large mailboxes with Cassandra

### DIFF
--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerProvider.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerProvider.java
@@ -56,7 +56,7 @@ public class CassandraMailboxManagerProvider {
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
         CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(session, messageIdFactory);
         CassandraMessageIdToImapUidDAO imapUidDAO = new CassandraMessageIdToImapUidDAO(session, messageIdFactory);
-        CassandraMessageDAO messageDAO = new CassandraMessageDAO(session, cassandraTypesProvider, messageIdFactory);
+        CassandraMessageDAO messageDAO = new CassandraMessageDAO(session, cassandraTypesProvider);
         CassandraMailboxCounterDAO mailboxCounterDAO = new CassandraMailboxCounterDAO(session);
         CassandraMailboxRecentsDAO mailboxRecentsDAO = new CassandraMailboxRecentsDAO(session);
         CassandraMailboxDAO mailboxDAO = new CassandraMailboxDAO(session, cassandraTypesProvider, MAX_ACL_RETRY);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
@@ -80,7 +80,7 @@ public class CassandraTestSystemFixture {
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
         CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(CASSANDRA.getConf(), messageIdFactory);
         CassandraMessageIdToImapUidDAO imapUidDAO = new CassandraMessageIdToImapUidDAO(CASSANDRA.getConf(), messageIdFactory);
-        CassandraMessageDAO messageDAO = new CassandraMessageDAO(CASSANDRA.getConf(), CASSANDRA.getTypesProvider(), messageIdFactory);
+        CassandraMessageDAO messageDAO = new CassandraMessageDAO(CASSANDRA.getConf(), CASSANDRA.getTypesProvider());
         CassandraMailboxCounterDAO mailboxCounterDAO = new CassandraMailboxCounterDAO(CASSANDRA.getConf());
         CassandraMailboxRecentsDAO mailboxRecentsDAO = new CassandraMailboxRecentsDAO(CASSANDRA.getConf());
         CassandraApplicableFlagDAO applicableFlagDAO = new CassandraApplicableFlagDAO(CASSANDRA.getConf());

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxManagerAttachmentTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxManagerAttachmentTest.java
@@ -76,7 +76,7 @@ public class CassandraMailboxManagerAttachmentTest extends AbstractMailboxManage
                 new CassandraUidProvider(cassandra.getConf()),
                 new CassandraModSeqProvider(cassandra.getConf()),
                 cassandra.getConf(),
-                new CassandraMessageDAO(cassandra.getConf(), cassandra.getTypesProvider(), messageIdFactory),
+                new CassandraMessageDAO(cassandra.getConf(), cassandra.getTypesProvider()),
                 new CassandraMessageIdDAO(cassandra.getConf(), messageIdFactory),
                 new CassandraMessageIdToImapUidDAO(cassandra.getConf(), messageIdFactory),
                 new CassandraMailboxCounterDAO(cassandra.getConf()),

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMapperProvider.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMapperProvider.java
@@ -110,7 +110,7 @@ public class CassandraMapperProvider implements MapperProvider {
             new CassandraUidProvider(cassandra.getConf()),
             cassandraModSeqProvider,
             cassandra.getConf(),
-            new CassandraMessageDAO(cassandra.getConf(), cassandra.getTypesProvider(), MESSAGE_ID_FACTORY),
+            new CassandraMessageDAO(cassandra.getConf(), cassandra.getTypesProvider()),
             new CassandraMessageIdDAO(cassandra.getConf(), MESSAGE_ID_FACTORY),
             new CassandraMessageIdToImapUidDAO(cassandra.getConf(), MESSAGE_ID_FACTORY),
             new CassandraMailboxCounterDAO(cassandra.getConf()),

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
@@ -107,7 +107,7 @@ public class CassandraHostSystem extends JamesImapHostSystem {
         CassandraUidProvider uidProvider = new CassandraUidProvider(session);
         CassandraTypesProvider typesProvider = new CassandraTypesProvider(mailboxModule, session);
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
-        CassandraMessageDAO messageDAO = new CassandraMessageDAO(session, typesProvider, messageIdFactory);
+        CassandraMessageDAO messageDAO = new CassandraMessageDAO(session, typesProvider);
         CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(session, messageIdFactory);
         CassandraMessageIdToImapUidDAO imapUidDAO = new CassandraMessageIdToImapUidDAO(session, messageIdFactory);
         CassandraMailboxCounterDAO mailboxCounterDAO = new CassandraMailboxCounterDAO(session);

--- a/server/container/util-java8/src/main/java/org/apache/james/util/streams/JamesCollectors.java
+++ b/server/container/util-java8/src/main/java/org/apache/james/util/streams/JamesCollectors.java
@@ -22,8 +22,10 @@ package org.apache.james.util.streams;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.google.common.base.Preconditions;
 
@@ -32,5 +34,11 @@ public class JamesCollectors {
         Preconditions.checkArgument(chunkSize > 0, "ChunkSize should be strictly positive");
         AtomicInteger counter = new AtomicInteger(-1);
         return Collectors.groupingBy(x -> counter.incrementAndGet() / chunkSize);
+    }
+
+    public static <D> Function<Stream<D>, Stream<List<D>>> chunk(int chunkSize) {
+        return stream -> stream.collect(chunker(chunkSize))
+            .values()
+            .stream();
     }
 }


### PR DESCRIPTION
The idea is:

 - to batch EXPUNGE by packages of 100 to not overwhelm DB
 - to get rid of the IN clause in CassandraMessageDAO, prefer using individual parallel reads, also chunked to not overwhelm DB
 - to prepare CassandraMessageDAO select query

I used https://github.com/linagora/gatling-imap/pull/22 to run Gatling metrics and conduct testing:

| branch  | 5% | 20%| 100% |
| --  | --  | -- | --  |
| master  | 105/103 |660/218/X/195  | X/X
| this one| 94/1034|371/256/191/206| 598/550|

X means failure. Results are in ms.

About these stats:
 - Order of run was strictly the same (20%, 5%, 5%, 20%, 20%, 20%, 100%, 100%) for warm up reasons.
 - We did not get much performance improvements, but we see now we can expunge large mailboxes, what was before impossible.

Hence this is a huge win: it solves aims at solving both of the very common Cassandra failures upon IMAP. 