### PR TITLE
JAMES-2315 HomePage should match compliance criteria

### DIFF
--- a/src/homepage/index.html
+++ b/src/homepage/index.html
@@ -192,32 +192,32 @@ WHAT WILL YOU TRY:</b><br>
                 </span>
               </li>
               <li class="post-template center-icon">
-                <a href="http://www.apache.org/security/" alt="Report security vulnerabilities"><span class="icon fa-shield "></span></a>
+                <a href="https://www.apache.org/security/" alt="Report security vulnerabilities"><span class="icon fa-shield "></span></a>
                 <span class="details">
                   <b>Reporting security vulnerabilities:</b><br/>
-                  <a class="comm" alt="Security" href="http://www.apache.org/security/">Security</a>: Vulnerabilities should be announced to the Apache Security team.<br/>
+                  <a class="comm" alt="Security" href="https://www.apache.org/security/">Security</a>: Vulnerabilities should be announced to the Apache Security team.<br/>
                   PMCs will be notified about them, and will work hard to propose fixes as fast as possible.
                 </span>
               </li>
               <li class="post-template center-icon">
-                <a href="http://twitter.com/ApacheJames" alt="twitter account"><span class="icon fa-twitter"></span></a>
+                <a href="https://twitter.com/ApacheJames" alt="twitter account"><span class="icon fa-twitter"></span></a>
                 <span class="details">
                   <b>Twitter:</b>
-                  <br/>Express yourself and follow us <a href="http://twitter.com/ApacheJames" class="comm" alt="twitter account">@ApacheJames</a>.
+                  <br/>Express yourself and follow us <a href="https://twitter.com/ApacheJames" class="comm" alt="twitter account">@ApacheJames</a>.
                 </span>
               </li>
               <li class="post-template center-icon">
-                <a href="http://james.apache.org/download.cgi" alt="Downloads"><span class="icon fa-cloud-download "></span></a>
+                <a href="https://james.apache.org/download.cgi" alt="Downloads"><span class="icon fa-cloud-download "></span></a>
                 <span class="details">
                   <b>Download Apache James releases:</b>
-                  <br/>Our <a href="http://james.apache.org/download.cgi">download page</a> allows you to download artifacts and sources for the James Server and James libraries.
+                  <br/>Our <a href="https://james.apache.org/download.cgi">download page</a> allows you to download artifacts and sources for the James Server and James libraries.
                 </span>
               </li>
               <li class="post-template center-icon">
-                <a href="http://james.apache.org/support.html" alt="Professional support"><span class="icon fa-briefcase"></span></a>
+                <a href="https://james.apache.org/support.html" alt="Professional support"><span class="icon fa-briefcase"></span></a>
                 <span class="details">
                   <b>Professional support:</b>
-                  <br/>Find a list of companies which can provide you some <a href="http://james.apache.org/support.html" class="comm" alt="Professional support">
+                  <br/>Find a list of companies which can provide you some <a href="https://james.apache.org/support.html" class="comm" alt="Professional support">
                   support on James</a>.
                 </span>
               </li>
@@ -241,15 +241,15 @@ WHAT WILL YOU TRY:</b><br>
           <div id="openpaas" style="background:#fff" class="lity-hide">
               <div class="padding about-table james-use-case-content">
                 <header class="major">
-                  <h2><a href="http://open-paas.org/"><img src="/images/openpaas.png"></a></h2>
+                  <h2><a href="https://open-paas.org/"><img src="/images/openpaas.png"></a></h2>
                 </header>
                 <p class="post-template">
                   At&nbsp;<a href="https://linagora.com/" class="comm">LINAGORA</a>, we chose JAMES as the Mail Delivery Agent of our&nbsp;
-                  <a href="http://open-paas.org/" class="comm">OpenPaaS</a>&nbsp;product:</p>
+                  <a href="https://open-paas.org/" class="comm">OpenPaaS</a>&nbsp;product:</p>
                 <ul class="james-ul">
                   <li class="james-use-case-li center-icon"><span class="icon fa-arrow-right"></span>For easy administration of email load balancing and high availability</li>
                   <li class="james-use-case-li center-icon"><span class="icon fa-arrow-right"></span>To allow email interactions with the platform</li>
-                  <li class="james-use-case-li center-icon"><span class="icon fa-arrow-right"></span>To use the&nbsp;<a href="http://jmap.io/" class="comm">JMAP</a>&nbsp;protocol (the browser interacts directly with the mail server)</li>
+                  <li class="james-use-case-li center-icon"><span class="icon fa-arrow-right"></span>To use the&nbsp;<a href="https://jmap.io/" class="comm">JMAP</a>&nbsp;protocol (the browser interacts directly with the mail server)</li>
                 </ul>
                 <p>Our deployment currently allows serving a hundred user over JMAP, SMTP and IMAP.</p>
               </div>
@@ -302,21 +302,21 @@ WHAT WILL YOU TRY:</b><br>
       <section>
         <h2>Connect</h2>
         <ul class="icons">
-          <li><a href="http://james.apache.org/mail.html" class="icon fa-envelope-o alt"><span class="label">Mailing-list</span></a></li>
+          <li><a href="https://james.apache.org/mail.html" class="icon fa-envelope-o alt"><span class="label">Mailing-list</span></a></li>
           <li><a href="https://gitter.im/apache/james-project" class="icon fa-wechat alt"><span class="label">Gitter</span></a></li>
           <li><a href="https://github.com/apache/james-project" class="icon fa-github alt"><span class="label">GitHub</span></a></li>
-          <li><a href="http://twitter.com/ApacheJames" class="icon fa-twitter alt"><span class="label">Twitter</span></a></li>
-          <li><a href="http://james.apache.org/support.html" class="icon fa-briefcase alt"><span class="label">Support</span></a></li>
+          <li><a href="https://twitter.com/ApacheJames" class="icon fa-twitter alt"><span class="label">Twitter</span></a></li>
+          <li><a href="https://james.apache.org/support.html" class="icon fa-briefcase alt"><span class="label">Support</span></a></li>
           <li><a href="http://www.apache.org/events/current-event" class="icon fa-calendar alt"><span class="label">Apache Foundation events</span></a></li>
           </ul>
       </section>
       <section class="legal-section">
         <h2>Copyright</h2>
         Apache James and related projects are trademarks of the Apache Software Foundation.<br/>
-        <a href="http://www.apache.org/">Copyright 2006-2018 The Apache Software Foundation.. All Rights Reserved.</a><br/>
-        <a href="http://www.apache.org/licenses/">License</a><br/>
-        <a href="http://www.apache.org/foundation/sponsorship.html">Donate</a> to support the Apache Foundation<br/>
-        <a href="http://www.apache.org/foundation/thanks.html">Thanks</a><br/>
+        <a href="https://www.apache.org/">Copyright 2006-2018 The Apache Software Foundation. All Rights Reserved.</a><br/>
+        <a href="https://www.apache.org/licenses/">License</a><br/>
+        <a href="https://www.apache.org/foundation/sponsorship.html">Donate</a> to support the Apache Foundation<br/>
+        <a href="https://www.apache.org/foundation/thanks.html">Thanks</a><br/>
         Design: <a href="https://html5up.net">HTML5 UP</a><br/>
         Thanks to <a href="http://www.neoma-interactive.com/">Neoma by Linagora</a> for the website design
       </section>

--- a/src/homepage/index.html
+++ b/src/homepage/index.html
@@ -307,6 +307,7 @@ WHAT WILL YOU TRY:</b><br>
           <li><a href="https://github.com/apache/james-project" class="icon fa-github alt"><span class="label">GitHub</span></a></li>
           <li><a href="http://twitter.com/ApacheJames" class="icon fa-twitter alt"><span class="label">Twitter</span></a></li>
           <li><a href="http://james.apache.org/support.html" class="icon fa-briefcase alt"><span class="label">Support</span></a></li>
+          <li><a href="http://www.apache.org/events/current-event" class="icon fa-calendar alt"><span class="label">Apache Foundation events</span></a></li>
           </ul>
       </section>
       <section class="legal-section">

--- a/src/homepage/index.html
+++ b/src/homepage/index.html
@@ -296,7 +296,7 @@ WHAT WILL YOU TRY:</b><br>
       </section>
       <section class="legal-section">
         <h2>Copyright</h2>
-        Copyright <a href="http://www.apache.org/"> 2006-2018 The Apache Software Foundation. All Rights Reserved.</a><br/>
+        <a href="http://www.apache.org/">Copyright 2006-2018 The Apache Software Foundation.. All Rights Reserved.</a><br/>
         Design: <a href="https://html5up.net">HTML5 UP</a><br/>
         Thanks to <a href="http://www.neoma-interactive.com/">Neoma by Linagora</a> for the website design
       </section>

--- a/src/homepage/index.html
+++ b/src/homepage/index.html
@@ -129,7 +129,7 @@ WHAT WILL YOU TRY:</b><br>
         </section>
         <footer>
           <ul class="actions">
-            <li><a href="posts.html" class="button">READ MORE POST</a></li>
+            <li><a href="posts.html" class="button">READ MORE POSTS</a></li>
           </ul>
         </footer>
       </section>

--- a/src/homepage/index.html
+++ b/src/homepage/index.html
@@ -299,6 +299,7 @@ WHAT WILL YOU TRY:</b><br>
         Apache James and related projects are trademarks of the Apache Software Foundation.<br/>
         <a href="http://www.apache.org/">Copyright 2006-2018 The Apache Software Foundation.. All Rights Reserved.</a><br/>
         <a href="http://www.apache.org/foundation/sponsorship.html">Donate</a> to support the Apache Foundation<br/>
+        <a href="http://www.apache.org/foundation/thanks.html">Thanks</a><br/>
         Design: <a href="https://html5up.net">HTML5 UP</a><br/>
         Thanks to <a href="http://www.neoma-interactive.com/">Neoma by Linagora</a> for the website design
       </section>

--- a/src/homepage/index.html
+++ b/src/homepage/index.html
@@ -297,6 +297,7 @@ WHAT WILL YOU TRY:</b><br>
       <section class="legal-section">
         <h2>Copyright</h2>
         <a href="http://www.apache.org/">Copyright 2006-2018 The Apache Software Foundation.. All Rights Reserved.</a><br/>
+        <a href="http://www.apache.org/foundation/sponsorship.html">Donate</a> to support the Apache Foundation<br/>
         Design: <a href="https://html5up.net">HTML5 UP</a><br/>
         Thanks to <a href="http://www.neoma-interactive.com/">Neoma by Linagora</a> for the website design
       </section>

--- a/src/homepage/index.html
+++ b/src/homepage/index.html
@@ -296,6 +296,7 @@ WHAT WILL YOU TRY:</b><br>
       </section>
       <section class="legal-section">
         <h2>Copyright</h2>
+        Apache James and related projects are trademarks of the Apache Software Foundation.<br/>
         <a href="http://www.apache.org/">Copyright 2006-2018 The Apache Software Foundation.. All Rights Reserved.</a><br/>
         <a href="http://www.apache.org/foundation/sponsorship.html">Donate</a> to support the Apache Foundation<br/>
         Design: <a href="https://html5up.net">HTML5 UP</a><br/>

--- a/src/homepage/index.html
+++ b/src/homepage/index.html
@@ -306,6 +306,7 @@ WHAT WILL YOU TRY:</b><br>
         <h2>Copyright</h2>
         Apache James and related projects are trademarks of the Apache Software Foundation.<br/>
         <a href="http://www.apache.org/">Copyright 2006-2018 The Apache Software Foundation.. All Rights Reserved.</a><br/>
+        <a href="http://www.apache.org/licenses/">License</a><br/>
         <a href="http://www.apache.org/foundation/sponsorship.html">Donate</a> to support the Apache Foundation<br/>
         <a href="http://www.apache.org/foundation/thanks.html">Thanks</a><br/>
         Design: <a href="https://html5up.net">HTML5 UP</a><br/>

--- a/src/homepage/index.html
+++ b/src/homepage/index.html
@@ -207,6 +207,13 @@ WHAT WILL YOU TRY:</b><br>
                 </span>
               </li>
               <li class="post-template center-icon">
+                <a href="http://james.apache.org/download.cgi" alt="Downloads"><span class="icon fa-cloud-download "></span></a>
+                <span class="details">
+                  <b>Download Apache James releases:</b>
+                  <br/>Our <a href="http://james.apache.org/download.cgi">download page</a> allows you to download artifacts and sources for the James Server and James libraries.
+                </span>
+              </li>
+              <li class="post-template center-icon">
                 <a href="http://james.apache.org/support.html" alt="Professional support"><span class="icon fa-briefcase"></span></a>
                 <span class="details">
                   <b>Professional support:</b>

--- a/src/homepage/index.html
+++ b/src/homepage/index.html
@@ -192,6 +192,14 @@ WHAT WILL YOU TRY:</b><br>
                 </span>
               </li>
               <li class="post-template center-icon">
+                <a href="http://www.apache.org/security/" alt="Report security vulnerabilities"><span class="icon fa-shield "></span></a>
+                <span class="details">
+                  <b>Reporting security vulnerabilities:</b><br/>
+                  <a class="comm" alt="Security" href="http://www.apache.org/security/">Security</a>: Vulnerabilities should be announced to the Apache Security team.<br/>
+                  PMCs will be notified about them, and will work hard to propose fixes as fast as possible.
+                </span>
+              </li>
+              <li class="post-template center-icon">
                 <a href="http://twitter.com/ApacheJames" alt="twitter account"><span class="icon fa-twitter"></span></a>
                 <span class="details">
                   <b>Twitter:</b>


### PR DESCRIPTION
CF: https://whimsy.apache.org/site/project/james

The new **download** and **security** sections.

![capture d ecran de 2018-01-31 09-40-50](https://user-images.githubusercontent.com/6928740/35602506-2bc75e58-066b-11e8-9bc6-a282438057e2.png)

The additionnal footer links:

![capture d ecran de 2018-01-31 09-41-16](https://user-images.githubusercontent.com/6928740/35602526-45e5b046-066b-11e8-8438-d34855d5cd95.png)

A next PR will split the Community section in 2: **Community** and **Contribute**.

