### PR TITLE
JAMES-2355 Add a missing setenv directive in Spring wiring APP

### DIFF
--- a/server/app/pom.xml
+++ b/server/app/pom.xml
@@ -829,6 +829,7 @@
                                 <!-- this is needed because appassembler is not really smart on some settings -->
                                 <replace file="${project.build.directory}/appassembler/jsw/james/conf/wrapper.conf" token="lib/wrapper.jar" value="%REPO_DIR%/wrapper.jar" />
                                 <replace file="${project.build.directory}/appassembler/jsw/james/bin/james" token="logs" value="var" />
+                                <replace file="${project.build.directory}/appassembler/jsw/james/bin/james" token="setenv" value="setenv.sh" />
 
                                 <!-- copy the linux wrapper-linux-x86-32 to wrapper, so use it as default if no matching wrapper was found -->
                                 <copy file="${project.build.directory}/appassembler/jsw/james/bin/wrapper-linux-x86-32" tofile="${project.build.directory}/appassembler/jsw/james/bin/wrapper" />

--- a/server/app/src/main/app/bin/setenv.bat
+++ b/server/app/src/main/app/bin/setenv.bat
@@ -1,5 +1,5 @@
 @REM ----------------------------------------------------------------------------
-@REM Copyright 2001-2010 The Apache Software Foundation.
+@REM Copyright 2001-2018 The Apache Software Foundation.
 @REM
 @REM Licensed under the Apache License, Version 2.0 (the "License");
 @REM you may not use this file except in compliance with the License.
@@ -15,5 +15,17 @@
 @REM ----------------------------------------------------------------------------
 @REM
 
+@REM   This file is sourced (using 'CALL') by the various start scripts. 
+@REM   You can use it to add extra environment variables to the startup 
+@REM   procedure.
+@REM   
+@REM   NOTE:  Instead of changing this file it is better to create a new file
+@REM          named setenv.bat in the ../conf directory as the files in the
+@REM          bin directory should generally not be changed.
+
+
 @REM Add every needed extra jar to this 
-set CLASSPATH_PREFIX=../conf/lib/*
+set CLASSPATH_PREFIX=..\conf\lib\*
+
+
+if exist "%BASEDIR%\conf\setenv.bat" call "%BASEDIR%\conf\setenv.bat"

--- a/server/app/src/main/app/bin/setenv.sh
+++ b/server/app/src/main/app/bin/setenv.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # ----------------------------------------------------------------------------
-# Copyright 2001-2010 The Apache Software Foundation.
+# Copyright 2001-2018 The Apache Software Foundation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,15 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 #
+# This file is sourced by the various start scripts. You can use it to
+# add extra environment variables to the startup procedure.
+#
+#   NOTE:  Instead of changing this file it is better to create a file
+#          named setenv.sh in the ../conf directory as the files in the
+#          bin directory should generally not be changed.
+
 # Add every needed extra jar to this
 CLASSPATH_PREFIX=../conf/lib/*
 export CLASSPATH_PREFIX
+
+[ -f "$BASEDIR"/conf/setenv.sh ] && . "$BASEDIR"/conf/setenv.sh

--- a/server/app/src/main/resources/setenv.sh
+++ b/server/app/src/main/resources/setenv.sh
@@ -1,0 +1,18 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+# In this script, one can define environment variables to run James server with in UNIX environment

--- a/server/app/src/main/resources/setenv.sh
+++ b/server/app/src/main/resources/setenv.sh
@@ -16,3 +16,7 @@
 #  under the License.
 
 # In this script, one can define environment variables to run James server with in UNIX environment
+
+# This example shows you how you can, for instance, add specific folders to your CLASSPATH_PREFIX
+# 
+# export CLASSPATH_PREFIX=$CLASSPATH_PREFIX:/my/new/classpath/


### PR DESCRIPTION
`james` runnable was sourcing environment from `setenv` while the existing file is `setenv.sh`

The problem had been spotted and investigated by [phansson]. He also provided this patch.