### PR TITLE
JAMES-2272 Introduce a TaskManager for James

### DIFF
--- a/backends-common/cassandra/pom.xml
+++ b/backends-common/cassandra/pom.xml
@@ -37,6 +37,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>james-server-task</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>james-server-util-java8</artifactId>
         </dependency>
         <dependency>

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/migration/CassandraMigrationService.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/migration/CassandraMigrationService.java
@@ -58,7 +58,6 @@ public class CassandraMigrationService {
 
     public Migration upgradeToVersion(SchemaVersion newVersion) {
         SchemaVersion currentVersion = getCurrentVersion().orElse(DEFAULT_VERSION);
-        assertMigrationNeeded(newVersion, currentVersion);
 
         Migration migrationCombination = IntStream.range(currentVersion.getValue(), newVersion.getValue())
             .boxed()
@@ -67,13 +66,6 @@ public class CassandraMigrationService {
             .map(this::toMigration)
             .reduce(Migration.IDENTITY, Migration::combine);
         return new MigrationTask(migrationCombination, newVersion);
-    }
-
-    private void assertMigrationNeeded(SchemaVersion newVersion, SchemaVersion currentVersion) {
-        boolean needMigration = currentVersion.isBefore(newVersion);
-        if (!needMigration) {
-            throw new IllegalStateException("Current version is already up to date");
-        }
     }
 
     private SchemaVersion validateVersionNumber(SchemaVersion versionNumber) {
@@ -94,7 +86,7 @@ public class CassandraMigrationService {
             SchemaVersion newVersion = version.next();
             SchemaVersion currentVersion = getCurrentVersion().orElse(DEFAULT_VERSION);
             if (currentVersion.isAfterOrEquals(newVersion)) {
-                return Migration.Result.PARTIAL;
+                return Migration.Result.COMPLETED;
             }
 
             LOG.info("Migrating to version {} ", newVersion);

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/migration/CassandraMigrationService.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/migration/CassandraMigrationService.java
@@ -17,7 +17,7 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.webadmin.service;
+package org.apache.james.backends.cassandra.migration;
 
 import java.util.Map;
 import java.util.Optional;
@@ -29,8 +29,6 @@ import javax.inject.Named;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionDAO;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager;
-import org.apache.james.mailbox.cassandra.mail.migration.Migration;
-import org.apache.james.webadmin.dto.CassandraVersionResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,12 +49,12 @@ public class CassandraMigrationService {
         this.allMigrationClazz = allMigrationClazz;
     }
 
-    public CassandraVersionResponse getCurrentVersion() {
-        return new CassandraVersionResponse(schemaVersionDAO.getCurrentSchemaVersion().join());
+    public Optional<Integer> getCurrentVersion() {
+        return schemaVersionDAO.getCurrentSchemaVersion().join();
     }
 
-    public CassandraVersionResponse getLatestVersion() {
-        return new CassandraVersionResponse(Optional.of(latestVersion));
+    public Optional<Integer> getLatestVersion() {
+        return Optional.of(latestVersion);
     }
 
     public synchronized void upgradeToVersion(int newVersion) {
@@ -77,8 +75,8 @@ public class CassandraMigrationService {
     private void doMigration(Integer version) {
         if (allMigrationClazz.containsKey(version)) {
             LOG.info("Migrating to version {} ", version + 1);
-            Migration.MigrationResult migrationResult = allMigrationClazz.get(version).run();
-            if (migrationResult == Migration.MigrationResult.COMPLETED) {
+            Migration.Result migrationResult = allMigrationClazz.get(version).run();
+            if (migrationResult == Migration.Result.COMPLETED) {
                 schemaVersionDAO.updateVersion(version + 1);
                 LOG.info("Migrating to version {} done", version + 1);
             } else {

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/migration/Migration.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/migration/Migration.java
@@ -1,0 +1,26 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.cassandra.migration;
+
+import org.apache.james.task.Task;
+
+public interface Migration extends Task {
+
+}

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/migration/MigrationException.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/migration/MigrationException.java
@@ -17,7 +17,7 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.webadmin.service;
+package org.apache.james.backends.cassandra.migration;
 
 public class MigrationException extends RuntimeException {
     public MigrationException(String message) {

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/migration/MigrationTask.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/migration/MigrationTask.java
@@ -22,11 +22,12 @@ package org.apache.james.backends.cassandra.migration;
 import java.util.Optional;
 
 import org.apache.james.backends.cassandra.versions.SchemaVersion;
+import org.apache.james.task.TaskExecutionDetails;
 
 public class MigrationTask implements Migration {
     public static final String CASSANDRA_MIGRATION = "CassandraMigration";
 
-    public static class Details {
+    public static class Details implements TaskExecutionDetails.AdditionalInformation {
         private final SchemaVersion toVersion;
 
         public Details(SchemaVersion toVersion) {
@@ -57,7 +58,7 @@ public class MigrationTask implements Migration {
     }
 
     @Override
-    public Optional<Object> details() {
+    public Optional<TaskExecutionDetails.AdditionalInformation> details() {
         return Optional.of(new Details(toVersion));
     }
 }

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/migration/MigrationTask.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/migration/MigrationTask.java
@@ -19,18 +19,43 @@
 
 package org.apache.james.backends.cassandra.migration;
 
-import org.apache.james.task.Task;
+import java.util.Optional;
 
-public interface Migration extends Task {
-    Migration IDENTITY = () -> Result.COMPLETED;
+public class MigrationTask implements Migration {
+    public static final String CASSANDRA_MIGRATION = "CassandraMigration";
 
-    static Migration combine(Migration migration1, Migration migration2) {
-        return () -> {
-            Result migration1Result = migration1.run();
-            if (migration1Result == Result.COMPLETED) {
-                return migration2.run();
-            }
-            return Result.PARTIAL;
-        };
+    public static class Details {
+        private final int toVersion;
+
+        public Details(int toVersion) {
+            this.toVersion = toVersion;
+        }
+
+        public int getToVersion() {
+            return toVersion;
+        }
+    }
+
+    private final Migration migration;
+    private final int toVersion;
+
+    public MigrationTask(Migration migration, int toVersion) {
+        this.migration = migration;
+        this.toVersion = toVersion;
+    }
+
+    @Override
+    public Result run() {
+        return migration.run();
+    }
+
+    @Override
+    public String type() {
+        return CASSANDRA_MIGRATION;
+    }
+
+    @Override
+    public Optional<Object> details() {
+        return Optional.of(new Details(toVersion));
     }
 }

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAO.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAO.java
@@ -66,18 +66,19 @@ public class CassandraSchemaVersionDAO {
                 .value(VALUE, bindMarker(VALUE)));
     }
 
-    public CompletableFuture<Optional<Integer>> getCurrentSchemaVersion() {
+    public CompletableFuture<Optional<SchemaVersion>> getCurrentSchemaVersion() {
         return cassandraAsyncExecutor.execute(readVersionStatement.bind())
             .thenApply(resultSet -> cassandraUtils.convertToStream(resultSet)
                 .map(row -> row.getInt(VALUE))
-                .reduce(Math::max));
+                .reduce(Math::max))
+            .thenApply(i -> i.map(SchemaVersion::new));
     }
 
-    public CompletableFuture<Void> updateVersion(int newVersion) {
+    public CompletableFuture<Void> updateVersion(SchemaVersion newVersion) {
         return cassandraAsyncExecutor.executeVoid(
             writeVersionStatement.bind()
                 .setUUID(KEY, UUIDs.timeBased())
-                .setInt(VALUE, newVersion));
+                .setInt(VALUE, newVersion.getValue()));
     }
 }
 

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/SchemaVersion.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/SchemaVersion.java
@@ -17,47 +17,60 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.backends.cassandra.migration;
+package org.apache.james.backends.cassandra.versions;
 
-import java.util.Optional;
+import java.util.Objects;
 
-import org.apache.james.backends.cassandra.versions.SchemaVersion;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
 
-public class MigrationTask implements Migration {
-    public static final String CASSANDRA_MIGRATION = "CassandraMigration";
+public class SchemaVersion {
+    private final int value;
 
-    public static class Details {
-        private final SchemaVersion toVersion;
+    public SchemaVersion(int value) {
+        Preconditions.checkArgument(value > 0, "version needs to be strictly positive");
+        this.value = value;
+    }
 
-        public Details(SchemaVersion toVersion) {
-            this.toVersion = toVersion;
+    public int getValue() {
+        return value;
+    }
+
+    public boolean isAfterOrEquals(SchemaVersion other) {
+        return this.value >= other.value;
+    }
+
+    public SchemaVersion next() {
+        return new SchemaVersion(value + 1);
+    }
+
+    public SchemaVersion previous() {
+        return new SchemaVersion(value - 1);
+    }
+
+    public boolean isBefore(SchemaVersion other) {
+        return this.value < other.value;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof SchemaVersion) {
+            SchemaVersion that = (SchemaVersion) o;
+
+            return Objects.equals(this.value, that.value);
         }
-
-        public int getToVersion() {
-            return toVersion.getValue();
-        }
-    }
-
-    private final Migration migration;
-    private final SchemaVersion toVersion;
-
-    public MigrationTask(Migration migration, SchemaVersion toVersion) {
-        this.migration = migration;
-        this.toVersion = toVersion;
+        return false;
     }
 
     @Override
-    public Result run() {
-        return migration.run();
+    public final int hashCode() {
+        return Objects.hash(value);
     }
 
     @Override
-    public String type() {
-        return CASSANDRA_MIGRATION;
-    }
-
-    @Override
-    public Optional<Object> details() {
-        return Optional.of(new Details(toVersion));
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("version", value)
+            .toString();
     }
 }

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/migration/CassandraMigrationServiceTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/migration/CassandraMigrationServiceTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Executors;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionDAO;
 import org.apache.james.backends.cassandra.versions.SchemaVersion;
+import org.apache.james.task.Task;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -91,12 +92,11 @@ public class CassandraMigrationServiceTest {
     }
 
     @Test
-    public void upgradeToVersionShouldThrowWhenCurrentVersionIsUpToDate() throws Exception {
-        expectedException.expect(IllegalStateException.class);
-
+    public void upgradeToVersionShouldNotThrowWhenCurrentVersionIsUpToDate() throws Exception {
         when(schemaVersionDAO.getCurrentSchemaVersion()).thenReturn(CompletableFuture.completedFuture(Optional.of(CURRENT_VERSION)));
 
-        testee.upgradeToVersion(OLDER_VERSION).run();
+        assertThat(testee.upgradeToVersion(OLDER_VERSION).run())
+            .isEqualTo(Task.Result.COMPLETED);
     }
 
     @Test
@@ -109,12 +109,12 @@ public class CassandraMigrationServiceTest {
     }
 
     @Test
-    public void upgradeToLastVersionShouldThrowWhenVersionIsUpToDate() throws Exception {
-        expectedException.expect(IllegalStateException.class);
+    public void upgradeToLastVersionShouldNotThrowWhenVersionIsUpToDate() throws Exception {
 
         when(schemaVersionDAO.getCurrentSchemaVersion()).thenReturn(CompletableFuture.completedFuture(Optional.of(LATEST_VERSION)));
 
-        testee.upgradeToLastVersion().run();
+        assertThat(testee.upgradeToLastVersion().run())
+            .isEqualTo(Task.Result.COMPLETED);
     }
 
     @Test

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/migration/CassandraMigrationServiceTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/migration/CassandraMigrationServiceTest.java
@@ -17,7 +17,7 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.webadmin.service;
+package org.apache.james.backends.cassandra.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.eq;
@@ -38,7 +38,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.lang.NotImplementedException;
-import org.apache.james.backends.cassandra.migration.Migration;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionDAO;
 import org.junit.After;
 import org.junit.Before;
@@ -85,12 +84,12 @@ public class CassandraMigrationServiceTest {
     public void getCurrentVersionShouldReturnCurrentVersion() throws Exception {
         when(schemaVersionDAO.getCurrentSchemaVersion()).thenReturn(CompletableFuture.completedFuture(Optional.of(CURRENT_VERSION)));
 
-        assertThat(testee.getCurrentVersion().getversion().get()).isEqualTo(CURRENT_VERSION);
+        assertThat(testee.getCurrentVersion().get()).isEqualTo(CURRENT_VERSION);
     }
 
     @Test
     public void getLatestVersionShouldReturnTheLatestVersion() throws Exception {
-        assertThat(testee.getLatestVersion().getversion().get()).isEqualTo(LATEST_VERSION);
+        assertThat(testee.getLatestVersion().get()).isEqualTo(LATEST_VERSION);
     }
 
     @Test

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/migration/MigrationTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/migration/MigrationTest.java
@@ -1,0 +1,89 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.cassandra.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+public class MigrationTest {
+    @Test
+    public void combineShouldNotExecuteSecondMigrationExecutionWhenTheFirstOneIsFailing() {
+        AtomicBoolean migration2Done = new AtomicBoolean(false);
+
+        Migration migration1 = () -> Migration.Result.PARTIAL;
+        Migration migration2 = () -> {
+            migration2Done.set(true);
+            return Migration.Result.COMPLETED;
+        };
+
+        Migration.combine(migration1, migration2).run();
+
+        assertThat(migration2Done).isFalse();
+    }
+
+    @Test
+    public void combineShouldTriggerSecondMigrationWhenTheFirstOneSucceed() {
+        AtomicBoolean migration2Done = new AtomicBoolean(false);
+
+        Migration migration1 = () -> Migration.Result.COMPLETED;
+        Migration migration2 = () -> {
+            migration2Done.set(true);
+            return Migration.Result.COMPLETED;
+        };
+
+        Migration.combine(migration1, migration2).run();
+
+        assertThat(migration2Done).isTrue();
+    }
+
+    @Test
+    public void combineShouldExecuteTheFirstMigrationWhenSecondWillFail() {
+        AtomicBoolean migration1Done = new AtomicBoolean(false);
+
+        Migration migration1 = () -> {
+            migration1Done.set(true);
+            return Migration.Result.COMPLETED;
+        };
+        Migration migration2 = () -> Migration.Result.PARTIAL;
+
+
+        Migration.combine(migration1, migration2).run();
+
+        assertThat(migration1Done).isTrue();
+    }
+
+    @Test
+    public void combineShouldExecuteTheFirstMigration() {
+        AtomicBoolean migration1Done = new AtomicBoolean(false);
+
+        Migration migration1 = () -> {
+            migration1Done.set(true);
+            return Migration.Result.COMPLETED;
+        };
+        Migration migration2 = () -> Migration.Result.COMPLETED;
+
+        Migration.combine(migration1, migration2).run();
+
+        assertThat(migration1Done).isTrue();
+    }
+}

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAOTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAOTest.java
@@ -59,7 +59,7 @@ public class CassandraSchemaVersionDAOTest {
 
     @Test
     public void getCurrentSchemaVersionShouldReturnVersionPresentInTheTable() {
-        int version = 42;
+        SchemaVersion version = new SchemaVersion(42);
 
         testee.updateVersion(version).join();
 
@@ -68,11 +68,11 @@ public class CassandraSchemaVersionDAOTest {
 
     @Test
     public void getCurrentSchemaVersionShouldBeIdempotent() {
-        int version = 42;
+        SchemaVersion version = new SchemaVersion(42);
 
-        testee.updateVersion(version + 1).join();
+        testee.updateVersion(version.next()).join();
         testee.updateVersion(version).join();
 
-        assertThat(testee.getCurrentSchemaVersion().join()).contains(version + 1);
+        assertThat(testee.getCurrentSchemaVersion().join()).contains(version.next());
     }
 }

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionManagerTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionManagerTest.java
@@ -19,10 +19,10 @@
 
 package org.apache.james.backends.cassandra.versions;
 
-import static org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager.SchemaState.UP_TO_DATE;
-import static org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager.SchemaState.UPGRADABLE;
 import static org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager.SchemaState.TOO_OLD;
 import static org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager.SchemaState.TOO_RECENT;
+import static org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager.SchemaState.UPGRADABLE;
+import static org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager.SchemaState.UP_TO_DATE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -38,8 +38,8 @@ import org.junit.rules.ExpectedException;
 
 public class CassandraSchemaVersionManagerTest {
 
-    private final int minVersion = 2;
-    private final int maxVersion = 4;
+    private final SchemaVersion minVersion = new SchemaVersion(2);
+    private final SchemaVersion maxVersion = new SchemaVersion(4);
     private CassandraSchemaVersionDAO schemaVersionDAO;
 
     @Rule
@@ -52,7 +52,7 @@ public class CassandraSchemaVersionManagerTest {
 
     @Test
     public void computeSchemaStateShouldReturnTooOldWhenVersionIsLessThanMinVersion() {
-        int currentVersion = minVersion - 1;
+        SchemaVersion currentVersion = minVersion.previous();
 
         when(schemaVersionDAO.getCurrentSchemaVersion())
             .thenReturn(CompletableFuture.completedFuture(Optional.of(currentVersion)));
@@ -67,7 +67,7 @@ public class CassandraSchemaVersionManagerTest {
 
     @Test
     public void computeSchemaStateShouldReturnTooOldWhenVersionIsMoreThanMaxVersion() {
-        int currentVersion = maxVersion + 1;
+        SchemaVersion currentVersion = maxVersion.next();
 
         when(schemaVersionDAO.getCurrentSchemaVersion())
             .thenReturn(CompletableFuture.completedFuture(Optional.of(currentVersion)));
@@ -82,7 +82,7 @@ public class CassandraSchemaVersionManagerTest {
 
     @Test
     public void computeSchemaStateShouldReturnUpToDateWhenVersionEqualsMaxVersion() {
-        int currentVersion = maxVersion;
+        SchemaVersion currentVersion = maxVersion;
 
         when(schemaVersionDAO.getCurrentSchemaVersion())
             .thenReturn(CompletableFuture.completedFuture(Optional.of(currentVersion)));
@@ -97,7 +97,7 @@ public class CassandraSchemaVersionManagerTest {
 
     @Test
     public void computeSchemaStateShouldReturnUpgradableWhenVersionBetweenMinAnd() {
-        int currentVersion = maxVersion - 1;
+        SchemaVersion currentVersion = minVersion.next();
 
         when(schemaVersionDAO.getCurrentSchemaVersion())
             .thenReturn(CompletableFuture.completedFuture(Optional.of(currentVersion)));
@@ -111,51 +111,11 @@ public class CassandraSchemaVersionManagerTest {
     }
 
     @Test
-    public void constructorShouldThrowOnNegativeMinVersion() {
-        expectedException.expect(IllegalArgumentException.class);
-
-        new CassandraSchemaVersionManager(
-            schemaVersionDAO,
-            -1,
-            maxVersion);
-    }
-
-    @Test
-    public void constructorShouldThrowOnZeroMinVersion() {
-        expectedException.expect(IllegalArgumentException.class);
-
-        new CassandraSchemaVersionManager(
-            schemaVersionDAO,
-            0,
-            maxVersion);
-    }
-
-    @Test
-    public void constructorShouldThrowOnNegativeMaxVersion() {
-        expectedException.expect(IllegalArgumentException.class);
-
-        new CassandraSchemaVersionManager(
-            schemaVersionDAO,
-            minVersion,
-            -1);
-    }
-
-    @Test
-    public void constructorShouldThrowOnZeroMaxVersion() {
-        expectedException.expect(IllegalArgumentException.class);
-
-        new CassandraSchemaVersionManager(
-            schemaVersionDAO,
-            minVersion,
-            0);
-    }
-
-    @Test
     public void constructorShouldThrowMinVersionIsSuperiorToMaxVersion() {
         expectedException.expect(IllegalArgumentException.class);
 
-        int minVersion = 4;
-        int maxVersion = 2;
+        SchemaVersion minVersion = new SchemaVersion(4);
+        SchemaVersion maxVersion = new SchemaVersion(2);
         new CassandraSchemaVersionManager(
             schemaVersionDAO,
             minVersion,
@@ -164,9 +124,9 @@ public class CassandraSchemaVersionManagerTest {
 
     @Test
     public void computeSchemaStateShouldReturnUpToDateWhenMinMaxAndVersionEquals() {
-        int minVersion = 4;
-        int maxVersion = 4;
-        int currentVersion = 4;
+        SchemaVersion minVersion = new SchemaVersion(4);
+        SchemaVersion maxVersion = new SchemaVersion(4);
+        SchemaVersion currentVersion = new SchemaVersion(4);
         when(schemaVersionDAO.getCurrentSchemaVersion())
             .thenReturn(CompletableFuture.completedFuture(Optional.of(currentVersion)));
 

--- a/mailbox/cassandra/pom.xml
+++ b/mailbox/cassandra/pom.xml
@@ -64,6 +64,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>james-server-task</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>james-server-util</artifactId>
             <scope>test</scope>
         </dependency>

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentMessageIdCreation.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentMessageIdCreation.java
@@ -25,6 +25,7 @@ import org.apache.james.backends.cassandra.migration.Migration;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentMessageIdDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO.MessageIdAttachmentIds;
+import org.apache.james.task.Task;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +47,7 @@ public class AttachmentMessageIdCreation implements Migration {
             return cassandraMessageDAO.retrieveAllMessageIdAttachmentIds()
                 .join()
                 .map(this::createIndex)
-                .reduce(Result.COMPLETED, Migration::combine);
+                .reduce(Result.COMPLETED, Task::combine);
         } catch (Exception e) {
             LOGGER.error("Error while creation attachmentId -> messageIds index", e);
             return Result.PARTIAL;

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentMessageIdCreation.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentMessageIdCreation.java
@@ -21,6 +21,7 @@ package org.apache.james.mailbox.cassandra.mail.migration;
 
 import javax.inject.Inject;
 
+import org.apache.james.backends.cassandra.migration.Migration;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentMessageIdDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO.MessageIdAttachmentIds;
@@ -40,27 +41,28 @@ public class AttachmentMessageIdCreation implements Migration {
     }
 
     @Override
-    public MigrationResult run() {
+    public Result run() {
         try {
             return cassandraMessageDAO.retrieveAllMessageIdAttachmentIds()
                 .join()
                 .map(this::createIndex)
-                .reduce(MigrationResult.COMPLETED, Migration::combine);
+                .reduce(Result.COMPLETED, Migration::combine);
         } catch (Exception e) {
             LOGGER.error("Error while creation attachmentId -> messageIds index", e);
-            return MigrationResult.PARTIAL;
+            return Result.PARTIAL;
         }
     }
 
-    private MigrationResult createIndex(MessageIdAttachmentIds message) {
+    private Result createIndex(MessageIdAttachmentIds message) {
         try {
             message.getAttachmentId()
-                .stream()
-                .forEach(attachmentId -> attachmentMessageIdDAO.storeAttachmentForMessageId(attachmentId, message.getMessageId()).join());
-            return MigrationResult.COMPLETED;
+                .forEach(attachmentId -> attachmentMessageIdDAO
+                    .storeAttachmentForMessageId(attachmentId, message.getMessageId())
+                    .join());
+            return Result.COMPLETED;
         } catch (Exception e) {
             LOGGER.error("Error while creation attachmentId -> messageIds index", e);
-            return MigrationResult.PARTIAL;
+            return Result.PARTIAL;
         }
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentV2Migration.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentV2Migration.java
@@ -26,6 +26,7 @@ import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
 import org.apache.james.mailbox.cassandra.mail.CassandraBlobsDAO;
 import org.apache.james.mailbox.model.Attachment;
+import org.apache.james.task.Task;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +50,7 @@ public class AttachmentV2Migration implements Migration {
         try {
             return attachmentDAOV1.retrieveAll()
                 .map(this::migrateAttachment)
-                .reduce(Result.COMPLETED, Migration::combine);
+                .reduce(Result.COMPLETED, Task::combine);
         } catch (Exception e) {
             LOGGER.error("Error while performing attachmentDAO V2 migration", e);
             return Result.PARTIAL;

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentMessageIdCreationTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentMessageIdCreationTest.java
@@ -37,6 +37,7 @@ import javax.mail.util.SharedByteArrayInputStream;
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.DockerCassandraRule;
 import org.apache.james.backends.cassandra.init.CassandraModuleComposite;
+import org.apache.james.backends.cassandra.migration.Migration;
 import org.apache.james.backends.cassandra.utils.CassandraUtils;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.cassandra.ids.CassandraId;
@@ -99,7 +100,7 @@ public class AttachmentMessageIdCreationTest {
     @Test
     public void emptyMigrationShouldSucceed() {
         assertThat(migration.run())
-            .isEqualTo(Migration.MigrationResult.COMPLETED);
+            .isEqualTo(Migration.Result.COMPLETED);
     }
 
     @Test
@@ -110,7 +111,7 @@ public class AttachmentMessageIdCreationTest {
         cassandraMessageDAO.save(message).join();
 
         assertThat(migration.run())
-            .isEqualTo(Migration.MigrationResult.COMPLETED);
+            .isEqualTo(Migration.Result.COMPLETED);
     }
 
     @Test
@@ -121,7 +122,7 @@ public class AttachmentMessageIdCreationTest {
         cassandraMessageDAO.save(message).join();
 
         assertThat(migration.run())
-            .isEqualTo(Migration.MigrationResult.COMPLETED);
+            .isEqualTo(Migration.Result.COMPLETED);
     }
 
     @Test
@@ -145,7 +146,7 @@ public class AttachmentMessageIdCreationTest {
 
         when(cassandraMessageDAO.retrieveAllMessageIdAttachmentIds()).thenThrow(new RuntimeException());
 
-        assertThat(migration.run()).isEqualTo(Migration.MigrationResult.PARTIAL);
+        assertThat(migration.run()).isEqualTo(Migration.Result.PARTIAL);
     }
 
     @Test
@@ -162,7 +163,7 @@ public class AttachmentMessageIdCreationTest {
         when(attachmentMessageIdDAO.storeAttachmentForMessageId(any(AttachmentId.class), any(MessageId.class)))
             .thenThrow(new RuntimeException());
 
-        assertThat(migration.run()).isEqualTo(Migration.MigrationResult.PARTIAL);
+        assertThat(migration.run()).isEqualTo(Migration.Result.PARTIAL);
     }
 
     private SimpleMailboxMessage createMessage(MessageId messageId, Collection<MessageAttachment> attachments) {

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentV2MigrationTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentV2MigrationTest.java
@@ -32,6 +32,7 @@ import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.DockerCassandraRule;
 import org.apache.james.backends.cassandra.init.CassandraConfiguration;
 import org.apache.james.backends.cassandra.init.CassandraModuleComposite;
+import org.apache.james.backends.cassandra.migration.Migration;
 import org.apache.james.backends.cassandra.utils.CassandraUtils;
 import org.apache.james.mailbox.cassandra.ids.BlobId;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAO;
@@ -91,7 +92,7 @@ public class AttachmentV2MigrationTest {
     @Test
     public void emptyMigrationShouldSucceed() {
         assertThat(migration.run())
-            .isEqualTo(Migration.MigrationResult.COMPLETED);
+            .isEqualTo(Migration.Result.COMPLETED);
     }
 
     @Test
@@ -100,7 +101,7 @@ public class AttachmentV2MigrationTest {
         attachmentDAO.storeAttachment(attachment2).join();
 
         assertThat(migration.run())
-            .isEqualTo(Migration.MigrationResult.COMPLETED);
+            .isEqualTo(Migration.Result.COMPLETED);
     }
 
     @Test
@@ -142,7 +143,7 @@ public class AttachmentV2MigrationTest {
 
         when(attachmentDAO.retrieveAll()).thenThrow(new RuntimeException());
 
-        assertThat(migration.run()).isEqualTo(Migration.MigrationResult.PARTIAL);
+        assertThat(migration.run()).isEqualTo(Migration.Result.PARTIAL);
     }
 
     @Test
@@ -157,7 +158,7 @@ public class AttachmentV2MigrationTest {
             attachment2));
         when(blobsDAO.save(any())).thenThrow(new RuntimeException());
 
-        assertThat(migration.run()).isEqualTo(Migration.MigrationResult.PARTIAL);
+        assertThat(migration.run()).isEqualTo(Migration.Result.PARTIAL);
     }
 
     @Test
@@ -176,7 +177,7 @@ public class AttachmentV2MigrationTest {
             .thenReturn(CompletableFuture.completedFuture(BlobId.forPayload(attachment2.getBytes())));
         when(attachmentDAOV2.storeAttachment(any())).thenThrow(new RuntimeException());
 
-        assertThat(migration.run()).isEqualTo(Migration.MigrationResult.PARTIAL);
+        assertThat(migration.run()).isEqualTo(Migration.Result.PARTIAL);
     }
 
     @Test
@@ -196,7 +197,7 @@ public class AttachmentV2MigrationTest {
         when(attachmentDAOV2.storeAttachment(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(attachmentDAO.deleteAttachment(any())).thenThrow(new RuntimeException());
 
-        assertThat(migration.run()).isEqualTo(Migration.MigrationResult.PARTIAL);
+        assertThat(migration.run()).isEqualTo(Migration.Result.PARTIAL);
     }
 
     @Test
@@ -216,7 +217,7 @@ public class AttachmentV2MigrationTest {
         when(attachmentDAOV2.storeAttachment(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(attachmentDAO.deleteAttachment(any())).thenReturn(CompletableFuture.completedFuture(null));
 
-        assertThat(migration.run()).isEqualTo(Migration.MigrationResult.PARTIAL);
+        assertThat(migration.run()).isEqualTo(Migration.Result.PARTIAL);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1426,7 +1426,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-jsr310</artifactId>
-                <version>2.6.3</version>
+                <version>${jackson-databinding.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.github.dpaukov</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1316,6 +1316,11 @@
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>james-server-task</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>james-server-util</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
@@ -192,13 +192,17 @@ public class CassandraSessionModule extends AbstractModule {
                 case TOO_OLD:
                     throw new IllegalStateException(
                         String.format("Current schema version is %d whereas minimum required version is %d. " +
-                            "Recommended version is %d", versionManager.computeVersion(), versionManager.getMinimumSupportedVersion(),
-                            versionManager.getMaximumSupportedVersion()));
+                            "Recommended version is %d",
+                            versionManager.computeVersion().getValue(),
+                            versionManager.getMinimumSupportedVersion().getValue(),
+                            versionManager.getMaximumSupportedVersion().getValue()));
                 case TOO_RECENT:
                     throw new IllegalStateException(
                         String.format("Current schema version is %d whereas the minimum supported version is %d. " +
-                            "Recommended version is %d.", versionManager.computeVersion(), versionManager.getMinimumSupportedVersion(),
-                            versionManager.getMaximumSupportedVersion()));
+                            "Recommended version is %d.",
+                            versionManager.computeVersion().getValue(),
+                            versionManager.getMinimumSupportedVersion().getValue(),
+                            versionManager.getMaximumSupportedVersion().getValue()));
                 case UP_TO_DATE:
                     LOGGER.info("Schema version is up-to-date");
                     return;

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraVersionCheckingTest.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraVersionCheckingTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionDAO;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager;
+import org.apache.james.backends.cassandra.versions.SchemaVersion;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -43,9 +44,8 @@ public class CassandraVersionCheckingTest {
 
     private static final String LOCAL_HOST = "127.0.0.1";
     private static final int IMAP_PORT = 1143;
-    private static final int MIN_VERSION = 2;
-    private static final int MAX_VERSION = 4;
-
+    private static final SchemaVersion MIN_VERSION = new SchemaVersion(2);
+    private static final SchemaVersion MAX_VERSION = new SchemaVersion(4);
 
     @ClassRule
     public static DockerCassandraRule cassandra = new DockerCassandraRule();
@@ -92,7 +92,7 @@ public class CassandraVersionCheckingTest {
     @Test
     public void serverShouldStartSuccessfullyWhenBetweenMinAndMaxVersion() throws Exception {
         when(versionDAO.getCurrentSchemaVersion())
-            .thenReturn(CompletableFuture.completedFuture(Optional.of(MIN_VERSION + 1)));
+            .thenReturn(CompletableFuture.completedFuture(Optional.of(MIN_VERSION.next())));
 
         jamesServer = cassandraJmapTestRule.jmapServer(
             cassandra.getModule(),
@@ -122,7 +122,7 @@ public class CassandraVersionCheckingTest {
     @Test
     public void serverShouldNotStartWhenUnderMinVersion() throws Exception {
         when(versionDAO.getCurrentSchemaVersion())
-            .thenReturn(CompletableFuture.completedFuture(Optional.of(MIN_VERSION - 1)));
+            .thenReturn(CompletableFuture.completedFuture(Optional.of(MIN_VERSION.previous())));
 
         jamesServer = cassandraJmapTestRule.jmapServer(
             cassandra.getModule(),
@@ -139,7 +139,7 @@ public class CassandraVersionCheckingTest {
     @Test
     public void serverShouldNotStartWhenAboveMaxVersion() throws Exception {
         when(versionDAO.getCurrentSchemaVersion())
-            .thenReturn(CompletableFuture.completedFuture(Optional.of(MAX_VERSION + 1)));
+            .thenReturn(CompletableFuture.completedFuture(Optional.of(MAX_VERSION.next())));
 
         jamesServer = cassandraJmapTestRule.jmapServer(
             cassandra.getModule(),

--- a/server/container/guice/guice-common/pom.xml
+++ b/server/container/guice/guice-common/pom.xml
@@ -129,6 +129,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>james-server-task</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-api</artifactId>
         </dependency>
         <dependency>

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/modules/CommonServicesModule.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/modules/CommonServicesModule.java
@@ -24,15 +24,16 @@ import java.util.Optional;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.james.server.core.JamesServerResourceLoader;
-import org.apache.james.server.core.filesystem.FileSystemImpl;
 import org.apache.james.filesystem.api.FileSystem;
 import org.apache.james.filesystem.api.JamesDirectoriesProvider;
 import org.apache.james.modules.server.AsyncTasksExecutorModule;
 import org.apache.james.modules.server.ConfigurationProviderModule;
 import org.apache.james.modules.server.DNSServiceModule;
 import org.apache.james.modules.server.DropWizardMetricsModule;
+import org.apache.james.modules.server.TaskManagerModule;
 import org.apache.james.onami.lifecycle.PreDestroyModule;
+import org.apache.james.server.core.JamesServerResourceLoader;
+import org.apache.james.server.core.filesystem.FileSystemImpl;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.GuiceProbe;
 
@@ -56,6 +57,7 @@ public class CommonServicesModule extends AbstractModule {
         install(new DNSServiceModule());
         install(new AsyncTasksExecutorModule());
         install(new DropWizardMetricsModule());
+        install(new TaskManagerModule());
 
         bind(FileSystemImpl.class).in(Scopes.SINGLETON);
 

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/modules/server/TaskManagerModule.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/modules/server/TaskManagerModule.java
@@ -1,0 +1,34 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.server;
+
+import org.apache.james.task.MemoryTaskManager;
+import org.apache.james.task.TaskManager;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+
+public class TaskManagerModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(MemoryTaskManager.class).in(Scopes.SINGLETON);
+        bind(TaskManager.class).to(MemoryTaskManager.class);
+    }
+}

--- a/server/container/guice/protocols/webadmin-cassandra/src/main/java/org/apache/james/modules/server/CassandraRoutesModule.java
+++ b/server/container/guice/protocols/webadmin-cassandra/src/main/java/org/apache/james/modules/server/CassandraRoutesModule.java
@@ -19,13 +19,13 @@
 
 package org.apache.james.modules.server;
 
+import org.apache.james.backends.cassandra.migration.CassandraMigrationService;
 import org.apache.james.backends.cassandra.migration.Migration;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager;
 import org.apache.james.mailbox.cassandra.mail.migration.AttachmentMessageIdCreation;
 import org.apache.james.mailbox.cassandra.mail.migration.AttachmentV2Migration;
 import org.apache.james.webadmin.Routes;
 import org.apache.james.webadmin.routes.CassandraMigrationRoutes;
-import org.apache.james.webadmin.service.CassandraMigrationService;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;

--- a/server/container/guice/protocols/webadmin-cassandra/src/main/java/org/apache/james/modules/server/CassandraRoutesModule.java
+++ b/server/container/guice/protocols/webadmin-cassandra/src/main/java/org/apache/james/modules/server/CassandraRoutesModule.java
@@ -19,10 +19,10 @@
 
 package org.apache.james.modules.server;
 
+import org.apache.james.backends.cassandra.migration.Migration;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager;
 import org.apache.james.mailbox.cassandra.mail.migration.AttachmentMessageIdCreation;
 import org.apache.james.mailbox.cassandra.mail.migration.AttachmentV2Migration;
-import org.apache.james.mailbox.cassandra.mail.migration.Migration;
 import org.apache.james.webadmin.Routes;
 import org.apache.james.webadmin.routes.CassandraMigrationRoutes;
 import org.apache.james.webadmin.service.CassandraMigrationService;
@@ -47,7 +47,7 @@ public class CassandraRoutesModule extends AbstractModule {
         routesMultibinder.addBinding().to(CassandraMigrationRoutes.class);
 
         MapBinder<Integer, Migration> allMigrationClazzBinder = MapBinder.newMapBinder(binder(), Integer.class, Migration.class);
-        allMigrationClazzBinder.addBinding(FROM_V2_TO_V3).toInstance(() -> Migration.MigrationResult.COMPLETED);
+        allMigrationClazzBinder.addBinding(FROM_V2_TO_V3).toInstance(() -> Migration.Result.COMPLETED);
         allMigrationClazzBinder.addBinding(FROM_V3_TO_V4).to(AttachmentV2Migration.class);
         allMigrationClazzBinder.addBinding(FROM_V4_TO_V5).to(AttachmentMessageIdCreation.class);
 

--- a/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/TaskRoutesModule.java
+++ b/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/TaskRoutesModule.java
@@ -17,30 +17,21 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.webadmin.utils;
+package org.apache.james.modules.server;
 
-import java.io.IOException;
+import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.routes.TasksRoutes;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
 
-public class JsonExtractor<Request> {
+public class TaskRoutesModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(TasksRoutes.class).in(Scopes.SINGLETON);
 
-    private final ObjectMapper objectMapper;
-    private final Class<Request> type;
-
-    public JsonExtractor(Class<Request> type) {
-        this.objectMapper = new ObjectMapper()
-            .registerModule(new Jdk8Module());
-        this.type = type;
+        Multibinder<Routes> routesMultibinder = Multibinder.newSetBinder(binder(), Routes.class);
+        routesMultibinder.addBinding().to(TasksRoutes.class);
     }
-
-    public Request parse(String text) throws JsonExtractException {
-        try {
-            return objectMapper.readValue(text, type);
-        } catch (IOException | IllegalArgumentException e) {
-            throw new JsonExtractException(e);
-        }
-    }
-
 }

--- a/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/WebAdminServerModule.java
+++ b/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/WebAdminServerModule.java
@@ -69,6 +69,8 @@ public class WebAdminServerModule extends AbstractModule {
 
     @Override
     protected void configure() {
+        install(new TaskRoutesModule());
+
         bind(JsonTransformer.class).in(Scopes.SINGLETON);
         bind(WebAdminServer.class).in(Scopes.SINGLETON);
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -98,6 +98,7 @@
         <module>queue/queue-file</module>
         <module>queue/queue-jms</module>
 
+        <module>task</module>
         <module>testing</module>
     </modules>
 

--- a/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/WebAdminServerIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/WebAdminServerIntegrationTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.webadmin.integration;
 
 import static com.jayway.restassured.RestAssured.given;
+import static com.jayway.restassured.RestAssured.with;
 import static com.jayway.restassured.config.EncoderConfig.encoderConfig;
 import static com.jayway.restassured.config.RestAssuredConfig.newConfig;
 import static org.apache.james.webadmin.Constants.JSON_CONTENT_TYPE;
@@ -30,6 +31,8 @@ import static org.hamcrest.Matchers.is;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.james.CassandraJmapTestRule;
 import org.apache.james.DockerCassandraRule;
@@ -37,6 +40,8 @@ import org.apache.james.GuiceJamesServer;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager;
 import org.apache.james.modules.MailboxProbeImpl;
 import org.apache.james.probe.DataProbe;
+import org.apache.james.task.TaskManager;
+import org.apache.james.util.concurrency.ConcurrentTestRunner;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.WebAdminGuiceProbe;
 import org.apache.james.webadmin.routes.DomainsRoutes;
@@ -49,6 +54,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.builder.RequestSpecBuilder;
@@ -226,13 +232,16 @@ public class WebAdminServerIntegrationTest {
 
     @Test
     public void postShouldDoMigrationAndUpdateCurrentVersion() throws Exception {
-        given()
+        String taskId = with()
             .port(webAdminGuiceProbe.getWebAdminPort())
             .body(String.valueOf(CassandraSchemaVersionManager.MAX_VERSION))
-        .when()
-            .post(UPGRADE_VERSION)
-        .then()
-            .statusCode(HttpStatus.NO_CONTENT_204);
+        .post(UPGRADE_VERSION)
+            .jsonPath()
+            .get("taskId");
+
+        with()
+            .port(webAdminGuiceProbe.getWebAdminPort())
+            .get("/task/" + taskId + "/await");
 
         given()
             .port(webAdminGuiceProbe.getWebAdminPort())
@@ -246,12 +255,15 @@ public class WebAdminServerIntegrationTest {
 
     @Test
     public void postShouldDoMigrationAndUpdateToTheLatestVersion() throws Exception {
-        given()
+        String taskId = with()
             .port(webAdminGuiceProbe.getWebAdminPort())
-        .when()
-            .post(UPGRADE_TO_LATEST_VERSION)
-        .then()
-            .statusCode(HttpStatus.OK_200);
+        .post(UPGRADE_TO_LATEST_VERSION)
+            .jsonPath()
+            .get("taskId");
+
+        with()
+            .port(webAdminGuiceProbe.getWebAdminPort())
+            .get("/task/" + taskId + "/await");
 
         given()
             .port(webAdminGuiceProbe.getWebAdminPort())
@@ -261,6 +273,40 @@ public class WebAdminServerIntegrationTest {
             .statusCode(HttpStatus.OK_200)
             .contentType(JSON_CONTENT_TYPE)
             .body(is("{\"version\":" + CassandraSchemaVersionManager.MAX_VERSION + "}"));
+    }
+
+    @Test
+    public void concurrentMigrationIsNotAllowed() throws Exception {
+        ConcurrentLinkedQueue<String> taskIds = new ConcurrentLinkedQueue<>();
+        int threadCount = 2;
+        int operationCount = 1;
+        new ConcurrentTestRunner(threadCount, operationCount, (a, b) -> {
+            String migrationId = with()
+                .port(webAdminGuiceProbe.getWebAdminPort())
+                .post(UPGRADE_TO_LATEST_VERSION)
+                .jsonPath()
+                .get("taskId");
+            taskIds.add(migrationId);
+        }).run()
+            .awaitTermination(1, TimeUnit.MINUTES);
+
+        String id1 = taskIds.poll();
+        String id2 = taskIds.poll();
+        String status1 = with()
+            .port(webAdminGuiceProbe.getWebAdminPort())
+            .get("/tasks/" + id1 + "/await")
+            .jsonPath()
+            .get("status");
+        String status2 = with()
+            .port(webAdminGuiceProbe.getWebAdminPort())
+            .get("/tasks/" + id2 + "/await")
+            .jsonPath()
+            .get("status");
+
+        assertThat(ImmutableList.of(status1, status2))
+            .containsOnly(
+                TaskManager.Status.COMPLETED.getValue(),
+                TaskManager.Status.FAILED.getValue());
     }
 
     @Test

--- a/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/WebAdminServerIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/WebAdminServerIntegrationTest.java
@@ -227,14 +227,14 @@ public class WebAdminServerIntegrationTest {
         .then()
             .statusCode(HttpStatus.OK_200)
             .contentType(JSON_CONTENT_TYPE)
-            .body(is("{\"version\":" + CassandraSchemaVersionManager.MAX_VERSION + "}"));
+            .body(is("{\"version\":" + CassandraSchemaVersionManager.MAX_VERSION.getValue() + "}"));
     }
 
     @Test
     public void postShouldDoMigrationAndUpdateCurrentVersion() throws Exception {
         String taskId = with()
             .port(webAdminGuiceProbe.getWebAdminPort())
-            .body(String.valueOf(CassandraSchemaVersionManager.MAX_VERSION))
+            .body(String.valueOf(CassandraSchemaVersionManager.MAX_VERSION.getValue()))
         .post(UPGRADE_VERSION)
             .jsonPath()
             .get("taskId");
@@ -250,7 +250,7 @@ public class WebAdminServerIntegrationTest {
         .then()
             .statusCode(HttpStatus.OK_200)
             .contentType(JSON_CONTENT_TYPE)
-            .body(is("{\"version\":" + CassandraSchemaVersionManager.MAX_VERSION + "}"));
+            .body(is("{\"version\":" + CassandraSchemaVersionManager.MAX_VERSION.getValue() + "}"));
     }
 
     @Test
@@ -272,7 +272,7 @@ public class WebAdminServerIntegrationTest {
         .then()
             .statusCode(HttpStatus.OK_200)
             .contentType(JSON_CONTENT_TYPE)
-            .body(is("{\"version\":" + CassandraSchemaVersionManager.MAX_VERSION + "}"));
+            .body(is("{\"version\":" + CassandraSchemaVersionManager.MAX_VERSION.getValue() + "}"));
     }
 
     @Test

--- a/server/protocols/webadmin/webadmin-cassandra/src/main/java/org/apache/james/webadmin/dto/CassandraVersionRequest.java
+++ b/server/protocols/webadmin/webadmin-cassandra/src/main/java/org/apache/james/webadmin/dto/CassandraVersionRequest.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.webadmin.dto;
 
+import org.apache.james.backends.cassandra.versions.SchemaVersion;
+
 import com.google.common.base.Preconditions;
 
 public class CassandraVersionRequest {
@@ -30,11 +32,11 @@ public class CassandraVersionRequest {
     private final int value;
 
     private CassandraVersionRequest(int value) {
-        Preconditions.checkArgument(value >= 0);
+        Preconditions.checkArgument(value > 0);
         this.value = value;
     }
 
-    public int getValue() {
-        return value;
+    public SchemaVersion getValue() {
+        return new SchemaVersion(value);
     }
 }

--- a/server/protocols/webadmin/webadmin-cassandra/src/main/java/org/apache/james/webadmin/dto/CassandraVersionResponse.java
+++ b/server/protocols/webadmin/webadmin-cassandra/src/main/java/org/apache/james/webadmin/dto/CassandraVersionResponse.java
@@ -21,7 +21,13 @@ package org.apache.james.webadmin.dto;
 
 import java.util.Optional;
 
+import org.apache.james.backends.cassandra.versions.SchemaVersion;
+
 public class CassandraVersionResponse {
+
+    public static CassandraVersionResponse from(Optional<SchemaVersion> schemaVersion) {
+        return new CassandraVersionResponse(schemaVersion.map(SchemaVersion::getValue));
+    }
 
     private final Optional<Integer> version;
 

--- a/server/protocols/webadmin/webadmin-cassandra/src/main/java/org/apache/james/webadmin/routes/CassandraMigrationRoutes.java
+++ b/server/protocols/webadmin/webadmin-cassandra/src/main/java/org/apache/james/webadmin/routes/CassandraMigrationRoutes.java
@@ -21,11 +21,11 @@ package org.apache.james.webadmin.routes;
 
 import javax.inject.Inject;
 
+import org.apache.james.backends.cassandra.migration.CassandraMigrationService;
+import org.apache.james.backends.cassandra.migration.MigrationException;
 import org.apache.james.webadmin.Constants;
 import org.apache.james.webadmin.Routes;
 import org.apache.james.webadmin.dto.CassandraVersionRequest;
-import org.apache.james.webadmin.service.CassandraMigrationService;
-import org.apache.james.webadmin.service.MigrationException;
 import org.apache.james.webadmin.utils.ErrorResponder;
 import org.apache.james.webadmin.utils.ErrorResponder.ErrorType;
 import org.apache.james.webadmin.utils.JsonTransformer;

--- a/server/protocols/webadmin/webadmin-cassandra/src/main/java/org/apache/james/webadmin/routes/CassandraMigrationRoutes.java
+++ b/server/protocols/webadmin/webadmin-cassandra/src/main/java/org/apache/james/webadmin/routes/CassandraMigrationRoutes.java
@@ -167,7 +167,7 @@ public class CassandraMigrationRoutes implements Routes {
         @ApiResponse(code = HttpStatus.OK_200, message = "The latest version of the schema", response = CassandraVersionResponse.class)
     })
     public CassandraVersionResponse getCassandraLatestVersion() {
-        return new CassandraVersionResponse(cassandraMigrationService.getLatestVersion());
+        return CassandraVersionResponse.from(cassandraMigrationService.getLatestVersion());
     }
 
     @GET
@@ -176,6 +176,6 @@ public class CassandraMigrationRoutes implements Routes {
         @ApiResponse(code = HttpStatus.OK_200, message = "The current version of the schema", response = CassandraVersionResponse.class)
     })
     public CassandraVersionResponse getCassandraCurrentVersion() {
-        return new CassandraVersionResponse(cassandraMigrationService.getCurrentVersion());
+        return CassandraVersionResponse.from(cassandraMigrationService.getCurrentVersion());
     }
 }

--- a/server/protocols/webadmin/webadmin-cassandra/src/test/java/org/apache/james/webadmin/dto/VersionRequestTest.java
+++ b/server/protocols/webadmin/webadmin-cassandra/src/test/java/org/apache/james/webadmin/dto/VersionRequestTest.java
@@ -20,48 +20,41 @@
 package org.apache.james.webadmin.dto;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Rule;
+import org.apache.james.backends.cassandra.versions.SchemaVersion;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class VersionRequestTest {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
     public void parseShouldThrowWhenNullVersion() throws Exception {
-        expectedException.expect(NullPointerException.class);
-
-        CassandraVersionRequest.parse(null);
+        assertThatThrownBy(() -> CassandraVersionRequest.parse(null))
+            .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     public void parseShouldThrowWhenNonIntegerVersion() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-
-        CassandraVersionRequest.parse("NoInt");
+        assertThatThrownBy(() -> CassandraVersionRequest.parse("NoInt"))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void parseShouldThrowWhenNegativeVersion() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-
-        CassandraVersionRequest.parse("-1");
+        assertThatThrownBy(() -> CassandraVersionRequest.parse("-1"))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void parseShouldAcceptZeroVersion() throws Exception {
-        CassandraVersionRequest cassandraVersionRequest = CassandraVersionRequest.parse("0");
-
-        assertThat(cassandraVersionRequest.getValue()).isEqualTo(0);
+        assertThatThrownBy(() -> CassandraVersionRequest.parse("0"))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void parseShouldParseTheVersionValue() throws Exception {
         CassandraVersionRequest cassandraVersionRequest = CassandraVersionRequest.parse("1");
 
-        assertThat(cassandraVersionRequest.getValue()).isEqualTo(1);
+        assertThat(cassandraVersionRequest.getValue()).isEqualTo(new SchemaVersion(1));
     }
 
 }

--- a/server/protocols/webadmin/webadmin-cassandra/src/test/java/org/apache/james/webadmin/dto/VersionRequestTest.java
+++ b/server/protocols/webadmin/webadmin-cassandra/src/test/java/org/apache/james/webadmin/dto/VersionRequestTest.java
@@ -45,7 +45,7 @@ public class VersionRequestTest {
     }
 
     @Test
-    public void parseShouldAcceptZeroVersion() throws Exception {
+    public void parseShouldThrowWhenZeroVersion() throws Exception {
         assertThatThrownBy(() -> CassandraVersionRequest.parse("0"))
             .isInstanceOf(IllegalArgumentException.class);
     }

--- a/server/protocols/webadmin/webadmin-cassandra/src/test/java/org/apache/james/webadmin/routes/CassandraMigrationRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-cassandra/src/test/java/org/apache/james/webadmin/routes/CassandraMigrationRoutesTest.java
@@ -37,12 +37,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.james.backends.cassandra.migration.CassandraMigrationService;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionDAO;
 import org.apache.james.mailbox.cassandra.mail.migration.Migration;
 import org.apache.james.metrics.logger.DefaultMetricFactory;
 import org.apache.james.webadmin.WebAdminServer;
 import org.apache.james.webadmin.WebAdminUtils;
-import org.apache.james.webadmin.service.CassandraMigrationService;
 import org.apache.james.webadmin.utils.JsonTransformer;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.After;

--- a/server/protocols/webadmin/webadmin-cassandra/src/test/java/org/apache/james/webadmin/service/CassandraMigrationServiceTest.java
+++ b/server/protocols/webadmin/webadmin-cassandra/src/test/java/org/apache/james/webadmin/service/CassandraMigrationServiceTest.java
@@ -38,8 +38,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.lang.NotImplementedException;
+import org.apache.james.backends.cassandra.migration.Migration;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionDAO;
-import org.apache.james.mailbox.cassandra.mail.migration.Migration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -66,7 +66,7 @@ public class CassandraMigrationServiceTest {
     public void setUp() throws Exception {
         schemaVersionDAO = mock(CassandraSchemaVersionDAO.class);
         successfulMigration = mock(Migration.class);
-        when(successfulMigration.run()).thenReturn(Migration.MigrationResult.COMPLETED);
+        when(successfulMigration.run()).thenReturn(Migration.Result.COMPLETED);
         Map<Integer, Migration> allMigrationClazz = ImmutableMap.<Integer, Migration>builder()
             .put(OLDER_VERSION, successfulMigration)
             .put(CURRENT_VERSION, successfulMigration)
@@ -167,7 +167,7 @@ public class CassandraMigrationServiceTest {
         Migration wait1SecondMigration = mock(Migration.class);
         doAnswer(invocation -> {
             Thread.sleep(1000);
-            return Migration.MigrationResult.COMPLETED;
+            return Migration.Result.COMPLETED;
         }).when(wait1SecondMigration).run();
         Map<Integer, Migration> allMigrationClazz = ImmutableMap.<Integer, Migration>builder()
             .put(OLDER_VERSION, wait1SecondMigration)
@@ -201,7 +201,7 @@ public class CassandraMigrationServiceTest {
     @Test
     public void partialMigrationShouldThrow() throws Exception {
         Migration migration1 = mock(Migration.class);
-        when(migration1.run()).thenReturn(Migration.MigrationResult.PARTIAL);
+        when(migration1.run()).thenReturn(Migration.Result.PARTIAL);
         Migration migration2 = successfulMigration;
 
         Map<Integer, Migration> allMigrationClazz = ImmutableMap.<Integer, Migration>builder()
@@ -218,9 +218,9 @@ public class CassandraMigrationServiceTest {
     @Test
     public void partialMigrationShouldAbortMigrations() throws Exception {
         Migration migration1 = mock(Migration.class);
-        when(migration1.run()).thenReturn(Migration.MigrationResult.PARTIAL);
+        when(migration1.run()).thenReturn(Migration.Result.PARTIAL);
         Migration migration2 = mock(Migration.class);
-        when(migration2.run()).thenReturn(Migration.MigrationResult.COMPLETED);
+        when(migration2.run()).thenReturn(Migration.Result.COMPLETED);
 
         Map<Integer, Migration> allMigrationClazz = ImmutableMap.<Integer, Migration>builder()
             .put(OLDER_VERSION, migration1)

--- a/server/protocols/webadmin/webadmin-core/pom.xml
+++ b/server/protocols/webadmin/webadmin-core/pom.xml
@@ -63,6 +63,10 @@
             <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.fge</groupId>
             <artifactId>throwing-lambdas</artifactId>
         </dependency>

--- a/server/protocols/webadmin/webadmin-core/pom.xml
+++ b/server/protocols/webadmin/webadmin-core/pom.xml
@@ -55,6 +55,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>james-server-task</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
@@ -73,6 +77,11 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.restassured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.sparkjava</groupId>

--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/dto/ExecutionDetailsDto.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/dto/ExecutionDetailsDto.java
@@ -1,0 +1,95 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.dto;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.apache.james.task.TaskExecutionDetails;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.github.steveash.guavate.Guavate;
+
+public class ExecutionDetailsDto {
+    public static List<ExecutionDetailsDto> from(List<TaskExecutionDetails> tasksDetails) {
+        return tasksDetails.stream()
+            .map(ExecutionDetailsDto::new)
+            .collect(Guavate.toImmutableList());
+    }
+
+    public static ExecutionDetailsDto from(TaskExecutionDetails taskDetails) {
+        return new ExecutionDetailsDto(taskDetails);
+    }
+
+    private final TaskExecutionDetails executionDetails;
+
+    private ExecutionDetailsDto(TaskExecutionDetails executionDetails) {
+        this.executionDetails = executionDetails;
+    }
+
+    public UUID getTaskId() {
+        return executionDetails.getTaskId().getValue();
+    }
+
+    public String getType() {
+        return executionDetails.getType();
+    }
+
+    public String getStatus() {
+        return executionDetails.getStatus().getValue();
+    }
+
+    public Optional<Object> getAdditionalInformation() {
+        return executionDetails.getAdditionalInformation();
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+    public Optional<ZonedDateTime> getSubmitDate() {
+        return executionDetails.getSubmitDate();
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+    public Optional<ZonedDateTime> getStartedDate() {
+        return executionDetails.getStartedDate();
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+    public Optional<ZonedDateTime> getCompletedDate() {
+        return executionDetails.getCompletedDate();
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+    public Optional<ZonedDateTime> getCanceledDate() {
+        return executionDetails.getCanceledDate();
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+    public Optional<ZonedDateTime> getFailedDate() {
+        return executionDetails.getFailedDate();
+    }
+}

--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/dto/ExecutionDetailsDto.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/dto/ExecutionDetailsDto.java
@@ -59,7 +59,7 @@ public class ExecutionDetailsDto {
         return executionDetails.getStatus().getValue();
     }
 
-    public Optional<Object> getAdditionalInformation() {
+    public Optional<TaskExecutionDetails.AdditionalInformation> getAdditionalInformation() {
         return executionDetails.getAdditionalInformation();
     }
 

--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/dto/TaskIdDto.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/dto/TaskIdDto.java
@@ -17,30 +17,24 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.webadmin.utils;
+package org.apache.james.webadmin.dto;
 
-import java.io.IOException;
+import java.util.UUID;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import org.apache.james.task.TaskId;
 
-public class JsonExtractor<Request> {
-
-    private final ObjectMapper objectMapper;
-    private final Class<Request> type;
-
-    public JsonExtractor(Class<Request> type) {
-        this.objectMapper = new ObjectMapper()
-            .registerModule(new Jdk8Module());
-        this.type = type;
+public class TaskIdDto {
+    public static TaskIdDto from(TaskId id) {
+        return new TaskIdDto(id.getValue());
     }
 
-    public Request parse(String text) throws JsonExtractException {
-        try {
-            return objectMapper.readValue(text, type);
-        } catch (IOException | IllegalArgumentException e) {
-            throw new JsonExtractException(e);
-        }
+    private final UUID uuid;
+
+    public TaskIdDto(UUID uuid) {
+        this.uuid = uuid;
     }
 
+    public UUID getTaskId() {
+        return uuid;
+    }
 }

--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/dto/TaskIdDto.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/dto/TaskIdDto.java
@@ -19,11 +19,24 @@
 
 package org.apache.james.webadmin.dto;
 
+import static org.eclipse.jetty.http.HttpHeader.LOCATION;
+
 import java.util.UUID;
 
 import org.apache.james.task.TaskId;
+import org.apache.james.webadmin.routes.TasksRoutes;
+import org.eclipse.jetty.http.HttpStatus;
+
+import spark.Response;
 
 public class TaskIdDto {
+
+    public static TaskIdDto respond(Response response, TaskId taskId) {
+        response.status(HttpStatus.CREATED_201);
+        response.header(LOCATION.asString(), TasksRoutes.BASE + "/" + taskId.toString());
+        return TaskIdDto.from(taskId);
+    }
+
     public static TaskIdDto from(TaskId id) {
         return new TaskIdDto(id.getValue());
     }

--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/routes/TasksRoutes.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/routes/TasksRoutes.java
@@ -1,0 +1,127 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.routes;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import javax.inject.Inject;
+
+import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.task.TaskId;
+import org.apache.james.task.TaskManager;
+import org.apache.james.task.TaskNotFoundException;
+import org.apache.james.webadmin.Constants;
+import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.dto.ExecutionDetailsDto;
+import org.apache.james.webadmin.utils.ErrorResponder;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
+
+import spark.Request;
+import spark.Response;
+import spark.Service;
+
+public class TasksRoutes implements Routes {
+    public static final String BASE = "/tasks";
+    private final TaskManager taskManager;
+    private final JsonTransformer jsonTransformer;
+
+    @Inject
+    public TasksRoutes(TaskManager taskManager, JsonTransformer jsonTransformer) {
+        this.taskManager = taskManager;
+        this.jsonTransformer = jsonTransformer;
+    }
+
+    @Override
+    public void define(Service service) {
+        service.get(BASE + "/:id", this::getStatus, jsonTransformer);
+
+        service.get(BASE + "/:id/await", this::await, jsonTransformer);
+
+        service.delete(BASE + "/:id", this::cancel, jsonTransformer);
+
+        service.get(BASE, this::list, jsonTransformer);
+    }
+
+    private Object list(Request req, Response response) {
+        try {
+            return ExecutionDetailsDto.from(
+                Optional.ofNullable(req.queryParams("status"))
+                .map(TaskManager.Status::fromString)
+                .map(taskManager::list)
+                .orElse(taskManager.list()));
+        } catch (IllegalArgumentException e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .cause(e)
+                .message("Invalid status query parameter")
+                .haltError();
+        }
+    }
+
+    private Object getStatus(Request req, Response response) {
+        TaskId taskId = getTaskId(req);
+        return respondStatus(taskId,
+            () -> taskManager.getExecutionDetails(getTaskId(req)));
+    }
+
+    private Object await(Request req, Response response) {
+        TaskId taskId = getTaskId(req);
+        return respondStatus(taskId,
+            () -> taskManager.await(getTaskId(req)));
+    }
+
+    private Object respondStatus(TaskId taskId, Supplier<TaskExecutionDetails> executionDetailsSupplier) {
+        try {
+            TaskExecutionDetails executionDetails = executionDetailsSupplier.get();
+            return ExecutionDetailsDto.from(executionDetails);
+        } catch (TaskNotFoundException e) {
+            throw ErrorResponder.builder()
+                .message(String.format("%s can not be found", taskId.getValue()))
+                .statusCode(HttpStatus.NOT_FOUND_404)
+                .type(ErrorResponder.ErrorType.NOT_FOUND)
+                .haltError();
+        }
+    }
+
+    private Object cancel(Request req, Response response) {
+        TaskId taskId = getTaskId(req);
+        taskManager.cancel(taskId);
+        response.status(HttpStatus.NO_CONTENT_204);
+        return Constants.EMPTY_BODY;
+    }
+
+    private TaskId getTaskId(Request req) {
+        try {
+            String id = req.params("id");
+            return new TaskId(UUID.fromString(id));
+        } catch (Exception e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .cause(e)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("Invalid task id")
+                .haltError();
+        }
+    }
+}

--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/routes/TasksRoutes.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/routes/TasksRoutes.java
@@ -19,11 +19,16 @@
 
 package org.apache.james.webadmin.routes;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
 
 import javax.inject.Inject;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 
 import org.apache.james.task.TaskExecutionDetails;
 import org.apache.james.task.TaskId;
@@ -36,10 +41,19 @@ import org.apache.james.webadmin.utils.ErrorResponder;
 import org.apache.james.webadmin.utils.JsonTransformer;
 import org.eclipse.jetty.http.HttpStatus;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import spark.Request;
 import spark.Response;
 import spark.Service;
 
+@Api(tags = "Tasks")
+@Path(":task")
+@Produces("application/json")
 public class TasksRoutes implements Routes {
     public static final String BASE = "/tasks";
     private final TaskManager taskManager;
@@ -62,7 +76,23 @@ public class TasksRoutes implements Routes {
         service.get(BASE, this::list, jsonTransformer);
     }
 
-    private Object list(Request req, Response response) {
+    @GET
+    @ApiOperation(value = "Listing tasks")
+    @ApiImplicitParams({
+        @ApiImplicitParam(
+            required = false,
+            paramType = "query parameter",
+            dataType = "String",
+            defaultValue = "None",
+            example = "?status=inProgress",
+            value = "If present, allow to filter the tasks and keep only the one with a given status.")
+    })
+    @ApiResponses(value = {
+        @ApiResponse(code = HttpStatus.OK_200, message = "A specific class execution details", response = List.class),
+        @ApiResponse(code = HttpStatus.BAD_REQUEST_400, message = "The provided payload is invalid (JSON error or invalid status)"),
+        @ApiResponse(code = HttpStatus.NOT_FOUND_404, message = "The taskId is not found")
+    })
+    public Object list(Request req, Response response) {
         try {
             return ExecutionDetailsDto.from(
                 Optional.ofNullable(req.queryParams("status"))
@@ -79,13 +109,29 @@ public class TasksRoutes implements Routes {
         }
     }
 
-    private Object getStatus(Request req, Response response) {
+    @GET
+    @Path("/{taskId}")
+    @ApiOperation(value = "Getting a task execution details")
+    @ApiResponses(value = {
+        @ApiResponse(code = HttpStatus.OK_200, message = "A specific class execution details", response = ExecutionDetailsDto.class),
+        @ApiResponse(code = HttpStatus.BAD_REQUEST_400, message = "The taskId is invalid"),
+        @ApiResponse(code = HttpStatus.NOT_FOUND_404, message = "The taskId is not found")
+    })
+    public Object getStatus(Request req, Response response) {
         TaskId taskId = getTaskId(req);
         return respondStatus(taskId,
             () -> taskManager.getExecutionDetails(getTaskId(req)));
     }
 
-    private Object await(Request req, Response response) {
+    @GET
+    @Path("/{taskId}/await")
+    @ApiOperation(value = "Await, then get a task execution details")
+    @ApiResponses(value = {
+        @ApiResponse(code = HttpStatus.OK_200, message = "A specific class execution details", response = ExecutionDetailsDto.class),
+        @ApiResponse(code = HttpStatus.BAD_REQUEST_400, message = "The taskId is invalid"),
+        @ApiResponse(code = HttpStatus.NOT_FOUND_404, message = "The taskId is not found")
+    })
+    public Object await(Request req, Response response) {
         TaskId taskId = getTaskId(req);
         return respondStatus(taskId,
             () -> taskManager.await(getTaskId(req)));
@@ -104,7 +150,14 @@ public class TasksRoutes implements Routes {
         }
     }
 
-    private Object cancel(Request req, Response response) {
+    @DELETE
+    @Path("/{taskId}")
+    @ApiOperation(value = "Cancel a given task")
+    @ApiResponses(value = {
+        @ApiResponse(code = HttpStatus.NO_CONTENT_204, message = "Task is cancelled"),
+        @ApiResponse(code = HttpStatus.BAD_REQUEST_400, message = "The taskId is invalid")
+    })
+    public Object cancel(Request req, Response response) {
         TaskId taskId = getTaskId(req);
         taskManager.cancel(taskId);
         response.status(HttpStatus.NO_CONTENT_204);

--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/routes/TasksRoutes.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/routes/TasksRoutes.java
@@ -85,7 +85,8 @@ public class TasksRoutes implements Routes {
             dataType = "String",
             defaultValue = "None",
             example = "?status=inProgress",
-            value = "If present, allow to filter the tasks and keep only the one with a given status.")
+            value = "If present, allow to filter the tasks and keep only the one with a given status. " +
+                "The status are one of [waiting, inProgress, failed, canceled, completed]")
     })
     @ApiResponses(value = {
         @ApiResponse(code = HttpStatus.OK_200, message = "A specific class execution details", response = List.class),

--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/utils/ErrorResponder.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/utils/ErrorResponder.java
@@ -33,6 +33,7 @@ import spark.HaltException;
 public class ErrorResponder {
     public enum ErrorType {
         INVALID_ARGUMENT("InvalidArgument"),
+        NOT_FOUND("notFound"),
         WRONG_STATE("WrongState"),
         SERVER_ERROR("ServerError");
 

--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/utils/JsonTransformer.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/utils/JsonTransformer.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import spark.ResponseTransformer;
 
@@ -31,9 +32,10 @@ public class JsonTransformer implements ResponseTransformer {
     private final ObjectMapper objectMapper;
 
     public JsonTransformer() {
-        objectMapper = new ObjectMapper();
-        objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
-        objectMapper.registerModule(new Jdk8Module());
+        objectMapper = new ObjectMapper()
+            .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+            .registerModule(new Jdk8Module())
+            .registerModule(new JavaTimeModule());
     }
 
     @Override

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/routes/TasksRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/routes/TasksRoutesTest.java
@@ -1,0 +1,277 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.routes;
+
+import static com.jayway.restassured.RestAssured.given;
+import static com.jayway.restassured.RestAssured.when;
+import static com.jayway.restassured.RestAssured.with;
+import static com.jayway.restassured.config.EncoderConfig.encoderConfig;
+import static com.jayway.restassured.config.RestAssuredConfig.newConfig;
+import static org.apache.james.webadmin.WebAdminServer.NO_CONFIGURATION;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.james.metrics.logger.DefaultMetricFactory;
+import org.apache.james.task.MemoryTaskManager;
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskId;
+import org.apache.james.task.TaskManager;
+import org.apache.james.webadmin.WebAdminServer;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Throwables;
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.builder.RequestSpecBuilder;
+import com.jayway.restassured.http.ContentType;
+
+public class TasksRoutesTest {
+
+    private MemoryTaskManager taskManager;
+    private WebAdminServer webAdminServer;
+
+    @Before
+    public void setUp() throws Exception {
+        taskManager = new MemoryTaskManager();
+
+        webAdminServer = WebAdminUtils.createWebAdminServer(
+            new DefaultMetricFactory(),
+            new TasksRoutes(taskManager, new JsonTransformer()));
+
+        webAdminServer.configure(NO_CONFIGURATION);
+        webAdminServer.await();
+
+        RestAssured.requestSpecification = new RequestSpecBuilder()
+            .setContentType(ContentType.JSON)
+            .setAccept(ContentType.JSON)
+            .setBasePath(TasksRoutes.BASE)
+            .setPort(webAdminServer.getPort().get().getValue())
+            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(Charsets.UTF_8)))
+            .build();
+    }
+
+    @After
+    public void tearDown() {
+        taskManager.stop();
+        webAdminServer.destroy();
+    }
+
+    @Test
+    public void listShouldReturnEmptyWhenNoTask() {
+        when()
+            .get()
+        .then()
+            .body("", hasSize(0));
+    }
+
+    @Test
+    public void listShouldReturnTaskDetailsWhenTaskInProgress() {
+        TaskId taskId = taskManager.submit(() -> {
+            await();
+            return Task.Result.COMPLETED;
+        });
+
+        when()
+            .get()
+        .then()
+            .statusCode(HttpStatus.OK_200)
+            .body("", hasSize(1))
+            .body("[0].status", is(TaskManager.Status.IN_PROGRESS.getValue()))
+            .body("[0].taskId", is(taskId.getValue().toString()))
+            .body("[0].class", is(not(empty())));
+    }
+
+    private void await() {
+        try {
+            new CountDownLatch(1).await();
+        } catch (InterruptedException e) {
+            Throwables.propagate(e);
+        }
+    }
+
+    @Test
+    public void listShouldListTaskWhenStatusFilter() {
+        TaskId taskId = taskManager.submit(() -> {
+            await();
+            return Task.Result.COMPLETED;
+        });
+
+        given()
+            .param("status", TaskManager.Status.IN_PROGRESS.getValue())
+        .when()
+            .get()
+        .then()
+            .statusCode(HttpStatus.OK_200)
+            .body("", hasSize(1))
+            .body("[0].status", is(TaskManager.Status.IN_PROGRESS.getValue()))
+            .body("[0].taskId", is(taskId.getValue().toString()))
+            .body("[0].type", is(Task.UNKNOWN));
+    }
+
+    @Test
+    public void listShouldReturnEmptyWhenNonMatchingStatusFilter() {
+        taskManager.submit(() -> {
+            await();
+            return Task.Result.COMPLETED;
+        });
+
+        given()
+            .param("status", TaskManager.Status.WAITING.getValue())
+        .when()
+            .get()
+        .then()
+            .statusCode(HttpStatus.OK_200)
+            .body("", hasSize(0));
+    }
+
+    @Test
+    public void getShouldReturnTaskDetails() {
+        TaskId taskId = taskManager.submit(() -> {
+            await();
+            return Task.Result.COMPLETED;
+        });
+
+        when()
+            .get("/" + taskId.getValue())
+        .then()
+            .statusCode(HttpStatus.OK_200)
+            .body("status", is("inProgress"));
+    }
+
+    @Test
+    public void getAwaitShouldAwaitTaskCompletion() {
+        TaskId taskId = taskManager.submit(() -> {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                throw Throwables.propagate(e);
+            }
+            return Task.Result.COMPLETED;
+        });
+
+        when()
+            .get("/" + taskId.getValue() + "/await")
+        .then()
+            .statusCode(HttpStatus.OK_200)
+            .body("status", is("completed"));
+    }
+
+    @Test
+    public void deleteShouldReturnOk() {
+        TaskId taskId = taskManager.submit(() -> {
+            await();
+            return Task.Result.COMPLETED;
+        });
+
+        when()
+            .delete("/" + taskId.getValue())
+        .then()
+            .statusCode(HttpStatus.NO_CONTENT_204);
+    }
+
+    @Test
+    public void deleteShouldCancelMatchingTask() {
+        TaskId taskId = taskManager.submit(() -> {
+            await();
+            return Task.Result.COMPLETED;
+        });
+
+        with()
+            .delete("/" + taskId.getValue());
+
+        when()
+            .get("/" + taskId.getValue())
+        .then()
+            .statusCode(HttpStatus.OK_200)
+            .body("status", is("canceled"));
+    }
+
+    @Test
+    public void getShouldReturnNotFoundWhenIdDoesNotExist() {
+        String taskId = UUID.randomUUID().toString();
+
+        when()
+            .get("/" + taskId)
+        .then()
+            .statusCode(HttpStatus.NOT_FOUND_404)
+            .body("statusCode", is(HttpStatus.NOT_FOUND_404))
+            .body("type", is("notFound"))
+            .body("message", is(String.format("%s can not be found", taskId)));
+    }
+
+    @Test
+    public void getShouldReturnErrorWhenInvalidId() {
+        String taskId = "invalid";
+
+        when()
+            .get("/" + taskId)
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400)
+            .body("statusCode", is(HttpStatus.BAD_REQUEST_400))
+            .body("type", is("InvalidArgument"))
+            .body("message", is("Invalid task id"));
+    }
+
+    @Test
+    public void deleteShouldReturnOkWhenNonExistingId() {
+        String taskId = UUID.randomUUID().toString();
+
+        when()
+            .delete("/" + taskId)
+        .then()
+            .statusCode(HttpStatus.NO_CONTENT_204);
+    }
+
+    @Test
+    public void deleteShouldReturnAnErrorOnInvalidId() {
+        String taskId = "invalid";
+
+        when()
+            .delete("/" + taskId)
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400)
+            .body("statusCode", is(HttpStatus.BAD_REQUEST_400))
+            .body("type", is("InvalidArgument"))
+            .body("message", is("Invalid task id"));
+    }
+
+    @Test
+    public void listShouldReturnErrorWhenNonExistingStatus() {
+        given()
+            .param("status", "invalid")
+            .get()
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400)
+            .body("statusCode", is(HttpStatus.BAD_REQUEST_400))
+            .body("type", is("InvalidArgument"))
+            .body("message", is("Invalid status query parameter"));
+    }
+
+}

--- a/server/task/pom.xml
+++ b/server/task/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>james-server</artifactId>
+        <groupId>org.apache.james</groupId>
+        <version>3.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>james-server-task</artifactId>
+    <name>Apache James :: Server :: Task</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>james-server-util-java8</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/server/task/src/main/java/org/apache/james/task/MemoryTaskManager.java
+++ b/server/task/src/main/java/org/apache/james/task/MemoryTaskManager.java
@@ -1,0 +1,156 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.task;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+
+import javax.annotation.PreDestroy;
+
+import org.apache.james.util.MDCBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.fge.lambdas.Throwing;
+import com.github.steveash.guavate.Guavate;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+
+public class MemoryTaskManager implements TaskManager {
+    private static final boolean INTERRUPT_IF_RUNNING = true;
+    private static final Logger LOGGER = LoggerFactory.getLogger(MemoryTaskManager.class);
+
+    private final ConcurrentHashMap<TaskId, TaskExecutionDetails> idToExecutionDetails;
+    private final ConcurrentHashMap<TaskId, Future> idToFuture;
+    private final ExecutorService executor;
+
+    public MemoryTaskManager() {
+        idToExecutionDetails = new ConcurrentHashMap<>();
+        idToFuture = new ConcurrentHashMap<>();
+        executor = Executors.newSingleThreadExecutor();
+    }
+
+    @Override
+    public TaskId submit(Task task) {
+        return submit(task, id -> {});
+    }
+
+    @VisibleForTesting
+    TaskId submit(Task task, Consumer<TaskId> callback) {
+        TaskId taskId = TaskId.generateTaskId();
+        TaskExecutionDetails executionDetails = TaskExecutionDetails.from(task, taskId);
+
+        idToExecutionDetails.put(taskId, executionDetails);
+        idToFuture.put(taskId,
+            executor.submit(() -> runWithMdc(executionDetails, task, callback)));
+        return taskId;
+    }
+
+    private void runWithMdc(TaskExecutionDetails executionDetails, Task task, Consumer<TaskId> callback) {
+        MDCBuilder.withMdc(
+            MDCBuilder.create()
+                .addContext(Task.TASK_ID, executionDetails.getTaskId())
+                .addContext(Task.TASK_TYPE, executionDetails.getType())
+                .addContext(Task.TASK_DETAILS, executionDetails.getAdditionalInformation()),
+            () -> run(executionDetails, task, callback));
+    }
+
+    private void run(TaskExecutionDetails executionDetails, Task task, Consumer<TaskId> callback) {
+        TaskExecutionDetails started = executionDetails.start();
+        idToExecutionDetails.put(started.getTaskId(), started);
+        try {
+            task.run()
+                .onComplete(() -> success(started))
+                .onFailure(() -> failed(started,
+                    logger -> logger.info("Task was partially performed. Check logs for more details")));
+        } catch (Exception e) {
+            failed(started,
+                logger -> logger.error("Error while running task", executionDetails, e));
+        } finally {
+            idToFuture.remove(executionDetails.getTaskId());
+            callback.accept(executionDetails.getTaskId());
+        }
+    }
+
+    private void success(TaskExecutionDetails started) {
+        if (!wasCancelled(started.getTaskId())) {
+            idToExecutionDetails.put(started.getTaskId(), started.completed());
+            LOGGER.info("Task success");
+        }
+    }
+
+    private void failed(TaskExecutionDetails started, Consumer<Logger> logOperation) {
+        if (!wasCancelled(started.getTaskId())) {
+            idToExecutionDetails.put(started.getTaskId(), started.failed());
+            logOperation.accept(LOGGER);
+        }
+    }
+
+    private boolean wasCancelled(TaskId taskId) {
+        return idToExecutionDetails.get(taskId).getStatus() == Status.CANCELLED;
+    }
+
+    @Override
+    public TaskExecutionDetails getExecutionDetails(TaskId id) {
+        return Optional.ofNullable(idToExecutionDetails.get(id))
+            .orElseThrow(TaskNotFoundException::new);
+    }
+
+    @Override
+    public List<TaskExecutionDetails> list() {
+        return ImmutableList.copyOf(idToExecutionDetails.values());
+    }
+
+    @Override
+    public List<TaskExecutionDetails> list(Status status) {
+        return idToExecutionDetails.values()
+            .stream()
+            .filter(details -> details.getStatus().equals(status))
+            .collect(Guavate.toImmutableList());
+    }
+
+    @Override
+    public void cancel(TaskId id) {
+        Optional.ofNullable(idToFuture.get(id))
+            .ifPresent(future -> {
+                TaskExecutionDetails executionDetails = idToExecutionDetails.get(id);
+                idToExecutionDetails.put(id, executionDetails.cancel());
+                future.cancel(INTERRUPT_IF_RUNNING);
+                idToFuture.remove(id);
+            });
+    }
+
+    @Override
+    public TaskExecutionDetails await(TaskId id) {
+        Optional.ofNullable(idToFuture.get(id))
+            .ifPresent(Throwing.consumer(Future::get));
+        return getExecutionDetails(id);
+    }
+
+    @PreDestroy
+    public void stop() {
+        executor.shutdownNow();
+    }
+}

--- a/server/task/src/main/java/org/apache/james/task/Task.java
+++ b/server/task/src/main/java/org/apache/james/task/Task.java
@@ -1,0 +1,44 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.task;
+
+public interface Task {
+
+    enum Result {
+        COMPLETED,
+        PARTIAL
+    }
+
+    static Result combine(Result result1, Result result2) {
+        if (result1 == Result.COMPLETED
+            && result2 == Result.COMPLETED) {
+            return Result.COMPLETED;
+        }
+        return Result.PARTIAL;
+    }
+
+    /**
+     * Runs the migration
+     *
+     * @return Return true if fully migrated. Returns false otherwise.
+     */
+    Result run();
+
+}

--- a/server/task/src/main/java/org/apache/james/task/Task.java
+++ b/server/task/src/main/java/org/apache/james/task/Task.java
@@ -81,7 +81,7 @@ public interface Task {
         return UNKNOWN;
     }
 
-    default Optional<Object> details() {
+    default Optional<TaskExecutionDetails.AdditionalInformation> details() {
         return Optional.empty();
     }
 

--- a/server/task/src/main/java/org/apache/james/task/Task.java
+++ b/server/task/src/main/java/org/apache/james/task/Task.java
@@ -20,6 +20,7 @@
 package org.apache.james.task;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,4 +76,18 @@ public interface Task {
      */
     Result run();
 
+
+    default String type() {
+        return UNKNOWN;
+    }
+
+    default Optional<Object> details() {
+        return Optional.empty();
+    }
+
+    String TASK_ID = "taskId";
+    String TASK_TYPE = "taskType";
+    String TASK_DETAILS = "taskDetails";
+
+    String UNKNOWN = "unknown";
 }

--- a/server/task/src/main/java/org/apache/james/task/TaskExecutionDetails.java
+++ b/server/task/src/main/java/org/apache/james/task/TaskExecutionDetails.java
@@ -25,6 +25,11 @@ import java.util.Optional;
 import com.google.common.base.Preconditions;
 
 public class TaskExecutionDetails {
+
+    public interface AdditionalInformation {
+
+    }
+
     public static TaskExecutionDetails from(Task task, TaskId id) {
         return new TaskExecutionDetails(
             id,
@@ -41,14 +46,15 @@ public class TaskExecutionDetails {
     private final TaskId taskId;
     private final String type;
     private final TaskManager.Status status;
-    private final Optional<Object> additionalInformation;
+    private final Optional<AdditionalInformation> additionalInformation;
     private final Optional<ZonedDateTime> submitDate;
     private final Optional<ZonedDateTime> startedDate;
     private final Optional<ZonedDateTime> completedDate;
     private final Optional<ZonedDateTime> canceledDate;
     private final Optional<ZonedDateTime> failedDate;
 
-    public TaskExecutionDetails(TaskId taskId, String type, TaskManager.Status status, Optional<Object> additionalInformation,
+    public TaskExecutionDetails(TaskId taskId, String type, TaskManager.Status status,
+                                Optional<AdditionalInformation> additionalInformation,
                                 Optional<ZonedDateTime> submitDate, Optional<ZonedDateTime> startedDate,
                                 Optional<ZonedDateTime> completedDate, Optional<ZonedDateTime> canceledDate,
                                 Optional<ZonedDateTime> failedDate) {
@@ -75,7 +81,7 @@ public class TaskExecutionDetails {
         return status;
     }
 
-    public Optional<Object> getAdditionalInformation() {
+    public Optional<AdditionalInformation> getAdditionalInformation() {
         return additionalInformation;
     }
 

--- a/server/task/src/main/java/org/apache/james/task/TaskExecutionDetails.java
+++ b/server/task/src/main/java/org/apache/james/task/TaskExecutionDetails.java
@@ -1,0 +1,158 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.task;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import com.google.common.base.Preconditions;
+
+public class TaskExecutionDetails {
+    public static TaskExecutionDetails from(Task task, TaskId id) {
+        return new TaskExecutionDetails(
+            id,
+            task.type(),
+            TaskManager.Status.WAITING,
+            task.details(),
+            Optional.of(ZonedDateTime.now()),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    }
+
+    private final TaskId taskId;
+    private final String type;
+    private final TaskManager.Status status;
+    private final Optional<Object> additionalInformation;
+    private final Optional<ZonedDateTime> submitDate;
+    private final Optional<ZonedDateTime> startedDate;
+    private final Optional<ZonedDateTime> completedDate;
+    private final Optional<ZonedDateTime> canceledDate;
+    private final Optional<ZonedDateTime> failedDate;
+
+    public TaskExecutionDetails(TaskId taskId, String type, TaskManager.Status status, Optional<Object> additionalInformation,
+                                Optional<ZonedDateTime> submitDate, Optional<ZonedDateTime> startedDate,
+                                Optional<ZonedDateTime> completedDate, Optional<ZonedDateTime> canceledDate,
+                                Optional<ZonedDateTime> failedDate) {
+        this.taskId = taskId;
+        this.type = type;
+        this.status = status;
+        this.additionalInformation = additionalInformation;
+        this.submitDate = submitDate;
+        this.startedDate = startedDate;
+        this.completedDate = completedDate;
+        this.canceledDate = canceledDate;
+        this.failedDate = failedDate;
+    }
+
+    public TaskId getTaskId() {
+        return taskId;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public TaskManager.Status getStatus() {
+        return status;
+    }
+
+    public Optional<Object> getAdditionalInformation() {
+        return additionalInformation;
+    }
+
+    public Optional<ZonedDateTime> getSubmitDate() {
+        return submitDate;
+    }
+
+    public Optional<ZonedDateTime> getStartedDate() {
+        return startedDate;
+    }
+
+    public Optional<ZonedDateTime> getCompletedDate() {
+        return completedDate;
+    }
+
+    public Optional<ZonedDateTime> getCanceledDate() {
+        return canceledDate;
+    }
+
+    public Optional<ZonedDateTime> getFailedDate() {
+        return failedDate;
+    }
+
+    public TaskExecutionDetails start() {
+        Preconditions.checkState(status == TaskManager.Status.WAITING);
+        return new TaskExecutionDetails(
+            taskId,
+            type,
+            TaskManager.Status.IN_PROGRESS,
+            additionalInformation,
+            submitDate,
+            Optional.of(ZonedDateTime.now()),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    }
+
+    public TaskExecutionDetails completed() {
+        Preconditions.checkState(status == TaskManager.Status.IN_PROGRESS);
+        return new TaskExecutionDetails(
+            taskId,
+            type,
+            TaskManager.Status.COMPLETED,
+            additionalInformation,
+            submitDate,
+            startedDate,
+            Optional.of(ZonedDateTime.now()),
+            Optional.empty(),
+            Optional.empty());
+    }
+
+    public TaskExecutionDetails failed() {
+        Preconditions.checkState(status == TaskManager.Status.IN_PROGRESS);
+        return new TaskExecutionDetails(
+            taskId,
+            type,
+            TaskManager.Status.FAILED,
+            additionalInformation,
+            submitDate,
+            startedDate,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(ZonedDateTime.now()));
+    }
+
+    public TaskExecutionDetails cancel() {
+        Preconditions.checkState(status == TaskManager.Status.IN_PROGRESS
+            || status == TaskManager.Status.WAITING);
+        return new TaskExecutionDetails(
+            taskId,
+            type,
+            TaskManager.Status.CANCELLED,
+            additionalInformation,
+            submitDate,
+            startedDate,
+            Optional.empty(),
+            Optional.of(ZonedDateTime.now()),
+            Optional.empty());
+    }
+}

--- a/server/task/src/main/java/org/apache/james/task/TaskExecutionDetails.java
+++ b/server/task/src/main/java/org/apache/james/task/TaskExecutionDetails.java
@@ -33,9 +33,8 @@ public class TaskExecutionDetails {
     public static TaskExecutionDetails from(Task task, TaskId id) {
         return new TaskExecutionDetails(
             id,
-            task.type(),
+            task,
             TaskManager.Status.WAITING,
-            task.details(),
             Optional.of(ZonedDateTime.now()),
             Optional.empty(),
             Optional.empty(),
@@ -44,24 +43,21 @@ public class TaskExecutionDetails {
     }
 
     private final TaskId taskId;
-    private final String type;
+    private final Task task;
     private final TaskManager.Status status;
-    private final Optional<AdditionalInformation> additionalInformation;
     private final Optional<ZonedDateTime> submitDate;
     private final Optional<ZonedDateTime> startedDate;
     private final Optional<ZonedDateTime> completedDate;
     private final Optional<ZonedDateTime> canceledDate;
     private final Optional<ZonedDateTime> failedDate;
 
-    public TaskExecutionDetails(TaskId taskId, String type, TaskManager.Status status,
-                                Optional<AdditionalInformation> additionalInformation,
+    public TaskExecutionDetails(TaskId taskId, Task task, TaskManager.Status status,
                                 Optional<ZonedDateTime> submitDate, Optional<ZonedDateTime> startedDate,
                                 Optional<ZonedDateTime> completedDate, Optional<ZonedDateTime> canceledDate,
                                 Optional<ZonedDateTime> failedDate) {
         this.taskId = taskId;
-        this.type = type;
+        this.task = task;
         this.status = status;
-        this.additionalInformation = additionalInformation;
         this.submitDate = submitDate;
         this.startedDate = startedDate;
         this.completedDate = completedDate;
@@ -74,7 +70,7 @@ public class TaskExecutionDetails {
     }
 
     public String getType() {
-        return type;
+        return task.type();
     }
 
     public TaskManager.Status getStatus() {
@@ -82,7 +78,7 @@ public class TaskExecutionDetails {
     }
 
     public Optional<AdditionalInformation> getAdditionalInformation() {
-        return additionalInformation;
+        return task.details();
     }
 
     public Optional<ZonedDateTime> getSubmitDate() {
@@ -109,9 +105,8 @@ public class TaskExecutionDetails {
         Preconditions.checkState(status == TaskManager.Status.WAITING);
         return new TaskExecutionDetails(
             taskId,
-            type,
+            task,
             TaskManager.Status.IN_PROGRESS,
-            additionalInformation,
             submitDate,
             Optional.of(ZonedDateTime.now()),
             Optional.empty(),
@@ -123,9 +118,8 @@ public class TaskExecutionDetails {
         Preconditions.checkState(status == TaskManager.Status.IN_PROGRESS);
         return new TaskExecutionDetails(
             taskId,
-            type,
+            task,
             TaskManager.Status.COMPLETED,
-            additionalInformation,
             submitDate,
             startedDate,
             Optional.of(ZonedDateTime.now()),
@@ -137,9 +131,8 @@ public class TaskExecutionDetails {
         Preconditions.checkState(status == TaskManager.Status.IN_PROGRESS);
         return new TaskExecutionDetails(
             taskId,
-            type,
+            task,
             TaskManager.Status.FAILED,
-            additionalInformation,
             submitDate,
             startedDate,
             Optional.empty(),
@@ -152,9 +145,8 @@ public class TaskExecutionDetails {
             || status == TaskManager.Status.WAITING);
         return new TaskExecutionDetails(
             taskId,
-            type,
+            task,
             TaskManager.Status.CANCELLED,
-            additionalInformation,
             submitDate,
             startedDate,
             Optional.empty(),

--- a/server/task/src/main/java/org/apache/james/task/TaskId.java
+++ b/server/task/src/main/java/org/apache/james/task/TaskId.java
@@ -1,0 +1,64 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.task;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.google.common.base.MoreObjects;
+
+public class TaskId {
+
+    public static TaskId generateTaskId() {
+        return new TaskId(UUID.randomUUID());
+    }
+
+    private final UUID value;
+
+    public TaskId(UUID value) {
+        this.value = value;
+    }
+
+    public UUID getValue() {
+        return value;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof TaskId) {
+            TaskId taskId = (TaskId) o;
+
+            return Objects.equals(this.value, taskId.value);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("value", value)
+            .toString();
+    }
+}

--- a/server/task/src/main/java/org/apache/james/task/TaskManager.java
+++ b/server/task/src/main/java/org/apache/james/task/TaskManager.java
@@ -1,0 +1,63 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.task;
+
+import java.util.Arrays;
+import java.util.List;
+
+public interface TaskManager {
+    enum Status {
+        WAITING("waiting"),
+        IN_PROGRESS("inProgress"),
+        COMPLETED("completed"),
+        CANCELLED("canceled"),
+        FAILED("failed");
+
+        public static Status fromString(String value) {
+            return Arrays.stream(values())
+                .filter(status -> status.value.equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                    String.format("Unknown status value '%s'", value)));
+        }
+
+        private final String value;
+
+        Status(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    TaskId submit(Task task);
+
+    TaskExecutionDetails getExecutionDetails(TaskId id);
+
+    List<TaskExecutionDetails> list();
+
+    List<TaskExecutionDetails> list(Status status);
+
+    void cancel(TaskId id);
+
+    TaskExecutionDetails await(TaskId id);
+}

--- a/server/task/src/main/java/org/apache/james/task/TaskNotFoundException.java
+++ b/server/task/src/main/java/org/apache/james/task/TaskNotFoundException.java
@@ -1,0 +1,23 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.task;
+
+public class TaskNotFoundException extends RuntimeException {
+}

--- a/server/task/src/test/java/org/apache/james/task/MemoryTaskManagerTest.java
+++ b/server/task/src/test/java/org/apache/james/task/MemoryTaskManagerTest.java
@@ -1,0 +1,434 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.github.fge.lambdas.Throwing;
+import com.github.fge.lambdas.consumers.ConsumerChainer;
+import com.google.common.base.Throwables;
+
+public class MemoryTaskManagerTest {
+
+    private MemoryTaskManager memoryTaskManager;
+
+    @Rule
+    public JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+    @Before
+    public void setUp() {
+        memoryTaskManager = new MemoryTaskManager();
+    }
+
+    @After
+    public void tearDown() {
+        memoryTaskManager.stop();
+    }
+
+    @Test
+    public void getStatusShouldReturnUnknownWhenUnknownId() {
+        TaskId unknownId = TaskId.generateTaskId();
+        assertThatThrownBy(() -> memoryTaskManager.getExecutionDetails(unknownId))
+            .isInstanceOf(TaskNotFoundException.class);
+    }
+
+    @Test
+    public void getStatusShouldReturnWaitingWhenNotYetProcessed() {
+        CountDownLatch task1Latch = new CountDownLatch(1);
+
+        memoryTaskManager.submit(() -> {
+            await(task1Latch);
+            return Task.Result.COMPLETED;
+        });
+
+        TaskId taskId = memoryTaskManager.submit(() -> Task.Result.COMPLETED);
+
+        assertThat(memoryTaskManager.getExecutionDetails(taskId).getStatus())
+            .isEqualTo(TaskManager.Status.WAITING);
+    }
+
+    @Test
+    public void taskCodeAfterCancelIsNotRun() {
+        CountDownLatch task1Latch = new CountDownLatch(1);
+        AtomicInteger count = new AtomicInteger(0);
+
+        TaskId id = memoryTaskManager.submit(() -> {
+            await(task1Latch);
+            count.incrementAndGet();
+            return Task.Result.COMPLETED;
+        });
+
+        memoryTaskManager.cancel(id);
+        task1Latch.countDown();
+
+        assertThat(count.get()).isEqualTo(0);
+    }
+
+    @Test
+    public void getStatusShouldReturnCancelledWhenCancelled() throws Exception {
+        CountDownLatch task1Latch = new CountDownLatch(1);
+        CountDownLatch ensureStartedLatch = new CountDownLatch(1);
+        CountDownLatch ensureFinishedLatch = new CountDownLatch(1);
+
+        TaskId id = memoryTaskManager.submit(() -> {
+            ensureStartedLatch.countDown();
+            await(task1Latch);
+            return Task.Result.COMPLETED;
+        },
+            any -> ensureFinishedLatch.countDown());
+
+        ensureStartedLatch.await();
+        memoryTaskManager.cancel(id);
+        ensureFinishedLatch.await();
+
+        assertThat(memoryTaskManager.getExecutionDetails(id).getStatus())
+            .isEqualTo(TaskManager.Status.CANCELLED);
+    }
+
+    @Test
+    public void cancelShouldBeIdempotent() {
+        CountDownLatch task1Latch = new CountDownLatch(1);
+
+        TaskId id = memoryTaskManager.submit(() -> {
+            await(task1Latch);
+            return Task.Result.COMPLETED;
+        });
+
+        memoryTaskManager.cancel(id);
+        assertThatCode(() -> memoryTaskManager.cancel(id))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void getStatusShouldReturnInProgressWhenProcessingIsInProgress() throws Exception {
+        CountDownLatch latch1 = new CountDownLatch(1);
+        CountDownLatch latch2 = new CountDownLatch(1);
+
+        TaskId taskId = memoryTaskManager.submit(() -> {
+            latch2.countDown();
+            await(latch1);
+            return Task.Result.COMPLETED;
+        });
+        latch2.await();
+
+        assertThat(memoryTaskManager.getExecutionDetails(taskId).getStatus())
+            .isEqualTo(TaskManager.Status.IN_PROGRESS);
+    }
+
+    @Test
+    public void getStatusShouldReturnCompletedWhenRunSuccessfully() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        TaskId taskId = memoryTaskManager.submit(
+            () -> Task.Result.COMPLETED,
+            countDownCallback(latch));
+
+        latch.await();
+
+        assertThat(memoryTaskManager.getExecutionDetails(taskId).getStatus())
+            .isEqualTo(TaskManager.Status.COMPLETED);
+    }
+
+    @Test
+    public void getStatusShouldReturnFailedWhenRunPartially() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        TaskId taskId = memoryTaskManager.submit(
+            () -> Task.Result.PARTIAL,
+            countDownCallback(latch));
+
+        latch.await();
+
+        assertThat(memoryTaskManager.getExecutionDetails(taskId).getStatus())
+            .isEqualTo(TaskManager.Status.FAILED);
+    }
+
+    private ConsumerChainer<TaskId> countDownCallback(CountDownLatch latch) {
+        return Throwing.consumer(id -> latch.countDown());
+    }
+
+    @Test
+    public void listShouldReturnTaskSatus() throws Exception {
+        CountDownLatch latch1 = new CountDownLatch(1);
+        CountDownLatch latch2 = new CountDownLatch(1);
+        CountDownLatch latch3 = new CountDownLatch(1);
+
+        TaskId failedId = memoryTaskManager.submit(
+            () -> Task.Result.PARTIAL);
+        TaskId successfulId = memoryTaskManager.submit(
+            () -> Task.Result.COMPLETED);
+        TaskId inProgressId = memoryTaskManager.submit(
+            () -> {
+                await(latch1);
+                latch2.countDown();
+                await(latch3);
+                return Task.Result.COMPLETED;
+            });
+        TaskId waitingId = memoryTaskManager.submit(
+            () -> {
+                await(latch3);
+                latch2.countDown();
+                return Task.Result.COMPLETED;
+            });
+
+        latch1.countDown();
+        latch2.await();
+
+        List<TaskExecutionDetails> list = memoryTaskManager.list();
+        softly.assertThat(list).hasSize(4);
+        softly.assertThat(entryWithId(list, failedId))
+            .isEqualTo(TaskManager.Status.FAILED);
+        softly.assertThat(entryWithId(list, waitingId))
+            .isEqualTo(TaskManager.Status.WAITING);
+        softly.assertThat(entryWithId(list, successfulId))
+            .isEqualTo(TaskManager.Status.COMPLETED);
+        softly.assertThat(entryWithId(list, inProgressId))
+            .isEqualTo(TaskManager.Status.IN_PROGRESS);
+    }
+
+    private TaskManager.Status entryWithId(List<TaskExecutionDetails> list, TaskId taskId) {
+        return list.stream()
+            .filter(e -> e.getTaskId().equals(taskId))
+            .findFirst().get()
+            .getStatus();
+    }
+
+    @Test
+    public void listShouldAllowToSeeWaitingTasks() throws Exception {
+        CountDownLatch latch1 = new CountDownLatch(1);
+        CountDownLatch latch2 = new CountDownLatch(1);
+        CountDownLatch latch3 = new CountDownLatch(1);
+
+        memoryTaskManager.submit(
+            () -> Task.Result.PARTIAL);
+        memoryTaskManager.submit(
+            () -> Task.Result.COMPLETED);
+        memoryTaskManager.submit(
+            () -> {
+                await(latch1);
+                latch2.countDown();
+                await(latch3);
+                return Task.Result.COMPLETED;
+            });
+        TaskId waitingId = memoryTaskManager.submit(
+            () -> {
+                await(latch3);
+                latch2.countDown();
+                return Task.Result.COMPLETED;
+            });
+
+        latch1.countDown();
+        latch2.await();
+
+        assertThat(memoryTaskManager.list(TaskManager.Status.WAITING))
+            .extracting(TaskExecutionDetails::getTaskId)
+            .containsOnly(waitingId);
+    }
+
+    @Test
+    public void listShouldAllowToSeeInProgressTasks() throws Exception {
+        CountDownLatch latch1 = new CountDownLatch(1);
+        CountDownLatch latch2 = new CountDownLatch(1);
+        CountDownLatch latch3 = new CountDownLatch(1);
+
+        memoryTaskManager.submit(
+            () -> Task.Result.PARTIAL);
+        TaskId successfulId = memoryTaskManager.submit(
+            () -> Task.Result.COMPLETED);
+        memoryTaskManager.submit(
+            () -> {
+                await(latch1);
+                latch2.countDown();
+                await(latch3);
+                return Task.Result.COMPLETED;
+            });
+        memoryTaskManager.submit(
+            () -> {
+                await(latch3);
+                latch2.countDown();
+                return Task.Result.COMPLETED;
+            });
+
+        latch1.countDown();
+        latch2.await();
+
+        assertThat(memoryTaskManager.list(TaskManager.Status.COMPLETED))
+            .extracting(TaskExecutionDetails::getTaskId)
+            .containsOnly(successfulId);
+    }
+
+    @Test
+    public void listShouldAllowToSeeFailedTasks() throws Exception {
+        CountDownLatch latch1 = new CountDownLatch(1);
+        CountDownLatch latch2 = new CountDownLatch(1);
+        CountDownLatch latch3 = new CountDownLatch(1);
+
+        TaskId failedId = memoryTaskManager.submit(
+            () -> Task.Result.PARTIAL);
+        memoryTaskManager.submit(
+            () -> Task.Result.COMPLETED);
+        memoryTaskManager.submit(
+            () -> {
+                await(latch1);
+                latch2.countDown();
+                await(latch3);
+                return Task.Result.COMPLETED;
+            });
+        memoryTaskManager.submit(
+            () -> {
+                await(latch3);
+                latch2.countDown();
+                return Task.Result.COMPLETED;
+            });
+
+        latch1.countDown();
+        latch2.await();
+
+        assertThat(memoryTaskManager.list(TaskManager.Status.FAILED))
+            .extracting(TaskExecutionDetails::getTaskId)
+            .containsOnly(failedId);
+    }
+
+    @Test
+    public void listShouldAllowToSeeSuccessfulTasks() throws Exception {
+        CountDownLatch latch1 = new CountDownLatch(1);
+        CountDownLatch latch2 = new CountDownLatch(1);
+        CountDownLatch latch3 = new CountDownLatch(1);
+
+        memoryTaskManager.submit(
+            () -> Task.Result.PARTIAL);
+        memoryTaskManager.submit(
+            () -> Task.Result.COMPLETED);
+        TaskId inProgressId = memoryTaskManager.submit(
+            () -> {
+                await(latch1);
+                latch2.countDown();
+                await(latch3);
+                return Task.Result.COMPLETED;
+            });
+        memoryTaskManager.submit(
+            () -> {
+                await(latch3);
+                latch2.countDown();
+                return Task.Result.COMPLETED;
+            });
+
+        latch1.countDown();
+        latch2.await();
+
+        assertThat(memoryTaskManager.list(TaskManager.Status.IN_PROGRESS))
+            .extracting(TaskExecutionDetails::getTaskId)
+            .containsOnly(inProgressId);
+    }
+
+    @Test
+    public void listShouldBeEmptyWhenNoTasks() throws Exception {
+        assertThat(memoryTaskManager.list()).isEmpty();
+    }
+
+    @Test
+    public void listCancelledShouldBeEmptyWhenNoTasks() throws Exception {
+        assertThat(memoryTaskManager.list(TaskManager.Status.CANCELLED)).isEmpty();
+    }
+
+    @Test
+    public void awaitShouldNotThrowWhenCompletedTask() throws Exception {
+        TaskId taskId = memoryTaskManager.submit(
+            () -> Task.Result.COMPLETED);
+        memoryTaskManager.await(taskId);
+        memoryTaskManager.await(taskId);
+    }
+
+    @Test
+    public void submittedTaskShouldExecuteSequentially() {
+        ConcurrentLinkedQueue<Integer> queue = new ConcurrentLinkedQueue<>();
+
+        TaskId id1 = memoryTaskManager.submit(() -> {
+            queue.add(1);
+            sleep(500);
+            queue.add(2);
+            return Task.Result.COMPLETED;
+        });
+        TaskId id2 = memoryTaskManager.submit(() -> {
+            queue.add(3);
+            sleep(500);
+            queue.add(4);
+            return Task.Result.COMPLETED;
+        });
+        memoryTaskManager.await(id1);
+        memoryTaskManager.await(id2);
+
+        assertThat(queue)
+            .containsExactly(1, 2, 3, 4);
+    }
+
+    @Test
+    public void awaitShouldReturnFailedWhenExceptionThrown() {
+        TaskId taskId = memoryTaskManager.submit(() -> {
+            throw new RuntimeException();
+        });
+
+        TaskExecutionDetails executionDetails = memoryTaskManager.await(taskId);
+
+        assertThat(executionDetails.getStatus())
+            .isEqualTo(TaskManager.Status.FAILED);
+    }
+
+    @Test
+    public void getStatusShouldReturnFailedWhenExceptionThrown() {
+        TaskId taskId = memoryTaskManager.submit(() -> {
+            throw new RuntimeException();
+        });
+
+        memoryTaskManager.await(taskId);
+
+        assertThat(memoryTaskManager.getExecutionDetails(taskId).getStatus())
+            .isEqualTo(TaskManager.Status.FAILED);
+    }
+
+    public void sleep(int durationInMs) {
+        try {
+            Thread.sleep(durationInMs);
+        } catch (InterruptedException e) {
+            Throwables.propagate(e);
+        }
+    }
+
+    public void await(CountDownLatch countDownLatch) {
+        try {
+            countDownLatch.await();
+        } catch (InterruptedException e) {
+            Throwables.propagate(e);
+        }
+    }
+}

--- a/server/task/src/test/java/org/apache/james/task/TaskIdTest.java
+++ b/server/task/src/test/java/org/apache/james/task/TaskIdTest.java
@@ -1,0 +1,34 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.task;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class TaskIdTest {
+
+    @Test
+    public void taskIdShouldMatchBeanContract() {
+        EqualsVerifier.forClass(TaskId.class)
+            .allFieldsShouldBeUsed()
+            .verify();
+    }
+}

--- a/server/task/src/test/java/org/apache/james/task/TaskTest.java
+++ b/server/task/src/test/java/org/apache/james/task/TaskTest.java
@@ -17,27 +17,36 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.mailbox.cassandra.mail.migration;
+package org.apache.james.task;
 
-public interface Migration {
+import static org.assertj.core.api.Assertions.assertThat;
 
-    enum MigrationResult {
-        COMPLETED,
-        PARTIAL
+import org.junit.Test;
+
+public class TaskTest {
+
+    @Test
+    public void combineShouldReturnCompletedWhenBothCompleted() {
+        assertThat(Task.combine(Task.Result.COMPLETED, Task.Result.COMPLETED))
+            .isEqualTo(Task.Result.COMPLETED);
     }
 
-    static MigrationResult combine(MigrationResult result1, MigrationResult result2) {
-        if (result1 == MigrationResult.COMPLETED
-            && result2 == MigrationResult.COMPLETED) {
-            return MigrationResult.COMPLETED;
-        }
-        return MigrationResult.PARTIAL;
+    @Test
+    public void combineShouldReturnPartialWhenPartialLeft() {
+        assertThat(Task.combine(Task.Result.PARTIAL, Task.Result.COMPLETED))
+            .isEqualTo(Task.Result.PARTIAL);
     }
 
-    /**
-     * Runs the migration
-     *
-     * @return Return true if fully migrated. Returns false otherwise.
-     */
-    MigrationResult run();
+    @Test
+    public void combineShouldReturnPartialWhenPartialRight() {
+        assertThat(Task.combine(Task.Result.COMPLETED, Task.Result.PARTIAL))
+            .isEqualTo(Task.Result.PARTIAL);
+    }
+
+    @Test
+    public void combineShouldReturnPartialWhenBothPartial() {
+        assertThat(Task.combine(Task.Result.PARTIAL, Task.Result.PARTIAL))
+            .isEqualTo(Task.Result.PARTIAL);
+    }
+
 }

--- a/server/task/src/test/java/org/apache/james/task/TaskTest.java
+++ b/server/task/src/test/java/org/apache/james/task/TaskTest.java
@@ -20,6 +20,9 @@
 package org.apache.james.task;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 
@@ -47,6 +50,103 @@ public class TaskTest {
     public void combineShouldReturnPartialWhenBothPartial() {
         assertThat(Task.combine(Task.Result.PARTIAL, Task.Result.PARTIAL))
             .isEqualTo(Task.Result.PARTIAL);
+    }
+
+
+    @Test
+    public void onCompleteShouldExecuteOperationWhenCompleted() {
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+
+        Task.Result.COMPLETED
+            .onComplete(atomicInteger::incrementAndGet);
+
+        assertThat(atomicInteger.get())
+            .isEqualTo(1);
+    }
+
+    @Test
+    public void onFailureShouldNotExecuteOperationWhenCompleted() {
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+
+        Task.Result.COMPLETED
+            .onFailure(atomicInteger::incrementAndGet);
+
+        assertThat(atomicInteger.get())
+            .isEqualTo(0);
+    }
+
+    @Test
+    public void onCompleteShouldNotExecuteOperationWhenPartial() {
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+
+        Task.Result.PARTIAL
+            .onComplete(atomicInteger::incrementAndGet);
+
+        assertThat(atomicInteger.get())
+            .isEqualTo(0);
+    }
+
+    @Test
+    public void onFailureShouldExecuteOperationWhenPartial() {
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+
+        Task.Result.PARTIAL
+            .onFailure(atomicInteger::incrementAndGet);
+
+        assertThat(atomicInteger.get())
+            .isEqualTo(1);
+    }
+
+    @Test
+    public void onCompleteShouldReturnPartialWhenPartial() {
+        assertThat(
+            Task.Result.PARTIAL
+                .onComplete(() -> {}))
+            .isEqualTo(Task.Result.PARTIAL);
+    }
+
+    @Test
+    public void onFailureShouldReturnCompletedWhenCompleted() {
+        assertThat(
+            Task.Result.COMPLETED
+                .onFailure(() -> {}))
+            .isEqualTo(Task.Result.COMPLETED);
+    }
+
+    @Test
+    public void onCompleteShouldReturnCompletedWhenCompleted() {
+        assertThat(
+            Task.Result.COMPLETED
+                .onComplete(() -> {}))
+            .isEqualTo(Task.Result.COMPLETED);
+    }
+
+    @Test
+    public void onFailureShouldReturnPartialWhenPartial() {
+        assertThat(
+            Task.Result.PARTIAL
+                .onFailure(() -> {}))
+            .isEqualTo(Task.Result.PARTIAL);
+    }
+
+    @Test
+    public void onCompleteShouldReturnPartialWhenOperationThrows() {
+        assertThat(
+            Task.Result.COMPLETED
+                .onComplete(() -> {
+                    throw new RuntimeException();
+                }))
+            .isEqualTo(Task.Result.PARTIAL);
+    }
+
+    @Test
+    public void onFailureShouldPreserveExceptions() {
+        assertThatThrownBy(() ->
+            Task.Result.PARTIAL
+                .onFailure(() -> {
+                    throw new RuntimeException();
+                }))
+            .isInstanceOf(RuntimeException.class);
     }
 
 }

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -417,6 +417,7 @@ Response codes:
  - 200: Success. The scheduled task taskId is returned.
  - 400: The version is invalid. The version should be a strictly positive number.
  - 410: Error while planning this migration. This resource is gone away. Reason is mentionned in the body.
+ - 500: Internal error while creating the migration task.
 
 Note that several calls to this endpoint will be run in a sequential pattern.
 
@@ -453,6 +454,7 @@ Response codes:
 
  - 200: Success. The scheduled task taskId is returned.
  - 410: Error while planning this migration. This resource is gone away. Reason is mentionned in the body.
+ - 500: Internal error while creating the migration task.
 
 Note that several calls to this endpoint will be run in a sequential pattern.
 

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -8,12 +8,15 @@ The web administration supports for now the CRUD operations on the domains,the u
 Please also note **webadmin** is only enabled with **Guice**. You can not use it when using James with **Spring**, as the required injections are not implemented.
 
 In case of any error, the system will return an error message which is json format like this:
+
+```
 {
     statusCode: <error_code>,
     type: <error_type>,
     message: <the_error_message>
     cause: <the_detail_message_from_throwable>
 }
+```
 
 ## Administrating domains
 

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -405,18 +405,29 @@ Response codes:
 curl -XPOST http://ip:port/cassandra/version/upgrade -d '3'
 ```
 
-Will run the migrations you need to reach schema version 3.
+
+Will schedule the run of the migrations you need to reach schema version 3. The `taskId` will allow you to monitor and manage this process.
+
+```
+{"taskId":"3294a976-ce63-491e-bd52-1b6f465ed7a2"}
+```
 
 Response codes:
 
- - 204: Success
+ - 200: Success. The scheduled task taskId is returned.
  - 400: The version is invalid. The version should be a strictly positive number.
- - 410: Error running the migration. This resource is gone away. Reason is mentionned in the body.
- - 500: Internal error. This can result from a partial migration, in which case the reason is contained in the body.
+ - 410: Error while planning this migration. This resource is gone away. Reason is mentionned in the body.
 
 Note that several calls to this endpoint will be run in a sequential pattern.
 
 If the server restarts during the migration, the migration is silently aborted.
+
+
+The scheduled task will have the following type `CassandraMigration` and the following `additionalInformation`:
+
+```
+{"toVersion":3}
+```
 
 ### Upgrading to the latest version
 
@@ -424,17 +435,34 @@ If the server restarts during the migration, the migration is silently aborted.
 curl -XPOST http://ip:port/cassandra/version/upgrade/latest
 ```
 
-Will run the migrations you need to reach the latest schema version.
+Will schedule the run of the migrations you need to reach the latest schema version. The `taskId` will allow you to monitor and manage this process.
+
+```
+{"taskId":"3294a976-ce63-491e-bd52-1b6f465ed7a2"}
+```
+
+Positionned headers:
+
+ - Location header indicates the location of the resource associated with the scheduled task. Example:
+
+```
+Location: /tasks/3294a976-ce63-491e-bd52-1b6f465ed7a2
+```
 
 Response codes:
 
- - 204: Success
- - 410: Error running the migration. This resource is gone away. Reason is mentionned in the body.
- - 500: Internal error. This can result from a partial migration, in which case the reason is contained in the body.
+ - 200: Success. The scheduled task taskId is returned.
+ - 410: Error while planning this migration. This resource is gone away. Reason is mentionned in the body.
 
 Note that several calls to this endpoint will be run in a sequential pattern.
 
 If the server restarts during the migration, the migration is silently aborted.
+
+The scheduled task will have the following type `CassandraMigration` and the following `additionalInformation`:
+
+```
+{"toVersion":2}
+```
 
 ## Creating address group
 
@@ -513,3 +541,102 @@ Response codes:
  - 200: Success
  - 400: Group structure or member is not valid
  - 500: Internal error
+
+## Task management
+
+Some webadmin features schedules tasks. The task management API allow to monitor and manage the execution of the following tasks.
+
+Note that the `taskId` used in the following APIs is returned by other WebAdmin APIs scheduling tasks.
+
+### Getting a task details
+
+```
+curl -XGET http://ip:port/tasks/3294a976-ce63-491e-bd52-1b6f465ed7a2
+```
+
+An Execution Report will be returned:
+
+```
+{
+    "submitDate": "2017-12-27T15:15:24.805+0700",
+    "startedDate": "2017-12-27T15:15:24.809+0700",
+    "completedDate": "2017-12-27T15:15:24.815+0700",
+    "cancelledDate": null,
+    "failedDate": null,
+    "taskId": "3294a976-ce63-491e-bd52-1b6f465ed7a2",
+    "additionalInformation": {},
+    "status": "completed",
+    "type": "typeOfTheTask"
+}
+```
+
+Note that:
+
+ - `status` can have the value:
+    - `waiting`: The task is schedule but its execution did not start yet
+    - `inProgress`: The task is currently executed
+    - `cancelled`: The task had been cancelled
+    - `completed`: The task execution is finished, and this execution is a success
+    - `failed`: The task execution is finished, and this execution is a failure
+
+ - `additionalInformation` is a task specific object giving additional informationa and context about that task. The structure
+   of this `additionalInformation` field is provided along the specific task submission endpoint.
+
+Response codes:
+
+ - 200: The specific task was found and the execution report exposed above is returned
+ - 400: Invalid task ID
+ - 404: Task ID was not found
+
+### Awaiting a task
+
+One can await the end of a task, then receive it's final execution report.
+
+That feature is especially usefull for testing purpose but still can serve real-life scenari.
+
+```
+curl -XGET http://ip:port/tasks/3294a976-ce63-491e-bd52-1b6f465ed7a2/await
+```
+
+An Execution Report will be returned.
+
+Response codes:
+
+ - 200: The specific task was found and the execution report exposed above is returned
+ - 400: Invalid task ID
+ - 404: Task ID was not found
+
+### Cancelling a task
+
+You can cancel a task by calling:
+
+```
+curl -XDELETE http://ip:port/tasks/3294a976-ce63-491e-bd52-1b6f465ed7a2
+```
+
+Response codes:
+ - 204: Task had been cancelled
+ - 400: Invalid task ID
+
+### Listing tasks
+
+A list of all tasks can be retrieved:
+
+```
+curl -XGET /tasks
+```
+
+Will return a list of Execution reports
+
+One can filter the above results by status. For example:
+
+```
+curl -XGET /tasks?status=inProgress
+```
+
+Will return a list of Execution reports that are currently in progress.
+
+Response codes:
+
+ - 200: A list of corresponding tasks is returned
+ - 400: Invalid status value

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -575,13 +575,13 @@ An Execution Report will be returned:
 Note that:
 
  - `status` can have the value:
-    - `waiting`: The task is schedule but its execution did not start yet
+    - `waiting`: The task is scheduled but its execution did not start yet
     - `inProgress`: The task is currently executed
     - `cancelled`: The task had been cancelled
     - `completed`: The task execution is finished, and this execution is a success
     - `failed`: The task execution is finished, and this execution is a failure
 
- - `additionalInformation` is a task specific object giving additional informationa and context about that task. The structure
+ - `additionalInformation` is a task specific object giving additional information and context about that task. The structure
    of this `additionalInformation` field is provided along the specific task submission endpoint.
 
 Response codes:


### PR DESCRIPTION
This task manager allows:
 - To submit operations
 - To get execution details for specific operations
 - To await an operation execution
 - To list submitted tasks, with an optional execution status filter
 - To cancel tasks
 - Tasks are run sequentially

There is a webadmin API for managing tasks.

Cassandra migration API now rely on Tasks.

Webasite doc and Swagger documentation is contributed.

This work was required here: https://github.com/linagora/james-project/pull/1199#discussion_r158468663

Cf: https://github.com/linagora/james-project/pull/1199