### PR TITLE
End of Sprint documentation PR

### DIFF
--- a/dockerfiles/run/guice/cassandra-ldap/destination/conf/mailrepositorystore.xml
+++ b/dockerfiles/run/guice/cassandra-ldap/destination/conf/mailrepositorystore.xml
@@ -30,5 +30,10 @@
             <!-- Set if the messages should be listed sorted. False by default -->
             <config FIFO="false" CACHEKEYS="true"/>
         </mailrepository>
+        <mailrepository class="org.apache.james.mailrepository.cassandra.CassandraMailRepository">
+            <protocols>
+                <protocol>cassandra</protocol>
+            </protocols>
+        </mailrepository>
     </mailrepositories>
 </mailrepositorystore>

--- a/dockerfiles/run/guice/cassandra/destination/conf/mailrepositorystore.xml
+++ b/dockerfiles/run/guice/cassandra/destination/conf/mailrepositorystore.xml
@@ -30,5 +30,10 @@
             <!-- Set if the messages should be listed sorted. False by default -->
             <config FIFO="false" CACHEKEYS="true"/>
         </mailrepository>
+        <mailrepository class="org.apache.james.mailrepository.cassandra.CassandraMailRepository">
+            <protocols>
+                <protocol>cassandra</protocol>
+            </protocols>
+        </mailrepository>
     </mailrepositories>
 </mailrepositorystore>

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/resources/mailrepositorystore.xml
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/resources/mailrepositorystore.xml
@@ -27,5 +27,10 @@
             </protocols>
             <config FIFO="false" CACHEKEYS="true"/>
         </mailrepository>
+        <mailrepository class="org.apache.james.mailrepository.cassandra.CassandraMailRepository">
+            <protocols>
+                <protocol>cassandra</protocol>
+            </protocols>
+        </mailrepository>
     </mailrepositories>
 </mailrepositorystore>

--- a/server/protocols/webadmin-integration-test/src/test/resources/mailrepositorystore.xml
+++ b/server/protocols/webadmin-integration-test/src/test/resources/mailrepositorystore.xml
@@ -27,5 +27,10 @@
             </protocols>
             <config FIFO="false" CACHEKEYS="true"/>
         </mailrepository>
+        <mailrepository class="org.apache.james.mailrepository.cassandra.CassandraMailRepository">
+            <protocols>
+                <protocol>cassandra</protocol>
+            </protocols>
+        </mailrepository>
     </mailrepositories>
 </mailrepositorystore>

--- a/src/homepage/_posts/2018-01-26-admin-features.markdown
+++ b/src/homepage/_posts/2018-01-26-admin-features.markdown
@@ -5,10 +5,10 @@ date:   2018-01-26 00:00:22 +0200
 categories: james update
 ---
 
-An often asked feature for James is the abilitiy to handle the mails that after some processing
-have landed in a repository, for example /var/mail/error/.
+An often asked feature for James is the ability to handle the mails, that after some processing,
+have landed in a [repository], for example /var/mail/error/.
 
-A brand new webadmin API allows you to handle the content of these repositores, see the documentation in [manage-webadmin].
+A brand new webadmin API allows you to handle the content of these repositories, see the documentation in [manage-webadmin].
 It allows you to list the repositories, their content, but also to reprocess one or several mails in the processor and queue
 of your choice.
 
@@ -17,4 +17,8 @@ Oh! And bonus, now you can forget this non scalable file repository and use the 
 On the same documentation page you will also find the new mail queue management API, done to list queued mails, remove some
 of them regarding different criteria, but also flush delayed mails.
 
+Most of the work on these already usable features is done, but we still have some ideas for related improvements. [Contributions] are welcomed!
+
+[repository]: http://james.apache.org/server/feature-persistence.html
+[Contributions]: https://issues.apache.org/jira/issues/?jql=project%20%3D%20JAMES%20AND%20resolution%20%3D%20Unresolved%20AND%20labels%20in%20(feature)%20AND%20component%20%20in%20(Queue%2C%20%22MailStore%20%26%20MailRepository%22)%20AND%20type%20in%20(Improvement)
 [manage-webadmin]: https://james.apache.org/server/manage-webadmin.html

--- a/src/homepage/_posts/2018-01-26-admin-features.markdown
+++ b/src/homepage/_posts/2018-01-26-admin-features.markdown
@@ -1,0 +1,20 @@
+---
+layout: post
+title:  "New administration features: manage your queues and your reporitories"
+date:   2018-01-26 00:00:22 +0200
+categories: james update
+---
+
+An often asked feature for James is the abilitiy to handle the mails that after some processing
+have landed in a repository, for example /var/mail/error/.
+
+A brand new webadmin API allows you to handle the content of these repositores, see the documentation in [manage-webadmin].
+It allows you to list the repositories, their content, but also to reprocess one or several mails in the processor and queue
+of your choice.
+
+Oh! And bonus, now you can forget this non scalable file repository and use the brand new Cassandra repository!
+
+On the same documentation page you will also find the new mail queue management API, done to list queued mails, remove some
+of them regarding different criteria, but also flush delayed mails.
+
+[manage-webadmin]: https://james.apache.org/server/manage-webadmin.html

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -1,7 +1,7 @@
 Web administration for JAMES
 ============================
 
-The web administration supports for now the CRUD operations on the domains,the users, their mailboxes and their quotas,
+The web administration supports for now the CRUD operations on the domains, the users, their mailboxes and their quotas,
  managing mail repositories, performing cassandra migrations, and much more, as described in the following sections.
 
 **WARNING**: This API allow authentication only via the use of JWT. If not configured with JWT, an administrator should ensure an attacker can not use this API.
@@ -606,24 +606,24 @@ The answer looks like:
 [
     {
         "repository": "file://var/mail/error/",
-        "encodedUrl": "file%3A%2F%2Fvar%2Fmail%2Ferror%2F"
+        "id": "file%3A%2F%2Fvar%2Fmail%2Ferror%2F"
     },
     {
         "repository": "file://var/mail/relay-denied/",
-        "encodedUrl": "file%3A%2F%2Fvar%2Fmail%2Frelay-denied%2F"
+        "id": "file%3A%2F%2Fvar%2Fmail%2Frelay-denied%2F"
     },
     {
         "repository": "file://var/mail/spam/",
-        "encodedUrl": "file%3A%2F%2Fvar%2Fmail%2Fspam%2F"
+        "id": "file%3A%2F%2Fvar%2Fmail%2Fspam%2F"
     },
     {
         "repository": "file://var/mail/address-error/",
-        "encodedUrl": "file%3A%2F%2Fvar%2Fmail%2Faddress-error%2F"
+        "id": "file%3A%2F%2Fvar%2Fmail%2Faddress-error%2F"
     }
 ]
 ```
 
-You can use `encodedUrl` to access the repository.
+You can use `id`, the encoded URL of the repository, to access it in later requests.
 
 Response codes:
 
@@ -647,7 +647,7 @@ The answer looks like:
 ```
 {
    "repository": "file://var/mail/error/",
-   "encodedUrl": "file%3A%2F%2Fvar%2Fmail%2Ferror%2F",
+   "id": "file%3A%2F%2Fvar%2Fmail%2Ferror%2F",
    "size": 243
 }
 ```
@@ -667,7 +667,7 @@ curl -XGET http://ip:port/mailRepositories/encodedUrlOfTheRepository/mails
 Resource name `encodedUrlOfTheRepository` should be the encoded URL of an existing mail repository. Example:
 
 ```
-curl -XGET http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/
+curl -XGET http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/mails
 ```
 
 The answer will contains all mailKey contained in that repository.
@@ -689,7 +689,7 @@ You can pass additional URL parameters to this call in order to limit the output
 Example:
 
 ```
-curl -XGET http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/?limit=100&offset=500
+curl -XGET http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/mails?limit=100&offset=500
 ```
 
 Response codes:
@@ -743,7 +743,7 @@ curl -XDELETE http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F
 
 Response codes:
 
- - 204: This mail no longer exist in this repository
+ - 204: This mail no longer exists in this repository
  - 404: This repository can not be found
  - 500: Internal error
 
@@ -856,7 +856,7 @@ The scheduled task will have the following type `reprocessingAllTask` and the fo
 
 ### Reprocessing a specific mail from a mail repository
 
-To reprocess mails from a specific mail from a mail repository:
+To reprocess a specific mail from a mail repository:
 
 ```
 curl -XPATCH http://ip:port/mailRepositories/encodedUrlOfTheRepository/mails/mailKey?action=reprocess

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -636,7 +636,7 @@ Response codes:
 curl -XGET http://ip:port/mailRepositories/encodedUrlOfTheRepository/
 ```
 
-Resource name `encodedUrlOfTheRepository` should be the encoded URL of an existing mail repository. Example:
+Resource name `encodedUrlOfTheRepository` should be the resource id of an existing mail repository. Example:
 
 ```
 curl -XGET http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/
@@ -664,7 +664,7 @@ Response codes:
 curl -XGET http://ip:port/mailRepositories/encodedUrlOfTheRepository/mails
 ```
 
-Resource name `encodedUrlOfTheRepository` should be the encoded URL of an existing mail repository. Example:
+Resource name `encodedUrlOfTheRepository` should be the resource id of an existing mail repository. Example:
 
 ```
 curl -XGET http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/mails
@@ -705,7 +705,7 @@ Response codes:
 curl -XGET http://ip:port/mailRepositories/encodedUrlOfTheRepository/mails/mailKey
 ```
 
-Resource name `encodedUrlOfTheRepository` should be the encoded URL of an existing mail repository. Resource name `mailKey` should be the key of a mail stored in that repository. Example:
+Resource name `encodedUrlOfTheRepository` should be the resource id of an existing mail repository. Resource name `mailKey` should be the key of a mail stored in that repository. Example:
 
 ```
 curl -XGET http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/mails/mail-key-1
@@ -735,7 +735,7 @@ Response codes:
 curl -XDELETE http://ip:port/mailRepositories/encodedUrlOfTheRepository/mails/mailKey
 ```
 
-Resource name `encodedUrlOfTheRepository` should be the encoded URL of an existing mail repository. Resource name `mailKey` should be the key of a mail stored in that repository. Example:
+Resource name `encodedUrlOfTheRepository` should be the resource id of an existing mail repository. Resource name `mailKey` should be the key of a mail stored in that repository. Example:
 
 ```
 curl -XDELETE http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/mails/mail-key-1
@@ -754,7 +754,7 @@ Response codes:
 curl -XDELETE http://ip:port/mailRepositories/encodedUrlOfTheRepository/mails
 ```
 
-Resource name `encodedUrlOfTheRepository` should be the encoded URL of an existing mail repository. Example:
+Resource name `encodedUrlOfTheRepository` should be the resource id of an existing mail repository. Example:
 
 ```
 curl -XDELETE http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/mails
@@ -800,7 +800,7 @@ To reprocess mails from a repository:
 curl -XPATCH http://ip:port/mailRepositories/encodedUrlOfTheRepository/mails?action=reprocess
 ```
 
-Resource name `encodedUrlOfTheRepository` should be the encoded URL of an existing mail repository. Example:
+Resource name `encodedUrlOfTheRepository` should be the resource id of an existing mail repository. Example:
 
 For instance:
 
@@ -862,7 +862,7 @@ To reprocess a specific mail from a mail repository:
 curl -XPATCH http://ip:port/mailRepositories/encodedUrlOfTheRepository/mails/mailKey?action=reprocess
 ```
 
-Resource name `encodedUrlOfTheRepository` should be the encoded URL of an existing mail repository. Resource name `mailKey` should be the key of a mail stored in that repository. Example:
+Resource name `encodedUrlOfTheRepository` should be the resource id of an existing mail repository. Resource name `mailKey` should be the key of a mail stored in that repository. Example:
 
 For instance:
 

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -1,7 +1,8 @@
 Web administration for JAMES
 ============================
 
-The web administration supports for now the CRUD operations on the domains,the users, their mailboxes and their quotas, as described in the following sections.
+The web administration supports for now the CRUD operations on the domains,the users, their mailboxes and their quotas,
+ managing mail repositories, performing cassandra migrations, and much more, as described in the following sections.
 
 **WARNING**: This API allow authentication only via the use of JWT. If not configured with JWT, an administrator should ensure an attacker can not use this API.
 
@@ -590,6 +591,329 @@ Response codes:
  - 200: Success
  - 400: Group structure or member is not valid
  - 500: Internal error
+
+## Administrating mail repositories
+
+### Listing mail repositories
+
+```
+curl -XGET http://ip:port/mailRepositories
+```
+
+The answer looks like:
+
+```
+[
+    {
+        "repository": "file://var/mail/error/",
+        "encodedUrl": "file%3A%2F%2Fvar%2Fmail%2Ferror%2F"
+    },
+    {
+        "repository": "file://var/mail/relay-denied/",
+        "encodedUrl": "file%3A%2F%2Fvar%2Fmail%2Frelay-denied%2F"
+    },
+    {
+        "repository": "file://var/mail/spam/",
+        "encodedUrl": "file%3A%2F%2Fvar%2Fmail%2Fspam%2F"
+    },
+    {
+        "repository": "file://var/mail/address-error/",
+        "encodedUrl": "file%3A%2F%2Fvar%2Fmail%2Faddress-error%2F"
+    }
+]
+```
+
+You can use `encodedUrl` to access the repository.
+
+Response codes:
+
+ - 200: The list of mail repositories
+ - 500: Internal error
+
+### Getting additional information for a mail repository
+
+```
+curl -XGET http://ip:port/mailRepositories/encodedUrlOfTheRepository/
+```
+
+Resource name `encodedUrlOfTheRepository` should be the encoded URL of an existing mail repository. Example:
+
+```
+curl -XGET http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/
+```
+
+The answer looks like:
+
+```
+{
+   "repository": "file://var/mail/error/",
+   "encodedUrl": "file%3A%2F%2Fvar%2Fmail%2Ferror%2F",
+   "size": 243
+}
+```
+
+Response codes:
+
+ - 200: Additonnal information for that repository
+ - 404: This repository can not be found
+ - 500: Internal error
+
+### Listing mails contained in a mail repository
+
+```
+curl -XGET http://ip:port/mailRepositories/encodedUrlOfTheRepository/mails
+```
+
+Resource name `encodedUrlOfTheRepository` should be the encoded URL of an existing mail repository. Example:
+
+```
+curl -XGET http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/
+```
+
+The answer will contains all mailKey contained in that repository.
+
+```
+[
+    "mail-key-1",
+    "mail-key-2",
+    "mail-key-3"
+]
+```
+
+Note that this can be used to read mail details.
+
+You can pass additional URL parameters to this call in order to limit the output:
+ - A limit: no more elements than the specified limit will be returned. This needs to be strictly positive. If no value is specified, no limit will be applied.
+ - An offset: allow to skip elements. This needs to be positive. Default value is zero.
+
+Example:
+
+```
+curl -XGET http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/?limit=100&offset=500
+```
+
+Response codes:
+
+ - 200: The list of mail keys contained in that mail repository
+ - 400: Invalid parameters
+ - 404: This repository can not be found
+ - 500: Internal error
+
+### Reading a mail details
+
+```
+curl -XGET http://ip:port/mailRepositories/encodedUrlOfTheRepository/mails/mailKey
+```
+
+Resource name `encodedUrlOfTheRepository` should be the encoded URL of an existing mail repository. Resource name `mailKey` should be the key of a mail stored in that repository. Example:
+
+```
+curl -XGET http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/mails/mail-key-1
+```
+
+Response looks like:
+
+```
+{
+    "name": "mail-key-1",
+    "sender": "sender@domain.com",
+    "recipients": ["recipient1@domain.com", "recipient2@domain.com"],
+    "state": "address-error",
+    "error": "A small message explaining what happened to that mail..."
+}
+```
+
+Response codes:
+
+ - 200: Details of the mail
+ - 404: This repository or mail can not be found
+ - 500: Internal error
+
+### Removing a mail from a mail repository
+
+```
+curl -XDELETE http://ip:port/mailRepositories/encodedUrlOfTheRepository/mails/mailKey
+```
+
+Resource name `encodedUrlOfTheRepository` should be the encoded URL of an existing mail repository. Resource name `mailKey` should be the key of a mail stored in that repository. Example:
+
+```
+curl -XDELETE http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/mails/mail-key-1
+```
+
+Response codes:
+
+ - 204: This mail no longer exist in this repository
+ - 404: This repository can not be found
+ - 500: Internal error
+
+### Removing all mails from a mail repository
+
+
+```
+curl -XDELETE http://ip:port/mailRepositories/encodedUrlOfTheRepository/mails
+```
+
+Resource name `encodedUrlOfTheRepository` should be the encoded URL of an existing mail repository. Example:
+
+```
+curl -XDELETE http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/mails
+```
+
+The response to that request will be the scheduled `taskId` :
+
+```
+{"taskId":"5641376-02ed-47bd-bcc7-76ff6262d92a"}
+```
+
+Positionned headers:
+
+ - Location header indicates the location of the resource associated with the scheduled task. Example:
+
+```
+Location: /tasks/3294a976-ce63-491e-bd52-1b6f465ed7a2
+```
+
+Response codes:
+
+ - 201: Success. Corresponding task id is returned.
+ - 404: Could not find that mail repository
+ - 500: Internal error
+
+The scheduled task will have the following type `clearMailRepository` and the following `additionalInformation`:
+
+```
+{
+  "repositoryUrl":"file://var/mail/error/",
+  "initialCount": 243,
+  "remainingCount": 17
+}
+```
+
+### Reprocessing mails from a mail repository
+
+Sometime, you want to re-process emails stored in a mail repository. For instance, you can make a configuration error, or there can be a James bug that makes processing of some mails fail. Those mail will be stored in a mail repository. Once you solved the problem, you can reprocess them.
+
+To reprocess mails from a repository:
+
+```
+curl -XPATCH http://ip:port/mailRepositories/encodedUrlOfTheRepository/mails?action=reprocess
+```
+
+Resource name `encodedUrlOfTheRepository` should be the encoded URL of an existing mail repository. Example:
+
+For instance:
+
+```
+curl -XPATCH http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/mails?action=reprocess
+```
+
+Additional query paramaters are supported:
+ - `queue` allow you to target the mail queue you want to enqueue the mails in.
+ - `processor` allow you to overwrite the state of the reprocessing mails, and thus select the processors they will start their processing in.
+
+
+For instance:
+
+```
+curl -XPATCH http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/mails?action=reprocess&processor=transport&queue=spool
+```
+
+Note that the `action` query parameter is compulsary and can only take value `reprocess`.
+
+
+The response to that request will be the scheduled `taskId` :
+
+```
+{"taskId":"5641376-02ed-47bd-bcc7-76ff6262d92a"}
+```
+
+Positionned headers:
+
+ - Location header indicates the location of the resource associated with the scheduled task. Example:
+
+```
+Location: /tasks/3294a976-ce63-491e-bd52-1b6f465ed7a2
+```
+
+Response codes:
+
+ - 201: Success. Corresponding task id is returned.
+ - 404: Could not find that mail repository
+ - 500: Internal error
+
+The scheduled task will have the following type `reprocessingAllTask` and the following `additionalInformation`:
+
+```
+{
+  "repositoryUrl":"file://var/mail/error/",
+  "targetQueue":"spool",
+  "targetProcessor":"transport",
+  "initialCount": 243,
+  "remainingCount": 17
+}
+```
+
+### Reprocessing a specific mail from a mail repository
+
+To reprocess mails from a specific mail from a mail repository:
+
+```
+curl -XPATCH http://ip:port/mailRepositories/encodedUrlOfTheRepository/mails/mailKey?action=reprocess
+```
+
+Resource name `encodedUrlOfTheRepository` should be the encoded URL of an existing mail repository. Resource name `mailKey` should be the key of a mail stored in that repository. Example:
+
+For instance:
+
+```
+curl -XPATCH http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/mails/name1?action=reprocess
+```
+
+Additional query paramaters are supported:
+ - `queue` allow you to target the mail queue you want to enqueue the mails in.
+ - `processor` allow you to overwrite the state of the reprocessing mails, and thus select the processors they will start their processing in.
+
+
+For instance:
+
+```
+curl -XPATCH http://ip:port/mailRepositories/file%3A%2F%2Fvar%2Fmail%2Ferror%2F/mails/name1?action=reprocess&processor=transport&queue=spool
+```
+
+Note that the `action` query parameter is compulsary and can only take value `reprocess`.
+
+
+The response to that request will be the scheduled `taskId` :
+
+```
+{"taskId":"5641376-02ed-47bd-bcc7-76ff6262d92a"}
+```
+
+Positionned headers:
+
+ - Location header indicates the location of the resource associated with the scheduled task. Example:
+
+```
+Location: /tasks/3294a976-ce63-491e-bd52-1b6f465ed7a2
+```
+
+Response codes:
+
+ - 201: Success. Corresponding task id is returned.
+ - 404: Could not find that mail repository
+ - 500: Internal error
+
+The scheduled task will have the following type `reprocessingOneTask` and the following `additionalInformation`:
+
+```
+{
+  "repositoryUrl":"file://var/mail/error/",
+  "targetQueue":"spool",
+  "targetProcessor":"transport",
+  "mailKey":"name1"
+}
+```
 
 ## Task management
 

--- a/src/site/xdoc/server/config-mailrepositorystore.xml
+++ b/src/site/xdoc/server/config-mailrepositorystore.xml
@@ -33,8 +33,8 @@
     
       <p>Consult <a href="https://github.com/apache/james-project/tree/master/server/app/src/main/resources/mailrepositorystore.xml">mailrepositorystore.xml</a> in GIT to get some examples and hints.</p>
 
-      <p>Mail Repository Stores are distinguished by where they store data.  There are five types of 
-        storage: File, Database, DBFile, MBox and JCR.</p>
+      <p>Mail Repository Stores are distinguished by where they store data.  There are several types of
+        storage: File, Database, Cassandra, DBFile, MBox and JCR.</p>
         
     </subsection>
         
@@ -100,7 +100,10 @@
       <p>If you enable this you need to make sure that embedded Jackrabbit instance is started as well. Check the container configuration</p>
         
     </subsection>
-  
+
+    <subsection name="CassandraMailRepository">
+      <p>Cassandra Guice wiring allows to use the <code>cassandra://</code> protocol for your ToRepository mailets.</p>
+    </subsection>
   </section>
 
 </body>

--- a/src/site/xdoc/server/feature-persistence.xml
+++ b/src/site/xdoc/server/feature-persistence.xml
@@ -51,6 +51,24 @@
     </subsection>
   
     <subsection name="Mail Repository Store Persistence">
+
+      <p>Mail repository allow the administrator to store mail being processed in the mailet-container. The mails are typically
+      added by the <strong>ToRepository</strong> mailet. Then for Guice wiring <a href="manage-webadmin.html">webAdmin</a> API allows to read, delete and
+      reprocess these mails.</p>
+
+        <p>
+          Typical use cases might be:
+          <ul>
+            <li>Error management: mails can be stored if an error is encountered during the mail processing, be the error caused by a bug,
+                a configuration mistake, a parsing error, temporary unavailable services. Reprocessing the mails once the problem fixed allows to
+                avoid data loss. Note that you can use mail repositories of different types on the same James server in order to not
+                be dependant from a single data-store.</li>
+            <li>Debugging: MDC context allows to follow mail processing, and isolate logs of a single mail. You can then configure
+                James in order to collect all mails processed in one part of your pipeline, and thus better understand this one.</li>
+            <li>Data collection: Collect spam, suspicious mails and much more. You can then later on analyze them or for instance train
+                your anti-spam system.</li>
+          </ul>
+        </p>
   
       <p>Available Mail Repository Store are defined in mailrepositorystore.xml. 
          Each has an URL prefix (file, db, dbfile,...) that can be used in mailetcontainer.xml 


### PR DESCRIPTION
Currently contains documentation changes for:
 - Explaining a bit better **MailRepository** feature
 - JAMES-2293 WebAdmin routes for MailRepository management
 - JAMES-2294 WebAdmin routes for mail reprocessing
 - JAMES-2291 CassandraMailRepository

Additionally a bit of configuration is modified in order to use directly `cassandra://...` as `ToRepository` paramenters.