### PR TITLE
JAMES-2369 Relax PortTest assertion

### DIFF
--- a/server/container/util-java8/src/test/java/org/apache/james/util/PortTest.java
+++ b/server/container/util-java8/src/test/java/org/apache/james/util/PortTest.java
@@ -86,7 +86,7 @@ public class PortTest {
     @Test
     public void generateValidUnprivilegedPortShouldReturnAValidPort() {
         assertThat(Port.generateValidUnprivilegedPort())
-            .isStrictlyBetween(Port.PRIVILEGED_PORT_BOUND, Port.MAX_PORT_VALUE);
+            .isBetween(Port.PRIVILEGED_PORT_BOUND, Port.MAX_PORT_VALUE);
     }
 
 }


### PR DESCRIPTION
1024 is the first valid unprivileged port
65535 the last

Both values should be accepted.

Test failure at the origin of that PR:

```
[875f21caab5cd150b415ed19c674a2dffb431862] Failed tests: 
[875f21caab5cd150b415ed19c674a2dffb431862]   PortTest.generateValidUnprivilegedPortShouldReturnAValidPort:89 
[875f21caab5cd150b415ed19c674a2dffb431862] Expecting:
[875f21caab5cd150b415ed19c674a2dffb431862]  <1024>
[875f21caab5cd150b415ed19c674a2dffb431862] to be between:
[875f21caab5cd150b415ed19c674a2dffb431862]  ]1024, 65535[
```