### PR TITLE
JAMES-2047 Fix unstable test

### DIFF
--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOTest.java
@@ -103,7 +103,7 @@ public class CassandraMessageDAOTest {
                         .isInline(true)
                         .build()));
 
-        testee.save(messageWith1Attachment);
+        testee.save(messageWith1Attachment).join();
 
         List<Optional<CassandraMessageDAO.MessageAttachmentRepresentation>> attachmentRepresentation = testee.retrieveMessages(messageIds, MessageMapper.FetchType.Body, Optional.empty())
                 .get()
@@ -125,7 +125,7 @@ public class CassandraMessageDAOTest {
                         .isInline(true)
                         .build()));
 
-        testee.save(messageWith1Attachment);
+        testee.save(messageWith1Attachment).join();
 
         List<Optional<CassandraMessageDAO.MessageAttachmentRepresentation>> attachmentRepresentation = testee.retrieveMessages(messageIds, MessageMapper.FetchType.Body, Optional.empty())
                 .get()

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -562,7 +562,9 @@ public class StoreMailboxManager implements MailboxManager {
                     }
                 }, true);
 
-            return Optional.fromNullable(Iterables.getLast(mailboxIds));
+            if (!mailboxIds.isEmpty()) {
+                return Optional.fromNullable(Iterables.getLast(mailboxIds));
+            }
         }
         return Optional.absent();
     }


### PR DESCRIPTION
The mailboxId creation can be skept during mapper execution and swallowed, leading in an empty collection.

Here is the code giving more context:

```
locker.executeWithLock(mailboxSession, mailbox, new LockAwareExecution<Void>() {

                    public Void execute() throws MailboxException {
                        if (!mailboxExists(mailbox, mailboxSession)) {
                            final org.apache.james.mailbox.store.mail.model.Mailbox m = doCreateMailbox(mailbox, mailboxSession);
                            final MailboxMapper mapper = mailboxSessionMapperFactory.getMailboxMapper(mailboxSession);
                            mapper.execute(new TransactionalMapper.VoidTransaction() {

                                public void runVoid() throws MailboxException {
                                    mailboxIds.add(mapper.save(m));
                                }

                            });

                            // notify listeners
                            dispatcher.mailboxAdded(mailboxSession, m);
                        }
                        return null;

                    }
                }, true);
```

This "skipping mailboxes at the last moment" is done for not preventing hierarchical creation. It might be bad, but I don't think here we should fix this.