### PR TITLE
James 2083 cassandra migration - detection part

### DIFF
--- a/backends-common/cassandra/pom.xml
+++ b/backends-common/cassandra/pom.xml
@@ -169,15 +169,21 @@
                     <scope>test</scope>
                 </dependency>
                 <dependency>
-                    <groupId>nl.jqno.equalsverifier</groupId>
-                    <artifactId>equalsverifier</artifactId>
-                    <version>1.7.6</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
                     <groupId>org.cassandraunit</groupId>
                     <artifactId>cassandra-unit</artifactId>
                     <version>2.1.9.2</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                    <version>1.9.0</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>nl.jqno.equalsverifier</groupId>
+                    <artifactId>equalsverifier</artifactId>
+                    <version>1.7.6</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAO.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAO.java
@@ -1,0 +1,78 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.cassandra.versions;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static org.apache.james.backends.cassandra.versions.table.CassandraSchemaVersionTable.KEY;
+import static org.apache.james.backends.cassandra.versions.table.CassandraSchemaVersionTable.KEY_FOR_VERSION;
+import static org.apache.james.backends.cassandra.versions.table.CassandraSchemaVersionTable.TABLE_NAME;
+import static org.apache.james.backends.cassandra.versions.table.CassandraSchemaVersionTable.VALUE;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
+import org.apache.james.backends.cassandra.versions.table.CassandraSchemaVersionTable;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+
+import javax.inject.Inject;
+
+public class CassandraSchemaVersionDAO {
+    private final PreparedStatement readVersionStatement;
+    private final PreparedStatement writeVersionStatement;
+    private final CassandraAsyncExecutor cassandraAsyncExecutor;
+
+    @Inject
+    public CassandraSchemaVersionDAO(Session session) {
+        cassandraAsyncExecutor = new CassandraAsyncExecutor(session);
+        readVersionStatement = prepareReadVersionStatement(session);
+        writeVersionStatement = prepareWriteVersionStatement(session);
+    }
+
+    private PreparedStatement prepareReadVersionStatement(Session session) {
+        return session.prepare(
+            QueryBuilder.select(VALUE)
+                .from(TABLE_NAME)
+                .where(QueryBuilder.eq(KEY, KEY_FOR_VERSION)));
+    }
+
+    private PreparedStatement prepareWriteVersionStatement(Session session) {
+        return session.prepare(
+            QueryBuilder.insertInto(CassandraSchemaVersionTable.TABLE_NAME).value(KEY, KEY_FOR_VERSION)
+                .value(VALUE, bindMarker(VALUE)));
+    }
+
+    public CompletableFuture<Optional<Integer>> getCurrentSchemaVersion() {
+        return cassandraAsyncExecutor.executeSingleRow(readVersionStatement.bind())
+            .thenApply(rowOptional ->
+                rowOptional
+                    .map(row -> row.getInt(VALUE)));
+    }
+
+    public CompletableFuture<Void> updateVersion(int newVersion) {
+        return cassandraAsyncExecutor.executeVoid(
+            writeVersionStatement.bind()
+                .setInt(VALUE, newVersion));
+    }
+}
+

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAO.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAO.java
@@ -20,6 +20,8 @@
 package org.apache.james.backends.cassandra.versions;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 import static org.apache.james.backends.cassandra.versions.table.CassandraSchemaVersionTable.KEY;
 import static org.apache.james.backends.cassandra.versions.table.CassandraSchemaVersionTable.KEY_FOR_VERSION;
 import static org.apache.james.backends.cassandra.versions.table.CassandraSchemaVersionTable.TABLE_NAME;
@@ -29,11 +31,13 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
+import org.apache.james.backends.cassandra.utils.CassandraUtils;
 import org.apache.james.backends.cassandra.versions.table.CassandraSchemaVersionTable;
 
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.datastax.driver.core.utils.UUIDs;
 
 import javax.inject.Inject;
 
@@ -51,27 +55,28 @@ public class CassandraSchemaVersionDAO {
 
     private PreparedStatement prepareReadVersionStatement(Session session) {
         return session.prepare(
-            QueryBuilder.select(VALUE)
-                .from(TABLE_NAME)
-                .where(QueryBuilder.eq(KEY, KEY_FOR_VERSION)));
+            select(VALUE)
+                .from(TABLE_NAME));
     }
 
     private PreparedStatement prepareWriteVersionStatement(Session session) {
         return session.prepare(
-            QueryBuilder.insertInto(CassandraSchemaVersionTable.TABLE_NAME).value(KEY, KEY_FOR_VERSION)
+            insertInto(CassandraSchemaVersionTable.TABLE_NAME)
+                .value(KEY, bindMarker(KEY))
                 .value(VALUE, bindMarker(VALUE)));
     }
 
     public CompletableFuture<Optional<Integer>> getCurrentSchemaVersion() {
-        return cassandraAsyncExecutor.executeSingleRow(readVersionStatement.bind())
-            .thenApply(rowOptional ->
-                rowOptional
-                    .map(row -> row.getInt(VALUE)));
+        return cassandraAsyncExecutor.execute(readVersionStatement.bind())
+            .thenApply(resultSet -> CassandraUtils.convertToStream(resultSet)
+                .map(row -> row.getInt(VALUE))
+                .reduce(Math::max));
     }
 
     public CompletableFuture<Void> updateVersion(int newVersion) {
         return cassandraAsyncExecutor.executeVoid(
             writeVersionStatement.bind()
+                .setUUID(KEY, UUIDs.timeBased())
                 .setInt(VALUE, newVersion));
     }
 }

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionManager.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionManager.java
@@ -1,0 +1,97 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.cassandra.versions;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+
+public class CassandraSchemaVersionManager {
+    public static final int MIN_VERSION = 1;
+    public static final int MAX_VERSION = 1;
+    public static final int DEFAULT_VERSION = 1;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CassandraSchemaVersionManager.class);
+
+    private final int minVersion;
+    private final int maxVersion;
+    private final int version;
+
+    @Inject
+    public CassandraSchemaVersionManager(CassandraSchemaVersionDAO schemaVersionDAO) {
+        this(schemaVersionDAO, MIN_VERSION, MAX_VERSION);
+    }
+
+    @VisibleForTesting
+    public CassandraSchemaVersionManager(CassandraSchemaVersionDAO schemaVersionDAO, int minVersion, int maxVersion) {
+        Preconditions.checkArgument(minVersion > 0, "minVersion needs to be strictly positive");
+        Preconditions.checkArgument(maxVersion > 0, "maxVersion needs to be strictly positive");
+        Preconditions.checkArgument(maxVersion >= minVersion,
+            "maxVersion should not be inferior to minVersion");
+
+        this.minVersion = minVersion;
+        this.maxVersion = maxVersion;
+        this.version = schemaVersionDAO
+            .getCurrentSchemaVersion()
+            .join()
+            .orElseGet(() -> {
+                LOGGER.warn("No schema version information found on Cassandra, we assume schema is at version {}",
+                    CassandraSchemaVersionManager.DEFAULT_VERSION);
+                return DEFAULT_VERSION;
+            });
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public int getMinimumSupportedVersion() {
+        return minVersion;
+    }
+
+    public int getMaximumSupportedVersion() {
+        return maxVersion;
+    }
+
+    public void ensureSchemaIsSupported() {
+        if (version < minVersion) {
+
+            throw new IllegalStateException(
+                String.format("Current schema version is %d whereas minimum required version is %d. " +
+                    "Recommended version is %d", version, minVersion, maxVersion));
+        } else if (version < maxVersion) {
+
+            LOGGER.warn("Current schema version is %d. Recommended version is %d", version, maxVersion);
+        } else if (version == maxVersion){
+
+            LOGGER.info("Schema version is up-to-date");
+        } else {
+
+            throw new IllegalStateException(
+                String.format("Current schema version is %d whereas the minimum supported version is %d. " +
+                    "Recommended version is %d.", version, minVersion, maxVersion));
+        }
+    }
+
+}

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionManager.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionManager.java
@@ -19,18 +19,18 @@
 
 package org.apache.james.backends.cassandra.versions;
 
-import static org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager.SchemaState.UP_TO_DATE;
-import static org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager.SchemaState.UPGRADABLE;
 import static org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager.SchemaState.TOO_OLD;
 import static org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager.SchemaState.TOO_RECENT;
+import static org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager.SchemaState.UPGRADABLE;
+import static org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager.SchemaState.UP_TO_DATE;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
+import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 
 public class CassandraSchemaVersionManager {
     public static final int MIN_VERSION = 1;
@@ -92,11 +92,10 @@ public class CassandraSchemaVersionManager {
             return TOO_OLD;
         } else if (version < maxVersion) {
             return UPGRADABLE;
-        } else if (version == maxVersion){
+        } else if (version == maxVersion) {
             return UP_TO_DATE;
         } else {
             return TOO_RECENT;
         }
     }
-
 }

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionModule.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionModule.java
@@ -1,0 +1,57 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.cassandra.versions;
+
+import static com.datastax.driver.core.DataType.cint;
+
+import java.util.List;
+
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.components.CassandraTable;
+import org.apache.james.backends.cassandra.components.CassandraType;
+import org.apache.james.backends.cassandra.versions.table.CassandraSchemaVersionTable;
+
+import com.datastax.driver.core.schemabuilder.SchemaBuilder;
+import com.google.common.collect.ImmutableList;
+
+public class CassandraSchemaVersionModule implements CassandraModule {
+
+    private final List<CassandraTable> tables;
+
+    public CassandraSchemaVersionModule() {
+        this.tables = ImmutableList.of(
+            new CassandraTable(CassandraSchemaVersionTable.TABLE_NAME,
+                SchemaBuilder.createTable(CassandraSchemaVersionTable.TABLE_NAME)
+                    .ifNotExists()
+                    .addPartitionKey(CassandraSchemaVersionTable.KEY, cint())
+                    .addClusteringColumn(CassandraSchemaVersionTable.VALUE, cint())));
+    }
+
+
+    @Override
+    public List<CassandraTable> moduleTables() {
+        return tables;
+    }
+
+    @Override
+    public List<CassandraType> moduleTypes() {
+        return ImmutableList.of();
+    }
+}

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionModule.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionModule.java
@@ -20,6 +20,7 @@
 package org.apache.james.backends.cassandra.versions;
 
 import static com.datastax.driver.core.DataType.cint;
+import static com.datastax.driver.core.DataType.timeuuid;
 
 import java.util.List;
 
@@ -40,7 +41,7 @@ public class CassandraSchemaVersionModule implements CassandraModule {
             new CassandraTable(CassandraSchemaVersionTable.TABLE_NAME,
                 SchemaBuilder.createTable(CassandraSchemaVersionTable.TABLE_NAME)
                     .ifNotExists()
-                    .addPartitionKey(CassandraSchemaVersionTable.KEY, cint())
+                    .addPartitionKey(CassandraSchemaVersionTable.KEY, timeuuid())
                     .addClusteringColumn(CassandraSchemaVersionTable.VALUE, cint())));
     }
 

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/table/CassandraSchemaVersionTable.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/table/CassandraSchemaVersionTable.java
@@ -1,0 +1,29 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.cassandra.versions.table;
+
+public interface CassandraSchemaVersionTable {
+    String TABLE_NAME = "schemaVersion";
+
+    String KEY = "key";
+    String VALUE = "value";
+
+    int KEY_FOR_VERSION = 0;
+}

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAOTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAOTest.java
@@ -1,0 +1,65 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.cassandra.versions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CassandraSchemaVersionDAOTest {
+
+    private CassandraCluster cassandra;
+
+    private CassandraSchemaVersionDAO testee;
+
+
+    @Before
+    public void setUp() {
+        cassandra = CassandraCluster.create(new CassandraSchemaVersionModule());
+        cassandra.ensureAllTables();
+
+        testee = new CassandraSchemaVersionDAO(cassandra.getConf());
+    }
+
+    @After
+    public void tearDown() {
+        cassandra.clearAllTables();
+        cassandra.close();
+    }
+
+    @Test
+    public void getCurrentSchemaVersionShouldReturn1WhenTableIsEmpty() {
+        assertThat(testee.getCurrentSchemaVersion().join().isPresent()).isFalse();
+    }
+
+    @Test
+    public void getCurrentSchemaVersionShouldReturnVersionPresentInTheTable() {
+        int version = 42;
+
+        testee.updateVersion(version).join();
+
+        assertThat(testee.getCurrentSchemaVersion().join()).isEqualTo(Optional.of(version));
+    }
+}

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAOTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAOTest.java
@@ -22,6 +22,7 @@ package org.apache.james.backends.cassandra.versions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.utils.CassandraUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,7 +40,7 @@ public class CassandraSchemaVersionDAOTest {
         cassandra = CassandraCluster.create(new CassandraSchemaVersionModule());
         cassandra.ensureAllTables();
 
-        testee = new CassandraSchemaVersionDAO(cassandra.getConf());
+        testee = new CassandraSchemaVersionDAO(cassandra.getConf(), CassandraUtils.WITH_DEFAULT_CONFIGURATION);
     }
 
     @After

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAOTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAOTest.java
@@ -34,7 +34,6 @@ public class CassandraSchemaVersionDAOTest {
 
     private CassandraSchemaVersionDAO testee;
 
-
     @Before
     public void setUp() {
         cassandra = CassandraCluster.create(new CassandraSchemaVersionModule());
@@ -60,6 +59,16 @@ public class CassandraSchemaVersionDAOTest {
 
         testee.updateVersion(version).join();
 
-        assertThat(testee.getCurrentSchemaVersion().join()).isEqualTo(Optional.of(version));
+        assertThat(testee.getCurrentSchemaVersion().join()).contains(version);
+    }
+
+    @Test
+    public void getCurrentSchemaVersionShouldBeIdempotent() {
+        int version = 42;
+
+        testee.updateVersion(version + 1).join();
+        testee.updateVersion(version).join();
+
+        assertThat(testee.getCurrentSchemaVersion().join()).contains(version + 1);
     }
 }

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAOTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAOTest.java
@@ -21,12 +21,12 @@ package org.apache.james.backends.cassandra.versions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Optional;
-
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Optional;
 
 public class CassandraSchemaVersionDAOTest {
 
@@ -49,8 +49,9 @@ public class CassandraSchemaVersionDAOTest {
     }
 
     @Test
-    public void getCurrentSchemaVersionShouldReturn1WhenTableIsEmpty() {
-        assertThat(testee.getCurrentSchemaVersion().join().isPresent()).isFalse();
+    public void getCurrentSchemaVersionShouldReturnEmptyWhenTableIsEmpty() {
+        assertThat(testee.getCurrentSchemaVersion().join())
+            .isEqualTo(Optional.empty());
     }
 
     @Test
@@ -59,7 +60,8 @@ public class CassandraSchemaVersionDAOTest {
 
         testee.updateVersion(version).join();
 
-        assertThat(testee.getCurrentSchemaVersion().join()).contains(version);
+        assertThat(testee.getCurrentSchemaVersion().join())
+            .contains(version);
     }
 
     @Test
@@ -69,6 +71,7 @@ public class CassandraSchemaVersionDAOTest {
         testee.updateVersion(version + 1).join();
         testee.updateVersion(version).join();
 
-        assertThat(testee.getCurrentSchemaVersion().join()).contains(version + 1);
+        assertThat(testee.getCurrentSchemaVersion().join())
+            .contains(version + 1);
     }
 }

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionManagerTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionManagerTest.java
@@ -1,0 +1,240 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.cassandra.versions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.org.lidalia.slf4jtest.LoggingEvent.info;
+import static uk.org.lidalia.slf4jtest.LoggingEvent.warn;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import uk.org.lidalia.slf4jtest.TestLogger;
+import uk.org.lidalia.slf4jtest.TestLoggerFactory;
+
+public class CassandraSchemaVersionManagerTest {
+
+    private final int minVersion = 2;
+    private final int maxVersion = 4;
+    private CassandraSchemaVersionDAO schemaVersionDAO;
+    private TestLogger logger = TestLoggerFactory.getTestLogger(CassandraSchemaVersionManager.class);
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    public void setUp() {
+        schemaVersionDAO = mock(CassandraSchemaVersionDAO.class);
+    }
+
+    @After
+    public void tearDown() {
+        TestLoggerFactory.clear();
+    }
+
+    @Test
+    public void ensureSchemaIsSupportedShouldThrowIfSchemaVersionIsTooOld() {
+        expectedException.expect(IllegalStateException.class);
+
+        int currentVersion = minVersion - 1;
+
+        when(schemaVersionDAO.getCurrentSchemaVersion())
+            .thenReturn(CompletableFuture.completedFuture(Optional.of(currentVersion)));
+
+        CassandraSchemaVersionManager testee = new CassandraSchemaVersionManager(
+            schemaVersionDAO,
+            minVersion,
+            maxVersion);
+
+        testee.ensureSchemaIsSupported();
+    }
+
+    @Test
+    public void ensureSchemaIsSupportedShouldThrowIfSchemaVersionIsTooRecent() {
+        expectedException.expect(IllegalStateException.class);
+
+        int currentVersion = maxVersion + 1;
+
+        when(schemaVersionDAO.getCurrentSchemaVersion())
+            .thenReturn(CompletableFuture.completedFuture(Optional.of(currentVersion)));
+
+        CassandraSchemaVersionManager testee = new CassandraSchemaVersionManager(
+            schemaVersionDAO,
+            minVersion,
+            maxVersion);
+
+        testee.ensureSchemaIsSupported();
+    }
+
+    @Test
+    public void ensureSchemaIsSupportedShouldLogOkIfSchemaIsUpToDate() {
+        int currentVersion = maxVersion;
+
+        when(schemaVersionDAO.getCurrentSchemaVersion())
+            .thenReturn(CompletableFuture.completedFuture(Optional.of(currentVersion)));
+
+        CassandraSchemaVersionManager testee = new CassandraSchemaVersionManager(
+            schemaVersionDAO,
+            minVersion,
+            maxVersion);
+
+        testee.ensureSchemaIsSupported();
+
+        assertThat(logger.getLoggingEvents()).containsExactly(info("Schema version is up-to-date"));
+    }
+
+    @Test
+    public void ensureSchemaIsSupportedShouldLogAsWarningIfSchemaIsSupportedButNotUpToDate() {
+        int currentVersion = maxVersion - 1;
+
+        when(schemaVersionDAO.getCurrentSchemaVersion())
+            .thenReturn(CompletableFuture.completedFuture(Optional.of(currentVersion)));
+
+        CassandraSchemaVersionManager testee = new CassandraSchemaVersionManager(
+            schemaVersionDAO,
+            minVersion,
+            maxVersion);
+
+        testee.ensureSchemaIsSupported();
+
+        assertThat(logger.getLoggingEvents())
+            .containsExactly(warn("Current schema version is %d. Recommended version is %d",
+                currentVersion,
+                maxVersion));
+    }
+
+    @Test
+    public void constructorShouldThrowOnNegativeMinVersion() {
+        expectedException.expect(IllegalArgumentException.class);
+
+        new CassandraSchemaVersionManager(
+            schemaVersionDAO,
+            -1,
+            maxVersion);
+    }
+
+    @Test
+    public void constructorShouldThrowOnZeroMinVersion() {
+        expectedException.expect(IllegalArgumentException.class);
+
+        new CassandraSchemaVersionManager(
+            schemaVersionDAO,
+            0,
+            maxVersion);
+    }
+
+    @Test
+    public void constructorShouldThrowOnNegativeMaxVersion() {
+        expectedException.expect(IllegalArgumentException.class);
+
+        new CassandraSchemaVersionManager(
+            schemaVersionDAO,
+            minVersion,
+            -1);
+    }
+
+    @Test
+    public void constructorShouldThrowOnZeroMaxVersion() {
+        expectedException.expect(IllegalArgumentException.class);
+
+        new CassandraSchemaVersionManager(
+            schemaVersionDAO,
+            minVersion,
+            0);
+    }
+
+    @Test
+    public void constructorShouldThrowMinVersionIsSuperiorToMaxVersion() {
+        expectedException.expect(IllegalArgumentException.class);
+
+        int minVersion = 4;
+        int maxVersion = 2;
+        new CassandraSchemaVersionManager(
+            schemaVersionDAO,
+            minVersion,
+            maxVersion);
+    }
+
+    @Test
+    public void ensureSchemaIsSupportedShouldActAsUpToDateWhenMinMaxAndCurrentVersionsAreTheSame() {
+        int minVersion = 4;
+        int maxVersion = 4;
+        int currentVersion = 4;
+        when(schemaVersionDAO.getCurrentSchemaVersion())
+            .thenReturn(CompletableFuture.completedFuture(Optional.of(currentVersion)));
+
+        CassandraSchemaVersionManager testee = new CassandraSchemaVersionManager(
+            schemaVersionDAO,
+            minVersion,
+            maxVersion);
+
+        testee.ensureSchemaIsSupported();
+
+        assertThat(logger.getLoggingEvents()).containsExactly(info("Schema version is up-to-date"));
+    }
+
+    @Test
+    public void ensureSchemaIsSupportedShouldNotThrowOnNewCassandra() {
+        when(schemaVersionDAO.getCurrentSchemaVersion())
+            .thenReturn(CompletableFuture.completedFuture(Optional.of(CassandraSchemaVersionManager.DEFAULT_VERSION)));
+
+        new CassandraSchemaVersionManager(schemaVersionDAO).ensureSchemaIsSupported();
+    }
+
+    @Test
+    public void ensureSchemaIsSupportedShouldNotThrowButLogWhenNoVersionNumberFoundOnCassandra() {
+        when(schemaVersionDAO.getCurrentSchemaVersion())
+            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+        new CassandraSchemaVersionManager(schemaVersionDAO).ensureSchemaIsSupported();
+
+        assertThat(logger.getAllLoggingEvents())
+            .contains(warn("No schema version information found on Cassandra, we assume schema is at version {}",
+                CassandraSchemaVersionManager.DEFAULT_VERSION));
+    }
+
+    @Test
+    public void ensureSchemaDefaultConstructorUseCorrectMinVersion() {
+        when(schemaVersionDAO.getCurrentSchemaVersion())
+            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+        CassandraSchemaVersionManager testee = new CassandraSchemaVersionManager(schemaVersionDAO);
+
+        assertThat(testee.getMinimumSupportedVersion()).isEqualTo(CassandraSchemaVersionManager.MIN_VERSION);
+    }
+
+    @Test
+    public void ensureSchemaDefaultConstructorUseCorrectMaxVersion() {
+        when(schemaVersionDAO.getCurrentSchemaVersion())
+            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+        CassandraSchemaVersionManager testee = new CassandraSchemaVersionManager(schemaVersionDAO);
+
+        assertThat(testee.getMinimumSupportedVersion()).isEqualTo(CassandraSchemaVersionManager.MAX_VERSION);
+    }
+}

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
@@ -39,8 +39,13 @@ import org.apache.james.backends.cassandra.init.ClusterWithKeyspaceCreatedFactor
 import org.apache.james.backends.cassandra.init.QueryLoggerConfiguration;
 import org.apache.james.backends.cassandra.init.SessionWithInitializedTablesFactory;
 import org.apache.james.backends.cassandra.utils.CassandraUtils;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionDAO;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.lifecycle.api.Configurable;
 import org.apache.james.mailbox.store.BatchSizes;
 import org.apache.james.util.Host;
+import org.apache.james.utils.ConfigurationPerformer;
 import org.apache.james.utils.PropertiesProvider;
 import org.apache.james.utils.RetryExecutorUtil;
 import org.slf4j.Logger;
@@ -55,7 +60,9 @@ import com.datastax.driver.core.Session;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
@@ -94,6 +101,12 @@ public class CassandraSessionModule extends AbstractModule {
 
         Multibinder<CassandraModule> cassandraDataDefinitions = Multibinder.newSetBinder(binder(), CassandraModule.class);
         cassandraDataDefinitions.addBinding().to(CassandraZonedDateTimeModule.class);
+        cassandraDataDefinitions.addBinding().to(CassandraSchemaVersionModule.class);
+
+        bind(CassandraSchemaVersionManager.class).in(Scopes.SINGLETON);
+        bind(CassandraSchemaVersionDAO.class).in(Scopes.SINGLETON);
+
+        Multibinder.newSetBinder(binder(), ConfigurationPerformer.class).addBinding().to(CassandraSchemaChecker.class);
     }
 
     @Provides
@@ -288,6 +301,25 @@ public class CassandraSessionModule extends AbstractModule {
             PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
             propertiesConfiguration.addProperty(CASSANDRA_NODES, LOCALHOST);
             return propertiesConfiguration;
+        }
+    }
+
+    public static class CassandraSchemaChecker implements ConfigurationPerformer {
+        private final CassandraSchemaVersionManager versionManager;
+
+        @Inject
+        public CassandraSchemaChecker(CassandraSchemaVersionManager versionManager) {
+            this.versionManager = versionManager;
+        }
+
+        @Override
+        public void initModule() {
+            versionManager.ensureSchemaIsSupported();
+        }
+
+        @Override
+        public List<Class<? extends Configurable>> forClasses() {
+            return ImmutableList.of();
         }
     }
 }

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
@@ -41,6 +41,7 @@ import org.apache.james.backends.cassandra.init.SessionWithInitializedTablesFact
 import org.apache.james.backends.cassandra.utils.CassandraUtils;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionDAO;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager.SchemaState;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
 import org.apache.james.lifecycle.api.Configurable;
 import org.apache.james.mailbox.store.BatchSizes;
@@ -314,7 +315,28 @@ public class CassandraSessionModule extends AbstractModule {
 
         @Override
         public void initModule() {
-            versionManager.ensureSchemaIsSupported();
+            SchemaState schemaState = versionManager.computeSchemaState();
+            switch (schemaState) {
+                case TOO_OLD:
+                    throw new IllegalStateException(
+                        String.format("Current schema version is %d whereas minimum required version is %d. " +
+                            "Recommended version is %d", versionManager.computeVersion(), versionManager.getMinimumSupportedVersion(),
+                            versionManager.getMaximumSupportedVersion()));
+                case TOO_RECENT:
+                    throw new IllegalStateException(
+                        String.format("Current schema version is %d whereas the minimum supported version is %d. " +
+                            "Recommended version is %d.", versionManager.computeVersion(), versionManager.getMinimumSupportedVersion(),
+                            versionManager.getMaximumSupportedVersion()));
+                case UP_TO_DATE:
+                    LOGGER.info("Schema version is up-to-date");
+                    return;
+                case UPGRADABLE:
+                    LOGGER.warn("Current schema version is {}. Recommended version is {}", versionManager.computeVersion(),
+                        versionManager.getMaximumSupportedVersion());
+                    return;
+                default:
+                    throw new IllegalStateException("Unknown schema state " + schemaState);
+            }
         }
 
         @Override

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraVersionCheckingTest.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraVersionCheckingTest.java
@@ -1,0 +1,161 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import java.nio.charset.Charset;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionDAO;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class CassandraVersionCheckingTest {
+
+    private static final String LOCAL_HOST = "127.0.0.1";
+    private static final int IMAP_PORT = 1143;
+    private static final int MIN_VERSION = 2;
+    private static final int MAX_VERSION = 4;
+
+    @Rule
+    public CassandraJmapTestRule cassandraJmapTestRule = CassandraJmapTestRule.defaultTestRule();
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private GuiceJamesServer jamesServer;
+    private SocketChannel socketChannel;
+    private CassandraSchemaVersionDAO versionDAO;
+
+    @Before
+    public void setUp() throws IOException {
+        socketChannel = SocketChannel.open();
+        versionDAO = mock(CassandraSchemaVersionDAO.class);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        socketChannel.close();
+        if (jamesServer != null) {
+            jamesServer.stop();
+        }
+    }
+
+    @Test
+    public void serverShouldStartSuccessfullyWhenMaxVersion() throws Exception {
+        when(versionDAO.getCurrentSchemaVersion())
+            .thenReturn(CompletableFuture.completedFuture(Optional.of(MAX_VERSION)));
+
+        jamesServer = cassandraJmapTestRule.jmapServer(
+            binder -> binder.bind(CassandraSchemaVersionDAO.class)
+                .toInstance(versionDAO),
+            binder -> binder.bind(CassandraSchemaVersionManager.class)
+                .toInstance(new CassandraSchemaVersionManager(versionDAO, MIN_VERSION, MAX_VERSION)));
+
+        assertThatServerStartCorrectly();
+    }
+
+    @Test
+    public void serverShouldStartSuccessfullyWhenBetweenMinAndMaxVersion() throws Exception {
+        when(versionDAO.getCurrentSchemaVersion())
+            .thenReturn(CompletableFuture.completedFuture(Optional.of(MIN_VERSION + 1)));
+
+        jamesServer = cassandraJmapTestRule.jmapServer(
+            binder -> binder.bind(CassandraSchemaVersionDAO.class)
+                .toInstance(versionDAO),
+            binder -> binder.bind(CassandraSchemaVersionManager.class)
+                .toInstance(new CassandraSchemaVersionManager(versionDAO, MIN_VERSION, MAX_VERSION)));
+
+        assertThatServerStartCorrectly();
+    }
+
+    @Test
+    public void serverShouldStartSuccessfullyWhenMinVersion() throws Exception {
+        when(versionDAO.getCurrentSchemaVersion())
+            .thenReturn(CompletableFuture.completedFuture(Optional.of(MIN_VERSION)));
+
+        jamesServer = cassandraJmapTestRule.jmapServer(
+            binder -> binder.bind(CassandraSchemaVersionDAO.class)
+                .toInstance(versionDAO),
+            binder -> binder.bind(CassandraSchemaVersionManager.class)
+                .toInstance(new CassandraSchemaVersionManager(versionDAO, MIN_VERSION, MAX_VERSION)));
+
+        assertThatServerStartCorrectly();
+    }
+
+    @Test
+    public void serverShouldNotStartWhenUnderMinVersion() throws Exception {
+        when(versionDAO.getCurrentSchemaVersion())
+            .thenReturn(CompletableFuture.completedFuture(Optional.of(MIN_VERSION - 1)));
+
+        jamesServer = cassandraJmapTestRule.jmapServer(
+            binder -> binder.bind(CassandraSchemaVersionDAO.class)
+                .toInstance(versionDAO),
+            binder -> binder.bind(CassandraSchemaVersionManager.class)
+                .toInstance(new CassandraSchemaVersionManager(versionDAO, MIN_VERSION, MAX_VERSION)));
+
+        expectedException.expect(IllegalStateException.class);
+
+        jamesServer.start();
+    }
+
+    @Test
+    public void serverShouldNotStartWhenAboveMaxVersion() throws Exception {
+        when(versionDAO.getCurrentSchemaVersion())
+            .thenReturn(CompletableFuture.completedFuture(Optional.of(MAX_VERSION + 1)));
+
+        jamesServer = cassandraJmapTestRule.jmapServer(
+            binder -> binder.bind(CassandraSchemaVersionDAO.class)
+                .toInstance(versionDAO),
+            binder -> binder.bind(CassandraSchemaVersionManager.class)
+                .toInstance(new CassandraSchemaVersionManager(versionDAO, MIN_VERSION, MAX_VERSION)));
+
+        expectedException.expect(IllegalStateException.class);
+
+        jamesServer.start();
+    }
+
+    private void assertThatServerStartCorrectly() throws Exception {
+        jamesServer.start();
+        socketChannel.connect(new InetSocketAddress(LOCAL_HOST, IMAP_PORT));
+        assertThat(getServerConnectionResponse(socketChannel))
+            .startsWith("* OK JAMES IMAP4rev1 Server");
+    }
+
+    private String getServerConnectionResponse(SocketChannel socketChannel) throws IOException {
+        ByteBuffer byteBuffer = ByteBuffer.allocate(1000);
+        socketChannel.read(byteBuffer);
+        byte[] bytes = byteBuffer.array();
+
+        return new String(bytes, Charset.forName("UTF-8"));
+    }
+
+}

--- a/server/data/data-ldap-integration-testing/src/test/java/org/apache/james/user/ldap/LdapGenericContainer.java
+++ b/server/data/data-ldap-integration-testing/src/test/java/org/apache/james/user/ldap/LdapGenericContainer.java
@@ -20,6 +20,7 @@ package org.apache.james.user.ldap;
 
 import org.apache.james.util.streams.SwarmGenericContainer;
 import org.junit.rules.ExternalResource;
+import org.testcontainers.containers.wait.HostPortWaitStrategy;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import com.google.common.base.Preconditions;
@@ -65,7 +66,8 @@ public class LdapGenericContainer extends ExternalResource {
                 .withAffinityToContainer()
                 .withEnv("SLAPD_DOMAIN", domain)
                 .withEnv("SLAPD_PASSWORD", password)
-                .withEnv("SLAPD_CONFIG_PASSWORD", password);
+                .withEnv("SLAPD_CONFIG_PASSWORD", password)
+                .waitingFor(new HostPortWaitStrategy());
         }
     }
 


### PR DESCRIPTION
It miss some cleaning:
 - DAO should not replace Nothing by default value but let the manager doing that
 - when no schema version in cassandra a warn log should be displayed IMO

- it miss a integration test.