### PR TITLE
Upgrade Guava to 19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -643,7 +643,7 @@
         <assertj.version>3.3.0</assertj.version>
         <es.version>2.2.1</es.version>
         <es-reporter.version>2.2.0</es-reporter.version>
-        <guava.version>18.0</guava.version>
+        <guava.version>19.0</guava.version>
 
         <apache-commons-io.version>1.3.2</apache-commons-io.version>
         <jutf7.version>1.0.0</jutf7.version>


### PR DESCRIPTION
Using Guava 18.0, Datastax prints a log message saying it uses a compatibility layer :

```
14:22:22.707 [INFO ] c.d.d.c.GuavaCompatibility - Detected Guava < 19 in the classpath, using legacy compatibility layer
```

Using guava 19.0, this message is no more printed