### PR TITLE
PROTOCOLS-117 General fixes: Fix MAILDIR MPT tests

### DIFF
--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMessageMapper.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMessageMapper.java
@@ -259,7 +259,7 @@ public class MaildirMessageMapper extends AbstractMessageMapper {
     @Override
     protected MessageMetaData copy(Mailbox mailbox, MessageUid uid, long modSeq, MailboxMessage original)
             throws MailboxException {
-        SimpleMailboxMessage theCopy = SimpleMailboxMessage.copy(mailbox.getMailboxId(), original);
+        SimpleMailboxMessage theCopy = SimpleMailboxMessage.copyWithoutAttachments(mailbox.getMailboxId(), original);
         Flags flags = theCopy.createFlags();
         flags.add(Flag.RECENT);
         theCopy.setFlags(flags);

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/model/MaildirMessage.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/model/MaildirMessage.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.mailbox.maildir.MaildirMessageName;
 import org.apache.james.mailbox.model.MessageAttachment;
 import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.store.mail.model.DefaultMessageId;
 import org.apache.james.mailbox.store.mail.model.Message;
 import org.apache.james.mailbox.store.mail.model.Property;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
@@ -239,7 +240,7 @@ public class MaildirMessage implements Message {
 
     @Override
     public MessageId getMessageId() {
-        return null;
+        return new DefaultMessageId();
     }
 
     @Override

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/FlagsFactory.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/FlagsFactory.java
@@ -25,6 +25,8 @@ import java.util.stream.Stream;
 
 import javax.mail.Flags;
 
+import com.google.common.collect.ImmutableList;
+
 public class FlagsFactory {
 
     private static Flags asFlags(MailboxMessage mailboxMessage, String[] userFlags) {
@@ -93,7 +95,9 @@ public class FlagsFactory {
         }
 
         public Builder addUserFlags(String... userFlags) {
-            this.userFlags.addAll(Arrays.asList(userFlags));
+            this.userFlags.addAll(Optional.ofNullable(userFlags)
+                .map(Arrays::asList)
+                .orElse(ImmutableList.of()));
             return this;
         }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailboxMessage.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailboxMessage.java
@@ -24,10 +24,12 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+
 import javax.mail.Flags;
 import javax.mail.internet.SharedInputStream;
 import javax.mail.util.SharedByteArrayInputStream;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.ComposedMessageId;
@@ -39,7 +41,6 @@ import org.apache.james.mailbox.store.mail.model.DelegatingMailboxMessage;
 import org.apache.james.mailbox.store.mail.model.FlagsFactory;
 import org.apache.james.mailbox.store.mail.model.FlagsFilter;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
-import org.apache.commons.io.IOUtils;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -149,6 +150,15 @@ public class SimpleMailboxMessage extends DelegatingMailboxMessage {
     }
 
     public static Builder from(MailboxMessage original) throws MailboxException {
+        return fromWithoutAttachments(original)
+            .addAttachments(original.getAttachments());
+    }
+
+    public static SimpleMailboxMessage copy(MailboxId mailboxId, MailboxMessage original) throws MailboxException {
+        return from(original).mailboxId(mailboxId).build();
+    }
+
+    public static Builder fromWithoutAttachments(MailboxMessage original) throws MailboxException {
         PropertyBuilder propertyBuilder = new PropertyBuilder(original.getProperties());
         propertyBuilder.setTextualLineCount(original.getTextualLineCount());
         return builder()
@@ -158,12 +168,12 @@ public class SimpleMailboxMessage extends DelegatingMailboxMessage {
             .internalDate(original.getInternalDate())
             .size(original.getFullContentOctets())
             .flags(original.createFlags())
-            .propertyBuilder(propertyBuilder)
-            .addAttachments(original.getAttachments());
+            .propertyBuilder(propertyBuilder);
     }
 
-    public static SimpleMailboxMessage copy(MailboxId mailboxId, MailboxMessage original) throws MailboxException {
-        return from(original).mailboxId(mailboxId).build();
+    public static SimpleMailboxMessage copyWithoutAttachments(MailboxId mailboxId, MailboxMessage original) throws MailboxException {
+        return fromWithoutAttachments(original)
+            .mailboxId(mailboxId).build();
     }
 
     private static SharedByteArrayInputStream copyFullContent(MailboxMessage original) throws MailboxException {

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/FlagsFactoryTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/FlagsFactoryTest.java
@@ -60,6 +60,15 @@ public class FlagsFactoryTest {
     }
 
     @Test
+    public void builderShouldAcceptNullUserFlags() {
+        assertThat(
+            FlagsFactory.builder()
+                .addUserFlags(null)
+                .build())
+            .isEqualTo(new Flags());
+    }
+
+    @Test
     public void builderShouldFilterUserFlags() {
         Flags actual = FlagsFactory.builder()
             .flags(someFlags)


### PR DESCRIPTION
 - We need a non null MessageId
 - User flags can be null, FlagsFactory need to support it
 - Attachment copy is not supported


I'll add the maildir profile in a separate PR (PRO TIP: limit build isolation problems ;-))