### PR TITLE
JAMES-2257 Allow Message::isDraft property modification via JMAP

### DIFF
--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
@@ -5077,7 +5077,6 @@ public abstract class SetMessagesMethodTest {
             .body(ARGUMENTS + ".list[0].isForwarded", equalTo(true));
     }
 
-    @Ignore("JAMES-2257 isDraft is rejected during message creation")
     @Test
     public void setMessagesShouldNotReturnAnErrorWhenTryingToChangeDraftFlagAmongOthers() {
         String messageCreationId = "creationId1337";
@@ -5140,7 +5139,6 @@ public abstract class SetMessagesMethodTest {
 
     }
 
-    @Ignore("JAMES-2257 isDraft is rejected during message creation")
     @Test
     public void setMessagesShouldModifyTheMessageWhenTryingToChangeDraftFlagAmongOthers() {
         String messageCreationId = "creationId1337";

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
@@ -5077,8 +5077,9 @@ public abstract class SetMessagesMethodTest {
             .body(ARGUMENTS + ".list[0].isForwarded", equalTo(true));
     }
 
+    @Ignore("JAMES-2257 isDraft is rejected during message creation")
     @Test
-    public void setMessagesShouldReturnErrorWhenTryingToChangeDraftFlagAmongOthers() {
+    public void setMessagesShouldNotReturnAnErrorWhenTryingToChangeDraftFlagAmongOthers() {
         String messageCreationId = "creationId1337";
         String fromAddress = USERNAME;
         String requestBody = "[" +
@@ -5133,11 +5134,15 @@ public abstract class SetMessagesMethodTest {
         .when()
             .post("/jmap")
         .then()
-            .statusCode(400);
+            .statusCode(200)
+            .body(ARGUMENTS + ".updated", hasSize(1))
+            .body(ARGUMENTS + ".updated", contains(messageId));
+
     }
 
+    @Ignore("JAMES-2257 isDraft is rejected during message creation")
     @Test
-    public void setMessagesShouldNotModifyTheMessageWhenTryingToChangeDraftFlagAmongOthers() {
+    public void setMessagesShouldModifyTheMessageWhenTryingToChangeDraftFlagAmongOthers() {
         String messageCreationId = "creationId1337";
         String fromAddress = USERNAME;
         String requestBody = "[" +
@@ -5200,10 +5205,10 @@ public abstract class SetMessagesMethodTest {
             .log().ifValidationFails()
             .body(NAME, equalTo("messages"))
             .body(ARGUMENTS + ".list", hasSize(1))
-            .body(ARGUMENTS + ".list[0].isUnread", equalTo(true))
-            .body(ARGUMENTS + ".list[0].isFlagged", equalTo(true))
-            .body(ARGUMENTS + ".list[0].isAnswered", equalTo(true))
-            .body(ARGUMENTS + ".list[0].isDraft", equalTo(true))
+            .body(ARGUMENTS + ".list[0].isUnread", equalTo(false))
+            .body(ARGUMENTS + ".list[0].isFlagged", equalTo(false))
+            .body(ARGUMENTS + ".list[0].isAnswered", equalTo(false))
+            .body(ARGUMENTS + ".list[0].isDraft", equalTo(false))
             .body(ARGUMENTS + ".list[0].isForwarded", equalTo(true));
     }
 }

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/SetMessagesMethodStepdefs.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/SetMessagesMethodStepdefs.java
@@ -199,6 +199,27 @@ public class SetMessagesMethodStepdefs {
         });
     }
 
+    @When("^\"([^\"]*)\" marks the message \"([^\"]*)\" as draft")
+    public void draft(String username, String message) throws Throwable {
+        userStepdefs.execWithUser(username, () -> {
+            MessageId messageId = messageIdStepdefs.getMessageId(message);
+
+            httpClient.post("[" +
+                "  [" +
+                "    \"setMessages\"," +
+                "    {" +
+                "      \"update\": { \"" + messageId.serialize() + "\" : {" +
+                "        \"isDraft\": true" +
+                "      }}" +
+                "    }," +
+                "    \"#0\"" +
+                "  ]" +
+                "]");
+            mainStepdefs.awaitMethod.run();
+        });
+    }
+
+
     @When("^\"([^\"]*)\" destroys message \"([^\"]*)\"$")
     public void destroyMessage(String username, String message) {
         MessageId messageId = messageIdStepdefs.getMessageId(message);

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/SetMessages.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/SetMessages.feature
@@ -98,6 +98,11 @@ Feature: SetMessages method
     When "bob@domain.tld" moves "mBob" to user mailbox "Drafts"
     Then message "mBob" is updated
 
+  Scenario: A user can update $Draft keyword using isDraft property
+    Given "bob@domain.tld" has a mailbox "Drafts"
+    When "bob@domain.tld" marks the message "mBob" as draft
+    Then message "mBob" is updated
+
   Scenario: A user can copy draft out of draft mailbox
     Given "bob@domain.tld" has a mailbox "Drafts"
     When "bob@domain.tld" copies "mBob" from mailbox "mailbox" to mailbox "Drafts"

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/MessageAppender.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/MessageAppender.java
@@ -92,9 +92,11 @@ public class MessageAppender {
 
     private Flags getFlags(CreationMessage message) {
         return message.getOldKeyword()
-                .map(OldKeyword::asFlags)
-                .orElseGet(() -> keywordsOrDefault(message)
-                                    .asFlags());
+            .map(OldKeyword::asKeywords)
+            .map(Optional::of)
+            .orElse(message.getKeywords())
+            .orElse(Keywords.DEFAULT_VALUE)
+            .asFlags();
     }
 
     private Keywords keywordsOrDefault(CreationMessage message) {

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/MessageAppender.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/MessageAppender.java
@@ -29,9 +29,7 @@ import javax.mail.util.SharedByteArrayInputStream;
 import org.apache.james.jmap.methods.ValueWithId.CreationMessageEntry;
 import org.apache.james.jmap.model.Attachment;
 import org.apache.james.jmap.model.CreationMessage;
-import org.apache.james.jmap.model.Keywords;
 import org.apache.james.jmap.model.MessageFactory;
-import org.apache.james.jmap.model.OldKeyword;
 import org.apache.james.mailbox.AttachmentManager;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
@@ -80,7 +78,7 @@ public class MessageAppender {
 
         return MessageFactory.MetaDataWithContent.builder()
             .uid(message.getUid())
-            .keywords(keywordsOrDefault(createdEntry.getValue()))
+            .keywords(createdEntry.getValue().getKeywords())
             .internalDate(internalDate.toInstant())
             .sharedContent(content)
             .size(messageContent.length)
@@ -91,17 +89,7 @@ public class MessageAppender {
     }
 
     private Flags getFlags(CreationMessage message) {
-        return message.getOldKeyword()
-            .map(OldKeyword::asKeywords)
-            .map(Optional::of)
-            .orElse(message.getKeywords())
-            .orElse(Keywords.DEFAULT_VALUE)
-            .asFlags();
-    }
-
-    private Keywords keywordsOrDefault(CreationMessage message) {
-        return message.getKeywords()
-                .orElse(Keywords.DEFAULT_VALUE);
+        return message.getKeywords().asFlags();
     }
 
     public MessageFactory.MetaDataWithContent appendMessageInMailbox(CreationMessageEntry createdEntry,

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMessagesCreationProcessor.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMessagesCreationProcessor.java
@@ -44,6 +44,7 @@ import org.apache.james.jmap.model.MessageFactory;
 import org.apache.james.jmap.model.MessageFactory.MetaDataWithContent;
 import org.apache.james.jmap.model.MessageProperties;
 import org.apache.james.jmap.model.MessageProperties.MessageProperty;
+import org.apache.james.jmap.model.OldKeyword;
 import org.apache.james.jmap.model.SetError;
 import org.apache.james.jmap.model.SetMessagesError;
 import org.apache.james.jmap.model.SetMessagesRequest;
@@ -211,13 +212,10 @@ public class SetMessagesCreationProcessor implements SetMessagesProcessor {
 
 
     private Boolean isDraft(CreationMessage creationMessage) {
-        if (creationMessage.getOldKeyword().isPresent()) {
-            return creationMessage.getOldKeyword().get()
-                        .isDraft()
-                        .orElse(false);
-        }
-        return creationMessage
-            .getKeywords()
+        return creationMessage.getOldKeyword()
+            .map(OldKeyword::asKeywords)
+            .map(Optional::of)
+            .orElse(creationMessage.getKeywords())
             .map(keywords -> keywords.contains(Keyword.DRAFT))
             .orElse(false);
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMessagesCreationProcessor.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMessagesCreationProcessor.java
@@ -38,13 +38,11 @@ import org.apache.james.jmap.methods.ValueWithId.MessageWithId;
 import org.apache.james.jmap.model.CreationMessage;
 import org.apache.james.jmap.model.CreationMessage.DraftEmailer;
 import org.apache.james.jmap.model.Envelope;
-import org.apache.james.jmap.model.Keyword;
 import org.apache.james.jmap.model.Message;
 import org.apache.james.jmap.model.MessageFactory;
 import org.apache.james.jmap.model.MessageFactory.MetaDataWithContent;
 import org.apache.james.jmap.model.MessageProperties;
 import org.apache.james.jmap.model.MessageProperties.MessageProperty;
-import org.apache.james.jmap.model.OldKeyword;
 import org.apache.james.jmap.model.SetError;
 import org.apache.james.jmap.model.SetMessagesError;
 import org.apache.james.jmap.model.SetMessagesRequest;
@@ -181,7 +179,7 @@ public class SetMessagesCreationProcessor implements SetMessagesProcessor {
     private void performCreate(CreationMessageEntry entry, Builder responseBuilder, MailboxSession session) throws MailboxException, InvalidMailboxForCreationException, MessagingException, AttachmentsNotFoundException {
         if (isAppendToMailboxWithRole(Role.OUTBOX, entry.getValue(), session)) {
             sendMailViaOutbox(entry, responseBuilder, session);
-        } else if (isDraft(entry.getValue())) {
+        } else if (entry.getValue().isDraft()) {
             assertNoOutbox(entry, session);
             saveDraft(entry, responseBuilder, session);
         } else {
@@ -208,16 +206,6 @@ public class SetMessagesCreationProcessor implements SetMessagesProcessor {
         attachmentChecker.assertAttachmentsExist(entry, session);
         MessageWithId created = handleDraftMessages(entry, session);
         responseBuilder.created(created.getCreationId(), created.getValue());
-    }
-
-
-    private Boolean isDraft(CreationMessage creationMessage) {
-        return creationMessage.getOldKeyword()
-            .map(OldKeyword::asKeywords)
-            .map(Optional::of)
-            .orElse(creationMessage.getKeywords())
-            .map(keywords -> keywords.contains(Keyword.DRAFT))
-            .orElse(false);
     }
 
     private void validateArguments(CreationMessageEntry entry, MailboxSession session) throws MailboxInvalidMessageCreationException, AttachmentsNotFoundException, MailboxException {

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/CreationMessage.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/CreationMessage.java
@@ -221,7 +221,8 @@ public class CreationMessage {
             }
 
             Optional<Keywords> maybeKeywords = creationKeywords();
-            Optional<OldKeyword> oldKeywords = getOldKeywords();
+            Optional<OldKeyword> oldKeywords = OldKeyword.computeOldKeywords(
+                isUnread, isFlagged, isAnswered, isDraft, isForwarded);
             Preconditions.checkArgument(!(maybeKeywords.isPresent() && oldKeywords.isPresent()), "Does not support keyword and is* at the same time");
             return new CreationMessage(mailboxIds, Optional.ofNullable(inReplyToMessageId), headers.build(), from,
                     to.build(), cc.build(), bcc.build(), replyTo.build(), subject, date, Optional.ofNullable(textBody), Optional.ofNullable(htmlBody),
@@ -234,12 +235,6 @@ public class CreationMessage {
                     .fromMap(map));
         }
 
-        private Optional<OldKeyword> getOldKeywords() {
-            if (isAnswered.isPresent() || isFlagged.isPresent() || isUnread.isPresent() || isDraft.isPresent() || isForwarded.isPresent()) {
-                return Optional.of(new OldKeyword(isUnread, isFlagged, isAnswered, isDraft, isForwarded));
-            }
-            return Optional.empty();
-        }
     }
 
     private final ImmutableList<String> mailboxIds;

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/CreationMessage.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/CreationMessage.java
@@ -333,6 +333,13 @@ public class CreationMessage {
         return validate().isEmpty();
     }
 
+    public boolean isDraft() {
+        return oldKeyword
+            .map(OldKeyword::isDraft)
+            .orElse(keywords.map(keywords -> keywords.contains(Keyword.DRAFT)))
+            .orElse(false);
+    }
+
     public Optional<Keywords> getKeywords() {
         return keywords;
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/CreationMessage.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/CreationMessage.java
@@ -223,13 +223,20 @@ public class CreationMessage {
             Preconditions.checkArgument(!(maybeKeywords.isPresent() && oldKeywords.isPresent()), "Does not support keyword and is* at the same time");
             return new CreationMessage(mailboxIds, Optional.ofNullable(inReplyToMessageId), headers.build(), from,
                     to.build(), cc.build(), bcc.build(), replyTo.build(), subject, date, Optional.ofNullable(textBody), Optional.ofNullable(htmlBody),
-                    attachments, attachedMessages, maybeKeywords, oldKeywords);
+                    attachments, attachedMessages, computeKeywords(maybeKeywords, oldKeywords));
         }
 
         private Optional<Keywords> creationKeywords() {
             return keywords.map(map -> Keywords.factory()
                     .throwOnImapNonExposedKeywords()
                     .fromMap(map));
+        }
+
+        public Keywords computeKeywords(Optional<Keywords> keywords, Optional<OldKeyword> oldKeyword) {
+            return oldKeyword.map(OldKeyword::asKeywords)
+                .map(Optional::of)
+                .orElse(keywords)
+                .orElse(Keywords.DEFAULT_VALUE);
         }
 
     }
@@ -248,13 +255,12 @@ public class CreationMessage {
     private final Optional<String> htmlBody;
     private final ImmutableList<Attachment> attachments;
     private final ImmutableMap<BlobId, SubMessage> attachedMessages;
-    private final Optional<Keywords> keywords;
-    private final Optional<OldKeyword> oldKeyword;
+    private final Keywords keywords;
 
     @VisibleForTesting
     CreationMessage(ImmutableList<String> mailboxIds, Optional<String> inReplyToMessageId, ImmutableMap<String, String> headers, Optional<DraftEmailer> from,
                     ImmutableList<DraftEmailer> to, ImmutableList<DraftEmailer> cc, ImmutableList<DraftEmailer> bcc, ImmutableList<DraftEmailer> replyTo, String subject, ZonedDateTime date, Optional<String> textBody, Optional<String> htmlBody, ImmutableList<Attachment> attachments,
-                    ImmutableMap<BlobId, SubMessage> attachedMessages, Optional<Keywords> keywords, Optional<OldKeyword> oldKeyword) {
+                    ImmutableMap<BlobId, SubMessage> attachedMessages, Keywords keywords) {
         this.mailboxIds = mailboxIds;
         this.inReplyToMessageId = inReplyToMessageId;
         this.headers = headers;
@@ -270,7 +276,10 @@ public class CreationMessage {
         this.attachments = attachments;
         this.attachedMessages = attachedMessages;
         this.keywords = keywords;
-        this.oldKeyword = oldKeyword;
+    }
+
+    public Keywords getKeywords() {
+        return keywords;
     }
 
     public ImmutableList<String> getMailboxIds() {
@@ -334,18 +343,7 @@ public class CreationMessage {
     }
 
     public boolean isDraft() {
-        return oldKeyword
-            .map(OldKeyword::isDraft)
-            .orElse(keywords.map(keywords -> keywords.contains(Keyword.DRAFT)))
-            .orElse(false);
-    }
-
-    public Optional<Keywords> getKeywords() {
-        return keywords;
-    }
-
-    public Optional<OldKeyword> getOldKeyword() {
-        return oldKeyword;
+        return keywords.contains(Keyword.DRAFT);
     }
 
     public List<ValidationResult> validate() {

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/CreationMessage.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/CreationMessage.java
@@ -34,6 +34,7 @@ import javax.mail.internet.InternetAddress;
 import org.apache.james.jmap.methods.ValidationResult;
 import org.apache.james.jmap.model.MessageProperties.MessageProperty;
 import org.apache.james.mailbox.MessageManager;
+import org.apache.james.util.OptionalUtils;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -233,8 +234,9 @@ public class CreationMessage {
 
         public Keywords computeKeywords(Optional<Keywords> keywords, Optional<OldKeyword> oldKeywords) {
             Preconditions.checkArgument(!(keywords.isPresent() && oldKeywords.isPresent()), "Does not support keyword and is* at the same time");
-            return keywords.map(Optional::of)
-                .orElse(oldKeywords.map(OldKeyword::asKeywords))
+            return OptionalUtils
+                .or(keywords,
+                    oldKeywords.map(OldKeyword::asKeywords))
                 .orElse(Keywords.DEFAULT_VALUE);
         }
 

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/CreationMessage.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/CreationMessage.java
@@ -220,7 +220,6 @@ public class CreationMessage {
             Optional<Keywords> maybeKeywords = creationKeywords();
             Optional<OldKeyword> oldKeywords = oldKeywordBuilder.computeOldKeyword();
 
-            Preconditions.checkArgument(!(maybeKeywords.isPresent() && oldKeywords.isPresent()), "Does not support keyword and is* at the same time");
             return new CreationMessage(mailboxIds, Optional.ofNullable(inReplyToMessageId), headers.build(), from,
                     to.build(), cc.build(), bcc.build(), replyTo.build(), subject, date, Optional.ofNullable(textBody), Optional.ofNullable(htmlBody),
                     attachments, attachedMessages, computeKeywords(maybeKeywords, oldKeywords));
@@ -232,10 +231,10 @@ public class CreationMessage {
                     .fromMap(map));
         }
 
-        public Keywords computeKeywords(Optional<Keywords> keywords, Optional<OldKeyword> oldKeyword) {
-            return oldKeyword.map(OldKeyword::asKeywords)
-                .map(Optional::of)
-                .orElse(keywords)
+        public Keywords computeKeywords(Optional<Keywords> keywords, Optional<OldKeyword> oldKeywords) {
+            Preconditions.checkArgument(!(keywords.isPresent() && oldKeywords.isPresent()), "Does not support keyword and is* at the same time");
+            return keywords.map(Optional::of)
+                .orElse(oldKeywords.map(OldKeyword::asKeywords))
                 .orElse(Keywords.DEFAULT_VALUE);
         }
 

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/CreationMessage.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/CreationMessage.java
@@ -204,11 +204,9 @@ public class CreationMessage {
         }
 
         private static Predicate<BlobId> inAttachments(ImmutableList<Attachment> attachments) {
-            return (key) -> {
-                return attachments.stream()
-                    .map(Attachment::getBlobId)
-                    .anyMatch(blobId -> blobId.equals(key));
-            };
+            return (key) -> attachments.stream()
+                .map(Attachment::getBlobId)
+                .anyMatch(blobId -> blobId.equals(key));
         }
 
         public CreationMessage build() {

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/CreationMessage.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/CreationMessage.java
@@ -59,11 +59,7 @@ public class CreationMessage {
     public static class Builder {
         private ImmutableList<String> mailboxIds;
         private String inReplyToMessageId;
-        private Optional<Boolean> isUnread = Optional.empty();
-        private Optional<Boolean> isFlagged = Optional.empty();
-        private Optional<Boolean> isAnswered = Optional.empty();
-        private Optional<Boolean> isDraft = Optional.empty();
-        private Optional<Boolean> isForwarded = Optional.empty();
+        private final OldKeyword.Builder oldKeywordBuilder;
         private final ImmutableMap.Builder<String, String> headers;
         private Optional<DraftEmailer> from = Optional.empty();
         private final ImmutableList.Builder<DraftEmailer> to;
@@ -86,6 +82,7 @@ public class CreationMessage {
             attachments = ImmutableList.builder();
             attachedMessages = ImmutableMap.builder();
             headers = ImmutableMap.builder();
+            oldKeywordBuilder = OldKeyword.builder();
         }
 
         public Builder mailboxId(String... mailboxIds) {
@@ -104,27 +101,27 @@ public class CreationMessage {
         }
 
         public Builder isUnread(Optional<Boolean> isUnread) {
-            this.isUnread = isUnread;
+            oldKeywordBuilder.isUnread(isUnread);
             return this;
         }
 
         public Builder isFlagged(Optional<Boolean> isFlagged) {
-            this.isFlagged = isFlagged;
+            oldKeywordBuilder.isFlagged(isFlagged);
             return this;
         }
 
         public Builder isAnswered(Optional<Boolean> isAnswered) {
-            this.isAnswered = isAnswered;
+            oldKeywordBuilder.isAnswered(isAnswered);
             return this;
         }
 
         public Builder isDraft(Optional<Boolean> isDraft) {
-            this.isDraft = isDraft;
+            oldKeywordBuilder.isDraft(isDraft);
             return this;
         }
 
         public Builder isForwarded(Optional<Boolean> isForwarded) {
-            this.isForwarded = isForwarded;
+            oldKeywordBuilder.isForwarded(isForwarded);
             return this;
         }
 
@@ -221,8 +218,8 @@ public class CreationMessage {
             }
 
             Optional<Keywords> maybeKeywords = creationKeywords();
-            Optional<OldKeyword> oldKeywords = OldKeyword.computeOldKeywords(
-                isUnread, isFlagged, isAnswered, isDraft, isForwarded);
+            Optional<OldKeyword> oldKeywords = oldKeywordBuilder.computeOldKeyword();
+
             Preconditions.checkArgument(!(maybeKeywords.isPresent() && oldKeywords.isPresent()), "Does not support keyword and is* at the same time");
             return new CreationMessage(mailboxIds, Optional.ofNullable(inReplyToMessageId), headers.build(), from,
                     to.build(), cc.build(), bcc.build(), replyTo.build(), subject, date, Optional.ofNullable(textBody), Optional.ofNullable(htmlBody),

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/Keywords.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/Keywords.java
@@ -43,7 +43,7 @@ import com.google.common.collect.ImmutableSet;
 
 public class Keywords {
 
-    public static final Keywords DEFAULT_VALUE = factory().fromSet(ImmutableSet.of(), Optional.empty());
+    public static final Keywords DEFAULT_VALUE = factory().fromSet(ImmutableSet.of());
     private static final Logger LOGGER = LoggerFactory.getLogger(Keywords.class);
 
     public interface KeywordsValidator {
@@ -78,27 +78,24 @@ public class Keywords {
             return this;
         }
 
-        public Keywords fromSet(Set<Keyword> setKeywords, Optional<OldKeyword> oldKeyword) {
+        public Keywords fromSet(Set<Keyword> setKeywords) {
             validator.orElse(keywords -> {})
                 .validate(setKeywords);
 
             return new Keywords(setKeywords.stream()
                     .filter(filter.orElse(keyword -> true))
-                    .collect(Guavate.toImmutableSet()),
-                oldKeyword);
+                    .collect(Guavate.toImmutableSet()));
         }
 
         public Keywords from(Keyword... keywords) {
             return fromSet(Arrays.stream(keywords)
-                    .collect(Guavate.toImmutableSet()),
-                Optional.empty());
+                    .collect(Guavate.toImmutableSet()));
         }
 
         public Keywords fromList(List<String> keywords) {
             return fromSet(keywords.stream()
                     .map(Keyword::new)
-                    .collect(Guavate.toImmutableSet()),
-                Optional.empty());
+                    .collect(Guavate.toImmutableSet()));
         }
 
         @VisibleForTesting
@@ -111,7 +108,7 @@ public class Keywords {
                 .map(Keyword::new)
                 .collect(Guavate.toImmutableSet());
 
-            return fromSet(setKeywords, Optional.empty());
+            return fromSet(setKeywords);
         }
 
         public Keywords fromFlags(Flags flags) {
@@ -120,8 +117,7 @@ public class Keywords {
                             .flatMap(this::asKeyword),
                         Stream.of(flags.getSystemFlags())
                             .map(Keyword::fromFlag))
-                    .collect(Guavate.toImmutableSet()),
-                Optional.empty());
+                    .collect(Guavate.toImmutableSet()));
         }
 
         private Stream<Keyword> asKeyword(String flagName) {
@@ -139,11 +135,9 @@ public class Keywords {
     }
 
     private final ImmutableSet<Keyword> keywords;
-    private final Optional<OldKeyword> oldKeyword;
 
-    private Keywords(ImmutableSet<Keyword> keywords, Optional<OldKeyword> oldKeyword) {
+    private Keywords(ImmutableSet<Keyword> keywords) {
         this.keywords = keywords;
-        this.oldKeyword = oldKeyword;
     }
 
     public Flags asFlags() {
@@ -181,22 +175,20 @@ public class Keywords {
     public final boolean equals(Object other) {
         if (other instanceof Keywords) {
             Keywords otherKeyword = (Keywords) other;
-            return Objects.equal(keywords, otherKeyword.keywords)
-                && Objects.equal(oldKeyword, otherKeyword.oldKeyword);
+            return Objects.equal(keywords, otherKeyword.keywords);
         }
         return false;
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hashCode(keywords, oldKeyword);
+        return Objects.hashCode(keywords);
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
             .add("keywords", keywords)
-            .add("oldKeyword", oldKeyword)
             .toString();
     }
 

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/OldKeyword.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/OldKeyword.java
@@ -173,28 +173,6 @@ public class OldKeyword {
         return newStateFlags;
     }
 
-    public Flags asFlags() {
-        Flags newStateFlags = new Flags();
-
-        if (isFlagged().orElse(false)) {
-            newStateFlags.add(Flags.Flag.FLAGGED);
-        }
-        if (isAnswered().orElse(false)) {
-            newStateFlags.add(Flags.Flag.ANSWERED);
-        }
-        if (isDraft().orElse(false)) {
-            newStateFlags.add(Flags.Flag.DRAFT);
-        }
-        if (isForwarded().orElse(false)) {
-            newStateFlags.add(new Flags("$Forwarded"));
-        }
-        boolean shouldMessageBeMarkSeen = isUnread().map(b -> !b).orElse(false);
-        if (shouldMessageBeMarkSeen) {
-            newStateFlags.add(Flags.Flag.SEEN);
-        }
-        return newStateFlags;
-    }
-
     public Keywords asKeywords() {
         return Keywords.factory()
             .fromSet(

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/OldKeyword.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/OldKeyword.java
@@ -28,7 +28,6 @@ import org.apache.james.util.OptionalUtils;
 import org.apache.james.util.StreamUtils;
 
 import com.github.steveash.guavate.Guavate;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
@@ -113,15 +112,6 @@ public class OldKeyword {
     private final Optional<Boolean> isAnswered;
     private final Optional<Boolean> isDraft;
     private final Optional<Boolean> isForwarded;
-
-    @VisibleForTesting
-    OldKeyword(boolean isUnread, boolean isFlagged, boolean isAnswered, boolean isDraft, boolean isForwarded) {
-        this.isUnread = Optional.of(isUnread);
-        this.isFlagged = Optional.of(isFlagged);
-        this.isAnswered = Optional.of(isAnswered);
-        this.isDraft = Optional.of(isDraft);
-        this.isForwarded = Optional.of(isForwarded);
-    }
 
     private OldKeyword(Optional<Boolean> isUnread, Optional<Boolean> isFlagged, Optional<Boolean> isAnswered,
                       Optional<Boolean> isDraft, Optional<Boolean> isForwarded) {

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/OldKeyword.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/OldKeyword.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.jmap.model;
 
+import java.util.Arrays;
 import java.util.Optional;
 
 import javax.mail.Flags;
@@ -169,6 +170,14 @@ public class OldKeyword {
         boolean shouldMessageBeMarkSeen = isUnread().map(b -> !b).orElse(currentFlags.contains(Flags.Flag.SEEN));
         if (shouldMessageBeMarkSeen) {
             newStateFlags.add(Flags.Flag.SEEN);
+        }
+        Arrays.stream(currentFlags.getUserFlags())
+            .forEach(newStateFlags::add);
+        if (currentFlags.contains(Flags.Flag.RECENT)) {
+            newStateFlags.add(Flags.Flag.RECENT);
+        }
+        if (currentFlags.contains(Flags.Flag.DELETED)) {
+            newStateFlags.add(Flags.Flag.DELETED);
         }
         return newStateFlags;
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/OldKeyword.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/OldKeyword.java
@@ -174,14 +174,14 @@ public class OldKeyword {
 
     public Keywords asKeywords() {
         return Keywords.factory()
-            .fromSet(
-                StreamUtils.flatten(
+            .fromSet(StreamUtils
+                .flatten(
                     OptionalUtils.toStream(isAnswered.filter(b -> b).map(b -> Keyword.ANSWERED)),
                     OptionalUtils.toStream(isDraft.filter(b -> b).map(b -> Keyword.DRAFT)),
                     OptionalUtils.toStream(isForwarded.filter(b -> b).map(b -> Keyword.FORWARDED)),
                     OptionalUtils.toStream(isFlagged.filter(b -> b).map(b -> Keyword.FLAGGED)),
                     OptionalUtils.toStream(isUnread.filter(b -> !b).map(b -> Keyword.SEEN)))
-                    .collect(Guavate.toImmutableSet()));
+                .collect(Guavate.toImmutableSet()));
     }
 
     @Override

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/OldKeyword.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/OldKeyword.java
@@ -23,6 +23,10 @@ import java.util.Optional;
 
 import javax.mail.Flags;
 
+import org.apache.james.util.OptionalUtils;
+import org.apache.james.util.StreamUtils;
+
+import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -189,6 +193,18 @@ public class OldKeyword {
             newStateFlags.add(Flags.Flag.SEEN);
         }
         return newStateFlags;
+    }
+
+    public Keywords asKeywords() {
+        return Keywords.factory()
+            .fromSet(
+                StreamUtils.flatten(
+                    OptionalUtils.toStream(isAnswered.filter(b -> b).map(b -> Keyword.ANSWERED)),
+                    OptionalUtils.toStream(isDraft.filter(b -> b).map(b -> Keyword.DRAFT)),
+                    OptionalUtils.toStream(isForwarded.filter(b -> b).map(b -> Keyword.FORWARDED)),
+                    OptionalUtils.toStream(isFlagged.filter(b -> b).map(b -> Keyword.FLAGGED)),
+                    OptionalUtils.toStream(isUnread.filter(b -> !b).map(b -> Keyword.SEEN)))
+                    .collect(Guavate.toImmutableSet()));
     }
 
     @Override

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/OldKeyword.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/OldKeyword.java
@@ -28,6 +28,14 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 public class OldKeyword {
+    public static Optional<OldKeyword> computeOldKeywords(Optional<Boolean> isUnread, Optional<Boolean> isFlagged, Optional<Boolean> isAnswered,
+                                                          Optional<Boolean> isDraft, Optional<Boolean> isForwarded) {
+        if (isAnswered.isPresent() || isFlagged.isPresent() || isUnread.isPresent() || isForwarded.isPresent() || isDraft.isPresent()) {
+            return Optional.of(new OldKeyword(isUnread, isFlagged, isAnswered, isDraft, isForwarded));
+        }
+        return Optional.empty();
+    }
+
     private final Optional<Boolean> isUnread;
     private final Optional<Boolean> isFlagged;
     private final Optional<Boolean> isAnswered;
@@ -43,7 +51,7 @@ public class OldKeyword {
         this.isForwarded = Optional.of(isForwarded);
     }
 
-    public OldKeyword(Optional<Boolean> isUnread, Optional<Boolean> isFlagged, Optional<Boolean> isAnswered,
+    private OldKeyword(Optional<Boolean> isUnread, Optional<Boolean> isFlagged, Optional<Boolean> isAnswered,
                       Optional<Boolean> isDraft, Optional<Boolean> isForwarded) {
         this.isUnread = isUnread;
         this.isFlagged = isFlagged;

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/OldKeyword.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/OldKeyword.java
@@ -28,12 +28,79 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 public class OldKeyword {
-    public static Optional<OldKeyword> computeOldKeywords(Optional<Boolean> isUnread, Optional<Boolean> isFlagged, Optional<Boolean> isAnswered,
-                                                          Optional<Boolean> isDraft, Optional<Boolean> isForwarded) {
-        if (isAnswered.isPresent() || isFlagged.isPresent() || isUnread.isPresent() || isForwarded.isPresent() || isDraft.isPresent()) {
-            return Optional.of(new OldKeyword(isUnread, isFlagged, isAnswered, isDraft, isForwarded));
+
+    public static class Builder {
+        private Optional<Boolean> isUnread;
+        private Optional<Boolean> isFlagged;
+        private Optional<Boolean> isAnswered;
+        private Optional<Boolean> isDraft;
+        private Optional<Boolean> isForwarded;
+
+        private Builder() {
+            isUnread = Optional.empty();
+            isFlagged = Optional.empty();
+            isAnswered = Optional.empty();
+            isDraft = Optional.empty();
+            isForwarded = Optional.empty();
         }
-        return Optional.empty();
+
+        public Builder isFlagged(Optional<Boolean> isFlagged) {
+            this.isFlagged = isFlagged;
+            return this;
+        }
+
+        public Builder isFlagged(boolean isFlagged) {
+            return isFlagged(Optional.of(isFlagged));
+        }
+
+        public Builder isUnread(Optional<Boolean> isUnread) {
+            this.isUnread = isUnread;
+            return this;
+        }
+
+        public Builder isUnread(boolean isUnread) {
+            return isUnread(Optional.of(isUnread));
+        }
+
+        public Builder isAnswered(Optional<Boolean> isAnswered) {
+            this.isAnswered = isAnswered;
+            return this;
+        }
+
+        public Builder isAnswered(boolean isAnswered) {
+            return isAnswered(Optional.of(isAnswered));
+        }
+
+        public Builder isDraft(Optional<Boolean> isDraft) {
+            this.isDraft = isDraft;
+            return this;
+        }
+
+        public Builder isDraft(boolean isDraft) {
+            return isDraft(Optional.of(isDraft));
+        }
+
+        public Builder isForwarded(Optional<Boolean> isForwarded) {
+            this.isForwarded = isForwarded;
+            return this;
+        }
+
+        public Builder isForwarded(boolean isForwarded) {
+            return isForwarded(Optional.of(isForwarded));
+        }
+
+        public Optional<OldKeyword> computeOldKeyword() {
+            if (isAnswered.isPresent() || isFlagged.isPresent() || isUnread.isPresent() || isForwarded.isPresent() || isDraft.isPresent()) {
+                return Optional.of(new OldKeyword(isUnread, isFlagged, isAnswered, isDraft, isForwarded));
+            }
+
+            return Optional.empty();
+        }
+
+    }
+
+    public static Builder builder() {
+        return new Builder();
     }
 
     private final Optional<Boolean> isUnread;

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/UpdateMessagePatch.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/UpdateMessagePatch.java
@@ -47,11 +47,7 @@ public class UpdateMessagePatch {
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
         private Optional<List<String>> mailboxIds = Optional.empty();
-        private Optional<Boolean> isFlagged = Optional.empty();
-        private Optional<Boolean> isUnread = Optional.empty();
-        private Optional<Boolean> isAnswered = Optional.empty();
-        private Optional<Boolean> isForwarded = Optional.empty();
-        private Optional<Boolean> isDraft = Optional.empty();
+        private OldKeyword.Builder oldKeyworkBuilder = OldKeyword.builder();
         private Optional<Map<String, Boolean>> keywords = Optional.empty();
         private Set<ValidationResult> validationResult = Sets.newHashSet();
 
@@ -66,27 +62,27 @@ public class UpdateMessagePatch {
         }
 
         public Builder isFlagged(Boolean isFlagged) {
-            this.isFlagged = Optional.of(isFlagged);
+            oldKeyworkBuilder.isFlagged(isFlagged);
             return this;
         }
 
         public Builder isUnread(Boolean isUnread) {
-            this.isUnread = Optional.of(isUnread);
+            oldKeyworkBuilder.isUnread(isUnread);
             return this;
         }
 
         public Builder isAnswered(Boolean isAnswered) {
-            this.isAnswered = Optional.of(isAnswered);
+            oldKeyworkBuilder.isAnswered(isAnswered);
             return this;
         }
 
-        public Builder isDraft(Boolean isAnswered) {
-            this.isDraft = Optional.of(isAnswered);
+        public Builder isDraft(Boolean isDraft) {
+            oldKeyworkBuilder.isDraft(isDraft);
             return this;
         }
 
         public Builder isForwarded(Boolean isForwarded) {
-            this.isForwarded = Optional.of(isForwarded);
+            oldKeyworkBuilder.isForwarded(isForwarded);
             return this;
         }
 
@@ -104,8 +100,7 @@ public class UpdateMessagePatch {
             }
 
             Optional<Keywords> mayBeKeywords = creationKeywords();
-            Optional<OldKeyword> oldKeywords = OldKeyword.computeOldKeywords(
-                isUnread, isFlagged, isAnswered, isDraft, isForwarded);
+            Optional<OldKeyword> oldKeywords = oldKeyworkBuilder.computeOldKeyword();
             Preconditions.checkArgument(!(mayBeKeywords.isPresent() && oldKeywords.isPresent()), "Does not support keyword and is* at the same time");
 
             return new UpdateMessagePatch(mailboxIds, mayBeKeywords, oldKeywords, ImmutableList.copyOf(validationResult));

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/UpdateMessagePatch.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/UpdateMessagePatch.java
@@ -51,6 +51,7 @@ public class UpdateMessagePatch {
         private Optional<Boolean> isUnread = Optional.empty();
         private Optional<Boolean> isAnswered = Optional.empty();
         private Optional<Boolean> isForwarded = Optional.empty();
+        private Optional<Boolean> isDraft = Optional.empty();
         private Optional<Map<String, Boolean>> keywords = Optional.empty();
         private Set<ValidationResult> validationResult = Sets.newHashSet();
 
@@ -79,6 +80,11 @@ public class UpdateMessagePatch {
             return this;
         }
 
+        public Builder isDraft(Boolean isAnswered) {
+            this.isDraft = Optional.of(isAnswered);
+            return this;
+        }
+
         public Builder isForwarded(Boolean isForwarded) {
             this.isForwarded = Optional.of(isForwarded);
             return this;
@@ -98,7 +104,8 @@ public class UpdateMessagePatch {
             }
 
             Optional<Keywords> mayBeKeywords = creationKeywords();
-            Optional<OldKeyword> oldKeywords = getOldKeywords();
+            Optional<OldKeyword> oldKeywords = OldKeyword.computeOldKeywords(
+                isUnread, isFlagged, isAnswered, isDraft, isForwarded);
             Preconditions.checkArgument(!(mayBeKeywords.isPresent() && oldKeywords.isPresent()), "Does not support keyword and is* at the same time");
 
             return new UpdateMessagePatch(mailboxIds, mayBeKeywords, oldKeywords, ImmutableList.copyOf(validationResult));
@@ -108,14 +115,6 @@ public class UpdateMessagePatch {
             return keywords.map(map -> Keywords.factory()
                     .throwOnImapNonExposedKeywords()
                     .fromMap(map));
-        }
-
-        private Optional<OldKeyword> getOldKeywords() {
-            if (isAnswered.isPresent() || isFlagged.isPresent() || isUnread.isPresent() || isForwarded.isPresent()) {
-                Optional<Boolean> isDraft = Optional.empty();
-                return Optional.of(new OldKeyword(isUnread, isFlagged, isAnswered, isDraft, isForwarded));
-            }
-            return Optional.empty();
         }
 
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/UpdateMessagePatch.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/UpdateMessagePatch.java
@@ -135,14 +135,6 @@ public class UpdateMessagePatch {
         return mailboxIds;
     }
 
-    public Optional<Keywords> getKeywords() {
-        return keywords;
-    }
-
-    public Optional<OldKeyword> getOldKeyword() {
-        return oldKeywords;
-    }
-
     public boolean isFlagsIdentity() {
         return !oldKeywords.isPresent() && !keywords.isPresent();
     }
@@ -156,8 +148,10 @@ public class UpdateMessagePatch {
     }
 
     public Flags applyToState(Flags currentFlags) {
-        return keywords
-            .map(keyword -> keyword.asFlagsWithRecentAndDeletedFrom(currentFlags))
-            .orElse(currentFlags);
+        return oldKeywords
+            .map(oldKeyword -> oldKeyword.applyToState(currentFlags))
+            .orElse(keywords
+                .map(keyword -> keyword.asFlagsWithRecentAndDeletedFrom(currentFlags))
+                .orElse(currentFlags));
     }
 }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/KeywordsCombiner.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/utils/KeywordsCombiner.java
@@ -20,7 +20,6 @@
 package org.apache.james.jmap.utils;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.BinaryOperator;
 
@@ -47,8 +46,7 @@ public class KeywordsCombiner implements BinaryOperator<Keywords> {
         return keywordsFactory
             .fromSet(Sets.union(
                         union(keywords.getKeywords(), keywords2.getKeywords(), KEYWORD_NOT_TO_UNION),
-                        intersect(keywords.getKeywords(), keywords2.getKeywords(), KEYWORD_TO_INTERSECT)),
-                    Optional.empty());
+                        intersect(keywords.getKeywords(), keywords2.getKeywords(), KEYWORD_TO_INTERSECT)));
     }
 
     public Set<Keyword> union(Set<Keyword> set1, Set<Keyword> set2, List<Keyword> exceptKeywords) {

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/json/ParsingWritingObjects.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/json/ParsingWritingObjects.java
@@ -77,7 +77,7 @@ public interface ParsingWritingObjects {
             .threadId(Common.THREAD_ID)
             .mailboxIds(Common.MAILBOX_IDS)
             .inReplyToMessageId(Common.IN_REPLY_TO_MESSAGE_ID)
-            .keywords(Keywords.factory().fromSet(Common.KEYWORDS, Optional.empty()))
+            .keywords(Keywords.factory().fromSet(Common.KEYWORDS))
             .headers(Common.HEADERS)
             .from(Common.FROM)
             .to(Common.TO)

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/CreationMessageTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/CreationMessageTest.java
@@ -159,4 +159,69 @@ public class CreationMessageTest {
 
         assertThat(message.getMailboxIds()).containsExactly(mailboxId);
     }
+
+    @Test
+    public void isDraftWhenNoKeywordsSpecified() {
+        String mailboxId = "123";
+        CreationMessage message = CreationMessage.builder()
+            .mailboxId(mailboxId)
+            .build();
+
+        assertThat(message.isDraft()).isFalse();
+    }
+
+    @Test
+    public void isDraftShouldBeTrueWhenOldKeywordDraft() {
+        String mailboxId = "123";
+        CreationMessage message = CreationMessage.builder()
+            .mailboxId(mailboxId)
+            .isDraft(Optional.of(true))
+            .build();
+
+        assertThat(message.isDraft()).isTrue();
+    }
+
+    @Test
+    public void isDraftShouldBeFalseWhenOldKeywordNonDraft() {
+        String mailboxId = "123";
+        CreationMessage message = CreationMessage.builder()
+            .mailboxId(mailboxId)
+            .isAnswered(Optional.of(true))
+            .build();
+
+        assertThat(message.isDraft()).isFalse();
+    }
+
+    @Test
+    public void isDraftShouldBeFalseWhenEmptyKeywords() {
+        String mailboxId = "123";
+        CreationMessage message = CreationMessage.builder()
+            .keywords(ImmutableMap.of())
+            .mailboxId(mailboxId)
+            .build();
+
+        assertThat(message.isDraft()).isFalse();
+    }
+
+    @Test
+    public void isDraftShouldBeFalseWhenKeywordsDoesNotContainsDraft() {
+        String mailboxId = "123";
+        CreationMessage message = CreationMessage.builder()
+            .keywords(ImmutableMap.of(Keyword.ANSWERED.getFlagName(), true))
+            .mailboxId(mailboxId)
+            .build();
+
+        assertThat(message.isDraft()).isFalse();
+    }
+
+    @Test
+    public void isDraftShouldBeTrueWhenKeywordsContainsDraft() {
+        String mailboxId = "123";
+        CreationMessage message = CreationMessage.builder()
+            .keywords(ImmutableMap.of(Keyword.DRAFT.getFlagName(), true))
+            .mailboxId(mailboxId)
+            .build();
+
+        assertThat(message.isDraft()).isTrue();
+    }
 }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/CreationMessageTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/CreationMessageTest.java
@@ -161,7 +161,7 @@ public class CreationMessageTest {
     }
 
     @Test
-    public void isDraftWhenNoKeywordsSpecified() {
+    public void isDraftShouldBeFalseWhenNoKeywordsSpecified() {
         String mailboxId = "123";
         CreationMessage message = CreationMessage.builder()
             .mailboxId(mailboxId)

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/KeywordsTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/KeywordsTest.java
@@ -22,7 +22,6 @@ package org.apache.james.jmap.model;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
-import java.util.Optional;
 
 import javax.mail.Flags;
 import javax.mail.Flags.Flag;
@@ -77,7 +76,7 @@ public class KeywordsTest {
     @Test
     public void fromSetShouldReturnKeywordsFromSetOfKeywords() throws Exception {
         Keywords keywords = Keywords.factory()
-            .fromSet(ImmutableSet.of(Keyword.ANSWERED), Optional.empty());
+            .fromSet(ImmutableSet.of(Keyword.ANSWERED));
 
         assertThat(keywords.getKeywords())
             .containsOnly(Keyword.ANSWERED);
@@ -86,7 +85,7 @@ public class KeywordsTest {
     @Test
     public void asFlagsShouldBuildFlagsFromKeywords() throws Exception {
         assertThat(Keywords.factory()
-                .fromSet(ImmutableSet.of(Keyword.ANSWERED), Optional.empty())
+                .fromSet(ImmutableSet.of(Keyword.ANSWERED))
                 .asFlags())
             .isEqualTo(new Flags(Flags.Flag.ANSWERED));
     }
@@ -102,7 +101,7 @@ public class KeywordsTest {
             .build();
 
         assertThat(Keywords.factory()
-                .fromSet(ImmutableSet.of(Keyword.ANSWERED), Optional.empty())
+                .fromSet(ImmutableSet.of(Keyword.ANSWERED))
                 .asFlagsWithRecentAndDeletedFrom(originFlags))
             .isEqualTo(expectedFlags);
     }
@@ -118,7 +117,7 @@ public class KeywordsTest {
             .build();
 
         assertThat(Keywords.factory()
-                .fromSet(ImmutableSet.of(Keyword.ANSWERED), Optional.empty())
+                .fromSet(ImmutableSet.of(Keyword.ANSWERED))
                 .asFlagsWithRecentAndDeletedFrom(originFlags))
             .isEqualTo(expectedFlags);
     }
@@ -126,7 +125,7 @@ public class KeywordsTest {
     @Test
     public void asMapShouldReturnEmptyWhenEmptyMapOfStringAndBoolean() throws Exception {
         assertThat(Keywords.factory()
-                .fromSet(ImmutableSet.of(), Optional.empty())
+                .fromSet(ImmutableSet.of())
                 .asMap())
             .isEmpty();;
     }
@@ -135,7 +134,7 @@ public class KeywordsTest {
     public void asMapShouldReturnMapOfStringAndBoolean() throws Exception {
         Map<String, Boolean> expectedMap = ImmutableMap.of("$Answered", Keyword.FLAG_VALUE);
         assertThat(Keywords.factory()
-                .fromSet(ImmutableSet.of(Keyword.ANSWERED), Optional.empty())
+                .fromSet(ImmutableSet.of(Keyword.ANSWERED))
                 .asMap())
             .isEqualTo(expectedMap);
     }
@@ -146,14 +145,14 @@ public class KeywordsTest {
 
         Keywords.factory()
             .throwOnImapNonExposedKeywords()
-            .fromSet(ImmutableSet.of(Keyword.DRAFT, Keyword.DELETED), Optional.empty());
+            .fromSet(ImmutableSet.of(Keyword.DRAFT, Keyword.DELETED));
     }
 
     @Test
     public void throwWhenUnsupportedKeywordShouldNotThrowWhenHaveDraft() throws Exception {
         Keywords keywords = Keywords.factory()
             .throwOnImapNonExposedKeywords()
-            .fromSet(ImmutableSet.of(Keyword.ANSWERED, Keyword.DRAFT), Optional.empty());
+            .fromSet(ImmutableSet.of(Keyword.ANSWERED, Keyword.DRAFT));
 
         assertThat(keywords.getKeywords())
             .containsOnly(Keyword.ANSWERED, Keyword.DRAFT);
@@ -163,7 +162,7 @@ public class KeywordsTest {
     public void filterUnsupportedShouldFilter() throws Exception {
         Keywords keywords = Keywords.factory()
             .filterImapNonExposedKeywords()
-            .fromSet(ImmutableSet.of(Keyword.ANSWERED, Keyword.DELETED, Keyword.RECENT, Keyword.DRAFT), Optional.empty());
+            .fromSet(ImmutableSet.of(Keyword.ANSWERED, Keyword.DELETED, Keyword.RECENT, Keyword.DRAFT));
 
         assertThat(keywords.getKeywords())
             .containsOnly(Keyword.ANSWERED, Keyword.DRAFT);
@@ -172,7 +171,7 @@ public class KeywordsTest {
     @Test
     public void containsShouldReturnTrueWhenKeywordsContainKeyword() {
         Keywords keywords = Keywords.factory()
-            .fromSet(ImmutableSet.of(Keyword.SEEN), Optional.empty());
+            .fromSet(ImmutableSet.of(Keyword.SEEN));
 
         assertThat(keywords.contains(Keyword.SEEN)).isTrue();
     }
@@ -180,7 +179,7 @@ public class KeywordsTest {
     @Test
     public void containsShouldReturnFalseWhenKeywordsDoNotContainKeyword() {
         Keywords keywords = Keywords.factory()
-            .fromSet(ImmutableSet.of(), Optional.empty());
+            .fromSet(ImmutableSet.of());
 
         assertThat(keywords.contains(Keyword.SEEN)).isFalse();
     }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/OldKeywordTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/OldKeywordTest.java
@@ -37,15 +37,27 @@ public class OldKeywordTest {
     }
 
     @Test
+    public void computeOldKeywordsShouldReturnEmptyWhenAllEmpty() {
+        Optional<Boolean> isUnread = Optional.empty();
+        Optional<Boolean> isFlagged = Optional.empty();
+        Optional<Boolean> isAnswered = Optional.empty();
+        Optional<Boolean> isDraft = Optional.empty();
+        Optional<Boolean> isForwarded = Optional.empty();
+        Optional<OldKeyword> testee = OldKeyword.computeOldKeywords(isUnread, isFlagged, isAnswered, isDraft, isForwarded);
+
+        assertThat(testee).isEmpty();
+    }
+
+    @Test
     public void applyStateShouldSetFlaggedOnlyWhenIsFlagged() {
         Optional<Boolean> isUnread = Optional.empty();
         Optional<Boolean> isFlagged = Optional.of(true);
         Optional<Boolean> isAnswered = Optional.empty();
         Optional<Boolean> isDraft = Optional.empty();
         Optional<Boolean> isForwarded = Optional.empty();
-        OldKeyword testee = new OldKeyword(isUnread, isFlagged, isAnswered, isDraft, isForwarded);
-        
-        assertThat(testee.applyToState(new Flags())).isEqualTo(new Flags(Flag.FLAGGED));
+        Optional<OldKeyword> testee = OldKeyword.computeOldKeywords(isUnread, isFlagged, isAnswered, isDraft, isForwarded);
+
+        assertThat(testee.get().applyToState(new Flags())).isEqualTo(new Flags(Flag.FLAGGED));
     }
 
     @Test
@@ -55,9 +67,9 @@ public class OldKeywordTest {
         Optional<Boolean> isAnswered = Optional.empty();
         Optional<Boolean> isDraft = Optional.empty();
         Optional<Boolean> isForwarded = Optional.empty();
-        OldKeyword testee = new OldKeyword(isUnread, isFlagged, isAnswered, isDraft, isForwarded);
+        Optional<OldKeyword> testee = OldKeyword.computeOldKeywords(isUnread, isFlagged, isAnswered, isDraft, isForwarded);
         
-        assertThat(testee.applyToState(new Flags(Flag.FLAGGED))).isEqualTo(new Flags());
+        assertThat(testee.get().applyToState(new Flags(Flag.FLAGGED))).isEqualTo(new Flags());
     }
 
     @Test
@@ -67,9 +79,9 @@ public class OldKeywordTest {
         Optional<Boolean> isAnswered = Optional.empty();
         Optional<Boolean> isDraft = Optional.empty();
         Optional<Boolean> isForwarded = Optional.empty();
-        OldKeyword testee = new OldKeyword(isUnread, isFlagged, isAnswered, isDraft, isForwarded);
-        
-        assertThat(testee.applyToState(new Flags(Flag.SEEN))).isEqualTo(new Flags());
+        Optional<OldKeyword> testee = OldKeyword.computeOldKeywords(isUnread, isFlagged, isAnswered, isDraft, isForwarded);
+
+        assertThat(testee.get().applyToState(new Flags(Flag.SEEN))).isEqualTo(new Flags());
     }
 
     @Test
@@ -79,8 +91,8 @@ public class OldKeywordTest {
         Optional<Boolean> isAnswered = Optional.empty();
         Optional<Boolean> isDraft = Optional.empty();
         Optional<Boolean> isForwarded = Optional.empty();
-        OldKeyword testee = new OldKeyword(isUnread, isFlagged, isAnswered, isDraft, isForwarded);
-        
-        assertThat(testee.applyToState(new Flags(Flag.SEEN))).isEqualTo(new Flags(Flag.SEEN));
+        Optional<OldKeyword> testee = OldKeyword.computeOldKeywords(isUnread, isFlagged, isAnswered, isDraft, isForwarded);
+
+        assertThat(testee.get().applyToState(new Flags(Flag.SEEN))).isEqualTo(new Flags(Flag.SEEN));
     }
 }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/OldKeywordTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/OldKeywordTest.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import javax.mail.Flags;
 import javax.mail.Flags.Flag;
 
+import org.apache.james.mailbox.FlagsBuilder;
 import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -241,5 +242,33 @@ public class OldKeywordTest {
             .computeOldKeyword();
 
         assertThat(testee.get().applyToState(new Flags(Flag.SEEN))).isEqualTo(new Flags(Flag.SEEN));
+    }
+
+    @Test
+    public void applyStateShouldPreserveRecentFlag() {
+        Optional<OldKeyword> testee = OldKeyword.builder()
+            .isUnread(Optional.of(false))
+            .isFlagged(Optional.empty())
+            .isAnswered(Optional.empty())
+            .isDraft(Optional.empty())
+            .isForwarded(Optional.empty())
+            .computeOldKeyword();
+
+        assertThat(testee.get().applyToState(new Flags(Flag.RECENT)))
+            .isEqualTo(new FlagsBuilder().add(Flag.RECENT, Flag.SEEN).build());
+    }
+
+    @Test
+    public void applyStateShouldDeletedFlag() {
+        Optional<OldKeyword> testee = OldKeyword.builder()
+            .isUnread(Optional.of(false))
+            .isFlagged(Optional.empty())
+            .isAnswered(Optional.empty())
+            .isDraft(Optional.empty())
+            .isForwarded(Optional.empty())
+            .computeOldKeyword();
+
+        assertThat(testee.get().applyToState(new Flags(Flag.DELETED)))
+            .isEqualTo(new FlagsBuilder().add(Flag.DELETED, Flag.SEEN).build());
     }
 }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/OldKeywordTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/OldKeywordTest.java
@@ -40,11 +40,7 @@ public class OldKeywordTest {
     @Test
     public void asKeywordsShouldContainFlaggedWhenIsFlagged() {
         Optional<OldKeyword> testee = OldKeyword.builder()
-            .isUnread(Optional.empty())
             .isFlagged(Optional.of(true))
-            .isAnswered(Optional.empty())
-            .isDraft(Optional.empty())
-            .isForwarded(Optional.empty())
             .computeOldKeyword();
 
         assertThat(testee.get().asKeywords())
@@ -54,11 +50,7 @@ public class OldKeywordTest {
     @Test
     public void asKeywordsShouldNotContainFlaggedWhenIsnotFlagged() {
         Optional<OldKeyword> testee = OldKeyword.builder()
-            .isUnread(Optional.empty())
             .isFlagged(Optional.of(false))
-            .isAnswered(Optional.empty())
-            .isDraft(Optional.empty())
-            .isForwarded(Optional.empty())
             .computeOldKeyword();
 
         assertThat(testee.get().asKeywords())
@@ -69,10 +61,6 @@ public class OldKeywordTest {
     public void asKeywordsShouldNotContainSeenWhenIsUnRead() {
         Optional<OldKeyword> testee = OldKeyword.builder()
             .isUnread(Optional.of(true))
-            .isFlagged(Optional.empty())
-            .isAnswered(Optional.empty())
-            .isDraft(Optional.empty())
-            .isForwarded(Optional.empty())
             .computeOldKeyword();
 
         assertThat(testee.get().asKeywords())
@@ -83,10 +71,6 @@ public class OldKeywordTest {
     public void asKeywordsShouldContainSeenWhenIsRead() {
         Optional<OldKeyword> testee = OldKeyword.builder()
             .isUnread(Optional.of(false))
-            .isFlagged(Optional.empty())
-            .isAnswered(Optional.empty())
-            .isDraft(Optional.empty())
-            .isForwarded(Optional.empty())
             .computeOldKeyword();
 
 
@@ -97,11 +81,7 @@ public class OldKeywordTest {
     @Test
     public void asKeywordsShouldContainAnsweredSeenWhenIsAnswered() {
         Optional<OldKeyword> testee = OldKeyword.builder()
-            .isUnread(Optional.empty())
-            .isFlagged(Optional.empty())
             .isAnswered(Optional.of(true))
-            .isDraft(Optional.empty())
-            .isForwarded(Optional.empty())
             .computeOldKeyword();
 
         assertThat(testee.get().asKeywords())
@@ -111,11 +91,7 @@ public class OldKeywordTest {
     @Test
     public void asKeywordsShouldNotContainAnsweredSeenWhenIsNotAnswered() {
         Optional<OldKeyword> testee = OldKeyword.builder()
-            .isUnread(Optional.empty())
-            .isFlagged(Optional.empty())
             .isAnswered(Optional.of(false))
-            .isDraft(Optional.empty())
-            .isForwarded(Optional.empty())
             .computeOldKeyword();
 
         assertThat(testee.get().asKeywords())
@@ -125,11 +101,7 @@ public class OldKeywordTest {
     @Test
     public void asKeywordsShouldContainDraftSeenWhenIsDraft() {
         Optional<OldKeyword> testee = OldKeyword.builder()
-            .isUnread(Optional.empty())
-            .isFlagged(Optional.empty())
-            .isAnswered(Optional.empty())
             .isDraft(Optional.of(true))
-            .isForwarded(Optional.empty())
             .computeOldKeyword();
 
         assertThat(testee.get().asKeywords())
@@ -139,11 +111,7 @@ public class OldKeywordTest {
     @Test
     public void asKeywordsShouldNotContainDraftSeenWhenIsNotDraft() {
         Optional<OldKeyword> testee = OldKeyword.builder()
-            .isUnread(Optional.empty())
-            .isFlagged(Optional.empty())
-            .isAnswered(Optional.empty())
             .isDraft(Optional.of(false))
-            .isForwarded(Optional.empty())
             .computeOldKeyword();
 
         assertThat(testee.get().asKeywords())
@@ -153,10 +121,6 @@ public class OldKeywordTest {
     @Test
     public void asKeywordsShouldNContainForwardedSeenWhenIsNForwarded() {
         Optional<OldKeyword> testee = OldKeyword.builder()
-            .isUnread(Optional.empty())
-            .isFlagged(Optional.empty())
-            .isAnswered(Optional.empty())
-            .isDraft(Optional.empty())
             .isForwarded(Optional.of(true))
             .computeOldKeyword();
 
@@ -167,10 +131,6 @@ public class OldKeywordTest {
     @Test
     public void asKeywordsShouldNotContainForwardedSeenWhenIsNotForwarded() {
         Optional<OldKeyword> testee = OldKeyword.builder()
-            .isUnread(Optional.empty())
-            .isFlagged(Optional.empty())
-            .isAnswered(Optional.empty())
-            .isDraft(Optional.empty())
             .isForwarded(Optional.of(false))
             .computeOldKeyword();
 
@@ -181,11 +141,6 @@ public class OldKeywordTest {
     @Test
     public void computeOldKeywordsShouldReturnEmptyWhenAllEmpty() {
         Optional<OldKeyword> testee = OldKeyword.builder()
-            .isUnread(Optional.empty())
-            .isFlagged(Optional.empty())
-            .isAnswered(Optional.empty())
-            .isDraft(Optional.empty())
-            .isForwarded(Optional.empty())
             .computeOldKeyword();
 
         assertThat(testee).isEmpty();
@@ -194,11 +149,7 @@ public class OldKeywordTest {
     @Test
     public void applyStateShouldSetFlaggedOnlyWhenIsFlagged() {
         Optional<OldKeyword> testee = OldKeyword.builder()
-            .isUnread(Optional.empty())
             .isFlagged(Optional.of(true))
-            .isAnswered(Optional.empty())
-            .isDraft(Optional.empty())
-            .isForwarded(Optional.empty())
             .computeOldKeyword();
 
         assertThat(testee.get().applyToState(new Flags())).isEqualTo(new Flags(Flag.FLAGGED));
@@ -207,11 +158,7 @@ public class OldKeywordTest {
     @Test
     public void applyStateShouldRemoveFlaggedWhenEmptyIsFlaggedOnFlaggedMessage() {
         Optional<OldKeyword> testee = OldKeyword.builder()
-            .isUnread(Optional.empty())
             .isFlagged(Optional.of(false))
-            .isAnswered(Optional.empty())
-            .isDraft(Optional.empty())
-            .isForwarded(Optional.empty())
             .computeOldKeyword();
 
         assertThat(testee.get().applyToState(new Flags(Flag.FLAGGED))).isEqualTo(new Flags());
@@ -222,10 +169,6 @@ public class OldKeywordTest {
     public void applyStateShouldReturnUnreadFlagWhenUnreadSetOnSeenMessage() {
         Optional<OldKeyword> testee = OldKeyword.builder()
             .isUnread(Optional.of(true))
-            .isFlagged(Optional.empty())
-            .isAnswered(Optional.empty())
-            .isDraft(Optional.empty())
-            .isForwarded(Optional.empty())
             .computeOldKeyword();
 
         assertThat(testee.get().applyToState(new Flags(Flag.SEEN))).isEqualTo(new Flags());
@@ -235,10 +178,6 @@ public class OldKeywordTest {
     public void applyStateShouldReturnSeenWhenPatchSetsSeenOnSeenMessage() {
         Optional<OldKeyword> testee = OldKeyword.builder()
             .isUnread(Optional.of(false))
-            .isFlagged(Optional.empty())
-            .isAnswered(Optional.empty())
-            .isDraft(Optional.empty())
-            .isForwarded(Optional.empty())
             .computeOldKeyword();
 
         assertThat(testee.get().applyToState(new Flags(Flag.SEEN))).isEqualTo(new Flags(Flag.SEEN));
@@ -248,10 +187,6 @@ public class OldKeywordTest {
     public void applyStateShouldPreserveRecentFlag() {
         Optional<OldKeyword> testee = OldKeyword.builder()
             .isUnread(Optional.of(false))
-            .isFlagged(Optional.empty())
-            .isAnswered(Optional.empty())
-            .isDraft(Optional.empty())
-            .isForwarded(Optional.empty())
             .computeOldKeyword();
 
         assertThat(testee.get().applyToState(new Flags(Flag.RECENT)))
@@ -262,10 +197,6 @@ public class OldKeywordTest {
     public void applyStateShouldDeletedFlag() {
         Optional<OldKeyword> testee = OldKeyword.builder()
             .isUnread(Optional.of(false))
-            .isFlagged(Optional.empty())
-            .isAnswered(Optional.empty())
-            .isDraft(Optional.empty())
-            .isForwarded(Optional.empty())
             .computeOldKeyword();
 
         assertThat(testee.get().applyToState(new Flags(Flag.DELETED)))

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/OldKeywordTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/OldKeywordTest.java
@@ -194,12 +194,23 @@ public class OldKeywordTest {
     }
 
     @Test
-    public void applyStateShouldDeletedFlag() {
+    public void applyStateShouldPreserveDeletedFlag() {
         Optional<OldKeyword> testee = OldKeyword.builder()
             .isUnread(Optional.of(false))
             .computeOldKeyword();
 
         assertThat(testee.get().applyToState(new Flags(Flag.DELETED)))
             .isEqualTo(new FlagsBuilder().add(Flag.DELETED, Flag.SEEN).build());
+    }
+
+    @Test
+    public void applyStateShouldPreserveCustomFlag() {
+        Optional<OldKeyword> testee = OldKeyword.builder()
+            .isUnread(Optional.of(false))
+            .computeOldKeyword();
+
+        String customFlag = "custom";
+        assertThat(testee.get().applyToState(new Flags(customFlag)))
+            .isEqualTo(new FlagsBuilder().add(Flag.SEEN).add(customFlag).build());
     }
 }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/OldKeywordTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/OldKeywordTest.java
@@ -48,7 +48,7 @@ public class OldKeywordTest {
     }
 
     @Test
-    public void asKeywordsShouldNotContainFlaggedWhenIsnotFlagged() {
+    public void asKeywordsShouldNotContainFlaggedWhenIsNotFlagged() {
         Optional<OldKeyword> testee = OldKeyword.builder()
             .isFlagged(Optional.of(false))
             .computeOldKeyword();
@@ -79,7 +79,7 @@ public class OldKeywordTest {
     }
 
     @Test
-    public void asKeywordsShouldContainAnsweredSeenWhenIsAnswered() {
+    public void asKeywordsShouldContainAnsweredWhenIsAnswered() {
         Optional<OldKeyword> testee = OldKeyword.builder()
             .isAnswered(Optional.of(true))
             .computeOldKeyword();
@@ -89,7 +89,7 @@ public class OldKeywordTest {
     }
 
     @Test
-    public void asKeywordsShouldNotContainAnsweredSeenWhenIsNotAnswered() {
+    public void asKeywordsShouldNotContainAnsweredWhenIsNotAnswered() {
         Optional<OldKeyword> testee = OldKeyword.builder()
             .isAnswered(Optional.of(false))
             .computeOldKeyword();
@@ -99,7 +99,7 @@ public class OldKeywordTest {
     }
 
     @Test
-    public void asKeywordsShouldContainDraftSeenWhenIsDraft() {
+    public void asKeywordsShouldContainDraftWhenIsDraft() {
         Optional<OldKeyword> testee = OldKeyword.builder()
             .isDraft(Optional.of(true))
             .computeOldKeyword();
@@ -109,7 +109,7 @@ public class OldKeywordTest {
     }
 
     @Test
-    public void asKeywordsShouldNotContainDraftSeenWhenIsNotDraft() {
+    public void asKeywordsShouldNotContainDraftWhenIsNotDraft() {
         Optional<OldKeyword> testee = OldKeyword.builder()
             .isDraft(Optional.of(false))
             .computeOldKeyword();
@@ -119,7 +119,7 @@ public class OldKeywordTest {
     }
 
     @Test
-    public void asKeywordsShouldContainForwardedSeenWhenIsForwarded() {
+    public void asKeywordsShouldContainForwardedWhenIsForwarded() {
         Optional<OldKeyword> testee = OldKeyword.builder()
             .isForwarded(Optional.of(true))
             .computeOldKeyword();
@@ -129,7 +129,7 @@ public class OldKeywordTest {
     }
 
     @Test
-    public void asKeywordsShouldNotContainForwardedSeenWhenIsNotForwarded() {
+    public void asKeywordsShouldNotContainForwardedWhenIsNotForwarded() {
         Optional<OldKeyword> testee = OldKeyword.builder()
             .isForwarded(Optional.of(false))
             .computeOldKeyword();

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/OldKeywordTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/OldKeywordTest.java
@@ -119,7 +119,7 @@ public class OldKeywordTest {
     }
 
     @Test
-    public void asKeywordsShouldNContainForwardedSeenWhenIsNForwarded() {
+    public void asKeywordsShouldContainForwardedSeenWhenIsForwarded() {
         Optional<OldKeyword> testee = OldKeyword.builder()
             .isForwarded(Optional.of(true))
             .computeOldKeyword();

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/OldKeywordTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/OldKeywordTest.java
@@ -38,60 +38,66 @@ public class OldKeywordTest {
 
     @Test
     public void computeOldKeywordsShouldReturnEmptyWhenAllEmpty() {
-        Optional<Boolean> isUnread = Optional.empty();
-        Optional<Boolean> isFlagged = Optional.empty();
-        Optional<Boolean> isAnswered = Optional.empty();
-        Optional<Boolean> isDraft = Optional.empty();
-        Optional<Boolean> isForwarded = Optional.empty();
-        Optional<OldKeyword> testee = OldKeyword.computeOldKeywords(isUnread, isFlagged, isAnswered, isDraft, isForwarded);
+        Optional<OldKeyword> testee = OldKeyword.builder()
+            .isUnread(Optional.empty())
+            .isFlagged(Optional.empty())
+            .isAnswered(Optional.empty())
+            .isDraft(Optional.empty())
+            .isForwarded(Optional.empty())
+            .computeOldKeyword();
 
         assertThat(testee).isEmpty();
     }
 
     @Test
     public void applyStateShouldSetFlaggedOnlyWhenIsFlagged() {
-        Optional<Boolean> isUnread = Optional.empty();
-        Optional<Boolean> isFlagged = Optional.of(true);
-        Optional<Boolean> isAnswered = Optional.empty();
-        Optional<Boolean> isDraft = Optional.empty();
-        Optional<Boolean> isForwarded = Optional.empty();
-        Optional<OldKeyword> testee = OldKeyword.computeOldKeywords(isUnread, isFlagged, isAnswered, isDraft, isForwarded);
+        Optional<OldKeyword> testee = OldKeyword.builder()
+            .isUnread(Optional.empty())
+            .isFlagged(Optional.of(true))
+            .isAnswered(Optional.empty())
+            .isDraft(Optional.empty())
+            .isForwarded(Optional.empty())
+            .computeOldKeyword();
 
         assertThat(testee.get().applyToState(new Flags())).isEqualTo(new Flags(Flag.FLAGGED));
     }
 
     @Test
     public void applyStateShouldRemoveFlaggedWhenEmptyIsFlaggedOnFlaggedMessage() {
-        Optional<Boolean> isUnread = Optional.empty();
-        Optional<Boolean> isFlagged = Optional.of(false);
-        Optional<Boolean> isAnswered = Optional.empty();
-        Optional<Boolean> isDraft = Optional.empty();
-        Optional<Boolean> isForwarded = Optional.empty();
-        Optional<OldKeyword> testee = OldKeyword.computeOldKeywords(isUnread, isFlagged, isAnswered, isDraft, isForwarded);
-        
+        Optional<OldKeyword> testee = OldKeyword.builder()
+            .isUnread(Optional.empty())
+            .isFlagged(Optional.of(false))
+            .isAnswered(Optional.empty())
+            .isDraft(Optional.empty())
+            .isForwarded(Optional.empty())
+            .computeOldKeyword();
+
         assertThat(testee.get().applyToState(new Flags(Flag.FLAGGED))).isEqualTo(new Flags());
     }
 
+
     @Test
     public void applyStateShouldReturnUnreadFlagWhenUnreadSetOnSeenMessage() {
-        Optional<Boolean> isUnread = Optional.of(true);
-        Optional<Boolean> isFlagged = Optional.empty();
-        Optional<Boolean> isAnswered = Optional.empty();
-        Optional<Boolean> isDraft = Optional.empty();
-        Optional<Boolean> isForwarded = Optional.empty();
-        Optional<OldKeyword> testee = OldKeyword.computeOldKeywords(isUnread, isFlagged, isAnswered, isDraft, isForwarded);
+        Optional<OldKeyword> testee = OldKeyword.builder()
+            .isUnread(Optional.of(true))
+            .isFlagged(Optional.empty())
+            .isAnswered(Optional.empty())
+            .isDraft(Optional.empty())
+            .isForwarded(Optional.empty())
+            .computeOldKeyword();
 
         assertThat(testee.get().applyToState(new Flags(Flag.SEEN))).isEqualTo(new Flags());
     }
 
     @Test
     public void applyStateShouldReturnSeenWhenPatchSetsSeenOnSeenMessage() {
-        Optional<Boolean> isUnread = Optional.of(false);
-        Optional<Boolean> isFlagged = Optional.empty();
-        Optional<Boolean> isAnswered = Optional.empty();
-        Optional<Boolean> isDraft = Optional.empty();
-        Optional<Boolean> isForwarded = Optional.empty();
-        Optional<OldKeyword> testee = OldKeyword.computeOldKeywords(isUnread, isFlagged, isAnswered, isDraft, isForwarded);
+        Optional<OldKeyword> testee = OldKeyword.builder()
+            .isUnread(Optional.of(false))
+            .isFlagged(Optional.empty())
+            .isAnswered(Optional.empty())
+            .isDraft(Optional.empty())
+            .isForwarded(Optional.empty())
+            .computeOldKeyword();
 
         assertThat(testee.get().applyToState(new Flags(Flag.SEEN))).isEqualTo(new Flags(Flag.SEEN));
     }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/OldKeywordTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/OldKeywordTest.java
@@ -37,6 +37,147 @@ public class OldKeywordTest {
     }
 
     @Test
+    public void asKeywordsShouldContainFlaggedWhenIsFlagged() {
+        Optional<OldKeyword> testee = OldKeyword.builder()
+            .isUnread(Optional.empty())
+            .isFlagged(Optional.of(true))
+            .isAnswered(Optional.empty())
+            .isDraft(Optional.empty())
+            .isForwarded(Optional.empty())
+            .computeOldKeyword();
+
+        assertThat(testee.get().asKeywords())
+            .isEqualTo(Keywords.factory().from(Keyword.FLAGGED));
+    }
+
+    @Test
+    public void asKeywordsShouldNotContainFlaggedWhenIsnotFlagged() {
+        Optional<OldKeyword> testee = OldKeyword.builder()
+            .isUnread(Optional.empty())
+            .isFlagged(Optional.of(false))
+            .isAnswered(Optional.empty())
+            .isDraft(Optional.empty())
+            .isForwarded(Optional.empty())
+            .computeOldKeyword();
+
+        assertThat(testee.get().asKeywords())
+            .isEqualTo(Keywords.factory().from());
+    }
+
+    @Test
+    public void asKeywordsShouldNotContainSeenWhenIsUnRead() {
+        Optional<OldKeyword> testee = OldKeyword.builder()
+            .isUnread(Optional.of(true))
+            .isFlagged(Optional.empty())
+            .isAnswered(Optional.empty())
+            .isDraft(Optional.empty())
+            .isForwarded(Optional.empty())
+            .computeOldKeyword();
+
+        assertThat(testee.get().asKeywords())
+            .isEqualTo(Keywords.factory().from());
+    }
+
+    @Test
+    public void asKeywordsShouldContainSeenWhenIsRead() {
+        Optional<OldKeyword> testee = OldKeyword.builder()
+            .isUnread(Optional.of(false))
+            .isFlagged(Optional.empty())
+            .isAnswered(Optional.empty())
+            .isDraft(Optional.empty())
+            .isForwarded(Optional.empty())
+            .computeOldKeyword();
+
+
+        assertThat(testee.get().asKeywords())
+            .isEqualTo(Keywords.factory().from(Keyword.SEEN));
+    }
+
+    @Test
+    public void asKeywordsShouldContainAnsweredSeenWhenIsAnswered() {
+        Optional<OldKeyword> testee = OldKeyword.builder()
+            .isUnread(Optional.empty())
+            .isFlagged(Optional.empty())
+            .isAnswered(Optional.of(true))
+            .isDraft(Optional.empty())
+            .isForwarded(Optional.empty())
+            .computeOldKeyword();
+
+        assertThat(testee.get().asKeywords())
+            .isEqualTo(Keywords.factory().from(Keyword.ANSWERED));
+    }
+
+    @Test
+    public void asKeywordsShouldNotContainAnsweredSeenWhenIsNotAnswered() {
+        Optional<OldKeyword> testee = OldKeyword.builder()
+            .isUnread(Optional.empty())
+            .isFlagged(Optional.empty())
+            .isAnswered(Optional.of(false))
+            .isDraft(Optional.empty())
+            .isForwarded(Optional.empty())
+            .computeOldKeyword();
+
+        assertThat(testee.get().asKeywords())
+            .isEqualTo(Keywords.factory().from());
+    }
+
+    @Test
+    public void asKeywordsShouldContainDraftSeenWhenIsDraft() {
+        Optional<OldKeyword> testee = OldKeyword.builder()
+            .isUnread(Optional.empty())
+            .isFlagged(Optional.empty())
+            .isAnswered(Optional.empty())
+            .isDraft(Optional.of(true))
+            .isForwarded(Optional.empty())
+            .computeOldKeyword();
+
+        assertThat(testee.get().asKeywords())
+            .isEqualTo(Keywords.factory().from(Keyword.DRAFT));
+    }
+
+    @Test
+    public void asKeywordsShouldNotContainDraftSeenWhenIsNotDraft() {
+        Optional<OldKeyword> testee = OldKeyword.builder()
+            .isUnread(Optional.empty())
+            .isFlagged(Optional.empty())
+            .isAnswered(Optional.empty())
+            .isDraft(Optional.of(false))
+            .isForwarded(Optional.empty())
+            .computeOldKeyword();
+
+        assertThat(testee.get().asKeywords())
+            .isEqualTo(Keywords.factory().from());
+    }
+
+    @Test
+    public void asKeywordsShouldNContainForwardedSeenWhenIsNForwarded() {
+        Optional<OldKeyword> testee = OldKeyword.builder()
+            .isUnread(Optional.empty())
+            .isFlagged(Optional.empty())
+            .isAnswered(Optional.empty())
+            .isDraft(Optional.empty())
+            .isForwarded(Optional.of(true))
+            .computeOldKeyword();
+
+        assertThat(testee.get().asKeywords())
+            .isEqualTo(Keywords.factory().from(Keyword.FORWARDED));
+    }
+
+    @Test
+    public void asKeywordsShouldNotContainForwardedSeenWhenIsNotForwarded() {
+        Optional<OldKeyword> testee = OldKeyword.builder()
+            .isUnread(Optional.empty())
+            .isFlagged(Optional.empty())
+            .isAnswered(Optional.empty())
+            .isDraft(Optional.empty())
+            .isForwarded(Optional.of(false))
+            .computeOldKeyword();
+
+        assertThat(testee.get().asKeywords())
+            .isEqualTo(Keywords.factory().from());
+    }
+
+    @Test
     public void computeOldKeywordsShouldReturnEmptyWhenAllEmpty() {
         Optional<OldKeyword> testee = OldKeyword.builder()
             .isUnread(Optional.empty())

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/UpdateMessagePatchTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/UpdateMessagePatchTest.java
@@ -47,6 +47,39 @@ public class UpdateMessagePatchTest {
     }
 
     @Test
+    public void applyToStateShouldNotResetSystemFlagsWhenUsingOldKeywords() {
+        UpdateMessagePatch testee = UpdateMessagePatch.builder()
+            .isAnswered(true)
+            .build();
+
+        Flags isSeen = new Flags(Flags.Flag.SEEN);
+        assertThat(testee.applyToState(isSeen).getSystemFlags())
+            .containsExactly(Flags.Flag.ANSWERED, Flags.Flag.SEEN);
+    }
+
+    @Test
+    public void applyToStateShouldNotModifySpecifiedOldKeywordsWhenAlreadySet() {
+        UpdateMessagePatch testee = UpdateMessagePatch.builder()
+            .isAnswered(true)
+            .build();
+
+        Flags isSeen = new Flags(Flags.Flag.ANSWERED);
+        assertThat(testee.applyToState(isSeen).getSystemFlags())
+            .containsExactly(Flags.Flag.ANSWERED);
+    }
+
+    @Test
+    public void applyToStateShouldResetSpecifiedOldKeywords() {
+        UpdateMessagePatch testee = UpdateMessagePatch.builder()
+            .isAnswered(false)
+            .build();
+
+        Flags isSeen = new Flags(Flags.Flag.ANSWERED);
+        assertThat(testee.applyToState(isSeen).getSystemFlags())
+            .containsExactly();
+    }
+
+    @Test
     public void applyStateShouldReturnNewFlagsWhenKeywords() {
         ImmutableMap<String, Boolean> keywords = ImmutableMap.of(
                 "$Answered", true,


### PR DESCRIPTION
Re-open of https://github.com/linagora/james-project/pull/1183

```
Re-reading this, I was not happy with the overall code quality of the OldKeywords overall feature.

I don't know where but we lost isolation of that design choice in recent refactorings. I will open a PR that re-enforce this.
```

The present PR clean the implementation of **OldKeywords**