### PR TITLE
JAMES-2281 James download page improvments

### DIFF
--- a/src/site/markdown/mailet/quickstart.md
+++ b/src/site/markdown/mailet/quickstart.md
@@ -20,7 +20,7 @@ Just include something like this in your *pom.xml*
     <dependency>
         <groupId>org.apache.james</groupId>
         <artifactId>apache-mailet-api</artifactId>
-        <version>2.5.0</version>
+        <version>3.0.1</version>
     </dependency>
     <!-- other dependencies -->
 </dependencies>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -175,11 +175,11 @@
             <item name="Mailets" href="/mailet/index.html" collapse="true">
                 <item name="Quick Start" href="/mailet/quickstart.html"/>
                 <item name="Mailet API" href="/mailet/api/index.html"/>
-                <item name="Mailet AI" href="/mailet/ai/index.html"/>
                 <item name="Basic Mailet Toolkit" href="/mailet/base/index.html"/>
-                <item name="Crypto Mailets" href="/mailet/crypto/index.html"/>
-                <item name="MailetDocs" href="/mailet/mailetdocs-maven-plugin/index.html"/>
                 <item name="Standard Mailets" href="/mailet/standard/index.html"/>
+                <item name="Crypto Mailets" href="/mailet/crypto/index.html"/>
+                <item name="Mailet AI" href="/mailet/ai/index.html"/>
+                <item name="MailetDocs" href="/mailet/mailetdocs-maven-plugin/index.html"/>
                 <item name="Mailing Lists" href="/mail.html#Mailet_API_List" />
                 <item name="Release Notes" href="/mailet/release-notes.html"/>
                 <item name="Java Docs" href="/mailet/apidocs"/>

--- a/src/site/xdoc/download.xml
+++ b/src/site/xdoc/download.xml
@@ -70,10 +70,8 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
       <li><a href='#Apache_Crypto_Mailets'>Apache James Crypto Mailets</a></li>
       <li><a href='#Apache_James_Protocols'>Apache James Protocols</a></li>
       <li><a href='#Apache_MPT'>Apache James MPT</a></li>
-      <li>Apache James IMAP 0.3 is available from the James Maven repositories (*)</li>
-      <li>Apache James Mailbox 0.4 is available from the James Maven repositories (*)</li>
+      <li><a href='#Apache_HUPA'>Apache James Hupa</a></li>
       <li>Apache MailetDoc Plugin for Maven is available from the standard Maven repositories (*)</li>
-      <li>Apache James Hupa is available from the James Maven repositories (*)</li>
     </ul>
  
     <p>(*) James maven repositories can be found on 

--- a/src/site/xdoc/download.xml
+++ b/src/site/xdoc/download.xml
@@ -226,28 +226,43 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
   <section name="Apache Mime4J">
   
-    <p>Apache Mime4J 0.7.2 is the latest stable version:</p>
-    <ul>
-    
-    <li>Binary (Unix TAR): <a
-    href="[preferred]/james/mime4j/0.7.2/apache-mime4j-0.7.2-bin.tar.gz">apache-mime4j-0.7.2-bin.tar.gz</a> [<a
-    href="http://www.apache.org/dist/james/mime4j/0.7.2/apache-mime4j-0.7.2-bin.tar.gz.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/mime4j/0.7.2/apache-mime4j-0.7.2-bin.tar.gz.md5">MD5</a>]</li>
-    
-    <li>Binary (ZIP Format): <a
-    href="[preferred]/james/mime4j/0.7.2/apache-mime4j-0.7.2-bin.zip">apache-mime4j-0.7.2-bin.zip</a> [<a
-    href="http://www.apache.org/dist/james/mime4j/0.7.2/apache-mime4j-0.7.2-bin.zip.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/mime4j/0.7.2/apache-mime4j-0.7.2-bin.zip.md5">MD5</a>]</li>
-    
-    <li>Source (ZIP Format): <a
-    href="[preferred]/james/mime4j/0.7.2/apache-mime4j-project-0.7.2-source-release.zip">apache-mime4j-0.7.2-src.zip</a> [<a
-    href="http://www.apache.org/dist/james/mime4j/0.7.2/apache-mime4j-project-0.7.2-source-release.zip.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/mime4j/0.7.2/apache-mime4j-project-0.7.2-source-release.zip.md5">MD5</a>]</li>
-    
-    <li><a
-    href="[preferred]/james/mime4j/">Other Files</a> (javadoc.jar, sha1 checksums...)</li>
-    
-    </ul>
+    <p>Apache Mime4J 0.8.1 is the latest stable version.</p>
+
+    <p>You can directly use the core library with maven:</p>
+
+    <pre>
+      <code>
+  &lt;dependency&gt;
+    &lt;groupId&gt;org.apache.james&lt;/groupId&gt;
+    &lt;artifactId&gt;apache-mime4j-core&lt;/artifactId&gt;
+    &lt;version&gt;0.8.1&lt;/version&gt;
+  &lt;/dependency&gt;
+     </code>
+    </pre>
+
+    <p>In order to use Mime-4j DOM:</p>
+
+    <pre>
+      <code>
+  &lt;dependency&gt;
+    &lt;groupId&gt;org.apache.james&lt;/groupId&gt;
+    &lt;artifactId&gt;apache-mime4j-dom&lt;/artifactId&gt;
+    &lt;version&gt;0.8.1&lt;/version&gt;
+  &lt;/dependency&gt;
+     </code>
+    </pre>
+
+    <p>An aggregator project is also available:</p>
+
+    <pre>
+      <code>
+  &lt;dependency&gt;
+    &lt;groupId&gt;org.apache.james&lt;/groupId&gt;
+    &lt;artifactId&gt;apache-mime4j&lt;/artifactId&gt;
+    &lt;version&gt;0.8.1&lt;/version&gt;
+  &lt;/dependency&gt;
+     </code>
+    </pre>
   
   </section>
 

--- a/src/site/xdoc/download.xml
+++ b/src/site/xdoc/download.xml
@@ -238,6 +238,11 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
      </code>
     </pre>
 
+    <p>Direct download link:
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-mime4j-core/0.8.1/apache-mime4j-core-0.8.1.jar">(Jar)</a>
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-mime4j-core/0.8.1/apache-mime4j-core-0.8.1-sources.jar">(Sources)</a>
+    </p>
+
     <p>In order to use Mime-4j DOM:</p>
 
     <pre>
@@ -250,6 +255,11 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
      </code>
     </pre>
 
+    <p>Direct download link:
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-mime4j-dom/0.8.1/apache-mime4j-dom-0.8.1.jar">(Jar)</a>
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-mime4j-dom/0.8.1/apache-mime4j-dom-0.8.1-sources.jar">(Sources)</a>
+    </p>
+
     <p>An aggregator project is also available:</p>
 
     <pre>
@@ -261,6 +271,11 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
   &lt;/dependency&gt;
      </code>
     </pre>
+
+    <p>Direct download link:
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-mime4j/0.8.1/apache-mime4j-0.8.1-bin.tar.gz">(Tar)</a>
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-mime4j/0.8.1/apache-mime4j-0.8.1-bin.zip">(Zip)</a>
+    </p>
   
   </section>
 
@@ -279,6 +294,11 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
   &lt;/dependency&gt;
       </code>
     </pre>
+
+    <p>Direct download link:
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-jspf/0.9.5/apache-jspf-0.9.5.jar">(Jar)</a>
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-jspf/0.9.5/apache-jspf-0.9.5-sources.jar">(Sources)</a>
+    </p>
   
   </section>
   
@@ -290,13 +310,18 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
     <pre>
       <code>
-        &lt;dependency&gt;
-        &lt;groupId&gt;org.apache.james.jdkim&lt;/groupId&gt;
-        &lt;artifactId&gt;apache-jdkim&lt;/artifactId&gt;
-        &lt;version&gt;0.2&lt;/version&gt;
-        &lt;/dependency&gt;
+  &lt;dependency&gt;
+    &lt;groupId&gt;org.apache.james.jdkim&lt;/groupId&gt;
+    &lt;artifactId&gt;apache-jdkim&lt;/artifactId&gt;
+    &lt;version&gt;0.2&lt;/version&gt;
+  &lt;/dependency&gt;
       </code>
     </pre>
+
+    <p>Direct download link:
+      <a href="http://central.maven.org/maven2/org/apache/james/jdkim/apache-jdkim/0.2/apache-jdkim-0.2-bin.tar.gz">(Tar)</a>
+      <a href="http://central.maven.org/maven2/org/apache/james/jdkim/apache-jdkim/0.2/apache-jdkim-0.2-bin.zip">(Zip)</a>
+    </p>
   
   </section>
   
@@ -316,6 +341,11 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
       </code>
     </pre>
 
+    <p>Direct download link:
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-jsieve-core/0.7/apache-jsieve-core-0.7.jar">(Jar)</a>
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-jsieve-core/0.7/apache-jsieve-core-0.7-sources.jar">(Sources)</a>
+    </p>
+
     <p>An aggregator project is also available:</p>
 
     <pre>
@@ -327,6 +357,11 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
   &lt;/dependency&gt;
       </code>
     </pre>
+
+    <p>Direct download link:
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-jsieve/0.7/apache-jsieve-0.7-project.tar.gz">(Tar)</a>
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-jsieve/0.7/apache-jsieve-0.7-project.zip">(Zip)</a>
+    </p>
   
   </section>
 
@@ -343,6 +378,11 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
   &lt;/dependency&gt;
       </code>
     </pre>
+
+    <p>Direct download link:
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-api/3.0.1/apache-mailet-api-3.0.1.jar">(Jar)</a>
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-api/3.0.1/apache-mailet-api-3.0.1-sources.jar">(Sources)</a>
+    </p>
     
   </section>
 
@@ -360,6 +400,11 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
       </code>
     </pre>
 
+    <p>Direct download link:
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-base/3.0.1/apache-mailet-base-3.0.1.jar">(Jar)</a>
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-base/3.0.1/apache-mailet-base-3.0.1-sources.jar">(Sources)</a>
+    </p>
+
   </section>
 
   <section name="Apache Mailet Standard">
@@ -375,6 +420,11 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
   &lt;/dependency&gt;
       </code>
     </pre>
+
+    <p>Direct download link:
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-standard/3.0.1/apache-mailet-standard-3.0.1.jar">(Jar)</a>
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-standard/3.0.1/apache-mailet-standard-3.0.1-tests.jar">(Sources)</a>
+    </p>
 
   </section>
 
@@ -407,6 +457,11 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
   &lt;/dependency&gt;
       </code>
     </pre>
+
+    <p>Direct download links:
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-ai/3.0.1/apache-mailet-ai-3.0.1.jar">(Jar)</a>
+      <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-ai/3.0.1/apache-mailet-ai-3.0.1-sources.jar">(Sources)</a>
+    </p>
     
   </section>
 

--- a/src/site/xdoc/download.xml
+++ b/src/site/xdoc/download.xml
@@ -240,8 +240,7 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
     <p>Direct download link:
       <a href="http://central.maven.org/maven2/org/apache/james/apache-mime4j-core/0.8.1/apache-mime4j-core-0.8.1.jar">(Jar)</a>
-      <a href="http://central.maven.org/maven2/org/apache/james/apache-mime4j-core/0.8.1/apache-mime4j-core-0.8.1-sources.jar">(Sources)</a>
-    </p>
+      </p>
 
     <p>In order to use Mime-4j DOM:</p>
 
@@ -257,7 +256,6 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
     <p>Direct download link:
       <a href="http://central.maven.org/maven2/org/apache/james/apache-mime4j-dom/0.8.1/apache-mime4j-dom-0.8.1.jar">(Jar)</a>
-      <a href="http://central.maven.org/maven2/org/apache/james/apache-mime4j-dom/0.8.1/apache-mime4j-dom-0.8.1-sources.jar">(Sources)</a>
     </p>
 
     <p>An aggregator project is also available:</p>
@@ -275,6 +273,7 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
     <p>Direct download link:
       <a href="http://central.maven.org/maven2/org/apache/james/apache-mime4j/0.8.1/apache-mime4j-0.8.1-bin.tar.gz">(Tar)</a>
       <a href="http://central.maven.org/maven2/org/apache/james/apache-mime4j/0.8.1/apache-mime4j-0.8.1-bin.zip">(Zip)</a>
+      <a href="https://github.com/apache/james-mime4j/releases/tag/apache-mime4j-project-0.8.1">(Sources)</a>
     </p>
   
   </section>
@@ -297,7 +296,7 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
     <p>Direct download link:
       <a href="http://central.maven.org/maven2/org/apache/james/apache-jspf/0.9.5/apache-jspf-0.9.5.jar">(Jar)</a>
-      <a href="http://central.maven.org/maven2/org/apache/james/apache-jspf/0.9.5/apache-jspf-0.9.5-sources.jar">(Sources)</a>
+      <a href="https://github.com/apache/james-jspf/releases/tag/apache-jspf-project-1.0.1">(Sources)</a>
     </p>
   
   </section>
@@ -321,6 +320,7 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
     <p>Direct download link:
       <a href="http://central.maven.org/maven2/org/apache/james/jdkim/apache-jdkim/0.2/apache-jdkim-0.2-bin.tar.gz">(Tar)</a>
       <a href="http://central.maven.org/maven2/org/apache/james/jdkim/apache-jdkim/0.2/apache-jdkim-0.2-bin.zip">(Zip)</a>
+      <a href="https://github.com/apache/james-jdkim/releases/tag/apache-jdkim-project-0.2">(Sources)</a>
     </p>
   
   </section>
@@ -343,7 +343,7 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
     <p>Direct download link:
       <a href="http://central.maven.org/maven2/org/apache/james/apache-jsieve-core/0.7/apache-jsieve-core-0.7.jar">(Jar)</a>
-      <a href="http://central.maven.org/maven2/org/apache/james/apache-jsieve-core/0.7/apache-jsieve-core-0.7-sources.jar">(Sources)</a>
+      <a href="https://github.com/apache/james-jsieve/releases/tag/apache-jsieve-0.7">(Sources)</a>
     </p>
 
     <p>An aggregator project is also available:</p>
@@ -381,7 +381,7 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
     <p>Direct download link:
       <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-api/3.0.1/apache-mailet-api-3.0.1.jar">(Jar)</a>
-      <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-api/3.0.1/apache-mailet-api-3.0.1-sources.jar">(Sources)</a>
+      <a href="https://github.com/apache/james-project/releases/tag/james-project-3.0.1">(Sources are in the <code>mailet/api</code> folder)</a>
     </p>
     
   </section>
@@ -402,7 +402,7 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
     <p>Direct download link:
       <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-base/3.0.1/apache-mailet-base-3.0.1.jar">(Jar)</a>
-      <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-base/3.0.1/apache-mailet-base-3.0.1-sources.jar">(Sources)</a>
+      <a href="https://github.com/apache/james-project/releases/tag/james-project-3.0.1">(Sources are in the <code>mailet/base</code> folder)</a>
     </p>
 
   </section>
@@ -423,7 +423,7 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
     <p>Direct download link:
       <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-standard/3.0.1/apache-mailet-standard-3.0.1.jar">(Jar)</a>
-      <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-standard/3.0.1/apache-mailet-standard-3.0.1-tests.jar">(Sources)</a>
+      <a href="https://github.com/apache/james-project/releases/tag/james-project-3.0.1">(Sources are in the <code>mailet/standard</code> folder)</a>
     </p>
 
   </section>
@@ -460,7 +460,7 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
     <p>Direct download links:
       <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-ai/3.0.1/apache-mailet-ai-3.0.1.jar">(Jar)</a>
-      <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-ai/3.0.1/apache-mailet-ai-3.0.1-sources.jar">(Sources)</a>
+      <a href="https://github.com/apache/james-project/releases/tag/james-project-3.0.1">(Sources are in the <code>mailet/ai</code> folder)</a>
     </p>
     
   </section>

--- a/src/site/xdoc/download.xml
+++ b/src/site/xdoc/download.xml
@@ -414,19 +414,17 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
   <section name="Apache James Protocols">
   
-    <p>Apache James Protocols 1.6.2 is the latest stable version:</p>
+    <p>Apache James Protocols 3.0.1 is the latest stable version.</p>
+
     <ul>
-    <li>Source (Unix TAR): <a
-    href="[preferred]/james/protocols/1.6.3/protocols-1.6.2-source-release.tar.gz">protocols-1.6.2-source-release.tar.gz</a> [<a
-    href="http://www.apache.org/dist/james/protocols/1.6.3/protocols-1.6.2-source-release.tar.gz.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/protocols/1.6.3/protocols-1.6.2-source-release.tar.gz.md5">MD5</a>]</li>
-    
-    <li>Source (ZIP Format): <a
-    href="[preferred]/james/protocols/1.6.3/protocols-1.6.2-source-release.zip">protocols-1.6.2-source-release.zip</a> [<a
-    href="http://www.apache.org/dist/james/protocols/1.6.3/protocols-1.6.2-source-release.zip.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/protocols/1.6.3/protocols-1.6.2-source-release.zip.md5">MD5</a>]</li>
-    <li>Jars (including source and javadocs) for the modules are distributed through the standard 
-    <a href='http://maven.apache.org'>Maven</a> repositories on <a href="http://repo1.maven.org/maven2/org/apache/james/protocols">http://repo1.maven.org/maven2/org/apache/james/protocols</a>.</li>
+      You can get the James implementation of various protocols using maven:
+      <li><a href="https://mvnrepository.com/artifact/org.apache.james.protocols/protocols-api/3.0.1">API</a></li>
+      <li><a href="https://mvnrepository.com/artifact/org.apache.james.protocols/protocols-netty/3.0.1">NETTY</a></li>
+      <li><a href="https://mvnrepository.com/artifact/org.apache.james.protocols/protocols-smtp/3.0.1">SMTP</a></li>
+      <li><a href="https://mvnrepository.com/artifact/org.apache.james.protocols/protocols-lmtp/3.0.1">LMTP</a></li>
+      <li><a href="https://mvnrepository.com/artifact/org.apache.james.protocols/protocols-imap/3.0.1">IMAP</a></li>
+      <li><a href="https://mvnrepository.com/artifact/org.apache.james.protocols/protocols-pop3/3.0.1">POP3</a></li>
+      <li><a href="https://mvnrepository.com/artifact/org.apache.james.protocols/protocols-managesieve/3.0.1">MANAGESIEVE</a></li>
     </ul>
   
   </section>

--- a/src/site/xdoc/download.xml
+++ b/src/site/xdoc/download.xml
@@ -307,30 +307,31 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
   
   <section name="Apache JSieve">
   
-    <p>Apache JSieve 0.5 is the latest stable version:</p>
-    <ul>
-    
-    <li>Binary (Unix TAR): <a
-    href="[preferred]/james/jsieve/0.5/apache-jsieve-all-0.5-bin.tar.gz">apache-jsieve-all-0.5-bin.tar.gz</a> [<a
-    href="http://www.apache.org/dist/james/jsieve/0.5/apache-jsieve-all-0.5-bin.tar.gz.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/jsieve/0.5/apache-jsieve-all-0.5-bin.tar.gz.asc.md5">MD5</a>]</li>
-    
-    <li>Binary (ZIP Format): <a
-    href="[preferred]/james/jsieve/0.5/apache-jsieve-all-0.5-bin.zip">apache-jsieve-all-0.5-bin.zip</a> [<a
-    href="http://www.apache.org/dist/james/jsieve/0.5/apache-jsieve-all-0.5-bin.zip.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/jsieve/0.5/apache-jsieve-all-0.5-bin.zip.asc.md5">MD5</a>]</li>
-    
-    <li>Source (Unix TAR): <a
-    href="[preferred]/james/jsieve/0.5/apache-jsieve-all-0.5-src.tar.gz">apache-jsieve-all-0.5-src.tar.gz</a> [<a
-    href="http://www.apache.org/dist/james/jsieve/0.5/apache-jsieve-all-0.5-src.tar.gz.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/jsieve/0.5/apache-jsieve-all-0.5-src.tar.gz.asc.md5">MD5</a>]</li>
-    
-    <li>Source (ZIP Format): <a
-    href="[preferred]/james/jsieve/0.5/apache-jsieve-all-0.5-src.zip">apache-jsieve-all-0.5-src.zip</a> [<a
-    href="http://www.apache.org/dist/james/jsieve/0.5/apache-jsieve-all-0.5-src.zip.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/jsieve/0.5/apache-jsieve-all-0.5-src.zip.asc.md5">MD5</a>]</li>
-    
-    </ul>
+    <p>Apache JSieve 0.7 is the latest stable version.</p>
+
+    <p>You can directly use it with maven:</p>
+
+    <pre>
+      <code>
+  &lt;dependency&gt;
+    &lt;groupId&gt;org.apache.james&lt;/groupId&gt;
+    &lt;artifactId&gt;apache-jsieve-core&lt;/artifactId&gt;
+    &lt;version&gt;0.7&lt;/version&gt;
+  &lt;/dependency&gt;
+      </code>
+    </pre>
+
+    <p>An aggregator project is also available:</p>
+
+    <pre>
+      <code>
+  &lt;dependency&gt;
+    &lt;groupId&gt;org.apache.james&lt;/groupId&gt;
+    &lt;artifactId&gt;apache-jsieve-all&lt;/artifactId&gt;
+    &lt;version&gt;0.7&lt;/version&gt;
+  &lt;/dependency&gt;
+      </code>
+    </pre>
   
   </section>
 

--- a/src/site/xdoc/download.xml
+++ b/src/site/xdoc/download.xml
@@ -334,119 +334,55 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
   <section name="Apache Mailet">
   
-    <p>Apache Mailet 2.4 is the latest stable version:</p>
-    <ul>
-    
-    <li>Binary (Unix TAR): <a
-    href="[preferred]/james/apache-mailet/2.4/apache-mailet-2.4.tar.gz">apache-mailet-2.4.tar.gz</a> [<a
-    href="http://www.apache.org/dist/james/apache-mailet/2.4/apache-mailet-2.4.tar.gz.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-mailet/2.4/apache-mailet-2.4.tar.gz.md5">MD5</a>]</li>
-    
-    <li>Binary (ZIP Format): <a
-    href="[preferred]/james/apache-mailet/2.4/apache-mailet-2.4.zip">apache-mailet-2.4.zip</a> [<a
-    href="http://www.apache.org/dist/james/apache-mailet/2.4/apache-mailet-2.4.zip.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-mailet/2.4/apache-mailet-2.4.zip.md5">MD5</a>]</li>
-    
-    <li>Source (Unix TAR): <a
-    href="[preferred]/james/apache-mailet/2.4/apache-mailet-2.4-src.tar.gz">apache-mailet-2.4-src.tar.gz</a> [<a
-    href="http://www.apache.org/dist/james/apache-mailet/2.4/apache-mailet-2.4-src.tar.gz.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-mailet/2.4/apache-mailet-2.4-src.tar.gz.md5">MD5</a>]</li>
-    
-    <li>Source (ZIP Format): <a
-    href="[preferred]/james/apache-mailet/2.4/apache-mailet-2.4-src.zip">apache-mailet-2.4-src.zip</a> [<a
-    href="http://www.apache.org/dist/james/apache-mailet/2.4/apache-mailet-2.4-src.zip.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-mailet/2.4/apache-mailet-2.4-src.zip.md5">MD5</a>]</li>
-    
-    <li><abbr title='Java ARchive'>JAR</abbr> library only: <a
-    href="[preferred]/james/apache-mailet/2.4/apache-mailet-2.4.jar">apache-mailet-2.4.jar</a> [<a
-    href="http://www.apache.org/dist/james/apache-mailet/2.4/apache-mailet-2.4.jar.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-mailet/2.4/apache-mailet-2.4.jar.md5">MD5</a>]</li>
-    
-    </ul>
+    <p>Apache Mailet 3.0.1 is the latest stable version. You can use the mailet API using this maven dependency:</p>
+
+    <pre>
+      <code>
+  &lt;dependency&gt;
+    &lt;groupId&gt;org.apache.james&lt;/groupId&gt;
+    &lt;artifactId&gt;apache-mailet-api&lt;/artifactId&gt;
+    &lt;version&gt;3.0.1&lt;/version&gt;
+  &lt;/dependency&gt;
+      </code>
+    </pre>
     
   </section>
 
   <section name="Apache Mailet Base">
-  
-    <p>Apache Mailet Base 1.1 is the latest stable version:</p>
-    <ul>
-    
-    <li>Binary (Unix TAR): <a
-    href="[preferred]/james/apache-mailet-base/1.1/apache-mailet-base-1.1-bin.tar.gz">apache-mailet-base-1.1.tar.gz</a> [<a
-    href="http://www.apache.org/dist/james/apache-mailet-base/1.1/apache-mailet-base-1.1-bin.tar.gz.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-mailet-base/1.1/apache-mailet-base-1.1-bin.tar.gz.md5">MD5</a>]</li>
-    
-    <li>Binary (ZIP Format): <a
-    href="[preferred]/james/apache-mailet-base/1.1/apache-mailet-base-1.1-bin.zip">apache-mailet-base-1.1.zip</a> [<a
-    href="http://www.apache.org/dist/james/apache-mailet-base/1.1/apache-mailet-base-1.1-bin.zip.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-mailet-base/1.1/apache-mailet-base-1.1-bin.zip.md5">MD5</a>]</li>
-    
-    <li>Source (Unix TAR): <a
-    href="[preferred]/james/apache-mailet-base/1.1/apache-mailet-base-1.1-src.tar.gz">apache-mailet-base-1.1-src.tar.gz</a> [<a
-    href="http://www.apache.org/dist/james/apache-mailet-base/1.1/apache-mailet-base-1.1-src.tar.gz.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-mailet-base/1.1/apache-mailet-base-1.1-src.tar.gz.md5">MD5</a>]</li>
-    
-    <li>Source (ZIP Format): <a
-    href="[preferred]/james/apache-mailet-base/1.1/apache-mailet-base-1.1-src.zip">apache-mailet-base-1.1-src.zip</a> [<a
-    href="http://www.apache.org/dist/james/apache-mailet-base/1.1/apache-mailet-base-1.1-src.zip.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-mailet-base/1.1/apache-mailet-base-1.1-src.zip.md5">MD5</a>]</li>
-    
-    <li>Source (Jar Format): <a
-    href="[preferred]/james/apache-mailet-base/1.1/apache-mailet-base-1.1-sources.jar">apache-mailet-base-1.1-sources.jar</a> [<a
-    href="http://www.apache.org/dist/james/apache-mailet-base/1.1/apache-mailet-base-1.1-sources.jar.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-mailet-base/1.1/apache-mailet-base-1.1-sources.jar.md5">MD5</a>]</li>
-    
-    <li><abbr title='Java ARchive'>JAR</abbr> library only: <a
-    href="[preferred]/james/apache-mailet-base/1.1/apache-mailet-base-1.1.jar">apache-mailet-base-1.1.jar</a> [<a
-    href="http://www.apache.org/dist/james/apache-mailet-base/1.1/apache-mailet-base-1.1.jar.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-mailet-base/1.1/apache-mailet-base-1.1.jar.md5">MD5</a>]</li>
-    
-    </ul>
-  
+
+    <p>Apache Mailet Base 3.0.1 is the latest stable version. You can use Mailet Base content using this maven dependency:</p>
+
+    <pre>
+      <code>
+  &lt;dependency&gt;
+    &lt;groupId&gt;org.apache.james&lt;/groupId&gt;
+    &lt;artifactId&gt;apache-mailet-base&lt;/artifactId&gt;
+    &lt;version&gt;3.0.1&lt;/version&gt;
+  &lt;/dependency&gt;
+      </code>
+    </pre>
+
   </section>
 
   <section name="Apache Mailet Standard">
-  
-    <p>Apache Mailet Standard 1.0 is the latest stable version:</p>
-    <ul>
-    
-    <li>Binary (Unix TAR): <a
-    href="[preferred]/james/apache-standard-mailets/1.0/apache-standard-mailets-1.0-bin.tar.gz">apache-standard-mailets-1.0.tar.gz</a> [<a
-    href="http://www.apache.org/dist/james/apache-standard-mailets/1.0/apache-standard-mailets-1.0-bin.tar.gz.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-standard-mailets/1.0/apache-standard-mailets-1.0-bin.tar.gz.md5">MD5</a>]</li>
-    
-    <li>Binary (ZIP Format): <a
-    href="[preferred]/james/apache-standard-mailets/1.0/apache-standard-mailets-1.0-bin.zip">apache-standard-mailets-1.0.zip</a> [<a
-    href="http://www.apache.org/dist/james/apache-standard-mailets/1.0/apache-standard-mailets-1.0-bin.zip.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-standard-mailets/1.0/apache-standard-mailets-1.0-bin.zip.md5">MD5</a>]</li>
-    
-    <li>Source (Unix TAR): <a
-    href="[preferred]/james/apache-standard-mailets/1.0/apache-standard-mailets-1.0-src.tar.gz">apache-standard-mailets-1.0-src.tar.gz</a> [<a
-    href="http://www.apache.org/dist/james/apache-standard-mailets/1.0/apache-standard-mailets-1.0-src.tar.gz.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-standard-mailets/1.0/apache-standard-mailets-1.0-src.tar.gz.md5">MD5</a>]</li>
-    
-    <li>Source (ZIP Format): <a
-    href="[preferred]/james/apache-standard-mailets/1.0/apache-standard-mailets-1.0-src.zip">apache-standard-mailets-1.0-src.zip</a> [<a
-    href="http://www.apache.org/dist/james/apache-standard-mailets/1.0/apache-standard-mailets-1.0-src.zip.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-standard-mailets/1.0/apache-standard-mailets-1.0-src.zip.md5">MD5</a>]</li>
-    
-    <li>Source (Jar Format): <a
-    href="[preferred]/james/apache-standard-mailets/1.0/apache-standard-mailets-1.0-sources.jar">apache-standard-mailets-1.0-sources.jar</a> [<a
-    href="http://www.apache.org/dist/james/apache-standard-mailets/1.0/apache-standard-mailets-1.0-sources.jar.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-standard-mailets/1.0/apache-standard-mailets-1.0-sources.jar.md5">MD5</a>]</li>
-    
-    <li><abbr title='Java ARchive'>JAR</abbr> library only: <a
-    href="[preferred]/james/apache-standard-mailets/1.0/apache-standard-mailets-1.0.jar">apache-standard-mailets-1.0.jar</a> [<a
-    href="http://www.apache.org/dist/james/apache-standard-mailets/1.0/apache-standard-mailets-1.0.jar.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-standard-mailets/1.0/apache-standard-mailets-1.0.jar.md5">MD5</a>]</li>
-    
-    </ul>
-  
+
+    <p>Apache Mailet Standard 3.0.1 is the latest stable version. You can use mailet Standard content using this maven dependency:</p>
+
+    <pre>
+      <code>
+  &lt;dependency&gt;
+    &lt;groupId&gt;org.apache.james&lt;/groupId&gt;
+    &lt;artifactId&gt;apache-mailet-standard&lt;/artifactId&gt;
+    &lt;version&gt;3.0.1&lt;/version&gt;
+  &lt;/dependency&gt;
+      </code>
+    </pre>
+
   </section>
 
   <section name="Apache Crypto Mailets">
   
-    <p>Apache Crypto Mailets 1.0 is the latest stable version:</p>
+    <p>Apache Crypto Mailets 3.0.1 is the latest stable version.</p>
     
   <div class="ui-widget">
     <div class="ui-priority-secondary ui-corner-all apache-james-crypto-notice">
@@ -461,39 +397,18 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
       </ul>
     </div>
   </div>
-    <ul>
-    
-    <li>Binary (Unix TAR): <a
-    href="[preferred]/james/apache-crypto-mailets/1.0/apache-crypto-mailets-1.0-bin.tar.gz">apache-crypto-mailets-1.0.tar.gz</a> [<a
-    href="http://www.apache.org/dist/james/apache-crypto-mailets/1.0/apache-crypto-mailets-1.0-bin.tar.gz.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-crypto-mailets/1.0/apache-crypto-mailets-1.0-bin.tar.gz.md5">MD5</a>]</li>
-    
-    <li>Binary (ZIP Format): <a
-    href="[preferred]/james/apache-crypto-mailets/1.0/apache-crypto-mailets-1.0-bin.zip">apache-crypto-mailets-1.0.zip</a> [<a
-    href="http://www.apache.org/dist/james/apache-crypto-mailets/1.0/apache-crypto-mailets-1.0-bin.zip.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-crypto-mailets/1.0/apache-crypto-mailets-1.0-bin.zip.md5">MD5</a>]</li>
-    
-    <li>Source (Unix TAR): <a
-    href="[preferred]/james/apache-crypto-mailets/1.0/apache-crypto-mailets-1.0-src.tar.gz">apache-crypto-mailets-1.0-src.tar.gz</a> [<a
-    href="http://www.apache.org/dist/james/apache-crypto-mailets/1.0/apache-crypto-mailets-1.0-src.tar.gz.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-crypto-mailets/1.0/apache-crypto-mailets-1.0-src.tar.gz.md5">MD5</a>]</li>
-    
-    <li>Source (ZIP Format): <a
-    href="[preferred]/james/apache-crypto-mailets/1.0/apache-crypto-mailets-1.0-src.zip">apache-crypto-mailets-1.0-src.zip</a> [<a
-    href="http://www.apache.org/dist/james/apache-crypto-mailets/1.0/apache-crypto-mailets-1.0-src.zip.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-crypto-mailets/1.0/apache-crypto-mailets-1.0-src.zip.md5">MD5</a>]</li>
-    
-    <li>Source (Jar Format): <a
-    href="[preferred]/james/apache-crypto-mailets/1.0/apache-crypto-mailets-1.0-sources.jar">apache-crypto-mailets-1.0-sources.jar</a> [<a
-    href="http://www.apache.org/dist/james/apache-crypto-mailets/1.0/apache-crypto-mailets-1.0-sources.jar.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-crypto-mailets/1.0/apache-crypto-mailets-1.0-sources.jar.md5">MD5</a>]</li>
-    
-    <li><abbr title='Java ARchive'>JAR</abbr> library only: <a
-    href="[preferred]/james/apache-crypto-mailets/1.0/apache-crypto-mailets-1.0.jar">apache-crypto-mailets-1.0.jar</a> [<a
-    href="http://www.apache.org/dist/james/apache-crypto-mailets/1.0/apache-crypto-mailets-1.0.jar.asc">PGP</a>][<a
-    href="http://www.apache.org/dist/james/apache-crypto-mailets/1.0/apache-crypto-mailets-1.0.jar.md5">MD5</a>]</li>
-    
-    </ul>
+
+    <p>You can use Mailet AI content using this maven dependency:</p>
+
+    <pre>
+      <code>
+  &lt;dependency&gt;
+    &lt;groupId&gt;org.apache.james&lt;/groupId&gt;
+    &lt;artifactId&gt;apache-mailet-ai&lt;/artifactId&gt;
+    &lt;version&gt;3.0.1&lt;/version&gt;
+  &lt;/dependency&gt;
+      </code>
+    </pre>
     
   </section>
 

--- a/src/site/xdoc/download.xml
+++ b/src/site/xdoc/download.xml
@@ -273,7 +273,8 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
     <p>Direct download link:
       <a href="http://central.maven.org/maven2/org/apache/james/apache-mime4j/0.8.1/apache-mime4j-0.8.1-bin.tar.gz">(Tar)</a>
       <a href="http://central.maven.org/maven2/org/apache/james/apache-mime4j/0.8.1/apache-mime4j-0.8.1-bin.zip">(Zip)</a>
-      <a href="https://github.com/apache/james-mime4j/releases/tag/apache-mime4j-project-0.8.1">(Sources)</a>
+      <a href="https://github.com/apache/james-mime4j/archive/apache-mime4j-project-0.8.1.zip">(Sources Zip)</a>
+      <a href="https://github.com/apache/james-mime4j/archive/apache-mime4j-project-0.8.1.tar.gz">(Sources tar.gz)</a>
     </p>
   
   </section>
@@ -296,7 +297,8 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
     <p>Direct download link:
       <a href="http://central.maven.org/maven2/org/apache/james/apache-jspf/0.9.5/apache-jspf-0.9.5.jar">(Jar)</a>
-      <a href="https://github.com/apache/james-jspf/releases/tag/apache-jspf-project-1.0.1">(Sources)</a>
+      <a href="https://github.com/apache/james-jspf/archive/apache-jspf-project-1.0.1.zip">(Sources Zip)</a>
+      <a href="https://github.com/apache/james-jspf/archive/apache-jspf-project-1.0.1.tar.gz">(Sources tar.gz)</a>
     </p>
   
   </section>
@@ -320,7 +322,8 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
     <p>Direct download link:
       <a href="http://central.maven.org/maven2/org/apache/james/jdkim/apache-jdkim/0.2/apache-jdkim-0.2-bin.tar.gz">(Tar)</a>
       <a href="http://central.maven.org/maven2/org/apache/james/jdkim/apache-jdkim/0.2/apache-jdkim-0.2-bin.zip">(Zip)</a>
-      <a href="https://github.com/apache/james-jdkim/releases/tag/apache-jdkim-project-0.2">(Sources)</a>
+      <a href="https://github.com/apache/james-jdkim/archive/apache-jdkim-project-0.2.zip">(Sources Zip)</a>
+      <a href="https://github.com/apache/james-jdkim/archive/apache-jdkim-project-0.2.tar.gz">(Sources tar.gz)</a>
     </p>
   
   </section>
@@ -343,7 +346,8 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
     <p>Direct download link:
       <a href="http://central.maven.org/maven2/org/apache/james/apache-jsieve-core/0.7/apache-jsieve-core-0.7.jar">(Jar)</a>
-      <a href="https://github.com/apache/james-jsieve/releases/tag/apache-jsieve-0.7">(Sources)</a>
+      <a href="https://github.com/apache/james-jsieve/archive/apache-jsieve-0.7.zip">(Sources Zip)</a>
+      <a href="https://github.com/apache/james-jsieve/archive/apache-jsieve-0.7.tar.gz">(Sources tar.gz)</a>
     </p>
 
     <p>An aggregator project is also available:</p>
@@ -381,7 +385,8 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
     <p>Direct download link:
       <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-api/3.0.1/apache-mailet-api-3.0.1.jar">(Jar)</a>
-      <a href="https://github.com/apache/james-project/releases/tag/james-project-3.0.1">(Sources are in the <code>mailet/api</code> folder)</a>
+      <a href="https://github.com/apache/james-project/archive/james-project-3.0.1.zip">(Sources are in the <code>mailet/api</code> folder Zip)</a>
+      <a href="https://github.com/apache/james-project/archive/james-project-3.0.1.tar.gz">(Sources are in the <code>mailet/api</code> folder tar.gz)</a>
     </p>
     
   </section>
@@ -402,8 +407,8 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
     <p>Direct download link:
       <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-base/3.0.1/apache-mailet-base-3.0.1.jar">(Jar)</a>
-      <a href="https://github.com/apache/james-project/releases/tag/james-project-3.0.1">(Sources are in the <code>mailet/base</code> folder)</a>
-    </p>
+      <a href="https://github.com/apache/james-project/archive/james-project-3.0.1.zip">(Sources are in the <code>mailet/base</code> folder Zip)</a>
+      <a href="https://github.com/apache/james-project/archive/james-project-3.0.1.tar.gz">(Sources are in the <code>mailet/base</code> folder tar.gz)</a>    </p>
 
   </section>
 
@@ -423,8 +428,8 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
     <p>Direct download link:
       <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-standard/3.0.1/apache-mailet-standard-3.0.1.jar">(Jar)</a>
-      <a href="https://github.com/apache/james-project/releases/tag/james-project-3.0.1">(Sources are in the <code>mailet/standard</code> folder)</a>
-    </p>
+      <a href="https://github.com/apache/james-project/archive/james-project-3.0.1.zip">(Sources are in the <code>mailet/standard</code> folder Zip)</a>
+      <a href="https://github.com/apache/james-project/archive/james-project-3.0.1.tar.gz">(Sources are in the <code>mailet/standard</code> folder tar.gz)</a>    </p>
 
   </section>
 
@@ -460,8 +465,8 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
     <p>Direct download links:
       <a href="http://central.maven.org/maven2/org/apache/james/apache-mailet-ai/3.0.1/apache-mailet-ai-3.0.1.jar">(Jar)</a>
-      <a href="https://github.com/apache/james-project/releases/tag/james-project-3.0.1">(Sources are in the <code>mailet/ai</code> folder)</a>
-    </p>
+      <a href="https://github.com/apache/james-project/archive/james-project-3.0.1.zip">(Sources are in the <code>mailet/ai</code> folder Zip)</a>
+      <a href="https://github.com/apache/james-project/archive/james-project-3.0.1.tar.gz">(Sources are in the <code>mailet/ai</code> folder tar.gz)</a>    </p>
     
   </section>
 

--- a/src/site/xdoc/download.xml
+++ b/src/site/xdoc/download.xml
@@ -268,28 +268,19 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
 
   <section name="Apache jSPF">
   
-    <p>Apache James jSPF 1.0.0 is the latest jSPF stable version:</p>
-    <ul>
-    
-    <li>Binary (ZIP Format): <a
-    href="[preferred]/james/jspf/1.0.0/apache-jspf-1.0.0-bin.zip">apache-jspf-1.0.0-bin.zip</a> [<a
-    href="http://www.apache.org/dist/james/jspf/1.0.0/apache-jspf-1.0.0-bin.zip.asc">PGP</a>]</li>
-    
-    <li>Binary (Unix TAR.GZ): <a
-    href="[preferred]/james/jspf/1.0.0/apache-jspf-1.0.0-bin.tar.gz">apache-jspf-1.0.0-bin.tar.gz</a> [<a
-    href="http://www.apache.org/dist/james/jspf/1.0.0/apache-jspf-1.0.0-bin.tar.gz.asc">PGP</a>]</li>
-    
-    <li>Source (Unix TAR.GZ): <a
-    href="[preferred]/james/jspf/1.0.0/apache-jspf-1.0.0-src.tar.gz">apache-jspf-1.0.0-src.tar.gz</a> [<a
-    href="http://www.apache.org/dist/james/jspf/1.0.0/apache-jspf-1.0.0-src.tar.gz.asc">PGP</a>]</li>
-    
-    <li>Source (ZIP Format): <a
-    href="[preferred]/james/jspf/1.0.0/apache-jspf-1.0.0-src.zip">apache-jspf-1.0.0-src.zip</a> [<a
-    href="http://www.apache.org/dist/james/jspf/1.0.0/apache-jspf-1.0.0-src.zip.asc">PGP</a>]</li>
-    
-    <li><a href="[preferred]/james/jspf/1.0.0/">Other Binaries</a></li>
-    
-    </ul>
+    <p>Apache James jSPF 1.0.1 is the latest jSPF stable version.</p>
+
+    <p>You can directly use it with maven:</p>
+
+    <pre>
+      <code>
+  &lt;dependency&gt;
+    &lt;groupId&gt;org.apache.james.jspf&lt;/groupId&gt;
+    &lt;artifactId&gt;apache-jspf&lt;/artifactId&gt;
+    &lt;version&gt;1.0.1&lt;/version&gt;
+  &lt;/dependency&gt;
+      </code>
+    </pre>
   
   </section>
   

--- a/src/site/xdoc/download.xml
+++ b/src/site/xdoc/download.xml
@@ -286,22 +286,19 @@ is found <a href='http://www.apache.org/licenses/exports/'>here</a>.
   
   <section name="Apache jDKIM">
   
-    <p>Apache James jDKIM 0.2 is the latest jDKIM stable version:</p>
-    <ul>
-    
-    <li>Binary (ZIP Format): <a
-    href="[preferred]/james/jdkim/apache-jdkim-0.2-bin.zip">apache-jdkim-0.2-bin.zip</a> [<a
-    href="http://www.apache.org/dist/james/jdkim/apache-jdkim-0.2-bin.zip.asc">PGP</a>]</li>
-    
-    <li>Binary (Unix TAR.GZ): <a
-    href="[preferred]/james/jdkim/apache-jdkim-0.2-bin.tar.gz">apache-jdkim-0.2-bin.tar.gz</a> [<a
-    href="http://www.apache.org/dist/james/jdkim/apache-jdkim-0.2-bin.tar.gz.asc">PGP</a>]</li>
-    
-    <li>Source (ZIP Format): <a
-    href="[preferred]/james/jdkim/apache-jdkim-project-0.2-source-release.zip">apache-jdkim-project-0.2-source-release.zip</a> [<a
-    href="http://www.apache.org/dist/james/jdkim/apache-jdkim-project-0.2-source-release.zip.asc">PGP</a>]</li>
-    
-    </ul>
+    <p>Apache James jDKIM 0.2 is the latest jDKIM stable version.</p>
+
+    <p>You can directly use it with maven:</p>
+
+    <pre>
+      <code>
+        &lt;dependency&gt;
+        &lt;groupId&gt;org.apache.james.jdkim&lt;/groupId&gt;
+        &lt;artifactId&gt;apache-jdkim&lt;/artifactId&gt;
+        &lt;version&gt;0.2&lt;/version&gt;
+        &lt;/dependency&gt;
+      </code>
+    </pre>
   
   </section>
   

--- a/src/site/xdoc/server/index.xml
+++ b/src/site/xdoc/server/index.xml
@@ -40,22 +40,22 @@
 	      <a href="manage.html">manage</a>, <a href="monitor.html">monitor</a> 
 	      and <a href="dev.html">develop</a> Apache James Server.</p>
 
-        <p>Download Apache James Mail Server 3.0.0 and <a href="quick-start.html">quick-start</a> it!</p>
+        <p>Download Apache James Mail Server 3.0.1 and <a href="quick-start.html">quick-start</a> it!</p>
         <p>
           <span class="minibutton btn-download">
             <a href="http://james.apache.org/download.cgi#Apache_James_Server">
-              <span><span class="icon"></span>Apache James Server 3.0.0</span>
+              <span><span class="icon"></span>Apache James Server 3.0.1</span>
             </a>
           </span>
         </p>
          <p>You can also have a look to the last stable version</p>
 
-        <p>Apache James Server 3.0 represents the leading edge of development. This code stream has many more
+        <p>Apache James Server 3.0.1 represents the leading edge of development. This code stream has many more
           features than the 2.3 code, but is not be as well tested in production. Reasonable
           configuration compatibility has been retained with 2.3.2.</p>
           
-        <p>Apache James Server 3.0 requires Java 1.6. A migration guide for
-           users willing to upgrade from 2.3 to 3.0 is <a href="upgrade-2.3.html">available</a>. If relying on Guice
+        <p>Apache James Server 3.0.1 requires Java 1.6. A migration guide for
+           users willing to upgrade from 2.3 to 3.0.1 is <a href="upgrade-2.3.html">available</a>. If relying on Guice
            wiring, you can use some additional components (Cassandra, ElasticSearch, ...). Guice wiring requires java-8.</p>
     
 


### PR DESCRIPTION
CF: https://issues.apache.org/jira/browse/JAMES-2281

We should :

 - Avoid referencing outdated objects
 - Rely more on maven for libraries that do not contain binaries
 - Re-order a bit top links.

Rationals:
 - We do not upload the libraries binary releases. Using maven will automate that process.
 - Users might get confused by today release page, cf MIME4J-266