### PR TITLE
JAMES-2240 Fix use of MD5 for checksum to index email body

### DIFF
--- a/server/data/data-file/src/main/java/org/apache/james/mailrepository/file/MBoxMailRepository.java
+++ b/server/data/data-file/src/main/java/org/apache/james/mailrepository/file/MBoxMailRepository.java
@@ -173,9 +173,7 @@ public class MBoxMailRepository implements MailRepository, Configurable {
             mboxFile = destination.substring("mbox://".length());
         }
 
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("MBoxMailRepository.destinationURL: " + destination);
-        }
+        LOGGER.debug("MBoxMailRepository.destinationURL: {}", destination);
 
         String checkType = configuration.getString("[@type]");
         if (!(checkType.equals("MAIL") || checkType.equals("SPOOL"))) {
@@ -225,9 +223,8 @@ public class MBoxMailRepository implements MailRepository, Configurable {
             LOGGER.error("Unable to parse mime message!", e);
         }
 
-        if (mimeMessage == null && LOGGER.isDebugEnabled()) {
-            String logBuffer = this.getClass().getName() + " Mime message is null";
-            LOGGER.debug(logBuffer);
+        if (mimeMessage == null) {
+            LOGGER.debug("Mime message is null");
         }
 
         /*
@@ -266,11 +263,7 @@ public class MBoxMailRepository implements MailRepository, Configurable {
      *            The action to take when a message is found
      */
     private MimeMessage parseMboxFile(RandomAccessFile ins, MessageAction messAct) {
-        if ((LOGGER.isDebugEnabled())) {
-            String logBuffer = this.getClass().getName() + " Start parsing " + mboxFile;
-
-            LOGGER.debug(logBuffer);
-        }
+        LOGGER.debug("Start parsing {}", mboxFile);
         try {
 
             Pattern sepMatchPattern = Pattern.compile("^From (.*) (.*):(.*):(.*)$");
@@ -358,11 +351,7 @@ public class MBoxMailRepository implements MailRepository, Configurable {
         } catch (PatternSyntaxException e) {
             LOGGER.error("Bad regex passed " + mboxFile, e);
         } finally {
-            if ((LOGGER.isDebugEnabled())) {
-                String logBuffer = this.getClass().getName() + " Finished parsing " + mboxFile;
-
-                LOGGER.debug(logBuffer);
-            }
+            LOGGER.debug("Finished parsing {}", mboxFile);
         }
         return null;
     }
@@ -404,19 +393,11 @@ public class MBoxMailRepository implements MailRepository, Configurable {
         // Can we find the key first
         if (mList == null || !mList.containsKey(key)) {
             // Not initiailised so no point looking
-            if ((LOGGER.isDebugEnabled())) {
-                String logBuffer = this.getClass().getName() + " mList - key not found " + mboxFile;
-
-                LOGGER.debug(logBuffer);
-            }
+            LOGGER.debug("mList - key not found {}", mboxFile);
             return foundMessage;
         }
         long messageStart = mList.get(key);
-        if ((LOGGER.isDebugEnabled())) {
-            String logBuffer = this.getClass().getName() + " Load message starting at offset " + messageStart + " from file " + mboxFile;
-
-            LOGGER.debug(logBuffer);
-        }
+        LOGGER.debug("Load message starting at offset {} from file {}", messageStart, mboxFile);
         // Now try and find the position in the file
         RandomAccessFile ins = null;
         try {
@@ -444,11 +425,7 @@ public class MBoxMailRepository implements MailRepository, Configurable {
             LOGGER.error("Unable to write file (General I/O problem) " + mboxFile, e);
         } finally {
             if (foundMessage == null) {
-                if ((LOGGER.isDebugEnabled())) {
-                    String logBuffer = this.getClass().getName() + " select - message not found " + mboxFile;
-
-                    LOGGER.debug(logBuffer);
-                }
+                LOGGER.debug("select - message not found {}", mboxFile);
             }
             if (ins != null)
                 try {
@@ -486,9 +463,7 @@ public class MBoxMailRepository implements MailRepository, Configurable {
                 public MimeMessage messageAction(String messageSeparator, String bodyText, long messageStart) {
                     String key = generateKeyValue(bodyText);
                     mList.put(key, messageStart);
-                    if ((LOGGER.isDebugEnabled())) {
-                        LOGGER.debug(this.getClass().getName() + " Key " + key + " at " + messageStart);
-                    }
+                    LOGGER.debug("Key {} at {}", key, messageStart);
 
                     return null;
                 }
@@ -513,12 +488,8 @@ public class MBoxMailRepository implements MailRepository, Configurable {
      * @see org.apache.james.mailrepository.api.MailRepository#store(Mail)
      */
     public void store(Mail mc) {
+        LOGGER.debug("Will store message to file {}", mboxFile);
 
-        if ((LOGGER.isDebugEnabled())) {
-            String logBuffer = this.getClass().getName() + " Will store message to file " + mboxFile;
-
-            LOGGER.debug(logBuffer);
-        }
         this.mList = null;
         // Now make up the from header
         String fromHeader = null;
@@ -564,11 +535,8 @@ public class MBoxMailRepository implements MailRepository, Configurable {
             // correct for it BEFORE we return the iterator.
             findMessage(keys.iterator().next());
         }
-        if ((LOGGER.isDebugEnabled())) {
-            String logBuffer = this.getClass().getName() + " " + keys.size() + " keys to be iterated over.";
 
-            LOGGER.debug(logBuffer);
-        }
+        LOGGER.debug("{} keys to be iterated over.", keys.size());
         if (fifo)
             Collections.sort(keys); // Keys is a HashSet; impose FIFO for apps
                                     // that need it
@@ -591,11 +559,7 @@ public class MBoxMailRepository implements MailRepository, Configurable {
         res = new MailImpl();
         res.setMessage(foundMessage);
         res.setName(key);
-        if ((LOGGER.isDebugEnabled())) {
-            String logBuffer = this.getClass().getName() + " Retrieving entry for key " + key;
-
-            LOGGER.debug(logBuffer);
-        }
+        LOGGER.debug("Retrieving entry for key {}", key);
         return res;
     }
 
@@ -623,11 +587,7 @@ public class MBoxMailRepository implements MailRepository, Configurable {
             // So wait for a file
             while (!mBoxLock.createNewFile() && sleepCount < MAXSLEEPTIMES) {
                 try {
-                    if ((LOGGER.isDebugEnabled())) {
-                        String logBuffer = this.getClass().getName() + " Waiting for lock on file " + mboxFile;
-
-                        LOGGER.debug(logBuffer);
-                    }
+                    LOGGER.debug("Waiting for lock on file {}", mboxFile);
 
                     Thread.sleep(LOCKSLEEPDELAY);
                     sleepCount++;
@@ -661,11 +621,7 @@ public class MBoxMailRepository implements MailRepository, Configurable {
      * @see org.apache.james.mailrepository.api.MailRepository#remove(Collection)
      */
     public void remove(final Collection<Mail> mails) {
-        if ((LOGGER.isDebugEnabled())) {
-            String logBuffer = this.getClass().getName() + " Removing entry for key " + mails;
-
-            LOGGER.debug(logBuffer);
-        }
+        LOGGER.debug("Removing entry for key {}", mails);
         // The plan is as follows:
         // Attempt to locate the message in the file
         // by reading through the

--- a/server/data/data-file/src/main/java/org/apache/james/mailrepository/file/MBoxMailRepository.java
+++ b/server/data/data-file/src/main/java/org/apache/james/mailrepository/file/MBoxMailRepository.java
@@ -227,22 +227,6 @@ public class MBoxMailRepository implements MailRepository, Configurable {
             LOGGER.debug("Mime message is null");
         }
 
-        /*
-         * String toAddr = null; try { // Attempt to read the TO field and see
-         * if it errors toAddr =
-         * mimeMessage.getRecipients(javax.mail.Message.RecipientType
-         * .TO).toString(); } catch (Exception e) { // It has errored, so time
-         * for plan B // use the from field I suppose try {
-         * mimeMessage.setRecipients(javax.mail.Message.RecipientType.TO,
-         * mimeMessage.getFrom()); if (LOGGER.isDebugEnabled()) {
-         * StringBuffer logBuffer = new StringBuffer(128)
-         * .append(this.getClass().getName())
-         * .append(" Patching To: field for message ")
-         * .append(" with  From: field");
-         * LOGGER.debug(logBuffer.toString()); } } catch
-         * (MessagingException e1) {
-         * LOGGER.error("Unable to set to: field to from: field", e); } }
-         */
         return mimeMessage;
     }
 
@@ -281,11 +265,6 @@ public class MBoxMailRepository implements MailRepository, Configurable {
                     foundSep = sepMatchPattern.matcher(line).matches();
 
                     if (foundSep && inMessage) {
-                        // if ((DEEP_DEBUG) && (LOGGER.isDebugEnabled())) {
-                        // LOGGER.debug(this.getClass().getName() +
-                        // " Invoking " + messAct.getClass() + " at " +
-                        // prevMessageStart);
-                        // }
                         MimeMessage endResult = messAct.messageAction(previousMessageSeparator, messageBuffer.toString(), prevMessageStart);
                         if (messAct.isComplete()) {
                             // I've got what I want so just exit
@@ -311,12 +290,6 @@ public class MBoxMailRepository implements MailRepository, Configurable {
                     if (c == 10) {
                         foundSep = sepMatchPattern.matcher(line).matches();
                         if (foundSep && inMessage) {
-                            // if ((DEEP_DEBUG) &&
-                            // (LOGGER.isDebugEnabled())) {
-                            // LOGGER.debug(this.getClass().getName() +
-                            // " Invoking " + messAct.getClass() + " at " +
-                            // prevMessageStart);
-                            // }
                             MimeMessage endResult = messAct.messageAction(previousMessageSeparator, messageBuffer.toString(), prevMessageStart);
                             if (messAct.isComplete()) {
                                 // I've got what I want so just exit


### PR DESCRIPTION
MD5 is vulnerable to lots of collisions and an attacker could manage to replace (understand "overwrite") an existing indexed email body by another one, leading to many potential abuses.

Replace MD5 with the more cryptographically secure SHA-256.

No unit test is associated as the MD5 hash is computed on the byte[] representation of the emailBody String and I did not find a clean way to reproduce a collision in those conditions.
