### PR TITLE
James-2066 mailet to parse mime

### DIFF
--- a/mailet/api/pom.xml
+++ b/mailet/api/pom.xml
@@ -55,11 +55,16 @@
             <version>1.7.5</version>
             <scope>test</scope>
         </dependency>
-            <dependency>
-                <groupId>org.assertj</groupId>
-                <artifactId>assertj-core</artifactId>
-                <scope>test</scope>
-            </dependency>
+        <dependency>
+            <groupId>org.apache.james</groupId>
+            <artifactId>apache-mime4j</artifactId>
+            <version>0.8.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/mailet/api/src/main/java/org/apache/mailet/Mail.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Mail.java
@@ -23,6 +23,7 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
 import org.apache.mailet.PerRecipientHeaders.Header;
+import org.apache.james.mime4j.dom.Message;
 
 import java.io.Serializable;
 import java.util.Collection;
@@ -98,7 +99,9 @@ public interface Mail extends Serializable, Cloneable {
      * @throws MessagingException when an error occurs while retrieving the message
      */
     MimeMessage getMessage() throws MessagingException;
-    
+
+    Message getParsedMimeMessage() throws MessagingException;
+
     /**
      * Returns the message recipients as a Collection of MailAddress objects,
      * as specified by the SMTP "RCPT TO" command, or internally defined.


### PR DESCRIPTION
I did this PR to open a discussion. The idea was to parse mime once for ever using a mailet.
But we have a big issue because mim4j.dom.message is not serializable do you see an other way around this issue ?
Maybe we should an other way than using attribute to pass the mime to mailet ?