### PR TITLE
Upgrade elasticsearch libraries.

### DIFF
--- a/backends-common/elasticsearch/pom.xml
+++ b/backends-common/elasticsearch/pom.xml
@@ -59,12 +59,12 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>2.2.1</version>
+            <version>2.4.6</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>2.2.1</version>
+            <version>2.4.6</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/mailbox/elasticsearch/pom.xml
+++ b/mailbox/elasticsearch/pom.xml
@@ -153,12 +153,12 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>2.2.1</version>
+            <version>2.4.6</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>2.2.1</version>
+            <version>2.4.6</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
2.2.1 is rolling upgrade compatible with 2.4.6 https://www.elastic.co/guide/en/elasticsearch/reference/2.4/setup-upgrade.html

CI check for https://github.com/apache/james-project/pull/100