### PR TITLE
JAMES-1854 Better manage virtual hosting

### DIFF
--- a/mailet/crypto/src/main/java/org/apache/james/transport/mailets/AbstractSign.java
+++ b/mailet/crypto/src/main/java/org/apache/james/transport/mailets/AbstractSign.java
@@ -605,10 +605,7 @@ public abstract class AbstractSign extends GenericMailet {
 
     private String getUsername(MailAddress mailAddress) {
         try {
-            if (usersRepository.supportVirtualHosting()) {
-                return mailAddress.asString();
-            }
-            return mailAddress.getLocalPart();
+            return usersRepository.getUser(mailAddress);
         } catch (UsersRepositoryException e) {
             throw Throwables.propagate(e);
         }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
@@ -47,15 +47,7 @@ public abstract class AbstractSenderAuthIdentifyVerificationRcptHook implements 
             String authUser = (session.getUser()).toLowerCase(Locale.US);
             MailAddress senderAddress = (MailAddress) session.getAttachment(
                     SMTPSession.SENDER, ProtocolSession.State.Transaction);
-            String username = null;
-
-            if (senderAddress != null && !sender.isNullSender()) {
-                if (useVirtualHosting()) {
-                    username = senderAddress.asString();
-                } else {
-                    username = senderAddress.getLocalPart();
-                }
-            }
+            String username = retrieveSender(sender, senderAddress);
             
             // Check if the sender address is the same as the user which was used to authenticate.
             // Its important to ignore case here to fix JAMES-837. This is save todo because if the handler is called
@@ -68,8 +60,14 @@ public abstract class AbstractSenderAuthIdentifyVerificationRcptHook implements 
         }
         return HookResult.declined();
     }
-    
-    
+
+    public String retrieveSender(MailAddress sender, MailAddress senderAddress) {
+        if (senderAddress != null && !sender.isNullSender()) {
+            return getUser(senderAddress);
+        }
+        return null;
+    }
+
     /**
      * Return true if the given domain is a local domain for this server
      * 
@@ -84,6 +82,6 @@ public abstract class AbstractSenderAuthIdentifyVerificationRcptHook implements 
      * 
      * @return useVirtualHosting
      */
-    protected abstract boolean useVirtualHosting();
+    protected abstract String getUser(MailAddress mailAddress);
 
 }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
@@ -77,10 +77,9 @@ public abstract class AbstractSenderAuthIdentifyVerificationRcptHook implements 
     protected abstract boolean isLocalDomain(Domain domain);
     
     /**
-     * Return true if virtualHosting should get used. If so the full email address will get used to 
-     * match against the supplied auth username
+     * Return the username corresponding to the given mail address.
      * 
-     * @return useVirtualHosting
+     * @return username corresponding to the mail address
      */
     protected abstract String getUser(MailAddress mailAddress);
 

--- a/server/data/data-api/src/main/java/org/apache/james/user/api/UsersRepository.java
+++ b/server/data/data-api/src/main/java/org/apache/james/user/api/UsersRepository.java
@@ -138,13 +138,9 @@ public interface UsersRepository {
     String getUser(MailAddress mailAddress) throws UsersRepositoryException;
 
     /**
-     * Returns one of the possible mail address to be used to send a mail to that user
+     * Returns one of the possible mail addresses to be used to send a mail to that user
      *
-     * This makes sense as it handles virtual-hosting logics.
-     *
-     * @param user The user parameter
-     * @return A mail address corresponding to this user
-     * @throws UsersRepositoryException upon exceptions
+     * This makes sense as it handles virtual-hosting logic.
      */
     MailAddress getMailAddressFor(org.apache.james.core.User user) throws UsersRepositoryException;
     

--- a/server/data/data-api/src/main/java/org/apache/james/user/api/UsersRepository.java
+++ b/server/data/data-api/src/main/java/org/apache/james/user/api/UsersRepository.java
@@ -136,6 +136,17 @@ public interface UsersRepository {
      * @throws UsersRepositoryException
      */
     String getUser(MailAddress mailAddress) throws UsersRepositoryException;
+
+    /**
+     * Returns one of the possible mail address to be used to send a mail to that user
+     *
+     * This makes sens as it handles virtual-hosting logics.
+     *
+     * @param user The user parameter
+     * @return A mail address corresponding to this user
+     * @throws UsersRepositoryException upon exceptions
+     */
+    MailAddress getMailAddressFor(org.apache.james.core.User user) throws UsersRepositoryException;
     
     /**
      * Return true if the user is an admin for this repository

--- a/server/data/data-api/src/main/java/org/apache/james/user/api/UsersRepository.java
+++ b/server/data/data-api/src/main/java/org/apache/james/user/api/UsersRepository.java
@@ -140,7 +140,7 @@ public interface UsersRepository {
     /**
      * Returns one of the possible mail address to be used to send a mail to that user
      *
-     * This makes sens as it handles virtual-hosting logics.
+     * This makes sense as it handles virtual-hosting logics.
      *
      * @param user The user parameter
      * @return A mail address corresponding to this user

--- a/server/data/data-ldap-integration-testing/pom.xml
+++ b/server/data/data-ldap-integration-testing/pom.xml
@@ -70,6 +70,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>

--- a/server/data/data-ldap-integration-testing/src/test/java/org/apache/james/user/ldap/ReadOnlyUsersLDAPRepositoryTest.java
+++ b/server/data/data-ldap-integration-testing/src/test/java/org/apache/james/user/ldap/ReadOnlyUsersLDAPRepositoryTest.java
@@ -19,11 +19,12 @@
 package org.apache.james.user.ldap;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
-import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.commons.configuration.plist.PropertyListConfiguration;
 import org.apache.james.core.MailAddress;
+import org.apache.james.domainlist.api.DomainList;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,10 +44,12 @@ public class ReadOnlyUsersLDAPRepositoryTest {
 
     private LdapGenericContainer ldapContainer;
     private ReadOnlyUsersLDAPRepository ldapRepository;
+    private DomainList domainList;
 
     @Before
-    public void setup() throws Exception {
+    public void setup() {
         startLdapContainer();
+        domainList = mock(DomainList.class);
     }
 
     private void startLdapContainer() {
@@ -57,13 +60,13 @@ public class ReadOnlyUsersLDAPRepositoryTest {
         ldapContainer.start();
     }
 
-    private void startUsersRepository(HierarchicalConfiguration ldapRepositoryConfiguration) throws ConfigurationException, Exception {
-        ldapRepository = new ReadOnlyUsersLDAPRepository();
+    private void startUsersRepository(HierarchicalConfiguration ldapRepositoryConfiguration) throws Exception {
+        ldapRepository = new ReadOnlyUsersLDAPRepository(domainList);
         ldapRepository.configure(ldapRepositoryConfiguration);
         ldapRepository.init();
     }
 
-    private HierarchicalConfiguration ldapRepositoryConfiguration() throws ConfigurationException {
+    private HierarchicalConfiguration ldapRepositoryConfiguration() {
         PropertyListConfiguration configuration = new PropertyListConfiguration();
         configuration.addProperty("[@ldapHost]", ldapContainer.getLdapHost());
         configuration.addProperty("[@principal]", "cn=admin\\,dc=james\\,dc=org");
@@ -78,7 +81,7 @@ public class ReadOnlyUsersLDAPRepositoryTest {
         return configuration;
     }
 
-    private HierarchicalConfiguration ldapRepositoryConfigurationWithVirtualHosting() throws ConfigurationException {
+    private HierarchicalConfiguration ldapRepositoryConfigurationWithVirtualHosting() {
         PropertyListConfiguration configuration = new PropertyListConfiguration();
         configuration.addProperty("[@ldapHost]", ldapContainer.getLdapHost());
         configuration.addProperty("[@principal]", "cn=admin\\,dc=james\\,dc=org");

--- a/server/data/data-ldap/pom.xml
+++ b/server/data/data-ldap/pom.xml
@@ -71,6 +71,11 @@
             <artifactId>assertj-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>

--- a/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/ReadOnlyUsersLDAPRepository.java
+++ b/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/ReadOnlyUsersLDAPRepository.java
@@ -342,11 +342,6 @@ public class ReadOnlyUsersLDAPRepository implements UsersRepository, Configurabl
 
     private final DomainList domainList;
 
-    /**
-     * Creates a new instance of ReadOnlyUsersLDAPRepository.
-     *
-     * @param domainList
-     */
     @Inject
     public ReadOnlyUsersLDAPRepository(DomainList domainList) {
         super();
@@ -794,12 +789,12 @@ public class ReadOnlyUsersLDAPRepository implements UsersRepository, Configurabl
 
 
     @Override
-    public MailAddress getMailAddressFor(org.apache.james.user.api.model.User user) throws UsersRepositoryException {
+    public MailAddress getMailAddressFor(org.apache.james.core.User user) throws UsersRepositoryException {
         try {
             if (supportVirtualHosting()) {
-                return new MailAddress(user.getUserName());
+                return new MailAddress(user.asString());
             }
-            return new MailAddress(user.getUserName(), domainList.getDefaultDomain());
+            return new MailAddress(user.getLocalPart(), domainList.getDefaultDomain());
         } catch (Exception e) {
             throw new UsersRepositoryException("Failed to compute mail address associated with the user", e);
         }

--- a/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/ReadOnlyUsersLDAPRepository.java
+++ b/server/data/data-ldap/src/main/java/org/apache/james/user/ldap/ReadOnlyUsersLDAPRepository.java
@@ -30,6 +30,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import javax.annotation.PostConstruct;
+import javax.inject.Inject;
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
@@ -45,6 +46,7 @@ import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.commons.lang.StringUtils;
 import org.apache.directory.api.ldap.model.filter.FilterEncoder;
 import org.apache.james.core.MailAddress;
+import org.apache.james.domainlist.api.DomainList;
 import org.apache.james.lifecycle.api.Configurable;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.UsersRepositoryException;
@@ -338,12 +340,17 @@ public class ReadOnlyUsersLDAPRepository implements UsersRepository, Configurabl
     // retries.
     private int maxRetries = 0;
 
+    private final DomainList domainList;
+
     /**
      * Creates a new instance of ReadOnlyUsersLDAPRepository.
      *
+     * @param domainList
      */
-    public ReadOnlyUsersLDAPRepository() {
+    @Inject
+    public ReadOnlyUsersLDAPRepository(DomainList domainList) {
         super();
+        this.domainList = domainList;
     }
 
     /**
@@ -783,5 +790,18 @@ public class ReadOnlyUsersLDAPRepository implements UsersRepository, Configurabl
     @Override
     public boolean isReadOnly() {
         return true;
+    }
+
+
+    @Override
+    public MailAddress getMailAddressFor(org.apache.james.user.api.model.User user) throws UsersRepositoryException {
+        try {
+            if (supportVirtualHosting()) {
+                return new MailAddress(user.getUserName());
+            }
+            return new MailAddress(user.getUserName(), domainList.getDefaultDomain());
+        } catch (Exception e) {
+            throw new UsersRepositoryException("Failed to compute mail address associated with the user", e);
+        }
     }
 }

--- a/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/ReadOnlyUsersLDAPRepositoryTest.java
+++ b/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/ReadOnlyUsersLDAPRepositoryTest.java
@@ -20,11 +20,14 @@
 package org.apache.james.user.ldap;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.ConversionException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.commons.configuration.plist.PropertyListConfiguration;
+import org.apache.james.domainlist.api.DomainList;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -33,10 +36,16 @@ public class ReadOnlyUsersLDAPRepositoryTest {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+    private DomainList domainList;
+
+    @Before
+    public void setUp() {
+        domainList = mock(DomainList.class);
+    }
 
     @Test
     public void supportVirtualHostingShouldReturnFalseByDefault() throws Exception {
-        ReadOnlyUsersLDAPRepository usersLDAPRepository = new ReadOnlyUsersLDAPRepository();
+        ReadOnlyUsersLDAPRepository usersLDAPRepository = new ReadOnlyUsersLDAPRepository(domainList);
         usersLDAPRepository.configure(ldapRepositoryConfiguration());
 
         assertThat(usersLDAPRepository.supportVirtualHosting()).isFalse();
@@ -47,7 +56,7 @@ public class ReadOnlyUsersLDAPRepositoryTest {
         HierarchicalConfiguration configuration = ldapRepositoryConfiguration();
         configuration.addProperty(ReadOnlyUsersLDAPRepository.SUPPORTS_VIRTUAL_HOSTING, "true");
 
-        ReadOnlyUsersLDAPRepository usersLDAPRepository = new ReadOnlyUsersLDAPRepository();
+        ReadOnlyUsersLDAPRepository usersLDAPRepository = new ReadOnlyUsersLDAPRepository(domainList);
         usersLDAPRepository.configure(configuration);
 
         assertThat(usersLDAPRepository.supportVirtualHosting()).isTrue();
@@ -58,7 +67,7 @@ public class ReadOnlyUsersLDAPRepositoryTest {
         HierarchicalConfiguration configuration = ldapRepositoryConfiguration();
         configuration.addProperty(ReadOnlyUsersLDAPRepository.SUPPORTS_VIRTUAL_HOSTING, "false");
 
-        ReadOnlyUsersLDAPRepository usersLDAPRepository = new ReadOnlyUsersLDAPRepository();
+        ReadOnlyUsersLDAPRepository usersLDAPRepository = new ReadOnlyUsersLDAPRepository(domainList);
         usersLDAPRepository.configure(configuration);
 
         assertThat(usersLDAPRepository.supportVirtualHosting()).isFalse();
@@ -69,7 +78,7 @@ public class ReadOnlyUsersLDAPRepositoryTest {
         HierarchicalConfiguration configuration = ldapRepositoryConfiguration();
         configuration.addProperty(ReadOnlyUsersLDAPRepository.SUPPORTS_VIRTUAL_HOSTING, "bad");
 
-        ReadOnlyUsersLDAPRepository usersLDAPRepository = new ReadOnlyUsersLDAPRepository();
+        ReadOnlyUsersLDAPRepository usersLDAPRepository = new ReadOnlyUsersLDAPRepository(domainList);
 
         expectedException.expect(ConversionException.class);
 

--- a/server/data/data-library/src/main/java/org/apache/james/user/lib/AbstractUsersRepository.java
+++ b/server/data/data-library/src/main/java/org/apache/james/user/lib/AbstractUsersRepository.java
@@ -144,4 +144,16 @@ public abstract class AbstractUsersRepository implements UsersRepository, Config
     public boolean isReadOnly() {
         return false;
     }
+
+    @Override
+    public MailAddress getMailAddressFor(User user) throws UsersRepositoryException {
+        try {
+            if (supportVirtualHosting()) {
+                return new MailAddress(user.asString());
+            }
+            return new MailAddress(user.getLocalPart(), domainList.getDefaultDomain());
+        } catch (Exception e) {
+            throw new UsersRepositoryException("Failed to compute mail address associated with the user", e);
+        }
+    }
 }

--- a/server/data/data-library/src/test/java/org/apache/james/domainlist/api/mock/SimpleDomainList.java
+++ b/server/data/data-library/src/test/java/org/apache/james/domainlist/api/mock/SimpleDomainList.java
@@ -35,12 +35,12 @@ public class SimpleDomainList implements DomainList {
     private final List<Domain> domains = new LinkedList<>();
 
     @Override
-    public boolean containsDomain(Domain domain) throws DomainListException {
+    public boolean containsDomain(Domain domain) {
         return domains.contains(domain);
     }
 
     @Override
-    public List<Domain> getDomains() throws DomainListException {
+    public List<Domain> getDomains() {
         return ImmutableList.copyOf(domains);
     }
 

--- a/server/protocols/protocols-lmtp/src/main/java/org/apache/james/lmtpserver/hook/MailboxDeliverToRecipientHandler.java
+++ b/server/protocols/protocols-lmtp/src/main/java/org/apache/james/lmtpserver/hook/MailboxDeliverToRecipientHandler.java
@@ -69,16 +69,10 @@ public class MailboxDeliverToRecipientHandler implements DeliverToRecipientHook 
     
     @Override
     public HookResult deliver(SMTPSession session, MailAddress recipient, MailEnvelope envelope) {
-        String username;
         HookResult result;
 
         try {
-
-            if (users.supportVirtualHosting()) {
-                username = recipient.toString();
-            } else {
-                username = recipient.getLocalPart();
-            }
+            String username = users.getUser(recipient);
 
             MailboxSession mailboxSession = mailboxManager.createSystemSession(username);
             MailboxPath inbox = MailboxPath.inbox(mailboxSession);

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SenderAuthIdentifyVerificationRcptHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SenderAuthIdentifyVerificationRcptHook.java
@@ -83,12 +83,12 @@ public class SenderAuthIdentifyVerificationRcptHook extends AbstractSenderAuthId
     }
 
     @Override
-    protected boolean useVirtualHosting() {
+    protected String getUser(MailAddress mailAddress) {
         try {
-            return users.supportVirtualHosting();
+            return users.getUser(mailAddress);
         } catch (UsersRepositoryException e) {
             throw Throwables.propagate(e);
         }
     }
-    
+
 }

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptHandler.java
@@ -94,15 +94,10 @@ public class ValidRcptHandler extends AbstractValidRcptHandler implements Protoc
 
     @Override
     protected boolean isValidRecipient(SMTPSession session, MailAddress recipient) {
-
-        String username = recipient.toString();
-
         // check if the server use virtualhosting, if not use only the localpart
         // as username
         try {
-            if (!users.supportVirtualHosting()) {
-                username = recipient.getLocalPart();
-            }
+            String username = users.getUser(recipient);
 
             if (users.contains(username)) {
                 return true;


### PR DESCRIPTION
Sending email upon quota events requires finding the email address associated with a user....

Which is linked to virtual-hosting....

Working a bit on the topic, I found out we can rely more on **UsersRepository** for such concerns and better isolate virtual hosting knowledge.