### PR TITLE
JAMES-2037 SELECT without reading messages

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/ApplicableFlagBuilder.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/ApplicableFlagBuilder.java
@@ -25,7 +25,8 @@ import com.google.common.annotations.VisibleForTesting;
 public class ApplicableFlagBuilder {
 
     @VisibleForTesting
-    static final Flags DEFAULT_APPLICABLE_FLAGS = FlagsBuilder.builder().add(Flags.Flag.ANSWERED,
+    static final Flags DEFAULT_APPLICABLE_FLAGS = FlagsBuilder.builder().add(
+        Flags.Flag.ANSWERED,
         Flags.Flag.DELETED,
         Flags.Flag.DRAFT,
         Flags.Flag.FLAGGED,

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/ApplicableFlagBuilder.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/ApplicableFlagBuilder.java
@@ -1,0 +1,64 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.mailbox;
+
+import javax.mail.Flags;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class ApplicableFlagBuilder {
+
+    @VisibleForTesting
+    static final Flags DEFAULT_APPLICABLE_FLAGS = FlagsBuilder.builder().add(Flags.Flag.ANSWERED,
+        Flags.Flag.DELETED,
+        Flags.Flag.DRAFT,
+        Flags.Flag.FLAGGED,
+        Flags.Flag.SEEN)
+        .build();
+
+    private final FlagsBuilder builder;
+
+    public static ApplicableFlagBuilder builder() {
+        return new ApplicableFlagBuilder();
+    }
+
+    private ApplicableFlagBuilder() {
+        builder = FlagsBuilder.builder().add(DEFAULT_APPLICABLE_FLAGS);
+    }
+
+    public ApplicableFlagBuilder add(String... flags) {
+        builder.add(flags);
+
+        return this;
+    }
+
+    public ApplicableFlagBuilder add(Flags flags) {
+        builder.add(flags);
+
+        return this;
+    }
+
+    public Flags build() {
+        Flags flags = builder.build();
+        flags.remove(Flags.Flag.RECENT);
+        flags.remove(Flags.Flag.USER);
+
+        return flags;
+    }
+}

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/FlagsBuilder.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/FlagsBuilder.java
@@ -34,21 +34,23 @@ public class FlagsBuilder {
     }
 
     public FlagsBuilder add(Flags.Flag... flags) {
-        for(Flags.Flag flag : flags) {
+        for (Flags.Flag flag : flags) {
             internalFlags.add(flag);
         }
         return this;
     }
 
     public FlagsBuilder add(String... flags) {
-        for(String userFlag : flags) {
+        for (String userFlag : flags) {
             internalFlags.add(userFlag);
         }
         return this;
     }
 
-    public FlagsBuilder add(Flags flags) {
-        internalFlags.add(flags);
+    public FlagsBuilder add(Flags... flagsArray) {
+        for (Flags flags: flagsArray) {
+            internalFlags.add(flags);
+        }
         return this;
     }
 

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
@@ -170,7 +170,7 @@ public interface MessageManager {
      */
     MailboxPath getMailboxPath() throws MailboxException;
 
-    Flags getApplicableFlag(MailboxSession session) throws MailboxException;
+    Flags getApplicableFlags(MailboxSession session) throws MailboxException;
 
     /**
      * Gets current meta data for the mailbox.<br>

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
@@ -190,6 +190,15 @@ public interface MessageManager {
     MetaData getMetaData(boolean resetRecent, MailboxSession mailboxSession, MessageManager.MetaData.FetchGroup fetchGroup) throws MailboxException;
 
     /**
+     * Offers direct access to UIDs. This allows per implementation optimisation for retrieving the whole UIDs of a mailbox.
+     *
+     * @param session MailboxSession for the user performing the request.
+     * @return Iterator of MessageUids in this mailbox. They are not necessarily sorted.
+     * @throws MailboxException
+     */
+    Iterator<MessageUid> getUids(MailboxSession session) throws MailboxException;
+
+    /**
      * Meta data about the current state of the mailbox.
      */
     interface MetaData {

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
@@ -190,15 +190,6 @@ public interface MessageManager {
     MetaData getMetaData(boolean resetRecent, MailboxSession mailboxSession, MessageManager.MetaData.FetchGroup fetchGroup) throws MailboxException;
 
     /**
-     * Offers direct access to UIDs. This allows per implementation optimisation for retrieving the whole UIDs of a mailbox.
-     *
-     * @param session MailboxSession for the user performing the request.
-     * @return Iterator of MessageUids in this mailbox. They are not necessarily sorted.
-     * @throws MailboxException
-     */
-    Iterator<MessageUid> getUids(MailboxSession session) throws MailboxException;
-
-    /**
      * Meta data about the current state of the mailbox.
      */
     interface MetaData {

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/SearchQuery.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/SearchQuery.java
@@ -692,9 +692,21 @@ public class SearchQuery implements Serializable {
 
     private final Set<MessageUid> recentMessageUids = new HashSet<MessageUid>();
 
-    private final List<Criterion> criterias = new ArrayList<Criterion>();
+    private final List<Criterion> criterias;
 
     private List<Sort> sorts = Collections.singletonList(new Sort(Sort.SortClause.Uid, false));
+
+    public SearchQuery(Criterion... criterias) {
+        this(new ArrayList<Criterion>(Arrays.asList(criterias)));
+    }
+
+    public SearchQuery() {
+        this(new ArrayList<Criterion>());
+    }
+
+    private SearchQuery(List<Criterion> criterias) {
+        this.criterias = criterias;
+    }
 
     public void andCriteria(Criterion crit) {
         criterias.add(crit);
@@ -756,12 +768,12 @@ public class SearchQuery implements Serializable {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         return Objects.hashCode(criterias);
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public final boolean equals(Object obj) {
         if (obj instanceof SearchQuery) {
             SearchQuery that = (SearchQuery) obj;
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/ApplicableFlagBuilderTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/ApplicableFlagBuilderTest.java
@@ -1,0 +1,96 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.mailbox;
+
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.mail.Flags;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ApplicableFlagBuilderTest {
+    @Rule
+    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+    @Test
+    public void shouldAtLeastContainAllDefaultApplicativeFlag() {
+        assertThat(ApplicableFlagBuilder.builder().build())
+            .isEqualTo(ApplicableFlagBuilder.DEFAULT_APPLICABLE_FLAGS);
+    }
+
+    @Test
+    public void shouldNeverRetainRecentAndUserFlag() {
+        Flags result = ApplicableFlagBuilder.builder()
+            .add(new Flags(Flags.Flag.RECENT))
+            .add(new Flags(Flags.Flag.USER))
+            .build();
+
+        softly.assertThat(result.contains(Flags.Flag.RECENT)).isFalse();
+        softly.assertThat(result.contains(Flags.Flag.USER)).isFalse();
+    }
+
+    @Test
+    public void shouldAddCustomUserFlagIfProvidedToDefaultFlag() {
+        Flags result = ApplicableFlagBuilder.builder()
+            .add("yolo", "vibe")
+            .build();
+
+        softly.assertThat(result.contains(ApplicableFlagBuilder.DEFAULT_APPLICABLE_FLAGS)).isTrue();
+        softly.assertThat(result.contains("yolo")).isTrue();
+        softly.assertThat(result.contains("vibe")).isTrue();
+    }
+
+    @Test
+    public void shouldAcceptUserCustomFlagInsideFlags() {
+        Flags result = ApplicableFlagBuilder.builder()
+            .add(new Flags("yolo"))
+            .build();
+
+        assertThat(result.contains("yolo")).isTrue();
+    }
+
+    @Test
+    public void shouldAcceptFlagsThatContainMultipleFlag() {
+        Flags flags = FlagsBuilder.builder()
+            .add("yolo", "vibes")
+            .build();
+
+        Flags result = ApplicableFlagBuilder.builder()
+            .add(flags)
+            .build();
+
+        softly.assertThat(result.contains("yolo")).isTrue();
+        softly.assertThat(result.contains("vibes")).isTrue();
+    }
+
+    @Test
+    public void shouldAcceptMultipleFlagAtOnce() {
+        Flags result = ApplicableFlagBuilder.builder()
+            .add("cartman", "butters")
+            .add("chef", "randy")
+            .build();
+
+        softly.assertThat(result.contains("cartman")).isTrue();
+        softly.assertThat(result.contains("butters")).isTrue();
+        softly.assertThat(result.contains("chef")).isTrue();
+        softly.assertThat(result.contains("randy")).isTrue();
+    }
+}

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/SearchQueryTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/SearchQueryTest.java
@@ -1,0 +1,46 @@
+/*
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+
+package org.apache.james.mailbox.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class SearchQueryTest {
+
+    @Test
+    public void searchQueryShouldRespectBeanContract() {
+        EqualsVerifier.forClass(SearchQuery.class).verify();
+    }
+
+    @Test
+    public void equalsShouldCompareCriteria() {
+        SearchQuery searchQuery1 = new SearchQuery();
+        SearchQuery searchQuery2 = new SearchQuery();
+        searchQuery1.andCriteria(SearchQuery.all());
+        searchQuery2.andCriteria(SearchQuery.all());
+
+        assertThat(searchQuery1).isEqualTo(searchQuery2);
+    }
+
+}

--- a/mailbox/caching/src/main/java/org/apache/james/mailbox/caching/CachingMessageMapper.java
+++ b/mailbox/caching/src/main/java/org/apache/james/mailbox/caching/CachingMessageMapper.java
@@ -35,6 +35,11 @@ public class CachingMessageMapper implements MessageMapper {
     }
 
     @Override
+    public Iterator<MessageUid> getUids(Mailbox mailbox) throws MailboxException {
+        return underlying.getUids(mailbox);
+    }
+
+    @Override
     public void endRequest() {
         underlying.endRequest();
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraApplicableFlagDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraApplicableFlagDAO.java
@@ -71,15 +71,11 @@ public class CassandraApplicableFlagDAO {
                 rowOptional.map(row -> new FlagsExtractor(row).getApplicableFlags()));
     }
 
-    public CompletableFuture<Void> updateApplicableFlags(CassandraId cassandraId, Flags oldFlags, Flags newFlags) {
-        ImmutableSet<String> oldUserFlags = ImmutableSet.copyOf(oldFlags.getUserFlags());
-        ImmutableSet<String> newUserFlags = ImmutableSet.copyOf(newFlags.getUserFlags());
-        Sets.SetView<String> addedUserFlags = Sets.difference(newUserFlags, oldUserFlags);
-
-        if (addedUserFlags.isEmpty()) {
+    public CompletableFuture<Void> updateApplicableFlags(CassandraId cassandraId, Set<String> toBeAdded) {
+        if (toBeAdded.isEmpty()) {
             return CompletableFuture.completedFuture(null);
         }
-        return cassandraAsyncExecutor.executeVoid(updateQuery(cassandraId, addedUserFlags));
+        return cassandraAsyncExecutor.executeVoid(updateQuery(cassandraId, toBeAdded));
     }
 
     private Update.Where updateQuery(CassandraId cassandraId, Set<String> userFlags) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraApplicableFlagDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraApplicableFlagDAO.java
@@ -23,34 +23,30 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.add;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.update;
 import static org.apache.james.mailbox.cassandra.table.CassandraApplicableFlagTable.FIELDS;
 import static org.apache.james.mailbox.cassandra.table.CassandraApplicableFlagTable.MAILBOX_ID;
 import static org.apache.james.mailbox.cassandra.table.CassandraApplicableFlagTable.TABLE_NAME;
-import static org.apache.james.mailbox.cassandra.table.Flag.FLAG_TO_STRING_MAP;
 import static org.apache.james.mailbox.cassandra.table.Flag.USER_FLAGS;
 
-import java.util.Arrays;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import javax.inject.Inject;
 import javax.mail.Flags;
-import javax.mail.Flags.Flag;
 
 import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
-import org.apache.james.mailbox.FlagsBuilder;
 import org.apache.james.mailbox.cassandra.CassandraId;
 
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.Update;
 import com.datastax.driver.core.querybuilder.Update.Assignments;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 public class CassandraApplicableFlagDAO {
-    private static final Flags.Flag[] ALL_APPLICABLE_FLAGS = {Flags.Flag.ANSWERED, Flags.Flag.DELETED, Flags.Flag.DRAFT, Flags.Flag.SEEN, Flags.Flag.FLAGGED };
-    private static final Flags EMPTY_FLAGS = new Flags();
 
     private final CassandraAsyncExecutor cassandraAsyncExecutor;
     private final PreparedStatement select;
@@ -75,36 +71,26 @@ public class CassandraApplicableFlagDAO {
                 rowOptional.map(row -> new FlagsExtractor(row).getApplicableFlags()));
     }
 
-    public CompletableFuture<Void> updateApplicableFlags(CassandraId cassandraId, Flags flags) {
-        Flags newFlags = new FlagsBuilder().add(flags).build();
-        newFlags.remove(Flag.RECENT);
-        newFlags.remove(Flag.USER);
+    public CompletableFuture<Void> updateApplicableFlags(CassandraId cassandraId, Flags oldFlags, Flags newFlags) {
+        ImmutableSet<String> oldUserFlags = ImmutableSet.copyOf(oldFlags.getUserFlags());
+        ImmutableSet<String> newUserFlags = ImmutableSet.copyOf(newFlags.getUserFlags());
+        Sets.SetView<String> addedUserFlags = Sets.difference(newUserFlags, oldUserFlags);
 
-        if (newFlags.equals(EMPTY_FLAGS)) {
+        if (addedUserFlags.isEmpty()) {
             return CompletableFuture.completedFuture(null);
         }
-        return cassandraAsyncExecutor.executeVoid(updateQuery(cassandraId, newFlags));
+        return cassandraAsyncExecutor.executeVoid(updateQuery(cassandraId, addedUserFlags));
     }
 
-    private Update.Where updateQuery(CassandraId cassandraId, Flags flags) {
-        return addSystemFlagsToQuery(flags,
-            addUserFlagsToQuery(flags,
-                update(TABLE_NAME).with()))
+    private Update.Where updateQuery(CassandraId cassandraId, Set<String> userFlags) {
+        return addUserFlagsToQuery(userFlags,
+                update(TABLE_NAME).with())
             .where(eq(MAILBOX_ID, cassandraId.asUuid()));
     }
 
-    private Assignments addUserFlagsToQuery(Flags flags, Assignments updateQuery) {
-        if (flags.getUserFlags() != null && flags.getUserFlags().length > 0) {
-            Arrays.stream(flags.getUserFlags())
-                .forEach(userFlag -> updateQuery.and(add(USER_FLAGS, userFlag)));
-        }
+    private Assignments addUserFlagsToQuery(Set<String> userFlags, Assignments updateQuery) {
+        userFlags.forEach(userFlag -> updateQuery.and(add(USER_FLAGS, userFlag)));
         return updateQuery;
     }
 
-    private Assignments addSystemFlagsToQuery(Flags flags, Assignments updateQuery) {
-        Arrays.stream(ALL_APPLICABLE_FLAGS)
-            .filter(flags::contains)
-            .forEach(flag -> updateQuery.and(set(FLAG_TO_STRING_MAP.get(flag), true)));
-        return updateQuery;
-    }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraIndexTableHandler.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraIndexTableHandler.java
@@ -70,14 +70,14 @@ public class CassandraIndexTableHandler {
             addRecentOnSave(mailboxId, message),
             incrementUnseenOnSave(mailboxId, flags),
             mailboxCounterDAO.incrementCount(mailboxId),
-            applicableFlagDAO.updateApplicableFlags(mailboxId, flags));
+            applicableFlagDAO.updateApplicableFlags(mailboxId, new Flags(), flags));
     }
 
     public CompletableFuture<Void> updateIndexOnFlagsUpdate(CassandraId mailboxId, UpdatedFlags updatedFlags) {
         return CompletableFuture.allOf(manageUnseenMessageCountsOnFlagsUpdate(mailboxId, updatedFlags),
                                        manageRecentOnFlagsUpdate(mailboxId, updatedFlags),
                                        updateFirstUnseenOnFlagsUpdate(mailboxId, updatedFlags),
-                                       applicableFlagDAO.updateApplicableFlags(mailboxId, updatedFlags.getNewFlags()),
+                                       applicableFlagDAO.updateApplicableFlags(mailboxId, updatedFlags.getOldFlags(), updatedFlags.getNewFlags()),
                                        updateDeletedOnFlagsUpdate(mailboxId, updatedFlags));
     }
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraIndexTableHandler.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraIndexTableHandler.java
@@ -30,6 +30,8 @@ import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 
+import com.google.common.collect.ImmutableSet;
+
 public class CassandraIndexTableHandler {
 
     private final CassandraMailboxRecentsDAO mailboxRecentDAO;
@@ -70,14 +72,14 @@ public class CassandraIndexTableHandler {
             addRecentOnSave(mailboxId, message),
             incrementUnseenOnSave(mailboxId, flags),
             mailboxCounterDAO.incrementCount(mailboxId),
-            applicableFlagDAO.updateApplicableFlags(mailboxId, new Flags(), flags));
+            applicableFlagDAO.updateApplicableFlags(mailboxId, ImmutableSet.copyOf(flags.getUserFlags())));
     }
 
     public CompletableFuture<Void> updateIndexOnFlagsUpdate(CassandraId mailboxId, UpdatedFlags updatedFlags) {
         return CompletableFuture.allOf(manageUnseenMessageCountsOnFlagsUpdate(mailboxId, updatedFlags),
                                        manageRecentOnFlagsUpdate(mailboxId, updatedFlags),
                                        updateFirstUnseenOnFlagsUpdate(mailboxId, updatedFlags),
-                                       applicableFlagDAO.updateApplicableFlags(mailboxId, updatedFlags.getOldFlags(), updatedFlags.getNewFlags()),
+                                       applicableFlagDAO.updateApplicableFlags(mailboxId, ImmutableSet.copyOf(updatedFlags.userFlagIterator())),
                                        updateDeletedOnFlagsUpdate(mailboxId, updatedFlags));
     }
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -108,6 +108,15 @@ public class CassandraMessageMapper implements MessageMapper {
     }
 
     @Override
+    public Iterator<MessageUid> getUids(Mailbox mailbox) throws MailboxException {
+        CassandraId cassandraId = (CassandraId) mailbox.getMailboxId();
+        return messageIdDAO.retrieveMessages(cassandraId, MessageRange.all())
+            .join()
+            .map(metaData -> metaData.getComposedMessageId().getUid())
+            .iterator();
+    }
+
+    @Override
     public long countMessagesInMailbox(Mailbox mailbox) throws MailboxException {
         return mailboxCounterDAO.countMessagesInMailbox(mailbox)
             .join()

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -32,6 +32,7 @@ import javax.mail.Flags;
 import javax.mail.Flags.Flag;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.james.mailbox.ApplicableFlagBuilder;
 import org.apache.james.mailbox.FlagsBuilder;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageUid;
@@ -358,9 +359,11 @@ public class CassandraMessageMapper implements MessageMapper {
 
     @Override
     public Flags getApplicableFlag(Mailbox mailbox) throws MailboxException {
-        return applicableFlagDAO.retrieveApplicableFlag((CassandraId) mailbox.getMailboxId())
-            .join()
-            .orElse(new Flags());
+        return ApplicableFlagBuilder.builder()
+            .add(applicableFlagDAO.retrieveApplicableFlag((CassandraId) mailbox.getMailboxId())
+                .join()
+                .orElse(new Flags()))
+            .build();
     }
 
     private CompletableFuture<Void> save(Mailbox mailbox, MailboxMessage message) throws MailboxException {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/FlagsExtractor.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/FlagsExtractor.java
@@ -47,11 +47,6 @@ public class FlagsExtractor {
 
     public Flags getApplicableFlags() {
         Flags flags = new Flags();
-        for (String flag : Flag.ALL_APPLICABLE_FLAG) {
-            if (row.getBool(flag)) {
-                flags.add(Flag.JAVAX_MAIL_FLAG.get(flag));
-            }
-        }
         row.getSet(Flag.USER_FLAGS, String.class)
             .stream()
             .forEach(flags::add);

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraApplicableFlagsModule.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraApplicableFlagsModule.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.mailbox.cassandra.modules;
 
-import static com.datastax.driver.core.DataType.cboolean;
 import static com.datastax.driver.core.DataType.set;
 import static com.datastax.driver.core.DataType.text;
 import static com.datastax.driver.core.DataType.timeuuid;
@@ -46,11 +45,6 @@ public class CassandraApplicableFlagsModule implements CassandraModule {
                 SchemaBuilder.createTable(CassandraApplicableFlagTable.TABLE_NAME)
                     .ifNotExists()
                     .addPartitionKey(CassandraApplicableFlagTable.MAILBOX_ID, timeuuid())
-                    .addColumn(Flag.ANSWERED, cboolean())
-                    .addColumn(Flag.DELETED, cboolean())
-                    .addColumn(Flag.DRAFT, cboolean())
-                    .addColumn(Flag.FLAGGED, cboolean())
-                    .addColumn(Flag.SEEN, cboolean())
                     .addColumn(Flag.USER_FLAGS, set(text()))
                     .withOptions()
                     .compactionOptions(SchemaBuilder.leveledStrategy())

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/table/CassandraApplicableFlagTable.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/table/CassandraApplicableFlagTable.java
@@ -24,5 +24,5 @@ public interface CassandraApplicableFlagTable {
     String TABLE_NAME = "applicableFlag";
     String MAILBOX_ID = "mailboxId";
 
-    String[] FIELDS = { MAILBOX_ID, Flag.ANSWERED, Flag.DELETED, Flag.DRAFT, Flag.FLAGGED, Flag.SEEN, Flag.USER_FLAGS };
+    String[] FIELDS = { MAILBOX_ID, Flag.USER_FLAGS };
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraApplicableFlagDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraApplicableFlagDAOTest.java
@@ -65,7 +65,7 @@ public class CassandraApplicableFlagDAOTest {
 
     @Test
     public void updateApplicableFlagsShouldSupportEmptyFlags() throws Exception {
-        testee.updateApplicableFlags(CASSANDRA_ID, new Flags()).join();
+        testee.updateApplicableFlags(CASSANDRA_ID, new Flags(), new Flags()).join();
 
         Optional<Flags> actual = testee.retrieveApplicableFlag(CASSANDRA_ID).join();
         assertThat(actual.isPresent()).isFalse();
@@ -73,102 +73,103 @@ public class CassandraApplicableFlagDAOTest {
 
     @Test
     public void updateApplicableFlagsShouldIgnoreRecentFlags() throws Exception {
-        testee.updateApplicableFlags(CASSANDRA_ID, new Flags(Flag.RECENT)).join();
+        testee.updateApplicableFlags(CASSANDRA_ID, new Flags(), new Flags(Flag.RECENT)).join();
 
         Optional<Flags> actual = testee.retrieveApplicableFlag(CASSANDRA_ID).join();
         assertThat(actual.isPresent()).isFalse();
     }
 
     @Test
-    public void updateApplicableFlagsShouldUpdateMultiFlags() throws Exception {
-        Flags flags = new FlagsBuilder().add(Flag.ANSWERED, Flag.DELETED).build();
-        testee.updateApplicableFlags(CASSANDRA_ID, flags).join();
-
-        Optional<Flags> actual = testee.retrieveApplicableFlag(CASSANDRA_ID).join();
-        assertThat(actual.isPresent()).isTrue();
-        assertThat(actual.get()).isEqualTo(flags);
-    }
-
-    @Test
-    public void updateApplicableFlagsShouldAddAnsweredFlag() throws Exception {
+    public void updateApplicableFlagsShouldIgnoreAnsweredFlag() throws Exception {
         Flags flags = new Flags(Flag.ANSWERED);
-        testee.updateApplicableFlags(CASSANDRA_ID, flags).join();
+        testee.updateApplicableFlags(CASSANDRA_ID, new Flags(), flags).join();
 
         Optional<Flags> actual = testee.retrieveApplicableFlag(CASSANDRA_ID).join();
-        assertThat(actual.isPresent()).isTrue();
-        assertThat(actual.get()).isEqualTo(flags);
+        assertThat(actual.isPresent()).isFalse();
     }
 
     @Test
-    public void updateApplicableFlagsShouldAddDeletedFlag() throws Exception {
+    public void updateApplicableFlagsShouldIgnoreDeletedFlag() throws Exception {
         Flags flags = new Flags(Flag.DELETED);
-        testee.updateApplicableFlags(CASSANDRA_ID, flags).join();
+        testee.updateApplicableFlags(CASSANDRA_ID, new Flags(), flags).join();
 
         Optional<Flags> actual = testee.retrieveApplicableFlag(CASSANDRA_ID).join();
-        assertThat(actual.isPresent()).isTrue();
-        assertThat(actual.get()).isEqualTo(flags);
+        assertThat(actual.isPresent()).isFalse();
     }
 
     @Test
-    public void updateApplicableFlagsShouldAddDraftFlag() throws Exception {
+    public void updateApplicableFlagsShouldIgnoreDraftFlag() throws Exception {
         Flags flags = new Flags(Flag.DRAFT);
-        testee.updateApplicableFlags(CASSANDRA_ID, flags).join();
+        testee.updateApplicableFlags(CASSANDRA_ID, new Flags(), flags).join();
 
         Optional<Flags> actual = testee.retrieveApplicableFlag(CASSANDRA_ID).join();
-        assertThat(actual.isPresent()).isTrue();
-        assertThat(actual.get()).isEqualTo(flags);
+        assertThat(actual.isPresent()).isFalse();
     }
 
     @Test
-    public void updateApplicableFlagsShouldAddFlaggedFlag() throws Exception {
+    public void updateApplicableFlagsShouldIgnoreFlaggedFlag() throws Exception {
         Flags flags = new Flags(Flag.FLAGGED);
-        testee.updateApplicableFlags(CASSANDRA_ID, flags).join();
+        testee.updateApplicableFlags(CASSANDRA_ID, new Flags(), flags).join();
 
         Optional<Flags> actual = testee.retrieveApplicableFlag(CASSANDRA_ID).join();
-        assertThat(actual.isPresent()).isTrue();
-        assertThat(actual.get()).isEqualTo(flags);
+        assertThat(actual.isPresent()).isFalse();
     }
 
     @Test
-    public void updateApplicableFlagsShouldAddSeenFlag() throws Exception {
+    public void updateApplicableFlagsShouldIgnoreSeenFlag() throws Exception {
         Flags flags = new Flags(Flag.SEEN);
-        testee.updateApplicableFlags(CASSANDRA_ID, flags).join();
+        testee.updateApplicableFlags(CASSANDRA_ID, new Flags(), flags).join();
 
         Optional<Flags> actual = testee.retrieveApplicableFlag(CASSANDRA_ID).join();
-        assertThat(actual.isPresent()).isTrue();
-        assertThat(actual.get()).isEqualTo(flags);
-    }
-
-    @Test
-    public void updateApplicableFlagsShouldUnionSystemFlags() throws Exception {
-        testee.updateApplicableFlags(CASSANDRA_ID, new Flags(Flag.ANSWERED)).join();
-        testee.updateApplicableFlags(CASSANDRA_ID, new Flags(Flag.SEEN)).join();
-
-        Optional<Flags> actual = testee.retrieveApplicableFlag(CASSANDRA_ID).join();
-        assertThat(actual.isPresent()).isTrue();
-        assertThat(actual.get()).isEqualTo(new FlagsBuilder().add(Flag.ANSWERED, Flag.SEEN).build());
+        assertThat(actual.isPresent()).isFalse();
     }
 
     @Test
     public void updateApplicableFlagsShouldUpdateUserFlag() throws Exception {
         Flags flags = new FlagsBuilder().add(Flag.ANSWERED).add(USER_FLAG).build();
 
-        testee.updateApplicableFlags(CASSANDRA_ID, flags).join();
+        testee.updateApplicableFlags(CASSANDRA_ID, new Flags(), flags).join();
 
         Optional<Flags> actual = testee.retrieveApplicableFlag(CASSANDRA_ID).join();
         assertThat(actual.isPresent()).isTrue();
-        assertThat(actual.get()).isEqualTo(flags);
+        assertThat(actual.get()).isEqualTo(new Flags(USER_FLAG));
     }
 
     @Test
     public void updateApplicableFlagsShouldUnionUserFlags() throws Exception {
-        testee.updateApplicableFlags(CASSANDRA_ID, new Flags(USER_FLAG)).join();
-
-        testee.updateApplicableFlags(CASSANDRA_ID, new Flags(USER_FLAG2)).join();
+        testee.updateApplicableFlags(CASSANDRA_ID, new Flags(), new Flags(USER_FLAG)).join();
+        testee.updateApplicableFlags(CASSANDRA_ID, new Flags(), new Flags(USER_FLAG2)).join();
 
         Optional<Flags> actual = testee.retrieveApplicableFlag(CASSANDRA_ID).join();
         assertThat(actual.isPresent()).isTrue();
         assertThat(actual.get()).isEqualTo(new FlagsBuilder().add(USER_FLAG, USER_FLAG2).build());
+    }
+
+    @Test
+    public void updateApplicableFlagsShouldSkipAlreadyStoredFlagsWhenNoop() throws Exception {
+        testee.updateApplicableFlags(CASSANDRA_ID, new Flags(USER_FLAG), new Flags(USER_FLAG)).join();
+
+        Optional<Flags> actual = testee.retrieveApplicableFlag(CASSANDRA_ID).join();
+        assertThat(actual.isPresent()).isFalse();
+    }
+
+    @Test
+    public void updateApplicableFlagsShouldSkipAlreadyStoredFlagsWhenAddingFlag() throws Exception {
+        testee.updateApplicableFlags(CASSANDRA_ID, new Flags(USER_FLAG), new Flags(USER_FLAG2)).join();
+
+        Optional<Flags> actual = testee.retrieveApplicableFlag(CASSANDRA_ID).join();
+        assertThat(actual.isPresent()).isTrue();
+        assertThat(actual.get()).isEqualTo(new FlagsBuilder().add(USER_FLAG2).build());
+    }
+
+    @Test
+    public void updateApplicableFlagsShouldUpdateMultiFlags() throws Exception {
+        Flags flags = new FlagsBuilder().add(USER_FLAG, USER_FLAG2).build();
+        testee.updateApplicableFlags(CASSANDRA_ID, new Flags(), flags).join();
+
+        Optional<Flags> actual = testee.retrieveApplicableFlag(CASSANDRA_ID).join();
+        assertThat(actual.isPresent()).isTrue();
+        assertThat(actual.get()).isEqualTo(flags);
     }
 
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraIndexTableHandlerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraIndexTableHandlerTest.java
@@ -26,9 +26,7 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 
 import javax.mail.Flags;
-import javax.mail.Flags.Flag;
 
-import com.github.steveash.guavate.Guavate;
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.init.CassandraModuleComposite;
 import org.apache.james.mailbox.FlagsBuilder;
@@ -51,6 +49,8 @@ import org.apache.james.mailbox.store.mail.model.impl.SimpleMailbox;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.github.steveash.guavate.Guavate;
 
 public class CassandraIndexTableHandlerTest {
 
@@ -644,42 +644,43 @@ public class CassandraIndexTableHandlerTest {
 
     @Test
     public void updateIndexOnAddShouldUpdateApplicableFlag() throws Exception {
-        Flags answeredFlag = new Flags(Flag.ANSWERED);
+        Flags customFlags = new Flags("custom");
         MailboxMessage message = mock(MailboxMessage.class);
-        when(message.createFlags()).thenReturn(answeredFlag);
+        when(message.createFlags()).thenReturn(customFlags);
         when(message.getUid()).thenReturn(MESSAGE_UID);
         testee.updateIndexOnAdd(message, MAILBOX_ID).join();
 
         Flags applicableFlag = applicableFlagDAO.retrieveApplicableFlag(MAILBOX_ID).join().get();
 
-        assertThat(applicableFlag).isEqualTo(answeredFlag);
+        assertThat(applicableFlag).isEqualTo(customFlags);
     }
 
     @Test
     public void updateIndexOnFlagsUpdateShouldUnionApplicableFlag() throws Exception {
-        Flags answeredFlag = new Flags(Flag.ANSWERED);
+        Flags customFlag = new Flags("custom");
         MailboxMessage message = mock(MailboxMessage.class);
-        when(message.createFlags()).thenReturn(answeredFlag);
+        when(message.createFlags()).thenReturn(customFlag);
         when(message.getUid()).thenReturn(MESSAGE_UID);
         testee.updateIndexOnAdd(message, MAILBOX_ID).join();
 
+        Flags customBis = new Flags("customBis");
         testee.updateIndexOnFlagsUpdate(MAILBOX_ID, UpdatedFlags.builder()
             .uid(MESSAGE_UID)
-            .newFlags(new Flags(Flag.DELETED))
-            .oldFlags(answeredFlag)
+            .newFlags(customBis)
+            .oldFlags(customFlag)
             .modSeq(MODSEQ)
             .build()).join();
 
         Flags applicableFlag = applicableFlagDAO.retrieveApplicableFlag(MAILBOX_ID).join().get();
 
-        assertThat(applicableFlag).isEqualTo(new FlagsBuilder().add(Flag.ANSWERED, Flag.DELETED).build());
+        assertThat(applicableFlag).isEqualTo(new FlagsBuilder().add(customFlag, customBis).build());
     }
 
     @Test
     public void applicableFlagShouldKeepAllFlagsEvenTheMessageRemovesFlag() throws Exception {
-        Flags messageFlags = new Flags(Flag.ANSWERED);
-        messageFlags.add(Flag.DELETED);
-        messageFlags.add(Flag.DRAFT);
+        Flags messageFlags = FlagsBuilder.builder()
+            .add("custom1", "custom2", "custom3")
+            .build();
 
         MailboxMessage message = mock(MailboxMessage.class);
         when(message.createFlags()).thenReturn(messageFlags);
@@ -695,6 +696,6 @@ public class CassandraIndexTableHandlerTest {
             .build()).join();
 
         Flags applicableFlag = applicableFlagDAO.retrieveApplicableFlag(MAILBOX_ID).join().get();
-        assertThat(applicableFlag).isEqualTo(new FlagsBuilder().add(Flag.ANSWERED, Flag.DRAFT, Flag.DELETED).build());
+        assertThat(applicableFlag).isEqualTo(messageFlags);
     }
 }

--- a/mailbox/hbase/src/main/java/org/apache/james/mailbox/hbase/mail/HBaseMessageMapper.java
+++ b/mailbox/hbase/src/main/java/org/apache/james/mailbox/hbase/mail/HBaseMessageMapper.java
@@ -48,6 +48,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nullable;
 import javax.mail.Flags;
 
 import org.apache.hadoop.conf.Configuration;
@@ -85,8 +86,10 @@ import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.utils.ApplicableFlagCalculator;
 import org.apache.james.mailbox.store.transaction.NonTransactionalMapper;
 
+import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
 
 /**
  * HBase implementation of a {@link MessageMapper}.
@@ -94,6 +97,14 @@ import com.google.common.collect.Iterables;
  *
  */
 public class HBaseMessageMapper extends NonTransactionalMapper implements MessageMapper {
+
+    private static final int UNLIMITED = -1;
+    private static final Function<MailboxMessage, MessageUid> TO_UID = new Function<MailboxMessage, MessageUid>() {
+        @Override
+        public MessageUid apply(MailboxMessage mailboxMessage) {
+            return mailboxMessage.getUid();
+        }
+    };
 
     private final Configuration conf;
     private final MailboxSession mailboxSession;
@@ -119,6 +130,11 @@ public class HBaseMessageMapper extends NonTransactionalMapper implements Messag
             .count(countMessagesInMailbox(mailbox))
             .unseen(countUnseenMessagesInMailbox(mailbox))
             .build();
+    }
+
+    @Override
+    public Iterator<MessageUid> getUids(final Mailbox mailbox) throws MailboxException {
+        return Iterators.transform(findInMailbox(mailbox, MessageRange.all(), FetchType.Full, UNLIMITED), TO_UID);
     }
 
     @Override

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMessageMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMessageMapper.java
@@ -55,14 +55,24 @@ import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.utils.ApplicableFlagCalculator;
 import org.apache.openjpa.persistence.ArgumentException;
 
+import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
 
 /**
  * JPA implementation of a {@link MessageMapper}. This class is not thread-safe!
  */
 public class JPAMessageMapper extends JPATransactionalMapper implements MessageMapper {
     private static final int UNLIMIT_MAX_SIZE = -1;
+    private static final int UNLIMITED = -1;
+    private static final Function<MailboxMessage, MessageUid> TO_UID = new Function<MailboxMessage, MessageUid>() {
+        @Override
+        public MessageUid apply(MailboxMessage mailboxMessage) {
+            return mailboxMessage.getUid();
+        }
+    };
+
     private final MessageUtils messageMetadataMapper;
 
     public JPAMessageMapper(MailboxSession mailboxSession, UidProvider uidProvider, ModSeqProvider modSeqProvider, EntityManagerFactory entityManagerFactory) {
@@ -76,6 +86,11 @@ public class JPAMessageMapper extends JPATransactionalMapper implements MessageM
             .count(countMessagesInMailbox(mailbox))
             .unseen(countUnseenMessagesInMailbox(mailbox))
             .build();
+    }
+
+    @Override
+    public Iterator<MessageUid> getUids(final Mailbox mailbox) throws MailboxException {
+        return Iterators.transform(findInMailbox(mailbox, MessageRange.all(), FetchType.Full, UNLIMITED), TO_UID);
     }
 
     /**

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMessageMapper.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMessageMapper.java
@@ -59,6 +59,11 @@ public class TransactionalMessageMapper implements MessageMapper {
     }
 
     @Override
+    public Iterator<MessageUid> getUids(Mailbox mailbox) throws MailboxException {
+        return messageMapper.getUids(mailbox);
+    }
+
+    @Override
     public <T> T execute(Transaction<T> transaction) throws MailboxException {
         throw new NotImplementedException();
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -868,7 +868,7 @@ public class StoreMessageManager implements org.apache.james.mailbox.MessageMana
     }
 
     @Override
-    public Flags getApplicableFlag(MailboxSession session) throws MailboxException {
+    public Flags getApplicableFlags(MailboxSession session) throws MailboxException {
         return mapperFactory.getMessageMapper(session)
             .getApplicableFlag(mailbox);
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -872,4 +872,16 @@ public class StoreMessageManager implements org.apache.james.mailbox.MessageMana
         return mapperFactory.getMessageMapper(session)
             .getApplicableFlag(mailbox);
     }
+
+    @Override
+    public Iterator<MessageUid> getUids(MailboxSession session) throws MailboxException {
+        final MessageMapper messageMapper = mapperFactory.getMessageMapper(session);
+
+        return messageMapper.execute(new Mapper.Transaction<Iterator<MessageUid>>() {
+            @Override
+            public Iterator<MessageUid> run() throws MailboxException {
+                return messageMapper.getUids(mailbox);
+            }
+        });
+    }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -748,6 +748,9 @@ public class StoreMessageManager implements org.apache.james.mailbox.MessageMana
 
     @Override
     public Iterator<MessageUid> search(SearchQuery query, MailboxSession mailboxSession) throws MailboxException {
+        if (query.equals(new SearchQuery(SearchQuery.all()))) {
+            return getUids(mailboxSession);
+        }
         return index.search(mailboxSession, getMailboxEntity(), query);
     }
 
@@ -873,8 +876,7 @@ public class StoreMessageManager implements org.apache.james.mailbox.MessageMana
             .getApplicableFlag(mailbox);
     }
 
-    @Override
-    public Iterator<MessageUid> getUids(MailboxSession session) throws MailboxException {
+    private Iterator<MessageUid> getUids(MailboxSession session) throws MailboxException {
         final MessageMapper messageMapper = mapperFactory.getMessageMapper(session);
 
         return messageMapper.execute(new Mapper.Transaction<Iterator<MessageUid>>() {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AbstractMessageMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AbstractMessageMapper.java
@@ -52,6 +52,7 @@ public abstract class AbstractMessageMapper extends TransactionalMapper implemen
             return input.getUid();
         }
     };
+
     private static final int UNLIMITED = -1;
 
     protected final MailboxSession mailboxSession;

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AbstractMessageMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AbstractMessageMapper.java
@@ -36,7 +36,9 @@ import org.apache.james.mailbox.store.mail.model.Mailbox;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.transaction.TransactionalMapper;
 
+import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.collect.Iterators;
 
 /**
  * Abstract base class for {@link MessageMapper} implementation
@@ -44,6 +46,14 @@ import com.google.common.base.Optional;
  *
  */
 public abstract class AbstractMessageMapper extends TransactionalMapper implements MessageMapper {
+    private static final Function<MailboxMessage, MessageUid> TO_UID = new Function<MailboxMessage, MessageUid>() {
+        @Override
+        public MessageUid apply(MailboxMessage input) {
+            return input.getUid();
+        }
+    };
+    private static final int UNLIMITED = -1;
+
     protected final MailboxSession mailboxSession;
     private final UidProvider uidProvider;
     private final ModSeqProvider modSeqProvider;
@@ -145,5 +155,9 @@ public abstract class AbstractMessageMapper extends TransactionalMapper implemen
      * Copy the MailboxMessage to the Mailbox, using the given uid and modSeq for the new MailboxMessage
      */
     protected abstract MessageMetaData copy(Mailbox mailbox, MessageUid uid, long modSeq, MailboxMessage original) throws MailboxException;
-    
+
+    @Override
+    public Iterator<MessageUid> getUids(Mailbox mailbox) throws MailboxException {
+        return Iterators.transform(findInMailbox(mailbox, MessageRange.all(), FetchType.Metadata, UNLIMITED), TO_UID);
+    }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
@@ -172,6 +172,8 @@ public interface MessageMapper extends Mapper {
 
     Flags getApplicableFlag(Mailbox mailbox) throws MailboxException;
 
+    Iterator<MessageUid> getUids(Mailbox mailbox) throws MailboxException;
+
     /**
      * Specify what data needs to get filled in a {@link MailboxMessage} before returning it
      * 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/utils/ApplicableFlagCalculator.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/utils/ApplicableFlagCalculator.java
@@ -22,8 +22,8 @@ package org.apache.james.mailbox.store.mail.utils;
 import java.util.List;
 
 import javax.mail.Flags;
-import javax.mail.Flags.Flag;
 
+import org.apache.james.mailbox.ApplicableFlagBuilder;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 
 import com.google.common.base.Function;
@@ -31,6 +31,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.FluentIterable;
 
 public class ApplicableFlagCalculator {
+
     private static Function<MailboxMessage, Flags> toFlags() {
         return new Function<MailboxMessage, Flags>() {
             @Override
@@ -48,22 +49,15 @@ public class ApplicableFlagCalculator {
     }
 
     public Flags computeApplicableFlags() {
+        ApplicableFlagBuilder flagsBuilder = ApplicableFlagBuilder.builder();
         List<Flags> messageFlags = FluentIterable.from(mailboxMessages)
             .transform(toFlags())
             .toList();
-        return getFlags(messageFlags);
-    }
 
-    private Flags getFlags(List<Flags> messageFlags) {
-        Flags flags = new Flags();
-
-        for (Flags flag : messageFlags) {
-            flags.add(flag);
+        for (Flags flags: messageFlags) {
+            flagsBuilder.add(flags);
         }
 
-        flags.remove(Flag.RECENT);
-        flags.remove(Flag.USER);
-
-        return flags;
+        return flagsBuilder.build();
     }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractCombinationManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractCombinationManagerTest.java
@@ -446,6 +446,34 @@ public abstract class AbstractCombinationManagerTest {
             .isEqualTo(expected);
     }
 
+    @Test
+    public void getUidsShouldInteractWellWithSetInMailboxes() throws Exception {
+        MessageId messageId = messageManager1.appendMessage(new ByteArrayInputStream(MAIL_CONTENT), new Date(), session, false, new Flags())
+            .getMessageId();
+
+        messageIdManager.setInMailboxes(messageId, ImmutableList.of(mailbox1.getMailboxId(), mailbox2.getMailboxId()), session);
+
+        List<MessageResult> listMessages = messageIdManager.getMessages(ImmutableList.of(messageId), FetchGroupImpl.MINIMAL, session);
+        MessageUid uid2 = FluentIterable.from(listMessages)
+            .filter(messageInMailbox2())
+            .get(0)
+            .getUid();
+
+        assertThat(messageManager2.getUids(session))
+            .hasSize(1)
+            .containsOnly(uid2);
+    }
+
+    @Test
+    public void getUidsShouldInteractWellWithDelete() throws Exception {
+        MessageId messageId = messageManager1.appendMessage(new ByteArrayInputStream(MAIL_CONTENT), new Date(), session, false, new Flags())
+            .getMessageId();
+
+        messageIdManager.delete(messageId, ImmutableList.of(mailbox1.getMailboxId()), session);
+
+        assertThat(messageManager1.getUids(session)).isEmpty();
+    }
+
     private Predicate<MessageResult> messageInMailbox2() {
         return new Predicate<MessageResult>() {
             @Override

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractCombinationManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractCombinationManagerTest.java
@@ -459,7 +459,8 @@ public abstract class AbstractCombinationManagerTest {
             .get(0)
             .getUid();
 
-        assertThat(messageManager2.getUids(session))
+        SearchQuery searchQuery = new SearchQuery(SearchQuery.all());
+        assertThat(messageManager2.search(searchQuery, session))
             .hasSize(1)
             .containsOnly(uid2);
     }
@@ -471,7 +472,8 @@ public abstract class AbstractCombinationManagerTest {
 
         messageIdManager.delete(messageId, ImmutableList.of(mailbox1.getMailboxId()), session);
 
-        assertThat(messageManager1.getUids(session)).isEmpty();
+        SearchQuery searchQuery = new SearchQuery(SearchQuery.all());
+        assertThat(messageManager1.search(searchQuery, session)).isEmpty();
     }
 
     private Predicate<MessageResult> messageInMailbox2() {

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxMessageResultIteratorTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxMessageResultIteratorTest.java
@@ -76,7 +76,12 @@ public class StoreMailboxMessageResultIteratorTest {
         public TestMessageMapper(MessageRange messageRange) {
             this.messageRange = messageRange;
         }
-        
+
+        @Override
+        public Iterator<MessageUid> getUids(Mailbox mailbox) throws MailboxException {
+            return messageRange.iterator();
+        }
+
         @Override
         public void endRequest() {
             throw new UnsupportedOperationException();

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -1070,6 +1070,31 @@ public abstract class MessageMapperTest {
                 .build());
     }
 
+    @Test
+    public void getUidsShouldReturnUidsOfMessagesInTheMailbox() throws Exception {
+        saveMessages();
+
+        assertThat(messageMapper.getUids(benwaInboxMailbox))
+            .containsOnly(message1.getUid(),
+                message2.getUid(),
+                message3.getUid(),
+                message4.getUid(),
+                message5.getUid());
+    }
+
+    @Test
+    public void getUidsShouldNotReturnUidsOfExpungedMessages() throws Exception {
+        saveMessages();
+
+        messageMapper.updateFlags(benwaInboxMailbox,
+            new FlagsUpdateCalculator(new Flags(Flag.DELETED), FlagsUpdateMode.ADD),
+            MessageRange.range(message2.getUid(), message4.getUid()));
+        messageMapper.expungeMarkedForDeletionInMailbox(benwaInboxMailbox, MessageRange.all());
+
+        assertThat(messageMapper.getUids(benwaInboxMailbox))
+            .containsOnly(message1.getUid(), message5.getUid());
+    }
+
     private Map<MessageUid, MessageMetaData> markThenPerformExpunge(MessageRange range) throws MailboxException {
         messageMapper.updateFlags(benwaInboxMailbox, new FlagsUpdateCalculator(new Flags(Flags.Flag.DELETED), FlagsUpdateMode.REPLACE), MessageRange.one(message1.getUid()));
         messageMapper.updateFlags(benwaInboxMailbox, new FlagsUpdateCalculator(new Flags(Flags.Flag.DELETED), FlagsUpdateMode.REPLACE), MessageRange.one(message4.getUid()));

--- a/protocols/imap/pom.xml
+++ b/protocols/imap/pom.xml
@@ -60,6 +60,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.james</groupId>
+            <artifactId>james-server-util</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.james</groupId>
             <artifactId>metrics-api</artifactId>
         </dependency>
         <dependency>

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -38,6 +38,7 @@ import org.apache.james.imap.api.process.SelectedMailbox;
 import org.apache.james.mailbox.MailboxListener;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.FetchGroupImpl;
@@ -63,17 +64,7 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
     private MailboxPath path;
 
     private final ImapSession session;
-    
 
-    private final static Flags FLAGS = new Flags();
-    static {
-        FLAGS.add(Flags.Flag.ANSWERED);
-        FLAGS.add(Flags.Flag.DELETED);
-        FLAGS.add(Flags.Flag.DRAFT);
-        FLAGS.add(Flags.Flag.FLAGGED);
-        FLAGS.add(Flags.Flag.SEEN);
-    }
-    
     private final long sessionId;
     private final Set<MessageUid> flagUpdateUids = new TreeSet<MessageUid>();
     private final Flags.Flag uninterestingFlag = Flags.Flag.RECENT;
@@ -82,7 +73,7 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
     private boolean isDeletedByOtherSession = false;
     private boolean sizeChanged = false;
     private boolean silentFlagChanges = false;
-    private final Flags applicableFlags = new Flags(FLAGS);
+    private final Flags applicableFlags;
 
     private boolean applicableFlagsChanged;
     
@@ -102,7 +93,20 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
         // Ignore events from our session
         setSilentFlagChanges(true);
         this.path = path;
-        init();
+
+        MailboxSession mailboxSession = ImapSessionUtils.getMailboxSession(session);
+
+        mailboxManager.addListener(path, this, mailboxSession);
+
+        MessageManager messageManager = mailboxManager.getMailbox(path, mailboxSession);
+        applicableFlags = messageManager.getApplicableFlags(mailboxSession);
+        MessageResultIterator messages = messageManager.getMessages(MessageRange.all(), FetchGroupImpl.MINIMAL, mailboxSession);
+        synchronized (this) {
+            while(messages.hasNext()) {
+                MessageResult mr = messages.next();
+                add(mr.getUid());
+            }
+        }
     }
 
     @Override
@@ -113,26 +117,6 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
     @Override
     public ExecutionMode getExecutionMode() {
         return ExecutionMode.SYNCHRONOUS;
-    }
-
-    private void init() throws MailboxException {
-        MailboxSession mailboxSession = ImapSessionUtils.getMailboxSession(session);
-        
-        mailboxManager.addListener(path, this, mailboxSession);
-
-        MessageResultIterator messages = mailboxManager.getMailbox(path, mailboxSession).getMessages(MessageRange.all(), FetchGroupImpl.MINIMAL, mailboxSession);
-        synchronized (this) {
-            while(messages.hasNext()) {
-                MessageResult mr = messages.next();
-                applicableFlags.add(mr.getFlags());
-                add(mr.getUid());
-            }
-            
-          
-            // \RECENT is not a applicable flag in imap so remove it from the list
-            applicableFlags.remove(Flags.Flag.RECENT);
-        }
-       
     }
 
     private void add(int msn, MessageUid uid) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -76,7 +76,7 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
     private final Flags applicableFlags;
 
     private boolean applicableFlagsChanged;
-    
+
     private final SortedMap<Integer, MessageUid> msnToUid =new TreeMap<Integer, MessageUid>();
 
     private final SortedMap<MessageUid, Integer> uidToMsn = new TreeMap<MessageUid, Integer>();
@@ -133,9 +133,8 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
     private void expunge(MessageUid uid) {
         final int msn = msn(uid);
         remove(msn, uid);
-        final List<Integer> renumberMsns = new ArrayList<Integer>(msnToUid.tailMap(msn + 1).keySet());
-        for (Integer msnInteger : renumberMsns) {
-            int aMsn = msnInteger.intValue();
+
+        for (int aMsn = msn + 1; aMsn <= msnToUid.size() + 1; aMsn++) {
             Optional<MessageUid> aUid = uid(aMsn);
             if (aUid.isPresent()) {
                 remove(aMsn, aUid.get());

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -43,7 +43,6 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.UpdatedFlags;
 
 import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
 
 /**
  * Default implementation of {@link SelectedMailbox}
@@ -88,10 +87,10 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
 
         MessageManager messageManager = mailboxManager.getMailbox(path, mailboxSession);
         applicableFlags = messageManager.getApplicableFlags(mailboxSession);
-        uidMsnConverter = getUidMsnMapper(mailboxSession, messageManager);
+        uidMsnConverter = getUidMsnConverter(mailboxSession, messageManager);
     }
     
-    private UidMsnConverter getUidMsnMapper(MailboxSession mailboxSession , MessageManager messageManager) throws MailboxException {
+    private UidMsnConverter getUidMsnConverter(MailboxSession mailboxSession , MessageManager messageManager) throws MailboxException {
         UidMsnConverter uidMsnConverter = new UidMsnConverter();
 
         Iterator<MessageUid> uids = messageManager.getUids(mailboxSession);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -91,18 +91,15 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
         uidMsnConverter = getUidMsnMapper(mailboxSession, messageManager);
     }
     
-    private UidMsnConverter getUidMsnMapper(MailboxSession mailboxSession , MessageManager messageManager) {
+    private UidMsnConverter getUidMsnMapper(MailboxSession mailboxSession , MessageManager messageManager) throws MailboxException {
         UidMsnConverter uidMsnConverter = new UidMsnConverter();
-        try {
-            Iterator<MessageUid> uids = messageManager.getUids(mailboxSession);
 
-            synchronized (SelectedMailboxImpl.this) {
-                while(uids.hasNext()) {
-                    uidMsnConverter.addUid(uids.next());
-                }
+        Iterator<MessageUid> uids = messageManager.getUids(mailboxSession);
+
+        synchronized (SelectedMailboxImpl.this) {
+            while(uids.hasNext()) {
+                uidMsnConverter.addUid(uids.next());
             }
-        } catch (MailboxException e) {
-            throw Throwables.propagate(e);
         }
 
         return uidMsnConverter;

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -307,13 +307,9 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
         return Collections.unmodifiableSet(new TreeSet<MessageUid>(expungedUids));
         
     }
-
-
-
-
     
     public synchronized Flags getApplicableFlags() {
-        return applicableFlags;
+        return new Flags(applicableFlags);
     }
 
     

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -92,18 +92,12 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
     }
     
     private UidMsnConverter getUidMsnConverter(MailboxSession mailboxSession , MessageManager messageManager) throws MailboxException {
-        UidMsnConverter uidMsnConverter = new UidMsnConverter();
-
         SearchQuery searchQuery = new SearchQuery(SearchQuery.all());
 
         synchronized (SelectedMailboxImpl.this) {
             Iterator<MessageUid> uids = messageManager.search(searchQuery, mailboxSession);
-            while(uids.hasNext()) {
-                uidMsnConverter.addUid(uids.next());
-            }
+            return new UidMsnConverter(uids);
         }
-
-        return uidMsnConverter;
     }
 
     @Override

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -25,8 +25,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.TreeSet;
 
 import javax.mail.Flags;
@@ -49,6 +47,7 @@ import org.apache.james.mailbox.model.MessageResultIterator;
 import org.apache.james.mailbox.model.UpdatedFlags;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
 
 /**
  * Default implementation of {@link SelectedMailbox}
@@ -69,6 +68,7 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
     private final Set<MessageUid> flagUpdateUids = new TreeSet<MessageUid>();
     private final Flags.Flag uninterestingFlag = Flags.Flag.RECENT;
     private final Set<MessageUid> expungedUids = new TreeSet<MessageUid>();
+    private final UidMsnMapper uidMsnMapper;
 
     private boolean isDeletedByOtherSession = false;
     private boolean sizeChanged = false;
@@ -77,14 +77,6 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
 
     private boolean applicableFlagsChanged;
 
-    private final SortedMap<Integer, MessageUid> msnToUid =new TreeMap<Integer, MessageUid>();
-
-    private final SortedMap<MessageUid, Integer> uidToMsn = new TreeMap<MessageUid, Integer>();
-
-    private MessageUid highestUid = MessageUid.MIN_VALUE;
-
-    private int highestMsn = 0;
-    
     public SelectedMailboxImpl(MailboxManager mailboxManager, ImapSession session, MailboxPath path) throws MailboxException {
         this.session = session;
         this.sessionId = ImapSessionUtils.getMailboxSession(session).getSessionId();
@@ -100,13 +92,25 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
 
         MessageManager messageManager = mailboxManager.getMailbox(path, mailboxSession);
         applicableFlags = messageManager.getApplicableFlags(mailboxSession);
-        MessageResultIterator messages = messageManager.getMessages(MessageRange.all(), FetchGroupImpl.MINIMAL, mailboxSession);
-        synchronized (this) {
-            while(messages.hasNext()) {
-                MessageResult mr = messages.next();
-                add(mr.getUid());
-            }
-        }
+        uidMsnMapper = getUidMsnMapper(mailboxSession, messageManager);
+    }
+    
+    private UidMsnMapper getUidMsnMapper(MailboxSession mailboxSession , MessageManager messageManager) {
+                UidMsnMapper uidMsnMapper = new UidMsnMapper();
+                try {
+                    MessageResultIterator messages = messageManager.getMessages(MessageRange.all(), FetchGroupImpl.MINIMAL, mailboxSession);
+
+                    synchronized (SelectedMailboxImpl.this) {
+                        while(messages.hasNext()) {
+                            MessageResult mr = messages.next();
+                            uidMsnMapper.addUid(mr.getUid());
+                        }
+                    }
+                } catch (MailboxException e) {
+                    throw Throwables.propagate(e);
+                }
+
+                return uidMsnMapper;
     }
 
     @Override
@@ -119,68 +123,16 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
         return ExecutionMode.SYNCHRONOUS;
     }
 
-    private void add(int msn, MessageUid uid) {
-        if (uid.compareTo(highestUid) > 0) {
-            highestUid = uid;
-        }
-        msnToUid.put(msn, uid);
-        uidToMsn.put(uid, msn);
-    }
-
-    /**
-     * Expunge the message with the given uid
-     */
-    private void expunge(MessageUid uid) {
-        final int msn = msn(uid);
-        remove(msn, uid);
-
-        for (int aMsn = msn + 1; aMsn <= msnToUid.size() + 1; aMsn++) {
-            Optional<MessageUid> aUid = uid(aMsn);
-            if (aUid.isPresent()) {
-                remove(aMsn, aUid.get());
-                add(aMsn - 1, aUid.get());
-            }
-        }
-        highestMsn--;
-    }
-
-    private void remove(int msn, MessageUid uid) {
-        uidToMsn.remove(uid);
-        msnToUid.remove(msn);
-    }
-
-    /**
-     * Add the give uid
-     * 
-     * @param uid
-     */
-    private void add(MessageUid uid) {
-        if (!uidToMsn.containsKey(uid)) {
-            highestMsn++;
-            add(highestMsn, uid);
-        }
-    }
-
     @Override
     public synchronized Optional<MessageUid> getFirstUid() {
-        if (uidToMsn.isEmpty()) {
-            return Optional.absent();
-        } else {
-            return Optional.of(uidToMsn.firstKey());
-        }
+        return uidMsnMapper.getFirstUid();
     }
 
     @Override
     public synchronized Optional<MessageUid> getLastUid() {
-        if (uidToMsn.isEmpty()) {
-            return Optional.absent();
-        } else {
-            return Optional.of(uidToMsn.lastKey());
-        }
+        return uidMsnMapper.getLastUid();
     }
 
-
-    
     public synchronized void deselect() {
         MailboxSession mailboxSession = ImapSessionUtils.getMailboxSession(session);
 
@@ -192,14 +144,11 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
             }
         }
         
-        uidToMsn.clear();
-        msnToUid.clear();
+        uidMsnMapper.clear();
         flagUpdateUids.clear();
 
         expungedUids.clear();
         recentUids.clear();
- 
-
     }
 
     @Override
@@ -265,11 +214,9 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
     @Override
     public synchronized  int remove(MessageUid uid) {
         final int result = msn(uid);
-        expunge(uid);
+        uidMsnMapper.remove(uid);
         return result;
     }
-
-
 
     private boolean interestingFlags(UpdatedFlags updated) {
         boolean result;
@@ -392,7 +339,7 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
                     final List<MessageUid> uids = ((Added) event).getUids();
                     SelectedMailbox sm = session.getSelected();
                     for (MessageUid uid : uids) {
-                        add(uid);
+                        uidMsnMapper.addUid(uid);
                         if (sm != null) {
                             sm.addRecent(uid);
                         }
@@ -467,31 +414,20 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
 
     @Override
     public synchronized int msn(MessageUid uid) {
-        Integer msn = uidToMsn.get(uid);
-        if (msn != null) {
-            return msn.intValue();
-        } else {
-            return SelectedMailbox.NO_SUCH_MESSAGE;
-        }
+        return uidMsnMapper.getMsn(uid).or(NO_SUCH_MESSAGE);
     }
 
     @Override
     public synchronized Optional<MessageUid> uid(int msn) {
-        if (msn == -1) {
+        if (msn == NO_SUCH_MESSAGE) {
             return Optional.absent();
         }
-        MessageUid uid = msnToUid.get(msn);
-        if (uid != null) {
-            return Optional.of(uid);
-        } else {
-            return Optional.absent();
-        }
+
+        return uidMsnMapper.getUid(msn);
     }
 
     
     public synchronized long existsCount() {
-        return uidToMsn.size();
+        return uidMsnMapper.getNumMessage();
     }
-    
-
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/SelectedMailboxImpl.java
@@ -40,6 +40,7 @@ import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.SearchQuery;
 import org.apache.james.mailbox.model.UpdatedFlags;
 
 import com.google.common.base.Optional;
@@ -93,9 +94,10 @@ public class SelectedMailboxImpl implements SelectedMailbox, MailboxListener{
     private UidMsnConverter getUidMsnConverter(MailboxSession mailboxSession , MessageManager messageManager) throws MailboxException {
         UidMsnConverter uidMsnConverter = new UidMsnConverter();
 
-        Iterator<MessageUid> uids = messageManager.getUids(mailboxSession);
+        SearchQuery searchQuery = new SearchQuery(SearchQuery.all());
 
         synchronized (SelectedMailboxImpl.this) {
+            Iterator<MessageUid> uids = messageManager.search(searchQuery, mailboxSession);
             while(uids.hasNext()) {
                 uidMsnConverter.addUid(uids.next());
             }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
@@ -32,14 +32,14 @@ import com.google.common.collect.Lists;
 
 import org.apache.james.mailbox.MessageUid;
 
-public class UidMsnMapper {
+public class UidMsnConverter {
 
     public final static int FIRST_MSN = 1;
 
     private final HashBiMap<Integer, MessageUid> msnToUid;
     private final ReadWriteLock readWriteLock;
 
-    public UidMsnMapper() {
+    public UidMsnConverter() {
         readWriteLock = new ReentrantReadWriteLock();
         msnToUid = HashBiMap.create();
     }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnConverter.java
@@ -109,7 +109,7 @@ public class UidMsnConverter {
         ImmutableList.Builder<MessageUid> result = ImmutableList.builder();
         int position = getLastMsn();
         Optional<MessageUid> maxUid = getUid(position);
-        while (maxUid.isPresent() && uid.asLong() < maxUid.get().asLong()) {
+        while (maxUid.isPresent() && uid.compareTo(maxUid.get()) < 0) {
             msnToUid.remove(position);
             result.add(maxUid.get());
             position--;

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnMapper.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnMapper.java
@@ -1,0 +1,99 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.imap.processor.base;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.ImmutableBiMap;
+
+import org.apache.james.mailbox.MessageUid;
+
+public class UidMsnMapper {
+
+    public final static int FIRST_MSN = 1;
+
+    private final HashBiMap<Integer, MessageUid> msnToUid;
+
+    public UidMsnMapper() {
+        msnToUid = HashBiMap.create();
+    }
+
+    public Optional<Integer> getMsn(MessageUid uid) {
+        return Optional.fromNullable(msnToUid.inverse().get(uid));
+    }
+
+    public Optional<MessageUid> getUid(int msn) {
+        return Optional.fromNullable(msnToUid.get(msn));
+    }
+
+    public Optional<MessageUid> getLastUid() {
+        return getUid(getLastMsn());
+    }
+
+    public Optional<MessageUid> getFirstUid() {
+        return getUid(FIRST_MSN);
+    }
+
+    public int getNumMessage() {
+        return msnToUid.size();
+    }
+
+    public synchronized void remove(MessageUid uid) {
+        int msn = getMsn(uid).get();
+        msnToUid.remove(msn);
+
+        for (int aMsn = msn + 1; aMsn <= getNumMessage() + 1; aMsn++) {
+            MessageUid aUid = msnToUid.remove(aMsn);
+            addMapping(aMsn - 1, aUid);
+        }
+    }
+
+    public boolean isEmpty() {
+        return msnToUid.isEmpty();
+    }
+
+    public synchronized void clear() {
+        msnToUid.clear();
+    }
+
+    public void addUid(MessageUid uid) {
+        this.addMapping(nextMsn(), uid);
+    }
+
+    @VisibleForTesting
+    ImmutableBiMap<Integer, MessageUid> getInternals() {
+        return ImmutableBiMap.copyOf(msnToUid);
+    }
+
+    private synchronized void addMapping(Integer msn, MessageUid uid) {
+        if (msnToUid.inverse().get(uid) == null) {
+            msnToUid.forcePut(msn, uid);
+        }
+    }
+
+    private int nextMsn() {
+        return getNumMessage() + FIRST_MSN;
+    }
+
+    private int getLastMsn() {
+        return getNumMessage();
+    }
+}

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnMapper.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/base/UidMsnMapper.java
@@ -74,7 +74,7 @@ public class UidMsnMapper {
         msnToUid.clear();
     }
 
-    public void addUid(MessageUid uid) {
+    public synchronized void addUid(MessageUid uid) {
         this.addMapping(nextMsn(), uid);
     }
 

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
@@ -324,8 +324,8 @@ public class MailboxEventAnalyserTest {
                 }
 
                 @Override
-                public Flags getApplicableFlag(MailboxSession session) throws MailboxException {
-                    throw new NotImplementedException();
+                public Flags getApplicableFlags(MailboxSession session) throws MailboxException {
+                    return new Flags();
                 }
             };
         }

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
@@ -177,11 +177,6 @@ public class MailboxEventAnalyserTest {
         public MessageManager getMailbox(MailboxPath mailboxPath, MailboxSession session) throws MailboxException {
             return new MessageManager() {
 
-                @Override
-                public Iterator<MessageUid> getUids(MailboxSession session) throws MailboxException {
-                    return ImmutableList.of(MESSAGE_UID).iterator();
-                }
-
                 public long getMessageCount(MailboxSession mailboxSession) throws MailboxException {
                     return 1;
                 }
@@ -201,7 +196,7 @@ public class MailboxEventAnalyserTest {
 
                 @Override
                 public Iterator<MessageUid> search(SearchQuery searchQuery, MailboxSession mailboxSession) throws MailboxException {
-                    throw new UnsupportedOperationException("Not implemented");
+                    return ImmutableList.of(MESSAGE_UID).iterator();
                 }
 
                 @Override

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
@@ -84,8 +84,9 @@ import com.google.common.collect.ImmutableList;
 public class MailboxEventAnalyserTest {
 
     private static final long BASE_SESSION_ID = 99;
+    public static final MessageUid MESSAGE_UID = MessageUid.of(1);
 
-    
+
     private MailboxPath mailboxPath = new MailboxPath("namespace", "user", "name");
     private final MailboxManager mockManager = new MailboxManager() {
 
@@ -176,6 +177,11 @@ public class MailboxEventAnalyserTest {
         public MessageManager getMailbox(MailboxPath mailboxPath, MailboxSession session) throws MailboxException {
             return new MessageManager() {
 
+                @Override
+                public Iterator<MessageUid> getUids(MailboxSession session) throws MailboxException {
+                    return ImmutableList.of(MESSAGE_UID).iterator();
+                }
+
                 public long getMessageCount(MailboxSession mailboxSession) throws MailboxException {
                     return 1;
                 }
@@ -235,7 +241,7 @@ public class MailboxEventAnalyserTest {
 
                                 @Override
                                 public MessageUid getUid() {
-                                    return MessageUid.of(1);
+                                    return MESSAGE_UID;
                                 }
 
                                 @Override

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
@@ -218,7 +218,7 @@ public class UidMsnConverterTest {
     }
 
     @Test
-    public void addUidShouldCommute() {
+    public void addUidShouldSupportOutOfOrderUpdates() {
         testee.addUid(messageUid1);
         testee.addUid(messageUid3);
         testee.addUid(messageUid2);
@@ -233,7 +233,7 @@ public class UidMsnConverterTest {
     }
 
     @Test
-    public void addUidShouldWorkWhenInsertInFirstPositon() {
+    public void addUidShouldLeadToValidConvertionWhenInsertInFirstPosition() {
         testee.addUid(messageUid2);
         testee.addUid(messageUid3);
         testee.addUid(messageUid4);
@@ -257,7 +257,7 @@ public class UidMsnConverterTest {
     }
 
     @Test
-    public void addAndRemoveShouldHaveGoodConcurrentBehaviorWellWhenMixed() throws Exception {
+    public void addAndRemoveShouldLeadToValidConvertionWhenMixed() throws Exception {
         final int initialCount = 1000;
         for (int i = 1; i <= initialCount; i++) {
             testee.addUid(MessageUid.of(i));
@@ -287,7 +287,7 @@ public class UidMsnConverterTest {
     }
 
     @Test
-    public void addShouldHaveGoodConcurrentBehavior() throws Exception {
+    public void addShouldLeadToValidConvertionWhenConcurrent() throws Exception {
         final int operationCount = 1000;
         int threadCount = 2;
 
@@ -310,7 +310,7 @@ public class UidMsnConverterTest {
     }
 
     @Test
-    public void removeShouldHaveGoodConcurrentBehaviorWellWhenMixed() throws Exception {
+    public void removeShouldLeadToValidConvertionWhenConcurrent() throws Exception {
         final int operationCount = 1000;
         int threadCount = 2;
         for (int i = 1; i <= operationCount * (threadCount + 1); i++) {

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
@@ -255,6 +255,22 @@ public class UidMsnConverterTest {
     }
 
     @Test
+    public void constructorWithOutOfOrderIteratorShouldLeadToValidConvertion() {
+        testee = new UidMsnConverter(ImmutableList.of(messageUid2,
+            messageUid3,
+            messageUid4,
+            messageUid1)
+            .iterator());
+
+        assertThat(testee.getConvertion().entrySet())
+            .containsOnlyElementsOf(ImmutableBiMap.of(
+                1, messageUid1,
+                2, messageUid2,
+                3, messageUid3,
+                4, messageUid4).entrySet());
+    }
+
+    @Test
     public void addUidShouldBeIdempotent() {
         testee.addUid(messageUid1);
         testee.addUid(messageUid1);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
@@ -31,8 +31,8 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableBiMap;
 
-public class UidMsnMapperTest {
-    private UidMsnMapper testee;
+public class UidMsnConverterTest {
+    private UidMsnConverter testee;
     private MessageUid messageUid1;
     private MessageUid messageUid2;
     private MessageUid messageUid3;
@@ -40,7 +40,7 @@ public class UidMsnMapperTest {
 
     @Before
     public void setUp() {
-        testee = new UidMsnMapper();
+        testee = new UidMsnConverter();
         messageUid1 = MessageUid.of(1);
         messageUid2 = MessageUid.of(2);
         messageUid3 = MessageUid.of(3);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
@@ -30,6 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableList;
 
 public class UidMsnConverterTest {
     private UidMsnConverter testee;
@@ -40,7 +41,7 @@ public class UidMsnConverterTest {
 
     @Before
     public void setUp() {
-        testee = new UidMsnConverter();
+        testee = new UidMsnConverter(ImmutableList.<MessageUid>of().iterator());
         messageUid1 = MessageUid.of(1);
         messageUid2 = MessageUid.of(2);
         messageUid3 = MessageUid.of(3);
@@ -49,6 +50,12 @@ public class UidMsnConverterTest {
 
     @Test
     public void getUidShouldReturnEmptyIfNoMessageWithTheGivenMessageNumber() {
+        assertThat(testee.getUid(1))
+            .isAbsent();
+    }
+
+    @Test
+    public void getUidShouldReturnEmptyIfZero() {
         assertThat(testee.getUid(0))
             .isAbsent();
     }
@@ -150,7 +157,7 @@ public class UidMsnConverterTest {
         testee.addUid(messageUid4);
         testee.addUid(messageUid2);
 
-        assertThat(testee.getInternals())
+        assertThat(testee.getConvertion())
             .isEqualTo(ImmutableBiMap.of(
                 1, messageUid1,
                 2, messageUid2,
@@ -178,7 +185,7 @@ public class UidMsnConverterTest {
 
         testee.remove(messageUid1);
 
-        assertThat(testee.getInternals())
+        assertThat(testee.getConvertion())
             .isEqualTo(ImmutableBiMap.of(
                 1, messageUid2,
                 2, messageUid3,
@@ -194,7 +201,7 @@ public class UidMsnConverterTest {
 
         testee.remove(messageUid4);
 
-        assertThat(testee.getInternals())
+        assertThat(testee.getConvertion())
             .isEqualTo(ImmutableBiMap.of(
                 1, messageUid1,
                 2, messageUid2,
@@ -210,7 +217,7 @@ public class UidMsnConverterTest {
 
         testee.remove(messageUid3);
 
-        assertThat(testee.getInternals())
+        assertThat(testee.getConvertion())
             .isEqualTo(ImmutableBiMap.of(
                 1, messageUid1,
                 2, messageUid2,
@@ -224,7 +231,7 @@ public class UidMsnConverterTest {
         testee.addUid(messageUid2);
         testee.addUid(messageUid4);
 
-        assertThat(testee.getInternals().entrySet())
+        assertThat(testee.getConvertion().entrySet())
             .containsOnlyElementsOf(ImmutableBiMap.of(
                 1, messageUid1,
                 2, messageUid2,
@@ -239,7 +246,7 @@ public class UidMsnConverterTest {
         testee.addUid(messageUid4);
         testee.addUid(messageUid1);
 
-        assertThat(testee.getInternals().entrySet())
+        assertThat(testee.getConvertion().entrySet())
             .containsOnlyElementsOf(ImmutableBiMap.of(
                 1, messageUid1,
                 2, messageUid2,
@@ -252,7 +259,7 @@ public class UidMsnConverterTest {
         testee.addUid(messageUid1);
         testee.addUid(messageUid1);
 
-        assertThat(testee.getInternals())
+        assertThat(testee.getConvertion())
             .isEqualTo(ImmutableBiMap.of(1, messageUid1));
     }
 
@@ -282,7 +289,7 @@ public class UidMsnConverterTest {
         for(int i = 1; i <= initialCount; i++) {
             resultBuilder.put(i, MessageUid.of(initialCount + i));
         }
-        assertThat(testee.getInternals().entrySet())
+        assertThat(testee.getConvertion().entrySet())
             .containsOnlyElementsOf(resultBuilder.build().entrySet());
     }
 
@@ -305,7 +312,7 @@ public class UidMsnConverterTest {
         for(int i = 1; i <= threadCount * operationCount; i++) {
             resultBuilder.put(i, MessageUid.of(i));
         }
-        assertThat(testee.getInternals().entrySet())
+        assertThat(testee.getConvertion().entrySet())
             .containsOnlyElementsOf(resultBuilder.build().entrySet());
     }
 
@@ -331,7 +338,7 @@ public class UidMsnConverterTest {
         for(int i = 1; i <= operationCount; i++) {
             resultBuilder.put(i, MessageUid.of((threadCount * operationCount) + i));
         }
-        assertThat(testee.getInternals().entrySet())
+        assertThat(testee.getConvertion().entrySet())
             .containsOnlyElementsOf(resultBuilder.build().entrySet());
     }
 

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
@@ -302,7 +302,7 @@ public class UidMsnConverterTest {
         concurrentTestRunner.awaitTermination(10, TimeUnit.SECONDS);
 
         ImmutableBiMap.Builder<Integer, MessageUid> resultBuilder = ImmutableBiMap.builder();
-        for(int i = 1; i <= initialCount; i++) {
+        for (int i = 1; i <= initialCount; i++) {
             resultBuilder.put(i, MessageUid.of(initialCount + i));
         }
         assertThat(testee.getConvertion().entrySet())
@@ -325,7 +325,7 @@ public class UidMsnConverterTest {
         concurrentTestRunner.awaitTermination(10, TimeUnit.SECONDS);
 
         ImmutableBiMap.Builder<Integer, MessageUid> resultBuilder = ImmutableBiMap.builder();
-        for(int i = 1; i <= threadCount * operationCount; i++) {
+        for (int i = 1; i <= threadCount * operationCount; i++) {
             resultBuilder.put(i, MessageUid.of(i));
         }
         assertThat(testee.getConvertion().entrySet())
@@ -351,7 +351,7 @@ public class UidMsnConverterTest {
         concurrentTestRunner.awaitTermination(10, TimeUnit.SECONDS);
 
         ImmutableBiMap.Builder<Integer, MessageUid> resultBuilder = ImmutableBiMap.builder();
-        for(int i = 1; i <= operationCount; i++) {
+        for (int i = 1; i <= operationCount; i++) {
             resultBuilder.put(i, MessageUid.of((threadCount * operationCount) + i));
         }
         assertThat(testee.getConvertion().entrySet())

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnMapperTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnMapperTest.java
@@ -1,0 +1,217 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.imap.processor.base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.guava.api.Assertions.assertThat;
+
+import org.apache.james.mailbox.MessageUid;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableBiMap;
+
+public class UidMsnMapperTest {
+    private UidMsnMapper testee;
+    private MessageUid messageUid1;
+    private MessageUid messageUid2;
+    private MessageUid messageUid3;
+    private MessageUid messageUid4;
+
+    @Before
+    public void setUp() {
+        testee = new UidMsnMapper();
+        messageUid1 = MessageUid.of(1);
+        messageUid2 = MessageUid.of(2);
+        messageUid3 = MessageUid.of(3);
+        messageUid4 = MessageUid.of(4);
+    }
+
+    @Test
+    public void getUidShouldReturnEmptyIfNoMessageWithTheGivenMessageNumber() {
+        assertThat(testee.getUid(0))
+            .isAbsent();
+    }
+
+    @Test
+    public void getUidShouldTheCorrespondingUidIfItExist() {
+        testee.addUid(messageUid1);
+
+        assertThat(testee.getUid(1))
+            .contains(messageUid1);
+    }
+
+    @Test
+    public void getFirstUidShouldReturnEmptyIfNoMessage() {
+        assertThat(testee.getFirstUid()).isAbsent();
+    }
+
+    @Test
+    public void getLastUidShouldReturnEmptyIfNoMessage() {
+        assertThat(testee.getLastUid()).isAbsent();
+    }
+
+    @Test
+    public void getFirstUidShouldReturnFirstUidIfAtLeastOneMessage() {
+        testee.addUid(messageUid1);
+        testee.addUid(messageUid2);
+
+        assertThat(testee.getFirstUid()).contains(messageUid1);
+    }
+
+    @Test
+    public void getLastUidShouldReturnLastUidIfAtLeastOneMessage() {
+        testee.addUid(messageUid1);
+        testee.addUid(messageUid2);
+
+        assertThat(testee.getLastUid()).contains(messageUid2);
+    }
+
+    @Test
+    public void getMsnShouldReturnAbsentIfNoCorrespondingMessage() {
+        testee.addUid(messageUid1);
+
+        assertThat(testee.getMsn(messageUid2)).isAbsent();
+    }
+
+    @Test
+    public void getMsnShouldReturnMessageNumberIfUidIsThere() {
+        testee.addUid(messageUid1);
+        testee.addUid(messageUid2);
+
+        assertThat(testee.getMsn(messageUid2))
+            .contains(2);
+    }
+
+    @Test
+    public void getNumMessageShouldReturnZeroIfNoMapping() {
+        assertThat(testee.getNumMessage())
+            .isEqualTo(0);
+    }
+
+    @Test
+    public void getNumMessageShouldReturnTheNumOfMessage() {
+        testee.addUid(messageUid1);
+        testee.addUid(messageUid2);
+
+        assertThat(testee.getNumMessage())
+            .isEqualTo(2);
+    }
+
+    @Test
+    public void isEmptyShouldReturnTrueIfNoMapping() {
+        assertThat(testee.isEmpty())
+            .isTrue();
+    }
+
+    @Test
+    public void isEmptyShouldReturnFalseIfMapping() {
+        testee.addUid(messageUid1);
+
+        assertThat(testee.isEmpty())
+            .isFalse();
+    }
+
+    @Test
+    public void clearShouldClearMapping() {
+        testee.addUid(messageUid1);
+
+        testee.clear();
+
+        assertThat(testee.isEmpty())
+            .isTrue();
+    }
+
+    @Test
+    public void addUidShouldKeepMessageNumberContiguous() {
+        testee.addUid(messageUid1);
+        testee.addUid(messageUid2);
+        testee.addUid(messageUid3);
+        testee.addUid(messageUid4);
+        testee.addUid(messageUid2);
+
+        assertThat(testee.getInternals())
+            .isEqualTo(ImmutableBiMap.of(
+                1, messageUid1,
+                2, messageUid2,
+                3, messageUid3,
+                4, messageUid4));
+    }
+
+    @Test
+    public void addUidShouldNotOverridePreviousMapping() {
+        testee.addUid(messageUid1);
+        testee.addUid(messageUid2);
+        testee.addUid(messageUid3);
+        testee.addUid(messageUid2);
+
+        assertThat(testee.getMsn(messageUid2))
+            .contains(2);
+    }
+
+    @Test
+    public void removeShouldKeepAValidMappingWhenDeletingBeginning() {
+        testee.addUid(messageUid1);
+        testee.addUid(messageUid2);
+        testee.addUid(messageUid3);
+        testee.addUid(messageUid4);
+
+        testee.remove(messageUid1);
+
+        assertThat(testee.getInternals())
+            .isEqualTo(ImmutableBiMap.of(
+                1, messageUid2,
+                2, messageUid3,
+                3, messageUid4));
+    }
+
+    @Test
+    public void removeShouldKeepAValidMappingWhenDeletingEnd() {
+        testee.addUid(messageUid1);
+        testee.addUid(messageUid2);
+        testee.addUid(messageUid3);
+        testee.addUid(messageUid4);
+
+        testee.remove(messageUid4);
+
+        assertThat(testee.getInternals())
+            .isEqualTo(ImmutableBiMap.of(
+                1, messageUid1,
+                2, messageUid2,
+                3, messageUid3));
+    }
+
+    @Test
+    public void removeShouldKeepAValidMappingWhenDeletingMiddle() {
+        testee.addUid(messageUid1);
+        testee.addUid(messageUid2);
+        testee.addUid(messageUid3);
+        testee.addUid(messageUid4);
+
+        testee.remove(messageUid3);
+
+        assertThat(testee.getInternals())
+            .isEqualTo(ImmutableBiMap.of(
+                1, messageUid1,
+                2, messageUid2,
+                3, messageUid4));
+    }
+
+}

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnMapperTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnMapperTest.java
@@ -218,6 +218,45 @@ public class UidMsnMapperTest {
     }
 
     @Test
+    public void addUidShouldCommute() {
+        testee.addUid(messageUid1);
+        testee.addUid(messageUid3);
+        testee.addUid(messageUid2);
+        testee.addUid(messageUid4);
+
+        assertThat(testee.getInternals().entrySet())
+            .containsOnlyElementsOf(ImmutableBiMap.of(
+                1, messageUid1,
+                2, messageUid2,
+                3, messageUid3,
+                4, messageUid4).entrySet());
+    }
+
+    @Test
+    public void addUidShouldWorkWhenInsertInFirstPositon() {
+        testee.addUid(messageUid2);
+        testee.addUid(messageUid3);
+        testee.addUid(messageUid4);
+        testee.addUid(messageUid1);
+
+        assertThat(testee.getInternals().entrySet())
+            .containsOnlyElementsOf(ImmutableBiMap.of(
+                1, messageUid1,
+                2, messageUid2,
+                3, messageUid3,
+                4, messageUid4).entrySet());
+    }
+
+    @Test
+    public void addUidShouldBeIdempotent() {
+        testee.addUid(messageUid1);
+        testee.addUid(messageUid1);
+
+        assertThat(testee.getInternals())
+            .isEqualTo(ImmutableBiMap.of(1, messageUid1));
+    }
+
+    @Test
     public void addAndRemoveShouldHaveGoodConcurrentBehaviorWellWhenMixed() throws Exception {
         final int initialCount = 1000;
         for (int i = 1; i <= initialCount; i++) {


### PR DESCRIPTION
This PR is a POC about  SELECT without reading messages to obtain UIDs and build UID <-> MSN mapping.

It uses some change sets introduced in https://github.com/linagora/james-project/pull/718

 - It adds concurrency correction to UidMsnMapper (addUid was not synchronised and lead to NPE)
 - Returns copies of ApplicableFlags

**Performance improvements**:

Bench used: SELECT 5000 non-RECENT messages (Aka already selected). This is mean time run on 10 SELECT. This is obtained after 5 runs for warm-up.

 - Before state: **master** + **MAILBOX-297** (https://github.com/linagora/james-project/pull/806)
 - After state: **master** + **MAILBOX-297** + this PR

Before results: ~ 1.07 seconds (mean 10 times)
After state: 103 ms (mean 10 times)

Basically: x10

Proposal: implement UNSELECT as part of Gatling IMAP?