### PR TITLE
MAILBOX-304 Store attachment payload as BlobId

### DIFF
--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandraRule.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandraRule.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.backends.cassandra;
 
+import java.util.UUID;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -80,6 +82,8 @@ public class DockerCassandraRule implements TestRule {
                         .run("echo \"JVM_OPTS=\\\"\\$JVM_OPTS -Dcassandra.skip_wait_for_gossip_to_settle=0\\\"\" >> " + CASSANDRA_ENV)
                         //make sure commit log disk flush won't happen
                         .run("sed -i -e \"s/commitlog_sync_period_in_ms: 10000/commitlog_sync_period_in_ms: 9999999/\" " + CASSANDRA_YAML)
+                        //Cassandra nodes should not cluster together
+                        .run("sed -i -e \"s/cluster_name: 'Test Cluster'/cluster_name: 'Test Cluster " + UUID.randomUUID() + "'/\" " + CASSANDRA_YAML)
                         //auto_bootstrap should be useless when no existing data
                         .run("echo auto_bootstrap: false >> " + CASSANDRA_YAML)
                         .run("echo \"-Xms1500M\" >> " + JVM_OPTIONS)

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/AttachmentId.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/AttachmentId.java
@@ -19,6 +19,9 @@
 package org.apache.james.mailbox.model;
 
 
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
 import org.apache.commons.codec.digest.DigestUtils;
 
 import com.google.common.base.MoreObjects;
@@ -46,6 +49,10 @@ public class AttachmentId {
 
     public String getId() {
         return id;
+    }
+
+    public UUID asUUID() {
+        return UUID.nameUUIDFromBytes(id.getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/AttachmentIdTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/AttachmentIdTest.java
@@ -21,7 +21,8 @@ package org.apache.james.mailbox.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.james.mailbox.model.AttachmentId;
+import java.util.UUID;
+
 import org.junit.Test;
 
 public class AttachmentIdTest {
@@ -53,5 +54,13 @@ public class AttachmentIdTest {
         String expectedId = "f07e5a815613c5abeddc4b682247a4c42d8a95df";
         AttachmentId attachmentId = AttachmentId.from(expectedId);
         assertThat(attachmentId.getId()).isEqualTo(expectedId);
+    }
+
+    @Test
+    public void asUUIDShouldReturnAValidUUID() {
+        AttachmentId attachmentId = AttachmentId.from("magic");
+
+        assertThat(attachmentId.asUUID())
+            .isEqualTo(UUID.fromString("2f3a4fcc-ca64-36e3-9bcf-33e92dd93135"));
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
@@ -29,6 +29,7 @@ import org.apache.james.mailbox.cassandra.mail.CassandraApplicableFlagDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentMapper;
+import org.apache.james.mailbox.cassandra.mail.CassandraBlobsDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraDeletedMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraFirstUnseenDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraIndexTableHandler;
@@ -76,9 +77,10 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
     private final CassandraApplicableFlagDAO applicableFlagDAO;
     private final CassandraAttachmentDAO attachmentDAO;
     private final CassandraAttachmentDAOV2 attachmentDAOV2;
+    private final CassandraDeletedMessageDAO deletedMessageDAO;
+    private final CassandraBlobsDAO blobsDAO;
     private CassandraUtils cassandraUtils;
     private CassandraConfiguration cassandraConfiguration;
-    private final CassandraDeletedMessageDAO deletedMessageDAO;
 
     @Inject
     public CassandraMailboxSessionMapperFactory(CassandraUidProvider uidProvider, CassandraModSeqProvider modSeqProvider, Session session,
@@ -86,8 +88,8 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
                                                 CassandraMessageIdDAO messageIdDAO, CassandraMessageIdToImapUidDAO imapUidDAO,
                                                 CassandraMailboxCounterDAO mailboxCounterDAO, CassandraMailboxRecentsDAO mailboxRecentsDAO, CassandraMailboxDAO mailboxDAO,
                                                 CassandraMailboxPathDAO mailboxPathDAO, CassandraFirstUnseenDAO firstUnseenDAO, CassandraApplicableFlagDAO applicableFlagDAO,
-                                                CassandraAttachmentDAO attachmentDAO, CassandraAttachmentDAOV2 attachmentDAOV2, CassandraDeletedMessageDAO deletedMessageDAO, CassandraUtils cassandraUtils,
-                                                CassandraConfiguration cassandraConfiguration) {
+                                                CassandraAttachmentDAO attachmentDAO, CassandraAttachmentDAOV2 attachmentDAOV2, CassandraDeletedMessageDAO deletedMessageDAO,
+                                                CassandraBlobsDAO blobsDAO, CassandraUtils cassandraUtils, CassandraConfiguration cassandraConfiguration) {
         this.uidProvider = uidProvider;
         this.modSeqProvider = modSeqProvider;
         this.session = session;
@@ -103,6 +105,7 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
         this.attachmentDAOV2 = attachmentDAOV2;
         this.deletedMessageDAO = deletedMessageDAO;
         this.applicableFlagDAO = applicableFlagDAO;
+        this.blobsDAO = blobsDAO;
         this.cassandraUtils = cassandraUtils;
         this.cassandraConfiguration = cassandraConfiguration;
         this.indexTableHandler = new CassandraIndexTableHandler(
@@ -147,7 +150,7 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
 
     @Override
     public AttachmentMapper createAttachmentMapper(MailboxSession mailboxSession) {
-        return new CassandraAttachmentMapper(attachmentDAO, attachmentDAOV2);
+        return new CassandraAttachmentMapper(attachmentDAO, attachmentDAOV2, blobsDAO);
     }
 
     @Override

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
@@ -22,16 +22,13 @@ package org.apache.james.mailbox.cassandra;
 import javax.inject.Inject;
 
 import org.apache.james.backends.cassandra.init.CassandraConfiguration;
-import org.apache.james.backends.cassandra.init.CassandraTypesProvider;
 import org.apache.james.backends.cassandra.utils.CassandraUtils;
 import org.apache.james.mailbox.MailboxSession;
-import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
 import org.apache.james.mailbox.cassandra.mail.CassandraAnnotationMapper;
 import org.apache.james.mailbox.cassandra.mail.CassandraApplicableFlagDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentMapper;
-import org.apache.james.mailbox.cassandra.mail.CassandraBlobsDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraDeletedMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraFirstUnseenDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraIndexTableHandler;
@@ -64,30 +61,6 @@ import com.datastax.driver.core.Session;
  * Cassandra implementation of {@link MailboxSessionMapperFactory}
  */
 public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFactory {
-
-    public static CassandraMailboxSessionMapperFactory forTests(Session session, CassandraTypesProvider typesProvider,
-                                                                CassandraMessageId.Factory factory) {
-        CassandraBlobsDAO cassandraBlobsDAO = new CassandraBlobsDAO(session);
-        return new CassandraMailboxSessionMapperFactory(
-            new CassandraUidProvider(session),
-            new CassandraModSeqProvider(session),
-            session,
-            new CassandraMessageDAO(session, typesProvider, cassandraBlobsDAO),
-            new CassandraMessageIdDAO(session, factory),
-            new CassandraMessageIdToImapUidDAO(session, factory),
-            new CassandraMailboxCounterDAO(session),
-            new CassandraMailboxRecentsDAO(session),
-            new CassandraMailboxDAO(session, typesProvider),
-            new CassandraMailboxPathDAO(session, typesProvider),
-            new CassandraFirstUnseenDAO(session),
-            new CassandraApplicableFlagDAO(session),
-            new CassandraAttachmentDAO(session),
-            new CassandraAttachmentDAOV2(session, cassandraBlobsDAO),
-            new CassandraDeletedMessageDAO(session),
-            CassandraUtils.WITH_DEFAULT_CONFIGURATION,
-            CassandraConfiguration.DEFAULT_CONFIGURATION);
-    }
-
     private final Session session;
     private final CassandraUidProvider uidProvider;
     private final CassandraModSeqProvider modSeqProvider;

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAO.java
@@ -81,24 +81,13 @@ public class CassandraAttachmentDAO {
     }
 
     public CompletableFuture<Optional<Attachment>> getAttachment(AttachmentId attachmentId) {
-        return getAttachment(attachmentId, NO_LOG_IF_EMPTY);
-    }
-
-    public CompletableFuture<Optional<Attachment>> getAttachment(AttachmentId attachmentId, boolean logIfEmpty) {
         Preconditions.checkArgument(attachmentId != null);
         return cassandraAsyncExecutor.executeSingleRow(
             selectStatement.bind()
                 .setString(ID, attachmentId.getId()))
-            .thenApply(optional -> optional.map(this::attachment))
-            .thenApply(optional -> logNotFound(attachmentId, logIfEmpty, optional));
+            .thenApply(optional -> optional.map(this::attachment));
     }
 
-    private Optional<Attachment> logNotFound(AttachmentId attachmentId, boolean logIfEmpty, Optional<Attachment> optional) {
-        if (!optional.isPresent() && logIfEmpty) {
-            LOGGER.warn("Failed retrieving attachment {}", attachmentId);
-        }
-        return optional;
-    }
 
     public CompletableFuture<Void> storeAttachment(Attachment attachment) throws IOException {
         return cassandraAsyncExecutor.executeVoid(

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAO.java
@@ -40,8 +40,6 @@ import javax.inject.Inject;
 import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
 import org.apache.james.mailbox.model.Attachment;
 import org.apache.james.mailbox.model.AttachmentId;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Row;
@@ -49,9 +47,6 @@ import com.datastax.driver.core.Session;
 import com.google.common.base.Preconditions;
 
 public class CassandraAttachmentDAO {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(CassandraAttachmentMapper.class);
-    private static final boolean NO_LOG_IF_EMPTY = false;
 
     private final CassandraAsyncExecutor cassandraAsyncExecutor;
     private final PreparedStatement insertStatement;

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAO.java
@@ -1,0 +1,119 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentTable.FIELDS;
+import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentTable.ID;
+import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentTable.PAYLOAD;
+import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentTable.SIZE;
+import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentTable.TABLE_NAME;
+import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentTable.TYPE;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import javax.inject.Inject;
+
+import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
+import org.apache.james.mailbox.model.Attachment;
+import org.apache.james.mailbox.model.AttachmentId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.google.common.base.Preconditions;
+
+public class CassandraAttachmentDAO {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CassandraAttachmentMapper.class);
+    private static final boolean NO_LOG_IF_EMPTY = false;
+
+    private final CassandraAsyncExecutor cassandraAsyncExecutor;
+    private final PreparedStatement insertStatement;
+    private final PreparedStatement selectStatement;
+
+    @Inject
+    public CassandraAttachmentDAO(Session session) {
+        this.cassandraAsyncExecutor = new CassandraAsyncExecutor(session);
+
+        this.selectStatement = prepareSelect(session);
+        this.insertStatement = prepareInsert(session);
+    }
+
+    private PreparedStatement prepareInsert(Session session) {
+        return session.prepare(
+            insertInto(TABLE_NAME)
+                .value(ID, bindMarker(ID))
+                .value(PAYLOAD, bindMarker(PAYLOAD))
+                .value(TYPE, bindMarker(TYPE))
+                .value(SIZE, bindMarker(SIZE)));
+    }
+
+    private PreparedStatement prepareSelect(Session session) {
+        return session.prepare(select(FIELDS)
+            .from(TABLE_NAME)
+            .where(eq(ID, bindMarker(ID))));
+    }
+
+    public CompletableFuture<Optional<Attachment>> getAttachment(AttachmentId attachmentId) {
+        return getAttachment(attachmentId, NO_LOG_IF_EMPTY);
+    }
+
+    public CompletableFuture<Optional<Attachment>> getAttachment(AttachmentId attachmentId, boolean logIfEmpty) {
+        Preconditions.checkArgument(attachmentId != null);
+        return cassandraAsyncExecutor.executeSingleRow(
+            selectStatement.bind()
+                .setString(ID, attachmentId.getId()))
+            .thenApply(optional -> optional.map(this::attachment))
+            .thenApply(optional -> logNotFound(attachmentId, logIfEmpty, optional));
+    }
+
+    private Optional<Attachment> logNotFound(AttachmentId attachmentId, boolean logIfEmpty, Optional<Attachment> optional) {
+        if (!optional.isPresent() && logIfEmpty) {
+            LOGGER.warn("Failed retrieving attachment {}", attachmentId);
+        }
+        return optional;
+    }
+
+    public CompletableFuture<Void> storeAttachment(Attachment attachment) throws IOException {
+        return cassandraAsyncExecutor.executeVoid(
+            insertStatement.bind()
+                .setString(ID, attachment.getAttachmentId().getId())
+                .setLong(SIZE, attachment.getSize())
+                .setString(TYPE, attachment.getType())
+                .setBytes(PAYLOAD, ByteBuffer.wrap(attachment.getBytes())));
+    }
+
+    private Attachment attachment(Row row) {
+        return Attachment.builder()
+            .attachmentId(AttachmentId.from(row.getString(ID)))
+            .bytes(row.getBytes(PAYLOAD).array())
+            .type(row.getString(TYPE))
+            .build();
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2.java
@@ -1,0 +1,132 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentV2Table.BLOB_ID;
+import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentV2Table.FIELDS;
+import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentV2Table.ID;
+import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentV2Table.SIZE;
+import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentV2Table.TABLE_NAME;
+import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentV2Table.TYPE;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import javax.inject.Inject;
+
+import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
+import org.apache.james.mailbox.cassandra.ids.BlobId;
+import org.apache.james.mailbox.cassandra.table.CassandraAttachmentTable;
+import org.apache.james.mailbox.model.Attachment;
+import org.apache.james.mailbox.model.AttachmentId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.google.common.base.Preconditions;
+
+public class CassandraAttachmentDAOV2 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CassandraAttachmentMapper.class);
+    private static final boolean NO_LOG_IF_EMPTY = false;
+
+    private final CassandraAsyncExecutor cassandraAsyncExecutor;
+    private final PreparedStatement insertStatement;
+    private final CassandraBlobsDAO blobsDAO;
+    private final PreparedStatement selectStatement;
+
+    @Inject
+    public CassandraAttachmentDAOV2(Session session, CassandraBlobsDAO blobsDAO) {
+        this.cassandraAsyncExecutor = new CassandraAsyncExecutor(session);
+        this.blobsDAO = blobsDAO;
+
+        this.selectStatement = prepareSelect(session);
+        this.insertStatement = prepareInsert(session);
+    }
+
+    private PreparedStatement prepareInsert(Session session) {
+        return session.prepare(
+            insertInto(TABLE_NAME)
+                .value(ID, bindMarker(ID))
+                .value(BLOB_ID, bindMarker(BLOB_ID))
+                .value(TYPE, bindMarker(TYPE))
+                .value(SIZE, bindMarker(SIZE)));
+    }
+
+    private PreparedStatement prepareSelect(Session session) {
+        return session.prepare(select(FIELDS)
+            .from(TABLE_NAME)
+            .where(eq(ID, bindMarker(ID))));
+    }
+
+    public CompletableFuture<Optional<Attachment>> getAttachment(AttachmentId attachmentId) {
+        return getAttachment(attachmentId, NO_LOG_IF_EMPTY);
+    }
+
+    public CompletableFuture<Optional<Attachment>> getAttachment(AttachmentId attachmentId, boolean logIfEmpty) {
+        Preconditions.checkArgument(attachmentId != null);
+        return cassandraAsyncExecutor.executeSingleRow(
+            selectStatement.bind()
+                .setString(CassandraAttachmentTable.ID, attachmentId.getId()))
+            .thenCompose(this::attachment)
+            .thenApply(optional -> logNotFound(attachmentId, logIfEmpty, optional));
+    }
+
+    private Optional<Attachment> logNotFound(AttachmentId attachmentId, boolean logIfEmpty, Optional<Attachment> optional) {
+        if (!optional.isPresent() && logIfEmpty) {
+            LOGGER.warn("Failed retrieving attachment {}", attachmentId);
+        }
+        return optional;
+    }
+
+    public CompletableFuture<Void> storeAttachment(Attachment attachment) {
+        return blobsDAO.save(attachment.getBytes())
+            .thenApply(Optional::get) // attachment payload is never null
+            .thenApply(blobId ->
+                insertStatement.bind()
+                    .setString(ID, attachment.getAttachmentId().getId())
+                    .setLong(SIZE, attachment.getSize())
+                    .setString(TYPE, attachment.getType())
+                    .setString(BLOB_ID, blobId.getId()))
+            .thenCompose(cassandraAsyncExecutor::executeVoid);
+    }
+
+    private CompletableFuture<Optional<Attachment>> attachment(Optional<Row> rowOptional) {
+        if (rowOptional.isPresent()) {
+            return attachment(rowOptional.get())
+                .thenApply(Optional::of);
+        }
+        return CompletableFuture.completedFuture(Optional.empty());
+    }
+
+    private CompletableFuture<Attachment> attachment(Row row) {
+        return blobsDAO.read(BlobId.from(row.getString(BLOB_ID)))
+            .thenApply(bytes -> Attachment.builder()
+                .attachmentId(AttachmentId.from(row.getString(ID)))
+                .bytes(bytes)
+                .type(row.getString(TYPE))
+                .build());
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2.java
@@ -48,13 +48,13 @@ import com.datastax.driver.core.Session;
 import com.google.common.base.Preconditions;
 
 public class CassandraAttachmentDAOV2 {
-    public static class DAOAttachmentModel {
+    public static class DAOAttachment {
         private final AttachmentId attachmentId;
         private final BlobId blobId;
         private final String type;
         private final long size;
 
-        private DAOAttachmentModel(AttachmentId attachmentId, BlobId blobId, String type, long size) {
+        private DAOAttachment(AttachmentId attachmentId, BlobId blobId, String type, long size) {
             this.attachmentId = attachmentId;
             this.blobId = blobId;
             this.type = type;
@@ -87,8 +87,8 @@ public class CassandraAttachmentDAOV2 {
 
         @Override
         public final boolean equals(Object o) {
-            if (o instanceof DAOAttachmentModel) {
-                DAOAttachmentModel that = (DAOAttachmentModel) o;
+            if (o instanceof DAOAttachment) {
+                DAOAttachment that = (DAOAttachment) o;
 
                 return Objects.equals(this.size, that.size)
                     && Objects.equals(this.attachmentId, that.attachmentId)
@@ -104,16 +104,16 @@ public class CassandraAttachmentDAOV2 {
         }
     }
 
-    public static DAOAttachmentModel from(Attachment attachment, BlobId blobId) {
-        return new DAOAttachmentModel(
+    public static DAOAttachment from(Attachment attachment, BlobId blobId) {
+        return new DAOAttachment(
             attachment.getAttachmentId(),
             blobId,
             attachment.getType(),
             attachment.getSize());
     }
 
-    private static DAOAttachmentModel fromRow(Row row) {
-        return new DAOAttachmentModel(
+    private static DAOAttachment fromRow(Row row) {
+        return new DAOAttachment(
             AttachmentId.from(row.getString(ID)),
             BlobId.from(row.getString(BLOB_ID)),
             row.getString(TYPE),
@@ -148,7 +148,7 @@ public class CassandraAttachmentDAOV2 {
             .where(eq(ID_AS_UUID, bindMarker(ID_AS_UUID))));
     }
 
-    public CompletableFuture<Optional<DAOAttachmentModel>> getAttachment(AttachmentId attachmentId) {
+    public CompletableFuture<Optional<DAOAttachment>> getAttachment(AttachmentId attachmentId) {
         Preconditions.checkArgument(attachmentId != null);
         return cassandraAsyncExecutor.executeSingleRow(
             selectStatement.bind()
@@ -156,7 +156,7 @@ public class CassandraAttachmentDAOV2 {
             .thenApply(row -> row.map(CassandraAttachmentDAOV2::fromRow));
     }
 
-    public CompletableFuture<Void> storeAttachment(DAOAttachmentModel attachment) {
+    public CompletableFuture<Void> storeAttachment(DAOAttachment attachment) {
         return cassandraAsyncExecutor.executeVoid(
             insertStatement.bind()
                 .setUUID(ID_AS_UUID, attachment.getAttachmentId().asUUID())

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2.java
@@ -104,7 +104,8 @@ public class CassandraAttachmentDAOV2 {
 
     public CompletableFuture<Void> storeAttachment(Attachment attachment) {
         return blobsDAO.save(attachment.getBytes())
-            .thenApply(Optional::get) // attachment payload is never null
+            // BlobDAO supports saving null blobs. But attachments ensure there blobs are never null. Hence optional unboxing is safe here.
+            .thenApply(Optional::get)
             .thenApply(blobId ->
                 insertStatement.bind()
                     .setUUID(ID_AS_UUID, attachment.getAttachmentId().asUUID())

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2.java
@@ -65,7 +65,7 @@ public class CassandraAttachmentDAOV2 {
             return attachmentId;
         }
 
-        public org.apache.james.mailbox.cassandra.ids.BlobId getBlobId() {
+        public BlobId getBlobId() {
             return blobId;
         }
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
@@ -28,6 +28,7 @@ import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentTable.
 import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentTable.SIZE;
 import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentTable.TABLE_NAME;
 import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentTable.TYPE;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collection;
@@ -35,6 +36,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
+
 import javax.inject.Inject;
 
 import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
@@ -45,6 +47,8 @@ import org.apache.james.mailbox.model.AttachmentId;
 import org.apache.james.mailbox.store.mail.AttachmentMapper;
 import org.apache.james.util.FluentFutureStream;
 import org.apache.james.util.OptionalUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
@@ -52,8 +56,7 @@ import com.github.fge.lambdas.Throwing;
 import com.github.fge.lambdas.ThrownByLambdaException;
 import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.google.common.collect.ImmutableList;
 
 public class CassandraAttachmentMapper implements AttachmentMapper {
 
@@ -99,7 +102,7 @@ public class CassandraAttachmentMapper implements AttachmentMapper {
         return getAttachmentsAsFuture(attachmentIds).join();
     }
 
-    public CompletableFuture<List<Attachment>> getAttachmentsAsFuture(Collection<AttachmentId> attachmentIds) {
+    public CompletableFuture<ImmutableList<Attachment>> getAttachmentsAsFuture(Collection<AttachmentId> attachmentIds) {
         Preconditions.checkArgument(attachmentIds != null);
 
         Stream<CompletableFuture<Optional<Attachment>>> attachments = attachmentIds
@@ -110,9 +113,7 @@ public class CassandraAttachmentMapper implements AttachmentMapper {
         return FluentFutureStream
             .of(attachments)
             .flatMap(OptionalUtils::toStream)
-            .completableFuture()
-            .thenApply(stream ->
-                stream.collect(Guavate.toImmutableList()));
+            .collect(Guavate.toImmutableList());
     }
 
     private CompletableFuture<Optional<Attachment>> getAttachmentAsFuture(AttachmentId attachmentId) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
@@ -131,8 +131,6 @@ public class CassandraAttachmentMapper implements AttachmentMapper {
 
     public CompletableFuture<Void> storeAttachmentAsync(Attachment attachment) {
         return blobsDAO.save(attachment.getBytes())
-            // BlobDAO supports saving null blobs. But attachments ensure there blobs are never null. Hence optional unboxing is safe here.
-            .thenApply(Optional::get)
             .thenApply(blobId -> CassandraAttachmentDAOV2.from(attachment, blobId))
             .thenCompose(attachmentDAOV2::storeAttachment);
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
@@ -75,11 +75,11 @@ public class CassandraAttachmentMapper implements AttachmentMapper {
     }
 
     @Nullable
-    private CompletionStage<Optional<Attachment>> retrievePayload(Optional<DAOAttachmentModel> input) {
-        if (!input.isPresent()) {
+    private CompletionStage<Optional<Attachment>> retrievePayload(Optional<DAOAttachmentModel> optionalModel) {
+        if (!optionalModel.isPresent()) {
             return CompletableFuture.completedFuture(Optional.empty());
         }
-        DAOAttachmentModel model = input.get();
+        DAOAttachmentModel model = optionalModel.get();
         return blobsDAO.read(model.getBlobId())
             .thenApply(bytes -> Optional.of(model.toAttachment(bytes)));
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
-import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2.DAOAttachmentModel;
+import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2.DAOAttachment;
 import org.apache.james.mailbox.exception.AttachmentNotFoundException;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Attachment;
@@ -75,13 +75,13 @@ public class CassandraAttachmentMapper implements AttachmentMapper {
     }
 
     @Nullable
-    private CompletionStage<Optional<Attachment>> retrievePayload(Optional<DAOAttachmentModel> optionalModel) {
-        if (!optionalModel.isPresent()) {
+    private CompletionStage<Optional<Attachment>> retrievePayload(Optional<DAOAttachment> daoAttachmentOptional) {
+        if (!daoAttachmentOptional.isPresent()) {
             return CompletableFuture.completedFuture(Optional.empty());
         }
-        DAOAttachmentModel model = optionalModel.get();
-        return blobsDAO.read(model.getBlobId())
-            .thenApply(bytes -> Optional.of(model.toAttachment(bytes)));
+        DAOAttachment daoAttachment = daoAttachmentOptional.get();
+        return blobsDAO.read(daoAttachment.getBlobId())
+            .thenApply(bytes -> Optional.of(daoAttachment.toAttachment(bytes)));
     }
 
     @Override

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
@@ -135,10 +135,10 @@ public class CassandraAttachmentMapper implements AttachmentMapper {
             .thenCompose(attachmentDAOV2::storeAttachment);
     }
 
-    private Optional<Attachment> logNotFound(AttachmentId attachmentId, Optional<Attachment> optional) {
-        if (!optional.isPresent()) {
+    private Optional<Attachment> logNotFound(AttachmentId attachmentId, Optional<Attachment> optionalAttachment) {
+        if (!optionalAttachment.isPresent()) {
             LOGGER.warn("Failed retrieving attachment {}", attachmentId);
         }
-        return optional;
+        return optionalAttachment;
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
@@ -97,8 +97,7 @@ public class CassandraMessageIdMapper implements MessageIdMapper {
         return FluentFutureStream.ofNestedStreams(
             messageIds.stream()
                 .map(messageId -> imapUidDAO.retrieve((CassandraMessageId) messageId, Optional.empty())))
-            .completableFuture()
-            .thenApply(stream -> stream.collect(Guavate.toImmutableList()))
+            .collect(Guavate.toImmutableList())
             .thenCompose(composedMessageIds -> messageDAO.retrieveMessages(composedMessageIds, fetchType, Limit.unlimited()))
             .thenApply(stream -> stream
                 .filter(CassandraMessageDAO.MessageResult::isFound)

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraAttachmentModule.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraAttachmentModule.java
@@ -29,6 +29,7 @@ import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.components.CassandraTable;
 import org.apache.james.backends.cassandra.components.CassandraType;
 import org.apache.james.mailbox.cassandra.table.CassandraAttachmentTable;
+import org.apache.james.mailbox.cassandra.table.CassandraAttachmentV2Table;
 
 import com.datastax.driver.core.schemabuilder.SchemaBuilder;
 import com.google.common.collect.ImmutableList;
@@ -48,7 +49,17 @@ public class CassandraAttachmentModule implements CassandraModule {
                     .addColumn(CassandraAttachmentTable.TYPE, text())
                     .addColumn(CassandraAttachmentTable.SIZE, bigint())
                     .withOptions()
-                    .comment("Holds attachment for fast attachment retrieval")));
+                    .comment("Holds attachment for fast attachment retrieval")),
+            new CassandraTable(CassandraAttachmentV2Table.TABLE_NAME,
+                SchemaBuilder.createTable(CassandraAttachmentV2Table.TABLE_NAME)
+                    .ifNotExists()
+                    .addPartitionKey(CassandraAttachmentV2Table.ID, text())
+                    .addColumn(CassandraAttachmentV2Table.BLOB_ID, text())
+                    .addColumn(CassandraAttachmentV2Table.TYPE, text())
+                    .addColumn(CassandraAttachmentV2Table.SIZE, bigint())
+                    .withOptions()
+                    .comment("Holds attachment for fast attachment retrieval. Content of messages is stored" +
+                        "in `blobs` and `blobparts` tables.")));
         types = ImmutableList.of();
     }
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraAttachmentModule.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraAttachmentModule.java
@@ -22,6 +22,7 @@ package org.apache.james.mailbox.cassandra.modules;
 import static com.datastax.driver.core.DataType.bigint;
 import static com.datastax.driver.core.DataType.blob;
 import static com.datastax.driver.core.DataType.text;
+import static com.datastax.driver.core.DataType.uuid;
 
 import java.util.List;
 
@@ -53,7 +54,8 @@ public class CassandraAttachmentModule implements CassandraModule {
             new CassandraTable(CassandraAttachmentV2Table.TABLE_NAME,
                 SchemaBuilder.createTable(CassandraAttachmentV2Table.TABLE_NAME)
                     .ifNotExists()
-                    .addPartitionKey(CassandraAttachmentV2Table.ID, text())
+                    .addPartitionKey(CassandraAttachmentV2Table.ID_AS_UUID, uuid())
+                    .addColumn(CassandraAttachmentV2Table.ID, text())
                     .addColumn(CassandraAttachmentV2Table.BLOB_ID, text())
                     .addColumn(CassandraAttachmentV2Table.TYPE, text())
                     .addColumn(CassandraAttachmentV2Table.SIZE, bigint())

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraAttachmentModule.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraAttachmentModule.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.components.CassandraTable;
 import org.apache.james.backends.cassandra.components.CassandraType;
+import org.apache.james.backends.cassandra.utils.CassandraConstants;
 import org.apache.james.mailbox.cassandra.table.CassandraAttachmentTable;
 import org.apache.james.mailbox.cassandra.table.CassandraAttachmentV2Table;
 
@@ -60,6 +61,9 @@ public class CassandraAttachmentModule implements CassandraModule {
                     .addColumn(CassandraAttachmentV2Table.TYPE, text())
                     .addColumn(CassandraAttachmentV2Table.SIZE, bigint())
                     .withOptions()
+                    .compactionOptions(SchemaBuilder.leveledStrategy())
+                    .caching(SchemaBuilder.KeyCaching.ALL,
+                        SchemaBuilder.rows(CassandraConstants.DEFAULT_CACHED_ROW_PER_PARTITION))
                     .comment("Holds attachment for fast attachment retrieval. Content of messages is stored" +
                         "in `blobs` and `blobparts` tables.")));
         types = ImmutableList.of();

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/table/CassandraAttachmentV2Table.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/table/CassandraAttachmentV2Table.java
@@ -1,0 +1,31 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.table;
+
+public interface CassandraAttachmentV2Table {
+
+    String TABLE_NAME = "attachmentV2";
+    String ID = "id";
+    String BLOB_ID = "blobId";
+    String TYPE = "type";
+    String SIZE = "size";
+    String[] FIELDS = { ID, BLOB_ID, TYPE, SIZE };
+
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/table/CassandraAttachmentV2Table.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/table/CassandraAttachmentV2Table.java
@@ -22,6 +22,7 @@ package org.apache.james.mailbox.cassandra.table;
 public interface CassandraAttachmentV2Table {
 
     String TABLE_NAME = "attachmentV2";
+    String ID_AS_UUID = "idAsUUID";
     String ID = "id";
     String BLOB_ID = "blobId";
     String TYPE = "type";

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerProvider.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerProvider.java
@@ -25,19 +25,6 @@ import org.apache.james.mailbox.acl.MailboxACLResolver;
 import org.apache.james.mailbox.acl.SimpleGroupMembershipResolver;
 import org.apache.james.mailbox.acl.UnionMailboxACLResolver;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
-import org.apache.james.mailbox.cassandra.mail.CassandraApplicableFlagDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraBlobsDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraDeletedMessageDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraFirstUnseenDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraMailboxCounterDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraMailboxDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraMailboxRecentsDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdToImapUidDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraModSeqProvider;
-import org.apache.james.mailbox.cassandra.mail.CassandraUidProvider;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.store.Authenticator;
 import org.apache.james.mailbox.store.Authorizator;
@@ -52,34 +39,12 @@ public class CassandraMailboxManagerProvider {
     private static final int LIMIT_ANNOTATION_SIZE = 30;
 
     public static CassandraMailboxManager provideMailboxManager(Session session, CassandraTypesProvider cassandraTypesProvider) {
-        CassandraUidProvider uidProvider = new CassandraUidProvider(session);
-        CassandraModSeqProvider modSeqProvider = new CassandraModSeqProvider(session);
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
-        CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(session, messageIdFactory);
-        CassandraMessageIdToImapUidDAO imapUidDAO = new CassandraMessageIdToImapUidDAO(session, messageIdFactory);
-        CassandraBlobsDAO blobsDAO = new CassandraBlobsDAO(session);
-        CassandraMessageDAO messageDAO = new CassandraMessageDAO(session, cassandraTypesProvider, blobsDAO);
-        CassandraMailboxCounterDAO mailboxCounterDAO = new CassandraMailboxCounterDAO(session);
-        CassandraMailboxRecentsDAO mailboxRecentsDAO = new CassandraMailboxRecentsDAO(session);
-        CassandraMailboxDAO mailboxDAO = new CassandraMailboxDAO(session, cassandraTypesProvider);
-        CassandraMailboxPathDAO mailboxPathDAO = new CassandraMailboxPathDAO(session, cassandraTypesProvider);
-        CassandraFirstUnseenDAO firstUnseenDAO = new CassandraFirstUnseenDAO(session);
-        CassandraApplicableFlagDAO applicableFlagDAO = new CassandraApplicableFlagDAO(session);
-        CassandraDeletedMessageDAO deletedMessageDAO = new CassandraDeletedMessageDAO(session);
 
-        CassandraMailboxSessionMapperFactory mapperFactory = new CassandraMailboxSessionMapperFactory(uidProvider,
-            modSeqProvider,
+        CassandraMailboxSessionMapperFactory mapperFactory = new CassandraMailboxSessionMapperFactory(
             session,
-            messageDAO,
-            messageIdDAO,
-            imapUidDAO,
-            mailboxCounterDAO,
-            mailboxRecentsDAO,
-            mailboxDAO,
-            mailboxPathDAO,
-            firstUnseenDAO,
-            applicableFlagDAO,
-            deletedMessageDAO);
+            cassandraTypesProvider,
+            messageIdFactory);
 
         MailboxACLResolver aclResolver = new UnionMailboxACLResolver();
         GroupMembershipResolver groupMembershipResolver = new SimpleGroupMembershipResolver();

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerProvider.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerProvider.java
@@ -41,7 +41,7 @@ public class CassandraMailboxManagerProvider {
     public static CassandraMailboxManager provideMailboxManager(Session session, CassandraTypesProvider cassandraTypesProvider) {
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
 
-        CassandraMailboxSessionMapperFactory mapperFactory = CassandraMailboxSessionMapperFactory.forTests(
+        CassandraMailboxSessionMapperFactory mapperFactory = TestCassandraMailboxSessionMapperFactory.forTests(
             session,
             cassandraTypesProvider,
             messageIdFactory);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerProvider.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerProvider.java
@@ -41,7 +41,7 @@ public class CassandraMailboxManagerProvider {
     public static CassandraMailboxManager provideMailboxManager(Session session, CassandraTypesProvider cassandraTypesProvider) {
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
 
-        CassandraMailboxSessionMapperFactory mapperFactory = new CassandraMailboxSessionMapperFactory(
+        CassandraMailboxSessionMapperFactory mapperFactory = CassandraMailboxSessionMapperFactory.forTests(
             session,
             cassandraTypesProvider,
             messageIdFactory);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraSubscriptionManagerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraSubscriptionManagerTest.java
@@ -29,6 +29,7 @@ import org.apache.james.mailbox.SubscriptionManager;
 import org.apache.james.mailbox.cassandra.mail.CassandraApplicableFlagDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
+import org.apache.james.mailbox.cassandra.mail.CassandraBlobsDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraDeletedMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraFirstUnseenDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxCounterDAO;
@@ -89,6 +90,7 @@ public class CassandraSubscriptionManagerTest extends AbstractSubscriptionManage
         CassandraAttachmentDAO attachmentDAO = null;
         CassandraDeletedMessageDAO deletedMessageDAO = null;
         CassandraAttachmentDAOV2 attachmentDAOV2 = null;
+        CassandraBlobsDAO cassandraBlobsDAO = null;
         return new CassandraSubscriptionManager(
             new CassandraMailboxSessionMapperFactory(
                 new CassandraUidProvider(cassandra.getConf()),
@@ -106,6 +108,7 @@ public class CassandraSubscriptionManagerTest extends AbstractSubscriptionManage
                 attachmentDAO,
                 attachmentDAOV2,
                 deletedMessageDAO,
+                cassandraBlobsDAO,
                 CassandraUtils.WITH_DEFAULT_CONFIGURATION,
                 CassandraConfiguration.DEFAULT_CONFIGURATION));
     }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraSubscriptionManagerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraSubscriptionManagerTest.java
@@ -21,10 +21,13 @@ package org.apache.james.mailbox.cassandra;
 
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.DockerCassandraRule;
+import org.apache.james.backends.cassandra.init.CassandraConfiguration;
 import org.apache.james.backends.cassandra.init.CassandraModuleComposite;
+import org.apache.james.backends.cassandra.utils.CassandraUtils;
 import org.apache.james.mailbox.AbstractSubscriptionManagerTest;
 import org.apache.james.mailbox.SubscriptionManager;
 import org.apache.james.mailbox.cassandra.mail.CassandraApplicableFlagDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraDeletedMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraFirstUnseenDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxCounterDAO;
@@ -82,6 +85,7 @@ public class CassandraSubscriptionManagerTest extends AbstractSubscriptionManage
         CassandraMailboxPathDAO mailboxPathDAO = null;
         CassandraFirstUnseenDAO firstUnseenDAO = null;
         CassandraApplicableFlagDAO applicableFlagDAO = null;
+        CassandraAttachmentDAO attachmentDAO = null;
         CassandraDeletedMessageDAO deletedMessageDAO = null;
         return new CassandraSubscriptionManager(
             new CassandraMailboxSessionMapperFactory(
@@ -97,6 +101,9 @@ public class CassandraSubscriptionManagerTest extends AbstractSubscriptionManage
                 mailboxPathDAO,
                 firstUnseenDAO,
                 applicableFlagDAO,
-                deletedMessageDAO));
+                attachmentDAO,
+                deletedMessageDAO,
+                CassandraUtils.WITH_DEFAULT_CONFIGURATION,
+                CassandraConfiguration.DEFAULT_CONFIGURATION));
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraSubscriptionManagerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraSubscriptionManagerTest.java
@@ -28,6 +28,7 @@ import org.apache.james.mailbox.AbstractSubscriptionManagerTest;
 import org.apache.james.mailbox.SubscriptionManager;
 import org.apache.james.mailbox.cassandra.mail.CassandraApplicableFlagDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
 import org.apache.james.mailbox.cassandra.mail.CassandraDeletedMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraFirstUnseenDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxCounterDAO;
@@ -87,6 +88,7 @@ public class CassandraSubscriptionManagerTest extends AbstractSubscriptionManage
         CassandraApplicableFlagDAO applicableFlagDAO = null;
         CassandraAttachmentDAO attachmentDAO = null;
         CassandraDeletedMessageDAO deletedMessageDAO = null;
+        CassandraAttachmentDAOV2 attachmentDAOV2 = null;
         return new CassandraSubscriptionManager(
             new CassandraMailboxSessionMapperFactory(
                 new CassandraUidProvider(cassandra.getConf()),
@@ -102,6 +104,7 @@ public class CassandraSubscriptionManagerTest extends AbstractSubscriptionManage
                 firstUnseenDAO,
                 applicableFlagDAO,
                 attachmentDAO,
+                attachmentDAOV2,
                 deletedMessageDAO,
                 CassandraUtils.WITH_DEFAULT_CONFIGURATION,
                 CassandraConfiguration.DEFAULT_CONFIGURATION));

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
@@ -44,7 +44,7 @@ public class CassandraTestSystemFixture {
     public static CassandraMailboxSessionMapperFactory createMapperFactory(CassandraCluster cassandra) {
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
 
-        return new CassandraMailboxSessionMapperFactory(
+        return CassandraMailboxSessionMapperFactory.forTests(
             cassandra.getConf(),
             cassandra.getTypesProvider(),
             messageIdFactory);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
@@ -23,19 +23,6 @@ import static org.mockito.Mockito.mock;
 
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
-import org.apache.james.mailbox.cassandra.mail.CassandraApplicableFlagDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraBlobsDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraDeletedMessageDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraFirstUnseenDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraMailboxCounterDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraMailboxDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraMailboxRecentsDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdToImapUidDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraModSeqProvider;
-import org.apache.james.mailbox.cassandra.mail.CassandraUidProvider;
 import org.apache.james.mailbox.cassandra.quota.CassandraCurrentQuotaManager;
 import org.apache.james.mailbox.cassandra.quota.CassandraPerUserMaxQuotaManager;
 import org.apache.james.mailbox.quota.CurrentQuotaManager;
@@ -55,35 +42,12 @@ public class CassandraTestSystemFixture {
     public static final int MOD_SEQ = 452;
 
     public static CassandraMailboxSessionMapperFactory createMapperFactory(CassandraCluster cassandra) {
-        CassandraUidProvider uidProvider = new CassandraUidProvider(cassandra.getConf());
-        CassandraModSeqProvider modSeqProvider = new CassandraModSeqProvider(cassandra.getConf());
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
-        CassandraMessageIdDAO messageIdDAO = new CassandraMessageIdDAO(cassandra.getConf(), messageIdFactory);
-        CassandraMessageIdToImapUidDAO imapUidDAO = new CassandraMessageIdToImapUidDAO(cassandra.getConf(), messageIdFactory);
-        CassandraBlobsDAO blobsDAO = new CassandraBlobsDAO(cassandra.getConf());
-        CassandraMessageDAO messageDAO = new CassandraMessageDAO(cassandra.getConf(), cassandra.getTypesProvider(), blobsDAO);
-        CassandraMailboxCounterDAO mailboxCounterDAO = new CassandraMailboxCounterDAO(cassandra.getConf());
-        CassandraMailboxRecentsDAO mailboxRecentsDAO = new CassandraMailboxRecentsDAO(cassandra.getConf());
-        CassandraApplicableFlagDAO applicableFlagDAO = new CassandraApplicableFlagDAO(cassandra.getConf());
 
-        CassandraMailboxDAO mailboxDAO = new CassandraMailboxDAO(cassandra.getConf(), cassandra.getTypesProvider());
-        CassandraMailboxPathDAO mailboxPathDAO = new CassandraMailboxPathDAO(cassandra.getConf(), cassandra.getTypesProvider());
-        CassandraFirstUnseenDAO firstUnseenDAO = new CassandraFirstUnseenDAO(cassandra.getConf());
-        CassandraDeletedMessageDAO deletedMessageDAO = new CassandraDeletedMessageDAO(cassandra.getConf());
-        
-        return new CassandraMailboxSessionMapperFactory(uidProvider,
-            modSeqProvider,
+        return new CassandraMailboxSessionMapperFactory(
             cassandra.getConf(),
-            messageDAO,
-            messageIdDAO,
-            imapUidDAO,
-            mailboxCounterDAO,
-            mailboxRecentsDAO,
-            mailboxDAO,
-            mailboxPathDAO,
-            firstUnseenDAO,
-            applicableFlagDAO,
-            deletedMessageDAO);
+            cassandra.getTypesProvider(),
+            messageIdFactory);
     }
 
     public static CassandraMailboxManager createMailboxManager(CassandraMailboxSessionMapperFactory mapperFactory) throws Exception{

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
@@ -44,7 +44,7 @@ public class CassandraTestSystemFixture {
     public static CassandraMailboxSessionMapperFactory createMapperFactory(CassandraCluster cassandra) {
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
 
-        return CassandraMailboxSessionMapperFactory.forTests(
+        return TestCassandraMailboxSessionMapperFactory.forTests(
             cassandra.getConf(),
             cassandra.getTypesProvider(),
             messageIdFactory);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/TestCassandraMailboxSessionMapperFactory.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/TestCassandraMailboxSessionMapperFactory.java
@@ -59,9 +59,9 @@ public class TestCassandraMailboxSessionMapperFactory {
             new CassandraFirstUnseenDAO(session),
             new CassandraApplicableFlagDAO(session),
             new CassandraAttachmentDAO(session),
-            new CassandraAttachmentDAOV2(session, cassandraBlobsDAO),
+            new CassandraAttachmentDAOV2(session),
             new CassandraDeletedMessageDAO(session),
-            CassandraUtils.WITH_DEFAULT_CONFIGURATION,
+            cassandraBlobsDAO, CassandraUtils.WITH_DEFAULT_CONFIGURATION,
             CassandraConfiguration.DEFAULT_CONFIGURATION);
     }
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/TestCassandraMailboxSessionMapperFactory.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/TestCassandraMailboxSessionMapperFactory.java
@@ -1,0 +1,68 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                 *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra;
+
+import org.apache.james.backends.cassandra.init.CassandraConfiguration;
+import org.apache.james.backends.cassandra.init.CassandraTypesProvider;
+import org.apache.james.backends.cassandra.utils.CassandraUtils;
+import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.cassandra.mail.CassandraApplicableFlagDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
+import org.apache.james.mailbox.cassandra.mail.CassandraBlobsDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraDeletedMessageDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraFirstUnseenDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxCounterDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxRecentsDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdToImapUidDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraModSeqProvider;
+import org.apache.james.mailbox.cassandra.mail.CassandraUidProvider;
+
+import com.datastax.driver.core.Session;
+
+public class TestCassandraMailboxSessionMapperFactory {
+    public static CassandraMailboxSessionMapperFactory forTests(Session session, CassandraTypesProvider typesProvider,
+                                                                CassandraMessageId.Factory factory) {
+        CassandraBlobsDAO cassandraBlobsDAO = new CassandraBlobsDAO(session);
+        return new CassandraMailboxSessionMapperFactory(
+            new CassandraUidProvider(session),
+            new CassandraModSeqProvider(session),
+            session,
+            new CassandraMessageDAO(session, typesProvider, cassandraBlobsDAO),
+            new CassandraMessageIdDAO(session, factory),
+            new CassandraMessageIdToImapUidDAO(session, factory),
+            new CassandraMailboxCounterDAO(session),
+            new CassandraMailboxRecentsDAO(session),
+            new CassandraMailboxDAO(session, typesProvider),
+            new CassandraMailboxPathDAO(session, typesProvider),
+            new CassandraFirstUnseenDAO(session),
+            new CassandraApplicableFlagDAO(session),
+            new CassandraAttachmentDAO(session),
+            new CassandraAttachmentDAOV2(session, cassandraBlobsDAO),
+            new CassandraDeletedMessageDAO(session),
+            CassandraUtils.WITH_DEFAULT_CONFIGURATION,
+            CassandraConfiguration.DEFAULT_CONFIGURATION);
+    }
+
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOTest.java
@@ -1,0 +1,79 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.DockerCassandraRule;
+import org.apache.james.mailbox.cassandra.modules.CassandraAttachmentModule;
+import org.apache.james.mailbox.model.Attachment;
+import org.apache.james.mailbox.model.AttachmentId;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class CassandraAttachmentDAOTest {
+    public static final AttachmentId ATTACHMENT_ID = AttachmentId.from("id1");
+
+    @ClassRule
+    public static DockerCassandraRule cassandraServer = new DockerCassandraRule();
+
+    private CassandraCluster cassandra;
+
+    private CassandraAttachmentDAO testee;
+
+    @Before
+    public void setUp() throws Exception {
+        cassandra = CassandraCluster.create(new CassandraAttachmentModule(),
+            cassandraServer.getIp(), cassandraServer.getBindingPort());
+        testee = new CassandraAttachmentDAO(cassandra.getConf());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        cassandra.close();
+    }
+
+    @Test
+    public void getAttachmentShouldReturnEmptyWhenAbsent() {
+        Optional<Attachment> attachment = testee.getAttachment(ATTACHMENT_ID).join();
+
+        assertThat(attachment).isEmpty();
+    }
+
+    @Test
+    public void getAttachmentShouldReturnAttachmentWhenStored() throws Exception {
+        Attachment attachment = Attachment.builder()
+            .attachmentId(ATTACHMENT_ID)
+            .type("application/json")
+            .bytes("{\"property\":`\"value\"}".getBytes(StandardCharsets.UTF_8))
+            .build();
+        testee.storeAttachment(attachment).join();
+
+        Optional<Attachment> actual = testee.getAttachment(ATTACHMENT_ID).join();
+
+        assertThat(actual).contains(attachment);
+    }
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2Test.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2Test.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.DockerCassandraRule;
 import org.apache.james.mailbox.cassandra.ids.BlobId;
-import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2.DAOAttachmentModel;
+import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2.DAOAttachment;
 import org.apache.james.mailbox.cassandra.modules.CassandraAttachmentModule;
 import org.apache.james.mailbox.model.Attachment;
 import org.apache.james.mailbox.model.AttachmentId;
@@ -63,7 +63,7 @@ public class CassandraAttachmentDAOV2Test {
 
     @Test
     public void getAttachmentShouldReturnEmptyWhenAbsent() {
-        Optional<DAOAttachmentModel> attachment = testee.getAttachment(ATTACHMENT_ID).join();
+        Optional<DAOAttachment> attachment = testee.getAttachment(ATTACHMENT_ID).join();
 
         assertThat(attachment).isEmpty();
     }
@@ -76,11 +76,11 @@ public class CassandraAttachmentDAOV2Test {
             .bytes("{\"property\":`\"value\"}".getBytes(StandardCharsets.UTF_8))
             .build();
         BlobId blobId = BlobId.from("blobId");
-        DAOAttachmentModel model = CassandraAttachmentDAOV2.from(attachment, blobId);
-        testee.storeAttachment(model).join();
+        DAOAttachment daoAttachment = CassandraAttachmentDAOV2.from(attachment, blobId);
+        testee.storeAttachment(daoAttachment).join();
 
-        Optional<DAOAttachmentModel> actual = testee.getAttachment(ATTACHMENT_ID).join();
+        Optional<DAOAttachment> actual = testee.getAttachment(ATTACHMENT_ID).join();
 
-        assertThat(actual).contains(model);
+        assertThat(actual).contains(daoAttachment);
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2Test.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2Test.java
@@ -1,0 +1,88 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.DockerCassandraRule;
+import org.apache.james.backends.cassandra.init.CassandraModuleComposite;
+import org.apache.james.mailbox.cassandra.modules.CassandraAttachmentModule;
+import org.apache.james.mailbox.cassandra.modules.CassandraBlobModule;
+import org.apache.james.mailbox.model.Attachment;
+import org.apache.james.mailbox.model.AttachmentId;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class CassandraAttachmentDAOV2Test {
+    public static final AttachmentId ATTACHMENT_ID = AttachmentId.from("id1");
+
+    @ClassRule
+    public static DockerCassandraRule cassandraServer = new DockerCassandraRule();
+
+    private CassandraCluster cassandra;
+
+    private CassandraAttachmentDAOV2 testee;
+
+    @Before
+    public void setUp() throws Exception {
+        CassandraModuleComposite compositeModule = new CassandraModuleComposite(
+            new CassandraAttachmentModule(),
+            new CassandraBlobModule());
+
+        cassandra = CassandraCluster.create(
+            compositeModule,
+            cassandraServer.getIp(),
+            cassandraServer.getBindingPort());
+
+        testee = new CassandraAttachmentDAOV2(cassandra.getConf(), new CassandraBlobsDAO(cassandra.getConf()));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        cassandra.close();
+    }
+
+    @Test
+    public void getAttachmentShouldReturnEmptyWhenAbsent() {
+        Optional<Attachment> attachment = testee.getAttachment(ATTACHMENT_ID).join();
+
+        assertThat(attachment).isEmpty();
+    }
+
+    @Test
+    public void getAttachmentShouldReturnAttachmentWhenStored() throws Exception {
+        Attachment attachment = Attachment.builder()
+            .attachmentId(ATTACHMENT_ID)
+            .type("application/json")
+            .bytes("{\"property\":`\"value\"}".getBytes(StandardCharsets.UTF_8))
+            .build();
+        testee.storeAttachment(attachment).join();
+
+        Optional<Attachment> actual = testee.getAttachment(ATTACHMENT_ID).join();
+
+        assertThat(actual).contains(attachment);
+    }
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentFallbackTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentFallbackTest.java
@@ -39,7 +39,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
-public class CassandraAttachmentFallbackTestTest {
+public class CassandraAttachmentFallbackTest {
     public static final AttachmentId ATTACHMENT_ID_1 = AttachmentId.from("id1");
     public static final AttachmentId ATTACHMENT_ID_2 = AttachmentId.from("id2");
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentFallbackTestTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentFallbackTestTest.java
@@ -100,7 +100,7 @@ public class CassandraAttachmentFallbackTestTest {
             .bytes("{\"property\":`\"different\"}".getBytes(StandardCharsets.UTF_8))
             .build();
 
-        BlobId blobId = blobsDAO.save(attachment.getBytes()).join().get();
+        BlobId blobId = blobsDAO.save(attachment.getBytes()).join();
         attachmentDAOV2.storeAttachment(CassandraAttachmentDAOV2.from(attachment, blobId)).join();
         attachmentDAO.storeAttachment(otherAttachment).join();
 
@@ -135,7 +135,7 @@ public class CassandraAttachmentFallbackTestTest {
             .bytes("{\"property\":`\"different\"}".getBytes(StandardCharsets.UTF_8))
             .build();
 
-        BlobId blobId = blobsDAO.save(attachment.getBytes()).join().get();
+        BlobId blobId = blobsDAO.save(attachment.getBytes()).join();
         attachmentDAOV2.storeAttachment(CassandraAttachmentDAOV2.from(attachment, blobId)).join();
         attachmentDAO.storeAttachment(otherAttachment).join();
 
@@ -170,7 +170,7 @@ public class CassandraAttachmentFallbackTestTest {
             .bytes("{\"property\":`\"different\"}".getBytes(StandardCharsets.UTF_8))
             .build();
 
-        BlobId blobId = blobsDAO.save(attachment.getBytes()).join().get();
+        BlobId blobId = blobsDAO.save(attachment.getBytes()).join();
         attachmentDAOV2.storeAttachment(CassandraAttachmentDAOV2.from(attachment, blobId)).join();
         attachmentDAO.storeAttachment(otherAttachment).join();
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxManagerAttachmentTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxManagerAttachmentTest.java
@@ -91,27 +91,10 @@ public class CassandraMailboxManagerAttachmentTest extends AbstractMailboxManage
     private void initSystemUnderTest() throws Exception {
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
 
-        CassandraMailboxDAO mailboxDAO = new CassandraMailboxDAO(cassandra.getConf(), cassandra.getTypesProvider());
-        CassandraMailboxPathDAO mailboxPathDAO = new CassandraMailboxPathDAO(cassandra.getConf(), cassandra.getTypesProvider());
-        CassandraFirstUnseenDAO firstUnseenDAO = new CassandraFirstUnseenDAO(cassandra.getConf());
-        CassandraDeletedMessageDAO deletedMessageDAO = new CassandraDeletedMessageDAO(cassandra.getConf());
-
-        CassandraBlobsDAO blobsDAO = new CassandraBlobsDAO(cassandra.getConf());
-        CassandraMessageDAO messageDAO = new CassandraMessageDAO(cassandra.getConf(), cassandra.getTypesProvider(), blobsDAO);
         mailboxSessionMapperFactory = new CassandraMailboxSessionMapperFactory(
-                new CassandraUidProvider(cassandra.getConf()),
-                new CassandraModSeqProvider(cassandra.getConf()),
-                cassandra.getConf(),
-            messageDAO,
-                new CassandraMessageIdDAO(cassandra.getConf(), messageIdFactory),
-                new CassandraMessageIdToImapUidDAO(cassandra.getConf(), messageIdFactory),
-                new CassandraMailboxCounterDAO(cassandra.getConf()),
-                new CassandraMailboxRecentsDAO(cassandra.getConf()),
-                mailboxDAO,
-                mailboxPathDAO,
-                firstUnseenDAO,
-                new CassandraApplicableFlagDAO(cassandra.getConf()),
-                deletedMessageDAO);
+            cassandra.getConf(),
+            cassandra.getTypesProvider(),
+            messageIdFactory);
         Authenticator noAuthenticator = null;
         Authorizator noAuthorizator = null;
         mailboxManager = new CassandraMailboxManager(mailboxSessionMapperFactory, noAuthenticator, noAuthorizator, new NoMailboxPathLocker(), new MessageParser(), messageIdFactory); 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxManagerAttachmentTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxManagerAttachmentTest.java
@@ -28,6 +28,7 @@ import org.apache.james.backends.cassandra.init.CassandraModuleComposite;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.cassandra.CassandraMailboxManager;
 import org.apache.james.mailbox.cassandra.CassandraMailboxSessionMapperFactory;
+import org.apache.james.mailbox.cassandra.TestCassandraMailboxSessionMapperFactory;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
 import org.apache.james.mailbox.cassandra.modules.CassandraAclModule;
 import org.apache.james.mailbox.cassandra.modules.CassandraApplicableFlagsModule;
@@ -91,7 +92,7 @@ public class CassandraMailboxManagerAttachmentTest extends AbstractMailboxManage
     private void initSystemUnderTest() throws Exception {
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
 
-        mailboxSessionMapperFactory = CassandraMailboxSessionMapperFactory.forTests(
+        mailboxSessionMapperFactory = TestCassandraMailboxSessionMapperFactory.forTests(
             cassandra.getConf(),
             cassandra.getTypesProvider(),
             messageIdFactory);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxManagerAttachmentTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxManagerAttachmentTest.java
@@ -91,7 +91,7 @@ public class CassandraMailboxManagerAttachmentTest extends AbstractMailboxManage
     private void initSystemUnderTest() throws Exception {
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
 
-        mailboxSessionMapperFactory = new CassandraMailboxSessionMapperFactory(
+        mailboxSessionMapperFactory = CassandraMailboxSessionMapperFactory.forTests(
             cassandra.getConf(),
             cassandra.getTypesProvider(),
             messageIdFactory);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMapperProvider.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMapperProvider.java
@@ -24,6 +24,7 @@ import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.cassandra.CassandraMailboxSessionMapperFactory;
+import org.apache.james.mailbox.cassandra.TestCassandraMailboxSessionMapperFactory;
 import org.apache.james.mailbox.cassandra.ids.CassandraId;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId.Factory;
@@ -78,7 +79,7 @@ public class CassandraMapperProvider implements MapperProvider {
     }
 
     private CassandraMailboxSessionMapperFactory createMapperFactory() {
-        return CassandraMailboxSessionMapperFactory.forTests(cassandra.getConf(),
+        return TestCassandraMailboxSessionMapperFactory.forTests(cassandra.getConf(),
             cassandra.getTypesProvider(),
             new CassandraMessageId.Factory());
     }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMapperProvider.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMapperProvider.java
@@ -78,7 +78,7 @@ public class CassandraMapperProvider implements MapperProvider {
     }
 
     private CassandraMailboxSessionMapperFactory createMapperFactory() {
-        return new CassandraMailboxSessionMapperFactory(cassandra.getConf(),
+        return CassandraMailboxSessionMapperFactory.forTests(cassandra.getConf(),
             cassandra.getTypesProvider(),
             new CassandraMessageId.Factory());
     }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMapperProvider.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMapperProvider.java
@@ -78,26 +78,9 @@ public class CassandraMapperProvider implements MapperProvider {
     }
 
     private CassandraMailboxSessionMapperFactory createMapperFactory() {
-        CassandraMailboxDAO mailboxDAO = new CassandraMailboxDAO(cassandra.getConf(), cassandra.getTypesProvider());
-        CassandraMailboxPathDAO mailboxPathDAO = new CassandraMailboxPathDAO(cassandra.getConf(), cassandra.getTypesProvider());
-        CassandraFirstUnseenDAO firstUnseenDAO = new CassandraFirstUnseenDAO(cassandra.getConf());
-        CassandraDeletedMessageDAO deletedMessageDAO = new CassandraDeletedMessageDAO(cassandra.getConf());
-        CassandraBlobsDAO blobsDAO = new CassandraBlobsDAO(cassandra.getConf());
-        CassandraMessageDAO messageDAO = new CassandraMessageDAO(cassandra.getConf(), cassandra.getTypesProvider(), blobsDAO);
-        return new CassandraMailboxSessionMapperFactory(
-            new CassandraUidProvider(cassandra.getConf()),
-            cassandraModSeqProvider,
-            cassandra.getConf(),
-            messageDAO,
-            new CassandraMessageIdDAO(cassandra.getConf(), MESSAGE_ID_FACTORY),
-            new CassandraMessageIdToImapUidDAO(cassandra.getConf(), MESSAGE_ID_FACTORY),
-            new CassandraMailboxCounterDAO(cassandra.getConf()),
-            new CassandraMailboxRecentsDAO(cassandra.getConf()),
-            mailboxDAO,
-            mailboxPathDAO,
-            firstUnseenDAO,
-            new CassandraApplicableFlagDAO(cassandra.getConf()),
-            deletedMessageDAO);
+        return new CassandraMailboxSessionMapperFactory(cassandra.getConf(),
+            cassandra.getTypesProvider(),
+            new CassandraMessageId.Factory());
     }
 
     @Override

--- a/mpt/impl/imap-mailbox/cassandra/pom.xml
+++ b/mpt/impl/imap-mailbox/cassandra/pom.xml
@@ -47,6 +47,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>apache-james-mailbox-cassandra</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>apache-james-mpt-imapmailbox-core</artifactId>
         </dependency>
     </dependencies>

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
@@ -27,6 +27,7 @@ import org.apache.james.imap.processor.main.DefaultImapProcessorFactory;
 import org.apache.james.mailbox.SubscriptionManager;
 import org.apache.james.mailbox.cassandra.CassandraMailboxManager;
 import org.apache.james.mailbox.cassandra.CassandraMailboxSessionMapperFactory;
+import org.apache.james.mailbox.cassandra.TestCassandraMailboxSessionMapperFactory;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
 import org.apache.james.mailbox.cassandra.modules.CassandraAclModule;
 import org.apache.james.mailbox.cassandra.modules.CassandraAnnotationModule;
@@ -102,7 +103,7 @@ public class CassandraHostSystem extends JamesImapHostSystem {
         cassandra = CassandraCluster.create(mailboxModule, cassandraHost, cassandraPort);
         com.datastax.driver.core.Session session = cassandra.getConf();
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
-        CassandraMailboxSessionMapperFactory mapperFactory = CassandraMailboxSessionMapperFactory.forTests(
+        CassandraMailboxSessionMapperFactory mapperFactory = TestCassandraMailboxSessionMapperFactory.forTests(
             cassandra.getConf(),
             cassandra.getTypesProvider(),
             messageIdFactory);

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
@@ -102,7 +102,7 @@ public class CassandraHostSystem extends JamesImapHostSystem {
         cassandra = CassandraCluster.create(mailboxModule, cassandraHost, cassandraPort);
         com.datastax.driver.core.Session session = cassandra.getConf();
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
-        CassandraMailboxSessionMapperFactory mapperFactory = new CassandraMailboxSessionMapperFactory(
+        CassandraMailboxSessionMapperFactory mapperFactory = CassandraMailboxSessionMapperFactory.forTests(
             cassandra.getConf(),
             cassandra.getTypesProvider(),
             messageIdFactory);

--- a/server/container/util-java8/src/main/java/org/apache/james/util/FluentFutureStream.java
+++ b/server/container/util-java8/src/main/java/org/apache/james/util/FluentFutureStream.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collector;
 import java.util.stream.Stream;
 
 public class FluentFutureStream<T> {
@@ -171,6 +172,14 @@ public class FluentFutureStream<T> {
      */
     public CompletableFuture<Stream<T>> completableFuture() {
         return this.completableFuture;
+    }
+
+    /**
+     * Returns the future of the underlying collected stream.
+     */
+    public <C> CompletableFuture<C> collect(Collector<T, ?, C> collector) {
+        return this.completableFuture
+            .thenApply(stream -> stream.collect(collector));
     }
 
     /**

--- a/server/container/util-java8/src/test/java/org/apache/james/util/FluentFutureStreamTest.java
+++ b/server/container/util-java8/src/test/java/org/apache/james/util/FluentFutureStreamTest.java
@@ -233,4 +233,26 @@ public class FluentFutureStreamTest {
         assertThat(sideEffects).containsOnly(1, 2, 3);
     }
 
+    @Test
+    public void collectShouldReturnTheCollectionOfData() {
+        assertThat(
+            FluentFutureStream.of(
+                Stream.of(
+                    CompletableFuture.completedFuture(1),
+                    CompletableFuture.completedFuture(2),
+                    CompletableFuture.completedFuture(3)))
+                .collect(Guavate.toImmutableList())
+                .join())
+            .containsExactly(1, 2, 3);
+    }
+
+    @Test
+    public void collectShouldReturnEmptyWhenSteamIsEmpty() {
+        assertThat(
+            FluentFutureStream.ofFutures()
+                .collect(Guavate.toImmutableList())
+                .join())
+            .isEmpty();
+    }
+
 }

--- a/server/container/util-java8/src/test/java/org/apache/james/util/FluentFutureStreamTest.java
+++ b/server/container/util-java8/src/test/java/org/apache/james/util/FluentFutureStreamTest.java
@@ -247,7 +247,7 @@ public class FluentFutureStreamTest {
     }
 
     @Test
-    public void collectShouldReturnEmptyWhenSteamIsEmpty() {
+    public void collectShouldReturnEmptyWhenStreamIsEmpty() {
         assertThat(
             FluentFutureStream.ofFutures()
                 .collect(Guavate.toImmutableList())


### PR DESCRIPTION
Includes also:
 - FluentFutureStream::collect (more convenient, less boiler plate in business classes)
 - Easy instantiation of the CassandraMessageMapperFactory for tests: limit argument hell, and makes writing tests from this simple. I don't want to keep changing specific tests every time we add a DAO.