### PR TITLE
JAMES-2243 Encode special characters in LDAP search filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1816,6 +1816,11 @@
                 <version>${derby.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.directory.api</groupId>
+                <artifactId>api-ldap-model</artifactId>
+                <version>1.0.0</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.framework</artifactId>
                 <version>${felix.version}</version>

--- a/server/data/data-ldap-integration-testing/src/test/java/org/apache/james/user/ldap/ReadOnlyUsersLDAPRepositoryTest.java
+++ b/server/data/data-ldap-integration-testing/src/test/java/org/apache/james/user/ldap/ReadOnlyUsersLDAPRepositoryTest.java
@@ -177,4 +177,12 @@ public class ReadOnlyUsersLDAPRepositoryTest {
         startUsersRepository(ldapRepositoryConfigurationWithVirtualHosting());
         assertThat(ldapRepository.contains(ldapRepository.getUser(new MailAddress(JAMES_USER_MAIL)))).isTrue();
     }
+
+    @Test
+    public void specialCharacterInUserInputShouldBeSanitized() throws Exception {
+        String patternMatchingMultipleUsers = "j*";
+
+        startUsersRepository(ldapRepositoryConfigurationWithVirtualHosting());
+        assertThat(ldapRepository.test(patternMatchingMultipleUsers, PASSWORD)).isFalse();
+    }
 }

--- a/server/data/data-ldap/pom.xml
+++ b/server/data/data-ldap/pom.xml
@@ -59,6 +59,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-model</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-annotation_1.1_spec</artifactId>
         </dependency>


### PR DESCRIPTION
The user-controlled "name" input is not sanitized when making LDAP searches with searchAndBuildUser(). This could lead to LDAP injections using special characters.