### PR TITLE
JAMES-2048 We should not reject blank CID already stored

### DIFF
--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/CidTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/CidTest.java
@@ -20,24 +20,26 @@
 package org.apache.james.mailbox.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.guava.api.Assertions.assertThat;
 
-import org.apache.james.mailbox.model.Cid;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import com.google.common.base.Optional;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class CidTest {
 
     @Rule public ExpectedException expectedException = ExpectedException.none();
-    
+
     @Test
     public void fromShouldThrowWhenNull() {
         expectedException.expect(IllegalArgumentException.class);
         Cid.from(null);
     }
-    
+
     @Test
     public void fromShouldThrowWhenEmpty() {
         expectedException.expect(IllegalArgumentException.class);
@@ -67,23 +69,259 @@ public class CidTest {
         Cid cid = Cid.from("<123>");
         assertThat(cid.getValue()).isEqualTo("123");
     }
-    
+
     @Test
     public void fromShouldNotRemoveTagsWhenNone() {
         Cid cid = Cid.from("123");
         assertThat(cid.getValue()).isEqualTo("123");
     }
-    
+
     @Test
     public void fromShouldNotRemoveTagsWhenNotEndTag() {
         Cid cid = Cid.from("<123");
         assertThat(cid.getValue()).isEqualTo("<123");
     }
-    
+
     @Test
     public void fromShouldNotRemoveTagsWhenNotStartTag() {
         Cid cid = Cid.from("123>");
         assertThat(cid.getValue()).isEqualTo("123>");
+    }
+
+    @Test
+    public void fromRelaxedNoUnwrapShouldReturnAbsentWhenNull() {
+        assertThat(Cid.parser()
+            .relaxed()
+            .parse(null))
+            .isAbsent();
+    }
+
+    @Test
+    public void fromRelaxedNoUnwrapShouldReturnAbsentWhenEmpty() {
+        assertThat(Cid.parser()
+            .relaxed()
+            .parse(""))
+            .isAbsent();
+    }
+
+    @Test
+    public void fromRelaxedNoUnwrapShouldReturnAbsentWhenBlank() {
+        assertThat(Cid.parser()
+            .relaxed()
+            .parse("     "))
+            .isAbsent();
+    }
+
+    @Test
+    public void fromRelaxedNoUnwrapShouldReturnCidWhenEmptyAfterRemoveTags() {
+        Optional<Cid> actual = Cid.parser()
+            .relaxed()
+            .parse("<>");
+        assertThat(actual).isPresent();
+        assertThat(actual.get().getValue()).isEqualTo("<>");
+    }
+
+    @Test
+    public void fromRelaxedNoUnwrapShouldReturnCidWhenBlankAfterRemoveTags() {
+        Optional<Cid> actual = Cid.parser()
+            .relaxed()
+            .parse("<   >");
+        assertThat(actual).isPresent();
+        assertThat(actual.get().getValue()).isEqualTo("<   >");
+    }
+
+    @Test
+    public void fromRelaxedNoUnwrapShouldNotRemoveTagsWhenExists() {
+        Optional<Cid> actual = Cid.parser()
+            .relaxed()
+            .parse("<123>");
+        assertThat(actual).isPresent();
+        assertThat(actual.get().getValue()).isEqualTo("<123>");
+    }
+
+    @Test
+    public void fromRelaxedNoUnwrapShouldNotRemoveTagsWhenNone() {
+        assertThat(Cid.parser()
+            .relaxed()
+            .parse("123"))
+            .contains(Cid.from("123"));
+    }
+
+    @Test
+    public void fromRelaxedNoUnwrapShouldNotRemoveTagsWhenNotEndTag() {
+        assertThat(Cid.parser()
+            .relaxed()
+            .parse("<123"))
+            .contains(Cid.from("<123"));
+    }
+
+    @Test
+    public void fromRelaxedNoUnwrapShouldNotRemoveTagsWhenNotStartTag() {
+        assertThat(Cid.parser()
+            .relaxed()
+            .parse("123>"))
+            .contains(Cid.from("123>"));
+    }
+
+
+    @Test
+    public void fromRelaxedUnwrapShouldReturnAbsentWhenNull() {
+        assertThat(Cid.parser()
+            .relaxed()
+            .unwrap()
+            .parse(null))
+            .isAbsent();
+    }
+
+    @Test
+    public void fromRelaxedUnwrapShouldReturnAbsentWhenEmpty() {
+        assertThat(Cid.parser()
+            .relaxed()
+            .unwrap()
+            .parse(""))
+            .isAbsent();
+    }
+
+    @Test
+    public void fromRelaxedUnwrapShouldReturnAbsentWhenBlank() {
+        assertThat(Cid.parser()
+            .relaxed()
+            .unwrap()
+            .parse("     "))
+            .isAbsent();
+    }
+
+    @Test
+    public void fromRelaxedUnwrapShouldReturnAbsentWhenEmptyAfterRemoveTags() {
+        assertThat(Cid.parser()
+            .relaxed()
+            .unwrap()
+            .parse("<>"))
+            .isAbsent();
+    }
+
+    @Test
+    public void fromRelaxedUnwrapShouldReturnAbsentWhenBlankAfterRemoveTags() {
+        assertThat(Cid.parser()
+            .relaxed()
+            .unwrap()
+            .parse("<   >"))
+            .isAbsent();
+    }
+
+    @Test
+    public void fromRelaxedUnwrapShouldRemoveTagsWhenExists() {
+        Optional<Cid> actual = Cid.parser()
+            .relaxed()
+            .unwrap()
+            .parse("<123>");
+        assertThat(actual).isPresent();
+        assertThat(actual.get().getValue()).isEqualTo("123");
+    }
+
+    @Test
+    public void fromRelaxedUnwrapShouldNotRemoveTagsWhenNone() {
+        assertThat(Cid.parser()
+            .relaxed()
+            .unwrap()
+            .parse("123"))
+            .contains(Cid.from("123"));
+    }
+
+    @Test
+    public void fromRelaxedUnwrapShouldNotRemoveTagsWhenNotEndTag() {
+        assertThat(Cid.parser()
+            .relaxed()
+            .unwrap()
+            .parse("<123"))
+            .contains(Cid.from("<123"));
+    }
+
+    @Test
+    public void fromRelaxedUnwrapShouldNotRemoveTagsWhenNotStartTag() {
+        assertThat(Cid.parser()
+            .relaxed()
+            .unwrap()
+            .parse("123>"))
+            .contains(Cid.from("123>"));
+    }
+
+    @Test
+    public void fromStrictNoUnwrapShouldThrowWhenNull() {
+        expectedException.expect(IllegalArgumentException.class);
+
+        Cid.parser()
+            .strict()
+            .parse(null);
+    }
+
+    @Test
+    public void fromStrictNoUnwrapShouldThrowWhenEmpty() {
+        expectedException.expect(IllegalArgumentException.class);
+
+        Cid.parser()
+            .strict()
+            .parse("");
+    }
+
+    @Test
+    public void fromStrinctNoUnwrapShouldThrowWhenBlank() {
+        expectedException.expect(IllegalArgumentException.class);
+
+        Cid.parser()
+            .strict()
+            .parse("   ");
+    }
+
+    @Test
+    public void fromStrictNoUnwrapShouldNotRemoveTagWhenEmptyAfterRemoveTags() {
+        Optional<Cid> actual = Cid.parser()
+            .strict()
+            .parse("<>");
+        assertThat(actual).isPresent();
+        assertThat(actual.get().getValue()).isEqualTo("<>");
+    }
+
+    @Test
+    public void fromStrictNoUnwrapShouldNotRemoveTagWhenBlankAfterRemoveTags() {
+        Optional<Cid> actual = Cid.parser()
+            .strict()
+            .parse("<   >");
+        assertThat(actual).isPresent();
+        assertThat(actual.get().getValue()).isEqualTo("<   >");
+    }
+
+    @Test
+    public void fromStrictNoUnwrapShouldNotRemoveTagsWhenExists() {
+        Optional<Cid> actual = Cid.parser()
+            .strict()
+            .parse("<123>");
+        assertThat(actual).isPresent();
+        assertThat(actual.get().getValue()).isEqualTo("<123>");
+    }
+
+    @Test
+    public void fromStrictNoUnwrapShouldNotRemoveTagsWhenNone() {
+        assertThat(Cid.parser()
+            .strict()
+            .parse("123"))
+            .contains(Cid.from("123"));
+    }
+
+    @Test
+    public void fromStrictNoUnwrapShouldNotRemoveTagsWhenNotEndTag() {
+        assertThat(Cid.parser()
+            .strict()
+            .parse("<123"))
+            .contains(Cid.from("<123"));
+    }
+
+    @Test
+    public void fromStrictNoUnwrapShouldNotRemoveTagsWhenNotStartTag() {
+        assertThat(Cid.parser()
+            .strict()
+            .parse("123>"))
+            .contains(Cid.from("123>"));
     }
 
     @Test


### PR DESCRIPTION
Encountered during migration, especially on the old messages, before JAMES-2048 was out to solve the issue.