### PR TITLE
JAMES-2170 Fix typo in output of james-cli command

### DIFF
--- a/server/container/cli/src/main/java/org/apache/james/cli/ServerCmd.java
+++ b/server/container/cli/src/main/java/org/apache/james/cli/ServerCmd.java
@@ -118,7 +118,7 @@ public class ServerCmd {
             .executeCommandLine(cmd, printStream);
         stopWatch.split();
         print(new String[] { Joiner.on(' ')
-                .join(cmdType.getCommand(), "command executed sucessfully in", stopWatch.getSplitTime(), "ms.")},
+                .join(cmdType.getCommand(), "command executed successfully in", stopWatch.getSplitTime(), "ms.")},
             printStream);
         stopWatch.stop();
     }


### PR DESCRIPTION
The output of james-cli commands always ends with the following line:
<command> command executed sucessfully in <time> ms.

There is a typo in "sucessfully", which should obviously be spelled as "successfully".
