### PR TITLE
MAILBOX-328 Avoid tables of more than 30 characters

### DIFF
--- a/backends-common/jpa/src/main/java/org/apache/james/backends/jpa/TableDeclaration.java
+++ b/backends-common/jpa/src/main/java/org/apache/james/backends/jpa/TableDeclaration.java
@@ -19,11 +19,17 @@
 
 package org.apache.james.backends.jpa;
 
+import com.google.common.base.Preconditions;
+
 public class TableDeclaration {
     private final Class<?> clazz;
     private final String tableName;
 
     public TableDeclaration(Class<?> clazz, String tableName) {
+        Preconditions.checkArgument(tableName.length() < 30,
+            "Error with table name '" + tableName + "'" +
+                "Tables of more than 30 characters are not supported by Oracle 11g," +
+                "and thus we avoid using it in James for compatibility reasons. See MAILBOX-328");
         this.clazz = clazz;
         this.tableName = tableName;
     }

--- a/backends-common/jpa/src/main/java/org/apache/james/backends/jpa/TableDeclaration.java
+++ b/backends-common/jpa/src/main/java/org/apache/james/backends/jpa/TableDeclaration.java
@@ -17,25 +17,22 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.mailbox.jpa.quota;
+package org.apache.james.backends.jpa;
 
-import org.apache.james.backends.jpa.JpaTestCluster;
-import org.apache.james.mailbox.jpa.JPAMailboxFixture;
-import org.apache.james.mailbox.quota.MaxQuotaManager;
-import org.apache.james.mailbox.store.quota.GenericMaxQuotaManagerTest;
-import org.junit.After;
+public class TableDeclaration {
+    private final Class<?> clazz;
+    private final String tableName;
 
-public class JPAPerUserMaxQuotaTest extends GenericMaxQuotaManagerTest {
-
-    private static final JpaTestCluster JPA_TEST_CLUSTER = JpaTestCluster.create(JPAMailboxFixture.QUOTA_PERSISTANCE_CLASSES);
-
-    @Override
-    protected MaxQuotaManager provideMaxQuotaManager() {
-        return new JPAPerUserMaxQuotaManager(new JPAPerUserMaxQuotaDAO(JPA_TEST_CLUSTER.getEntityManagerFactory()));
+    public TableDeclaration(Class<?> clazz, String tableName) {
+        this.clazz = clazz;
+        this.tableName = tableName;
     }
 
-    @After
-    public void cleanUp() {
-        JPA_TEST_CLUSTER.clear(JPAMailboxFixture.QUOTA_PERSISTANCE_CLASSES);
+    public Class<?> getClazz() {
+        return clazz;
+    }
+
+    public String getTableName() {
+        return tableName;
     }
 }

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxDomainMessageCount.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxDomainMessageCount.java
@@ -27,7 +27,7 @@ import javax.persistence.Table;
 import org.apache.james.core.Domain;
 
 @Entity(name = "MaxDomainMessageCount")
-@Table(name = "JAMES_MAX_DOMAIN_MESSAGE_COUNT")
+@Table(name = "JAMES_MAX_DOMAIN_M_COUNT")
 public class MaxDomainMessageCount {
     @Id
     @Column(name = "DOMAIN")

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxGlobalMessageCount.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxGlobalMessageCount.java
@@ -25,7 +25,7 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 
 @Entity(name = "MaxGlobalMessageCount")
-@Table(name = "JAMES_MAX_GLOBAL_MESSAGE_COUNT")
+@Table(name = "JAMES_MAX_GLOBAL_M_COUNT")
 public class MaxGlobalMessageCount {
     public static final String DEFAULT_KEY = "default_key";
     

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxUserMessageCount.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/model/MaxUserMessageCount.java
@@ -25,7 +25,7 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 
 @Entity(name = "MaxUserMessageCount")
-@Table(name = "JAMES_MAX_USER_MESSAGE_COUNT")
+@Table(name = "JAMES_MAX_USER_M_COUNT")
 public class MaxUserMessageCount {
     @Id
     @Column(name = "QUOTAROOT_ID")

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxFixture.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxFixture.java
@@ -52,11 +52,11 @@ public interface JPAMailboxFixture {
     );
 
     List<TableDeclaration> QUOTA_PERSISTANCE_CLASSES = ImmutableList.of(
-        new TableDeclaration(MaxGlobalMessageCount.class, "JAMES_MAX_GLOBAL_MESSAGE_COUNT"),
+        new TableDeclaration(MaxGlobalMessageCount.class, "JAMES_MAX_GLOBAL_M_COUNT"),
         new TableDeclaration(MaxGlobalStorage.class, "JAMES_MAX_GLOBAL_STORAGE"),
         new TableDeclaration(MaxDomainStorage.class, "JAMES_MAX_DOMAIN_STORAGE"),
-        new TableDeclaration(MaxDomainMessageCount.class, "JAMES_MAX_DOMAIN_MESSAGE_COUNT"),
-        new TableDeclaration(MaxUserMessageCount.class, "JAMES_MAX_USER_MESSAGE_COUNT"),
+        new TableDeclaration(MaxDomainMessageCount.class, "JAMES_MAX_DOMAIN_M_COUNT"),
+        new TableDeclaration(MaxUserMessageCount.class, "JAMES_MAX_USER_M_COUNT"),
         new TableDeclaration(MaxUserStorage.class, "JAMES_MAX_USER_STORAGE"),
         new TableDeclaration(JpaCurrentQuota.class, "JAMES_QUOTA_CURRENTQUOTA")
     );

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxFixture.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxFixture.java
@@ -21,6 +21,7 @@ package org.apache.james.mailbox.jpa;
 
 import java.util.List;
 
+import org.apache.james.backends.jpa.TableDeclaration;
 import org.apache.james.mailbox.jpa.mail.model.JPAMailbox;
 import org.apache.james.mailbox.jpa.mail.model.JPAMailboxAnnotation;
 import org.apache.james.mailbox.jpa.mail.model.JPAProperty;
@@ -40,41 +41,23 @@ import com.google.common.collect.ImmutableList;
 
 public interface JPAMailboxFixture {
 
-    List<Class<?>> MAILBOX_PERSISTANCE_CLASSES = ImmutableList.of(
-        JPAMailbox.class,
-        AbstractJPAMailboxMessage.class,
-        JPAMailboxMessage.class,
-        JPAProperty.class,
-        JPAUserFlag.class,
-        JPAMailboxAnnotation.class,
-        JPASubscription.class
+    List<TableDeclaration> MAILBOX_PERSISTANCE_CLASSES = ImmutableList.of(
+        new TableDeclaration(JPAMailbox.class, "JAMES_MAILBOX"),
+        new TableDeclaration(AbstractJPAMailboxMessage.class, "JAMES_MAIL"),
+        new TableDeclaration(JPAMailboxMessage.class, "JAMES_MAIL"),
+        new TableDeclaration(JPAProperty.class, "JAMES_MAIL_PROPERTY"),
+        new TableDeclaration(JPAUserFlag.class, "JAMES_MAIL_USERFLAG"),
+        new TableDeclaration(JPAMailboxAnnotation.class, "JAMES_MAILBOX_ANNOTATION"),
+        new TableDeclaration(JPASubscription.class, "JAMES_SUBSCRIPTION")
     );
 
-    List<Class<?>> QUOTA_PERSISTANCE_CLASSES = ImmutableList.of(
-        MaxGlobalMessageCount.class,
-        MaxGlobalStorage.class,
-        MaxDomainStorage.class,
-        MaxDomainMessageCount.class,
-        MaxUserMessageCount.class,
-        MaxUserStorage.class,
-        JpaCurrentQuota.class
-    );
-
-    List<String> MAILBOX_TABLE_NAMES = ImmutableList.of(
-        "JAMES_MAIL_USERFLAG",
-        "JAMES_MAIL_PROPERTY",
-        "JAMES_MAILBOX_ANNOTATION",
-        "JAMES_MAILBOX",
-        "JAMES_MAIL",
-        "JAMES_SUBSCRIPTION");
-
-    List<String> QUOTA_TABLES_NAMES = ImmutableList.of(
-        "JAMES_MAX_GLOBAL_MESSAGE_COUNT",
-        "JAMES_MAX_GLOBAL_STORAGE",
-        "JAMES_MAX_USER_MESSAGE_COUNT",
-        "JAMES_MAX_USER_STORAGE",
-        "JAMES_MAX_DOMAIN_MESSAGE_COUNT",
-        "JAMES_MAX_DOMAIN_STORAGE",
-        "JAMES_QUOTA_CURRENTQUOTA"
+    List<TableDeclaration> QUOTA_PERSISTANCE_CLASSES = ImmutableList.of(
+        new TableDeclaration(MaxGlobalMessageCount.class, "JAMES_MAX_GLOBAL_MESSAGE_COUNT"),
+        new TableDeclaration(MaxGlobalStorage.class, "JAMES_MAX_GLOBAL_STORAGE"),
+        new TableDeclaration(MaxDomainStorage.class, "JAMES_MAX_DOMAIN_STORAGE"),
+        new TableDeclaration(MaxDomainMessageCount.class, "JAMES_MAX_DOMAIN_MESSAGE_COUNT"),
+        new TableDeclaration(MaxUserMessageCount.class, "JAMES_MAX_USER_MESSAGE_COUNT"),
+        new TableDeclaration(MaxUserStorage.class, "JAMES_MAX_USER_STORAGE"),
+        new TableDeclaration(JpaCurrentQuota.class, "JAMES_QUOTA_CURRENTQUOTA")
     );
 }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxManagerTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxManagerTest.java
@@ -50,7 +50,7 @@ public class JPAMailboxManagerTest extends MailboxManagerTest {
     @Override
     @After
     public void tearDown() throws MailboxException {
-        JPA_TEST_CLUSTER.clear(JPAMailboxFixture.MAILBOX_TABLE_NAMES);
+        JPA_TEST_CLUSTER.clear(JPAMailboxFixture.MAILBOX_PERSISTANCE_CLASSES);
     }
 
 }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPASubscriptionManagerTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPASubscriptionManagerTest.java
@@ -54,6 +54,6 @@ public class JPASubscriptionManagerTest extends AbstractSubscriptionManagerTest 
     @Override
     @After
     public void teardown() throws SubscriptionException {
-        JPA_TEST_CLUSTER.clear(JPAMailboxFixture.MAILBOX_TABLE_NAMES);
+        JPA_TEST_CLUSTER.clear(JPAMailboxFixture.MAILBOX_PERSISTANCE_CLASSES);
     }
 }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JpaMailboxManagerStressTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JpaMailboxManagerStressTest.java
@@ -50,6 +50,6 @@ public class JpaMailboxManagerStressTest extends MailboxManagerStressTest {
 
     @After
     public void tearDown() throws MailboxException {
-        JPA_TEST_CLUSTER.clear(JPAMailboxFixture.MAILBOX_TABLE_NAMES);
+        JPA_TEST_CLUSTER.clear(JPAMailboxFixture.MAILBOX_PERSISTANCE_CLASSES);
     }
 }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAMapperProvider.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAMapperProvider.java
@@ -93,7 +93,7 @@ public class JPAMapperProvider implements MapperProvider {
 
     @Override
     public void clearMapper() throws MailboxException {
-        jpaTestCluster.clear(JPAMailboxFixture.MAILBOX_TABLE_NAMES);
+        jpaTestCluster.clear(JPAMailboxFixture.MAILBOX_PERSISTANCE_CLASSES);
     }
 
     @Override

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JpaMailboxMapperTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JpaMailboxMapperTest.java
@@ -43,6 +43,6 @@ public class JpaMailboxMapperTest extends MailboxMapperTest {
     
     @After
     public void cleanUp() {
-        JPA_TEST_CLUSTER.clear(JPAMailboxFixture.MAILBOX_TABLE_NAMES);
+        JPA_TEST_CLUSTER.clear(JPAMailboxFixture.MAILBOX_PERSISTANCE_CLASSES);
     }
 }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JpaMessageMapperTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JpaMessageMapperTest.java
@@ -43,6 +43,6 @@ public class JpaMessageMapperTest extends MessageMapperTest {
     
     @After
     public void cleanUp() {
-        JPA_TEST_CLUSTER.clear(JPAMailboxFixture.MAILBOX_TABLE_NAMES);
+        JPA_TEST_CLUSTER.clear(JPAMailboxFixture.MAILBOX_PERSISTANCE_CLASSES);
     }
 }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/quota/JPACurrentQuotaManagerTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/quota/JPACurrentQuotaManagerTest.java
@@ -36,7 +36,7 @@ public class JPACurrentQuotaManagerTest extends StoreCurrentQuotaManagerTest {
 
     @After
     public void tearDown() {
-        JPA_TEST_CLUSTER.clear(JPAMailboxFixture.QUOTA_TABLES_NAMES);
+        JPA_TEST_CLUSTER.clear(JPAMailboxFixture.QUOTA_PERSISTANCE_CLASSES);
     }
 
 }

--- a/server/container/guice/jpa-smtp/src/test/java/org/apache/james/JPAJamesServerTest.java
+++ b/server/container/guice/jpa-smtp/src/test/java/org/apache/james/JPAJamesServerTest.java
@@ -30,10 +30,7 @@ import java.nio.charset.Charset;
 import javax.persistence.EntityManagerFactory;
 
 import org.apache.james.backends.jpa.JpaTestCluster;
-import org.apache.james.domainlist.jpa.model.JPADomain;
 import org.apache.james.modules.TestFilesystemModule;
-import org.apache.james.rrt.jpa.model.JPARecipientRewrite;
-import org.apache.james.user.jpa.model.JPAUser;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -62,7 +59,10 @@ public class JPAJamesServerTest {
                         new TestFilesystemModule(temporaryFolder),
                         new TestJPAConfigurationModule(),
                         (binder) -> binder.bind(EntityManagerFactory.class)
-                            .toInstance(JpaTestCluster.create(JPAUser.class, JPADomain.class, JPARecipientRewrite.class)
+                            .toInstance(JpaTestCluster.create(
+                                JPADataTablesDeclarations.DOMAIN_TABLE,
+                                JPADataTablesDeclarations.USER_TABLE,
+                                JPADataTablesDeclarations.RRT_TABLE)
                                     .getEntityManagerFactory()));
     }
     

--- a/server/data/data-jpa/src/main/java/org/apache/james/JPADataTablesDeclarations.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/JPADataTablesDeclarations.java
@@ -17,25 +17,17 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.mailbox.jpa.quota;
+package org.apache.james;
 
-import org.apache.james.backends.jpa.JpaTestCluster;
-import org.apache.james.mailbox.jpa.JPAMailboxFixture;
-import org.apache.james.mailbox.quota.MaxQuotaManager;
-import org.apache.james.mailbox.store.quota.GenericMaxQuotaManagerTest;
-import org.junit.After;
+import org.apache.james.backends.jpa.TableDeclaration;
+import org.apache.james.domainlist.jpa.model.JPADomain;
+import org.apache.james.rrt.jpa.model.JPARecipientRewrite;
+import org.apache.james.user.jpa.model.JPAUser;
 
-public class JPAPerUserMaxQuotaTest extends GenericMaxQuotaManagerTest {
+public interface JPADataTablesDeclarations {
+     TableDeclaration USER_TABLE = new TableDeclaration(JPAUser.class, "JAMES_USER");
 
-    private static final JpaTestCluster JPA_TEST_CLUSTER = JpaTestCluster.create(JPAMailboxFixture.QUOTA_PERSISTANCE_CLASSES);
+     TableDeclaration DOMAIN_TABLE = new TableDeclaration(JPADomain.class, "JAMES_DOMAIN");
 
-    @Override
-    protected MaxQuotaManager provideMaxQuotaManager() {
-        return new JPAPerUserMaxQuotaManager(new JPAPerUserMaxQuotaDAO(JPA_TEST_CLUSTER.getEntityManagerFactory()));
-    }
-
-    @After
-    public void cleanUp() {
-        JPA_TEST_CLUSTER.clear(JPAMailboxFixture.QUOTA_PERSISTANCE_CLASSES);
-    }
+     TableDeclaration RRT_TABLE = new TableDeclaration(JPARecipientRewrite.class, "JamesRecipientRewrite");
 }

--- a/server/data/data-jpa/src/test/java/org/apache/james/domainlist/jpa/JPADomainListTest.java
+++ b/server/data/data-jpa/src/test/java/org/apache/james/domainlist/jpa/JPADomainListTest.java
@@ -18,10 +18,10 @@
  ****************************************************************/
 package org.apache.james.domainlist.jpa;
 
+import org.apache.james.JPADataTablesDeclarations;
 import org.apache.james.backends.jpa.JpaTestCluster;
 import org.apache.james.core.Domain;
 import org.apache.james.domainlist.api.DomainList;
-import org.apache.james.domainlist.jpa.model.JPADomain;
 import org.apache.james.domainlist.lib.AbstractDomainListTest;
 import org.junit.After;
 import org.junit.Before;
@@ -31,7 +31,7 @@ import org.junit.Before;
  */
 public class JPADomainListTest extends AbstractDomainListTest {
 
-    private static final JpaTestCluster JPA_TEST_CLUSTER = JpaTestCluster.create(JPADomain.class);
+    private static final JpaTestCluster JPA_TEST_CLUSTER = JpaTestCluster.create(JPADataTablesDeclarations.DOMAIN_TABLE);
 
     @Override
     @Before

--- a/server/data/data-jpa/src/test/java/org/apache/james/rrt/jpa/JPARecipientRewriteTableTest.java
+++ b/server/data/data-jpa/src/test/java/org/apache/james/rrt/jpa/JPARecipientRewriteTableTest.java
@@ -19,8 +19,8 @@
 package org.apache.james.rrt.jpa;
 
 import org.apache.commons.configuration.DefaultConfigurationBuilder;
+import org.apache.james.JPADataTablesDeclarations;
 import org.apache.james.backends.jpa.JpaTestCluster;
-import org.apache.james.rrt.jpa.model.JPARecipientRewrite;
 import org.apache.james.rrt.lib.AbstractRecipientRewriteTable;
 import org.apache.james.rrt.lib.AbstractRecipientRewriteTableTest;
 import org.junit.After;
@@ -31,7 +31,7 @@ import org.junit.Before;
  */
 public class JPARecipientRewriteTableTest extends AbstractRecipientRewriteTableTest {
 
-    private static final JpaTestCluster JPA_TEST_CLUSTER = JpaTestCluster.create(JPARecipientRewrite.class);
+    private static final JpaTestCluster JPA_TEST_CLUSTER = JpaTestCluster.create(JPADataTablesDeclarations.RRT_TABLE);
 
     @Override
     @Before

--- a/server/data/data-jpa/src/test/java/org/apache/james/rrt/jpa/JPAStepdefs.java
+++ b/server/data/data-jpa/src/test/java/org/apache/james/rrt/jpa/JPAStepdefs.java
@@ -19,8 +19,8 @@
 package org.apache.james.rrt.jpa;
 
 import org.apache.commons.configuration.DefaultConfigurationBuilder;
+import org.apache.james.JPADataTablesDeclarations;
 import org.apache.james.backends.jpa.JpaTestCluster;
-import org.apache.james.rrt.jpa.model.JPARecipientRewrite;
 import org.apache.james.rrt.lib.AbstractRecipientRewriteTable;
 import org.apache.james.rrt.lib.RewriteTablesStepdefs;
 
@@ -29,7 +29,7 @@ import cucumber.api.java.Before;
 
 public class JPAStepdefs {
 
-    private static final JpaTestCluster JPA_TEST_CLUSTER = JpaTestCluster.create(JPARecipientRewrite.class);
+    private static final JpaTestCluster JPA_TEST_CLUSTER = JpaTestCluster.create(JPADataTablesDeclarations.RRT_TABLE);
 
     private final RewriteTablesStepdefs mainStepdefs;
 
@@ -44,7 +44,7 @@ public class JPAStepdefs {
 
     @After
     public void tearDown() {
-        JPA_TEST_CLUSTER.clear(JPARecipientRewrite.JAMES_RECIPIENT_REWRITE);
+        JPA_TEST_CLUSTER.clear(JPADataTablesDeclarations.RRT_TABLE);
     }
 
     private AbstractRecipientRewriteTable getRecipientRewriteTable() throws Exception {

--- a/server/data/data-jpa/src/test/java/org/apache/james/user/jpa/JpaUsersRepositoryTest.java
+++ b/server/data/data-jpa/src/test/java/org/apache/james/user/jpa/JpaUsersRepositoryTest.java
@@ -19,8 +19,8 @@
 package org.apache.james.user.jpa;
 
 import org.apache.commons.configuration.DefaultConfigurationBuilder;
+import org.apache.james.JPADataTablesDeclarations;
 import org.apache.james.backends.jpa.JpaTestCluster;
-import org.apache.james.user.jpa.model.JPAUser;
 import org.apache.james.user.lib.AbstractUsersRepository;
 import org.apache.james.user.lib.AbstractUsersRepositoryTest;
 import org.junit.After;
@@ -28,7 +28,7 @@ import org.junit.Before;
 
 public class JpaUsersRepositoryTest extends AbstractUsersRepositoryTest {
 
-    private static final JpaTestCluster JPA_TEST_CLUSTER = JpaTestCluster.create(JPAUser.class);
+    private static final JpaTestCluster JPA_TEST_CLUSTER = JpaTestCluster.create(JPADataTablesDeclarations.USER_TABLE);
 
     @Before
     @Override
@@ -40,7 +40,7 @@ public class JpaUsersRepositoryTest extends AbstractUsersRepositoryTest {
     @After
     public void tearDown() throws Exception {
         super.tearDown();
-        JPA_TEST_CLUSTER.clear("JAMES_USER");
+        JPA_TEST_CLUSTER.clear(JPADataTablesDeclarations.USER_TABLE);
     }
 
     @Override


### PR DESCRIPTION
For compatibility with Oracle 11g database.

Please note procedure for migration and associated communication plan is in the message commit of commit https://github.com/linagora/james-project/commit/babb744e0148b3eb1269cb0f8ad2f521acc449b2

This simple to fix, user reported problem was discussed as needed with Raphael Ouazana.