### PR TITLE
PROTOCOLS-117 Introduce a generic class for user/domain parsing

### DIFF
--- a/core/src/main/java/org/apache/james/core/User.java
+++ b/core/src/main/java/org/apache/james/core/User.java
@@ -1,0 +1,122 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.core;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+
+public class User {
+    public static User fromUsername(String username) {
+        Preconditions.checkNotNull(username);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(username));
+
+        List<String> parts = Splitter.on('@').splitToList(username);
+        switch (parts.size()) {
+            case 1:
+                return fromLocalPartWithoutDomain(username);
+            case 2:
+                return fromLocalPartWithDomain(parts.get(0), parts.get(1));
+        }
+        throw new IllegalArgumentException("The username should not contain multiple domain delimiter.");
+    }
+
+    public static User fromLocalPartWithDomain(String localPart, String domain) {
+        Preconditions.checkNotNull(domain);
+
+        return from(localPart,
+            Optional.of(domain));
+    }
+
+    public static User fromLocalPartWithoutDomain(String localPart) {
+        return from(localPart,
+            Optional.empty());
+    }
+
+    public static User from(String localPart, Optional<String> domain) {
+       return new User(localPart, domain);
+    }
+
+    private final String localPart;
+    private final Optional<String> domainPart;
+
+    private User(String localPart, Optional<String> domainPart) {
+        Preconditions.checkNotNull(localPart);
+        Preconditions.checkArgument(!localPart.isEmpty(), "username should not be empty");
+        Preconditions.checkArgument(!localPart.contains("@"), "username can not contain domain delimiter");
+
+        Preconditions.checkArgument(!isEmptyString(domainPart), "domain part can not be empty");
+        Preconditions.checkArgument(!containsDomainDelimiter(domainPart), "domain can not contain domain delimiter");
+
+        this.localPart = localPart;
+        this.domainPart = domainPart;
+    }
+
+    private Boolean containsDomainDelimiter(Optional<String> domainPart) {
+        return domainPart.map(s -> s.contains("@")).orElse(false);
+    }
+
+    private Boolean isEmptyString(Optional<String> domainPart) {
+        return domainPart.map(String::isEmpty)
+            .orElse(false);
+    }
+
+    public String getLocalPart() {
+        return localPart;
+    }
+
+    public Optional<String> getDomainPart() {
+        return domainPart;
+    }
+
+    public String asString() {
+        return domainPart.map(domain -> localPart + "@" + domain)
+            .orElse(localPart);
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof User) {
+            User user = (User) o;
+
+            return Objects.equals(this.localPart, user.localPart)
+                && Objects.equals(this.domainPart, user.domainPart);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(localPart, domainPart);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("localPart", localPart)
+            .add("domainPart", domainPart)
+            .toString();
+    }
+}

--- a/core/src/test/java/org/apache/james/core/UserTest.java
+++ b/core/src/test/java/org/apache/james/core/UserTest.java
@@ -1,0 +1,169 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+public class UserTest {
+
+    @Test
+    public void fromShouldThrowOnEmptyLocalPart() {
+        assertThatThrownBy(() -> User.from("", Optional.empty()))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void fromShouldThrowOnNullDomainPart() {
+        assertThatThrownBy(() -> User.from(null, Optional.empty()))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void fromShouldThrowOnLocalPartWithDomainDelimiter() {
+        assertThatThrownBy(() -> User.from("aa@bb", Optional.empty()))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void fromShouldThrowOnEmptyDomain() {
+        assertThatThrownBy(() -> User.from("aa", Optional.of("")))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void fromShouldThrowWhenDomainContainsDomainDelimiter() {
+        assertThatThrownBy(() -> User.from("aa", Optional.of("bb@cc")))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void fromLocalPartWithDomainStringVersionShouldThrowOnNullLocalPart() {
+        assertThatThrownBy(() -> User.fromLocalPartWithDomain(null, "domain"))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void fromLocalPartWithDomainStringVersionShouldThrowOnEmptyLocalPart() {
+        assertThatThrownBy(() -> User.fromLocalPartWithDomain("", "domain"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void fromLocalPartWithDomainStringVersionShouldThrowOnLocalPartThatContainsDomainDelimiter() {
+        assertThatThrownBy(() -> User.fromLocalPartWithDomain("aa@bb", "domain"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void fromLocalPartWithDomainStringVersionShouldThrowOnNullDomainPart() {
+        assertThatThrownBy(() -> User.fromLocalPartWithDomain("local", null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void fromLocalPartWithDomainStringVersionShouldThrowOnEmptyDomainPart() {
+        assertThatThrownBy(() -> User.fromLocalPartWithDomain("local", ""))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void fromLocalPartWithDomainStringVersionShouldThrowOnDomainPartThatContainsDomainDelimiter() {
+        assertThatThrownBy(() -> User.fromLocalPartWithDomain("local", "aa@bb"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void fromLocalPartWithoutDomainShouldThrowOnEmpty() {
+        assertThatThrownBy(() -> User.fromLocalPartWithoutDomain(""))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void fromLocalPartWithoutDomainShouldThrowOnNull() {
+        assertThatThrownBy(() -> User.fromLocalPartWithoutDomain(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void fromLocalPartWithoutDomainShouldThrowOnUsernameThatContainsDomainDelimiter() {
+        assertThatThrownBy(() -> User.fromLocalPartWithoutDomain("aa@bb"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void fromUsernameShouldThrowOnNull() {
+        assertThatThrownBy(() -> User.fromUsername(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void fromUsernameShouldThrowOnEmpty() {
+        assertThatThrownBy(() -> User.fromUsername(""))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void fromUsernameShouldThrowWhenMultipleDomainDelimiter() {
+        assertThatThrownBy(() -> User.fromUsername("aa@aa@aa"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void fromUsernameShouldThrowWhenEndsWithDomainDelimiter() {
+        assertThatThrownBy(() -> User.fromUsername("aa@"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void fromUsernameShouldThrowWhenStartsWithDomainDelimiter() {
+        assertThatThrownBy(() -> User.fromUsername("@aa"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void fromUsernameShouldParseUsernameWithDomain() {
+        assertThat(User.fromUsername("aa@bb"))
+            .isEqualTo(User.from("aa", Optional.of("bb")));
+    }
+
+    @Test
+    public void fromUsernameShouldParseUsernameWithoutDomain() {
+        assertThat(User.fromUsername("aa"))
+            .isEqualTo(User.from("aa", Optional.empty()));
+    }
+
+    @Test
+    public void fromLocalPartWithDomainShouldReturnAValidUser() {
+        assertThat(User.fromLocalPartWithDomain("aa", "bb"))
+            .isEqualTo(User.from("aa", Optional.of("bb")));
+    }
+
+    @Test
+    public void fromLocalPartWithoutDomainShouldReturnAValidUser() {
+        assertThat(User.fromLocalPartWithoutDomain("aa"))
+            .isEqualTo(User.from("aa", Optional.empty()));
+    }
+
+}


### PR DESCRIPTION
Because user/domain parsing is required several time in recent PRs:

 - When checking mailbox shares belongs to the same domain ( https://github.com/linagora/james-project/pull/1091 )
 - When handling path conversion logic ( https://github.com/linagora/james-project/pull/1087 )
 - When ensuring characters are disabled in local parts (yet to come!)

Thus we should have:
 - A core object for this (maibox and server-data. As far as I know, we don't want hard dependency between them)
 - And it should just be a parsing utility.