### PR TITLE
JAMES-2209 Upgrade libraries containing CVEs

### DIFF
--- a/mpt/pom.xml
+++ b/mpt/pom.xml
@@ -65,8 +65,6 @@
         <log4j.version>1.2.16</log4j.version>
         <lucene-core.version>3.6.0</lucene-core.version>
         <slf4j.version>1.7.25</slf4j.version>
-
-        <logback.version>1.1.7</logback.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -578,7 +578,7 @@
         -->
         <deployTechnicalSiteDirectory />
 
-        <activemq.version>5.15.0</activemq.version>
+        <activemq.version>5.15.2</activemq.version>
         <apache-mime4j.version>0.8.1</apache-mime4j.version>
         <camel.version>2.19.1</camel.version>
         <derby.version>10.9.1.0</derby.version>

--- a/pom.xml
+++ b/pom.xml
@@ -672,7 +672,7 @@
         <guice.version>4.0</guice.version>
         <jackrabbit-core.version>2.5.2</jackrabbit-core.version>
 
-        <logback.version>1.1.7</logback.version>
+        <logback.version>1.1.11</logback.version>
     </properties>
 
     <dependencyManagement>
@@ -1396,7 +1396,7 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
-                <version>1.1.7</version>
+                <version>${logback.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.beetstra.jutf7</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -634,7 +634,7 @@
         <karaf.tooling.exam.container.version>2.3.0</karaf.tooling.exam.container.version>
         <pax-logging-api.version>1.6.4</pax-logging-api.version>
         <jackson-data.version>2.6.3</jackson-data.version>
-        <jetty.version>9.4.4.v20170414</jetty.version>
+        <jetty.version>9.4.7.v20170914</jetty.version>
         <cassandra-unit.version>2.1.9.2</cassandra-unit.version>
         <assertj-guava.version>3.1.0</assertj-guava.version>
         <testcontainers-version>1.4.2</testcontainers-version>

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/DownloadStepdefs.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/DownloadStepdefs.java
@@ -62,7 +62,7 @@ import cucumber.runtime.java.guice.ScenarioScoped;
 @ScenarioScoped
 public class DownloadStepdefs {
 
-    private static final String ONE_ATTACHMENT_EML_ATTACHMENT_BLOB_ID = "356b4005bf16f501505b144a2503b5c922837dee";
+    private static final String ONE_ATTACHMENT_EML_ATTACHMENT_BLOB_ID = "913ee2d903a68c3e8cb51169d34cf9ec257323c1bee254c0c7ab820930fdb8e7";
     private static final String EXPIRED_ATTACHMENT_TOKEN = "usera@domain.tld_"
             + "2016-06-29T13:41:22.124Z_"
             + "DiZa0O14MjLWrAA8P6MG35Gt5CBp7mt5U1EH/M++rIoZK7nlGJ4dPW0dvZD7h4m3o5b/Yd8DXU5x2x4+s0HOOKzD7X0RMlsU7JHJMNLvTvRGWF/C+MUyC8Zce7DtnRVPEQX2uAZhL2PBABV07Vpa8kH+NxoS9CL955Bc1Obr4G+KN2JorADlocFQA6ElXryF5YS/HPZSvq1MTC6aJIP0ku8WRpRnbwgwJnn26YpcHXcJjbkCBtd9/BhlMV6xNd2hTBkfZmYdoNo+UKBaXWzLxAlbLuxjpxwvDNJfOEyWFPgHDoRvzP+G7KzhVWjanHAHrhF0GilEa/MKpOI1qHBSwA==";

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/UploadStepdefs.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/UploadStepdefs.java
@@ -53,7 +53,7 @@ import cucumber.runtime.java.guice.ScenarioScoped;
 
 @ScenarioScoped
 public class UploadStepdefs {
-    private static final String _1M_ZEROED_FILE_BLOB_ID = "005caa8061cff547e3310182f394da6f8081d6a5";
+    private static final String _1M_ZEROED_FILE_BLOB_ID = "35d87cc65060b896a0541713e7868f5cb5f8be3f563ccf82b72e61c2fee67404";
     private static final int _1M = 1024 * 1024;
     private static final int _10M = 10 * _1M;
 

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/GetMessages.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/GetMessages.feature
@@ -189,19 +189,19 @@ Feature: GetMessages method
     And the hasAttachment of the message is "true"
     And the list of attachments of the message contains 2 attachments
     And the first attachment is:
-      |key      | value                                     |
-      |blobId   |"dc07cf16944187c1935daedc1bc89231635be63f" |
-      |type     |"image/jpeg"                               |
-      |size     |846                                        |
-      |cid      |null                                       |
-      |isInline |false                                      |
+      |key      | value                                                             |
+      |blobId   |"81dad497ef270bd4537f5b43906aa88ad2e7168744c572be9a7414707727bf58" |
+      |type     |"image/jpeg"                                                       |
+      |size     |846                                                                |
+      |cid      |null                                                               |
+      |isInline |false                                                              |
     And the second attachment is:
-      |key      | value                                     |
-      |blobId   |"21c3a55f516eeceff69969f3c40318f926404a6a" |
-      |type     |"image/jpeg"                               |
-      |size     |597                                        |
-      |cid      |"part1.37A15C92.A7C3488D@linagora.com"     |
-      |isInline |true                                       |
+      |key      | value                                                             |
+      |blobId   |"632b5341bbe044d26e0916b82a689282cc0891b806884b4d5a2339ea90b28e85" |
+      |type     |"image/jpeg"                                                       |
+      |size     |597                                                                |
+      |cid      |"part1.37A15C92.A7C3488D@linagora.com"                             |
+      |isInline |true                                                               |
 
   Scenario: Retrieving message should return attachments and html body when some attachments and html message
     Given "alice@domain.tld" has a message "m1" in "INBOX" mailbox with two attachments


### PR DESCRIPTION
The following libraries were reported by the OWASP Dependency Checker as containing CVEs:

- ActiveMQ (CVE-2015-5183 and CVE-2015-5184)
-> upgrade from 5.15.0 to 5.15.2 (last stable)

- logback-classic (CVE-2017-5929)
-> upgrade from 1.1.7 to 1.1.11 (last stable of 1.1.x)

- jetty (CVE-2017-9735)
-> upgrade from 9.4.4 to 9.4.7.v20170914 (last stable)