### PR TITLE
JAMES-2098 Some SetInMailboxes optimization on my free time

### DIFF
--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageIdManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageIdManager.java
@@ -177,7 +177,15 @@ public class StoreMessageIdManager implements MessageIdManager {
                 addMessageToMailboxes(messageIdMapper, mailboxMessage, mailboxesToAdd, mailboxSession);
             }
             if (!mailboxesToRemove.isEmpty()) {
-                delete(messageId, mailboxesToRemove, mailboxSession);
+                messageIdMapper.delete(messageId, mailboxesToRemove);
+
+                for (MailboxMessage message: mailboxMessages) {
+                    if (mailboxesToRemove.contains(message.getMailboxId())) {
+                        dispatcher.expunged(mailboxSession,
+                            new SimpleMessageMetaData(message),
+                            mailboxMapper.findMailboxById(message.getMailboxId()));
+                    }
+                }
             }
         }
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMessagesUpdateProcessor.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMessagesUpdateProcessor.java
@@ -117,8 +117,10 @@ public class SetMessagesUpdateProcessor implements SetMessagesProcessor {
 
     private Stream<MailboxException> updateFlags(MessageId messageId, UpdateMessagePatch updateMessagePatch, MailboxSession mailboxSession, MessageResult messageResult) {
         try {
-            Flags newState = updateMessagePatch.applyToState(messageResult.getFlags());
-            messageIdManager.setFlags(newState, MessageManager.FlagsUpdateMode.REPLACE, messageId, ImmutableList.of(messageResult.getMailboxId()), mailboxSession);
+            if (!updateMessagePatch.isFlagsIdentity()) {
+                Flags newState = updateMessagePatch.applyToState(messageResult.getFlags());
+                messageIdManager.setFlags(newState, MessageManager.FlagsUpdateMode.REPLACE, messageId, ImmutableList.of(messageResult.getMailboxId()), mailboxSession);
+            }
             return Stream.of();
         } catch (MailboxException e) {
             return Stream.of(e);

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/UpdateMessagePatch.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/UpdateMessagePatch.java
@@ -122,6 +122,12 @@ public class UpdateMessagePatch {
         return isAnswered;
     }
 
+    public boolean isFlagsIdentity() {
+        return !isAnswered.isPresent()
+            && !isFlagged.isPresent()
+            && !isUnread.isPresent();
+    }
+
     public ImmutableList<ValidationResult> getValidationErrors() {
         return validationErrors;
     }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/UpdateMessagePatchTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/UpdateMessagePatchTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.jmap.model;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
@@ -78,6 +77,40 @@ public class UpdateMessagePatchTest {
         Flags isSeen = new Flags(Flags.Flag.SEEN);
         List<Flags.Flag> updatedFlags = Arrays.asList(testee.applyToState(isSeen).getSystemFlags());
         assertThat(updatedFlags).containsExactly(Flags.Flag.SEEN);
+    }
+
+    @Test
+    public void isIdentityShouldReturnTrueWhenNoFlags() {
+        UpdateMessagePatch messagePatch = UpdateMessagePatch.builder().build();
+
+        assertThat(messagePatch.isFlagsIdentity()).isTrue();
+    }
+
+    @Test
+    public void isIdentityShouldReturnFalseWhenFlagsAnsweredUpdated() {
+        UpdateMessagePatch messagePatch = UpdateMessagePatch.builder()
+            .isAnswered(true)
+            .build();
+
+        assertThat(messagePatch.isFlagsIdentity()).isFalse();
+    }
+
+    @Test
+    public void isIdentityShouldReturnFalseWhenFlagsUnreadUpdated() {
+        UpdateMessagePatch messagePatch = UpdateMessagePatch.builder()
+            .isUnread(true)
+            .build();
+
+        assertThat(messagePatch.isFlagsIdentity()).isFalse();
+    }
+
+    @Test
+    public void isIdentityShouldReturnFalseWhenFlagsFlaggedUpdated() {
+        UpdateMessagePatch messagePatch = UpdateMessagePatch.builder()
+            .isFlagged(true)
+            .build();
+
+        assertThat(messagePatch.isFlagsIdentity()).isFalse();
     }
 
 }


### PR DESCRIPTION
Why is it needed?

![capture d ecran de 2017-07-25 09-02-31](https://user-images.githubusercontent.com/6928740/28552542-2b7924f0-7119-11e7-9955-f41bf6217957.png)

Issue details:

I was surprised to realise how SetInMailboxes operation is slow. See the attached screenshots for rationals. It was generated while sorting 2 weeks of email. Thus, I had an optimisation round on my free time. I found:

 -  That we can avoid a read in StoreMessageIdManager by avoiding calling delete (which comes at the cost of extra reads).
 -  We can avoid updating flags when none specified

The last point implies:

 -  Avoiding extra reads before updating flags
 -  Avoiding noop updates of search engine
 -  This noop updates is, in fact, a replace with current flags, which can compete with parallel flags updates. Thus, this optimisation also improve concurrent behaviours, by uncoupling SetFlags and SetInMailboxes

