### PR TITLE
JAMES-2103 Correcting quota management for StoreMessageManager

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/exception/OverQuotaException.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/exception/OverQuotaException.java
@@ -36,6 +36,8 @@ public class OverQuotaException extends MailboxException{
 
     public OverQuotaException(String msg, long max, long used) {
         super(msg);
+        this.used = used;
+        this.max = max;
     }
     public OverQuotaException(long max, long used) {
         this(null, max, used);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerQuotaTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerQuotaTest.java
@@ -1,0 +1,62 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra;
+
+import org.apache.james.mailbox.quota.CurrentQuotaManager;
+import org.apache.james.mailbox.quota.MaxQuotaManager;
+import org.apache.james.mailbox.quota.QuotaManager;
+import org.apache.james.mailbox.store.AbstractMessageIdManagerQuotaTest;
+import org.apache.james.mailbox.store.MessageIdManagerTestSystem;
+import org.apache.james.mailbox.store.quota.StoreQuotaManager;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+public class CassandraMessageIdManagerQuotaTest extends AbstractMessageIdManagerQuotaTest {
+
+    @BeforeClass
+    public static void init() {
+        CassandraMessageIdManagerTestSystem.initWithQuota();
+    }
+
+    @AfterClass
+    public static void close() {
+        CassandraMessageIdManagerTestSystem.stop();
+    }
+
+    @Override
+    protected MessageIdManagerTestSystem createTestSystem(QuotaManager quotaManager, CurrentQuotaManager currentQuotaManager) throws Exception {
+        return CassandraMessageIdManagerTestSystem.createTestingDataWithQuota(quotaManager, currentQuotaManager);
+    }
+
+    @Override
+    protected MaxQuotaManager createMaxQuotaManager() {
+        return CassandraTestSystemFixture.createMaxQuotaManager();
+    }
+
+    @Override
+    protected QuotaManager createQuotaManager(MaxQuotaManager maxQuotaManager, CurrentQuotaManager currentQuotaManager) {
+        return new StoreQuotaManager(currentQuotaManager, maxQuotaManager);
+    }
+
+    @Override
+    protected CurrentQuotaManager createCurrentQuotaManager() {
+        return CassandraTestSystemFixture.createCurrentQuotaManager();
+    }
+}

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/InMemoryMessageIdManagerTestSystem.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/InMemoryMessageIdManagerTestSystem.java
@@ -37,6 +37,7 @@ import org.apache.james.mailbox.store.MessageIdManagerTestSystem;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailbox;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
@@ -47,6 +48,7 @@ public class InMemoryMessageIdManagerTestSystem extends MessageIdManagerTestSyst
     private static final MessageId FIRST_MESSAGE_ID = InMemoryMessageId.of(1);
     private static final long ONE_HUNDRED = 100;
     private static final int UID_VALIDITY = 1024;
+    public static final byte[] CONTENT = "Subject: test\r\n\r\ntestmail".getBytes(Charsets.UTF_8);
 
     private final MailboxManager mailboxManager;
     private Optional<MessageId> lastMessageIdUsed;
@@ -68,7 +70,7 @@ public class InMemoryMessageIdManagerTestSystem extends MessageIdManagerTestSyst
     public MessageId persist(MailboxId mailboxId, MessageUid uid, Flags flags, MailboxSession session) {
         try {
             MessageManager messageManager = mailboxManager.getMailbox(mailboxId, session);
-            MessageId messageId = messageManager.appendMessage(new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes()), new Date(), session, false, flags)
+            MessageId messageId = messageManager.appendMessage(new ByteArrayInputStream(CONTENT), new Date(), session, false, flags)
                     .getMessageId();
             lastMessageIdUsed = Optional.of(messageId);
             return messageId;
@@ -112,4 +114,8 @@ public class InMemoryMessageIdManagerTestSystem extends MessageIdManagerTestSyst
 
     }
 
+    @Override
+    public int getConstantMessageSize() {
+        return CONTENT.length;
+    }
 }

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/manager/InMemoryIntegrationResources.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/manager/InMemoryIntegrationResources.java
@@ -76,8 +76,6 @@ public class InMemoryIntegrationResources implements IntegrationResources {
     
     @Override
     public QuotaManager createQuotaManager(MaxQuotaManager maxQuotaManager, MailboxManager mailboxManager) throws Exception {
-        StoreQuotaManager quotaManager = new StoreQuotaManager();
-        quotaManager.setCalculateWhenUnlimited(false);
 
         QuotaRootResolver quotaRootResolver =  createQuotaRootResolver(mailboxManager);
 
@@ -86,12 +84,9 @@ public class InMemoryIntegrationResources implements IntegrationResources {
             mailboxManager
         );
 
-        ListeningCurrentQuotaUpdater listeningCurrentQuotaUpdater = new ListeningCurrentQuotaUpdater();
-        listeningCurrentQuotaUpdater.setQuotaRootResolver(quotaRootResolver);
-        listeningCurrentQuotaUpdater.setCurrentQuotaManager(currentQuotaManager);
-
-        quotaManager.setCurrentQuotaManager(currentQuotaManager);
-        quotaManager.setMaxQuotaManager(maxQuotaManager);
+        ListeningCurrentQuotaUpdater listeningCurrentQuotaUpdater = new ListeningCurrentQuotaUpdater(currentQuotaManager, quotaRootResolver);
+        StoreQuotaManager quotaManager = new StoreQuotaManager(currentQuotaManager, maxQuotaManager);
+        quotaManager.setCalculateWhenUnlimited(false);
         ((StoreMailboxManager) mailboxManager).setQuotaManager(quotaManager);
         mailboxManager.addGlobalListener(listeningCurrentQuotaUpdater, null);
         return quotaManager;

--- a/mailbox/spring/src/main/resources/META-INF/spring/quota.xml
+++ b/mailbox/spring/src/main/resources/META-INF/spring/quota.xml
@@ -45,14 +45,14 @@
 
     <bean id="noQuotaManager" class="org.apache.james.mailbox.store.quota.NoQuotaManager" lazy-init="true"/>
     <bean id="storeQuotaManager" class="org.apache.james.mailbox.store.quota.StoreQuotaManager" lazy-init="true">
-        <property name="maxQuotaManager" ref="maxQuotaManager"/>
-        <property name="currentQuotaManager" ref="currentQuotaManager"/>
+        <constructor-arg index="0" ref="maxQuotaManager"/>
+        <constructor-arg index="1" ref="quotaRootResolver"/>
     </bean>
 
     <bean id="noQuotaUpdater" class="org.apache.james.mailbox.store.quota.NoQuotaUpdater" lazy-init="true"/>
     <bean id="eventQuotaUpdater" class="org.apache.james.mailbox.store.quota.ListeningCurrentQuotaUpdater" lazy-init="true">
-        <property name="quotaRootResolver" ref="quotaRootResolver"/>
-        <property name="currentQuotaManager" ref="currentQuotaManager"/>
+        <constructor-arg index="0" ref="quotaRootResolver"/>
+        <constructor-arg index="1" ref="currentQuotaManager"/>
     </bean>
 
 </beans>

--- a/mailbox/spring/src/main/resources/META-INF/spring/quota.xml
+++ b/mailbox/spring/src/main/resources/META-INF/spring/quota.xml
@@ -45,14 +45,14 @@
 
     <bean id="noQuotaManager" class="org.apache.james.mailbox.store.quota.NoQuotaManager" lazy-init="true"/>
     <bean id="storeQuotaManager" class="org.apache.james.mailbox.store.quota.StoreQuotaManager" lazy-init="true">
-        <constructor-arg index="0" ref="maxQuotaManager"/>
-        <constructor-arg index="1" ref="quotaRootResolver"/>
+        <constructor-arg index="0" ref="currentQuotaManager"/>
+        <constructor-arg index="1" ref="maxQuotaManager"/>
     </bean>
 
     <bean id="noQuotaUpdater" class="org.apache.james.mailbox.store.quota.NoQuotaUpdater" lazy-init="true"/>
     <bean id="eventQuotaUpdater" class="org.apache.james.mailbox.store.quota.ListeningCurrentQuotaUpdater" lazy-init="true">
-        <constructor-arg index="0" ref="quotaRootResolver"/>
-        <constructor-arg index="1" ref="currentQuotaManager"/>
+        <constructor-arg index="0" ref="currentQuotaManager"/>
+        <constructor-arg index="1" ref="quotaRootResolver"/>
     </bean>
 
 </beans>

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageIdManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageIdManager.java
@@ -208,7 +208,7 @@ public class StoreMessageIdManager implements MessageIdManager {
         for (Map.Entry<QuotaRoot, Integer> entry : messageCountByQuotaRoot.entrySet()) {
             if (entry.getValue() > 0) {
                 new QuotaChecker(quotaManager.getMessageQuota(entry.getKey()), quotaManager.getStorageQuota(entry.getKey()), entry.getKey())
-                    .tryAddition(entry.getValue(), mailboxMessage.getFullContentOctets());
+                    .tryAddition(entry.getValue(), entry.getValue() * mailboxMessage.getFullContentOctets());
             }
         }
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageIdManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageIdManager.java
@@ -207,8 +207,9 @@ public class StoreMessageIdManager implements MessageIdManager {
         Map<QuotaRoot, Integer> messageCountByQuotaRoot = buildMapQuotaRoot(mailboxIdsToBeAdded, mailboxIdsToBeRemove, mailboxMapper);
         for (Map.Entry<QuotaRoot, Integer> entry : messageCountByQuotaRoot.entrySet()) {
             if (entry.getValue() > 0) {
+                long additionalOccupiedSpace = entry.getValue() * mailboxMessage.getFullContentOctets();
                 new QuotaChecker(quotaManager.getMessageQuota(entry.getKey()), quotaManager.getStorageQuota(entry.getKey()), entry.getKey())
-                    .tryAddition(entry.getValue(), entry.getValue() * mailboxMessage.getFullContentOctets());
+                    .tryAddition(entry.getValue(), additionalOccupiedSpace);
             }
         }
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageIdManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageIdManager.java
@@ -206,10 +206,11 @@ public class StoreMessageIdManager implements MessageIdManager {
 
         Map<QuotaRoot, Integer> messageCountByQuotaRoot = buildMapQuotaRoot(mailboxIdsToBeAdded, mailboxIdsToBeRemove, mailboxMapper);
         for (Map.Entry<QuotaRoot, Integer> entry : messageCountByQuotaRoot.entrySet()) {
-            if (entry.getValue() > 0) {
-                long additionalOccupiedSpace = entry.getValue() * mailboxMessage.getFullContentOctets();
+            Integer additionalCopyCount = entry.getValue();
+            if (additionalCopyCount > 0) {
+                long additionalOccupiedSpace = additionalCopyCount * mailboxMessage.getFullContentOctets();
                 new QuotaChecker(quotaManager.getMessageQuota(entry.getKey()), quotaManager.getStorageQuota(entry.getKey()), entry.getKey())
-                    .tryAddition(entry.getValue(), additionalOccupiedSpace);
+                    .tryAddition(additionalCopyCount, additionalOccupiedSpace);
             }
         }
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/ListeningCurrentQuotaUpdater.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/ListeningCurrentQuotaUpdater.java
@@ -30,17 +30,13 @@ import javax.inject.Inject;
 
 public class ListeningCurrentQuotaUpdater implements MailboxListener, QuotaUpdater {
 
-    private StoreCurrentQuotaManager currentQuotaManager;
-    private QuotaRootResolver quotaRootResolver;
+    private final StoreCurrentQuotaManager currentQuotaManager;
+    private final QuotaRootResolver quotaRootResolver;
 
     @Inject
-    public void setQuotaRootResolver(QuotaRootResolver quotaRootResolver) {
-        this.quotaRootResolver = quotaRootResolver;
-    }
-
-    @Inject
-    public void setCurrentQuotaManager(StoreCurrentQuotaManager currentQuotaManager) {
+    public ListeningCurrentQuotaUpdater(StoreCurrentQuotaManager currentQuotaManager, QuotaRootResolver quotaRootResolver) {
         this.currentQuotaManager = currentQuotaManager;
+        this.quotaRootResolver = quotaRootResolver;
     }
 
     @Override

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/StoreQuotaManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/StoreQuotaManager.java
@@ -34,22 +34,18 @@ import javax.inject.Inject;
  * Relies on the CurrentQuotaManager and MaxQuotaManager provided.
  */
 public class StoreQuotaManager implements QuotaManager {
-    private CurrentQuotaManager currentQuotaManager;
-    private MaxQuotaManager maxQuotaManager;
+    private final CurrentQuotaManager currentQuotaManager;
+    private final MaxQuotaManager maxQuotaManager;
     private boolean calculateWhenUnlimited = false;
 
-    public void setCalculateWhenUnlimited(boolean calculateWhenUnlimited) {
-        this.calculateWhenUnlimited = calculateWhenUnlimited;
-    }
-
     @Inject
-    public void setMaxQuotaManager(MaxQuotaManager maxQuotaManager) {
+    public StoreQuotaManager(CurrentQuotaManager currentQuotaManager, MaxQuotaManager maxQuotaManager) {
+        this.currentQuotaManager = currentQuotaManager;
         this.maxQuotaManager = maxQuotaManager;
     }
 
-    @Inject
-    public void setCurrentQuotaManager(CurrentQuotaManager currentQuotaManager) {
-        this.currentQuotaManager = currentQuotaManager;
+    public void setCalculateWhenUnlimited(boolean calculateWhenUnlimited) {
+        this.calculateWhenUnlimited = calculateWhenUnlimited;
     }
 
     public Quota getMessageQuota(QuotaRoot quotaRoot) throws MailboxException {

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerQuotaTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerQuotaTest.java
@@ -27,7 +27,6 @@ import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.OverQuotaException;
 import org.apache.james.mailbox.manager.MailboxManagerFixture;
 import org.apache.james.mailbox.mock.MockMailboxSession;
-import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.quota.CurrentQuotaManager;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
@@ -35,7 +34,6 @@ import org.apache.james.mailbox.quota.QuotaManager;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -113,7 +111,6 @@ public abstract class AbstractMessageIdManagerQuotaTest {
         messageIdManager.setInMailboxes(messageId, ImmutableList.of(mailbox1.getMailboxId(), mailbox2.getMailboxId()), session);
     }
 
-    @Ignore
     @Test
     public void setInMailboxesShouldThrowWhenStorageQuotaExceededWhenCopiedToMultipleMailboxes() throws Exception {
         maxQuotaManager.setDefaultMaxStorage(2 * testingData.getConstantMessageSize());

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerQuotaTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerQuotaTest.java
@@ -1,0 +1,137 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.store;
+
+import javax.mail.Flags;
+
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageIdManager;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.exception.OverQuotaException;
+import org.apache.james.mailbox.manager.MailboxManagerFixture;
+import org.apache.james.mailbox.mock.MockMailboxSession;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.quota.CurrentQuotaManager;
+import org.apache.james.mailbox.quota.MaxQuotaManager;
+import org.apache.james.mailbox.quota.QuotaManager;
+import org.apache.james.mailbox.store.mail.model.Mailbox;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.google.common.collect.ImmutableList;
+
+public abstract class AbstractMessageIdManagerQuotaTest {
+    private static final MessageUid messageUid1 = MessageUid.of(111);
+
+    public static final Flags FLAGS = new Flags();
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private MessageIdManager messageIdManager;
+    private MailboxSession session;
+    private Mailbox mailbox1;
+    private Mailbox mailbox2;
+    private Mailbox mailbox3;
+    private MessageIdManagerTestSystem testingData;
+    private MaxQuotaManager maxQuotaManager;
+
+    protected abstract MessageIdManagerTestSystem createTestSystem(QuotaManager quotaManager, CurrentQuotaManager currentQuotaManager) throws Exception;
+
+    protected abstract MaxQuotaManager createMaxQuotaManager();
+    protected abstract CurrentQuotaManager createCurrentQuotaManager();
+    protected abstract QuotaManager createQuotaManager(MaxQuotaManager maxQuotaManager, CurrentQuotaManager currentQuotaManager);
+
+    @Before
+    public void setUp() throws Exception {
+        maxQuotaManager = createMaxQuotaManager();
+        CurrentQuotaManager currentQuotaManager = createCurrentQuotaManager();
+        QuotaManager quotaManager = createQuotaManager(maxQuotaManager, currentQuotaManager);
+
+        session = new MockMailboxSession("user");
+        testingData = createTestSystem(quotaManager, currentQuotaManager);
+        messageIdManager = testingData.getMessageIdManager();
+
+        mailbox1 = testingData.createMailbox(MailboxManagerFixture.MAILBOX_PATH1, session);
+        mailbox2 = testingData.createMailbox(MailboxManagerFixture.MAILBOX_PATH2, session);
+        mailbox3 = testingData.createMailbox(MailboxManagerFixture.MAILBOX_PATH3, session);
+    }
+
+    @After
+    public void tearDown() {
+        testingData.clean();
+    }
+
+    @Test
+    public void setInMailboxesShouldNotThrowWhenMessageQuotaNotExceeded() throws Exception {
+        maxQuotaManager.setDefaultMaxMessage(1);
+
+        MessageId messageId = testingData.persist(mailbox2.getMailboxId(), messageUid1, FLAGS, session);
+
+        messageIdManager.setInMailboxes(messageId, ImmutableList.of(mailbox1.getMailboxId()), session);
+    }
+
+    @Test
+    public void setInMailboxesShouldNotThrowWhenStorageQuotaNotExceeded() throws Exception {
+        maxQuotaManager.setDefaultMaxStorage(testingData.getConstantMessageSize());
+
+        MessageId messageId = testingData.persist(mailbox2.getMailboxId(), messageUid1, FLAGS, session);
+
+        messageIdManager.setInMailboxes(messageId, ImmutableList.of(mailbox1.getMailboxId()), session);
+    }
+
+    @Test
+    public void setInMailboxesShouldThrowWhenStorageQuotaExceeded() throws Exception {
+        maxQuotaManager.setDefaultMaxStorage(2 * testingData.getConstantMessageSize());
+
+        testingData.persist(mailbox1.getMailboxId(), messageUid1, FLAGS, session);
+        MessageId messageId = testingData.persist(mailbox2.getMailboxId(), messageUid1, FLAGS, session);
+
+        expectedException.expect(OverQuotaException.class);
+        messageIdManager.setInMailboxes(messageId, ImmutableList.of(mailbox1.getMailboxId(), mailbox2.getMailboxId()), session);
+    }
+
+    @Ignore
+    @Test
+    public void setInMailboxesShouldThrowWhenStorageQuotaExceededWhenCopiedToMultipleMailboxes() throws Exception {
+        maxQuotaManager.setDefaultMaxStorage(2 * testingData.getConstantMessageSize());
+
+        MessageId messageId = testingData.persist(mailbox1.getMailboxId(), messageUid1, FLAGS, session);
+
+        expectedException.expect(OverQuotaException.class);
+        messageIdManager.setInMailboxes(messageId, ImmutableList.of(mailbox1.getMailboxId(), mailbox2.getMailboxId(), mailbox3.getMailboxId()), session);
+    }
+
+    @Test
+    public void setInMailboxesShouldThrowWhenStorageMessageExceeded() throws Exception {
+        maxQuotaManager.setDefaultMaxMessage(2);
+
+        testingData.persist(mailbox1.getMailboxId(), messageUid1, FLAGS, session);
+        MessageId messageId = testingData.persist(mailbox2.getMailboxId(), messageUid1, FLAGS, session);
+
+        expectedException.expect(OverQuotaException.class);
+        messageIdManager.setInMailboxes(messageId, ImmutableList.of(mailbox1.getMailboxId(), mailbox2.getMailboxId(), mailbox3.getMailboxId()), session);
+    }
+}

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/MessageIdManagerTestSystem.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/MessageIdManagerTestSystem.java
@@ -61,4 +61,6 @@ public abstract class MessageIdManagerTestSystem {
     public abstract void deleteMailbox(MailboxId mailboxId, MailboxSession session);
 
     public abstract void clean();
+
+    public abstract int getConstantMessageSize();
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMessageIdManagerTestSystem.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMessageIdManagerTestSystem.java
@@ -104,4 +104,9 @@ public class StoreMessageIdManagerTestSystem extends MessageIdManagerTestSystem 
         when(mailboxMessage.createFlags()).thenReturn(flags);
         return mailboxMessage;
     }
+
+    @Override
+    public int getConstantMessageSize() {
+        throw new NotImplementedException();
+    }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/quota/ListeningCurrentQuotaUpdaterTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/quota/ListeningCurrentQuotaUpdaterTest.java
@@ -54,9 +54,7 @@ public class ListeningCurrentQuotaUpdaterTest {
     public void setUp() throws Exception {
         mockedQuotaRootResolver = mock(QuotaRootResolver.class);
         mockedCurrentQuotaManager = mock(StoreCurrentQuotaManager.class);
-        testee = new ListeningCurrentQuotaUpdater();
-        testee.setCurrentQuotaManager(mockedCurrentQuotaManager);
-        testee.setQuotaRootResolver(mockedQuotaRootResolver);
+        testee = new ListeningCurrentQuotaUpdater(mockedCurrentQuotaManager, mockedQuotaRootResolver);
     }
 
     @Test

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/quota/StoreQuotaManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/quota/StoreQuotaManagerTest.java
@@ -46,9 +46,7 @@ public class StoreQuotaManagerTest {
     public void setUp() {
         mockedCurrentQuotaManager = mock(CurrentQuotaManager.class);
         mockedMaxQuotaManager = mock(MaxQuotaManager.class);
-        testee = new StoreQuotaManager();
-        testee.setCurrentQuotaManager(mockedCurrentQuotaManager);
-        testee.setMaxQuotaManager(mockedMaxQuotaManager);
+        testee = new StoreQuotaManager(mockedCurrentQuotaManager, mockedMaxQuotaManager);
         quotaRoot = QuotaRootImpl.quotaRoot("benwa");
     }
 

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
@@ -146,13 +146,9 @@ public class CassandraHostSystem extends JamesImapHostSystem {
 
         CassandraCurrentQuotaManager currentQuotaManager = new CassandraCurrentQuotaManager(session);
 
-        StoreQuotaManager quotaManager = new StoreQuotaManager();
-        quotaManager.setMaxQuotaManager(perUserMaxQuotaManager);
-        quotaManager.setCurrentQuotaManager(currentQuotaManager);
+        StoreQuotaManager quotaManager = new StoreQuotaManager(currentQuotaManager, perUserMaxQuotaManager);
 
-        ListeningCurrentQuotaUpdater quotaUpdater = new ListeningCurrentQuotaUpdater();
-        quotaUpdater.setCurrentQuotaManager(currentQuotaManager);
-        quotaUpdater.setQuotaRootResolver(quotaRootResolver);
+        ListeningCurrentQuotaUpdater quotaUpdater = new ListeningCurrentQuotaUpdater(currentQuotaManager, quotaRootResolver);
 
         mailboxManager.setQuotaRootResolver(quotaRootResolver);
         mailboxManager.setQuotaManager(quotaManager);

--- a/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/host/InMemoryHostSystem.java
+++ b/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/host/InMemoryHostSystem.java
@@ -88,13 +88,9 @@ public class InMemoryHostSystem extends JamesImapHostSystem {
             new CurrentQuotaCalculator(mailboxManager.getMapperFactory(), quotaRootResolver),
             mailboxManager);
 
-        StoreQuotaManager quotaManager = new StoreQuotaManager();
-        quotaManager.setMaxQuotaManager(perUserMaxQuotaManager);
-        quotaManager.setCurrentQuotaManager(currentQuotaManager);
+        StoreQuotaManager quotaManager = new StoreQuotaManager(currentQuotaManager, perUserMaxQuotaManager);
 
-        ListeningCurrentQuotaUpdater quotaUpdater = new ListeningCurrentQuotaUpdater();
-        quotaUpdater.setCurrentQuotaManager(currentQuotaManager);
-        quotaUpdater.setQuotaRootResolver(quotaRootResolver);
+        ListeningCurrentQuotaUpdater quotaUpdater = new ListeningCurrentQuotaUpdater(currentQuotaManager, quotaRootResolver);
 
         mailboxManager.setQuotaRootResolver(quotaRootResolver);
         mailboxManager.setQuotaManager(quotaManager);

--- a/mpt/impl/imap-mailbox/jpa/src/test/java/org/apache/james/mpt/imapmailbox/jpa/host/JPAHostSystem.java
+++ b/mpt/impl/imap-mailbox/jpa/src/test/java/org/apache/james/mpt/imapmailbox/jpa/host/JPAHostSystem.java
@@ -98,12 +98,8 @@ public class JPAHostSystem extends JamesImapHostSystem {
         DefaultQuotaRootResolver quotaRootResolver = new DefaultQuotaRootResolver(mapperFactory);
         JpaCurrentQuotaManager currentQuotaManager = new JpaCurrentQuotaManager(entityManagerFactory);
         maxQuotaManager = new JPAPerUserMaxQuotaManager(entityManagerFactory);
-        StoreQuotaManager storeQuotaManager = new StoreQuotaManager();
-        storeQuotaManager.setCurrentQuotaManager(currentQuotaManager);
-        storeQuotaManager.setMaxQuotaManager(maxQuotaManager);
-        ListeningCurrentQuotaUpdater quotaUpdater = new ListeningCurrentQuotaUpdater();
-        quotaUpdater.setCurrentQuotaManager(currentQuotaManager);
-        quotaUpdater.setQuotaRootResolver(quotaRootResolver);
+        StoreQuotaManager storeQuotaManager = new StoreQuotaManager(currentQuotaManager, maxQuotaManager);
+        ListeningCurrentQuotaUpdater quotaUpdater = new ListeningCurrentQuotaUpdater(currentQuotaManager, quotaRootResolver);
 
         mailboxManager.setQuotaManager(storeQuotaManager);
         mailboxManager.setQuotaUpdater(quotaUpdater);

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/matchers/IsOverQuotaTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/matchers/IsOverQuotaTest.java
@@ -68,10 +68,9 @@ public class IsOverQuotaTest {
             new InMemoryMessageId.Factory());
 
         quotaRootResolver = new DefaultQuotaRootResolver(factory);
-        StoreQuotaManager quotaManager = new StoreQuotaManager();
         maxQuotaManager = new InMemoryPerUserMaxQuotaManager();
-        quotaManager.setMaxQuotaManager(maxQuotaManager);
-        quotaManager.setCurrentQuotaManager(new InMemoryCurrentQuotaManager(new CurrentQuotaCalculator(factory, quotaRootResolver), mailboxManager));
+        InMemoryCurrentQuotaManager currentQuotaManager = new InMemoryCurrentQuotaManager(new CurrentQuotaCalculator(factory, quotaRootResolver), mailboxManager);
+        StoreQuotaManager quotaManager = new StoreQuotaManager(currentQuotaManager, maxQuotaManager);
         usersRepository = mock(UsersRepository.class);
         testee = new IsOverQuota(quotaRootResolver, quotaManager, mailboxManager, usersRepository);
 


### PR DESCRIPTION
Description of vulnerability: Allow a user to potentially exceed his space quota

Details: During the copy, a multiplicative constant (the number of mailboxes the message is copied to) was forgotten, which leads to minimizing the space used by the user. It can be exploited to reduce the computed value of current quota space, and thus exceed one's quota space.

The two first commits are cleanups.

Then I show and solve the above problem in a TDD fashion.

Please note I needed a new test class as MessageIdManager was never tested with a real quota system.