### PR TITLE
Mailbox 297 Optimize ranges flags updates

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
@@ -193,9 +193,7 @@ public class CassandraMessageDAO {
     public CompletableFuture<Stream<Pair<MessageWithoutAttachment, Stream<MessageAttachmentRepresentation>>>> retrieveMessages(List<ComposedMessageIdWithMetaData> messageIds, FetchType fetchType, Optional<Integer> limit) {
         return CompletableFutureUtil.chainAll(
             getLimitedIdStream(messageIds.stream().distinct(), limit)
-                .collect(JamesCollectors.chunker(CHUNK_SIZE_ON_READ))
-                .values()
-                .stream(),
+                .collect(JamesCollectors.chunker(CHUNK_SIZE_ON_READ)),
             ids -> FluentFutureStream.of(
                 ids.stream()
                     .map(id -> retrieveRow(id, fetchType)

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -286,7 +286,7 @@ public class CassandraMessageMapper implements MessageMapper {
 
         FlagsUpdateStageResult firstResult = runUpdateStage(mailboxId, toBeUpdated, flagUpdateCalculator);
         FlagsUpdateStageResult finalResult = handleUpdatesStagedRetry(mailboxId, flagUpdateCalculator, firstResult);
-        if (!finalResult.getFailed().isEmpty()) {
+        if (finalResult.containsFailedResults()) {
             LOGGER.error("Can not update following UIDs {} for mailbox {}", finalResult.getFailed(), mailboxId.asUuid());
         }
         return finalResult.getSucceeded().iterator();
@@ -295,7 +295,7 @@ public class CassandraMessageMapper implements MessageMapper {
     private FlagsUpdateStageResult handleUpdatesStagedRetry(CassandraId mailboxId, FlagsUpdateCalculator flagUpdateCalculator, FlagsUpdateStageResult firstResult) {
         FlagsUpdateStageResult globalResult = firstResult;
         int retryCount = 0;
-        while (retryCount < maxRetries && !globalResult.getFailed().isEmpty()) {
+        while (retryCount < maxRetries && globalResult.containsFailedResults()) {
             retryCount++;
             globalResult = globalResult.keepSucceded()
                 .merge(retryUpdatesStage(mailboxId, flagUpdateCalculator, globalResult.getFailed()));

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -25,25 +25,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.mail.Flags;
 import javax.mail.Flags.Flag;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.james.backends.cassandra.utils.FunctionRunnerWithRetry;
 import org.apache.james.mailbox.FlagsBuilder;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.cassandra.CassandraId;
 import org.apache.james.mailbox.cassandra.CassandraMessageId;
-import org.apache.james.mailbox.cassandra.mail.utils.MessageDeletedDuringFlagsUpdateException;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.ComposedMessageId;
 import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.MailboxCounters;
-import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.UpdatedFlags;
@@ -61,16 +57,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.steveash.guavate.Guavate;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
 public class CassandraMessageMapper implements MessageMapper {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CassandraMessageMapper.class);
     public static final MailboxCounters INITIAL_COUNTERS =  MailboxCounters.builder()
         .count(0L)
         .unseen(0L)
         .build();
     public static final int EXPUNGE_BATCH_SIZE = 100;
+    public static final Logger LOGGER = LoggerFactory.getLogger(CassandraMessageMapper.class);
 
     private final CassandraModSeqProvider modSeqProvider;
     private final MailboxSession mailboxSession;
@@ -283,14 +278,51 @@ public class CassandraMessageMapper implements MessageMapper {
     @Override
     public Iterator<UpdatedFlags> updateFlags(Mailbox mailbox, FlagsUpdateCalculator flagUpdateCalculator, MessageRange set) throws MailboxException {
         CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
-        return messageIdDAO.retrieveMessages(mailboxId, set)
-                .join()
-                .flatMap(message -> updateFlagsOnMessage(mailbox, flagUpdateCalculator, message))
-                .map((UpdatedFlags updatedFlags) -> indexTableHandler.updateIndexOnFlagsUpdate(mailboxId, updatedFlags)
-                    .thenApply(voidValue -> updatedFlags))
-                .map(CompletableFuture::join)
-                .collect(Collectors.toList()) // This collect is here as we need to consume all the stream before returning result
-                .iterator();
+
+        return runUpdate(mailboxId, set, flagUpdateCalculator).iterator();
+    }
+
+    private List<UpdatedFlags> runUpdate(CassandraId mailboxId, MessageRange set, FlagsUpdateCalculator flagsUpdateCalculator) throws MailboxException {
+        Stream<ComposedMessageIdWithMetaData> toBeUpdated = messageIdDAO.retrieveMessages(mailboxId, set).join();
+
+        FlagsUpdateStageResult globalResult = runUpdateStage(mailboxId, toBeUpdated, flagsUpdateCalculator);
+
+        int retryCount = 0;
+
+        while (retryCount < maxRetries && !globalResult.getFailed().isEmpty()) {
+            retryCount++;
+            FlagsUpdateStageResult stageResult = runUpdateStage(mailboxId,
+                FluentFutureStream.of(
+                    globalResult.getFailed().stream()
+                        .map(uid -> messageIdDAO.retrieve(mailboxId, uid)))
+                    .flatMap(OptionalConverter::toStream)
+                    .completableFuture().join(),
+                flagsUpdateCalculator);
+
+            globalResult = globalResult.keepSuccess().merge(stageResult);
+        }
+
+        LOGGER.error("Can not update following UIDs {} for mailbox {}", globalResult.getFailed(), mailboxId.asUuid());
+
+        return globalResult.getSucceeded();
+    }
+
+    private FlagsUpdateStageResult runUpdateStage(CassandraId mailboxId, Stream<ComposedMessageIdWithMetaData> toBeUpdated, FlagsUpdateCalculator flagsUpdateCalculator) {
+        Long newModSeq = modSeqProvider.nextModSeq(mailboxId).join().orElseThrow(() -> new RuntimeException("ModSeq generation failed"));
+
+        FlagsUpdateStageResult result = toBeUpdated
+            .map(oldMetadata -> tryFlagsUpdate(flagsUpdateCalculator,
+                newModSeq,
+                oldMetadata))
+            .reduce(FlagsUpdateStageResult::merge)
+            .orElse(none());
+
+        result.getSucceeded().stream()
+            .map((UpdatedFlags updatedFlags) -> indexTableHandler.updateIndexOnFlagsUpdate(mailboxId, updatedFlags)
+                .thenApply(voidValue -> updatedFlags))
+            .forEach(CompletableFuture::join);
+
+        return result;
     }
 
     @Override
@@ -332,41 +364,30 @@ public class CassandraMessageMapper implements MessageMapper {
                 imapUidDAO.insert(composedMessageIdWithMetaData));
     }
 
-    private Stream<UpdatedFlags> updateFlagsOnMessage(Mailbox mailbox, FlagsUpdateCalculator flagUpdateCalculator, ComposedMessageIdWithMetaData composedMessageIdWithMetaData) {
-        return tryMessageFlagsUpdate(flagUpdateCalculator, mailbox, composedMessageIdWithMetaData)
-            .map(Stream::of)
-            .orElse(handleRetries(mailbox, flagUpdateCalculator, composedMessageIdWithMetaData));
-    }
 
-    private Optional<UpdatedFlags> tryMessageFlagsUpdate(FlagsUpdateCalculator flagUpdateCalculator, Mailbox mailbox, ComposedMessageIdWithMetaData oldMetaData) {
-        try {
-            long oldModSeq = oldMetaData.getModSeq();
-            Flags oldFlags = oldMetaData.getFlags();
-            Flags newFlags = flagUpdateCalculator.buildNewFlags(oldFlags);
+    private FlagsUpdateStageResult tryFlagsUpdate(FlagsUpdateCalculator flagUpdateCalculator, long newModSeq, ComposedMessageIdWithMetaData oldMetaData) {
+        Flags oldFlags = oldMetaData.getFlags();
+        Flags newFlags = flagUpdateCalculator.buildNewFlags(oldFlags);
 
-            boolean involveFlagsChanges = !identicalFlags(oldFlags, newFlags);
-            long newModSeq = generateNewModSeqIfNeeded(mailbox, oldModSeq, involveFlagsChanges);
-
-            if (updateFlags(oldMetaData, newFlags, newModSeq)) {
-                return Optional.of(UpdatedFlags.builder()
-                    .uid(oldMetaData.getComposedMessageId().getUid())
-                    .modSeq(newModSeq)
-                    .oldFlags(oldFlags)
-                    .newFlags(newFlags)
-                    .build());
-            } else {
-                return Optional.empty();
-            }
-        } catch (MailboxException e) {
-            throw Throwables.propagate(e);
+        if (identicalFlags(oldFlags, newFlags)) {
+            return success(UpdatedFlags.builder()
+                .uid(oldMetaData.getComposedMessageId().getUid())
+                .modSeq(oldMetaData.getModSeq())
+                .oldFlags(oldFlags)
+                .newFlags(newFlags)
+                .build());
         }
-    }
 
-    private long generateNewModSeqIfNeeded(Mailbox mailbox, long oldModSeq, boolean involveFlagsChanges) throws MailboxException {
-        if (involveFlagsChanges) {
-            return modSeqProvider.nextModSeq(mailboxSession, mailbox);
+        if (updateFlags(oldMetaData, newFlags, newModSeq)) {
+            return success(UpdatedFlags.builder()
+                .uid(oldMetaData.getComposedMessageId().getUid())
+                .modSeq(newModSeq)
+                .oldFlags(oldFlags)
+                .newFlags(newFlags)
+                .build());
+        } else {
+            return fail(oldMetaData.getComposedMessageId().getUid());
         }
-        return oldModSeq;
     }
 
     private boolean identicalFlags(Flags oldFlags, Flags newFlags) {
@@ -388,32 +409,49 @@ public class CassandraMessageMapper implements MessageMapper {
             .join();
     }
 
-    private Stream<UpdatedFlags> handleRetries(Mailbox mailbox, FlagsUpdateCalculator flagUpdateCalculator, ComposedMessageIdWithMetaData oldMetaData) {
-        try {
-            return Stream.of(
-                new FunctionRunnerWithRetry(maxRetries)
-                    .executeAndRetrieveObject(() -> retryMessageFlagsUpdate(mailbox,
-                            oldMetaData.getComposedMessageId().getMessageId(),
-                            flagUpdateCalculator)));
-        } catch (MessageDeletedDuringFlagsUpdateException e) {
-            mailboxSession.getLog().warn(e.getMessage());
-            return Stream.of();
-        } catch (MailboxDeleteDuringUpdateException e) {
-            LOGGER.info("Mailbox {} was deleted during flag update", mailbox.getMailboxId());
-            return Stream.of();
-        } catch (Exception e) {
-            throw Throwables.propagate(e);
-        }
+    private static FlagsUpdateStageResult success(UpdatedFlags updatedFlags) {
+        return new FlagsUpdateStageResult(ImmutableList.of(), ImmutableList.of(updatedFlags));
     }
 
-    private Optional<UpdatedFlags> retryMessageFlagsUpdate(Mailbox mailbox, MessageId messageId, FlagsUpdateCalculator flagUpdateCalculator) {
-        CassandraId cassandraId = (CassandraId) mailbox.getMailboxId();
-        ComposedMessageIdWithMetaData composedMessageIdWithMetaData = imapUidDAO.retrieve((CassandraMessageId) messageId, Optional.of(cassandraId))
-            .join()
-            .findFirst()
-            .orElseThrow(MailboxDeleteDuringUpdateException::new);
-        return tryMessageFlagsUpdate(flagUpdateCalculator,
-                mailbox,
-                composedMessageIdWithMetaData);
+    private static FlagsUpdateStageResult fail(MessageUid uid) {
+        return new FlagsUpdateStageResult(ImmutableList.of(uid), ImmutableList.of());
+    }
+
+    private static FlagsUpdateStageResult none() {
+        return new FlagsUpdateStageResult(ImmutableList.of(), ImmutableList.of());
+    }
+
+    private static class FlagsUpdateStageResult {
+        private final List<MessageUid> failed;
+        private final List<UpdatedFlags> succeeded;
+
+        public FlagsUpdateStageResult(List<MessageUid> failed, List<UpdatedFlags> succeeded) {
+            this.failed = failed;
+            this.succeeded = succeeded;
+        }
+
+        public List<MessageUid> getFailed() {
+            return failed;
+        }
+
+        public List<UpdatedFlags> getSucceeded() {
+            return succeeded;
+        }
+
+        public FlagsUpdateStageResult merge(FlagsUpdateStageResult other) {
+            return new FlagsUpdateStageResult(
+                ImmutableList.<MessageUid>builder()
+                    .addAll(this.failed)
+                    .addAll(other.failed)
+                    .build(),
+                ImmutableList.<UpdatedFlags>builder()
+                    .addAll(this.succeeded)
+                    .addAll(other.succeeded)
+                    .build());
+        }
+
+        public FlagsUpdateStageResult keepSuccess() {
+            return new FlagsUpdateStageResult(ImmutableList.of(), succeeded);
+        }
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -297,8 +297,8 @@ public class CassandraMessageMapper implements MessageMapper {
         int retryCount = 0;
         while (retryCount < maxRetries && globalResult.containsFailedResults()) {
             retryCount++;
-            globalResult = globalResult.keepSucceded()
-                .merge(retryUpdatesStage(mailboxId, flagUpdateCalculator, globalResult.getFailed()));
+            FlagsUpdateStageResult stageResult = retryUpdatesStage(mailboxId, flagUpdateCalculator, globalResult.getFailed());
+            globalResult = globalResult.keepSucceded().merge(stageResult);
         }
         return globalResult;
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -58,6 +58,7 @@ import org.apache.james.util.streams.JamesCollectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.fge.lambdas.Throwing;
 import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
@@ -333,7 +334,12 @@ public class CassandraMessageMapper implements MessageMapper {
     private CompletableFuture<FlagsUpdateStageResult> updateIndexesForUpdatesResult(CassandraId mailboxId, FlagsUpdateStageResult result) {
         return FluentFutureStream.of(
             result.getSucceeded().stream()
-                .map((UpdatedFlags updatedFlags) -> indexTableHandler.updateIndexOnFlagsUpdate(mailboxId, updatedFlags)))
+                .map(Throwing
+                    .function((UpdatedFlags updatedFlags) -> indexTableHandler.updateIndexOnFlagsUpdate(mailboxId, updatedFlags))
+                    .fallbackTo(failedindex -> {
+                        LOGGER.error("Could not update flag indexes for mailboxId {} UID {}. This will lead to inconsistencies across Cassandra tables");
+                        return CompletableFuture.completedFuture(null);
+                    })))
             .completableFuture()
             .thenApply(any -> result);
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -283,7 +283,7 @@ public class CassandraMessageMapper implements MessageMapper {
     @Override
     public Iterator<UpdatedFlags> updateFlags(Mailbox mailbox, FlagsUpdateCalculator flagUpdateCalculator, MessageRange set) throws MailboxException {
         CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
-        return retrieveMessages(retrieveMessageIds(mailboxId, set), FetchType.Metadata, Optional.empty())
+        return messageIdDAO.retrieveMessages(mailboxId, set)
                 .join()
                 .flatMap(message -> updateFlagsOnMessage(mailbox, flagUpdateCalculator, message))
                 .map((UpdatedFlags updatedFlags) -> indexTableHandler.updateIndexOnFlagsUpdate(mailboxId, updatedFlags)
@@ -332,26 +332,24 @@ public class CassandraMessageMapper implements MessageMapper {
                 imapUidDAO.insert(composedMessageIdWithMetaData));
     }
 
-    private Stream<UpdatedFlags> updateFlagsOnMessage(Mailbox mailbox, FlagsUpdateCalculator flagUpdateCalculator, MailboxMessage message) {
-        return tryMessageFlagsUpdate(flagUpdateCalculator, mailbox, message)
+    private Stream<UpdatedFlags> updateFlagsOnMessage(Mailbox mailbox, FlagsUpdateCalculator flagUpdateCalculator, ComposedMessageIdWithMetaData composedMessageIdWithMetaData) {
+        return tryMessageFlagsUpdate(flagUpdateCalculator, mailbox, composedMessageIdWithMetaData)
             .map(Stream::of)
-            .orElse(handleRetries(mailbox, flagUpdateCalculator, message));
+            .orElse(handleRetries(mailbox, flagUpdateCalculator, composedMessageIdWithMetaData));
     }
 
-    private Optional<UpdatedFlags> tryMessageFlagsUpdate(FlagsUpdateCalculator flagUpdateCalculator, Mailbox mailbox, MailboxMessage message) {
+    private Optional<UpdatedFlags> tryMessageFlagsUpdate(FlagsUpdateCalculator flagUpdateCalculator, Mailbox mailbox, ComposedMessageIdWithMetaData oldMetaData) {
         try {
-            long oldModSeq = message.getModSeq();
-            Flags oldFlags = message.createFlags();
+            long oldModSeq = oldMetaData.getModSeq();
+            Flags oldFlags = oldMetaData.getFlags();
             Flags newFlags = flagUpdateCalculator.buildNewFlags(oldFlags);
 
             boolean involveFlagsChanges = !identicalFlags(oldFlags, newFlags);
             long newModSeq = generateNewModSeqIfNeeded(mailbox, oldModSeq, involveFlagsChanges);
 
-            message.setFlags(newFlags);
-            message.setModSeq(newModSeq);
-            if (updateFlags(message, oldModSeq)) {
+            if (updateFlags(oldMetaData, newFlags, newModSeq)) {
                 return Optional.of(UpdatedFlags.builder()
-                    .uid(message.getUid())
+                    .uid(oldMetaData.getComposedMessageId().getUid())
                     .modSeq(newModSeq)
                     .oldFlags(oldFlags)
                     .newFlags(newFlags)
@@ -375,13 +373,13 @@ public class CassandraMessageMapper implements MessageMapper {
         return oldFlags.equals(newFlags);
     }
 
-    private boolean updateFlags(MailboxMessage message, long oldModSeq) {
+    private boolean updateFlags(ComposedMessageIdWithMetaData oldMetadata, Flags newFlags, long newModSeq) {
         ComposedMessageIdWithMetaData composedMessageIdWithMetaData = ComposedMessageIdWithMetaData.builder()
-                .composedMessageId(new ComposedMessageId(message.getMailboxId(), message.getMessageId(), message.getUid()))
-                .modSeq(message.getModSeq())
-                .flags(message.createFlags())
+                .composedMessageId(oldMetadata.getComposedMessageId())
+                .modSeq(newModSeq)
+                .flags(newFlags)
                 .build();
-        return imapUidDAO.updateMetadata(composedMessageIdWithMetaData, oldModSeq)
+        return imapUidDAO.updateMetadata(composedMessageIdWithMetaData, oldMetadata.getModSeq())
             .thenCompose(success -> Optional.of(success)
                 .filter(b -> b)
                 .map((Boolean any) -> messageIdDAO.updateMetadata(composedMessageIdWithMetaData)
@@ -390,12 +388,12 @@ public class CassandraMessageMapper implements MessageMapper {
             .join();
     }
 
-    private Stream<UpdatedFlags> handleRetries(Mailbox mailbox, FlagsUpdateCalculator flagUpdateCalculator, MailboxMessage message) {
+    private Stream<UpdatedFlags> handleRetries(Mailbox mailbox, FlagsUpdateCalculator flagUpdateCalculator, ComposedMessageIdWithMetaData oldMetaData) {
         try {
             return Stream.of(
                 new FunctionRunnerWithRetry(maxRetries)
                     .executeAndRetrieveObject(() -> retryMessageFlagsUpdate(mailbox,
-                            message.getMessageId(),
+                            oldMetaData.getComposedMessageId().getMessageId(),
                             flagUpdateCalculator)));
         } catch (MessageDeletedDuringFlagsUpdateException e) {
             mailboxSession.getLog().warn(e.getMessage());
@@ -416,9 +414,6 @@ public class CassandraMessageMapper implements MessageMapper {
             .orElseThrow(MailboxDeleteDuringUpdateException::new);
         return tryMessageFlagsUpdate(flagUpdateCalculator,
                 mailbox,
-                messageDAO.retrieveMessages(ImmutableList.of(composedMessageIdWithMetaData), FetchType.Metadata, Optional.empty()).join()
-                    .findFirst()
-                    .map(pair -> pair.getLeft().toMailboxMessage(ImmutableList.of()))
-                    .orElseThrow(() -> new MessageDeletedDuringFlagsUpdateException(cassandraId, (CassandraMessageId) messageId)));
+                composedMessageIdWithMetaData);
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/utils/FlagsUpdateStageResult.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/utils/FlagsUpdateStageResult.java
@@ -70,6 +70,10 @@ public class FlagsUpdateStageResult {
                 .build());
     }
 
+    public boolean containsFailedResults() {
+        return !failed.isEmpty();
+    }
+
     public FlagsUpdateStageResult keepSucceded() {
         return new FlagsUpdateStageResult(ImmutableList.of(), succeeded);
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/utils/FlagsUpdateStageResult.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/utils/FlagsUpdateStageResult.java
@@ -41,13 +41,13 @@ public class FlagsUpdateStageResult {
         return new FlagsUpdateStageResult(ImmutableList.of(), ImmutableList.of());
     }
 
-    private final List<MessageUid> failed;
-    private final List<UpdatedFlags> succeeded;
+    private final ImmutableList<MessageUid> failed;
+    private final ImmutableList<UpdatedFlags> succeeded;
 
     @VisibleForTesting
-    FlagsUpdateStageResult(List<MessageUid> failed, List<UpdatedFlags> succeeded) {
-        this.failed = ImmutableList.copyOf(failed);
-        this.succeeded = ImmutableList.copyOf(succeeded);
+    FlagsUpdateStageResult(ImmutableList<MessageUid> failed, ImmutableList<UpdatedFlags> succeeded) {
+        this.failed = failed;
+        this.succeeded = succeeded;
     }
 
     public List<MessageUid> getFailed() {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/utils/FlagsUpdateStageResult.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/utils/FlagsUpdateStageResult.java
@@ -46,8 +46,8 @@ public class FlagsUpdateStageResult {
 
     @VisibleForTesting
     FlagsUpdateStageResult(List<MessageUid> failed, List<UpdatedFlags> succeeded) {
-        this.failed = failed;
-        this.succeeded = succeeded;
+        this.failed = ImmutableList.copyOf(failed);
+        this.succeeded = ImmutableList.copyOf(succeeded);
     }
 
     public List<MessageUid> getFailed() {
@@ -70,7 +70,7 @@ public class FlagsUpdateStageResult {
                 .build());
     }
 
-    public FlagsUpdateStageResult keepSuccess() {
+    public FlagsUpdateStageResult keepSucceded() {
         return new FlagsUpdateStageResult(ImmutableList.of(), succeeded);
     }
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/utils/FlagsUpdateStageResult.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/utils/FlagsUpdateStageResult.java
@@ -1,0 +1,92 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.utils;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.model.UpdatedFlags;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+
+public class FlagsUpdateStageResult {
+    public static FlagsUpdateStageResult success(UpdatedFlags updatedFlags) {
+        return new FlagsUpdateStageResult(ImmutableList.of(), ImmutableList.of(updatedFlags));
+    }
+
+    public static FlagsUpdateStageResult fail(MessageUid uid) {
+        return new FlagsUpdateStageResult(ImmutableList.of(uid), ImmutableList.of());
+    }
+
+    public static FlagsUpdateStageResult none() {
+        return new FlagsUpdateStageResult(ImmutableList.of(), ImmutableList.of());
+    }
+
+    private final List<MessageUid> failed;
+    private final List<UpdatedFlags> succeeded;
+
+    @VisibleForTesting
+    FlagsUpdateStageResult(List<MessageUid> failed, List<UpdatedFlags> succeeded) {
+        this.failed = failed;
+        this.succeeded = succeeded;
+    }
+
+    public List<MessageUid> getFailed() {
+        return failed;
+    }
+
+    public List<UpdatedFlags> getSucceeded() {
+        return succeeded;
+    }
+
+    public FlagsUpdateStageResult merge(FlagsUpdateStageResult other) {
+        return new FlagsUpdateStageResult(
+            ImmutableList.<MessageUid>builder()
+                .addAll(this.failed)
+                .addAll(other.failed)
+                .build(),
+            ImmutableList.<UpdatedFlags>builder()
+                .addAll(this.succeeded)
+                .addAll(other.succeeded)
+                .build());
+    }
+
+    public FlagsUpdateStageResult keepSuccess() {
+        return new FlagsUpdateStageResult(ImmutableList.of(), succeeded);
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof FlagsUpdateStageResult) {
+            FlagsUpdateStageResult that = (FlagsUpdateStageResult) o;
+
+            return Objects.equals(this.succeeded, that.succeeded)
+                && Objects.equals(this.failed, that.failed);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(failed, succeeded);
+    }
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/utils/FlagsUpdateStageResultTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/utils/FlagsUpdateStageResultTest.java
@@ -131,4 +131,17 @@ public class FlagsUpdateStageResultTest {
             .isEqualTo(FlagsUpdateStageResult.success(UPDATED_FLAGS));
     }
 
+    @Test
+    public void containsFailedResultsShouldReturnTrueWhenFailed() {
+        assertThat(FlagsUpdateStageResult.fail(UID).containsFailedResults())
+            .isTrue();
+    }
+
+
+    @Test
+    public void containsFailedResultsShouldReturnFalseWhenSucceeded() {
+        assertThat(FlagsUpdateStageResult.success(UPDATED_FLAGS).containsFailedResults())
+            .isFalse();
+    }
+
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/utils/FlagsUpdateStageResultTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/utils/FlagsUpdateStageResultTest.java
@@ -1,0 +1,134 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.mail.Flags;
+
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.model.UpdatedFlags;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class FlagsUpdateStageResultTest {
+
+    public static final MessageUid UID = MessageUid.of(1L);
+    public static final MessageUid OTHER_UID = MessageUid.of(2L);
+    public static final UpdatedFlags UPDATED_FLAGS = UpdatedFlags.builder()
+        .uid(UID)
+        .modSeq(18L)
+        .oldFlags(new Flags())
+        .newFlags(new Flags(Flags.Flag.SEEN))
+        .build();
+    public static final UpdatedFlags OTHER_UPDATED_FLAGS = UpdatedFlags.builder()
+        .uid(OTHER_UID)
+        .modSeq(18L)
+        .oldFlags(new Flags())
+        .newFlags(new Flags(Flags.Flag.SEEN))
+        .build();
+
+    @Test
+    public void classShouldRespectBeanContract() {
+        EqualsVerifier.forClass(FlagsUpdateStageResult.class);
+    }
+
+    @Test
+    public void noneShouldCreateResultWithoutSuccessOrFails() {
+        assertThat(FlagsUpdateStageResult.none())
+            .isEqualTo(new FlagsUpdateStageResult(ImmutableList.of(), ImmutableList.of()));
+    }
+
+    @Test
+    public void failShouldCreateResultWithFailedUid() {
+        assertThat(FlagsUpdateStageResult.fail(UID))
+            .isEqualTo(new FlagsUpdateStageResult(ImmutableList.of(UID), ImmutableList.of()));
+    }
+
+    @Test
+    public void successShouldCreateResultWithSucceededUpdatedFlags() {
+        assertThat(FlagsUpdateStageResult.success(UPDATED_FLAGS))
+            .isEqualTo(new FlagsUpdateStageResult(ImmutableList.of(), ImmutableList.of(UPDATED_FLAGS)));
+    }
+
+    @Test
+    public void noneShouldBeWellMergedWithNone() {
+        assertThat(FlagsUpdateStageResult.none().merge(FlagsUpdateStageResult.none()))
+            .isEqualTo(FlagsUpdateStageResult.none());
+    }
+
+    @Test
+    public void noneShouldBeWellMergedWithFail() {
+        assertThat(FlagsUpdateStageResult.none().merge(FlagsUpdateStageResult.fail(UID)))
+            .isEqualTo(FlagsUpdateStageResult.fail(UID));
+    }
+
+    @Test
+    public void noneShouldBeWellMergedWithSuccess() {
+        assertThat(FlagsUpdateStageResult.none().merge(FlagsUpdateStageResult.success(UPDATED_FLAGS)))
+            .isEqualTo(FlagsUpdateStageResult.success(UPDATED_FLAGS));
+    }
+
+    @Test
+    public void failShouldBeWellMergedWithFail() {
+        assertThat(FlagsUpdateStageResult.fail(UID).merge(FlagsUpdateStageResult.fail(OTHER_UID)))
+            .isEqualTo(new FlagsUpdateStageResult(ImmutableList.of(UID, OTHER_UID), ImmutableList.of()));
+    }
+
+    @Test
+    public void successShouldBeWellMergedWithFail() {
+        assertThat(FlagsUpdateStageResult.success(UPDATED_FLAGS).merge(FlagsUpdateStageResult.fail(UID)))
+            .isEqualTo(new FlagsUpdateStageResult(ImmutableList.of(UID), ImmutableList.of(UPDATED_FLAGS)));
+    }
+
+    @Test
+    public void successShouldBeWellMergedWithSuccess() {
+        assertThat(FlagsUpdateStageResult.success(UPDATED_FLAGS).merge(FlagsUpdateStageResult.success(OTHER_UPDATED_FLAGS)))
+            .isEqualTo(new FlagsUpdateStageResult(ImmutableList.of(), ImmutableList.of(UPDATED_FLAGS, OTHER_UPDATED_FLAGS)));
+    }
+
+    @Test
+    public void getFailedShouldReturnFailedUid() {
+        FlagsUpdateStageResult flagsUpdateStageResult = new FlagsUpdateStageResult(ImmutableList.of(UID), ImmutableList.of(UPDATED_FLAGS));
+
+        assertThat(flagsUpdateStageResult.getFailed())
+            .containsExactly(UID);
+    }
+
+    @Test
+    public void getSucceededShouldReturnSucceedUpdatedFlags() {
+        FlagsUpdateStageResult flagsUpdateStageResult = new FlagsUpdateStageResult(ImmutableList.of(UID), ImmutableList.of(UPDATED_FLAGS));
+
+        assertThat(flagsUpdateStageResult.getSucceeded())
+            .containsExactly(UPDATED_FLAGS);
+    }
+
+    @Test
+    public void keepSuccessShouldDiscardFailedUids() {
+        FlagsUpdateStageResult flagsUpdateStageResult = new FlagsUpdateStageResult(ImmutableList.of(UID), ImmutableList.of(UPDATED_FLAGS));
+
+        assertThat(flagsUpdateStageResult.keepSuccess())
+            .isEqualTo(FlagsUpdateStageResult.success(UPDATED_FLAGS));
+    }
+
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/utils/FlagsUpdateStageResultTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/utils/FlagsUpdateStageResultTest.java
@@ -127,7 +127,7 @@ public class FlagsUpdateStageResultTest {
     public void keepSuccessShouldDiscardFailedUids() {
         FlagsUpdateStageResult flagsUpdateStageResult = new FlagsUpdateStageResult(ImmutableList.of(UID), ImmutableList.of(UPDATED_FLAGS));
 
-        assertThat(flagsUpdateStageResult.keepSuccess())
+        assertThat(flagsUpdateStageResult.keepSucceded())
             .isEqualTo(FlagsUpdateStageResult.success(UPDATED_FLAGS));
     }
 

--- a/server/container/util-java8/src/main/java/org/apache/james/util/CompletableFutureUtil.java
+++ b/server/container/util-java8/src/main/java/org/apache/james/util/CompletableFutureUtil.java
@@ -89,8 +89,12 @@ public class CompletableFutureUtil {
                 stream.map(action));
     }
 
-    public static <T, U> CompletableFuture<Optional<T>> reduce(BinaryOperator<T> binaryOperator, CompletableFuture<Stream<T>> futureStream) {
+    public static <T> CompletableFuture<Optional<T>> reduce(BinaryOperator<T> binaryOperator, CompletableFuture<Stream<T>> futureStream) {
         return futureStream.thenApply(stream -> stream.reduce(binaryOperator));
+    }
+
+    public static <T> CompletableFuture<T> reduce(BinaryOperator<T> binaryOperator, CompletableFuture<Stream<T>> futureStream, T emptyAccumulator) {
+        return futureStream.thenApply(stream -> stream.reduce(binaryOperator).orElse(emptyAccumulator));
     }
 
     public static <T> CompletableFuture<T> keepValue(Supplier<CompletableFuture<Void>> supplier, T value) {

--- a/server/container/util-java8/src/main/java/org/apache/james/util/FluentFutureStream.java
+++ b/server/container/util-java8/src/main/java/org/apache/james/util/FluentFutureStream.java
@@ -60,6 +60,10 @@ public class FluentFutureStream<T> {
         return CompletableFutureUtil.reduce(combiner, completableFuture);
     }
 
+    public CompletableFuture<T> reduce(T emptyAccumulator, BinaryOperator<T> combiner) {
+        return CompletableFutureUtil.reduce(combiner, completableFuture, emptyAccumulator);
+    }
+
     public <U> FluentFutureStream<U> thenComposeOnAll(Function<T, CompletableFuture<U>> function) {
         return FluentFutureStream.of(
             CompletableFutureUtil.thenComposeOnAll(completableFuture(), function));

--- a/server/container/util-java8/src/main/java/org/apache/james/util/streams/JamesCollectors.java
+++ b/server/container/util-java8/src/main/java/org/apache/james/util/streams/JamesCollectors.java
@@ -33,7 +33,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
 
 public class JamesCollectors {
     public static <D> Collector<D, ?, Stream<Collection<D>>> chunker(int chunkSize) {
@@ -52,7 +51,7 @@ public class JamesCollectors {
 
         @Override
         public Supplier<Multimap<Integer, D>> supplier() {
-            return () -> Multimaps.synchronizedListMultimap(ArrayListMultimap.<Integer, D>create());
+            return ArrayListMultimap::create;
         }
 
         @Override
@@ -75,7 +74,7 @@ public class JamesCollectors {
 
         @Override
         public Set<Characteristics> characteristics() {
-            return ImmutableSet.of(Characteristics.CONCURRENT);
+            return ImmutableSet.of();
         }
     }
 }

--- a/server/container/util-java8/src/test/java/org/apache/james/util/CompletableFutureUtilTest.java
+++ b/server/container/util-java8/src/test/java/org/apache/james/util/CompletableFutureUtilTest.java
@@ -363,19 +363,19 @@ public class CompletableFutureUtilTest {
     }
 
     @Test
-    public void reduceShouldEmptyAccumulatorWhenNoValue() {
-        long emptyAccumulator = 0L;
+    public void reduceShouldIdentityAccumulatorWhenNoValue() {
+        long identityAccumulator = 0L;
         assertThat(
             CompletableFutureUtil.reduce(
                 (i, j) -> i + j,
                 CompletableFutureUtil.<Long>allOfArray(),
-                emptyAccumulator)
+                identityAccumulator)
                 .join())
-            .isEqualTo(emptyAccumulator);
+            .isEqualTo(identityAccumulator);
     }
 
     @Test
-    public void reduceShouldWorkWithEmptyAccumulator() {
+    public void reduceShouldWorkWithIdentityAccumulator() {
         assertThat(
             CompletableFutureUtil.reduce(
                 (i, j) -> i + j,

--- a/server/container/util-java8/src/test/java/org/apache/james/util/CompletableFutureUtilTest.java
+++ b/server/container/util-java8/src/test/java/org/apache/james/util/CompletableFutureUtilTest.java
@@ -361,4 +361,31 @@ public class CompletableFutureUtilTest {
                 .join())
             .contains(6L);
     }
+
+    @Test
+    public void reduceShouldEmptyAccumulatorWhenNoValue() {
+        long emptyAccumulator = 0L;
+        assertThat(
+            CompletableFutureUtil.reduce(
+                (i, j) -> i + j,
+                CompletableFutureUtil.<Long>allOfArray(),
+                emptyAccumulator)
+                .join())
+            .isEqualTo(emptyAccumulator);
+    }
+
+    @Test
+    public void reduceShouldWorkWithEmptyAccumulator() {
+        assertThat(
+            CompletableFutureUtil.reduce(
+                (i, j) -> i + j,
+                CompletableFutureUtil.allOfArray(
+                    CompletableFuture.completedFuture(1L),
+                    CompletableFuture.completedFuture(2L),
+                    CompletableFuture.completedFuture(3L)
+                ),
+                0L)
+                .join())
+            .isEqualTo(6L);
+    }
 }

--- a/server/container/util-java8/src/test/java/org/apache/james/util/streams/JamesCollectorsTest.java
+++ b/server/container/util-java8/src/test/java/org/apache/james/util/streams/JamesCollectorsTest.java
@@ -40,7 +40,8 @@ public class JamesCollectorsTest {
     public void chunkerShouldAcceptEmptyStrem() {
         Stream<Integer> emptyStream = Stream.of();
 
-        assertThat(emptyStream.collect(JamesCollectors.chunker(10)))
+        assertThat(emptyStream.collect(JamesCollectors.chunker(10))
+            .collect(Guavate.toImmutableList()))
             .isEmpty();
     }
 
@@ -63,8 +64,6 @@ public class JamesCollectorsTest {
         Stream<Integer> monoValueStream = Stream.of(1);
 
         List<List<Integer>> values = monoValueStream.collect(JamesCollectors.chunker(10))
-            .values()
-            .stream()
             .map(ImmutableList::copyOf)
             .collect(Guavate.toImmutableList());
         assertThat(values)
@@ -76,8 +75,6 @@ public class JamesCollectorsTest {
         Stream<Integer> stream = Stream.of(1, 2);
 
         List<List<Integer>> values = stream.collect(JamesCollectors.chunker(3))
-            .values()
-            .stream()
             .map(ImmutableList::copyOf)
             .collect(Guavate.toImmutableList());
         assertThat(values)
@@ -89,8 +86,6 @@ public class JamesCollectorsTest {
         Stream<Integer> stream = Stream.of(1, 2, 3);
 
         List<List<Integer>> values = stream.collect(JamesCollectors.chunker(3))
-            .values()
-            .stream()
             .map(ImmutableList::copyOf)
             .collect(Guavate.toImmutableList());
         assertThat(values)
@@ -102,8 +97,6 @@ public class JamesCollectorsTest {
         Stream<Integer> stream = Stream.of(1, 2, 3, 4);
 
         List<List<Integer>> values = stream.collect(JamesCollectors.chunker(3))
-            .values()
-            .stream()
             .map(ImmutableList::copyOf)
             .collect(Guavate.toImmutableList());
         assertThat(values)
@@ -117,8 +110,6 @@ public class JamesCollectorsTest {
         Stream<Integer> stream = Stream.of(1, 2, 3, 4, 5, 6, 7);
 
         List<List<Integer>> values = stream.collect(JamesCollectors.chunker(3))
-            .values()
-            .stream()
             .map(ImmutableList::copyOf)
             .collect(Guavate.toImmutableList());
         assertThat(values)


### PR DESCRIPTION
[Apache issue](https://issues.apache.org/jira/browse/MAILBOX-297)

This PR proposes a x42 time improvement on flags updates for 5000 messages.

These results were obtained on master using https://github.com/linagora/gatling-imap/pull/24 :

![screenshot from 2017-05-23 10-27-26](https://cloud.githubusercontent.com/assets/6928740/26337743/495b4a34-3fa5-11e7-811e-4bfbd6e05f48.png)

Then I avoid reading messages (lead to this improvement):

![screenshot from 2017-05-23 10-27-28](https://cloud.githubusercontent.com/assets/6928740/26337773/7c7a1738-3fa5-11e7-976d-c61d9f9faf45.png)

Then reuse modseq value, where possible, implementing staged updates:

![screenshot from 2017-05-23 10-27-30](https://cloud.githubusercontent.com/assets/6928740/26337780/928448be-3fa5-11e7-969d-8cee8b5ffeed.png)

And finally, parallelised stage operations, by batches of 20 messages.

![screenshot from 2017-05-23 10-27-31](https://cloud.githubusercontent.com/assets/6928740/26337801/aa4d44e6-3fa5-11e7-8f30-29807119fa2c.png)
