### PR TITLE
Add metrics for SpamAssassin and Tika

### DIFF
--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/ElasticSearchIntegrationTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/ElasticSearchIntegrationTest.java
@@ -54,6 +54,7 @@ import org.apache.james.mailbox.tika.TikaConfiguration;
 import org.apache.james.mailbox.tika.TikaContainer;
 import org.apache.james.mailbox.tika.TikaHttpClientImpl;
 import org.apache.james.mailbox.tika.TikaTextExtractor;
+import org.apache.james.metrics.api.NoopMetricFactory;
 import org.elasticsearch.client.Client;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -81,7 +82,8 @@ public class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest
 
     @Override
     public void setUp() throws Exception {
-        textExtractor = new TikaTextExtractor(new TikaHttpClientImpl(TikaConfiguration.builder()
+        textExtractor = new TikaTextExtractor(new NoopMetricFactory(),
+            new TikaHttpClientImpl(TikaConfiguration.builder()
                 .host(tika.getIp())
                 .port(tika.getPort())
                 .timeoutInMillis(tika.getTimeoutInMillis())

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/IndexableMessageTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/IndexableMessageTest.java
@@ -46,6 +46,7 @@ import org.apache.james.mailbox.tika.TikaConfiguration;
 import org.apache.james.mailbox.tika.TikaContainer;
 import org.apache.james.mailbox.tika.TikaHttpClientImpl;
 import org.apache.james.mailbox.tika.TikaTextExtractor;
+import org.apache.james.metrics.api.NoopMetricFactory;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -64,7 +65,7 @@ public class IndexableMessageTest {
 
     @Before
     public void setUp() throws Exception {
-        textExtractor = new TikaTextExtractor(new TikaHttpClientImpl(TikaConfiguration.builder()
+        textExtractor = new TikaTextExtractor(new NoopMetricFactory(), new TikaHttpClientImpl(TikaConfiguration.builder()
                 .host(tika.getIp())
                 .port(tika.getPort())
                 .timeoutInMillis(tika.getTimeoutInMillis())

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/MessageToElasticSearchJsonTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/MessageToElasticSearchJsonTest.java
@@ -51,6 +51,7 @@ import org.apache.james.mailbox.tika.TikaConfiguration;
 import org.apache.james.mailbox.tika.TikaContainer;
 import org.apache.james.mailbox.tika.TikaHttpClientImpl;
 import org.apache.james.mailbox.tika.TikaTextExtractor;
+import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.james.util.ClassLoaderUtils;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -79,7 +80,7 @@ public class MessageToElasticSearchJsonTest {
 
     @Before
     public void setUp() throws Exception {
-        textExtractor = new TikaTextExtractor(new TikaHttpClientImpl(TikaConfiguration.builder()
+        textExtractor = new TikaTextExtractor(new NoopMetricFactory(), new TikaHttpClientImpl(TikaConfiguration.builder()
                 .host(tika.getIp())
                 .port(tika.getPort())
                 .timeoutInMillis(tika.getTimeoutInMillis())

--- a/mailbox/plugin/spamassassin/src/main/java/org/apache/james/mailbox/spamassassin/SpamAssassin.java
+++ b/mailbox/plugin/spamassassin/src/main/java/org/apache/james/mailbox/spamassassin/SpamAssassin.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.util.Host;
 import org.apache.james.util.scanner.SpamAssassinInvoker;
 
@@ -30,17 +31,19 @@ import com.github.fge.lambdas.Throwing;
 
 public class SpamAssassin {
 
+    private final MetricFactory metricFactory;
     private final SpamAssassinConfiguration spamAssassinConfiguration;
 
     @Inject
-    public SpamAssassin(SpamAssassinConfiguration spamAssassinConfiguration) {
+    public SpamAssassin(MetricFactory metricFactory, SpamAssassinConfiguration spamAssassinConfiguration) {
+        this.metricFactory = metricFactory;
         this.spamAssassinConfiguration = spamAssassinConfiguration;
     }
 
     public void learnSpam(List<InputStream> messages, String user) {
         if (spamAssassinConfiguration.isEnable()) {
             Host host = spamAssassinConfiguration.getHost().get();
-            SpamAssassinInvoker invoker = new SpamAssassinInvoker(host.getHostName(), host.getPort());
+            SpamAssassinInvoker invoker = new SpamAssassinInvoker(metricFactory, host.getHostName(), host.getPort());
             messages
                 .forEach(Throwing.consumer(message -> invoker.learnAsSpam(message, user)));
         }
@@ -49,7 +52,7 @@ public class SpamAssassin {
     public void learnHam(List<InputStream> messages, String user) {
         if (spamAssassinConfiguration.isEnable()) {
             Host host = spamAssassinConfiguration.getHost().get();
-            SpamAssassinInvoker invoker = new SpamAssassinInvoker(host.getHostName(), host.getPort());
+            SpamAssassinInvoker invoker = new SpamAssassinInvoker(metricFactory, host.getHostName(), host.getPort());
             messages
                 .forEach(Throwing.consumer(message -> invoker.learnAsHam(message, user)));
         }

--- a/mailbox/tika/pom.xml
+++ b/mailbox/tika/pom.xml
@@ -43,6 +43,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>metrics-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/TikaTextExtractor.java
+++ b/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/TikaTextExtractor.java
@@ -76,11 +76,13 @@ public class TikaTextExtractor implements TextExtractor {
     @Override
     public ParsedContent extractContent(InputStream inputStream, String contentType) throws Exception {
         return metricFactory.withMetric("tikaTextExtraction", Throwing.supplier(
-            () -> {
-                ContentAndMetadata contentAndMetadata = convert(tikaHttpClient.recursiveMetaDataAsJson(inputStream, contentType));
-                return new ParsedContent(contentAndMetadata.getContent(), contentAndMetadata.getMetadata());
-            })
+            () -> performContentExtraction(inputStream, contentType))
             .sneakyThrow());
+    }
+
+    public ParsedContent performContentExtraction(InputStream inputStream, String contentType) throws IOException {
+        ContentAndMetadata contentAndMetadata = convert(tikaHttpClient.recursiveMetaDataAsJson(inputStream, contentType));
+        return new ParsedContent(contentAndMetadata.getContent(), contentAndMetadata.getMetadata());
     }
 
     private ContentAndMetadata convert(InputStream json) throws IOException, JsonParseException, JsonMappingException {

--- a/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/TikaTextExtractor.java
+++ b/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/TikaTextExtractor.java
@@ -32,6 +32,7 @@ import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.james.mailbox.extractor.ParsedContent;
 import org.apache.james.mailbox.extractor.TextExtractor;
+import org.apache.james.metrics.api.MetricFactory;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
@@ -44,6 +45,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.fge.lambdas.Throwing;
 import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
@@ -52,11 +54,13 @@ import com.google.common.collect.ImmutableList;
 
 public class TikaTextExtractor implements TextExtractor {
 
+    private final MetricFactory metricFactory;
     private final TikaHttpClient tikaHttpClient;
     private final ObjectMapper objectMapper;
 
     @Inject
-    public TikaTextExtractor(TikaHttpClient tikaHttpClient) {
+    public TikaTextExtractor(MetricFactory metricFactory, TikaHttpClient tikaHttpClient) {
+        this.metricFactory = metricFactory;
         this.tikaHttpClient = tikaHttpClient;
         this.objectMapper = initializeObjectMapper();
     }
@@ -71,8 +75,12 @@ public class TikaTextExtractor implements TextExtractor {
 
     @Override
     public ParsedContent extractContent(InputStream inputStream, String contentType) throws Exception {
-        ContentAndMetadata contentAndMetadata = convert(tikaHttpClient.recursiveMetaDataAsJson(inputStream, contentType));
-        return new ParsedContent(contentAndMetadata.getContent(), contentAndMetadata.getMetadata());
+        return metricFactory.withMetric("tikaTextExtraction", Throwing.supplier(
+            () -> {
+                ContentAndMetadata contentAndMetadata = convert(tikaHttpClient.recursiveMetaDataAsJson(inputStream, contentType));
+                return new ParsedContent(contentAndMetadata.getContent(), contentAndMetadata.getMetadata());
+            })
+            .sneakyThrow());
     }
 
     private ContentAndMetadata convert(InputStream json) throws IOException, JsonParseException, JsonMappingException {

--- a/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/TikaTextExtractorTest.java
+++ b/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/TikaTextExtractorTest.java
@@ -32,6 +32,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.james.mailbox.extractor.ParsedContent;
 import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mailbox.tika.TikaTextExtractor.ContentAndMetadataDeserializer;
+import org.apache.james.metrics.api.NoopMetricFactory;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -54,7 +55,7 @@ public class TikaTextExtractorTest {
 
     @Before
     public void setUp() throws Exception {
-        textExtractor = new TikaTextExtractor(new TikaHttpClientImpl(TikaConfiguration.builder()
+        textExtractor = new TikaTextExtractor(new NoopMetricFactory(), new TikaHttpClientImpl(TikaConfiguration.builder()
                 .host(tika.getIp())
                 .port(tika.getPort())
                 .timeoutInMillis(tika.getTimeoutInMillis())
@@ -156,7 +157,7 @@ public class TikaTextExtractorTest {
     @Test
     public void deserializerShouldNotThrowWhenMoreThanOneNode() throws Exception {
         TikaTextExtractor textExtractor = new TikaTextExtractor(
-            (inputStream, contentType) -> new ByteArrayInputStream(("[{\"X-TIKA:content\": \"This is an awesome LibreOffice document !\"}, " +
+            new NoopMetricFactory(), (inputStream, contentType) -> new ByteArrayInputStream(("[{\"X-TIKA:content\": \"This is an awesome LibreOffice document !\"}, " +
                 "{\"Chroma BlackIsZero\": \"true\"}]").getBytes(StandardCharsets.UTF_8)));
 
         InputStream inputStream = null;
@@ -167,7 +168,7 @@ public class TikaTextExtractorTest {
     public void deserializerShouldTakeFirstNodeWhenSeveral() throws Exception {
         String expectedExtractedContent = "content A";
         TikaTextExtractor textExtractor = new TikaTextExtractor(
-            (inputStream, contentType) -> new ByteArrayInputStream(("[{\"X-TIKA:content\": \"" + expectedExtractedContent + "\"}, " +
+            new NoopMetricFactory(), (inputStream, contentType) -> new ByteArrayInputStream(("[{\"X-TIKA:content\": \"" + expectedExtractedContent + "\"}, " +
                 "{\"X-TIKA:content\": \"content B\"}]").getBytes(StandardCharsets.UTF_8)));
 
         InputStream inputStream = null;
@@ -182,7 +183,7 @@ public class TikaTextExtractorTest {
         expectedException.expectMessage("The element should be a Json object");
 
         TikaTextExtractor textExtractor = new TikaTextExtractor(
-            (inputStream, contentType) -> new ByteArrayInputStream("[\"value1\"]".getBytes(StandardCharsets.UTF_8)));
+            new NoopMetricFactory(), (inputStream, contentType) -> new ByteArrayInputStream("[\"value1\"]".getBytes(StandardCharsets.UTF_8)));
 
         InputStream inputStream = null;
         textExtractor.extractContent(inputStream, "text/plain");

--- a/server/container/guice/mailbox-plugin-spamassassin/src/main/java/org/apache/james/modules/spamassassin/SpamAssassinListenerModule.java
+++ b/server/container/guice/mailbox-plugin-spamassassin/src/main/java/org/apache/james/modules/spamassassin/SpamAssassinListenerModule.java
@@ -42,6 +42,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
+import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 
 public class SpamAssassinListenerModule extends AbstractModule {
@@ -51,6 +52,8 @@ public class SpamAssassinListenerModule extends AbstractModule {
 
     @Override
     protected void configure() {
+        bind(SpamAssassinListener.class).in(Scopes.SINGLETON);
+
         Multibinder.newSetBinder(binder(), ConfigurationPerformer.class).addBinding().to(SpamAssassinListenerConfigurationPerformer.class);
     }
     

--- a/server/container/guice/mailbox-plugin-spamassassin/src/main/java/org/apache/james/modules/spamassassin/SpamAssassinListenerModule.java
+++ b/server/container/guice/mailbox-plugin-spamassassin/src/main/java/org/apache/james/modules/spamassassin/SpamAssassinListenerModule.java
@@ -29,10 +29,8 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.james.lifecycle.api.Configurable;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.exception.MailboxException;
-import org.apache.james.mailbox.spamassassin.SpamAssassin;
 import org.apache.james.mailbox.spamassassin.SpamAssassinConfiguration;
 import org.apache.james.mailbox.spamassassin.SpamAssassinListener;
-import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.apache.james.utils.ConfigurationPerformer;
 import org.apache.james.utils.PropertiesProvider;
@@ -58,24 +56,19 @@ public class SpamAssassinListenerModule extends AbstractModule {
     
     @Singleton
     public static class SpamAssassinListenerConfigurationPerformer implements ConfigurationPerformer {
-
-        private final SpamAssassinConfiguration spamAssassinConfiguration;
+        private final SpamAssassinListener spamAssassinListener;
         private final StoreMailboxManager storeMailboxManager;
-        private final MailboxSessionMapperFactory mapperFactory;
 
         @Inject
-        public SpamAssassinListenerConfigurationPerformer(SpamAssassinConfiguration spamAssassinConfiguration,
-                                                          StoreMailboxManager storeMailboxManager,
-                                                          MailboxSessionMapperFactory mapperFactory) {
-            this.spamAssassinConfiguration = spamAssassinConfiguration;
+        public SpamAssassinListenerConfigurationPerformer(SpamAssassinListener spamAssassinListener,
+                                                          StoreMailboxManager storeMailboxManager) {
+            this.spamAssassinListener = spamAssassinListener;
             this.storeMailboxManager = storeMailboxManager;
-            this.mapperFactory = mapperFactory;
         }
 
         @Override
         public void initModule() {
             try {
-                SpamAssassinListener spamAssassinListener = new SpamAssassinListener(new SpamAssassin(spamAssassinConfiguration), mapperFactory);
                 MailboxSession session = null;
                 storeMailboxManager.addGlobalListener(spamAssassinListener, session);
             } catch (MailboxException e) {

--- a/server/container/util/pom.xml
+++ b/server/container/util/pom.xml
@@ -40,6 +40,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>metrics-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/server/container/util/src/test/java/org/apache/james/util/scanner/SpamAssassinInvokerTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/scanner/SpamAssassinInvokerTest.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 
 import javax.mail.internet.MimeMessage;
 
+import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.james.util.MimeMessageUtil;
 import org.apache.james.util.scanner.SpamAssassinExtension.SpamAssassin;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,7 +42,7 @@ public class SpamAssassinInvokerTest {
     @BeforeEach
     public void setup(SpamAssassin spamAssassin) throws Exception {
         this.spamAssassin = spamAssassin;
-        testee = new SpamAssassinInvoker(spamAssassin.getIp(), spamAssassin.getBindingPort());
+        testee = new SpamAssassinInvoker(new NoopMetricFactory(), spamAssassin.getIp(), spamAssassin.getBindingPort());
     }
 
     @Test

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/SpamAssassin.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/SpamAssassin.java
@@ -26,6 +26,7 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.UsersRepositoryException;
 import org.apache.james.util.Port;
@@ -69,13 +70,15 @@ public class SpamAssassin extends GenericMailet {
     public static final String DEFAULT_HOST = "127.0.0.1";
     public static final int DEFAULT_PORT = 783;
 
+    private final MetricFactory metricFactory;
     private final UsersRepository usersRepository;
 
     private String spamdHost;
     private int spamdPort;
 
     @Inject
-    public SpamAssassin(UsersRepository usersRepository) {
+    public SpamAssassin(MetricFactory metricFactory, UsersRepository usersRepository) {
+        this.metricFactory = metricFactory;
         this.usersRepository = usersRepository;
     }
 
@@ -94,7 +97,7 @@ public class SpamAssassin extends GenericMailet {
         MimeMessage message = mail.getMessage();
 
         // Invoke SpamAssassin connection and scan the message
-        SpamAssassinInvoker sa = new SpamAssassinInvoker(spamdHost, spamdPort);
+        SpamAssassinInvoker sa = new SpamAssassinInvoker(metricFactory, spamdHost, spamdPort);
         mail.getRecipients()
             .forEach(
                 Throwing.consumer((MailAddress recipient) -> querySpamAssassin(mail, message, sa, recipient))

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/SpamAssassinTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/SpamAssassinTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import javax.mail.MessagingException;
 
 import org.apache.james.core.builder.MimeMessageBuilder;
+import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.james.user.memory.MemoryUsersRepository;
 import org.apache.james.util.Port;
 import org.apache.james.util.scanner.SpamAssassinResult;
@@ -41,7 +42,7 @@ public class SpamAssassinTest {
     @Rule
     public MockSpamdTestRule spamd = new MockSpamdTestRule();
 
-    private SpamAssassin mailet = new SpamAssassin(MemoryUsersRepository.withVirtualHosting());
+    private SpamAssassin mailet = new SpamAssassin(new NoopMetricFactory(), MemoryUsersRepository.withVirtualHosting());
 
     @Test
     public void initShouldSetDefaultSpamdHostWhenNone() throws Exception {

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SpamAssassinHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SpamAssassinHandlerTest.java
@@ -27,6 +27,7 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
 import org.apache.james.core.builder.MimeMessageBuilder;
+import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.hook.HookResult;
 import org.apache.james.protocols.smtp.hook.HookReturnCode;
@@ -111,7 +112,7 @@ public class SpamAssassinHandlerTest {
     public void testNonSpam() throws Exception {
         SMTPSession session = setupMockedSMTPSession(setupMockedMail(setupMockedMimeMessage("test")));
 
-        SpamAssassinHandler handler = new SpamAssassinHandler();
+        SpamAssassinHandler handler = new SpamAssassinHandler(new NoopMetricFactory());
 
         handler.setSpamdHost(SPAMD_HOST);
         handler.setSpamdPort(spamd.getPort());
@@ -128,7 +129,7 @@ public class SpamAssassinHandlerTest {
     public void testSpam() throws Exception {
         SMTPSession session = setupMockedSMTPSession(setupMockedMail(setupMockedMimeMessage(MockSpamd.GTUBE)));
 
-        SpamAssassinHandler handler = new SpamAssassinHandler();
+        SpamAssassinHandler handler = new SpamAssassinHandler(new NoopMetricFactory());
 
         handler.setSpamdHost(SPAMD_HOST);
         handler.setSpamdPort(spamd.getPort());
@@ -144,7 +145,7 @@ public class SpamAssassinHandlerTest {
     public void testSpamReject() throws Exception {
         SMTPSession session = setupMockedSMTPSession(setupMockedMail(setupMockedMimeMessage(MockSpamd.GTUBE)));
 
-        SpamAssassinHandler handler = new SpamAssassinHandler();
+        SpamAssassinHandler handler = new SpamAssassinHandler(new NoopMetricFactory());
 
         handler.setSpamdHost(SPAMD_HOST);
         handler.setSpamdPort(spamd.getPort());


### PR DESCRIPTION
We suspect high delays upon message reception and message moving to be due to Tika and SpamAssassin that we recently added to our set up.

I order to confirm such a hypothesis, we need additional metrics on these two components. I added this as part of this pull request.