### PR TITLE
James 2146 Guice James Server does not stop when error during initialization

### DIFF
--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/CassandraJamesServerMain.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/CassandraJamesServerMain.java
@@ -49,7 +49,7 @@ import org.apache.james.modules.server.WebAdminServerModule;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
 
-public class CassandraJamesServerMain {
+public class CassandraJamesServerMain implements JamesServerMain {
 
     public static final Module webadmin = Modules.combine(
         new CassandraRoutesModule(),
@@ -86,7 +86,8 @@ public class CassandraJamesServerMain {
     public static void main(String[] args) throws Exception {
         GuiceJamesServer server = new GuiceJamesServer()
                     .combineWith(cassandraServerModule, protocols, new JMXServerModule());
-        server.start();
+
+        JamesServerMain.startJamesDaemon(server);
     }
 
 }

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/GuiceJamesServer.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/GuiceJamesServer.java
@@ -28,6 +28,8 @@ import org.apache.james.onami.lifecycle.Stager;
 import org.apache.james.utils.ConfigurationsPerformer;
 import org.apache.james.utils.GuiceProbe;
 import org.apache.james.utils.GuiceProbeProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Iterables;
 import com.google.inject.Guice;
@@ -38,6 +40,7 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.util.Modules;
 
 public class GuiceJamesServer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GuiceJamesServer.class);
 
     protected final Module module;
     private Stager<PreDestroy> preDestroy;
@@ -63,11 +66,17 @@ public class GuiceJamesServer {
     }
 
     public void start() throws Exception {
-        Injector injector = Guice.createInjector(module);
-        preDestroy = injector.getInstance(Key.get(new TypeLiteral<Stager<PreDestroy>>() {}));
-        injector.getInstance(ConfigurationsPerformer.class).initModules();
-        guiceProbeProvider = injector.getInstance(GuiceProbeProvider.class);
-        isStarted = true;
+        try {
+            Injector injector = Guice.createInjector(module);
+            preDestroy = injector.getInstance(Key.get(new TypeLiteral<Stager<PreDestroy>>() {}));
+            injector.getInstance(ConfigurationsPerformer.class).initModules();
+            guiceProbeProvider = injector.getInstance(GuiceProbeProvider.class);
+            isStarted = true;
+        } catch (Exception e) {
+            LOGGER.error("Error while starting James. Stopping server.", e);
+            throw e;
+        }
+
     }
 
     public void stop() {

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/JamesServerMain.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/JamesServerMain.java
@@ -1,0 +1,31 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+public interface JamesServerMain {
+    static void startJamesDaemon(GuiceJamesServer server) throws Exception {
+        try {
+            server.start();
+        } catch (Exception e) {
+            server.stop();
+            throw e;
+        }
+    }
+}

--- a/server/container/guice/jpa-guice/src/main/java/org/apache/james/JPAJamesServerMain.java
+++ b/server/container/guice/jpa-guice/src/main/java/org/apache/james/JPAJamesServerMain.java
@@ -44,7 +44,7 @@ import org.apache.james.modules.server.WebAdminServerModule;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
 
-public class JPAJamesServerMain {
+public class JPAJamesServerMain implements JamesServerMain {
 
     public static final Module webadmin = Modules.combine(
         new WebAdminServerModule(),
@@ -77,7 +77,8 @@ public class JPAJamesServerMain {
                     .combineWith(jpaServerModule, protocols, 
                             new JMXServerModule(), 
                             new LuceneSearchMailboxModule());
-        server.start();
+
+        JamesServerMain.startJamesDaemon(server);
     }
 
 }

--- a/server/container/guice/jpa-smtp/src/main/java/org/apache/james/JPAJamesServerMain.java
+++ b/server/container/guice/jpa-smtp/src/main/java/org/apache/james/JPAJamesServerMain.java
@@ -36,7 +36,7 @@ import org.apache.openjpa.persistence.OpenJPAPersistence;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
 
-public class JPAJamesServerMain {
+public class JPAJamesServerMain implements JamesServerMain {
 
     public static final Module protocols = Modules.combine(
         new ProtocolHandlerModule(),
@@ -56,7 +56,8 @@ public class JPAJamesServerMain {
     public static void main(String[] args) throws Exception {
         GuiceJamesServer server = new GuiceJamesServer()
                     .combineWith(jpaServerModule, protocols);
-        server.start();
+
+        JamesServerMain.startJamesDaemon(server);
     }
 
 }

--- a/server/container/guice/memory-guice/src/main/java/org/apache/james/MemoryJamesServerMain.java
+++ b/server/container/guice/memory-guice/src/main/java/org/apache/james/MemoryJamesServerMain.java
@@ -40,7 +40,7 @@ import org.apache.james.modules.server.WebAdminServerModule;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
 
-public class MemoryJamesServerMain {
+public class MemoryJamesServerMain implements JamesServerMain {
 
     public static final Module webadmin = Modules.combine(
             new WebAdminServerModule(),
@@ -67,9 +67,9 @@ public class MemoryJamesServerMain {
             protocols);
 
     public static void main(String[] args) throws Exception {
-        new GuiceJamesServer()
-            .combineWith(inMemoryServerModule, new JMXServerModule())
-            .start();
+        GuiceJamesServer server = new GuiceJamesServer()
+            .combineWith(inMemoryServerModule, new JMXServerModule());
+        JamesServerMain.startJamesDaemon(server);
     }
 
 }

--- a/server/container/guice/memory-guice/src/test/java/org/apache/james/StartFailJamesServerTest.java
+++ b/server/container/guice/memory-guice/src/test/java/org/apache/james/StartFailJamesServerTest.java
@@ -1,0 +1,91 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.channels.SocketChannel;
+
+import javax.inject.Inject;
+
+import org.apache.james.modules.server.WebAdminServerModule;
+import org.apache.james.webadmin.WebAdminServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StartFailJamesServerTest {
+    public static class FailingConfigurationPerformer extends WebAdminServerModule.WebAdminServerModuleConfigurationPerformer {
+        @Inject
+        public FailingConfigurationPerformer(WebAdminServer webAdminServer) {
+            super(webAdminServer);
+        }
+
+        @Override
+        public void initModule() {
+            throw new RuntimeException();
+        }
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StartFailJamesServerTest.class);
+    private static final String JAMES_SERVER_HOST = "127.0.0.1";
+    private static final int SMTP_PORT = 1025;
+
+
+    @Rule
+    public MemoryJmapTestRule memoryJmap = new MemoryJmapTestRule();
+
+    private GuiceJamesServer guiceJamesServer;
+    private SocketChannel socketChannel;
+
+
+    @Before
+    public void setUp() throws Exception {
+        guiceJamesServer = memoryJmap.jmapServer()
+            .overrideWith(binder -> binder.bind(WebAdminServerModule.WebAdminServerModuleConfigurationPerformer.class)
+                .to(FailingConfigurationPerformer.class));
+
+        socketChannel = SocketChannel.open();
+    }
+
+    @After
+    public void clean() {
+        try {
+            guiceJamesServer.stop();
+        } catch (Exception e) {
+            // If test succeed James is expected to be already stopped
+            LOGGER.warn("Error while stopping James server", e);
+        }
+    }
+
+    @Test
+    public void startShouldStopJamesServerWhenExceptionOnJamesInitialisation() throws Exception {
+        assertThatThrownBy(() -> JamesServerMain.startJamesDaemon(guiceJamesServer))
+            .isInstanceOf(RuntimeException.class);
+
+        assertThatThrownBy(() -> socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, SMTP_PORT)))
+            .isInstanceOf(IOException.class);
+    }
+}

--- a/server/container/guice/memory-guice/src/test/resources/domainlist.xml
+++ b/server/container/guice/memory-guice/src/test/resources/domainlist.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one   
+  or more contributor license agreements.  See the NOTICE file 
+  distributed with this work for additional information        
+  regarding copyright ownership.  The ASF licenses this file   
+  to you under the Apache License, Version 2.0 (the            
+  "License"); you may not use this file except in compliance   
+  with the License.  You may obtain a copy of the License at   
+                                                               
+    http://www.apache.org/licenses/LICENSE-2.0                 
+                                                               
+  Unless required by applicable law or agreed to in writing,   
+  software distributed under the License is distributed on an  
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       
+  KIND, either express or implied.  See the License for the    
+  specific language governing permissions and limitations      
+  under the License.                                           
+ -->
+
+<domainlist>
+    <autodetect>false</autodetect>
+    <autodetectIP>false</autodetectIP>
+    <defaultDomain>localhost</defaultDomain>
+</domainlist>


### PR DESCRIPTION
When using an alias different than "james" for the keystore, JMAP server silently crashes but James keeps running partly initialized (no JMX server).

Correct behavior would be to at least have James signaling this issue and simply stop its initialization as it also affects other components like IMAP or SMTP that uses the same keystore.
