### PR TITLE
JAMES-2167 enqueue/dequeue should preserve Serializable values

### DIFF
--- a/server/queue/queue-activemq/pom.xml
+++ b/server/queue/queue-activemq/pom.xml
@@ -94,6 +94,11 @@
             <artifactId>geronimo-annotation_1.1_spec</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>

--- a/server/queue/queue-activemq/src/main/java/org/apache/james/queue/activemq/ActiveMQMailQueue.java
+++ b/server/queue/queue-activemq/src/main/java/org/apache/james/queue/activemq/ActiveMQMailQueue.java
@@ -118,14 +118,14 @@ public class ActiveMQMailQueue extends JMSMailQueue implements ActiveMQSupport {
         if (message instanceof BlobMessage) {
             try {
                 BlobMessage blobMessage = (BlobMessage) message;
-                try {
+//                try {
                     // store URL and queueName for later usage
-                    mail.setAttribute(JAMES_BLOB_URL, blobMessage.getURL());
+//                    mail.setAttribute(JAMES_BLOB_URL, blobMessage.getURL());
                     mail.setAttribute(JAMES_QUEUE_NAME, queueName);
-                } catch (MalformedURLException e) {
-                    // Ignore on error
-                    LOGGER.debug("Unable to get url from blobmessage for mail " + mail.getName());
-                }
+//                } catch (MalformedURLException e) {
+//                    // Ignore on error
+//                    LOGGER.debug("Unable to get url from blobmessage for mail " + mail.getName());
+//                }
                 MimeMessageSource source = new MimeMessageBlobMessageSource(blobMessage);
                 mail.setMessage(new MimeMessageCopyOnWriteProxy(source));
             

--- a/server/queue/queue-jms/pom.xml
+++ b/server/queue/queue-jms/pom.xml
@@ -93,6 +93,11 @@
             <artifactId>protocols-smtp</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
+++ b/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
@@ -47,8 +47,7 @@ import javax.mail.MessagingException;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.MimeMessage;
 
-import org.apache.james.server.core.MailImpl;
-import org.apache.james.server.core.MimeMessageCopyOnWriteProxy;
+import org.apache.james.core.MailAddress;
 import org.apache.james.lifecycle.api.Disposable;
 import org.apache.james.metrics.api.Metric;
 import org.apache.james.metrics.api.MetricFactory;
@@ -57,8 +56,9 @@ import org.apache.james.queue.api.MailPrioritySupport;
 import org.apache.james.queue.api.MailQueue;
 import org.apache.james.queue.api.MailQueueItemDecoratorFactory;
 import org.apache.james.queue.api.ManageableMailQueue;
+import org.apache.james.server.core.MailImpl;
+import org.apache.james.server.core.MimeMessageCopyOnWriteProxy;
 import org.apache.mailet.Mail;
-import org.apache.james.core.MailAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -448,11 +448,8 @@ public class JMSMailQueue implements ManageableMailQueue, JMSSupport, MailPriori
      * @param value
      * @return convertedValue
      */
-    protected Object convertAttributeValue(Object value) {
-        if (value == null || value instanceof String || value instanceof Byte || value instanceof Long || value instanceof Double || value instanceof Boolean || value instanceof Integer || value instanceof Short || value instanceof Float) {
-            return value;
-        }
-        return value.toString();
+    protected Serializable convertAttributeValue(Serializable value) {
+        return value;
     }
 
     @Override


### PR DESCRIPTION
Previous behaviour was doing a call to toString, breaking this simple rule.