### PR TITLE
JAMES-2381 Correctly handle RRT loops

### DIFF
--- a/dockerfiles/run/guice/cassandra-ldap/destination/conf/mailetcontainer.xml
+++ b/dockerfiles/run/guice/cassandra-ldap/destination/conf/mailetcontainer.xml
@@ -63,7 +63,9 @@
                 <name>bcc</name>
                 <onMailetException>ignore</onMailetException>
             </mailet>
-            <mailet match="All" class="RecipientRewriteTable" />
+            <mailet match="All" class="RecipientRewriteTable">
+                <errorProcessor>rrt-error</errorProcessor>
+            </mailet>
             <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet"/>
             <mailet match="RecipientIsLocal" class="Sieve"/>
             <mailet match="RecipientIsLocal" class="AddDeliveredToHeader"/>
@@ -144,6 +146,15 @@
             <mailet match="All" class="DSNBounce">
                 <passThrough>false</passThrough>
             </mailet>
+        </processor>
+
+        <processor state="rrt-error" enableJmx="false">
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>cassandra://var/mail/rrt-error/</repositoryPath>
+                <passThrough>true</passThrough>
+            </mailet>
+            <mailet match="IsSenderInRRTLoop" class="Null"/>
+            <mailet match="All" class="Bounce"/>
         </processor>
 
     </processors>

--- a/dockerfiles/run/guice/cassandra/destination/conf/mailetcontainer.xml
+++ b/dockerfiles/run/guice/cassandra/destination/conf/mailetcontainer.xml
@@ -63,7 +63,9 @@
                 <name>bcc</name>
                 <onMailetException>ignore</onMailetException>
             </mailet>
-            <mailet match="All" class="RecipientRewriteTable" />
+            <mailet match="All" class="RecipientRewriteTable">
+                <errorProcessor>rrt-error</errorProcessor>
+            </mailet>
             <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet"/>
             <mailet match="RecipientIsLocal" class="Sieve"/>
             <mailet match="RecipientIsLocal" class="AddDeliveredToHeader"/>
@@ -147,6 +149,15 @@
             <mailet match="All" class="DSNBounce">
                 <passThrough>false</passThrough>
             </mailet>
+        </processor>
+
+        <processor state="rrt-error" enableJmx="false">
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>cassandra://var/mail/rrt-error/</repositoryPath>
+                <passThrough>true</passThrough>
+            </mailet>
+            <mailet match="IsSenderInRRTLoop" class="Null"/>
+            <mailet match="All" class="Bounce"/>
         </processor>
 
     </processors>

--- a/dockerfiles/run/guice/jpa/destination/conf/mailetcontainer.xml
+++ b/dockerfiles/run/guice/jpa/destination/conf/mailetcontainer.xml
@@ -63,7 +63,9 @@
                 <name>bcc</name>
                 <onMailetException>ignore</onMailetException>
             </mailet>
-            <mailet match="All" class="RecipientRewriteTable" />
+            <mailet match="All" class="RecipientRewriteTable">
+                <errorProcessor>rrt-error</errorProcessor>
+            </mailet>
             <mailet match="RecipientIsLocal" class="Sieve"/>
             <mailet match="RecipientIsLocal" class="AddDeliveredToHeader"/>
             <mailet match="RecipientIsLocal" class="LocalDelivery"/>
@@ -140,6 +142,15 @@
             <mailet match="All" class="DSNBounce">
                 <passThrough>false</passThrough>
             </mailet>
+        </processor>
+
+        <processor state="rrt-error" enableJmx="false">
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>file://var/mail/rrt-error/</repositoryPath>
+                <passThrough>true</passThrough>
+            </mailet>
+            <mailet match="IsSenderInRRTLoop" class="Null"/>
+            <mailet match="All" class="Bounce"/>
         </processor>
 
     </processors>

--- a/dockerfiles/run/spring/destination/conf/mailetcontainer.xml
+++ b/dockerfiles/run/spring/destination/conf/mailetcontainer.xml
@@ -63,7 +63,9 @@
                 <name>bcc</name>
                 <onMailetException>ignore</onMailetException>
             </mailet>
-            <mailet match="All" class="RecipientRewriteTable" />
+            <mailet match="All" class="RecipientRewriteTable">
+                <errorProcessor>rrt-error</errorProcessor>
+            </mailet>
             <mailet match="RecipientIsLocal" class="Sieve"/>
             <mailet match="RecipientIsLocal" class="AddDeliveredToHeader"/>
             <mailet match="RecipientIsLocal" class="LocalDelivery"/>
@@ -143,6 +145,15 @@
             <mailet match="All" class="DSNBounce">
                 <passThrough>false</passThrough>
             </mailet>
+        </processor>
+
+        <processor state="rrt-error" enableJmx="false">
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>file://var/mail/rrt-error/</repositoryPath>
+                <passThrough>true</passThrough>
+            </mailet>
+            <mailet match="IsSenderInRRTLoop" class="Null"/>
+            <mailet match="All" class="Bounce"/>
         </processor>
 
     </processors>

--- a/mpt/impl/smtp/cassandra/src/test/resources/mailetcontainer.xml
+++ b/mpt/impl/smtp/cassandra/src/test/resources/mailetcontainer.xml
@@ -64,7 +64,9 @@
                 <name>bcc</name>
             </mailet>
             <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet"/>
-            <mailet match="All" class="RecipientRewriteTable" />
+            <mailet match="All" class="RecipientRewriteTable">
+                <errorProcessor>rrt-error</errorProcessor>
+            </mailet>
             <mailet match="All" class="RemoteDelivery">
                 <outgoingQueue>outgoing</outgoingQueue>
                 <delayTime>5 minutes</delayTime>
@@ -106,6 +108,15 @@
             <mailet match="All" class="DSNBounce">
                 <passThrough>false</passThrough>
             </mailet>
+        </processor>
+
+        <processor state="rrt-error" enableJmx="false">
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>file://var/mail/rrt-error/</repositoryPath>
+                <passThrough>true</passThrough>
+            </mailet>
+            <mailet match="IsSenderInRRTLoop" class="Null"/>
+            <mailet match="All" class="Bounce"/>
         </processor>
     </processors>
 

--- a/protocols/lmtp/src/test/java/org/apache/james/protocols/lmtp/AbstractLMTPServerTest.java
+++ b/protocols/lmtp/src/test/java/org/apache/james/protocols/lmtp/AbstractLMTPServerTest.java
@@ -344,10 +344,10 @@ public abstract class AbstractLMTPServerTest extends AbstractSMTPServerTest {
         @Override
         public HookResult deliver(SMTPSession session, MailAddress recipient, MailEnvelope envelope) {
             if (RCPT1.equals(recipient.toString())) {
-                return new HookResult(HookReturnCode.deny());
+                return HookResult.DENY;
             } else {
                 delivered.add(envelope);
-                return new HookResult(HookReturnCode.ok());
+                return HookResult.OK;
             }
         }
         

--- a/protocols/lmtp/src/test/java/org/apache/james/protocols/lmtp/AbstractLMTPServerTest.java
+++ b/protocols/lmtp/src/test/java/org/apache/james/protocols/lmtp/AbstractLMTPServerTest.java
@@ -344,10 +344,10 @@ public abstract class AbstractLMTPServerTest extends AbstractSMTPServerTest {
         @Override
         public HookResult deliver(SMTPSession session, MailAddress recipient, MailEnvelope envelope) {
             if (RCPT1.equals(recipient.toString())) {
-                return new HookResult(HookReturnCode.DENY);
+                return new HookResult(HookReturnCode.deny());
             } else {
                 delivered.add(envelope);
-                return new HookResult(HookReturnCode.OK);
+                return new HookResult(HookReturnCode.ok());
             }
         }
         

--- a/protocols/smtp/pom.xml
+++ b/protocols/smtp/pom.xml
@@ -88,6 +88,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.james</groupId>
             <artifactId>james-server-util</artifactId>
         </dependency>

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractAuthRequiredToRelayRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractAuthRequiredToRelayRcptHook.java
@@ -32,19 +32,20 @@ import org.apache.james.protocols.smtp.hook.RcptHook;
  */
 public abstract class AbstractAuthRequiredToRelayRcptHook implements RcptHook {
 
-    private static final HookResult AUTH_REQUIRED = new HookResult(HookReturnCode.deny(),
-            SMTPRetCode.AUTH_REQUIRED, DSNStatus.getStatus(
-                    DSNStatus.PERMANENT,
-                    DSNStatus.SECURITY_AUTH)
-                    + " Authentication Required");
-    private static final HookResult RELAYING_DENIED = new HookResult(
-            HookReturnCode.deny(),
-            // sendmail returns 554 (SMTPRetCode.TRANSACTION_FAILED).
-            // it is not clear in RFC wether it is better to use 550 or 554.
-            SMTPRetCode.MAILBOX_PERM_UNAVAILABLE,
-            DSNStatus.getStatus(DSNStatus.PERMANENT,
-                    DSNStatus.SECURITY_AUTH)
-                    + " Requested action not taken: relaying denied");
+    private static final HookResult AUTH_REQUIRED = HookResult.builder()
+        .hookReturnCode(HookReturnCode.deny())
+        .smtpReturnCode(SMTPRetCode.AUTH_REQUIRED)
+        .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_AUTH)
+            + " Authentication Required")
+        .build();
+    // sendmail returns 554 (SMTPRetCode.TRANSACTION_FAILED).
+    // it is not clear in RFC wether it is better to use 550 or 554.
+    private static final HookResult RELAYING_DENIED = HookResult.builder()
+        .hookReturnCode(HookReturnCode.deny())
+        .smtpReturnCode(SMTPRetCode.MAILBOX_PERM_UNAVAILABLE)
+        .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_AUTH)
+            + " Requested action not taken: relaying denied")
+        .build();
     
     @Override
     public HookResult doRcpt(SMTPSession session, MailAddress sender,

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractAuthRequiredToRelayRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractAuthRequiredToRelayRcptHook.java
@@ -60,7 +60,7 @@ public abstract class AbstractAuthRequiredToRelayRcptHook implements RcptHook {
             }
 
         }
-        return HookResult.declined();
+        return HookResult.DECLINED;
     }
 
     

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractAuthRequiredToRelayRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractAuthRequiredToRelayRcptHook.java
@@ -32,13 +32,13 @@ import org.apache.james.protocols.smtp.hook.RcptHook;
  */
 public abstract class AbstractAuthRequiredToRelayRcptHook implements RcptHook {
 
-    private static final HookResult AUTH_REQUIRED = new HookResult(HookReturnCode.DENY,
+    private static final HookResult AUTH_REQUIRED = new HookResult(HookReturnCode.deny(),
             SMTPRetCode.AUTH_REQUIRED, DSNStatus.getStatus(
                     DSNStatus.PERMANENT,
                     DSNStatus.SECURITY_AUTH)
                     + " Authentication Required");
     private static final HookResult RELAYING_DENIED = new HookResult(
-            HookReturnCode.DENY,
+            HookReturnCode.deny(),
             // sendmail returns 554 (SMTPRetCode.TRANSACTION_FAILED).
             // it is not clear in RFC wether it is better to use 550 or 554.
             SMTPRetCode.MAILBOX_PERM_UNAVAILABLE,

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractHookableCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractHookableCmdHandler.java
@@ -124,9 +124,9 @@ public abstract class AbstractHookableCmdHandler<HookT extends org.apache.james.
                 }
 
                 // call the core cmd if we receive a ok return code of the hook so no other hooks are executed
-                if ((hRes.getResult() & HookReturnCode.OK) == HookReturnCode.OK) {
+                if (hRes.getResult().getAction() == HookReturnCode.Action.OK) {
                     final Response response = doCoreCmd(session, command, parameters);
-                    if ((hRes.getResult() & HookReturnCode.DISCONNECT) == HookReturnCode.DISCONNECT) {
+                    if (hRes.getResult().isDisconnected()) {
                         return new Response() {
 
                             @Override
@@ -176,11 +176,11 @@ public abstract class AbstractHookableCmdHandler<HookT extends org.apache.james.
      */
     public static SMTPResponse calcDefaultSMTPResponse(HookResult result) {
         if (result != null) {
-            int rCode = result.getResult();
+            HookReturnCode rCode = result.getResult();
             String smtpRetCode = result.getSmtpRetCode();
             String smtpDesc = result.getSmtpDescription();
     
-            if ((rCode & HookReturnCode.DENY) == HookReturnCode.DENY) {
+            if (rCode.getAction() == HookReturnCode.Action.DENY) {
                 if (smtpRetCode == null) {
                     smtpRetCode = SMTPRetCode.TRANSACTION_FAILED;
                 }
@@ -189,11 +189,11 @@ public abstract class AbstractHookableCmdHandler<HookT extends org.apache.james.
                 }
     
                 SMTPResponse response =  new SMTPResponse(smtpRetCode, smtpDesc);
-                if ((rCode & HookReturnCode.DISCONNECT) == HookReturnCode.DISCONNECT) {
+                if (rCode.isDisconnected()) {
                     response.setEndSession(true);
                 }
                 return response;
-            } else if ((rCode & HookReturnCode.DENYSOFT) == HookReturnCode.DENYSOFT) {
+            } else if (rCode.getAction() == HookReturnCode.Action.DENYSOFT) {
                 if (smtpRetCode == null) {
                     smtpRetCode = SMTPRetCode.LOCAL_ERROR;
                 }
@@ -202,11 +202,11 @@ public abstract class AbstractHookableCmdHandler<HookT extends org.apache.james.
                 }
     
                 SMTPResponse response = new SMTPResponse(smtpRetCode, smtpDesc);
-                if ((rCode & HookReturnCode.DISCONNECT) == HookReturnCode.DISCONNECT) {
+                if (rCode.isDisconnected()) {
                     response.setEndSession(true);
                 }
                 return response;
-            } else if ((rCode & HookReturnCode.OK) == HookReturnCode.OK) {
+            } else if (rCode.getAction() == HookReturnCode.Action.OK) {
                 if (smtpRetCode == null) {
                     smtpRetCode = SMTPRetCode.MAIL_OK;
                 }
@@ -215,11 +215,11 @@ public abstract class AbstractHookableCmdHandler<HookT extends org.apache.james.
                 }
     
                 SMTPResponse response = new SMTPResponse(smtpRetCode, smtpDesc);
-                if ((rCode & HookReturnCode.DISCONNECT) == HookReturnCode.DISCONNECT) {
+                if (rCode.isDisconnected()) {
                     response.setEndSession(true);
                 }
                 return response;
-            } else if ((rCode & HookReturnCode.DISCONNECT) == HookReturnCode.DISCONNECT) {
+            } else if (rCode.isDisconnected()) {
                 if (smtpRetCode == null) {
                     smtpRetCode = SMTPRetCode.TRANSACTION_FAILED;
                 }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
@@ -34,11 +34,12 @@ import org.apache.james.protocols.smtp.hook.RcptHook;
  * Handler which check if the authenticated user is the same as the one used as MAIL FROM
  */
 public abstract class AbstractSenderAuthIdentifyVerificationRcptHook implements RcptHook {  
-    private static final HookResult INVALID_AUTH =  new HookResult(HookReturnCode.deny(),
-            SMTPRetCode.BAD_SEQUENCE,
-            DSNStatus.getStatus(DSNStatus.PERMANENT,
-                    DSNStatus.SECURITY_AUTH)
-                    + " Incorrect Authentication for Specified Email Address");
+    private static final HookResult INVALID_AUTH = HookResult.builder()
+        .hookReturnCode(HookReturnCode.deny())
+        .smtpReturnCode(SMTPRetCode.BAD_SEQUENCE)
+        .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_AUTH)
+            + " Incorrect Authentication for Specified Email Address")
+        .build();
     
     @Override
     public HookResult doRcpt(SMTPSession session, MailAddress sender,

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
@@ -58,7 +58,7 @@ public abstract class AbstractSenderAuthIdentifyVerificationRcptHook implements 
                 return INVALID_AUTH;
             }
         }
-        return HookResult.declined();
+        return HookResult.DECLINED;
     }
 
     public String retrieveSender(MailAddress sender, MailAddress senderAddress) {

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
@@ -34,7 +34,7 @@ import org.apache.james.protocols.smtp.hook.RcptHook;
  * Handler which check if the authenticated user is the same as the one used as MAIL FROM
  */
 public abstract class AbstractSenderAuthIdentifyVerificationRcptHook implements RcptHook {  
-    private static final HookResult INVALID_AUTH =  new HookResult(HookReturnCode.DENY, 
+    private static final HookResult INVALID_AUTH =  new HookResult(HookReturnCode.deny(),
             SMTPRetCode.BAD_SEQUENCE,
             DSNStatus.getStatus(DSNStatus.PERMANENT,
                     DSNStatus.SECURITY_AUTH)

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AcceptRecipientIfRelayingIsAllowed.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AcceptRecipientIfRelayingIsAllowed.java
@@ -34,9 +34,9 @@ public class AcceptRecipientIfRelayingIsAllowed implements RcptHook {
     public HookResult doRcpt(SMTPSession session, MailAddress sender,
                              MailAddress rcpt) {
         if (session.isRelayingAllowed()) {
-            return HookResult.ok();
+            return HookResult.OK;
         }
-        return HookResult.declined();
+        return HookResult.DECLINED;
     }
 
     @Override

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/DataLineMessageHookHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/DataLineMessageHookHandler.java
@@ -41,7 +41,6 @@ import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.dsn.DSNStatus;
 import org.apache.james.protocols.smtp.hook.HookResult;
 import org.apache.james.protocols.smtp.hook.HookResultHook;
-import org.apache.james.protocols.smtp.hook.HookReturnCode;
 import org.apache.james.protocols.smtp.hook.MessageHook;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -153,7 +152,7 @@ public class DataLineMessageHookHandler implements DataLineFilter, ExtensibleHan
             }
 
             // Not queue the message!
-            return AbstractHookableCmdHandler.calcDefaultSMTPResponse(new HookResult(HookReturnCode.deny()));
+            return AbstractHookableCmdHandler.calcDefaultSMTPResponse(HookResult.DECLINED);
         }
         
         return null;

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/DataLineMessageHookHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/DataLineMessageHookHandler.java
@@ -153,7 +153,7 @@ public class DataLineMessageHookHandler implements DataLineFilter, ExtensibleHan
             }
 
             // Not queue the message!
-            return AbstractHookableCmdHandler.calcDefaultSMTPResponse(new HookResult(HookReturnCode.DENY));
+            return AbstractHookableCmdHandler.calcDefaultSMTPResponse(new HookResult(HookReturnCode.deny()));
         }
         
         return null;

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/PostmasterAbuseRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/PostmasterAbuseRcptHook.java
@@ -37,9 +37,9 @@ public class PostmasterAbuseRcptHook implements RcptHook {
     public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
         if (rcpt.getLocalPart().equalsIgnoreCase("postmaster") || rcpt.getLocalPart().equalsIgnoreCase("abuse")) {
             LOGGER.debug("Sender allowed");
-            return HookResult.ok();
+            return HookResult.OK;
         } else {
-            return HookResult.declined();
+            return HookResult.DECLINED;
         }
     }
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/AuthCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/AuthCmdHandler.java
@@ -549,7 +549,7 @@ public class AuthCmdHandler
     public HookResult doMailParameter(SMTPSession session, String paramName, String paramValue) {
         // Ignore the AUTH command.
         // TODO we should at least check for correct syntax and put the result in session
-        return HookResult.declined();
+        return HookResult.DECLINED;
     }
 
     @Override

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/AuthCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/AuthCmdHandler.java
@@ -429,11 +429,11 @@ public class AuthCmdHandler
      */
     protected Response calcDefaultSMTPResponse(HookResult result) {
         if (result != null) {
-            int rCode = result.getResult();
+            HookReturnCode rCode = result.getResult();
             String smtpRetCode = result.getSmtpRetCode();
             String smtpDesc = result.getSmtpDescription();
     
-            if ((rCode & HookReturnCode.DENY) == HookReturnCode.DENY) {
+            if (rCode.getAction() == HookReturnCode.Action.DENY) {
                 if (smtpRetCode == null) {
                     smtpRetCode = SMTPRetCode.AUTH_FAILED;
                 }
@@ -443,11 +443,11 @@ public class AuthCmdHandler
     
                 SMTPResponse response =  new SMTPResponse(smtpRetCode, smtpDesc);
 
-                if ((rCode & HookReturnCode.DISCONNECT) == HookReturnCode.DISCONNECT) {
+                if (rCode.isDisconnected()) {
                     response.setEndSession(true);
                 }
                 return response;
-            } else if ((rCode & HookReturnCode.DENYSOFT) == HookReturnCode.DENYSOFT) {
+            } else if (rCode.getAction() == HookReturnCode.Action.DENYSOFT) {
                 if (smtpRetCode == null) {
                     smtpRetCode = SMTPRetCode.LOCAL_ERROR;
                 }
@@ -457,11 +457,11 @@ public class AuthCmdHandler
     
                 SMTPResponse response =  new SMTPResponse(smtpRetCode, smtpDesc);
 
-                if ((rCode & HookReturnCode.DISCONNECT) == HookReturnCode.DISCONNECT) {
+                if (rCode.isDisconnected()) {
                     response.setEndSession(true);
                 }
                 return response;
-            } else if ((rCode & HookReturnCode.OK) == HookReturnCode.OK) {
+            } else if (rCode.getAction() == HookReturnCode.Action.OK) {
                 if (smtpRetCode == null) {
                     smtpRetCode = SMTPRetCode.AUTH_OK;
                 }
@@ -471,11 +471,11 @@ public class AuthCmdHandler
                 
                 SMTPResponse response =  new SMTPResponse(smtpRetCode, smtpDesc);
 
-                if ((rCode & HookReturnCode.DISCONNECT) == HookReturnCode.DISCONNECT) {
+                if (rCode.isDisconnected()) {
                     response.setEndSession(true);
                 }
                 return response;
-            } else if ((rCode & HookReturnCode.DISCONNECT) == HookReturnCode.DISCONNECT) {
+            } else if (rCode.isDisconnected()) {
                 SMTPResponse response =  new SMTPResponse("");
                 response.setEndSession(true);
             

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/MailSizeEsmtpExtension.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/MailSizeEsmtpExtension.java
@@ -188,7 +188,7 @@ public class MailSizeEsmtpExtension implements MailParametersHook, EhloExtension
             LOGGER.error("Rejected message from {} from {} exceeding system maximum message size of {}", session.getAttachment(SMTPSession.SENDER, State.Transaction), session.getRemoteAddress().getAddress().getHostAddress(), session.getConfiguration().getMaxMessageSize());
             return QUOTA_EXCEEDED;
         } else {
-            return HookResult.declined();
+            return HookResult.DECLINED;
         }
     }
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/MailSizeEsmtpExtension.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/MailSizeEsmtpExtension.java
@@ -53,8 +53,16 @@ public class MailSizeEsmtpExtension implements MailParametersHook, EhloExtension
     private static final String MESG_FAILED = "MESG_FAILED";   // Message failed flag
     private static final String[] MAIL_PARAMS = { "SIZE" };
     
-    private static final HookResult SYNTAX_ERROR = new HookResult(HookReturnCode.deny(), SMTPRetCode.SYNTAX_ERROR_ARGUMENTS, DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.DELIVERY_INVALID_ARG) + " Syntactically incorrect value for SIZE parameter");
-    private static final HookResult QUOTA_EXCEEDED = new HookResult(HookReturnCode.deny(), SMTPRetCode.QUOTA_EXCEEDED, DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SYSTEM_MSG_TOO_BIG) + " Message size exceeds fixed maximum message size");
+    private static final HookResult SYNTAX_ERROR = HookResult.builder()
+        .hookReturnCode(HookReturnCode.deny())
+        .smtpReturnCode(SMTPRetCode.SYNTAX_ERROR_ARGUMENTS)
+        .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.DELIVERY_INVALID_ARG) + " Syntactically incorrect value for SIZE parameter")
+        .build();
+    private static final HookResult QUOTA_EXCEEDED = HookResult.builder()
+        .hookReturnCode(HookReturnCode.deny())
+        .smtpReturnCode(SMTPRetCode.QUOTA_EXCEEDED)
+        .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SYSTEM_MSG_TOO_BIG) + " Message size exceeds fixed maximum message size")
+        .build();
     public static final int SINGLE_CHARACTER_LINE = 3;
     public static final int DOT_BYTE = 46;
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/MailSizeEsmtpExtension.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/MailSizeEsmtpExtension.java
@@ -53,8 +53,8 @@ public class MailSizeEsmtpExtension implements MailParametersHook, EhloExtension
     private static final String MESG_FAILED = "MESG_FAILED";   // Message failed flag
     private static final String[] MAIL_PARAMS = { "SIZE" };
     
-    private static final HookResult SYNTAX_ERROR = new HookResult(HookReturnCode.DENY, SMTPRetCode.SYNTAX_ERROR_ARGUMENTS, DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.DELIVERY_INVALID_ARG) + " Syntactically incorrect value for SIZE parameter");
-    private static final HookResult QUOTA_EXCEEDED = new HookResult(HookReturnCode.DENY, SMTPRetCode.QUOTA_EXCEEDED, DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SYSTEM_MSG_TOO_BIG) + " Message size exceeds fixed maximum message size");
+    private static final HookResult SYNTAX_ERROR = new HookResult(HookReturnCode.deny(), SMTPRetCode.SYNTAX_ERROR_ARGUMENTS, DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.DELIVERY_INVALID_ARG) + " Syntactically incorrect value for SIZE parameter");
+    private static final HookResult QUOTA_EXCEEDED = new HookResult(HookReturnCode.deny(), SMTPRetCode.QUOTA_EXCEEDED, DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SYSTEM_MSG_TOO_BIG) + " Message size exceeds fixed maximum message size");
     public static final int SINGLE_CHARACTER_LINE = 3;
     public static final int DOT_BYTE = 46;
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractGreylistHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractGreylistHandler.java
@@ -50,10 +50,18 @@ public abstract class AbstractGreylistHandler implements RcptHook {
     private long unseenLifeTime = 14400000;
 
 
-    private static final HookResult TO_FAST = new HookResult(HookReturnCode.denySoft(), SMTPRetCode.LOCAL_ERROR, DSNStatus.getStatus(DSNStatus.TRANSIENT, DSNStatus.NETWORK_DIR_SERVER)
-            + " Temporary rejected: Reconnect to fast. Please try again later");
-    private static final HookResult TEMPORARY_REJECT = new HookResult(HookReturnCode.denySoft(), SMTPRetCode.LOCAL_ERROR, DSNStatus.getStatus(DSNStatus.TRANSIENT, DSNStatus.NETWORK_DIR_SERVER)
-            + " Temporary rejected: Please try again later");
+    private static final HookResult TO_FAST = HookResult.builder()
+        .hookReturnCode(HookReturnCode.denySoft())
+        .smtpReturnCode(SMTPRetCode.LOCAL_ERROR)
+        .smtpDescription(DSNStatus.getStatus(DSNStatus.TRANSIENT, DSNStatus.NETWORK_DIR_SERVER)
+            + " Temporary rejected: Reconnect to fast. Please try again later")
+        .build();
+    private static final HookResult TEMPORARY_REJECT = HookResult.builder()
+        .hookReturnCode(HookReturnCode.denySoft())
+        .smtpReturnCode(SMTPRetCode.LOCAL_ERROR)
+        .smtpDescription(DSNStatus.getStatus(DSNStatus.TRANSIENT, DSNStatus.NETWORK_DIR_SERVER)
+            + " Temporary rejected: Please try again later")
+        .build();
 
     public void setUnseenLifeTime(long unseenLifeTime) {
         this.unseenLifeTime = unseenLifeTime;

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractGreylistHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractGreylistHandler.java
@@ -135,7 +135,7 @@ public abstract class AbstractGreylistHandler implements RcptHook {
             // just log the exception
             LOGGER.error("Error on greylist method: {}", e.getMessage());
         }
-        return HookResult.declined();
+        return HookResult.DECLINED;
     }
 
     /**
@@ -217,6 +217,6 @@ public abstract class AbstractGreylistHandler implements RcptHook {
         } else {
             LOGGER.info("IpAddress {} is allowed to send. Skip greylisting.", session.getRemoteAddress().getAddress().getHostAddress());
         }
-        return HookResult.declined();
+        return HookResult.DECLINED;
     }
 }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractGreylistHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractGreylistHandler.java
@@ -50,9 +50,9 @@ public abstract class AbstractGreylistHandler implements RcptHook {
     private long unseenLifeTime = 14400000;
 
 
-    private static final HookResult TO_FAST = new HookResult(HookReturnCode.DENYSOFT, SMTPRetCode.LOCAL_ERROR, DSNStatus.getStatus(DSNStatus.TRANSIENT, DSNStatus.NETWORK_DIR_SERVER) 
+    private static final HookResult TO_FAST = new HookResult(HookReturnCode.denySoft(), SMTPRetCode.LOCAL_ERROR, DSNStatus.getStatus(DSNStatus.TRANSIENT, DSNStatus.NETWORK_DIR_SERVER)
             + " Temporary rejected: Reconnect to fast. Please try again later");
-    private static final HookResult TEMPORARY_REJECT = new HookResult(HookReturnCode.DENYSOFT, SMTPRetCode.LOCAL_ERROR, DSNStatus.getStatus(DSNStatus.TRANSIENT, DSNStatus.NETWORK_DIR_SERVER) 
+    private static final HookResult TEMPORARY_REJECT = new HookResult(HookReturnCode.denySoft(), SMTPRetCode.LOCAL_ERROR, DSNStatus.getStatus(DSNStatus.TRANSIENT, DSNStatus.NETWORK_DIR_SERVER)
             + " Temporary rejected: Please try again later");
 
     public void setUnseenLifeTime(long unseenLifeTime) {

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractValidRcptHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractValidRcptHandler.java
@@ -39,12 +39,12 @@ public abstract class AbstractValidRcptHandler implements RcptHook {
     @Override
     public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
         if (!isLocalDomain(session, rcpt.getDomain())) {
-            return HookResult.declined();
+            return HookResult.DECLINED;
         }
         if (!isValidRecipient(session, rcpt)) {
             return reject(rcpt);
         }
-        return HookResult.declined();
+        return HookResult.DECLINED;
     }
 
     public HookResult reject(MailAddress rcpt) {

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractValidRcptHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractValidRcptHandler.java
@@ -31,7 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Handler which want to do an recipient check should extend this
+ * Handler which want to do a recipient check should extend this
  */
 public abstract class AbstractValidRcptHandler implements RcptHook {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractValidRcptHandler.class);

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractValidRcptHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractValidRcptHandler.java
@@ -39,21 +39,10 @@ public abstract class AbstractValidRcptHandler implements RcptHook {
     @Override
     public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
         if (!isLocalDomain(session, rcpt.getDomain())) {
-            return handleRemoteDomain(session, rcpt);
+            return HookResult.declined();
         }
-        return handleLocalDomain(session, rcpt);
-    }
-
-    public HookResult handleLocalDomain(SMTPSession session, MailAddress rcpt) {
         if (!isValidRecipient(session, rcpt)) {
             return reject(rcpt);
-        }
-        return HookResult.declined();
-    }
-
-    public HookResult handleRemoteDomain(SMTPSession session, MailAddress rcpt) {
-        if (!session.isRelayingAllowed()) {
-            LOGGER.debug("Unknown domain {} so reject it", rcpt.getDomain());
         }
         return HookResult.declined();
     }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractValidRcptHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractValidRcptHandler.java
@@ -49,9 +49,11 @@ public abstract class AbstractValidRcptHandler implements RcptHook {
 
     public HookResult reject(MailAddress rcpt) {
         LOGGER.info("Rejected message. Unknown user: {}", rcpt);
-        return new HookResult(HookReturnCode.deny(),
-            SMTPRetCode.MAILBOX_PERM_UNAVAILABLE,
-            DSNStatus.getStatus(DSNStatus.PERMANENT,DSNStatus.ADDRESS_MAILBOX) + " Unknown user: " + rcpt.toString());
+        return HookResult.builder()
+            .hookReturnCode(HookReturnCode.deny())
+            .smtpReturnCode(SMTPRetCode.MAILBOX_PERM_UNAVAILABLE)
+            .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT,DSNStatus.ADDRESS_MAILBOX) + " Unknown user: " + rcpt.asString())
+            .build();
     }
 
     /**

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractValidRcptHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractValidRcptHandler.java
@@ -60,7 +60,7 @@ public abstract class AbstractValidRcptHandler implements RcptHook {
 
     public HookResult reject(MailAddress rcpt) {
         LOGGER.info("Rejected message. Unknown user: {}", rcpt);
-        return new HookResult(HookReturnCode.DENY,
+        return new HookResult(HookReturnCode.deny(),
             SMTPRetCode.MAILBOX_PERM_UNAVAILABLE,
             DSNStatus.getStatus(DSNStatus.PERMANENT,DSNStatus.ADDRESS_MAILBOX) + " Unknown user: " + rcpt.toString());
     }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandler.java
@@ -195,7 +195,7 @@ public class DNSRBLHandler implements RcptHook {
                
             }
         }
-        return HookResult.declined();
+        return HookResult.DECLINED;
     }
 
     /**

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandler.java
@@ -186,11 +186,18 @@ public class DNSRBLHandler implements RcptHook {
     
             if (blocklisted != null) { // was found in the RBL
                 if (blocklistedDetail == null) {
-                    return new HookResult(HookReturnCode.deny(),DSNStatus.getStatus(DSNStatus.PERMANENT,
-                            DSNStatus.SECURITY_AUTH)  + " Rejected: unauthenticated e-mail from " + session.getRemoteAddress().getAddress() 
-                            + " is restricted.  Contact the postmaster for details.");
+                    return HookResult.builder()
+                        .hookReturnCode(HookReturnCode.deny())
+                        .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_AUTH)
+                            + " Rejected: unauthenticated e-mail from " + session.getRemoteAddress().getAddress()
+                            + " is restricted.  Contact the postmaster for details.")
+                        .build();
                 } else {
-                    return new HookResult(HookReturnCode.deny(),DSNStatus.getStatus(DSNStatus.PERMANENT,DSNStatus.SECURITY_AUTH) + " " + blocklistedDetail);
+
+                    return HookResult.builder()
+                        .hookReturnCode(HookReturnCode.deny())
+                        .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT,DSNStatus.SECURITY_AUTH) + " " + blocklistedDetail)
+                        .build();
                 }
                
             }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandler.java
@@ -186,11 +186,11 @@ public class DNSRBLHandler implements RcptHook {
     
             if (blocklisted != null) { // was found in the RBL
                 if (blocklistedDetail == null) {
-                    return new HookResult(HookReturnCode.DENY,DSNStatus.getStatus(DSNStatus.PERMANENT,
+                    return new HookResult(HookReturnCode.deny(),DSNStatus.getStatus(DSNStatus.PERMANENT,
                             DSNStatus.SECURITY_AUTH)  + " Rejected: unauthenticated e-mail from " + session.getRemoteAddress().getAddress() 
                             + " is restricted.  Contact the postmaster for details.");
                 } else {
-                    return new HookResult(HookReturnCode.DENY,DSNStatus.getStatus(DSNStatus.PERMANENT,DSNStatus.SECURITY_AUTH) + " " + blocklistedDetail);
+                    return new HookResult(HookReturnCode.deny(),DSNStatus.getStatus(DSNStatus.PERMANENT,DSNStatus.SECURITY_AUTH) + " " + blocklistedDetail);
                 }
                
             }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/MaxRcptHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/MaxRcptHandler.java
@@ -58,7 +58,7 @@ public class MaxRcptHandler implements RcptHook {
             
             return MAX_RCPT;
         } else {
-            return HookResult.declined();
+            return HookResult.DECLINED;
         }
     }
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/MaxRcptHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/MaxRcptHandler.java
@@ -36,8 +36,12 @@ import org.slf4j.LoggerFactory;
 public class MaxRcptHandler implements RcptHook {
     private static final Logger LOGGER = LoggerFactory.getLogger(MaxRcptHandler.class);
 
-    private static final HookResult MAX_RCPT = new HookResult(HookReturnCode.deny(), SMTPRetCode.SYSTEM_STORAGE_ERROR, DSNStatus.getStatus(DSNStatus.NETWORK, DSNStatus.DELIVERY_TOO_MANY_REC)
-            + " Requested action not taken: max recipients reached");
+    private static final HookResult MAX_RCPT = HookResult.builder()
+        .hookReturnCode(HookReturnCode.deny())
+        .smtpReturnCode(SMTPRetCode.SYSTEM_STORAGE_ERROR)
+        .smtpDescription(DSNStatus.getStatus(DSNStatus.NETWORK, DSNStatus.DELIVERY_TOO_MANY_REC)
+            + " Requested action not taken: max recipients reached")
+        .build();
     private int maxRcpt = 0;
 
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/MaxRcptHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/MaxRcptHandler.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 public class MaxRcptHandler implements RcptHook {
     private static final Logger LOGGER = LoggerFactory.getLogger(MaxRcptHandler.class);
 
-    private static final HookResult MAX_RCPT = new HookResult(HookReturnCode.DENY, SMTPRetCode.SYSTEM_STORAGE_ERROR, DSNStatus.getStatus(DSNStatus.NETWORK, DSNStatus.DELIVERY_TOO_MANY_REC)
+    private static final HookResult MAX_RCPT = new HookResult(HookReturnCode.deny(), SMTPRetCode.SYSTEM_STORAGE_ERROR, DSNStatus.getStatus(DSNStatus.NETWORK, DSNStatus.DELIVERY_TOO_MANY_REC)
             + " Requested action not taken: max recipients reached");
     private int maxRcpt = 0;
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/MaxUnknownCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/MaxUnknownCmdHandler.java
@@ -62,14 +62,12 @@ public class MaxUnknownCmdHandler implements UnknownHook {
         }
         session.setAttachment(UNKOWN_COMMAND_COUNT, count, State.Transaction);
         if (count > maxUnknown) {
-            return new HookResult(new HookReturnCode(
-                HookReturnCode.Action.DENY,
-                HookReturnCode.ConnectionStatus.Disconnected),
-                "521",
-                "Closing connection as too many unknown commands received");
-
+            return HookResult.builder()
+                .hookReturnCode(HookReturnCode.disconnected(HookReturnCode.Action.DENY))
+                .smtpReturnCode("521")
+                .smtpDescription("Closing connection as too many unknown commands received")
+                .build();
         } else {
-            
             return HookResult.DECLINED;
         }
     }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/MaxUnknownCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/MaxUnknownCmdHandler.java
@@ -70,7 +70,7 @@ public class MaxUnknownCmdHandler implements UnknownHook {
 
         } else {
             
-            return HookResult.declined();
+            return HookResult.DECLINED;
         }
     }
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/MaxUnknownCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/MaxUnknownCmdHandler.java
@@ -30,8 +30,6 @@ import org.apache.james.protocols.smtp.hook.UnknownHook;
 
 /**
  * {@link UnknownHook} implementation which disconnect the client after a issue to many unknown commands
- * 
- *
  */
 public class MaxUnknownCmdHandler implements UnknownHook {
 
@@ -64,7 +62,11 @@ public class MaxUnknownCmdHandler implements UnknownHook {
         }
         session.setAttachment(UNKOWN_COMMAND_COUNT, count, State.Transaction);
         if (count > maxUnknown) {
-            return new HookResult(HookReturnCode.DENY | HookReturnCode.DISCONNECT, "521", "Closing connection as too many unknown commands received");
+            return new HookResult(new HookReturnCode(
+                HookReturnCode.Action.DENY,
+                HookReturnCode.ConnectionStatus.Disconnected),
+                "521",
+                "Closing connection as too many unknown commands received");
 
         } else {
             

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandler.java
@@ -99,14 +99,14 @@ public class ResolvableEhloHeloHandler implements RcptHook, HeloHook {
                 SMTPRetCode.SYNTAX_ERROR_ARGUMENTS,DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.DELIVERY_INVALID_ARG)
                     + " Provided EHLO/HELO " + session.getAttachment(SMTPSession.CURRENT_HELO_NAME, State.Connection) + " can not resolved.");
         } else {
-            return HookResult.declined();
+            return HookResult.DECLINED;
         }
     }
 
     @Override
     public HookResult doHelo(SMTPSession session, String helo) {
         checkEhloHelo(session, helo);
-        return HookResult.declined();
+        return HookResult.DECLINED;
     }
 
 }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandler.java
@@ -95,9 +95,12 @@ public class ResolvableEhloHeloHandler implements RcptHook, HeloHook {
     @Override
     public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
         if (check(session,rcpt)) {
-            return new HookResult(HookReturnCode.deny(),
-                SMTPRetCode.SYNTAX_ERROR_ARGUMENTS,DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.DELIVERY_INVALID_ARG)
-                    + " Provided EHLO/HELO " + session.getAttachment(SMTPSession.CURRENT_HELO_NAME, State.Connection) + " can not resolved.");
+            return HookResult.builder()
+                .hookReturnCode(HookReturnCode.deny())
+                .smtpReturnCode(SMTPRetCode.SYNTAX_ERROR_ARGUMENTS)
+                .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.DELIVERY_INVALID_ARG)
+                    + " Provided EHLO/HELO " + session.getAttachment(SMTPSession.CURRENT_HELO_NAME, State.Connection) + " can not resolved.")
+                .build();
         } else {
             return HookResult.DECLINED;
         }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandler.java
@@ -95,7 +95,8 @@ public class ResolvableEhloHeloHandler implements RcptHook, HeloHook {
     @Override
     public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
         if (check(session,rcpt)) {
-            return new HookResult(HookReturnCode.DENY,SMTPRetCode.SYNTAX_ERROR_ARGUMENTS,DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.DELIVERY_INVALID_ARG)
+            return new HookResult(HookReturnCode.deny(),
+                SMTPRetCode.SYNTAX_ERROR_ARGUMENTS,DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.DELIVERY_INVALID_ARG)
                     + " Provided EHLO/HELO " + session.getAttachment(SMTPSession.CURRENT_HELO_NAME, State.Connection) + " can not resolved.");
         } else {
             return HookResult.declined();

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/SpamTrapHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/SpamTrapHandler.java
@@ -72,17 +72,17 @@ public class SpamTrapHandler implements RcptHook {
     public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
         String address = session.getRemoteAddress().getAddress().getHostAddress();
         if (isBlocked(address, session)) {
-            return HookResult.deny();
+            return HookResult.DENY;
         } else {
          
             if (spamTrapRecips.contains(rcpt.toString().toLowerCase(Locale.US))) {
         
                 addIp(address, session);
             
-                return HookResult.deny();
+                return HookResult.DENY;
             }
         }
-        return HookResult.declined();
+        return HookResult.DECLINED;
     }
     
     

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/SupressDuplicateRcptHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/SupressDuplicateRcptHandler.java
@@ -64,7 +64,11 @@ public class SupressDuplicateRcptHandler implements RcptHook {
                           .append(rcpt.toString())
                           .append("> OK");
             LOGGER.debug("Duplicate recipient not add to recipient list: {}", rcpt);
-            return new HookResult(HookReturnCode.ok(), SMTPRetCode.MAIL_OK, responseBuffer.toString());
+            return HookResult.builder()
+                .hookReturnCode(HookReturnCode.ok())
+                .smtpReturnCode(SMTPRetCode.MAIL_OK)
+                .smtpDescription(responseBuffer.toString())
+                .build();
         }
         return HookResult.DECLINED;
     }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/SupressDuplicateRcptHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/SupressDuplicateRcptHandler.java
@@ -66,6 +66,6 @@ public class SupressDuplicateRcptHandler implements RcptHook {
             LOGGER.debug("Duplicate recipient not add to recipient list: {}", rcpt);
             return new HookResult(HookReturnCode.ok(), SMTPRetCode.MAIL_OK, responseBuffer.toString());
         }
-        return HookResult.declined();
+        return HookResult.DECLINED;
     }
 }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/SupressDuplicateRcptHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/SupressDuplicateRcptHandler.java
@@ -64,7 +64,7 @@ public class SupressDuplicateRcptHandler implements RcptHook {
                           .append(rcpt.toString())
                           .append("> OK");
             LOGGER.debug("Duplicate recipient not add to recipient list: {}", rcpt);
-            return new HookResult(HookReturnCode.OK,SMTPRetCode.MAIL_OK, responseBuffer.toString());
+            return new HookResult(HookReturnCode.ok(), SMTPRetCode.MAIL_OK, responseBuffer.toString());
         }
         return HookResult.declined();
     }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandler.java
@@ -39,7 +39,7 @@ public abstract class ValidSenderDomainHandler implements MailHook {
             return new HookResult(HookReturnCode.deny(),
                 SMTPRetCode.SYNTAX_ERROR_ARGUMENTS, DSNStatus.getStatus(DSNStatus.PERMANENT,DSNStatus.ADDRESS_SYNTAX_SENDER) + " sender " + sender + " contains a domain with no valid MX records");
         } else {
-            return HookResult.declined();
+            return HookResult.DECLINED;
         }
     }
     

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandler.java
@@ -36,8 +36,11 @@ public abstract class ValidSenderDomainHandler implements MailHook {
     @Override
     public HookResult doMail(SMTPSession session, MailAddress sender) {
         if (sender != null  && !hasMXRecord(session,sender.getDomain().name())) {
-            return new HookResult(HookReturnCode.deny(),
-                SMTPRetCode.SYNTAX_ERROR_ARGUMENTS, DSNStatus.getStatus(DSNStatus.PERMANENT,DSNStatus.ADDRESS_SYNTAX_SENDER) + " sender " + sender + " contains a domain with no valid MX records");
+            return HookResult.builder()
+                .hookReturnCode(HookReturnCode.deny())
+                .smtpReturnCode(SMTPRetCode.SYNTAX_ERROR_ARGUMENTS)
+                .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT,DSNStatus.ADDRESS_SYNTAX_SENDER) + " sender " + sender + " contains a domain with no valid MX records")
+                .build();
         } else {
             return HookResult.DECLINED;
         }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandler.java
@@ -36,7 +36,8 @@ public abstract class ValidSenderDomainHandler implements MailHook {
     @Override
     public HookResult doMail(SMTPSession session, MailAddress sender) {
         if (sender != null  && !hasMXRecord(session,sender.getDomain().name())) {
-            return new HookResult(HookReturnCode.DENY,SMTPRetCode.SYNTAX_ERROR_ARGUMENTS,DSNStatus.getStatus(DSNStatus.PERMANENT,DSNStatus.ADDRESS_SYNTAX_SENDER) + " sender " + sender + " contains a domain with no valid MX records");
+            return new HookResult(HookReturnCode.deny(),
+                SMTPRetCode.SYNTAX_ERROR_ARGUMENTS, DSNStatus.getStatus(DSNStatus.PERMANENT,DSNStatus.ADDRESS_SYNTAX_SENDER) + " sender " + sender + " contains a domain with no valid MX records");
         } else {
             return HookResult.declined();
         }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/log/HookResultLogger.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/log/HookResultLogger.java
@@ -49,45 +49,20 @@ public class HookResultLogger implements HookResultHook {
 
     @Override
     public HookResult onHookResult(SMTPSession session, HookResult hResult, long executionTime, Hook hook) {
-        boolean match = false;
-        boolean info = false;
-        int result = hResult.getResult();
-        StringBuilder sb = new StringBuilder();
-        sb.append(hook.getClass().getName());
-        sb.append(": result=");
-        sb.append(result);
-        sb.append(" (");
-        if ((result & HookReturnCode.DECLINED) == HookReturnCode.DECLINED) {
-            sb.append("DECLINED");
-            match = true;
-        }
-        if ((result & HookReturnCode.OK) == HookReturnCode.OK) {
-            sb.append("OK");
-            match = true;
-        }
-        if ((result & HookReturnCode.DENY) == HookReturnCode.DENY) {
-            sb.append("DENY");
-            match = true;
-            info = true;
-        }
-        if ((result & HookReturnCode.DENYSOFT) == HookReturnCode.DENYSOFT) {
-            sb.append("DENYSOFT");
-            match = true;
-            info = true;
-        }
-        if ((result & HookReturnCode.DISCONNECT) == HookReturnCode.DISCONNECT) {
-            if (match) {
-                sb.append("|");
-            }
-            sb.append("DISCONNECT");
-            info = true;
-        }
-        sb.append(")");
+        HookReturnCode result = hResult.getResult();
 
-        if (info) {
-            LOGGER.info("{}", sb);
+        boolean requiresInfoLogging = result.getAction() == HookReturnCode.Action.DENY
+            || result.getAction() == HookReturnCode.Action.DENYSOFT
+            || result.isDisconnected();
+
+        if (requiresInfoLogging) {
+            LOGGER.info("{}: result= ({} {})", hook.getClass().getName(),
+                result.getAction(),
+                result.getConnectionStatus());
         } else {
-            LOGGER.debug("{}", sb);
+            LOGGER.debug("{}: result= ({} {})", hook.getClass().getName(),
+                result.getAction(),
+                result.getConnectionStatus());
         }
         return hResult;
     }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/HookResult.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/HookResult.java
@@ -27,31 +27,11 @@ import java.util.Optional;
  */
 public final class HookResult {
 
-    private static final HookResult DECLINED = new HookResult(HookReturnCode.declined());
-    private static final HookResult OK = new HookResult(HookReturnCode.ok());
-    private static final HookResult DENY = new HookResult(HookReturnCode.deny());
-    private static final HookResult DENYSOFT = new HookResult(HookReturnCode.denySoft());
-    private static final HookResult DISCONNECT = new HookResult(new HookReturnCode(HookReturnCode.Action.NONE, HookReturnCode.ConnectionStatus.Disconnected));
-
-    public static HookResult declined() {
-        return DECLINED;
-    }
-
-    public static HookResult ok() {
-        return OK;
-    }
-
-    public static HookResult deny() {
-        return DENY;
-    }
-
-    public static HookResult denysoft() {
-        return DENYSOFT;
-    }
-
-    public static HookResult disconnect() {
-        return DISCONNECT;
-    }
+    public static final HookResult DECLINED = new HookResult(HookReturnCode.declined());
+    public static final HookResult OK = new HookResult(HookReturnCode.ok());
+    public static final HookResult DENY = new HookResult(HookReturnCode.deny());
+    public static final HookResult DENYSOFT = new HookResult(HookReturnCode.denySoft());
+    public static final HookResult DISCONNECT = new HookResult(new HookReturnCode(HookReturnCode.Action.NONE, HookReturnCode.ConnectionStatus.Disconnected));
 
     private final HookReturnCode result;
     private final String smtpRetCode;
@@ -69,7 +49,7 @@ public final class HookResult {
         this(result, null, smtpDescription);
     }
 
-    public HookResult(HookReturnCode result) {
+    private HookResult(HookReturnCode result) {
         this(result, null, null);
     }
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/HookResult.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/HookResult.java
@@ -22,35 +22,77 @@ package org.apache.james.protocols.smtp.hook;
 import java.util.Objects;
 import java.util.Optional;
 
+import com.google.common.base.Preconditions;
+
 /**
  * Result which get used for hooks
  */
 public final class HookResult {
 
-    public static final HookResult DECLINED = new HookResult(HookReturnCode.declined());
-    public static final HookResult OK = new HookResult(HookReturnCode.ok());
-    public static final HookResult DENY = new HookResult(HookReturnCode.deny());
-    public static final HookResult DENYSOFT = new HookResult(HookReturnCode.denySoft());
-    public static final HookResult DISCONNECT = new HookResult(new HookReturnCode(HookReturnCode.Action.NONE, HookReturnCode.ConnectionStatus.Disconnected));
+    public static class Builder {
+        private HookReturnCode result;
+        private Optional<String> smtpReturnCode;
+        private Optional<String> smtpDescription;
 
+        public Builder() {
+            smtpDescription = Optional.empty();
+            smtpReturnCode = Optional.empty();
+        }
+
+        public Builder hookReturnCode(HookReturnCode hookReturnCode) {
+            this.result = hookReturnCode;
+            return this;
+        }
+
+        public Builder smtpReturnCode(String smtpReturnCode) {
+            this.smtpReturnCode = Optional.of(smtpReturnCode);
+            return this;
+        }
+
+        public Builder smtpDescription(String smtpDescription) {
+            this.smtpDescription = Optional.of(smtpDescription);
+            return this;
+        }
+
+        public HookResult build() {
+            Preconditions.checkNotNull(result);
+
+            return new HookResult(result,
+                smtpReturnCode.orElse(null),
+                smtpDescription.orElse(null));
+        }
+    }
+
+    public static final HookResult DECLINED = builder()
+        .hookReturnCode(HookReturnCode.declined())
+        .build();
+    public static final HookResult OK =  builder()
+        .hookReturnCode(HookReturnCode.ok())
+        .build();
+    public static final HookResult DENY =  builder()
+        .hookReturnCode(HookReturnCode.deny())
+        .build();
+    public static final HookResult DENYSOFT =  builder()
+        .hookReturnCode(HookReturnCode.denySoft())
+        .build();
+    public static final HookResult DISCONNECT =  builder()
+        .hookReturnCode(new HookReturnCode(HookReturnCode.Action.NONE, HookReturnCode.ConnectionStatus.Disconnected))
+        .build();
+
+    public static Builder builder() {
+        return new Builder();
+    }
+    
     private final HookReturnCode result;
     private final String smtpRetCode;
     private final String smtpDescription;
 
-    public HookResult(HookReturnCode result, String smtpRetCode, CharSequence smtpDescription) {
+    private HookResult(HookReturnCode result, String smtpRetCode, CharSequence smtpDescription) {
         this.result = result;
         this.smtpRetCode = smtpRetCode;
         this.smtpDescription = Optional.ofNullable(smtpDescription)
             .map(CharSequence::toString)
             .orElse(null);
-    }
-
-    public HookResult(HookReturnCode result, String smtpDescription) {
-        this(result, null, smtpDescription);
-    }
-
-    private HookResult(HookReturnCode result) {
-        this(result, null, null);
     }
 
     public HookReturnCode getResult() {

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/HookResult.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/HookResult.java
@@ -22,18 +22,16 @@ package org.apache.james.protocols.smtp.hook;
 import java.util.Objects;
 import java.util.Optional;
 
-import com.google.common.base.Preconditions;
-
 /**
  * Result which get used for hooks
  */
 public final class HookResult {
 
-    private static final HookResult DECLINED = new HookResult(HookReturnCode.DECLINED);
-    private static final HookResult OK = new HookResult(HookReturnCode.OK);
-    private static final HookResult DENY = new HookResult(HookReturnCode.DENY);
-    private static final HookResult DENYSOFT = new HookResult(HookReturnCode.DENYSOFT);
-    private static final HookResult DISCONNECT = new HookResult(HookReturnCode.DISCONNECT);
+    private static final HookResult DECLINED = new HookResult(HookReturnCode.declined());
+    private static final HookResult OK = new HookResult(HookReturnCode.ok());
+    private static final HookResult DENY = new HookResult(HookReturnCode.deny());
+    private static final HookResult DENYSOFT = new HookResult(HookReturnCode.denySoft());
+    private static final HookResult DISCONNECT = new HookResult(new HookReturnCode(HookReturnCode.Action.NONE, HookReturnCode.ConnectionStatus.Disconnected));
 
     public static HookResult declined() {
         return DECLINED;
@@ -55,37 +53,11 @@ public final class HookResult {
         return DISCONNECT;
     }
 
-    private final int result;
+    private final HookReturnCode result;
     private final String smtpRetCode;
     private final String smtpDescription;
 
-    public HookResult(int result, String smtpRetCode, CharSequence smtpDescription) {
-        boolean match = false;
-
-        if ((result & HookReturnCode.DECLINED) == HookReturnCode.DECLINED) {
-            if (match == true) {
-                throw new IllegalArgumentException();
-            }
-            match = true;
-        }
-        if ((result & HookReturnCode.OK) == HookReturnCode.OK) {
-            if (match == true) {
-                throw new IllegalArgumentException();
-            }
-            match = true;
-        }
-        if ((result & HookReturnCode.DENY) == HookReturnCode.DENY) {
-            if (match == true) {
-                throw new IllegalArgumentException();
-            }
-            match = true;
-        }
-        if ((result & HookReturnCode.DENYSOFT) == HookReturnCode.DENYSOFT) {
-            if (match == true) {
-                throw new IllegalArgumentException();
-            }
-            match = true;
-        }
+    public HookResult(HookReturnCode result, String smtpRetCode, CharSequence smtpDescription) {
         this.result = result;
         this.smtpRetCode = smtpRetCode;
         this.smtpDescription = Optional.ofNullable(smtpDescription)
@@ -93,15 +65,15 @@ public final class HookResult {
             .orElse(null);
     }
 
-    public HookResult(int result, String smtpDescription) {
+    public HookResult(HookReturnCode result, String smtpDescription) {
         this(result, null, smtpDescription);
     }
 
-    public HookResult(int result) {
+    public HookResult(HookReturnCode result) {
         this(result, null, null);
     }
 
-    public int getResult() {
+    public HookReturnCode getResult() {
         return result;
     }
     

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/HookResult.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/HookResult.java
@@ -19,9 +19,13 @@
 
 package org.apache.james.protocols.smtp.hook;
 
+import java.util.Objects;
+import java.util.Optional;
+
+import com.google.common.base.Preconditions;
+
 /**
  * Result which get used for hooks
- * 
  */
 public final class HookResult {
 
@@ -31,17 +35,30 @@ public final class HookResult {
     private static final HookResult DENYSOFT = new HookResult(HookReturnCode.DENYSOFT);
     private static final HookResult DISCONNECT = new HookResult(HookReturnCode.DISCONNECT);
 
+    public static HookResult declined() {
+        return DECLINED;
+    }
+
+    public static HookResult ok() {
+        return OK;
+    }
+
+    public static HookResult deny() {
+        return DENY;
+    }
+
+    public static HookResult denysoft() {
+        return DENYSOFT;
+    }
+
+    public static HookResult disconnect() {
+        return DISCONNECT;
+    }
+
     private final int result;
     private final String smtpRetCode;
     private final String smtpDescription;
-    
-    /**
-     * Construct new HookResult
-     * 
-     * @param result 
-     * @param smtpRetCode 
-     * @param smtpDescription
-     */
+
     public HookResult(int result, String smtpRetCode, CharSequence smtpDescription) {
         boolean match = false;
 
@@ -71,42 +88,25 @@ public final class HookResult {
         }
         this.result = result;
         this.smtpRetCode = smtpRetCode;
-        this.smtpDescription = (smtpDescription == null) ? null : smtpDescription.toString();
+        this.smtpDescription = Optional.ofNullable(smtpDescription)
+            .map(CharSequence::toString)
+            .orElse(null);
     }
-    
-    /**
-     * Construct new HookResult
-     * 
-     * @param result
-     * @param smtpDescription
-     */
+
     public HookResult(int result, String smtpDescription) {
-        this(result,null,smtpDescription);
+        this(result, null, smtpDescription);
     }
-    
-    /**
-     * Construct new HookResult
-     * 
-     * @param result
-     */
+
     public HookResult(int result) {
-        this(result,null,null);
+        this(result, null, null);
     }
-    
-   
-    /**
-     * Return the result
-     * 
-     * @return result
-     */
+
     public int getResult() {
         return result;
     }
     
     /**
-     * Return the SMTPRetCode which should used. If not set return null. 
-     * 
-     * @return smtpRetCode
+     * Return the SMTPRetCode which should used. If not set return null.
      */
     public String getSmtpRetCode() {
         return smtpRetCode;
@@ -114,30 +114,25 @@ public final class HookResult {
     
     /**
      * Return the SMTPDescription which should used. If not set return null
-     *  
-     * @return smtpDescription
      */
     public String getSmtpDescription() {
         return smtpDescription;
     }
-    
-    public static HookResult declined() {
-        return DECLINED;
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof HookResult) {
+            HookResult that = (HookResult) o;
+
+            return Objects.equals(this.result, that.result)
+                && Objects.equals(this.smtpRetCode, that.smtpRetCode)
+                && Objects.equals(this.smtpDescription, that.smtpDescription);
+        }
+        return false;
     }
-    
-    public static HookResult ok() {
-        return OK;
-    }
-    
-    public static HookResult deny() {
-        return DENY;
-    }
-    
-    public static HookResult denysoft() {
-        return DENYSOFT;
-    }
-    
-    public static HookResult disconnect() {
-        return DISCONNECT;
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(result, smtpRetCode, smtpDescription);
     }
 }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/HookReturnCode.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/HookReturnCode.java
@@ -65,6 +65,10 @@ public class HookReturnCode {
         return new HookReturnCode(action, ConnectionStatus.Connected);
     }
 
+    public static HookReturnCode disconnected(Action action) {
+        return new HookReturnCode(action, ConnectionStatus.Disconnected);
+    }
+
     private final Action action;
     private final ConnectionStatus connectionStatus;
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/HookReturnCode.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/HookReturnCode.java
@@ -19,18 +19,25 @@
 
 package org.apache.james.protocols.smtp.hook;
 
+import java.util.List;
 import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
 
 public class HookReturnCode {
+
 
     public enum Action {
         OK,
         DENY,
         DENYSOFT,
         DECLINED,
-        NONE
+        NONE;
+
+        public static List<Action> ACTIVE_ACTIONS =
+            ImmutableList.of(HookReturnCode.Action.DENY, HookReturnCode.Action.DENYSOFT, HookReturnCode.Action.OK);
+
     }
 
     public enum ConnectionStatus {

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/HookReturnCode.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/HookReturnCode.java
@@ -19,15 +19,86 @@
 
 package org.apache.james.protocols.smtp.hook;
 
-import com.google.common.collect.ImmutableList;
+import java.util.Objects;
+
+import com.google.common.base.MoreObjects;
 
 public class HookReturnCode {
-    public static final int OK = 0x1;
-    public static final int DENY = 0x1 << 1;
-    public static final int DENYSOFT = 0x1 << 2;
-    public static final int DECLINED = 0x1 << 3;
-    public static final int DISCONNECT = 0x1 << 4;
 
-    public static final ImmutableList<Integer> VALID_RETURN_CODE = ImmutableList.of(
-        DECLINED, OK, DENY, DENYSOFT, DISCONNECT);
+    public enum Action {
+        OK,
+        DENY,
+        DENYSOFT,
+        DECLINED,
+        NONE
+    }
+
+    public enum ConnectionStatus {
+        Disconnected,
+        Connected
+    }
+
+    public static HookReturnCode denySoft() {
+        return connected(Action.DENYSOFT);
+    }
+
+    public static HookReturnCode deny() {
+        return connected(Action.DENY);
+    }
+
+    public static HookReturnCode ok() {
+        return connected(Action.OK);
+    }
+
+    public static HookReturnCode declined() {
+        return connected(Action.DECLINED);
+    }
+
+    public static HookReturnCode connected(Action action) {
+        return new HookReturnCode(action, ConnectionStatus.Connected);
+    }
+
+    private final Action action;
+    private final ConnectionStatus connectionStatus;
+
+    public HookReturnCode(Action action, ConnectionStatus connectionStatus) {
+        this.action = action;
+        this.connectionStatus = connectionStatus;
+    }
+
+    public Action getAction() {
+        return action;
+    }
+
+    public ConnectionStatus getConnectionStatus() {
+        return connectionStatus;
+    }
+
+    public boolean isDisconnected() {
+        return connectionStatus == ConnectionStatus.Disconnected;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof HookReturnCode) {
+            HookReturnCode that = (HookReturnCode) o;
+
+            return Objects.equals(this.action, that.action)
+                && Objects.equals(this.connectionStatus, that.connectionStatus);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(action, connectionStatus);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("action", action)
+            .add("disconnection", connectionStatus)
+            .toString();
+    }
 }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/HookReturnCode.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/HookReturnCode.java
@@ -17,10 +17,9 @@
  * under the License.                                           *
  ****************************************************************/
 
-
-
-
 package org.apache.james.protocols.smtp.hook;
+
+import com.google.common.collect.ImmutableList;
 
 public class HookReturnCode {
     public static final int OK = 0x1;
@@ -28,4 +27,7 @@ public class HookReturnCode {
     public static final int DENYSOFT = 0x1 << 2;
     public static final int DECLINED = 0x1 << 3;
     public static final int DISCONNECT = 0x1 << 4;
+
+    public static final ImmutableList<Integer> VALID_RETURN_CODE = ImmutableList.of(
+        DECLINED, OK, DENY, DENYSOFT, DISCONNECT);
 }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/SimpleHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/SimpleHook.java
@@ -49,7 +49,7 @@ public class SimpleHook implements HeloHook, MailHook, RcptHook, MessageHook {
      */
     @Override
     public HookResult onMessage(SMTPSession session, MailEnvelope mail) {
-        return new HookResult(HookReturnCode.ok());
+        return HookResult.OK;
     }
 
     /**
@@ -57,7 +57,7 @@ public class SimpleHook implements HeloHook, MailHook, RcptHook, MessageHook {
      */
     @Override
     public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
-        return new HookResult(HookReturnCode.declined());
+        return HookResult.DECLINED;
 
     }
 
@@ -66,7 +66,7 @@ public class SimpleHook implements HeloHook, MailHook, RcptHook, MessageHook {
      */
     @Override
     public HookResult doMail(SMTPSession session, MailAddress sender) {
-        return new HookResult(HookReturnCode.declined());
+        return HookResult.DECLINED;
 
     }
 
@@ -75,7 +75,7 @@ public class SimpleHook implements HeloHook, MailHook, RcptHook, MessageHook {
      */
     @Override
     public HookResult doHelo(SMTPSession session, String helo) {
-        return new HookResult(HookReturnCode.declined());
+        return HookResult.DECLINED;
     }
 
 }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/SimpleHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/SimpleHook.java
@@ -49,7 +49,7 @@ public class SimpleHook implements HeloHook, MailHook, RcptHook, MessageHook {
      */
     @Override
     public HookResult onMessage(SMTPSession session, MailEnvelope mail) {
-        return new HookResult(HookReturnCode.OK);
+        return new HookResult(HookReturnCode.ok());
     }
 
     /**
@@ -57,7 +57,7 @@ public class SimpleHook implements HeloHook, MailHook, RcptHook, MessageHook {
      */
     @Override
     public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
-        return new HookResult(HookReturnCode.DECLINED);
+        return new HookResult(HookReturnCode.declined());
 
     }
 
@@ -66,7 +66,7 @@ public class SimpleHook implements HeloHook, MailHook, RcptHook, MessageHook {
      */
     @Override
     public HookResult doMail(SMTPSession session, MailAddress sender) {
-        return new HookResult(HookReturnCode.DECLINED);
+        return new HookResult(HookReturnCode.declined());
 
     }
 
@@ -75,7 +75,7 @@ public class SimpleHook implements HeloHook, MailHook, RcptHook, MessageHook {
      */
     @Override
     public HookResult doHelo(SMTPSession session, String helo) {
-        return new HookResult(HookReturnCode.DECLINED);
+        return new HookResult(HookReturnCode.declined());
     }
 
 }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
@@ -501,7 +501,7 @@ public abstract class AbstractSMTPServerTest {
 
             @Override
             public HookResult doHelo(SMTPSession session, String helo) {
-                return new HookResult(HookReturnCode.deny());
+                return HookResult.DENY;
             }
         };
         
@@ -549,7 +549,7 @@ public abstract class AbstractSMTPServerTest {
 
             @Override
             public HookResult doHelo(SMTPSession session, String helo) {
-                return new HookResult(HookReturnCode.denySoft());
+                return HookResult.DENYSOFT;
             }
         };
         
@@ -596,7 +596,7 @@ public abstract class AbstractSMTPServerTest {
 
             @Override
             public HookResult doMail(SMTPSession session, MailAddress sender) {
-                return new HookResult(HookReturnCode.deny());
+                return HookResult.DENY;
             }
         };
         
@@ -646,7 +646,7 @@ public abstract class AbstractSMTPServerTest {
 
             @Override
             public HookResult doMail(SMTPSession session, MailAddress sender) {
-                return new HookResult(HookReturnCode.denySoft());
+                return HookResult.DENYSOFT;
             }
         };
         
@@ -698,9 +698,9 @@ public abstract class AbstractSMTPServerTest {
             @Override
             public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
                 if (RCPT1.equals(rcpt.toString())) {
-                    return new HookResult(HookReturnCode.deny());
+                    return HookResult.DENY;
                 } else {
-                    return new HookResult(HookReturnCode.declined());
+                    return HookResult.DECLINED;
                 }
             }
 
@@ -762,9 +762,9 @@ public abstract class AbstractSMTPServerTest {
             @Override
             public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
                 if (RCPT1.equals(rcpt.toString())) {
-                    return new HookResult(HookReturnCode.denySoft());
+                    return HookResult.DENYSOFT;
                 } else {
-                    return new HookResult(HookReturnCode.declined());
+                    return HookResult.DECLINED;
                 }
             }
 
@@ -860,7 +860,7 @@ public abstract class AbstractSMTPServerTest {
 
             @Override
             public HookResult onMessage(SMTPSession session, MailEnvelope mail) {
-                return new HookResult(HookReturnCode.deny());
+                return HookResult.DENY;
             }
 
 
@@ -924,7 +924,7 @@ public abstract class AbstractSMTPServerTest {
 
             @Override
             public HookResult onMessage(SMTPSession session, MailEnvelope mail) {
-                return new HookResult(HookReturnCode.denySoft());
+                return HookResult.DENYSOFT;
             }
 
 

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
@@ -501,7 +501,7 @@ public abstract class AbstractSMTPServerTest {
 
             @Override
             public HookResult doHelo(SMTPSession session, String helo) {
-                return new HookResult(HookReturnCode.DENY);
+                return new HookResult(HookReturnCode.deny());
             }
         };
         
@@ -549,7 +549,7 @@ public abstract class AbstractSMTPServerTest {
 
             @Override
             public HookResult doHelo(SMTPSession session, String helo) {
-                return new HookResult(HookReturnCode.DENYSOFT);
+                return new HookResult(HookReturnCode.denySoft());
             }
         };
         
@@ -596,7 +596,7 @@ public abstract class AbstractSMTPServerTest {
 
             @Override
             public HookResult doMail(SMTPSession session, MailAddress sender) {
-                return new HookResult(HookReturnCode.DENY);
+                return new HookResult(HookReturnCode.deny());
             }
         };
         
@@ -646,7 +646,7 @@ public abstract class AbstractSMTPServerTest {
 
             @Override
             public HookResult doMail(SMTPSession session, MailAddress sender) {
-                return new HookResult(HookReturnCode.DENYSOFT);
+                return new HookResult(HookReturnCode.denySoft());
             }
         };
         
@@ -698,9 +698,9 @@ public abstract class AbstractSMTPServerTest {
             @Override
             public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
                 if (RCPT1.equals(rcpt.toString())) {
-                    return new HookResult(HookReturnCode.DENY);
+                    return new HookResult(HookReturnCode.deny());
                 } else {
-                    return new HookResult(HookReturnCode.DECLINED);
+                    return new HookResult(HookReturnCode.declined());
                 }
             }
 
@@ -762,9 +762,9 @@ public abstract class AbstractSMTPServerTest {
             @Override
             public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
                 if (RCPT1.equals(rcpt.toString())) {
-                    return new HookResult(HookReturnCode.DENYSOFT);
+                    return new HookResult(HookReturnCode.denySoft());
                 } else {
-                    return new HookResult(HookReturnCode.DECLINED);
+                    return new HookResult(HookReturnCode.declined());
                 }
             }
 
@@ -860,7 +860,7 @@ public abstract class AbstractSMTPServerTest {
 
             @Override
             public HookResult onMessage(SMTPSession session, MailEnvelope mail) {
-                return new HookResult(HookReturnCode.DENY);
+                return new HookResult(HookReturnCode.deny());
             }
 
 
@@ -924,7 +924,7 @@ public abstract class AbstractSMTPServerTest {
 
             @Override
             public HookResult onMessage(SMTPSession session, MailEnvelope mail) {
-                return new HookResult(HookReturnCode.DENYSOFT);
+                return new HookResult(HookReturnCode.denySoft());
             }
 
 

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/MaxRcptHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/MaxRcptHandlerTest.java
@@ -60,9 +60,9 @@ public class MaxRcptHandlerTest {
         MaxRcptHandler handler = new MaxRcptHandler();
         
         handler.setMaxRcpt(2);
-        int resp = handler.doRcpt(session,null,new MailAddress("test@test")).getResult();
+        HookReturnCode resp = handler.doRcpt(session,null,new MailAddress("test@test")).getResult();
     
-        assertEquals("Rejected.. To many recipients", resp, HookReturnCode.DENY);
+        assertEquals("Rejected.. To many recipients", resp, HookReturnCode.deny());
     }
   
   
@@ -72,9 +72,9 @@ public class MaxRcptHandlerTest {
         MaxRcptHandler handler = new MaxRcptHandler();    
 
         handler.setMaxRcpt(4);
-        int resp = handler.doRcpt(session,null,new MailAddress("test@test")).getResult();
+        HookReturnCode resp = handler.doRcpt(session,null,new MailAddress("test@test")).getResult();
         
-        assertEquals("Not Rejected..", resp, HookReturnCode.DECLINED);
+        assertEquals("Not Rejected..", resp, HookReturnCode.declined());
     }
 
 }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/MaxUnknownCmdHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/MaxUnknownCmdHandlerTest.java
@@ -70,13 +70,13 @@ public class MaxUnknownCmdHandlerTest {
         
         MaxUnknownCmdHandler handler = new MaxUnknownCmdHandler();
         handler.setMaxUnknownCmdCount(2);
-        int resp = handler.doUnknown(session, "what").getResult();
-        assertEquals(HookReturnCode.DECLINED, resp);
+        HookReturnCode resp = handler.doUnknown(session, "what").getResult();
+        assertEquals(HookReturnCode.declined(), resp);
 
         resp = handler.doUnknown(session, "what").getResult();
-        assertEquals(HookReturnCode.DECLINED, resp);
+        assertEquals(HookReturnCode.declined(), resp);
         
         resp = handler.doUnknown(session, "what").getResult();
-        assertEquals(HookReturnCode.DENY | HookReturnCode.DISCONNECT, resp);
+        assertEquals(new HookReturnCode(HookReturnCode.Action.DENY, HookReturnCode.ConnectionStatus.Disconnected), resp);
     }
 }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandlerTest.java
@@ -126,9 +126,9 @@ public class ResolvableEhloHeloHandlerTest {
         
         handler.doHelo(session, INVALID_HOST);
         assertNotNull("Invalid HELO",session.getAttachment(ResolvableEhloHeloHandler.BAD_EHLO_HELO, State.Transaction));
-        
-        int result = handler.doRcpt(session,null, mailAddress).getResult();
-        assertEquals("Reject", result,HookReturnCode.DENY);
+
+        HookReturnCode result = handler.doRcpt(session,null, mailAddress).getResult();
+        assertEquals("Reject", result,HookReturnCode.deny());
     }
     
     @Test
@@ -141,8 +141,8 @@ public class ResolvableEhloHeloHandlerTest {
         handler.doHelo(session, VALID_HOST);
         assertNull("Valid HELO",session.getAttachment(ResolvableEhloHeloHandler.BAD_EHLO_HELO, State.Transaction));
 
-        int result = handler.doRcpt(session,null, mailAddress).getResult();
-        assertEquals("Not reject", result,HookReturnCode.DECLINED);
+        HookReturnCode result = handler.doRcpt(session,null, mailAddress).getResult();
+        assertEquals("Not reject", result,HookReturnCode.declined());
     }
    
     @Test
@@ -154,10 +154,10 @@ public class ResolvableEhloHeloHandlerTest {
 
         handler.doHelo(session, INVALID_HOST);
         assertNotNull("Value stored",session.getAttachment(ResolvableEhloHeloHandler.BAD_EHLO_HELO, State.Transaction));
-        
-        
-        int result = handler.doRcpt(session,null, mailAddress).getResult();
-        assertEquals("Reject", result,HookReturnCode.DENY);
+
+
+        HookReturnCode result = handler.doRcpt(session,null, mailAddress).getResult();
+        assertEquals("Reject", result,HookReturnCode.deny());
     }
     
    
@@ -170,10 +170,10 @@ public class ResolvableEhloHeloHandlerTest {
 
         handler.doHelo(session, INVALID_HOST);
         assertNotNull("Value stored",session.getAttachment(ResolvableEhloHeloHandler.BAD_EHLO_HELO, State.Transaction));
-        
-        
-        int result = handler.doRcpt(session,null, mailAddress).getResult();
-        assertEquals("Reject", result,HookReturnCode.DENY);
+
+
+        HookReturnCode result = handler.doRcpt(session,null, mailAddress).getResult();
+        assertEquals("Reject", result,HookReturnCode.deny());
     }
 }
     

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/SpamTrapHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/SpamTrapHandlerTest.java
@@ -62,20 +62,20 @@ public class SpamTrapHandlerTest {
     
         handler.setBlockTime(blockTime);
         handler.setSpamTrapRecipients(rcpts);
+
+        HookReturnCode result = handler.doRcpt(setUpSMTPSession(ip),null,new MailAddress(SPAM_TRAP_RECIP1)).getResult();
     
-        int result = handler.doRcpt(setUpSMTPSession(ip),null,new MailAddress(SPAM_TRAP_RECIP1)).getResult();
-    
-        assertEquals("Blocked on first connect",HookReturnCode.DENY,result);
+        assertEquals("Blocked on first connect",HookReturnCode.deny(),result);
     
 
         result = handler.doRcpt(setUpSMTPSession(ip),null,new MailAddress(RECIP1)).getResult();
     
-        assertEquals("Blocked on second connect", HookReturnCode.DENY,result);
+        assertEquals("Blocked on second connect", HookReturnCode.deny(),result);
     
         
         result = handler.doRcpt(setUpSMTPSession(ip2),null,new MailAddress(RECIP1)).getResult();
     
-        assertEquals("Not Blocked", HookReturnCode.DECLINED,result);
+        assertEquals("Not Blocked", HookReturnCode.declined(),result);
     
         try {
             // Wait for the blockTime to exceed
@@ -86,6 +86,6 @@ public class SpamTrapHandlerTest {
     
         result = handler.doRcpt(setUpSMTPSession(ip),null,new MailAddress(RECIP1)).getResult();
     
-        assertEquals("Not blocked. BlockTime exceeded", HookReturnCode.DECLINED,result); 
+        assertEquals("Not blocked. BlockTime exceeded", HookReturnCode.declined(),result);
     }
 }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandlerTest.java
@@ -106,17 +106,17 @@ public class ValidSenderDomainHandlerTest {
     @Test
     public void testNullSenderNotReject() {
         ValidSenderDomainHandler handler = createHandler();
-        int response = handler.doMail(setupMockedSession(null),null).getResult();
+        HookReturnCode response = handler.doMail(setupMockedSession(null),null).getResult();
         
-        assertEquals("Not blocked cause its a nullsender",response,HookReturnCode.DECLINED);
+        assertEquals("Not blocked cause its a nullsender", response, HookReturnCode.declined());
     }
 
     @Test
     public void testInvalidSenderDomainReject() throws Exception {
         ValidSenderDomainHandler handler = createHandler();
         SMTPSession session = setupMockedSession(new MailAddress("invalid@invalid"));
-        int response = handler.doMail(session,(MailAddress) session.getAttachment(SMTPSession.SENDER, State.Transaction)).getResult();
+        HookReturnCode response = handler.doMail(session,(MailAddress) session.getAttachment(SMTPSession.SENDER, State.Transaction)).getResult();
         
-        assertEquals("Blocked cause we use reject action", response,HookReturnCode.DENY);
+        assertEquals("Blocked cause we use reject action", response, HookReturnCode.deny());
     }
 }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/hook/HookResultTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/hook/HookResultTest.java
@@ -1,0 +1,72 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.protocols.smtp.hook;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class HookResultTest {
+    @Test
+    public void shouldMatchBeanContract() {
+        EqualsVerifier.forClass(HookResult.class)
+            .allFieldsShouldBeUsed()
+            .verify();
+    }
+
+    @Test
+    public void shouldThrowOnInvalidReturnCode() {
+        assertThatThrownBy(() -> new HookResult(HookReturnCode.DENY + HookReturnCode.DECLINED))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void shouldNotThrowOnOK() {
+        assertThatCode(() -> new HookResult(HookReturnCode.OK))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void shouldNotThrowOnDeny() {
+        assertThatCode(() -> new HookResult(HookReturnCode.DENY))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void shouldNotThrowOnDenySoft() {
+        assertThatCode(() -> new HookResult(HookReturnCode.DENYSOFT))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void shouldNotThrowOnDeclined() {
+        assertThatCode(() -> new HookResult(HookReturnCode.DECLINED))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void shouldNotThrowOnDisconnect() {
+        assertThatCode(() -> new HookResult(HookReturnCode.DISCONNECT))
+            .doesNotThrowAnyException();
+    }
+}

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/hook/HookResultTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/hook/HookResultTest.java
@@ -19,14 +19,12 @@
 
 package org.apache.james.protocols.smtp.hook;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class HookResultTest {
+
     @Test
     public void shouldMatchBeanContract() {
         EqualsVerifier.forClass(HookResult.class)
@@ -34,39 +32,4 @@ public class HookResultTest {
             .verify();
     }
 
-    @Test
-    public void shouldThrowOnInvalidReturnCode() {
-        assertThatThrownBy(() -> new HookResult(HookReturnCode.DENY + HookReturnCode.DECLINED))
-            .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    public void shouldNotThrowOnOK() {
-        assertThatCode(() -> new HookResult(HookReturnCode.OK))
-            .doesNotThrowAnyException();
-    }
-
-    @Test
-    public void shouldNotThrowOnDeny() {
-        assertThatCode(() -> new HookResult(HookReturnCode.DENY))
-            .doesNotThrowAnyException();
-    }
-
-    @Test
-    public void shouldNotThrowOnDenySoft() {
-        assertThatCode(() -> new HookResult(HookReturnCode.DENYSOFT))
-            .doesNotThrowAnyException();
-    }
-
-    @Test
-    public void shouldNotThrowOnDeclined() {
-        assertThatCode(() -> new HookResult(HookReturnCode.DECLINED))
-            .doesNotThrowAnyException();
-    }
-
-    @Test
-    public void shouldNotThrowOnDisconnect() {
-        assertThatCode(() -> new HookResult(HookReturnCode.DISCONNECT))
-            .doesNotThrowAnyException();
-    }
 }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/utils/TestMessageHook.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/utils/TestMessageHook.java
@@ -36,7 +36,7 @@ public class TestMessageHook implements MessageHook {
     @Override
     public HookResult onMessage(SMTPSession session, MailEnvelope mail) {
         queued.add(mail);
-        return new HookResult(HookReturnCode.ok());
+        return HookResult.OK;
     }
  
     public List<MailEnvelope> getQueued() {

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/utils/TestMessageHook.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/utils/TestMessageHook.java
@@ -36,7 +36,7 @@ public class TestMessageHook implements MessageHook {
     @Override
     public HookResult onMessage(SMTPSession session, MailEnvelope mail) {
         queued.add(mail);
-        return new HookResult(HookReturnCode.OK);
+        return new HookResult(HookReturnCode.ok());
     }
  
     public List<MailEnvelope> getQueued() {

--- a/server/app/src/test/resources/mailetcontainer.xml
+++ b/server/app/src/test/resources/mailetcontainer.xml
@@ -417,7 +417,9 @@ Regards, Postmaster XXX.YYY
          -->
 
        <!--  The RecipientRewriteTable will use the definitions found in recipientrewritetablexml -->
-         <mailet match="All" class="RecipientRewriteTable" />
+        <mailet match="All" class="RecipientRewriteTable">
+            <errorProcessor>rrt-error</errorProcessor>
+        </mailet>
         
          <!-- Place a copy in the user Sent folder -->
          <mailet match="SenderIsLocal" class="ToSenderFolder">
@@ -674,6 +676,17 @@ Regards, Postmaster XXX.YYY
             -->
         </mailet>
     </processor>
+
+      <processor state="rrt-error" enableJmx="false">
+          <mailet match="All" class="ToRepository">
+              <repositoryPath>file://var/mail/rrt-error/</repositoryPath>
+              <passThrough>true</passThrough>
+          </mailet>
+          <mailet match="IsSenderInRRTLoop" class="Null"/>
+          <mailet match="All" class="Bounce">
+              <notice>We were unable to deliver the attached message to the following recipients due to an address rewriting issue.</notice>
+          </mailet>
+      </processor>
 
   </processors>
 

--- a/server/container/guice/cassandra-guice/src/test/resources/mailetcontainer.xml
+++ b/server/container/guice/cassandra-guice/src/test/resources/mailetcontainer.xml
@@ -57,7 +57,9 @@
             <mailet match="All" class="RemoveMimeHeader">
                 <name>bcc</name>
             </mailet>
-            <mailet match="All" class="RecipientRewriteTable" />
+            <mailet match="All" class="RecipientRewriteTable">
+                <errorProcessor>rrt-error</errorProcessor>
+            </mailet>
             <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet"/>
             <mailet match="RecipientIsLocal" class="SpamAssassin">
                 <spamdHost>localhost</spamdHost>
@@ -125,6 +127,15 @@
             <mailet match="All" class="DSNBounce">
                 <passThrough>false</passThrough>
             </mailet>
+        </processor>
+
+        <processor state="rrt-error" enableJmx="false">
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>cassandra://var/mail/rrt-error/</repositoryPath>
+                <passThrough>true</passThrough>
+            </mailet>
+            <mailet match="IsSenderInRRTLoop" class="Null"/>
+            <mailet match="All" class="Bounce"/>
         </processor>
 
     </processors>

--- a/server/container/guice/jpa-guice/src/test/resources/mailetcontainer.xml
+++ b/server/container/guice/jpa-guice/src/test/resources/mailetcontainer.xml
@@ -54,7 +54,9 @@
             <mailet match="All" class="RemoveMimeHeader">
                 <name>bcc</name>
             </mailet>
-            <mailet match="All" class="RecipientRewriteTable" />
+            <mailet match="All" class="RecipientRewriteTable">
+                <errorProcessor>rrt-error</errorProcessor>
+            </mailet>
             <mailet match="RecipientIsLocal" class="LocalDelivery"/>
             <mailet match="HostIsLocal" class="ToProcessor">
                 <processor>local-address-error</processor>
@@ -109,6 +111,15 @@
             <mailet match="All" class="DSNBounce">
                 <passThrough>false</passThrough>
             </mailet>
+        </processor>
+
+        <processor state="rrt-error" enableJmx="false">
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>file://var/mail/rrt-error/</repositoryPath>
+                <passThrough>true</passThrough>
+            </mailet>
+            <mailet match="IsSenderInRRTLoop" class="Null"/>
+            <mailet match="All" class="Bounce"/>
         </processor>
 
     </processors>

--- a/server/container/guice/jpa-smtp/src/test/resources/mailetcontainer.xml
+++ b/server/container/guice/jpa-smtp/src/test/resources/mailetcontainer.xml
@@ -67,7 +67,9 @@
             <mailet match="All" class="RemoveMimeHeader">
                 <name>bcc</name>
             </mailet>
-            <mailet match="All" class="RecipientRewriteTable" />
+            <mailet match="All" class="RecipientRewriteTable">
+                <errorProcessor>rrt-error</errorProcessor>
+            </mailet>
             <!-- <mailet match="HostIsLocal" class="ToProcessor">
                 <processor>local-address-error</processor>
                 <notice>550 - Requested action not taken: no such user here</notice>
@@ -115,6 +117,17 @@
         <processor state="bounces" enableJmx="true">
             <mailet match="All" class="DSNBounce">
                 <passThrough>false</passThrough>
+            </mailet>
+        </processor>
+
+        <processor state="rrt-error" enableJmx="false">
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>file://var/mail/rrt-error/</repositoryPath>
+                <passThrough>true</passThrough>
+            </mailet>
+            <mailet match="IsSenderInRRTLoop" class="Null"/>
+            <mailet match="All" class="Bounce">
+                <notice>We were unable to deliver the attached message to the following recipients due to an address rewriting issue.</notice>
             </mailet>
         </processor>
     </processors>

--- a/server/container/guice/memory-guice/src/test/resources/mailetcontainer.xml
+++ b/server/container/guice/memory-guice/src/test/resources/mailetcontainer.xml
@@ -54,7 +54,9 @@
             <mailet match="All" class="RemoveMimeHeader">
                 <name>bcc</name>
             </mailet>
-            <mailet match="All" class="RecipientRewriteTable" />
+            <mailet match="All" class="RecipientRewriteTable">
+                <errorProcessor>rrt-error</errorProcessor>
+            </mailet>
             <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet"/>
             <mailet match="RecipientIsLocal" class="SpamAssassin">
                 <spamdHost>localhost</spamdHost>
@@ -123,6 +125,15 @@
             <mailet match="All" class="DSNBounce">
                 <passThrough>false</passThrough>
             </mailet>
+        </processor>
+
+        <processor state="rrt-error" enableJmx="false">
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>file://var/mail/rrt-error/</repositoryPath>
+                <passThrough>true</passThrough>
+            </mailet>
+            <mailet match="IsSenderInRRTLoop" class="Null"/>
+            <mailet match="All" class="Bounce"/>
         </processor>
 
     </processors>

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
@@ -115,4 +115,12 @@ public interface RecipientRewriteTable {
         }
 
     }
+
+    class TooManyMappingException extends ErrorMappingException {
+        
+        public TooManyMappingException(String string) {
+            super(string);
+        }
+
+    }
 }

--- a/server/data/data-library/src/main/java/org/apache/james/domainlist/lib/AbstractDomainList.java
+++ b/server/data/data-library/src/main/java/org/apache/james/domainlist/lib/AbstractDomainList.java
@@ -22,7 +22,6 @@ package org.apache.james.domainlist.lib;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.apache.commons.configuration.ConfigurationException;
@@ -182,7 +181,7 @@ public abstract class AbstractDomainList implements DomainList, Configurable {
         if (autoDetect) {
             String hostName;
             try {
-                hostName = getDNSServer().getHostName(getDNSServer().getLocalHost());
+                hostName = dns.getHostName(dns.getLocalHost());
             } catch (UnknownHostException ue) {
                 hostName = "localhost";
             }
@@ -242,15 +241,6 @@ public abstract class AbstractDomainList implements DomainList, Configurable {
     public synchronized void setAutoDetectIP(boolean autoDetectIP) {
         LOGGER.info("Set autodetectIP to: {}", autoDetectIP);
         this.autoDetectIP = autoDetectIP;
-    }
-
-    /**
-     * Return dnsServer
-     * 
-     * @return dns
-     */
-    protected DNSService getDNSServer() {
-        return dns;
     }
 
     /**

--- a/server/data/data-library/src/main/java/org/apache/james/domainlist/lib/AbstractDomainList.java
+++ b/server/data/data-library/src/main/java/org/apache/james/domainlist/lib/AbstractDomainList.java
@@ -131,7 +131,7 @@ public abstract class AbstractDomainList implements DomainList, Configurable {
         return Domain.LOCALHOST.equals(defaultDomain);
     }
 
-    private void setDefaultDomain(Domain defaultDomain) throws DomainListException {
+    protected void setDefaultDomain(Domain defaultDomain) throws DomainListException {
         if (defaultDomain != null && !containsDomain(defaultDomain)) {
             addDomain(defaultDomain);
         }

--- a/server/data/data-library/src/main/java/org/apache/james/domainlist/lib/DomainListConfiguration.java
+++ b/server/data/data-library/src/main/java/org/apache/james/domainlist/lib/DomainListConfiguration.java
@@ -1,0 +1,165 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.domainlist.lib;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.apache.james.core.Domain;
+import org.apache.james.util.StreamUtils;
+
+import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+
+public class DomainListConfiguration {
+    public static class Builder {
+        private Optional<Boolean> autoDetectIp;
+        private Optional<Boolean> autoDetect;
+        private Optional<Domain> defaultDomain;
+        private ImmutableList.Builder<Domain> configuredDomains;
+
+        public Builder() {
+            autoDetectIp = Optional.empty();
+            autoDetect = Optional.empty();
+            defaultDomain = Optional.empty();
+            configuredDomains = ImmutableList.builder();
+        }
+
+        public Builder defaultDomain(Domain defaultDomain) {
+            this.defaultDomain = Optional.of(defaultDomain);
+            return this;
+        }
+
+        public Builder autoDetect(boolean autoDetect) {
+            this.autoDetect = Optional.of(autoDetect);
+            return this;
+        }
+
+        public Builder autoDetectIp(boolean autoDetectIp) {
+            this.autoDetectIp = Optional.of(autoDetectIp);
+            return this;
+        }
+
+        public Builder defaultDomain(Optional<Domain> defaultDomain) {
+            this.defaultDomain = defaultDomain;
+            return this;
+        }
+
+        public Builder autoDetect(Optional<Boolean> autoDetect) {
+            this.autoDetect = autoDetect;
+            return this;
+        }
+
+        public Builder autoDetectIp(Optional<Boolean> autoDetectIp) {
+            this.autoDetectIp = autoDetectIp;
+            return this;
+        }
+
+        public Builder addConfiguredDomain(Domain domain) {
+            this.configuredDomains.add(domain);
+            return this;
+        }
+
+        public Builder addConfiguredDomains(Collection<Domain> domains) {
+            this.configuredDomains.addAll(domains);
+            return this;
+        }
+
+        public DomainListConfiguration build() {
+            return new DomainListConfiguration(
+                autoDetectIp.orElse(true),
+                autoDetect.orElse(true),
+                defaultDomain.orElse(Domain.LOCALHOST),
+                configuredDomains.build());
+        }
+    }
+
+    public static final String CONFIGURE_AUTODETECT = "autodetect";
+    public static final String CONFIGURE_AUTODETECT_IP = "autodetectIP";
+    public static final String CONFIGURE_DEFAULT_DOMAIN = "defaultDomain";
+    public static final String CONFIGURE_DOMAIN_NAMES = "domainnames.domainname";
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static DomainListConfiguration from(HierarchicalConfiguration config) {
+        ImmutableList<Domain> configuredDomains = StreamUtils.ofNullable(config.getStringArray(CONFIGURE_DOMAIN_NAMES))
+            .filter(s -> !s.isEmpty())
+            .map(Domain::of)
+            .collect(Guavate.toImmutableList());
+
+        return builder()
+            .autoDetect(Optional.ofNullable(config.getBoolean(CONFIGURE_AUTODETECT, null)))
+            .autoDetectIp(Optional.ofNullable(config.getBoolean(CONFIGURE_AUTODETECT_IP, null)))
+            .defaultDomain(Optional.ofNullable(config.getString(CONFIGURE_DEFAULT_DOMAIN, null))
+                .map(Domain::of))
+            .addConfiguredDomains(configuredDomains)
+            .build();
+    }
+
+    private final boolean autoDetectIp;
+    private final boolean autoDetect;
+    private final Domain defaultDomain;
+    private final List<Domain> configuredDomains;
+
+    public DomainListConfiguration(boolean autoDetectIp, boolean autoDetect, Domain defaultDomain, List<Domain> configuredDomains) {
+        this.autoDetectIp = autoDetectIp;
+        this.autoDetect = autoDetect;
+        this.defaultDomain = defaultDomain;
+        this.configuredDomains = configuredDomains;
+    }
+
+    public boolean isAutoDetectIp() {
+        return autoDetectIp;
+    }
+
+    public boolean isAutoDetect() {
+        return autoDetect;
+    }
+
+    public Domain getDefaultDomain() {
+        return defaultDomain;
+    }
+
+    public List<Domain> getConfiguredDomains() {
+        return configuredDomains;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof DomainListConfiguration) {
+            DomainListConfiguration that = (DomainListConfiguration) o;
+
+            return Objects.equals(this.autoDetectIp, that.autoDetectIp)
+                && Objects.equals(this.autoDetect, that.autoDetect)
+                && Objects.equals(this.defaultDomain, that.defaultDomain);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(autoDetectIp, autoDetect, defaultDomain);
+    }
+}

--- a/server/data/data-library/src/main/java/org/apache/james/rrt/lib/AbstractRecipientRewriteTable.java
+++ b/server/data/data-library/src/main/java/org/apache/james/rrt/lib/AbstractRecipientRewriteTable.java
@@ -103,7 +103,7 @@ public abstract class AbstractRecipientRewriteTable implements RecipientRewriteT
         // We have to much mappings throw ErrorMappingException to avoid
         // infinity loop
         if (mappingLimit == 0) {
-            throw new ErrorMappingException("554 Too many mappings to process");
+            throw new TooManyMappingException("554 Too many mappings to process");
         }
 
         Mappings targetMappings = mapAddress(user.getLocalPart(), user.getDomainPart().get());

--- a/server/data/data-memory/src/main/java/org/apache/james/domainlist/memory/MemoryDomainList.java
+++ b/server/data/data-memory/src/main/java/org/apache/james/domainlist/memory/MemoryDomainList.java
@@ -73,8 +73,4 @@ public class MemoryDomainList extends AbstractDomainList {
             throw new DomainListException(domain.name() + " was not found");
         }
     }
-
-    public void setDefaultDomain(Domain defaultDomain) throws DomainListException {
-        super.setDefaultDomain(defaultDomain);
-    }
 }

--- a/server/data/data-memory/src/main/java/org/apache/james/domainlist/memory/MemoryDomainList.java
+++ b/server/data/data-memory/src/main/java/org/apache/james/domainlist/memory/MemoryDomainList.java
@@ -24,6 +24,8 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.james.core.Domain;
 import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.domainlist.api.DomainListException;
@@ -46,6 +48,12 @@ public class MemoryDomainList extends AbstractDomainList {
         return ImmutableList.copyOf(domains);
     }
 
+
+    @Override
+    public void configure(HierarchicalConfiguration config) throws ConfigurationException {
+        super.configure(config);
+    }
+
     @Override
     protected boolean containsDomainInternal(Domain domain) throws DomainListException {
         return domains.contains(domain);
@@ -64,5 +72,9 @@ public class MemoryDomainList extends AbstractDomainList {
         if (!domains.remove(domain)) {
             throw new DomainListException(domain.name() + " was not found");
         }
+    }
+
+    public void setDefaultDomain(Domain defaultDomain) throws DomainListException {
+        super.setDefaultDomain(defaultDomain);
     }
 }

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/GroupMappingTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/GroupMappingTest.java
@@ -294,6 +294,24 @@ public class GroupMappingTest {
     }
 
     @Test
+    public void messageShouldBeWellDeliveredToRecipientNotPartOfTheLoop() throws Exception {
+        webAdminApi.put(GroupsRoutes.ROOT_PATH + "/" + GROUP_ON_DOMAIN1 + "/" + GROUP_ON_DOMAIN2);
+
+        webAdminApi.put(GroupsRoutes.ROOT_PATH + "/" + GROUP_ON_DOMAIN2 + "/" + GROUP_ON_DOMAIN1);
+
+        messageSender.connect(LOCALHOST_IP, SMTP_PORT)
+            .sendMessage(FakeMail.builder()
+                .mimeMessage(message)
+                .sender(SENDER)
+                .recipients(GROUP_ON_DOMAIN1, USER_DOMAIN2));
+
+        imapMessageReader.connect(LOCALHOST_IP, IMAP_PORT)
+            .login(USER_DOMAIN2, PASSWORD)
+            .select(IMAPMessageReader.INBOX)
+            .awaitMessage(awaitAtMostOneMinute);
+    }
+
+    @Test
     public void messageShouldRedirectToUserWhenDomainMapping() throws Exception {
         dataProbe.addDomainAliasMapping(DOMAIN1, DOMAIN2);
 

--- a/server/mailet/mailetcontainer-camel/src/test/java/org/apache/james/mailetcontainer/impl/JamesMailetContextTest.java
+++ b/server/mailet/mailetcontainer-camel/src/test/java/org/apache/james/mailetcontainer/impl/JamesMailetContextTest.java
@@ -29,12 +29,11 @@ import java.util.concurrent.TimeUnit;
 
 import javax.mail.internet.MimeMessage;
 
-import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.builder.MimeMessageBuilder;
 import org.apache.james.dnsservice.api.DNSService;
-import org.apache.james.domainlist.lib.AbstractDomainList;
+import org.apache.james.domainlist.lib.DomainListConfiguration;
 import org.apache.james.domainlist.memory.MemoryDomainList;
 import org.apache.james.queue.api.MailQueue;
 import org.apache.james.queue.api.MailQueueFactory;
@@ -70,10 +69,10 @@ public class JamesMailetContextTest {
     @SuppressWarnings("unchecked")
     public void setUp() throws Exception {
         domainList = new MemoryDomainList(DNS_SERVICE);
-        HierarchicalConfiguration configuration = mock(HierarchicalConfiguration.class);
-        when(configuration.getBoolean(AbstractDomainList.CONFIGURE_AUTODETECT, true)).thenReturn(false);
-        when(configuration.getBoolean(AbstractDomainList.CONFIGURE_AUTODETECT_IP, true)).thenReturn(false);
-        domainList.configure(configuration);
+        domainList.configure(DomainListConfiguration.builder()
+            .autoDetect(false)
+            .autoDetectIp(false)
+            .build());
 
         usersRepository = MemoryUsersRepository.withVirtualHosting();
         usersRepository.setDomainList(domainList);
@@ -114,7 +113,11 @@ public class JamesMailetContextTest {
 
     @Test
     public void isLocalUserShouldReturnTrueWhenUsedWithLocalPartAndUserExistOnDefaultDomain() throws Exception {
-        domainList.setDefaultDomain(DOMAIN_COM);
+        domainList.configure(DomainListConfiguration.builder()
+            .autoDetect(false)
+            .autoDetectIp(false)
+            .defaultDomain(DOMAIN_COM)
+            .build());
 
         usersRepository.addUser(USERMAIL, PASSWORD);
 
@@ -123,7 +126,11 @@ public class JamesMailetContextTest {
 
     @Test
     public void isLocalUserShouldReturnFalseWhenUsedWithLocalPartAndUserDoNotExistOnDefaultDomain() throws Exception {
-        domainList.setDefaultDomain(Domain.of("any"));
+        domainList.configure(DomainListConfiguration.builder()
+            .autoDetect(false)
+            .autoDetectIp(false)
+            .defaultDomain(Domain.of("any"))
+            .build());
 
         domainList.addDomain(DOMAIN_COM);
         usersRepository.addUser(USERMAIL, PASSWORD);

--- a/server/mailet/mailetcontainer-camel/src/test/java/org/apache/james/mailetcontainer/impl/JamesMailetContextTest.java
+++ b/server/mailet/mailetcontainer-camel/src/test/java/org/apache/james/mailetcontainer/impl/JamesMailetContextTest.java
@@ -20,8 +20,6 @@
 package org.apache.james.mailetcontainer.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -116,11 +114,8 @@ public class JamesMailetContextTest {
 
     @Test
     public void isLocalUserShouldReturnTrueWhenUsedWithLocalPartAndUserExistOnDefaultDomain() throws Exception {
-        HierarchicalConfiguration configuration = mock(HierarchicalConfiguration.class);
-        when(configuration.getString(eq("defaultDomain"), any(String.class)))
-            .thenReturn(DOMAIN_COM.name());
+        domainList.setDefaultDomain(DOMAIN_COM);
 
-        domainList.configure(configuration);
         usersRepository.addUser(USERMAIL, PASSWORD);
 
         assertThat(testee.isLocalUser(USERNAME)).isTrue();
@@ -128,11 +123,8 @@ public class JamesMailetContextTest {
 
     @Test
     public void isLocalUserShouldReturnFalseWhenUsedWithLocalPartAndUserDoNotExistOnDefaultDomain() throws Exception {
-        HierarchicalConfiguration configuration = mock(HierarchicalConfiguration.class);
-        when(configuration.getString(eq("defaultDomain"), any(String.class)))
-            .thenReturn("any");
+        domainList.setDefaultDomain(Domain.of("any"));
 
-        domainList.configure(configuration);
         domainList.addDomain(DOMAIN_COM);
         usersRepository.addUser(USERMAIL, PASSWORD);
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTable.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTable.java
@@ -32,8 +32,22 @@ import com.google.common.base.Preconditions;
 /**
  * Mailet which should get used when using RecipientRewriteTable-Store to
  * implementations for mappings of forwards and aliases.
+ *
+ * By specifying an 'errorProcessor' you can specify your logic upon RecipientRewriteTable failures.
+ *
+ * Exemple:
+ *
+ * <pre>
+ * <code>
+ *  &lt;mailet match=&quot;All&quot; class=&quot;RecipientRewriteTable&quot;&gt;
+ *    &lt;errorProcessor&gt;x@rrt-errors&lt;/errorProcessor&gt;
+ *  &lt;/mailet&gt;
+ * </code>
+ * </pre>
  */
 public class RecipientRewriteTable extends GenericMailet {
+    public static final String ERROR_PROCESSOR = "errorProcessor";
+
     private final org.apache.james.rrt.api.RecipientRewriteTable virtualTableStore;
     private final DomainList domainList;
     private RecipientRewriteTableProcessor processor;
@@ -52,7 +66,8 @@ public class RecipientRewriteTable extends GenericMailet {
 
     @Override
     public void init() throws MessagingException {
-        processor = new RecipientRewriteTableProcessor(virtualTableStore, domainList, getMailetContext());
+        String errorProcessor = getInitParameter(ERROR_PROCESSOR, Mail.ERROR);
+        processor = new RecipientRewriteTableProcessor(virtualTableStore, domainList, getMailetContext(), errorProcessor);
     }
 
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessor.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessor.java
@@ -101,12 +101,18 @@ public class RecipientRewriteTableProcessor {
     private final RecipientRewriteTable virtualTableStore;
     private final MailetContext mailetContext;
     private final Supplier<Domain> defaultDomainSupplier;
+    private final String errorProcessor;
 
-    public RecipientRewriteTableProcessor(RecipientRewriteTable virtualTableStore, DomainList domainList, MailetContext mailetContext) {
+    public RecipientRewriteTableProcessor(RecipientRewriteTable virtualTableStore, DomainList domainList, MailetContext mailetContext, String errorProcessor) {
         this.virtualTableStore = virtualTableStore;
         this.mailetContext = mailetContext;
         this.defaultDomainSupplier = MemoizedSupplier.of(
             Throwing.supplier(() -> getDefaultDomain(domainList)).sneakyThrow());
+        this.errorProcessor = errorProcessor;
+    }
+
+    public RecipientRewriteTableProcessor(RecipientRewriteTable virtualTableStore, DomainList domainList, MailetContext mailetContext) {
+        this(virtualTableStore, domainList, mailetContext, Mail.ERROR);
     }
 
     private Domain getDefaultDomain(DomainList domainList) throws MessagingException {
@@ -121,7 +127,7 @@ public class RecipientRewriteTableProcessor {
         RrtExecutionResult executionResults = executeRrtFor(mail);
 
         if (!executionResults.recipientWithError.isEmpty()) {
-            mailetContext.sendMail(mail.getSender(), executionResults.recipientWithError, mail.getMessage(), Mail.ERROR);
+            mailetContext.sendMail(mail.getSender(), executionResults.recipientWithError, mail.getMessage(), errorProcessor);
         }
 
         if (executionResults.newRecipients.isEmpty()) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessor.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessor.java
@@ -154,7 +154,7 @@ public class RecipientRewriteTableProcessor {
             }
             return RrtExecutionResult.success(recipient);
         } catch (ErrorMappingException | RecipientRewriteTableException | MessagingException e) {
-            LOGGER.info("Error while process mail.", e);
+            LOGGER.warn("Could not rewrite recipient {}", recipient, e);
             return RrtExecutionResult.error(recipient);
         }
     }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/UsersRepositoryAliasingForwarding.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/UsersRepositoryAliasingForwarding.java
@@ -63,7 +63,7 @@ public class UsersRepositoryAliasingForwarding extends GenericMailet {
     public void init() throws MessagingException {
         if (usersRepository instanceof RecipientRewriteTable) {
             RecipientRewriteTable virtualTableStore = (RecipientRewriteTable) usersRepository;
-            processor = new RecipientRewriteTableProcessor(virtualTableStore, domainList, getMailetContext());
+            processor = new RecipientRewriteTableProcessor(virtualTableStore, domainList, getMailetContext(), Mail.ERROR);
         } else {
             throw new MessagingException("The user repository is not RecipientRewriteTable");
         }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/IsSenderInRRTLoop.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/IsSenderInRRTLoop.java
@@ -1,0 +1,67 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.matchers;
+
+import java.util.Collection;
+
+import javax.inject.Inject;
+
+import org.apache.james.core.MailAddress;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMatcher;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * This matcher allow you to know if the sender of an email is part of a RRT loop.
+ *
+ * This is useful when bouncing upon RRT execution issues: we don't want to create a bouncing loop
+ * (as the execution of that RRT loop will fail).
+ *
+ * Example:
+ *
+ * <pre><code>
+ * &lt;mailet match=&quot;IsSenderInRRTLoop&quot; class=&quot;&lt;any-class&gt;&quot;/&gt;
+ * </code></pre>
+ *
+ */
+public class IsSenderInRRTLoop extends GenericMatcher {
+
+    private final RecipientRewriteTable recipientRewriteTable;
+
+    @Inject
+    public IsSenderInRRTLoop(RecipientRewriteTable recipientRewriteTable) {
+        this.recipientRewriteTable = recipientRewriteTable;
+    }
+
+    @Override
+    public Collection<MailAddress> match(Mail mail) {
+        try {
+            recipientRewriteTable.getMappings(mail.getSender().getLocalPart(), mail.getSender().getDomain());
+        } catch (RecipientRewriteTable.TooMuchMappingException e) {
+            return mail.getRecipients();
+        } catch (Exception e) {
+            LoggerFactory.getLogger(IsSenderInRRTLoop.class).warn("Error while executing RRT");
+        }
+        return ImmutableList.of();
+    }
+}

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/IsSenderInRRTLoop.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/IsSenderInRRTLoop.java
@@ -57,7 +57,7 @@ public class IsSenderInRRTLoop extends GenericMatcher {
     public Collection<MailAddress> match(Mail mail) {
         try {
             recipientRewriteTable.getMappings(mail.getSender().getLocalPart(), mail.getSender().getDomain());
-        } catch (RecipientRewriteTable.TooMuchMappingException e) {
+        } catch (RecipientRewriteTable.TooManyMappingException e) {
             return mail.getRecipients();
         } catch (Exception e) {
             LoggerFactory.getLogger(IsSenderInRRTLoop.class).warn("Error while executing RRT");

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/matchers/IsSenderInRRTLoopTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/matchers/IsSenderInRRTLoopTest.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.lib.MappingSource;
 import org.apache.james.rrt.memory.MemoryRecipientRewriteTable;
 import org.apache.mailet.base.test.FakeMail;
 import org.junit.Before;
@@ -65,7 +66,7 @@ public class IsSenderInRRTLoopTest {
 
     @Test
     public void matchShouldReturnEmptyWhenNoRRTLoop() throws Exception {
-        recipientRewriteTable.addAddressMapping(SENDER.getLocalPart(), SENDER.getDomain(), RECIPIENT1.asString());
+        recipientRewriteTable.addAddressMapping(MappingSource.fromUser(SENDER.getLocalPart(), SENDER.getDomain()), RECIPIENT1.asString());
 
         Collection<MailAddress> result = testee.match(FakeMail.builder()
             .sender(SENDER)
@@ -77,8 +78,8 @@ public class IsSenderInRRTLoopTest {
 
     @Test
     public void matchShouldReturnRecipientsWhenLoop() throws Exception {
-        recipientRewriteTable.addAddressMapping(SENDER.getLocalPart(), SENDER.getDomain(), RECIPIENT1.asString());
-        recipientRewriteTable.addAddressMapping(RECIPIENT1.getLocalPart(), RECIPIENT1.getDomain(), SENDER.asString());
+        recipientRewriteTable.addAddressMapping(MappingSource.fromUser(SENDER.getLocalPart(), SENDER.getDomain()), RECIPIENT1.asString());
+        recipientRewriteTable.addAddressMapping(MappingSource.fromUser(RECIPIENT1.getLocalPart(), RECIPIENT1.getDomain()), SENDER.asString());
 
         Collection<MailAddress> result = testee.match(FakeMail.builder()
             .sender(SENDER)
@@ -90,8 +91,8 @@ public class IsSenderInRRTLoopTest {
 
     @Test
     public void matchShouldReturnEmptyWhenLoopButNoRecipient() throws Exception {
-        recipientRewriteTable.addAddressMapping(SENDER.getLocalPart(), SENDER.getDomain(), RECIPIENT1.asString());
-        recipientRewriteTable.addAddressMapping(RECIPIENT1.getLocalPart(), RECIPIENT1.getDomain(), SENDER.asString());
+        recipientRewriteTable.addAddressMapping(MappingSource.fromUser(SENDER.getLocalPart(), SENDER.getDomain()), RECIPIENT1.asString());
+        recipientRewriteTable.addAddressMapping(MappingSource.fromUser(RECIPIENT1.getLocalPart(), RECIPIENT1.getDomain()), SENDER.asString());
 
         Collection<MailAddress> result = testee.match(FakeMail.builder()
             .sender(SENDER)

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/matchers/IsSenderInRRTLoopTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/matchers/IsSenderInRRTLoopTest.java
@@ -1,0 +1,103 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.matchers;
+
+import static org.apache.mailet.base.MailAddressFixture.RECIPIENT1;
+import static org.apache.mailet.base.MailAddressFixture.RECIPIENT2;
+import static org.apache.mailet.base.MailAddressFixture.SENDER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+
+import org.apache.james.core.MailAddress;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.memory.MemoryRecipientRewriteTable;
+import org.apache.mailet.base.test.FakeMail;
+import org.junit.Before;
+import org.junit.Test;
+
+public class IsSenderInRRTLoopTest {
+
+    private RecipientRewriteTable recipientRewriteTable;
+    private IsSenderInRRTLoop testee;
+
+    @Before
+    public void setUp() {
+        recipientRewriteTable = new MemoryRecipientRewriteTable();
+        testee = new IsSenderInRRTLoop(recipientRewriteTable);
+    }
+
+    @Test
+    public void matchShouldReturnEmptyWhenSenderHasNoRRT() throws Exception {
+        Collection<MailAddress> result = testee.match(FakeMail.builder()
+            .sender(SENDER)
+            .recipient(RECIPIENT1)
+            .build());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void matchShouldNotFailWhenNoSender() throws Exception {
+        Collection<MailAddress> result = testee.match(FakeMail.builder()
+            .recipient(RECIPIENT1)
+            .build());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void matchShouldReturnEmptyWhenNoRRTLoop() throws Exception {
+        recipientRewriteTable.addAddressMapping(SENDER.getLocalPart(), SENDER.getDomain(), RECIPIENT1.asString());
+
+        Collection<MailAddress> result = testee.match(FakeMail.builder()
+            .sender(SENDER)
+            .recipient(RECIPIENT1)
+            .build());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void matchShouldReturnRecipientsWhenLoop() throws Exception {
+        recipientRewriteTable.addAddressMapping(SENDER.getLocalPart(), SENDER.getDomain(), RECIPIENT1.asString());
+        recipientRewriteTable.addAddressMapping(RECIPIENT1.getLocalPart(), RECIPIENT1.getDomain(), SENDER.asString());
+
+        Collection<MailAddress> result = testee.match(FakeMail.builder()
+            .sender(SENDER)
+            .recipient(RECIPIENT2)
+            .build());
+
+        assertThat(result).containsOnly(RECIPIENT2);
+    }
+
+    @Test
+    public void matchShouldReturnEmptyWhenLoopButNoRecipient() throws Exception {
+        recipientRewriteTable.addAddressMapping(SENDER.getLocalPart(), SENDER.getDomain(), RECIPIENT1.asString());
+        recipientRewriteTable.addAddressMapping(RECIPIENT1.getLocalPart(), RECIPIENT1.getDomain(), SENDER.asString());
+
+        Collection<MailAddress> result = testee.match(FakeMail.builder()
+            .sender(SENDER)
+            .build());
+
+        assertThat(result).isEmpty();
+    }
+
+}

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/resources/mailetcontainer.xml
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/resources/mailetcontainer.xml
@@ -56,7 +56,9 @@
                 <name>bcc</name>
             </mailet>
             <mailet match="All" class="org.apache.james.jmap.mailet.TextCalendarBodyToAttachment"/>
-            <mailet match="All" class="RecipientRewriteTable" />
+            <mailet match="All" class="RecipientRewriteTable">
+                <errorProcessor>rrt-error</errorProcessor>
+            </mailet>
             <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet"/>
             <mailet match="mdn-matcher" class="org.apache.james.jmap.mailet.ExtractMDNOriginalJMAPMessageId" />
             <mailet match="RecipientIsLocal" class="Sieve"/>
@@ -121,6 +123,15 @@
             <mailet match="All" class="DSNBounce">
                 <passThrough>false</passThrough>
             </mailet>
+        </processor>
+
+        <processor state="rrt-error" enableJmx="false">
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>cassandra://var/mail/rrt-error/</repositoryPath>
+                <passThrough>true</passThrough>
+            </mailet>
+            <mailet match="IsSenderInRRTLoop" class="Null"/>
+            <mailet match="All" class="Bounce"/>
         </processor>
 
     </processors>

--- a/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/resources/mailetcontainer.xml
+++ b/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/resources/mailetcontainer.xml
@@ -57,7 +57,9 @@
                 <name>bcc</name>
             </mailet>
             <mailet match="All" class="org.apache.james.jmap.mailet.TextCalendarBodyToAttachment"/>
-            <mailet match="All" class="RecipientRewriteTable" />
+            <mailet match="All" class="RecipientRewriteTable">
+                <errorProcessor>rrt-error</errorProcessor>
+            </mailet>
             <mailet match="RecipientIsLocal" class="org.apache.james.jmap.mailet.VacationMailet"/>
             <mailet match="mdn-matcher" class="org.apache.james.jmap.mailet.ExtractMDNOriginalJMAPMessageId" />
             <mailet match="RecipientIsLocal" class="Sieve"/>
@@ -119,6 +121,15 @@
             <mailet match="All" class="DSNBounce">
                 <passThrough>false</passThrough>
             </mailet>
+        </processor>
+
+        <processor state="rrt-error" enableJmx="false">
+            <mailet match="All" class="ToRepository">
+                <repositoryPath>file://var/mail/rrt-error/</repositoryPath>
+                <passThrough>true</passThrough>
+            </mailet>
+            <mailet match="IsSenderInRRTLoop" class="Null"/>
+            <mailet match="All" class="Bounce"/>
         </processor>
 
     </processors>

--- a/server/protocols/protocols-lmtp/src/main/java/org/apache/james/lmtpserver/hook/MailboxDeliverToRecipientHandler.java
+++ b/server/protocols/protocols-lmtp/src/main/java/org/apache/james/lmtpserver/hook/MailboxDeliverToRecipientHandler.java
@@ -69,8 +69,6 @@ public class MailboxDeliverToRecipientHandler implements DeliverToRecipientHook 
     
     @Override
     public HookResult deliver(SMTPSession session, MailAddress recipient, MailEnvelope envelope) {
-        HookResult result;
-
         try {
             String username = users.getUser(recipient);
 
@@ -90,12 +88,18 @@ public class MailboxDeliverToRecipientHandler implements DeliverToRecipientHook 
                     .build(envelope.getMessageInputStream()),
                     mailboxSession);
             mailboxManager.endProcessingRequest(mailboxSession);
-            result = new HookResult(HookReturnCode.ok(), SMTPRetCode.MAIL_OK, DSNStatus.getStatus(DSNStatus.SUCCESS, DSNStatus.CONTENT_OTHER) + " Message received");
+            return HookResult.builder()
+                .hookReturnCode(HookReturnCode.ok())
+                .smtpReturnCode(SMTPRetCode.MAIL_OK)
+                .smtpDescription(DSNStatus.getStatus(DSNStatus.SUCCESS, DSNStatus.CONTENT_OTHER) + " Message received")
+                .build();
         } catch (IOException | MailboxException | UsersRepositoryException e) {
             LOGGER.error("Unexpected error handling DATA stream", e);
-            result = new HookResult(HookReturnCode.denySoft(), " Temporary error deliver message to " + recipient);
+            return HookResult.builder()
+                .hookReturnCode(HookReturnCode.denySoft())
+                .smtpDescription(" Temporary error deliver message to " + recipient)
+                .build();
         }
-        return result;
     }
 
     @Override

--- a/server/protocols/protocols-lmtp/src/main/java/org/apache/james/lmtpserver/hook/MailboxDeliverToRecipientHandler.java
+++ b/server/protocols/protocols-lmtp/src/main/java/org/apache/james/lmtpserver/hook/MailboxDeliverToRecipientHandler.java
@@ -90,10 +90,10 @@ public class MailboxDeliverToRecipientHandler implements DeliverToRecipientHook 
                     .build(envelope.getMessageInputStream()),
                     mailboxSession);
             mailboxManager.endProcessingRequest(mailboxSession);
-            result = new HookResult(HookReturnCode.OK, SMTPRetCode.MAIL_OK, DSNStatus.getStatus(DSNStatus.SUCCESS, DSNStatus.CONTENT_OTHER) + " Message received");
+            result = new HookResult(HookReturnCode.ok(), SMTPRetCode.MAIL_OK, DSNStatus.getStatus(DSNStatus.SUCCESS, DSNStatus.CONTENT_OTHER) + " Message received");
         } catch (IOException | MailboxException | UsersRepositoryException e) {
             LOGGER.error("Unexpected error handling DATA stream", e);
-            result = new HookResult(HookReturnCode.DENYSOFT, " Temporary error deliver message to " + recipient);
+            result = new HookResult(HookReturnCode.denySoft(), " Temporary error deliver message to " + recipient);
         }
         return result;
     }

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/AddDefaultAttributesMessageHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/AddDefaultAttributesMessageHook.java
@@ -22,7 +22,6 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.hook.HookResult;
-import org.apache.james.protocols.smtp.hook.HookReturnCode;
 import org.apache.james.server.core.MailImpl;
 import org.apache.mailet.Mail;
 
@@ -61,7 +60,7 @@ public class AddDefaultAttributesMessageHook implements JamesMessageHook {
                 mail.setAttribute(SMTP_AUTH_NETWORK_NAME, "true");
             }
         }
-        return new HookResult(HookReturnCode.declined());
+        return HookResult.DECLINED;
     }
 
 }

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/AddDefaultAttributesMessageHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/AddDefaultAttributesMessageHook.java
@@ -61,7 +61,7 @@ public class AddDefaultAttributesMessageHook implements JamesMessageHook {
                 mail.setAttribute(SMTP_AUTH_NETWORK_NAME, "true");
             }
         }
-        return new HookResult(HookReturnCode.DECLINED);
+        return new HookResult(HookReturnCode.declined());
     }
 
 }

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/MailPriorityHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/MailPriorityHandler.java
@@ -32,7 +32,6 @@ import org.apache.james.core.MailAddress;
 import org.apache.james.protocols.api.handler.ProtocolHandler;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.hook.HookResult;
-import org.apache.james.protocols.smtp.hook.HookReturnCode;
 import org.apache.james.queue.api.MailPrioritySupport;
 import org.apache.mailet.Mail;
 
@@ -74,7 +73,7 @@ public class MailPriorityHandler implements JamesMessageHook, ProtocolHandler {
         if (p != null) {
             mail.setAttribute(MailPrioritySupport.MAIL_PRIORITY, p);
         }
-        return new HookResult(HookReturnCode.declined());
+        return HookResult.DECLINED;
     }
 
     @Override

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/MailPriorityHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/MailPriorityHandler.java
@@ -74,7 +74,7 @@ public class MailPriorityHandler implements JamesMessageHook, ProtocolHandler {
         if (p != null) {
             mail.setAttribute(MailPrioritySupport.MAIL_PRIORITY, p);
         }
-        return new HookResult(HookReturnCode.DECLINED);
+        return new HookResult(HookReturnCode.declined());
     }
 
     @Override

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SendMailHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SendMailHandler.java
@@ -64,7 +64,6 @@ public class SendMailHandler implements JamesMessageHook {
      */
     @Override
     public HookResult onMessage(SMTPSession session, Mail mail) {
-       
         LOGGER.debug("sending mail");
 
         try {
@@ -72,11 +71,15 @@ public class SendMailHandler implements JamesMessageHook {
             LOGGER.info("Successfully spooled mail {} from {} on {} for {}", mail.getName(), mail.getSender(), session.getRemoteAddress().getAddress(), mail.getRecipients());
         } catch (MessagingException me) {
             LOGGER.error("Unknown error occurred while processing DATA.", me);
-            return new HookResult(HookReturnCode.denySoft(), DSNStatus.getStatus(DSNStatus.TRANSIENT, DSNStatus.UNDEFINED_STATUS) + " Error processing message.");
+            return HookResult.builder()
+                .hookReturnCode(HookReturnCode.denySoft())
+                .smtpDescription(DSNStatus.getStatus(DSNStatus.TRANSIENT, DSNStatus.UNDEFINED_STATUS) + " Error processing message.")
+                .build();
         }
-        
-        return new HookResult(HookReturnCode.ok(), DSNStatus.getStatus(DSNStatus.SUCCESS, DSNStatus.CONTENT_OTHER) + " Message received");
-    
+        return HookResult.builder()
+            .hookReturnCode(HookReturnCode.ok())
+            .smtpDescription(DSNStatus.getStatus(DSNStatus.SUCCESS, DSNStatus.CONTENT_OTHER) + " Message received")
+            .build();
     }
 
 }

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SendMailHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SendMailHandler.java
@@ -72,10 +72,10 @@ public class SendMailHandler implements JamesMessageHook {
             LOGGER.info("Successfully spooled mail {} from {} on {} for {}", mail.getName(), mail.getSender(), session.getRemoteAddress().getAddress(), mail.getRecipients());
         } catch (MessagingException me) {
             LOGGER.error("Unknown error occurred while processing DATA.", me);
-            return new HookResult(HookReturnCode.DENYSOFT, DSNStatus.getStatus(DSNStatus.TRANSIENT, DSNStatus.UNDEFINED_STATUS) + " Error processing message.");
+            return new HookResult(HookReturnCode.denySoft(), DSNStatus.getStatus(DSNStatus.TRANSIENT, DSNStatus.UNDEFINED_STATUS) + " Error processing message.");
         }
         
-        return new HookResult(HookReturnCode.OK, DSNStatus.getStatus(DSNStatus.SUCCESS, DSNStatus.CONTENT_OTHER) + " Message received");
+        return new HookResult(HookReturnCode.ok(), DSNStatus.getStatus(DSNStatus.SUCCESS, DSNStatus.CONTENT_OTHER) + " Message received");
     
     }
 

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SenderAuthIdentifyVerificationRcptHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SenderAuthIdentifyVerificationRcptHook.java
@@ -29,7 +29,6 @@ import org.apache.james.domainlist.api.DomainListException;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.core.AbstractSenderAuthIdentifyVerificationRcptHook;
 import org.apache.james.protocols.smtp.hook.HookResult;
-import org.apache.james.protocols.smtp.hook.HookReturnCode;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.UsersRepositoryException;
 
@@ -69,7 +68,7 @@ public class SenderAuthIdentifyVerificationRcptHook extends AbstractSenderAuthId
         if (nSession.verifyIdentity()) {
             return super.doRcpt(session, sender, rcpt);
         } else {
-            return new HookResult(HookReturnCode.declined());
+            return HookResult.DECLINED;
         }
     }
 

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SenderAuthIdentifyVerificationRcptHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SenderAuthIdentifyVerificationRcptHook.java
@@ -69,7 +69,7 @@ public class SenderAuthIdentifyVerificationRcptHook extends AbstractSenderAuthId
         if (nSession.verifyIdentity()) {
             return super.doRcpt(session, sender, rcpt);
         } else {
-            return new HookResult(HookReturnCode.DECLINED);
+            return new HookResult(HookReturnCode.declined());
         }
     }
 

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SetMimeHeaderHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SetMimeHeaderHandler.java
@@ -26,7 +26,6 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.protocols.api.handler.ProtocolHandler;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.hook.HookResult;
-import org.apache.james.protocols.smtp.hook.HookReturnCode;
 import org.apache.mailet.Mail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,7 +80,7 @@ public class SetMimeHeaderHandler implements JamesMessageHook, ProtocolHandler {
             LOGGER.error(me.getMessage());
         }
 
-        return new HookResult(HookReturnCode.declined());
+        return HookResult.DECLINED;
     }
 
     @Override

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SetMimeHeaderHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SetMimeHeaderHandler.java
@@ -81,7 +81,7 @@ public class SetMimeHeaderHandler implements JamesMessageHook, ProtocolHandler {
             LOGGER.error(me.getMessage());
         }
 
-        return new HookResult(HookReturnCode.DECLINED);
+        return new HookResult(HookReturnCode.declined());
     }
 
     @Override

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/UsersRepositoryAuthHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/UsersRepositoryAuthHook.java
@@ -65,7 +65,10 @@ public class UsersRepositoryAuthHook implements AuthHook {
             if (users.test(username, password)) {
                 session.setUser(username);
                 session.setRelayingAllowed(true);
-                return new HookResult(HookReturnCode.ok(), "Authentication Successful");
+                return HookResult.builder()
+                    .hookReturnCode(HookReturnCode.ok())
+                    .smtpDescription("Authentication Successful")
+                    .build();
             }
         } catch (UsersRepositoryException e) {
             LOGGER.info("Unable to access UsersRepository", e);

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/UsersRepositoryAuthHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/UsersRepositoryAuthHook.java
@@ -70,7 +70,7 @@ public class UsersRepositoryAuthHook implements AuthHook {
         } catch (UsersRepositoryException e) {
             LOGGER.info("Unable to access UsersRepository", e);
         }
-        return new HookResult(HookReturnCode.declined());
+        return HookResult.DECLINED;
     }
 
     @Override

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/UsersRepositoryAuthHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/UsersRepositoryAuthHook.java
@@ -65,12 +65,12 @@ public class UsersRepositoryAuthHook implements AuthHook {
             if (users.test(username, password)) {
                 session.setUser(username);
                 session.setRelayingAllowed(true);
-                return new HookResult(HookReturnCode.OK, "Authentication Successful");
+                return new HookResult(HookReturnCode.ok(), "Authentication Successful");
             }
         } catch (UsersRepositoryException e) {
             LOGGER.info("Unable to access UsersRepository", e);
         }
-        return new HookResult(HookReturnCode.DECLINED);
+        return new HookResult(HookReturnCode.declined());
     }
 
     @Override

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/JDBCGreylistHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/JDBCGreylistHandler.java
@@ -45,7 +45,6 @@ import org.apache.james.protocols.api.handler.ProtocolHandler;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.core.fastfail.AbstractGreylistHandler;
 import org.apache.james.protocols.smtp.hook.HookResult;
-import org.apache.james.protocols.smtp.hook.HookReturnCode;
 import org.apache.james.util.TimeConverter;
 import org.apache.james.util.sql.JDBCUtil;
 import org.apache.james.util.sql.SqlResources;
@@ -360,7 +359,7 @@ public class JDBCGreylistHandler extends AbstractGreylistHandler implements Prot
         } else {
             LOGGER.info("IpAddress {} is whitelisted. Skip greylisting.", session.getRemoteAddress().getAddress().getHostAddress());
         }
-        return new HookResult(HookReturnCode.declined());
+        return HookResult.DECLINED;
     }
 
     @Override

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/JDBCGreylistHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/JDBCGreylistHandler.java
@@ -360,7 +360,7 @@ public class JDBCGreylistHandler extends AbstractGreylistHandler implements Prot
         } else {
             LOGGER.info("IpAddress {} is whitelisted. Skip greylisting.", session.getRemoteAddress().getAddress().getHostAddress());
         }
-        return new HookResult(HookReturnCode.DECLINED);
+        return new HookResult(HookReturnCode.declined());
     }
 
     @Override

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SPFHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SPFHandler.java
@@ -157,13 +157,13 @@ public class SPFHandler implements JamesMessageHook, MailHook, RcptHook, Protoco
                 return new HookResult(HookReturnCode.denySoft(), SMTPRetCode.LOCAL_ERROR, DSNStatus.getStatus(DSNStatus.TRANSIENT, DSNStatus.NETWORK_DIR_SERVER) + " " + "Temporarily rejected: Problem on SPF lookup");
             }
         }
-        return new HookResult(HookReturnCode.declined());
+        return HookResult.DECLINED;
     }
 
     @Override
     public HookResult doMail(SMTPSession session, MailAddress sender) {
         doSPFCheck(session, sender);
-        return new HookResult(HookReturnCode.declined());
+        return HookResult.DECLINED;
     }
 
     /**

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SPFHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SPFHandler.java
@@ -152,9 +152,17 @@ public class SPFHandler implements JamesMessageHook, MailHook, RcptHook, Protoco
         if (!session.isRelayingAllowed()) {
             // Check if session is blocklisted
             if (session.getAttachment(SPF_BLOCKLISTED, State.Transaction) != null) {
-                return new HookResult(HookReturnCode.deny(), DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_AUTH) + " " + session.getAttachment(SPF_TEMPBLOCKLISTED, State.Transaction));
+
+                return HookResult.builder()
+                    .hookReturnCode(HookReturnCode.deny())
+                    .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_AUTH) + " " + session.getAttachment(SPF_TEMPBLOCKLISTED, State.Transaction))
+                    .build();
             } else if (session.getAttachment(SPF_TEMPBLOCKLISTED, State.Transaction) != null) {
-                return new HookResult(HookReturnCode.denySoft(), SMTPRetCode.LOCAL_ERROR, DSNStatus.getStatus(DSNStatus.TRANSIENT, DSNStatus.NETWORK_DIR_SERVER) + " " + "Temporarily rejected: Problem on SPF lookup");
+                return HookResult.builder()
+                    .hookReturnCode(HookReturnCode.denySoft())
+                    .smtpReturnCode(SMTPRetCode.LOCAL_ERROR)
+                    .smtpDescription(DSNStatus.getStatus(DSNStatus.TRANSIENT, DSNStatus.NETWORK_DIR_SERVER) + " Temporarily rejected: Problem on SPF lookup")
+                    .build();
             }
         }
         return HookResult.DECLINED;

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SPFHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SPFHandler.java
@@ -152,18 +152,18 @@ public class SPFHandler implements JamesMessageHook, MailHook, RcptHook, Protoco
         if (!session.isRelayingAllowed()) {
             // Check if session is blocklisted
             if (session.getAttachment(SPF_BLOCKLISTED, State.Transaction) != null) {
-                return new HookResult(HookReturnCode.DENY, DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_AUTH) + " " + session.getAttachment(SPF_TEMPBLOCKLISTED, State.Transaction));
+                return new HookResult(HookReturnCode.deny(), DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_AUTH) + " " + session.getAttachment(SPF_TEMPBLOCKLISTED, State.Transaction));
             } else if (session.getAttachment(SPF_TEMPBLOCKLISTED, State.Transaction) != null) {
-                return new HookResult(HookReturnCode.DENYSOFT, SMTPRetCode.LOCAL_ERROR, DSNStatus.getStatus(DSNStatus.TRANSIENT, DSNStatus.NETWORK_DIR_SERVER) + " " + "Temporarily rejected: Problem on SPF lookup");
+                return new HookResult(HookReturnCode.denySoft(), SMTPRetCode.LOCAL_ERROR, DSNStatus.getStatus(DSNStatus.TRANSIENT, DSNStatus.NETWORK_DIR_SERVER) + " " + "Temporarily rejected: Problem on SPF lookup");
             }
         }
-        return new HookResult(HookReturnCode.DECLINED);
+        return new HookResult(HookReturnCode.declined());
     }
 
     @Override
     public HookResult doMail(SMTPSession session, MailAddress sender) {
         doSPFCheck(session, sender);
-        return new HookResult(HookReturnCode.DECLINED);
+        return new HookResult(HookReturnCode.declined());
     }
 
     /**

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SpamAssassinHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SpamAssassinHandler.java
@@ -143,7 +143,11 @@ public class SpamAssassinHandler implements JamesMessageHook, ProtocolHandler {
                         LOGGER.info(buffer);
 
                         // Message reject .. abort it!
-                        return new HookResult(HookReturnCode.deny(), DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_OTHER) + " This message reach the spam hits treshold. Please contact the Postmaster if the email is not SPAM. Message rejected");
+                        return HookResult.builder()
+                            .hookReturnCode(HookReturnCode.deny())
+                            .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_OTHER)
+                                + " This message reach the spam hits treshold. Please contact the Postmaster if the email is not SPAM. Message rejected")
+                            .build();
                     }
                 } catch (NumberFormatException e) {
                     // hits unknown

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SpamAssassinHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SpamAssassinHandler.java
@@ -152,7 +152,7 @@ public class SpamAssassinHandler implements JamesMessageHook, ProtocolHandler {
         } catch (MessagingException e) {
             LOGGER.error(e.getMessage());
         }
-        return new HookResult(HookReturnCode.declined());
+        return HookResult.DECLINED;
     }
 
     @Override

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SpamAssassinHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SpamAssassinHandler.java
@@ -143,7 +143,7 @@ public class SpamAssassinHandler implements JamesMessageHook, ProtocolHandler {
                         LOGGER.info(buffer);
 
                         // Message reject .. abort it!
-                        return new HookResult(HookReturnCode.DENY, DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_OTHER) + " This message reach the spam hits treshold. Please contact the Postmaster if the email is not SPAM. Message rejected");
+                        return new HookResult(HookReturnCode.deny(), DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_OTHER) + " This message reach the spam hits treshold. Please contact the Postmaster if the email is not SPAM. Message rejected");
                     }
                 } catch (NumberFormatException e) {
                     // hits unknown
@@ -152,7 +152,7 @@ public class SpamAssassinHandler implements JamesMessageHook, ProtocolHandler {
         } catch (MessagingException e) {
             LOGGER.error(e.getMessage());
         }
-        return new HookResult(HookReturnCode.DECLINED);
+        return new HookResult(HookReturnCode.declined());
     }
 
     @Override

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/URIRBLHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/URIRBLHandler.java
@@ -131,7 +131,7 @@ public class URIRBLHandler implements JamesMessageHook, ProtocolHandler {
             }
 
         } else {
-            return new HookResult(HookReturnCode.declined());
+            return HookResult.DECLINED;
         }
     }
 

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/URIRBLHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/URIRBLHandler.java
@@ -125,9 +125,15 @@ public class URIRBLHandler implements JamesMessageHook, ProtocolHandler {
             }
 
             if (detail != null) {
-                return new HookResult(HookReturnCode.deny(), DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_OTHER) + "Rejected: message contains domain " + target + " listed by " + uRblServer + " . Details: " + detail);
+                return HookResult.builder()
+                    .hookReturnCode(HookReturnCode.deny())
+                    .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_OTHER) + "Rejected: message contains domain " + target + " listed by " + uRblServer + " . Details: " + detail)
+                    .build();
             } else {
-                return new HookResult(HookReturnCode.deny(), DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_OTHER) + " Rejected: message contains domain " + target + " listed by " + uRblServer);
+                return HookResult.builder()
+                    .hookReturnCode(HookReturnCode.deny())
+                    .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_OTHER) + " Rejected: message contains domain " + target + " listed by " + uRblServer)
+                    .build();
             }
 
         } else {

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/URIRBLHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/URIRBLHandler.java
@@ -125,13 +125,13 @@ public class URIRBLHandler implements JamesMessageHook, ProtocolHandler {
             }
 
             if (detail != null) {
-                return new HookResult(HookReturnCode.DENY, DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_OTHER) + "Rejected: message contains domain " + target + " listed by " + uRblServer + " . Details: " + detail);
+                return new HookResult(HookReturnCode.deny(), DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_OTHER) + "Rejected: message contains domain " + target + " listed by " + uRblServer + " . Details: " + detail);
             } else {
-                return new HookResult(HookReturnCode.DENY, DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_OTHER) + " Rejected: message contains domain " + target + " listed by " + uRblServer);
+                return new HookResult(HookReturnCode.deny(), DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_OTHER) + " Rejected: message contains domain " + target + " listed by " + uRblServer);
             }
 
         } else {
-            return new HookResult(HookReturnCode.DECLINED);
+            return new HookResult(HookReturnCode.declined());
         }
     }
 

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptHandler.java
@@ -45,20 +45,20 @@ public class ValidRcptHandler extends AbstractValidRcptHandler implements Protoc
     private static final Logger LOGGER = LoggerFactory.getLogger(ValidRcptHandler.class);
 
     private final UsersRepository users;
-    private final RecipientRewriteTable vut;
+    private final RecipientRewriteTable recipientRewriteTable;
     private final DomainList domains;
 
-    private boolean useVut = true;
+    private boolean supportsRecipientRewriteTable = true;
 
     @Inject
-    public ValidRcptHandler(UsersRepository users, RecipientRewriteTable vut, DomainList domains) {
+    public ValidRcptHandler(UsersRepository users, RecipientRewriteTable recipientRewriteTable, DomainList domains) {
         this.users = users;
-        this.vut = vut;
+        this.recipientRewriteTable = recipientRewriteTable;
         this.domains = domains;
     }
 
-    public void setRecipientRewriteTableSupport(boolean useVut) {
-        this.useVut = useVut;
+    public void setSupportsRecipientRewriteTable(boolean supportsRecipientRewriteTable) {
+        this.supportsRecipientRewriteTable = supportsRecipientRewriteTable;
     }
 
     @Override
@@ -69,7 +69,7 @@ public class ValidRcptHandler extends AbstractValidRcptHandler implements Protoc
             if (users.contains(username)) {
                 return true;
             } else {
-                return useVut && isRedirected(recipient, username);
+                return supportsRecipientRewriteTable && isRedirected(recipient, username);
             }
         } catch (UsersRepositoryException e) {
             LOGGER.info("Unable to access UsersRepository", e);
@@ -81,7 +81,7 @@ public class ValidRcptHandler extends AbstractValidRcptHandler implements Protoc
         LOGGER.debug("Unknown user {} check if it's an alias", username);
 
         try {
-            Mappings targetString = vut.getMappings(recipient.getLocalPart(), recipient.getDomain());
+            Mappings targetString = recipientRewriteTable.getMappings(recipient.getLocalPart(), recipient.getDomain());
 
             if (!targetString.isEmpty()) {
                 return true;
@@ -107,8 +107,7 @@ public class ValidRcptHandler extends AbstractValidRcptHandler implements Protoc
 
     @Override
     public void init(Configuration config) throws ConfigurationException {
-        setRecipientRewriteTableSupport(config.getBoolean("enableRecipientRewriteTable", true));
-        
+        setSupportsRecipientRewriteTable(config.getBoolean("enableRecipientRewriteTable", true));
     }
 
     @Override

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptHandler.java
@@ -44,50 +44,19 @@ import org.slf4j.LoggerFactory;
 public class ValidRcptHandler extends AbstractValidRcptHandler implements ProtocolHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(ValidRcptHandler.class);
 
-    private UsersRepository users;
-
-    private RecipientRewriteTable vut;
+    private final UsersRepository users;
+    private final RecipientRewriteTable vut;
+    private final DomainList domains;
 
     private boolean useVut = true;
 
-    private DomainList domains;
-
-    /**
-     * Gets the users repository.
-     * 
-     * @return the users
-     */
-    public final UsersRepository getUsers() {
-        return users;
-    }
-
-    /**
-     * Sets the users repository.
-     * 
-     * @param users
-     *            the users to set
-     */
     @Inject
-    public final void setUsersRepository(UsersRepository users) {
+    public ValidRcptHandler(UsersRepository users, RecipientRewriteTable vut, DomainList domains) {
         this.users = users;
-    }
-
-    /**
-     * Sets the virtual user table store.
-     * 
-     * @param vut
-     *            the tableStore to set
-     */
-    @Inject
-    public final void setRecipientRewriteTable(RecipientRewriteTable vut) {
         this.vut = vut;
-    }
-
-    @Inject
-    public void setDomainList(DomainList domains) {
         this.domains = domains;
     }
-    
+
     public void setRecipientRewriteTableSupport(boolean useVut) {
         this.useVut = useVut;
     }

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptHandler.java
@@ -114,11 +114,11 @@ public class ValidRcptHandler extends AbstractValidRcptHandler implements Protoc
         try {
             Mappings targetString = vut.getMappings(recipient.getLocalPart(), recipient.getDomain());
 
-            if (targetString != null && !targetString.isEmpty()) {
+            if (!targetString.isEmpty()) {
                 return true;
             }
         } catch (ErrorMappingException e) {
-            return false;
+            return true;
         } catch (RecipientRewriteTableException e) {
             LOGGER.info("Unable to access RecipientRewriteTable", e);
             return false;

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptMX.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptMX.java
@@ -110,7 +110,12 @@ public class ValidRcptMX implements RcptHook, ProtocolHandler {
 
                         // Check for invalid MX
                         if (bNetwork.matchInetNetwork(ip)) {
-                            return new HookResult(HookReturnCode.deny(), SMTPRetCode.AUTH_REQUIRED, DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_AUTH) + " Invalid MX " + session.getRemoteAddress().getAddress().toString() + " for domain " + domain + ". Reject email");
+                            return HookResult.builder()
+                                .hookReturnCode(HookReturnCode.deny())
+                                .smtpReturnCode(SMTPRetCode.AUTH_REQUIRED)
+                                .smtpDescription(DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_AUTH)
+                                    + " Invalid MX " + session.getRemoteAddress().getAddress().toString() + " for domain " + domain.asString() + ". Reject email")
+                                .build();
                         }
                     } catch (UnknownHostException e) {
                         // Ignore this

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptMX.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptMX.java
@@ -98,7 +98,7 @@ public class ValidRcptMX implements RcptHook, ProtocolHandler {
             try {
                 mx = dnsService.findMXRecords(domain.name()).iterator();
             } catch (TemporaryResolutionException e1) {
-                return new HookResult(HookReturnCode.denySoft());
+                return HookResult.DENYSOFT;
             }
 
             if (mx != null && mx.hasNext()) {
@@ -118,7 +118,7 @@ public class ValidRcptMX implements RcptHook, ProtocolHandler {
                 }
             }
         }
-        return new HookResult(HookReturnCode.declined());
+        return HookResult.DECLINED;
     }
 
     @Override

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptMX.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptMX.java
@@ -98,7 +98,7 @@ public class ValidRcptMX implements RcptHook, ProtocolHandler {
             try {
                 mx = dnsService.findMXRecords(domain.name()).iterator();
             } catch (TemporaryResolutionException e1) {
-                return new HookResult(HookReturnCode.DENYSOFT);
+                return new HookResult(HookReturnCode.denySoft());
             }
 
             if (mx != null && mx.hasNext()) {
@@ -110,7 +110,7 @@ public class ValidRcptMX implements RcptHook, ProtocolHandler {
 
                         // Check for invalid MX
                         if (bNetwork.matchInetNetwork(ip)) {
-                            return new HookResult(HookReturnCode.DENY, SMTPRetCode.AUTH_REQUIRED, DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_AUTH) + " Invalid MX " + session.getRemoteAddress().getAddress().toString() + " for domain " + domain + ". Reject email");
+                            return new HookResult(HookReturnCode.deny(), SMTPRetCode.AUTH_REQUIRED, DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.SECURITY_AUTH) + " Invalid MX " + session.getRemoteAddress().getAddress().toString() + " for domain " + domain + ". Reject email");
                         }
                     } catch (UnknownHostException e) {
                         // Ignore this
@@ -118,7 +118,7 @@ public class ValidRcptMX implements RcptHook, ProtocolHandler {
                 }
             }
         }
-        return new HookResult(HookReturnCode.DECLINED);
+        return new HookResult(HookReturnCode.declined());
     }
 
     @Override

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/jmx/HookStats.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/jmx/HookStats.java
@@ -56,20 +56,21 @@ public class HookStats extends StandardMBean implements HookStatsMBean, Disposab
         mbeanserver.registerMBean(this, baseObjectName);
     }
 
-    public void increment(int code) {
-        if ((code & HookReturnCode.OK) == HookReturnCode.OK) {
-            ok.incrementAndGet();
+    public void increment(HookReturnCode code) {
+        switch (code.getAction()) {
+            case DECLINED:
+                declined.incrementAndGet();
+                break;
+            case DENY:
+                deny.incrementAndGet();
+                break;
+            case DENYSOFT:
+                denysoft.incrementAndGet();
+                break;
+            case OK:
+                ok.incrementAndGet();
+                break;
         }
-        if ((code & HookReturnCode.DECLINED) == HookReturnCode.DECLINED) {
-            declined.incrementAndGet();
-        }
-        if ((code & HookReturnCode.DENYSOFT) == HookReturnCode.DENYSOFT) {
-            denysoft.incrementAndGet();
-        }
-        if ((code & HookReturnCode.DENY) == HookReturnCode.DENY) {
-            deny.incrementAndGet();
-        }
-
         all.incrementAndGet();
     }
 

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SPFHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SPFHandlerTest.java
@@ -176,8 +176,8 @@ public class SPFHandlerTest {
 
         spf.setDNSService(mockedDnsService);
 
-        assertEquals("declined", HookReturnCode.DECLINED, spf.doMail(mockedSMTPSession, sender).getResult());
-        assertEquals("declined", HookReturnCode.DECLINED, spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult());
+        assertEquals("declined", HookReturnCode.declined(), spf.doMail(mockedSMTPSession, sender).getResult());
+        assertEquals("declined", HookReturnCode.declined(), spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult());
     }
 
     @Test
@@ -189,8 +189,8 @@ public class SPFHandlerTest {
 
         spf.setDNSService(mockedDnsService);
 
-        assertEquals("declined", HookReturnCode.DECLINED, spf.doMail(mockedSMTPSession, sender).getResult());
-        assertEquals("fail", HookReturnCode.DENY, spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult());
+        assertEquals("declined", HookReturnCode.declined(), spf.doMail(mockedSMTPSession, sender).getResult());
+        assertEquals("fail", HookReturnCode.deny(), spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult());
     }
 
     @Test
@@ -202,8 +202,8 @@ public class SPFHandlerTest {
 
         spf.setDNSService(mockedDnsService);
 
-        assertEquals("declined", HookReturnCode.DECLINED, spf.doMail(mockedSMTPSession, sender).getResult());
-        assertEquals("softfail declined", HookReturnCode.DECLINED,
+        assertEquals("declined", HookReturnCode.declined(), spf.doMail(mockedSMTPSession, sender).getResult());
+        assertEquals("softfail declined", HookReturnCode.declined(),
                 spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult());
     }
 
@@ -219,8 +219,8 @@ public class SPFHandlerTest {
 
         spf.setBlockSoftFail(true);
 
-        assertEquals("declined", HookReturnCode.DECLINED, spf.doMail(mockedSMTPSession, sender).getResult());
-        assertEquals("softfail reject", HookReturnCode.DENY, spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult());
+        assertEquals("declined", HookReturnCode.declined(), spf.doMail(mockedSMTPSession, sender).getResult());
+        assertEquals("softfail reject", HookReturnCode.deny(), spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult());
     }
 
     @Test
@@ -235,8 +235,8 @@ public class SPFHandlerTest {
 
         spf.setBlockSoftFail(true);
 
-        assertEquals("declined", HookReturnCode.DECLINED, spf.doMail(mockedSMTPSession, sender).getResult());
-        assertEquals("permerror reject", HookReturnCode.DENY, spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult());
+        assertEquals("declined", HookReturnCode.declined(), spf.doMail(mockedSMTPSession, sender).getResult());
+        assertEquals("permerror reject", HookReturnCode.deny(), spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult());
     }
 
     @Test
@@ -250,8 +250,8 @@ public class SPFHandlerTest {
 
         spf.setDNSService(mockedDnsService);
 
-        assertEquals("declined", HookReturnCode.DECLINED, spf.doMail(mockedSMTPSession, sender).getResult());
-        assertEquals("temperror denysoft", HookReturnCode.DENYSOFT, 
+        assertEquals("declined", HookReturnCode.declined(), spf.doMail(mockedSMTPSession, sender).getResult());
+        assertEquals("temperror denysoft", HookReturnCode.denySoft(),
                 spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult());
     }
 
@@ -265,8 +265,8 @@ public class SPFHandlerTest {
 
         spf.setDNSService(mockedDnsService);
 
-        assertEquals("declined", HookReturnCode.DECLINED, spf.doMail(mockedSMTPSession, sender).getResult());
-        assertEquals("declined", HookReturnCode.DECLINED, spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult());
+        assertEquals("declined", HookReturnCode.declined(), spf.doMail(mockedSMTPSession, sender).getResult());
+        assertEquals("declined", HookReturnCode.declined(), spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult());
     }
 
     @Test
@@ -280,7 +280,7 @@ public class SPFHandlerTest {
 
         spf.setBlockPermError(false);
 
-        assertEquals("declined", HookReturnCode.DECLINED, spf.doMail(mockedSMTPSession, sender).getResult());
-        assertEquals("declined", HookReturnCode.DECLINED, spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult());
+        assertEquals("declined", HookReturnCode.declined(), spf.doMail(mockedSMTPSession, sender).getResult());
+        assertEquals("declined", HookReturnCode.declined(), spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult());
     }
 }

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SpamAssassinHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SpamAssassinHandlerTest.java
@@ -119,7 +119,7 @@ public class SpamAssassinHandlerTest {
         handler.setSpamdRejectionHits(200.0);
         HookResult response = handler.onMessage(session, mockedMail);
 
-        assertEquals("Email was not rejected", response.getResult(), HookReturnCode.DECLINED);
+        assertEquals("Email was not rejected", response.getResult(), HookReturnCode.declined());
         assertEquals("email was not spam", mockedMail.getAttribute(SpamAssassinResult.FLAG_MAIL_ATTRIBUTE_NAME), "NO");
         assertNotNull("spam hits", mockedMail.getAttribute(SpamAssassinResult.STATUS_MAIL_ATTRIBUTE_NAME));
 
@@ -136,7 +136,7 @@ public class SpamAssassinHandlerTest {
         handler.setSpamdRejectionHits(2000.0);
         HookResult response = handler.onMessage(session, mockedMail);
 
-        assertEquals("Email was not rejected", response.getResult(), HookReturnCode.DECLINED);
+        assertEquals("Email was not rejected", response.getResult(), HookReturnCode.declined());
         assertEquals("email was spam", mockedMail.getAttribute(SpamAssassinResult.FLAG_MAIL_ATTRIBUTE_NAME), "YES");
         assertNotNull("spam hits", mockedMail.getAttribute(SpamAssassinResult.STATUS_MAIL_ATTRIBUTE_NAME));
     }
@@ -152,7 +152,7 @@ public class SpamAssassinHandlerTest {
         handler.setSpamdRejectionHits(200.0);
         HookResult response = handler.onMessage(session, mockedMail);
 
-        assertEquals("Email was rejected", response.getResult(), HookReturnCode.DENY);
+        assertEquals("Email was rejected", response.getResult(), HookReturnCode.deny());
         assertEquals("email was spam", mockedMail.getAttribute(SpamAssassinResult.FLAG_MAIL_ATTRIBUTE_NAME), "YES");
         assertNotNull("spam hits", mockedMail.getAttribute(SpamAssassinResult.STATUS_MAIL_ATTRIBUTE_NAME));
     }

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/URIRBLHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/URIRBLHandlerTest.java
@@ -170,7 +170,7 @@ public class URIRBLHandlerTest {
         handler.setUriRblServer(servers);
         HookResult response = handler.onMessage(session, mockedMail);
 
-        assertEquals("Email was not rejected", response.getResult(), HookReturnCode.DECLINED);
+        assertEquals("Email was not rejected", response.getResult(), HookReturnCode.declined());
     }
 
     @Test
@@ -188,7 +188,7 @@ public class URIRBLHandlerTest {
         handler.setUriRblServer(servers);
         HookResult response = handler.onMessage(session, mockedMail);
 
-        assertEquals("Email was rejected", response.getResult(), HookReturnCode.DENY);
+        assertEquals("Email was rejected", response.getResult(), HookReturnCode.deny());
     }
 
     @Test
@@ -206,7 +206,7 @@ public class URIRBLHandlerTest {
         handler.setUriRblServer(servers);
         HookResult response = handler.onMessage(session, mockedMail);
 
-        assertEquals("Email was rejected", response.getResult(), HookReturnCode.DENY);
+        assertEquals("Email was rejected", response.getResult(), HookReturnCode.deny());
     }
 
     /*

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
 import org.apache.james.dnsservice.api.DNSService;
+import org.apache.james.domainlist.lib.DomainListConfiguration;
 import org.apache.james.domainlist.memory.MemoryDomainList;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.hook.HookReturnCode;
@@ -59,7 +60,9 @@ public class ValidRcptHandlerTest {
         users.addUser(VALID_USER, PASSWORD);
 
         MemoryDomainList memoryDomainList = new MemoryDomainList(mock(DNSService.class));
-        memoryDomainList.setDefaultDomain(Domain.LOCALHOST);
+        memoryDomainList.configure(DomainListConfiguration.builder()
+            .defaultDomain(Domain.LOCALHOST)
+            .build());
 
         memoryRecipientRewriteTable = new MemoryRecipientRewriteTable();
         memoryRecipientRewriteTable.setDomainList(memoryDomainList);

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
@@ -64,10 +64,7 @@ public class ValidRcptHandlerTest {
         memoryRecipientRewriteTable = new MemoryRecipientRewriteTable();
         memoryRecipientRewriteTable.setDomainList(memoryDomainList);
 
-        handler = new ValidRcptHandler();
-        handler.setUsersRepository(users);
-        handler.setRecipientRewriteTable(memoryRecipientRewriteTable);
-        handler.setDomainList(memoryDomainList);
+        handler = new ValidRcptHandler(users, memoryRecipientRewriteTable, memoryDomainList);
 
         validUserEmail = new MailAddress(VALID_USER + "@localhost");
         user1mail = new MailAddress(USER1 + "@localhost");

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
@@ -18,8 +18,7 @@
  ****************************************************************/
 package org.apache.james.smtpserver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.io.ByteArrayInputStream;
@@ -127,7 +126,7 @@ public class ValidRcptHandlerTest {
 
         int rCode = handler.doRcpt(session, null, mailAddress).getResult();
 
-        assertEquals("Rejected", rCode, HookReturnCode.DENY);
+        assertThat(rCode).isEqualTo(HookReturnCode.DENY);
     }
 
     @Test
@@ -137,7 +136,7 @@ public class ValidRcptHandlerTest {
 
         int rCode = handler.doRcpt(session, null, mailAddress).getResult();
 
-        assertEquals("Rejected", rCode, HookReturnCode.DENY);
+        assertThat(rCode).isEqualTo(HookReturnCode.DENY);
     }
 
     @Test
@@ -147,7 +146,7 @@ public class ValidRcptHandlerTest {
 
         int rCode = handler.doRcpt(session, null, mailAddress).getResult();
 
-        assertEquals("Not rejected", rCode, HookReturnCode.DECLINED);
+        assertThat(rCode).isEqualTo(HookReturnCode.DECLINED);
     }
 
     @Test
@@ -157,7 +156,7 @@ public class ValidRcptHandlerTest {
 
         int rCode = handler.doRcpt(session, null, mailAddress).getResult();
 
-        assertEquals("Not rejected", rCode, HookReturnCode.DECLINED);
+        assertThat(rCode).isEqualTo(HookReturnCode.DECLINED);
     }
 
     @Test
@@ -167,8 +166,8 @@ public class ValidRcptHandlerTest {
 
         int rCode = handler.doRcpt(session, null, mailAddress).getResult();
 
-        assertNull("Valid Error mapping", session.getAttachment("VALID_USER", State.Transaction));
-        assertEquals("Error mapping", rCode, HookReturnCode.DENY);
+        assertThat(session.getAttachment("VALID_USER", State.Transaction)).isNull();
+        assertThat(rCode).isEqualTo(HookReturnCode.DENY);
     }
     
 }

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
@@ -115,18 +115,18 @@ public class ValidRcptHandlerTest {
     public void doRcptShouldRejectNotExistingLocalUsersWhenNoRelay() {
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        int rCode = handler.doRcpt(session, SENDER, invalidUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, SENDER, invalidUserEmail).getResult();
 
-        assertThat(rCode).isEqualTo(HookReturnCode.DENY);
+        assertThat(rCode).isEqualTo(HookReturnCode.deny());
     }
 
     @Test
     public void doRcptShouldDenyNotExistingLocalUsersWhenRelay() {
         SMTPSession session = setupMockedSMTPSession(RELAYING_ALLOWED);
 
-        int rCode = handler.doRcpt(session, SENDER, invalidUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, SENDER, invalidUserEmail).getResult();
 
-        assertThat(rCode).isEqualTo(HookReturnCode.DENY);
+        assertThat(rCode).isEqualTo(HookReturnCode.deny());
     }
 
     @Test
@@ -134,9 +134,9 @@ public class ValidRcptHandlerTest {
         MailAddress mailAddress = new MailAddress(INVALID_USER + "@otherdomain");
         SMTPSession session = setupMockedSMTPSession(RELAYING_ALLOWED);
 
-        int rCode = handler.doRcpt(session, SENDER, mailAddress).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, SENDER, mailAddress).getResult();
 
-        assertThat(rCode).isEqualTo(HookReturnCode.DECLINED);
+        assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
 
     @Test
@@ -144,27 +144,27 @@ public class ValidRcptHandlerTest {
         MailAddress mailAddress = new MailAddress(INVALID_USER + "@otherdomain");
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        int rCode = handler.doRcpt(session, SENDER, mailAddress).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, SENDER, mailAddress).getResult();
 
-        assertThat(rCode).isEqualTo(HookReturnCode.DECLINED);
+        assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
 
     @Test
     public void doRcptShouldDeclineValidUsersWhenNoRelay() throws Exception {
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        int rCode = handler.doRcpt(session, SENDER, validUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, SENDER, validUserEmail).getResult();
 
-        assertThat(rCode).isEqualTo(HookReturnCode.DECLINED);
+        assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
 
     @Test
     public void doRcptShouldDeclineValidUsersWhenRelay() throws Exception {
         SMTPSession session = setupMockedSMTPSession(RELAYING_ALLOWED);
 
-        int rCode = handler.doRcpt(session, SENDER, validUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, SENDER, validUserEmail).getResult();
 
-        assertThat(rCode).isEqualTo(HookReturnCode.DECLINED);
+        assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
 
     @Test
@@ -173,9 +173,9 @@ public class ValidRcptHandlerTest {
 
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        int rCode = handler.doRcpt(session, SENDER, validUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, SENDER, validUserEmail).getResult();
 
-        assertThat(rCode).isEqualTo(HookReturnCode.DECLINED);
+        assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
 
     @Test
@@ -185,9 +185,9 @@ public class ValidRcptHandlerTest {
 
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        int rCode = handler.doRcpt(session, SENDER, user1mail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, SENDER, user1mail).getResult();
 
-        assertThat(rCode).isEqualTo(HookReturnCode.DECLINED);
+        assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
 
     @Test
@@ -196,9 +196,9 @@ public class ValidRcptHandlerTest {
 
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        int rCode = handler.doRcpt(session, SENDER, user1mail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, SENDER, user1mail).getResult();
 
-        assertThat(rCode).isEqualTo(HookReturnCode.DECLINED);
+        assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
     
 }

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
@@ -21,10 +21,8 @@ package org.apache.james.smtpserver;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import java.io.ByteArrayInputStream;
 import java.util.HashMap;
 
-import org.apache.commons.configuration.DefaultConfigurationBuilder;
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
 import org.apache.james.dnsservice.api.DNSService;
@@ -46,7 +44,6 @@ import org.junit.Test;
 
 public class ValidRcptHandlerTest {
 
-    private static final Domain VALID_DOMAIN = Domain.of("localhost");
     private static final String VALID_USER = "postmaster";
     private static final String INVALID_USER = "invalid";
     private static final String USER1 = "user1";
@@ -61,11 +58,7 @@ public class ValidRcptHandlerTest {
         users.addUser(VALID_USER, "xxx");
 
         MemoryDomainList memoryDomainList = new MemoryDomainList(mock(DNSService.class));
-        memoryDomainList.addDomain(VALID_DOMAIN);
-        DefaultConfigurationBuilder config = new DefaultConfigurationBuilder();
-        String configString = "<domainlist><defaultDomain>localhost</defaultDomain></domainlist>";
-        config.load(new ByteArrayInputStream(configString.getBytes()));
-        memoryDomainList.configure(config);
+        memoryDomainList.setDefaultDomain(Domain.LOCALHOST);
 
         handler = new ValidRcptHandler();
         handler.setUsersRepository(users);

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
@@ -37,7 +37,6 @@ import org.apache.james.smtpserver.fastfail.ValidRcptHandler;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.memory.MemoryUsersRepository;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class ValidRcptHandlerTest {
@@ -179,7 +178,6 @@ public class ValidRcptHandlerTest {
         assertThat(rCode).isEqualTo(HookReturnCode.DECLINED);
     }
 
-    @Ignore
     @Test
     public void doRcptShouldDenyWhenHasMappingLoop() throws Exception {
         memoryRecipientRewriteTable.addAddressMapping(MappingSource.fromUser(USER1, Domain.LOCALHOST), USER2 + "@localhost");
@@ -192,7 +190,6 @@ public class ValidRcptHandlerTest {
         assertThat(rCode).isEqualTo(HookReturnCode.DECLINED);
     }
 
-    @Ignore
     @Test
     public void doRcptShouldDeclineWhenHasErrorMapping() throws Exception {
         memoryRecipientRewriteTable.addErrorMapping(MappingSource.fromUser(USER1, Domain.LOCALHOST), "554 BOUNCE");

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
@@ -32,7 +32,6 @@ import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.domainlist.api.DomainList;
 import org.apache.james.domainlist.memory.MemoryDomainList;
 import org.apache.james.protocols.api.ProtocolSession.State;
-import org.apache.james.protocols.smtp.SMTPConfiguration;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.hook.HookReturnCode;
 import org.apache.james.protocols.smtp.utils.BaseFakeSMTPSession;
@@ -75,8 +74,7 @@ public class ValidRcptHandlerTest {
         handler.setDomainList(memoryDomainList);
     }
 
-    private SMTPSession setupMockedSMTPSession(SMTPConfiguration conf, MailAddress rcpt,
-                                               final boolean relayingAllowed) {
+    private SMTPSession setupMockedSMTPSession(final boolean relayingAllowed) {
 
         return new BaseFakeSMTPSession() {
 
@@ -122,56 +120,10 @@ public class ValidRcptHandlerTest {
         return memoryRecipientRewriteTable;
     }
 
-    private SMTPConfiguration setupMockedSMTPConfiguration() {
-
-        return new SMTPConfiguration() {
-
-            @Override
-            public String getHelloName() {
-                throw new UnsupportedOperationException("Unimplemented Stub Method");
-            }
-
-            @Override
-            public long getMaxMessageSize() {
-                throw new UnsupportedOperationException("Unimplemented Stub Method");
-            }
-
-            @Override
-            public boolean isRelayingAllowed(String remoteIP) {
-                throw new UnsupportedOperationException("Unimplemented Stub Method");
-            }
-
-            @Override
-            public boolean useHeloEhloEnforcement() {
-                throw new UnsupportedOperationException("Unimplemented Stub Method");
-            }
-
-            @Override
-            public boolean useAddressBracketsEnforcement() {
-                return true;
-            }
-
-            @Override
-            public boolean isAuthRequired(String remoteIP) {
-                throw new UnsupportedOperationException("Unimplemented Stub Method");
-            }
-
-            @Override
-            public String getGreeting() {
-                return null;
-            }
-
-            @Override
-            public String getSoftwareName() {
-                return null;
-            }
-        };
-    }
-
     @Test
     public void testRejectInvalidUser() throws Exception {
         MailAddress mailAddress = new MailAddress(INVALID_USER + "@localhost");
-        SMTPSession session = setupMockedSMTPSession(setupMockedSMTPConfiguration(), mailAddress, false);
+        SMTPSession session = setupMockedSMTPSession(false);
 
         int rCode = handler.doRcpt(session, null, mailAddress).getResult();
 
@@ -181,7 +133,7 @@ public class ValidRcptHandlerTest {
     @Test
     public void testRejectInvalidUserRelay() throws Exception {
         MailAddress mailAddress = new MailAddress(INVALID_USER + "@localhost");
-        SMTPSession session = setupMockedSMTPSession(setupMockedSMTPConfiguration(), mailAddress, true);
+        SMTPSession session = setupMockedSMTPSession(true);
 
         int rCode = handler.doRcpt(session, null, mailAddress).getResult();
 
@@ -191,7 +143,7 @@ public class ValidRcptHandlerTest {
     @Test
     public void testNotRejectValidUser() throws Exception {
         MailAddress mailAddress = new MailAddress(VALID_USER + "@localhost");
-        SMTPSession session = setupMockedSMTPSession(setupMockedSMTPConfiguration(), mailAddress, false);
+        SMTPSession session = setupMockedSMTPSession(false);
 
         int rCode = handler.doRcpt(session, null, mailAddress).getResult();
 
@@ -201,7 +153,7 @@ public class ValidRcptHandlerTest {
     @Test
     public void testHasAddressMapping() throws Exception {
         MailAddress mailAddress = new MailAddress(USER1 + "@localhost");
-        SMTPSession session = setupMockedSMTPSession(setupMockedSMTPConfiguration(), mailAddress, false);
+        SMTPSession session = setupMockedSMTPSession(false);
 
         int rCode = handler.doRcpt(session, null, mailAddress).getResult();
 
@@ -211,7 +163,7 @@ public class ValidRcptHandlerTest {
     @Test
     public void testHasErrorMapping() throws Exception {
         MailAddress mailAddress = new MailAddress(USER2 + "@localhost");
-        SMTPSession session = setupMockedSMTPSession(setupMockedSMTPConfiguration(), mailAddress, false);
+        SMTPSession session = setupMockedSMTPSession(false);
 
         int rCode = handler.doRcpt(session, null, mailAddress).getResult();
 

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptMXTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptMXTest.java
@@ -82,8 +82,8 @@ public class ValidRcptMXTest {
         ValidRcptMX handler = new ValidRcptMX();
         handler.setDNSService(dns);
         handler.setBannedNetworks(ImmutableList.of(bannedAddress), dns);
-        int rCode = handler.doRcpt(session, null, mailAddress).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, null, mailAddress).getResult();
 
-        assertEquals("Reject", rCode, HookReturnCode.DENY);
+        assertEquals("Reject", rCode, HookReturnCode.deny());
     }
 }


### PR DESCRIPTION
Step 0: refactoring a bit SMTP layer

 - Remove bitewise operation over SMTP response code
 - Refactor a bit ValidRCPT related handlers

Step1: SMTP should accept email when RRT loops

Step2: RRT mailet should allow specification of an error processor. This enable fin grained control upon RRT errors.

Step3: Avoid infinite mailing loops, send bounces when possible, and always store mails in a separated  repository when loops.

Please note that Forward loops is not handled yet due to a prefix bug that https://github.com/linagora/james-project/pull/1378 attend to solve.

I will add Forward loops tests when possible, in a later PR.