### PR TITLE
JAMES-2332 JMSMailQueue with a single producer

### DIFF
--- a/server/queue/queue-activemq/src/main/java/org/apache/james/queue/activemq/ActiveMQMailQueue.java
+++ b/server/queue/queue-activemq/src/main/java/org/apache/james/queue/activemq/ActiveMQMailQueue.java
@@ -23,7 +23,6 @@ import java.net.MalformedURLException;
 import java.util.List;
 import java.util.Map;
 
-import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
 import javax.jms.MapMessage;
@@ -217,9 +216,9 @@ public class ActiveMQMailQueue extends JMSMailQueue implements ActiveMQSupport {
     }
 
     @Override
-    protected MailQueueItem createMailQueueItem(Connection connection, Session session, MessageConsumer consumer, Message message) throws JMSException, MessagingException {
+    protected MailQueueItem createMailQueueItem(Session session, MessageConsumer consumer, Message message) throws JMSException, MessagingException {
         Mail mail = createMail(message);
-        ActiveMQMailQueueItem activeMQMailQueueItem = new ActiveMQMailQueueItem(mail, connection, session, consumer, message);
+        ActiveMQMailQueueItem activeMQMailQueueItem = new ActiveMQMailQueueItem(mail, session, consumer, message);
         return mailQueueItemDecoratorFactory.decorate(activeMQMailQueueItem);
     }
 

--- a/server/queue/queue-activemq/src/main/java/org/apache/james/queue/activemq/ActiveMQMailQueueItem.java
+++ b/server/queue/queue-activemq/src/main/java/org/apache/james/queue/activemq/ActiveMQMailQueueItem.java
@@ -21,7 +21,6 @@ package org.apache.james.queue.activemq;
 
 import java.io.IOException;
 
-import javax.jms.Connection;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
@@ -44,8 +43,8 @@ public class ActiveMQMailQueueItem extends JMSMailQueueItem implements ActiveMQS
 
     private final Message message;
 
-    public ActiveMQMailQueueItem(Mail mail, Connection connection, Session session, MessageConsumer consumer, Message message) {
-        super(mail, connection, session, consumer);
+    public ActiveMQMailQueueItem(Mail mail, Session session, MessageConsumer consumer, Message message) {
+        super(mail,  session, consumer);
         this.message = message;
     }
 

--- a/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
+++ b/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
@@ -486,7 +486,7 @@ public class JMSMailQueue implements ManageableMailQueue, JMSSupport, MailPriori
         QueueBrowser browser = null;
         try {
             browser = session.createBrowser(queue);
-            Enumeration enumeration = browser.getEnumeration();
+            Enumeration<?> enumeration = browser.getEnumeration();
             return Iterators.size(new EnumerationIterator(enumeration));
         } catch (Exception e) {
             LOGGER.error("Unable to get size of queue {}", queueName, e);

--- a/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
+++ b/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
@@ -190,7 +190,6 @@ public class JMSMailQueue implements ManageableMailQueue, JMSSupport, MailPriori
     @Override
     public MailQueueItem deQueue() throws MailQueueException {
         Session session = null;
-        Message message;
         MessageConsumer consumer = null;
 
         while (true) {
@@ -200,7 +199,7 @@ public class JMSMailQueue implements ManageableMailQueue, JMSSupport, MailPriori
                 Queue queue = session.createQueue(queueName);
                 consumer = session.createConsumer(queue, getMessageSelector());
 
-                message = consumer.receive(10000);
+                Message message = consumer.receive(10000);
 
                 if (message != null) {
                     mailQueueSize.decrement();
@@ -220,7 +219,6 @@ public class JMSMailQueue implements ManageableMailQueue, JMSSupport, MailPriori
                 timeMetric.stopAndPublish();
             }
         }
-
     }
 
     @Override
@@ -474,7 +472,7 @@ public class JMSMailQueue implements ManageableMailQueue, JMSSupport, MailPriori
      * @throws MessagingException
      */
     protected MailQueueItem createMailQueueItem(Session session, MessageConsumer consumer, Message message) throws JMSException, MessagingException {
-        final Mail mail = createMail(message);
+        Mail mail = createMail(message);
         JMSMailQueueItem jmsMailQueueItem = new JMSMailQueueItem(mail, session, consumer);
         return mailQueueItemDecoratorFactory.decorate(jmsMailQueueItem);
     }
@@ -641,8 +639,8 @@ public class JMSMailQueue implements ManageableMailQueue, JMSSupport, MailPriori
         try {
             browser = session.createBrowser(queue);
 
-            final Enumeration<Message> messages = browser.getEnumeration();
-            final QueueBrowser myBrowser = browser;
+            Enumeration<Message> messages = browser.getEnumeration();
+            QueueBrowser myBrowser = browser;
 
             return new MailQueueIterator() {
 

--- a/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
+++ b/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
@@ -50,6 +50,7 @@ import javax.mail.MessagingException;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.MimeMessage;
 
+import org.apache.commons.collections.iterators.EnumerationIterator;
 import org.apache.james.core.MailAddress;
 import org.apache.james.lifecycle.api.Disposable;
 import org.apache.james.metrics.api.Metric;
@@ -67,6 +68,7 @@ import org.slf4j.LoggerFactory;
 import org.threeten.extra.Temporals;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.Iterators;
 
 /**
  * <p>
@@ -481,21 +483,13 @@ public class JMSMailQueue implements ManageableMailQueue, JMSSupport, MailPriori
         return JAMES_NEXT_DELIVERY + " <= " + System.currentTimeMillis() + " OR " + FORCE_DELIVERY + " = true";
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public long getSize() throws MailQueueException {
         QueueBrowser browser = null;
-        int size = 0;
         try {
             browser = session.createBrowser(queue);
-
-            Enumeration<Message> messages = browser.getEnumeration();
-
-            while (messages.hasMoreElements()) {
-                messages.nextElement();
-                size++;
-            }
-            return size;
+            Enumeration enumeration = browser.getEnumeration();
+            return Iterators.size(new EnumerationIterator(enumeration));
         } catch (Exception e) {
             LOGGER.error("Unable to get size of queue {}", queueName, e);
             throw new MailQueueException("Unable to get size of queue " + queueName, e);

--- a/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
+++ b/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
@@ -232,7 +232,6 @@ public class JMSMailQueue implements ManageableMailQueue, JMSSupport, MailPriori
             enqueuedMailsMetric.increment();
             mailQueueSize.increment();
         } catch (Exception e) {
-            rollback(session);
             throw new MailQueueException("Unable to enqueue mail " + mail, e);
         } finally {
             timeMetric.stopAndPublish();

--- a/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
+++ b/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
@@ -204,7 +204,7 @@ public class JMSMailQueue implements ManageableMailQueue, JMSSupport, MailPriori
 
                 if (message != null) {
                     mailQueueSize.decrement();
-                    return createMailQueueItem(connection, session, consumer, message);
+                    return createMailQueueItem(session, consumer, message);
                 } else {
                     session.commit();
                     closeConsumer(consumer);
@@ -473,9 +473,9 @@ public class JMSMailQueue implements ManageableMailQueue, JMSSupport, MailPriori
      * @throws JMSException
      * @throws MessagingException
      */
-    protected MailQueueItem createMailQueueItem(Connection connection, Session session, MessageConsumer consumer, Message message) throws JMSException, MessagingException {
+    protected MailQueueItem createMailQueueItem(Session session, MessageConsumer consumer, Message message) throws JMSException, MessagingException {
         final Mail mail = createMail(message);
-        JMSMailQueueItem jmsMailQueueItem = new JMSMailQueueItem(mail, connection, session, consumer);
+        JMSMailQueueItem jmsMailQueueItem = new JMSMailQueueItem(mail, session, consumer);
         return mailQueueItemDecoratorFactory.decorate(jmsMailQueueItem);
     }
 

--- a/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueueItem.java
+++ b/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueueItem.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.queue.jms;
 
-import javax.jms.Connection;
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
 import javax.jms.Session;
@@ -34,13 +33,11 @@ import org.apache.mailet.Mail;
 public class JMSMailQueueItem implements MailQueueItem {
 
     protected final Mail mail;
-    protected final Connection connection;
     protected final Session session;
     protected final MessageConsumer consumer;
 
-    public JMSMailQueueItem(Mail mail, Connection connection, Session session, MessageConsumer consumer) {
+    public JMSMailQueueItem(Mail mail, Session session, MessageConsumer consumer) {
         this.mail = mail;
-        this.connection = connection;
         this.session = session;
         this.consumer = consumer;
     }


### PR DESCRIPTION
This avoids the "not re-use" session anti-pattern mentioned in Artemis JMS client documentation, at least on the producer side.