### PR TITLE
JAMES-2264 Correct TaskRoute test synchronisation

### DIFF
--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/routes/TasksRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/routes/TasksRoutesTest.java
@@ -112,11 +112,15 @@ public class TasksRoutesTest {
     }
 
     @Test
-    public void listShouldListTaskWhenStatusFilter() {
+    public void listShouldListTaskWhenStatusFilter() throws Exception {
+        CountDownLatch inProgressLatch = new CountDownLatch(1);
         TaskId taskId = taskManager.submit(() -> {
+            inProgressLatch.countDown();
             await();
             return Task.Result.COMPLETED;
         });
+
+        inProgressLatch.await();
 
         given()
             .param("status", TaskManager.Status.IN_PROGRESS.getValue())
@@ -151,11 +155,15 @@ public class TasksRoutesTest {
     }
 
     @Test
-    public void getShouldReturnTaskDetails() {
+    public void getShouldReturnTaskDetails() throws Exception {
+        CountDownLatch inProgressLatch = new CountDownLatch(1);
         TaskId taskId = taskManager.submit(() -> {
+            inProgressLatch.countDown();
             await();
             return Task.Result.COMPLETED;
         });
+
+        inProgressLatch.await();
 
         when()
             .get("/" + taskId.getValue())


### PR DESCRIPTION
Still a bit of synchronisation missing in TaskRouteTest.

See https://github.com/linagora/james-project/pull/1283

```
[676f5dd109875b9881fa6e1e6ceafcfbcbcc5a2b] JSON path status doesn't match.
[676f5dd109875b9881fa6e1e6ceafcfbcbcc5a2b] Expected: is "inProgress"
[676f5dd109875b9881fa6e1e6ceafcfbcbcc5a2b]   Actual: waiting
[676f5dd109875b9881fa6e1e6ceafcfbcbcc5a2b] 
[676f5dd109875b9881fa6e1e6ceafcfbcbcc5a2b] 	at org.apache.james.webadmin.routes.TasksRoutesTest.getShouldReturnTaskDetails(TasksRoutesTest.java:164)
[676f5dd109875b9881fa6e1e6ceafcfbcbcc5a2b] 
[676f5dd109875b9881fa6e1e6ceafcfbcbcc5a2b] Running org.apache.james.webadmin.TlsConfigurationTest
[676f5dd109875b9881fa6e1e6ceafcfbcbcc5a2b] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.782 sec - in org.apache.james.webadmin.TlsConfigurationTest
[676f5dd109875b9881fa6e1e6ceafcfbcbcc5a2b] 
[676f5dd109875b9881fa6e1e6ceafcfbcbcc5a2b] Results :
[676f5dd109875b9881fa6e1e6ceafcfbcbcc5a2b] 
[676f5dd109875b9881fa6e1e6ceafcfbcbcc5a2b] Failed tests: 
[676f5dd109875b9881fa6e1e6ceafcfbcbcc5a2b]   TasksRoutesTest.getShouldReturnTaskDetails:164 1 expectation failed.
[676f5dd109875b9881fa6e1e6ceafcfbcbcc5a2b] JSON path status doesn't match.
[676f5dd109875b9881fa6e1e6ceafcfbcbcc5a2b] Expected: is "inProgress"
[676f5dd109875b9881fa6e1e6ceafcfbcbcc5a2b]   Actual: waiting
```

I did a full review of the rest of the class.