### PR TITLE
MAILBOX-301 Lucene terms length exceeded on some emails

### DIFF
--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/CassandraCluster.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/CassandraCluster.java
@@ -18,10 +18,11 @@
  ****************************************************************/
 package org.apache.james.backends.cassandra;
 
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.Session;
-import com.datastax.driver.core.exceptions.NoHostAvailableException;
-import com.google.common.base.Throwables;
+import java.util.Optional;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.init.CassandraTableManager;
 import org.apache.james.backends.cassandra.init.CassandraTypesProvider;
@@ -30,13 +31,13 @@ import org.apache.james.backends.cassandra.init.ClusterWithKeyspaceCreatedFactor
 import org.apache.james.backends.cassandra.init.SessionWithInitializedTablesFactory;
 import org.apache.james.backends.cassandra.utils.FunctionRunnerWithRetry;
 
-import javax.annotation.PreDestroy;
-import javax.inject.Inject;
-import java.util.Optional;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import com.google.common.base.Throwables;
 
 public final class CassandraCluster implements AutoCloseable {
     private static final String CLUSTER_IP = "localhost";
-    private static final int CLUSTER_PORT_TEST = 9142;
     private static final String KEYSPACE_NAME = "apache_james";
     private static final int REPLICATION_FACTOR = 1;
 
@@ -58,7 +59,7 @@ public final class CassandraCluster implements AutoCloseable {
         try {
             cluster = ClusterBuilder.builder()
                 .host(CLUSTER_IP)
-                .port(CLUSTER_PORT_TEST)
+                .port(embeddedCassandra.getPort())
                 .build();
             session = new FunctionRunnerWithRetry(MAX_RETRY).executeAndRetrieveObject(CassandraCluster.this::tryInitializeSession);
             typesProvider = new CassandraTypesProvider(module, session);

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/EmbeddedCassandra.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/EmbeddedCassandra.java
@@ -29,6 +29,7 @@ import com.google.common.base.Throwables;
 
 public class EmbeddedCassandra {
 
+    private int port;
 
     public static EmbeddedCassandra createStartServer() {
         return new EmbeddedCassandra();
@@ -36,10 +37,14 @@ public class EmbeddedCassandra {
 
     private EmbeddedCassandra() {
         try {
-            EmbeddedCassandraServerHelper.startEmbeddedCassandra(TimeUnit.SECONDS.toMillis(20));
-        } catch (ConfigurationException | TTransportException | IOException | InterruptedException e) {
+            EmbeddedCassandraServerHelper.startEmbeddedCassandra(EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE, TimeUnit.SECONDS.toMillis(20));
+            port = EmbeddedCassandraServerHelper.getNativeTransportPort();
+        } catch (ConfigurationException | TTransportException | IOException e) {
             Throwables.propagate(e);
         }
     }
-    
+
+    public int getPort() {
+        return port;
+    }
 }

--- a/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/NodeMappingFactory.java
+++ b/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/NodeMappingFactory.java
@@ -39,7 +39,6 @@ public class NodeMappingFactory {
     public static final String ANALYZER = "analyzer";
     public static final String SNOWBALL = "snowball";
     public static final String IGNORE_ABOVE = "ignore_above";
-    public static final int LUCENE_LIMIT = 32766;
 
     public static Client applyMapping(Client client, IndexName indexName, TypeName typeName, XContentBuilder mappingsSources) {
         client.admin()

--- a/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/MailboxMappingFactory.java
+++ b/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/MailboxMappingFactory.java
@@ -19,13 +19,58 @@
 
 package org.apache.james.mailbox.elasticsearch;
 
+import static org.apache.james.backends.es.IndexCreationFactory.CASE_INSENSITIVE;
+import static org.apache.james.backends.es.NodeMappingFactory.ANALYZER;
+import static org.apache.james.backends.es.NodeMappingFactory.BOOLEAN;
+import static org.apache.james.backends.es.NodeMappingFactory.FIELDS;
+import static org.apache.james.backends.es.NodeMappingFactory.FORMAT;
+import static org.apache.james.backends.es.NodeMappingFactory.IGNORE_ABOVE;
+import static org.apache.james.backends.es.NodeMappingFactory.INDEX;
+import static org.apache.james.backends.es.NodeMappingFactory.LONG;
+import static org.apache.james.backends.es.NodeMappingFactory.LUCENE_LIMIT;
+import static org.apache.james.backends.es.NodeMappingFactory.NESTED;
+import static org.apache.james.backends.es.NodeMappingFactory.NOT_ANALYZED;
+import static org.apache.james.backends.es.NodeMappingFactory.PROPERTIES;
+import static org.apache.james.backends.es.NodeMappingFactory.RAW;
+import static org.apache.james.backends.es.NodeMappingFactory.SNOWBALL;
+import static org.apache.james.backends.es.NodeMappingFactory.TYPE;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.BCC;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.CC;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.DATE;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.FROM;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.HAS_ATTACHMENT;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.HTML_BODY;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.IS_ANSWERED;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.IS_DELETED;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.IS_DRAFT;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.IS_FLAGGED;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.IS_RECENT;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.IS_UNREAD;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.MAILBOX_ID;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.MEDIA_TYPE;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.MESSAGE_ID;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.MODSEQ;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.SENT_DATE;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.SIZE;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.SUBJECT;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.SUBTYPE;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.TEXT;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.TEXT_BODY;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.TO;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.UID;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.USERS;
+import static org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.USER_FLAGS;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
 import java.io.IOException;
 
+import static org.apache.james.backends.es.NodeMappingFactory.STRING;
+
 import org.apache.james.backends.es.IndexCreationFactory;
 import org.apache.james.backends.es.NodeMappingFactory;
 import org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants;
+import org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.EMailer;
+import org.apache.james.mailbox.elasticsearch.json.JsonMessageConstants.Property;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import com.google.common.base.Throwables;
@@ -38,188 +83,205 @@ public class MailboxMappingFactory {
                 .startObject()
 
                     .startObject(MailboxElasticsearchConstants.MESSAGE_TYPE.getValue())
-                        .startObject(NodeMappingFactory.PROPERTIES)
-                            .startObject(JsonMessageConstants.MESSAGE_ID)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                .field(NodeMappingFactory.INDEX, NodeMappingFactory.NOT_ANALYZED)
-                            .endObject()
-                            .startObject(JsonMessageConstants.UID)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.LONG)
-                            .endObject()
-                            .startObject(JsonMessageConstants.MODSEQ)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.LONG)
-                            .endObject()
-                            .startObject(JsonMessageConstants.SIZE)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.LONG)
-                            .endObject()
-                            .startObject(JsonMessageConstants.IS_ANSWERED)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.BOOLEAN)
-                            .endObject()
-                            .startObject(JsonMessageConstants.IS_DELETED)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.BOOLEAN)
-                            .endObject()
-                            .startObject(JsonMessageConstants.IS_DRAFT)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.BOOLEAN)
-                            .endObject()
-                            .startObject(JsonMessageConstants.IS_FLAGGED)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.BOOLEAN)
-                            .endObject()
-                            .startObject(JsonMessageConstants.IS_RECENT)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.BOOLEAN)
-                            .endObject()
-                            .startObject(JsonMessageConstants.IS_UNREAD)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.BOOLEAN)
-                            .endObject()
-                            .startObject(JsonMessageConstants.DATE)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.DATE)
-                                .field(NodeMappingFactory.FORMAT, "yyyy-MM-dd'T'HH:mm:ssZ")
-                            .endObject()
-                            .startObject(JsonMessageConstants.SENT_DATE)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.DATE)
-                                .field(NodeMappingFactory.FORMAT, "yyyy-MM-dd'T'HH:mm:ssZ")
-                            .endObject()
-                            .startObject(JsonMessageConstants.MEDIA_TYPE)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                .field(NodeMappingFactory.INDEX, NodeMappingFactory.NOT_ANALYZED)
-                            .endObject()
-                            .startObject(JsonMessageConstants.SUBTYPE)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                .field(NodeMappingFactory.INDEX, NodeMappingFactory.NOT_ANALYZED)
-                            .endObject()
-                            .startObject(JsonMessageConstants.USER_FLAGS)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                .field(NodeMappingFactory.INDEX, NodeMappingFactory.NOT_ANALYZED)
+                        .startObject(PROPERTIES)
+
+                            .startObject(MESSAGE_ID)
+                                .field(TYPE, STRING)
+                                .field(INDEX, NOT_ANALYZED)
                             .endObject()
 
-                            .startObject(JsonMessageConstants.FROM)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.NESTED)
-                                .startObject(NodeMappingFactory.PROPERTIES)
-                                    .startObject(JsonMessageConstants.EMailer.NAME)
-                                        .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                        .startObject(NodeMappingFactory.FIELDS)
-                                            .startObject(NodeMappingFactory.RAW)
-                                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                                .field(NodeMappingFactory.ANALYZER, IndexCreationFactory.CASE_INSENSITIVE)
+                            .startObject(UID)
+                                .field(TYPE, LONG)
+                            .endObject()
+
+                            .startObject(MODSEQ)
+                                .field(TYPE, LONG)
+                            .endObject()
+
+                            .startObject(SIZE)
+                                .field(TYPE, LONG)
+                            .endObject()
+
+                            .startObject(IS_ANSWERED)
+                                .field(TYPE, BOOLEAN)
+                            .endObject()
+
+                            .startObject(IS_DELETED)
+                                .field(TYPE, BOOLEAN)
+                            .endObject()
+
+                            .startObject(IS_DRAFT)
+                                .field(TYPE, BOOLEAN)
+                            .endObject()
+
+                            .startObject(IS_FLAGGED)
+                                .field(TYPE, BOOLEAN)
+                            .endObject()
+
+                            .startObject(IS_RECENT)
+                                .field(TYPE, BOOLEAN)
+                            .endObject()
+
+                            .startObject(IS_UNREAD)
+                                .field(TYPE, BOOLEAN)
+                            .endObject()
+
+                            .startObject(DATE)
+                                .field(TYPE, NodeMappingFactory.DATE)
+                                .field(FORMAT, "yyyy-MM-dd'T'HH:mm:ssZ")
+                            .endObject()
+
+                            .startObject(SENT_DATE)
+                                .field(TYPE, NodeMappingFactory.DATE)
+                                .field(FORMAT, "yyyy-MM-dd'T'HH:mm:ssZ")
+                            .endObject()
+
+                            .startObject(MEDIA_TYPE)
+                                .field(TYPE, STRING)
+                                .field(INDEX, NOT_ANALYZED)
+                            .endObject()
+
+                            .startObject(SUBTYPE)
+                                .field(TYPE, STRING)
+                                .field(INDEX, NOT_ANALYZED)
+                            .endObject()
+
+                            .startObject(USER_FLAGS)
+                                .field(TYPE, STRING)
+                                .field(INDEX, NOT_ANALYZED)
+                            .endObject()
+
+                            .startObject(FROM)
+                                .field(TYPE, NESTED)
+                                .startObject(PROPERTIES)
+                                    .startObject(EMailer.NAME)
+                                        .field(TYPE, STRING)
+                                        .startObject(FIELDS)
+                                            .startObject(RAW)
+                                                .field(TYPE, STRING)
+                                                .field(ANALYZER, CASE_INSENSITIVE)
                                             .endObject()
                                         .endObject()
                                     .endObject()
-                                    .startObject(JsonMessageConstants.EMailer.ADDRESS)
-                                        .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                        .field(NodeMappingFactory.INDEX, NodeMappingFactory.NOT_ANALYZED)
+                                    .startObject(EMailer.ADDRESS)
+                                        .field(TYPE, STRING)
+                                        .field(INDEX, NOT_ANALYZED)
                                     .endObject()
                                 .endObject()
                             .endObject()
 
-                            .startObject(JsonMessageConstants.SUBJECT)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                .startObject(NodeMappingFactory.FIELDS)
-                                    .startObject(NodeMappingFactory.RAW)
-                                        .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                        .field(NodeMappingFactory.ANALYZER, IndexCreationFactory.CASE_INSENSITIVE)
+                            .startObject(SUBJECT)
+                                .field(TYPE, STRING)
+                                .startObject(FIELDS)
+                                    .startObject(RAW)
+                                        .field(TYPE, STRING)
+                                        .field(ANALYZER, CASE_INSENSITIVE)
                                     .endObject()
                                 .endObject()
                             .endObject()
 
-                            .startObject(JsonMessageConstants.TO)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.NESTED)
-                                .startObject(NodeMappingFactory.PROPERTIES)
-                                    .startObject(JsonMessageConstants.EMailer.NAME)
-                                        .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                        .startObject(NodeMappingFactory.FIELDS)
-                                            .startObject(NodeMappingFactory.RAW)
-                                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                                .field(NodeMappingFactory.ANALYZER, IndexCreationFactory.CASE_INSENSITIVE)
+                            .startObject(TO)
+                                .field(TYPE, NESTED)
+                                .startObject(PROPERTIES)
+                                    .startObject(EMailer.NAME)
+                                        .field(TYPE, STRING)
+                                        .startObject(FIELDS)
+                                            .startObject(RAW)
+                                                .field(TYPE, STRING)
+                                                .field(ANALYZER, CASE_INSENSITIVE)
                                             .endObject()
                                         .endObject()
                                     .endObject()
-                                    .startObject(JsonMessageConstants.EMailer.ADDRESS)
-                                        .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                        .field(NodeMappingFactory.INDEX, NodeMappingFactory.NOT_ANALYZED)
+                                    .startObject(EMailer.ADDRESS)
+                                        .field(TYPE, STRING)
+                                        .field(INDEX, NOT_ANALYZED)
                                     .endObject()
                                 .endObject()
                             .endObject()
 
-                            .startObject(JsonMessageConstants.CC)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.NESTED)
-                                .startObject(NodeMappingFactory.PROPERTIES)
-                                    .startObject(JsonMessageConstants.EMailer.NAME)
-                                        .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
+                            .startObject(CC)
+                                .field(TYPE, NESTED)
+                                .startObject(PROPERTIES)
+                                    .startObject(EMailer.NAME)
+                                        .field(TYPE, STRING)
                                     .endObject()
-                                    .startObject(JsonMessageConstants.EMailer.ADDRESS)
-                                        .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                        .field(NodeMappingFactory.INDEX, NodeMappingFactory.NOT_ANALYZED)
-                                    .endObject()
-                                .endObject()
-                            .endObject()
-
-                            .startObject(JsonMessageConstants.BCC)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.NESTED)
-                                .startObject(NodeMappingFactory.PROPERTIES)
-                                    .startObject(JsonMessageConstants.EMailer.NAME)
-                                        .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                    .endObject()
-                                    .startObject(JsonMessageConstants.EMailer.ADDRESS)
-                                        .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                        .field(NodeMappingFactory.INDEX, NodeMappingFactory.NOT_ANALYZED)
+                                    .startObject(EMailer.ADDRESS)
+                                        .field(TYPE, STRING)
+                                        .field(INDEX, NOT_ANALYZED)
                                     .endObject()
                                 .endObject()
                             .endObject()
 
-                            .startObject(JsonMessageConstants.MAILBOX_ID)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                .field(NodeMappingFactory.INDEX, NodeMappingFactory.NOT_ANALYZED)
-                            .endObject()
-                            .startObject(JsonMessageConstants.USERS)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                .field(NodeMappingFactory.INDEX, NodeMappingFactory.NOT_ANALYZED)
-                            .endObject()
-                            .startObject(JsonMessageConstants.PROPERTIES)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.NESTED)
-                                .startObject(NodeMappingFactory.PROPERTIES)
-                                    .startObject(JsonMessageConstants.Property.NAMESPACE)
-                                        .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                        .field(NodeMappingFactory.INDEX, NodeMappingFactory.NOT_ANALYZED)
+                            .startObject(BCC)
+                                .field(TYPE, NESTED)
+                                .startObject(PROPERTIES)
+                                    .startObject(EMailer.NAME)
+                                        .field(TYPE, STRING)
                                     .endObject()
-                                    .startObject(JsonMessageConstants.Property.NAME)
-                                        .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                        .field(NodeMappingFactory.INDEX, NodeMappingFactory.NOT_ANALYZED)
-                                    .endObject()
-                                    .startObject(JsonMessageConstants.Property.VALUE)
-                                        .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
+                                    .startObject(EMailer.ADDRESS)
+                                        .field(TYPE, STRING)
+                                        .field(INDEX, NOT_ANALYZED)
                                     .endObject()
                                 .endObject()
                             .endObject()
 
-                            .startObject(JsonMessageConstants.TEXT_BODY)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                .startObject(NodeMappingFactory.FIELDS)
-                                    .startObject(NodeMappingFactory.RAW)
-                                        .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                        .field(NodeMappingFactory.ANALYZER, IndexCreationFactory.CASE_INSENSITIVE)
-                                        .field(NodeMappingFactory.IGNORE_ABOVE, NodeMappingFactory.LUCENE_LIMIT)
+                            .startObject(MAILBOX_ID)
+                                .field(TYPE, STRING)
+                                .field(INDEX, NOT_ANALYZED)
+                            .endObject()
+
+                            .startObject(USERS)
+                                .field(TYPE, STRING)
+                                .field(INDEX, NOT_ANALYZED)
+                            .endObject()
+
+                            .startObject(PROPERTIES)
+                                .field(TYPE, NESTED)
+                                .startObject(PROPERTIES)
+                                    .startObject(Property.NAMESPACE)
+                                        .field(TYPE, STRING)
+                                        .field(INDEX, NOT_ANALYZED)
+                                    .endObject()
+                                    .startObject(Property.NAME)
+                                        .field(TYPE, STRING)
+                                        .field(INDEX, NOT_ANALYZED)
+                                    .endObject()
+                                    .startObject(Property.VALUE)
+                                        .field(TYPE, STRING)
                                     .endObject()
                                 .endObject()
                             .endObject()
 
-                            .startObject(JsonMessageConstants.HTML_BODY)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                .startObject(NodeMappingFactory.FIELDS)
-                                    .startObject(NodeMappingFactory.RAW)
-                                        .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                        .field(NodeMappingFactory.ANALYZER, IndexCreationFactory.CASE_INSENSITIVE)
-                                        .field(NodeMappingFactory.IGNORE_ABOVE, NodeMappingFactory.LUCENE_LIMIT)
+                            .startObject(TEXT_BODY)
+                                .field(TYPE, STRING)
+                                .startObject(FIELDS)
+                                    .startObject(RAW)
+                                        .field(TYPE, STRING)
+                                        .field(ANALYZER, CASE_INSENSITIVE)
+                                        .field(IGNORE_ABOVE, LUCENE_LIMIT)
                                     .endObject()
                                 .endObject()
                             .endObject()
 
-                            .startObject(JsonMessageConstants.HAS_ATTACHMENT)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.BOOLEAN)
+                            .startObject(HTML_BODY)
+                                .field(TYPE, STRING)
+                                .startObject(FIELDS)
+                                    .startObject(RAW)
+                                        .field(TYPE, STRING)
+                                        .field(ANALYZER, CASE_INSENSITIVE)
+                                        .field(IGNORE_ABOVE, LUCENE_LIMIT)
+                                    .endObject()
+                                .endObject()
                             .endObject()
 
-                            .startObject(JsonMessageConstants.TEXT)
-                                .field(NodeMappingFactory.TYPE, NodeMappingFactory.STRING)
-                                .field(NodeMappingFactory.ANALYZER, NodeMappingFactory.SNOWBALL)
-                                .field(NodeMappingFactory.IGNORE_ABOVE, NodeMappingFactory.LUCENE_LIMIT)
+                            .startObject(HAS_ATTACHMENT)
+                                .field(TYPE, BOOLEAN)
+                            .endObject()
+
+                            .startObject(TEXT)
+                                .field(TYPE, STRING)
+                                .field(ANALYZER, SNOWBALL)
+                                .field(IGNORE_ABOVE, LUCENE_LIMIT)
                             .endObject()
                         .endObject()
                     .endObject()

--- a/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/MailboxMappingFactory.java
+++ b/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/MailboxMappingFactory.java
@@ -27,7 +27,6 @@ import static org.apache.james.backends.es.NodeMappingFactory.FORMAT;
 import static org.apache.james.backends.es.NodeMappingFactory.IGNORE_ABOVE;
 import static org.apache.james.backends.es.NodeMappingFactory.INDEX;
 import static org.apache.james.backends.es.NodeMappingFactory.LONG;
-import static org.apache.james.backends.es.NodeMappingFactory.LUCENE_LIMIT;
 import static org.apache.james.backends.es.NodeMappingFactory.NESTED;
 import static org.apache.james.backends.es.NodeMappingFactory.NOT_ANALYZED;
 import static org.apache.james.backends.es.NodeMappingFactory.PROPERTIES;
@@ -76,6 +75,8 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import com.google.common.base.Throwables;
 
 public class MailboxMappingFactory {
+
+    private static final int MAXIMUM_TERM_LENGTH = 4096;
 
     public static XContentBuilder getMappingContent() {
         try {
@@ -258,7 +259,7 @@ public class MailboxMappingFactory {
                                     .startObject(RAW)
                                         .field(TYPE, STRING)
                                         .field(ANALYZER, CASE_INSENSITIVE)
-                                        .field(IGNORE_ABOVE, LUCENE_LIMIT)
+                                        .field(IGNORE_ABOVE, MAXIMUM_TERM_LENGTH)
                                     .endObject()
                                 .endObject()
                             .endObject()
@@ -269,7 +270,7 @@ public class MailboxMappingFactory {
                                     .startObject(RAW)
                                         .field(TYPE, STRING)
                                         .field(ANALYZER, CASE_INSENSITIVE)
-                                        .field(IGNORE_ABOVE, LUCENE_LIMIT)
+                                        .field(IGNORE_ABOVE, MAXIMUM_TERM_LENGTH)
                                     .endObject()
                                 .endObject()
                             .endObject()
@@ -281,7 +282,7 @@ public class MailboxMappingFactory {
                             .startObject(TEXT)
                                 .field(TYPE, STRING)
                                 .field(ANALYZER, SNOWBALL)
-                                .field(IGNORE_ABOVE, LUCENE_LIMIT)
+                                .field(IGNORE_ABOVE, MAXIMUM_TERM_LENGTH)
                             .endObject()
                         .endObject()
                     .endObject()

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/ElasticSearchIntegrationTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/ElasticSearchIntegrationTest.java
@@ -60,7 +60,6 @@ import org.apache.james.mailbox.store.extractor.DefaultTextExtractor;
 import org.apache.james.mailbox.store.mail.model.impl.MessageParser;
 import org.apache.james.mailbox.store.search.AbstractMessageSearchIndexTest;
 import org.elasticsearch.client.Client;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -123,7 +122,6 @@ public class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest
         storeMailboxManager.init();
     }
 
-    @Ignore("MAILBOX-301 Lucene terms length exceeded on some emails")
     @Test
     public void termsBetweenElasticSearchAndLuceneLimitDueTuNonAsciiCharsShouldNotMakeIndexingFail() throws Exception {
         MailboxPath mailboxPath = new MailboxPath(MailboxConstants.USER_NAMESPACE, USERNAME, INBOX);

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/ElasticSearchIntegrationTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/ElasticSearchIntegrationTest.java
@@ -19,8 +19,14 @@
 
 package org.apache.james.mailbox.elasticsearch;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
 import java.time.ZoneId;
+import java.util.Date;
 import java.util.concurrent.Executors;
+
+import javax.mail.Flags;
 
 import org.apache.james.backends.es.DeleteByQueryPerformer;
 import org.apache.james.backends.es.ElasticSearchIndexer;
@@ -28,6 +34,7 @@ import org.apache.james.backends.es.EmbeddedElasticSearch;
 import org.apache.james.backends.es.IndexCreationFactory;
 import org.apache.james.backends.es.NodeMappingFactory;
 import org.apache.james.backends.es.utils.TestingClientProvider;
+import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.acl.SimpleGroupMembershipResolver;
 import org.apache.james.mailbox.acl.UnionMailboxACLResolver;
 import org.apache.james.mailbox.elasticsearch.events.ElasticSearchListeningMessageSearchIndex;
@@ -40,6 +47,11 @@ import org.apache.james.mailbox.inmemory.InMemoryMailboxManager;
 import org.apache.james.mailbox.inmemory.InMemoryMailboxSessionMapperFactory;
 import org.apache.james.mailbox.inmemory.InMemoryMessageId;
 import org.apache.james.mailbox.inmemory.InMemoryMessageIdManager;
+import org.apache.james.mailbox.mock.MockMailboxSession;
+import org.apache.james.mailbox.model.ComposedMessageId;
+import org.apache.james.mailbox.model.MailboxConstants;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.SearchQuery;
 import org.apache.james.mailbox.store.FakeAuthenticator;
 import org.apache.james.mailbox.store.FakeAuthorizator;
 import org.apache.james.mailbox.store.JVMMailboxPathLocker;
@@ -48,14 +60,20 @@ import org.apache.james.mailbox.store.extractor.DefaultTextExtractor;
 import org.apache.james.mailbox.store.mail.model.impl.MessageParser;
 import org.apache.james.mailbox.store.search.AbstractMessageSearchIndexTest;
 import org.elasticsearch.client.Client;
+import org.junit.Ignore;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
 
 public class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest {
 
     private static final int BATCH_SIZE = 1;
     private static final int SEARCH_SIZE = 1;
+    private static final boolean IS_RECENT = true;
 
     private TemporaryFolder temporaryFolder = new TemporaryFolder();
     private EmbeddedElasticSearch embeddedElasticSearch= new EmbeddedElasticSearch(temporaryFolder, MailboxElasticsearchConstants.MAILBOX_INDEX);
@@ -103,5 +121,74 @@ public class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest
         messageIdManager = new InMemoryMessageIdManager(storeMailboxManager);
         storeMailboxManager.setMessageSearchIndex(messageSearchIndex);
         storeMailboxManager.init();
+    }
+
+    @Ignore("MAILBOX-301 Lucene terms length exceeded on some emails")
+    @Test
+    public void termsBetweenElasticSearchAndLuceneLimitDueTuNonAsciiCharsShouldNotMakeIndexingFail() throws Exception {
+        MailboxPath mailboxPath = new MailboxPath(MailboxConstants.USER_NAMESPACE, USERNAME, INBOX);
+        MockMailboxSession session = new MockMailboxSession(USERNAME);
+        MessageManager messageManager = storeMailboxManager.getMailbox(mailboxPath, session);
+
+        String recipient = "benwa@linagora.com";
+        ComposedMessageId composedMessageId = messageManager.appendMessage(new ByteArrayInputStream(("To: " + recipient + "\n" +
+            "\n" +
+            Strings.repeat("0à2345678é", 3200)).getBytes(Charsets.UTF_8)), new Date(), session, IS_RECENT, new Flags());
+
+        embeddedElasticSearch.awaitForElasticSearch();
+
+        assertThat(messageManager.search(new SearchQuery(SearchQuery.address(SearchQuery.AddressType.To, recipient)), session))
+            .containsExactly(composedMessageId.getUid());
+    }
+
+    @Test
+    public void tooLongTermsShouldNotMakeIndexingFail() throws Exception {
+        MailboxPath mailboxPath = new MailboxPath(MailboxConstants.USER_NAMESPACE, USERNAME, INBOX);
+        MockMailboxSession session = new MockMailboxSession(USERNAME);
+        MessageManager messageManager = storeMailboxManager.getMailbox(mailboxPath, session);
+
+        String recipient = "benwa@linagora.com";
+        ComposedMessageId composedMessageId = messageManager.appendMessage(new ByteArrayInputStream(("To: " + recipient + "\n" +
+            "\n" +
+            Strings.repeat("0123456789", 3300)).getBytes(Charsets.UTF_8)), new Date(), session, IS_RECENT, new Flags());
+
+        embeddedElasticSearch.awaitForElasticSearch();
+
+        assertThat(messageManager.search(new SearchQuery(SearchQuery.address(SearchQuery.AddressType.To, recipient)), session))
+            .containsExactly(composedMessageId.getUid());
+    }
+
+    @Test
+    public void fieldsExceedingLuceneLimitShouldNotBeIgnored() throws Exception {
+        MailboxPath mailboxPath = new MailboxPath(MailboxConstants.USER_NAMESPACE, USERNAME, INBOX);
+        MockMailboxSession session = new MockMailboxSession(USERNAME);
+        MessageManager messageManager = storeMailboxManager.getMailbox(mailboxPath, session);
+
+        String recipient = "benwa@linagora.com";
+        ComposedMessageId composedMessageId = messageManager.appendMessage(new ByteArrayInputStream(("To: " + recipient + "\n" +
+            "\n" +
+            Strings.repeat("0123456789 ", 5000)).getBytes(Charsets.UTF_8)), new Date(), session, IS_RECENT, new Flags());
+
+        embeddedElasticSearch.awaitForElasticSearch();
+
+        assertThat(messageManager.search(new SearchQuery(SearchQuery.bodyContains("0123456789")), session))
+            .containsExactly(composedMessageId.getUid());
+    }
+
+    @Test
+    public void fieldsWithTooLongTermShouldStillBeIndexed() throws Exception {
+        MailboxPath mailboxPath = new MailboxPath(MailboxConstants.USER_NAMESPACE, USERNAME, INBOX);
+        MockMailboxSession session = new MockMailboxSession(USERNAME);
+        MessageManager messageManager = storeMailboxManager.getMailbox(mailboxPath, session);
+
+        String recipient = "benwa@linagora.com";
+        ComposedMessageId composedMessageId = messageManager.appendMessage(new ByteArrayInputStream(("To: " + recipient + "\n" +
+            "\n" +
+            Strings.repeat("0123456789", 5000) + " matchMe").getBytes(Charsets.UTF_8)), new Date(), session, IS_RECENT, new Flags());
+
+        embeddedElasticSearch.awaitForElasticSearch();
+
+        assertThat(messageManager.search(new SearchQuery(SearchQuery.bodyContains("matchMe")), session))
+            .containsExactly(composedMessageId.getUid());
     }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/AbstractMessageSearchIndexTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/AbstractMessageSearchIndexTest.java
@@ -54,9 +54,9 @@ import com.google.common.collect.ImmutableList;
 
 public abstract class AbstractMessageSearchIndexTest {
 
-    private static final String INBOX = "INBOX";
-    private static final String OTHERUSER = "otheruser";
-    private static final String USERNAME = "benwa";
+    protected static final String INBOX = "INBOX";
+    protected static final String OTHERUSER = "otheruser";
+    protected static final String USERNAME = "benwa";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractMessageSearchIndexTest.class);
     public static final long LIMIT = 100L;


### PR DESCRIPTION
From the ticket:

```
Lucene supports a maximum term size of 32KB

This term size can get exceeded, causing the index to fail.

Thus, the team had position "ignore_above" filters to filter out too long terms and positionned it's value to Lucene maximum.

However, as stated in https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html :


{code:java}
Note:

The value for ignore_above is the character count, but Lucene counts bytes. If you use UTF-8 text with many non-ASCII characters, you may want to set the limit to 32766 / 3 = 10922 since UTF-8 characters may occupy at most 3 bytes.
{code}

Thus the maximum value is computed for string length in ES and not based on bytes length in Lucene.

We can craft a char sequence in UTF-8 exceeding the Lucene value but not triggering the ES limit.

A much lower value (like 4KB) seems more reasonable, as long terms my not be significant.

Note:
 - Implement tests:
    - Demonstrating this bug
    - Demonstrating only too long terms are ignored
```

Special care have to be taken to upate Mapping on prod.