### PR TITLE
JAMES-2235 Contact Extractor should accept non stritly parsable recipients

### DIFF
--- a/mailet/base/src/test/java/org/apache/mailet/base/test/MimeMessageBuilder.java
+++ b/mailet/base/src/test/java/org/apache/mailet/base/test/MimeMessageBuilder.java
@@ -192,6 +192,10 @@ public class MimeMessageBuilder {
         return new MimeMessage(Session.getDefaultInstance(new Properties()), inputStream);
     }
 
+    public static MimeMessage mimeMessageFromBytes(byte[] bytes) throws MessagingException {
+        return mimeMessageFromStream(new ByteArrayInputStream(bytes));
+    }
+
     public static MimeMessageBuilder mimeMessageBuilder() {
         return new MimeMessageBuilder();
     }

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/ContactExtractor.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/ContactExtractor.java
@@ -21,13 +21,19 @@ package org.apache.james.transport.mailets;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import javax.mail.Address;
+import javax.mail.Message;
+import javax.mail.Message.RecipientType;
 import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.mime4j.util.MimeUtil;
+import org.apache.james.util.StreamUtils;
 import org.apache.mailet.Mail;
 import org.apache.mailet.Mailet;
 import org.apache.mailet.MailetException;
@@ -95,26 +101,45 @@ public class ContactExtractor extends GenericMailet implements Mailet {
         }
     }
 
-    private Optional<String> extractContacts(Mail mail) throws MessagingException, IOException {
-        MimeMessage message = mail.getMessage();
+    @VisibleForTesting
+    Optional<String> extractContacts(Mail mail) throws MessagingException, IOException {
+        ImmutableList<String> allRecipients = getAllRecipients(mail.getMessage());
 
-        return Optional.of(mail.getSender())
-            .map(MailAddress::asString)
-            .filter(Throwing.predicate(sender -> hasRecipients(message)))
-            .map(Throwing.function(sender -> new ExtractedContacts(sender, recipients(message))))
-            .map(Throwing.function(extractedContacts -> objectMapper.writeValueAsString(extractedContacts)));
+        if (hasRecipient(allRecipients)) {
+            return Optional.of(mail.getSender())
+                .map(MailAddress::asString)
+                .map(sender -> new ExtractedContacts(sender, allRecipients))
+                .map(Throwing.function(extractedContacts -> objectMapper.writeValueAsString(extractedContacts)));
+        }
+
+        return Optional.empty();
     }
 
-    @VisibleForTesting boolean hasRecipients(MimeMessage mimeMessage) throws MessagingException {
-        return mimeMessage.getAllRecipients() != null 
-                && mimeMessage.getAllRecipients().length > 0;
+    private boolean hasRecipient(ImmutableList<String> allRecipients) {
+        return !allRecipients.isEmpty();
     }
 
-    private ImmutableList<String> recipients(MimeMessage mimeMessage) throws MessagingException {
-        return Arrays.stream(mimeMessage.getAllRecipients())
-                .map(Address::toString)
-                .map(MimeUtil::unscrambleHeaderValue)
-                .collect(Guavate.toImmutableList());
+    private ImmutableList<String> getAllRecipients(MimeMessage mimeMessage) throws MessagingException {
+        return StreamUtils
+            .flatten(
+                getRecipients(mimeMessage, Message.RecipientType.TO),
+                getRecipients(mimeMessage, Message.RecipientType.CC),
+                getRecipients(mimeMessage, Message.RecipientType.BCC))
+            .collect(Guavate.toImmutableList());
+    }
+
+    private Stream<String> getRecipients(MimeMessage mimeMessage, RecipientType recipientType) throws MessagingException {
+        boolean notStrict = false;
+        Function<String, InternetAddress[]> parseRecipient =
+            Throwing
+                .function((String header) -> InternetAddress.parseHeader(header, notStrict))
+                .sneakyThrow();
+        return Optional.ofNullable(mimeMessage.getHeader(recipientType.toString(), ","))
+            .map(parseRecipient)
+            .map(Arrays::stream)
+            .orElse(Stream.empty())
+            .map(Address::toString)
+            .map(MimeUtil::unscrambleHeaderValue);
     }
 
     public static class ExtractedContacts {

--- a/server/container/util-java8/src/main/java/org/apache/james/util/StreamUtils.java
+++ b/server/container/util-java8/src/main/java/org/apache/james/util/StreamUtils.java
@@ -19,16 +19,23 @@
 
 package org.apache.james.util;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class StreamUtils {
-    public static  <T> Stream<T> flatten(Collection<Stream<T>> streams) {
+
+    public static <T> Stream<T> flatten(Collection<Stream<T>> streams) {
         return flatten(streams.stream());
     }
 
-    public static  <T> Stream<T> flatten(Stream<Stream<T>> streams) {
+    public static <T> Stream<T> flatten(Stream<Stream<T>> streams) {
         return streams.flatMap(Function.identity());
+    }
+
+    @SafeVarargs
+    public static <T> Stream<T> flatten(Stream<T>... streams) {
+        return flatten(Arrays.stream(streams));
     }
 }

--- a/server/container/util-java8/src/test/java/org/apache/james/util/StreamUtilsTest.java
+++ b/server/container/util-java8/src/test/java/org/apache/james/util/StreamUtilsTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.stream.Stream;
 
@@ -77,4 +78,24 @@ public class StreamUtilsTest {
             .containsExactly(1, 2, 3);
     }
 
+    @Test
+    public void flattenShouldAcceptEmptyVarArg() {
+        assertThat(
+            StreamUtils.flatten()
+                .collect(Guavate.toImmutableList()))
+            .isEmpty();
+    }
+
+    @Test
+    public void flattenShouldThrowOnNullVarArg() {
+        Stream<String>[] streams = null;
+        assertThatThrownBy(() -> StreamUtils.flatten(streams).collect(Guavate.toImmutableList()))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void flattenShouldFlattenNonEmptyVarArg() {
+        assertThat(StreamUtils.flatten(Stream.of(1), Stream.of(2)).collect(Guavate.toImmutableList()))
+            .containsExactly(1, 2);
+    }
 }


### PR DESCRIPTION
Finally I did not use Mime4j because Mime4j is not very good to extract the name of the recipients.
It can be done with some ugly casting, but then it would be better to differentiate name from address in the collected contacts API, because Mime4j don't give back the name exactly like it has been parsed.