### PR TITLE
JAMES-2076 solve cassandra sieve concurrency issues

### DIFF
--- a/server/data/data-cassandra/src/main/java/org/apache/james/sieve/cassandra/CassandraSieveDAO.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/sieve/cassandra/CassandraSieveDAO.java
@@ -49,6 +49,7 @@ import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.Select;
+import com.github.steveash.guavate.Guavate;
 
 public class CassandraSieveDAO {
 
@@ -116,7 +117,7 @@ public class CassandraSieveDAO {
                 .map(row -> new ScriptSummary(
                     row.getString(SCRIPT_NAME),
                     row.getBool(IS_ACTIVE)))
-                .collect(Collectors.toList()));
+                .collect(Guavate.toImmutableList()));
     }
 
     public CompletableFuture<Boolean> updateScriptActivation(String user, String scriptName, boolean active) {

--- a/server/data/data-cassandra/src/main/java/org/apache/james/sieve/cassandra/CassandraSieveQuotaDAO.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/sieve/cassandra/CassandraSieveQuotaDAO.java
@@ -89,14 +89,12 @@ public class CassandraSieveQuotaDAO {
         deleteClusterQuotaStatement = session.prepare(
             delete()
                 .from(CassandraSieveClusterQuotaTable.TABLE_NAME)
-                .where(eq(CassandraSieveClusterQuotaTable.NAME, bindMarker(CassandraSieveClusterQuotaTable.NAME)))
-                .ifExists());
+                .where(eq(CassandraSieveClusterQuotaTable.NAME, bindMarker(CassandraSieveClusterQuotaTable.NAME))));
 
         deleteUserQuotaStatement = session.prepare(
             delete()
                 .from(CassandraSieveQuotaTable.TABLE_NAME)
-                .where(eq(CassandraSieveQuotaTable.USER_NAME, bindMarker(CassandraSieveQuotaTable.USER_NAME)))
-                .ifExists());
+                .where(eq(CassandraSieveQuotaTable.USER_NAME, bindMarker(CassandraSieveQuotaTable.USER_NAME))));
     }
 
     public CompletableFuture<Long> spaceUsedBy(String user) {
@@ -128,8 +126,8 @@ public class CassandraSieveQuotaDAO {
                 .setString(CassandraSieveClusterQuotaTable.NAME, CassandraSieveClusterQuotaTable.DEFAULT_NAME));
     }
 
-    public CompletableFuture<Boolean> removeQuota() {
-        return cassandraAsyncExecutor.executeReturnApplied(
+    public CompletableFuture<Void> removeQuota() {
+        return cassandraAsyncExecutor.executeVoid(
             deleteClusterQuotaStatement.bind()
                 .setString(CassandraSieveClusterQuotaTable.NAME, CassandraSieveClusterQuotaTable.DEFAULT_NAME));
     }
@@ -148,8 +146,8 @@ public class CassandraSieveQuotaDAO {
                 .setString(CassandraSieveQuotaTable.USER_NAME, user));
     }
 
-    public CompletableFuture<Boolean> removeQuota(String user)  {
-        return cassandraAsyncExecutor.executeReturnApplied(
+    public CompletableFuture<Void> removeQuota(String user)  {
+        return cassandraAsyncExecutor.executeVoid(
             deleteUserQuotaStatement.bind()
                 .setString(CassandraSieveQuotaTable.USER_NAME, user));
     }

--- a/server/data/data-cassandra/src/main/java/org/apache/james/sieve/cassandra/CassandraSieveRepository.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/sieve/cassandra/CassandraSieveRepository.java
@@ -237,9 +237,7 @@ public class CassandraSieveRepository implements SieveRepository {
 
     @Override
     public void removeQuota() throws QuotaNotFoundException {
-        if (!cassandraSieveQuotaDAO.removeQuota().join()) {
-            throw new QuotaNotFoundException();
-        }
+        cassandraSieveQuotaDAO.removeQuota().join();
     }
 
     @Override
@@ -266,9 +264,7 @@ public class CassandraSieveRepository implements SieveRepository {
 
     @Override
     public void removeQuota(String user) throws QuotaNotFoundException {
-        if (!cassandraSieveQuotaDAO.removeQuota(user).join()) {
-            throw new QuotaNotFoundException();
-        }
+        cassandraSieveQuotaDAO.removeQuota(user).join();
     }
 
 }

--- a/server/data/data-cassandra/src/main/java/org/apache/james/sieve/cassandra/CassandraSieveRepository.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/sieve/cassandra/CassandraSieveRepository.java
@@ -131,12 +131,12 @@ public class CassandraSieveRepository implements SieveRepository {
 
     @Override
     public void setActive(String user, String name) throws ScriptNotFoundException {
-        CompletableFuture<Void> unactivateOldScriptFuture = unactivateOldScript(user);
-        CompletableFuture<Boolean> activateNewScript = updateScriptActivation(user, name, true)
-            .thenCompose(CompletableFutureUtil.composeIfTrue(
-                () -> cassandraActiveScriptDAO.activate(user, name)));
+        CompletableFuture<Boolean> activateNewScript =
+            unactivateOldScript(user)
+                .thenCompose( any -> updateScriptActivation(user, name, true)
+                    .thenCompose(CompletableFutureUtil.composeIfTrue(
+                        () -> cassandraActiveScriptDAO.activate(user, name))));
 
-        unactivateOldScriptFuture.join();
         if (!activateNewScript.join()) {
             throw new ScriptNotFoundException();
         }

--- a/server/data/data-file/src/main/java/org/apache/james/sieverepository/file/SieveFileRepository.java
+++ b/server/data/data-file/src/main/java/org/apache/james/sieverepository/file/SieveFileRepository.java
@@ -420,7 +420,7 @@ public class SieveFileRepository implements SieveRepository {
     public synchronized void removeQuota() throws QuotaNotFoundException, StorageException {
         File file = getQuotaFile();
         if (!file.exists()) {
-            throw new QuotaNotFoundException("No default quota");
+            return;
         }
         try {
             FileUtils.forceDelete(file);
@@ -475,7 +475,7 @@ public class SieveFileRepository implements SieveRepository {
         synchronized (lock) {
             File file = getQuotaFile(user);
             if (!file.exists()) {
-                throw new QuotaNotFoundException("No quota for user: " + user);
+                return;
             }
             try {
                 FileUtils.forceDelete(file);

--- a/server/data/data-library/src/test/java/org/apache/james/sieverepository/lib/AbstractSieveRepositoryTest.java
+++ b/server/data/data-library/src/test/java/org/apache/james/sieverepository/lib/AbstractSieveRepositoryTest.java
@@ -303,9 +303,14 @@ public abstract class AbstractSieveRepositoryTest {
         assertThat(sieveRepository.hasQuota(USER)).isTrue();
     }
 
-    @Test(expected = QuotaNotFoundException.class)
-    public void removeQuotaShouldThrowIfRepositoryDoesNotHaveQuota() throws Exception {
+    @Test
+    public void removeQuotaShouldNotThrowIfRepositoryDoesNotHaveQuota() throws Exception {
         sieveRepository.removeQuota();
+    }
+
+    @Test
+    public void removeUserQuotaShouldNotThrowWhenAbsent() throws Exception {
+        sieveRepository.removeQuota(USER);
     }
 
     @Test


### PR DESCRIPTION
The underlying idea: ***removeQuota\*** is an internal James API*. Quota management encouraged in https://tools.ietf.org/html/rfc5804 is not formally defined. Thus we can modify **Sieve quota** to be **indepotent** upon deletes. This is expected to correct some concurrency issues.