### PR TITLE
JAMES-2247 Don't log owner ACL entry as unexpected

### DIFF
--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/mailbox/Rights.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/mailbox/Rights.java
@@ -189,6 +189,9 @@ public class Rights {
             LOGGER.info("Negative keys are not supported");
             return false;
         }
+        if (key.equals(MailboxACL.OWNER_KEY)) {
+            return false;
+        }
         if (key.getNameType() != MailboxACL.NameType.user) {
             LOGGER.info(key.getNameType() + " is not supported. Only 'user' is.");
             return false;


### PR DESCRIPTION
Each mailbox acl contains a special `owner` entry.

Thus, having that special entry is expected.

As JMAP layer right resolution don't support `special` right entry, these special entries are logged as unexpected. What they are not.

It leads to overkill logging.

We should keep filtering out special `owner` entry, but should not log it.