### PR TITLE
JAMES-2390 JMAP attachment performance issues

### DIFF
--- a/mailbox/api/pom.xml
+++ b/mailbox/api/pom.xml
@@ -79,6 +79,10 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/Attachment.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/Attachment.java
@@ -71,7 +71,7 @@ public class Attachment {
             if (attachmentId != null) {
                 return attachmentId;
             }
-            return AttachmentId.forPayloadAndType(bytes, type);
+            return AttachmentId.random();
         }
 
         private long size() {
@@ -118,7 +118,7 @@ public class Attachment {
 
     public Blob toBlob() {
         return Blob.builder()
-            .id(BlobId.fromString(attachmentId.getId()))
+            .id(BlobId.fromBytes(bytes))
             .payload(bytes)
             .contentType(type)
             .build();

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/AttachmentId.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/AttachmentId.java
@@ -19,48 +19,24 @@
 package org.apache.james.mailbox.model;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Optional;
 import java.util.UUID;
 
-import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.james.mime4j.codec.DecodeMonitor;
-import org.apache.james.mime4j.field.ContentTypeFieldImpl;
-import org.apache.james.mime4j.stream.RawField;
+import org.apache.commons.text.RandomStringGenerator;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import com.google.common.primitives.Bytes;
 
 public class AttachmentId {
 
-    private static final String DEFAULT_MIME_TYPE = "application/octet-stream";
-
-    public static AttachmentId forPayloadAndType(byte[] payload, String contentType) {
-        Preconditions.checkNotNull(payload);
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(contentType));
-
-        return new AttachmentId(computeRawId(payload, contentType));
-    }
-
-    private static String computeRawId(final byte[] payload, final String contentType) {
-        return DigestUtils.sha256Hex(
-            Bytes.concat(
-                asMimeType(contentType).getBytes(StandardCharsets.UTF_8),
-                DigestUtils.sha256Hex(payload).getBytes(StandardCharsets.UTF_8)));
-    }
-
-    @VisibleForTesting static String asMimeType(String contentType) {
-        return Optional.ofNullable(ContentTypeFieldImpl.PARSER
-                    .parse(new RawField("ContentType", contentType), DecodeMonitor.SILENT)
-                    .getMimeType())
-                .orElse(DEFAULT_MIME_TYPE);
-    }
+    public static final RandomStringGenerator RANDOM_STRING_GENERATOR = new RandomStringGenerator.Builder().withinRange('a', 'z').build();
 
     public static AttachmentId from(BlobId blobId) {
         return new AttachmentId(blobId.asString());
+    }
+
+    public static AttachmentId random() {
+        return new AttachmentId(RANDOM_STRING_GENERATOR.generate(20));
     }
 
     public static AttachmentId from(String id) {

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/BlobId.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/BlobId.java
@@ -21,11 +21,18 @@ package org.apache.james.mailbox.model;
 
 import java.util.Objects;
 
+import org.apache.commons.codec.digest.DigestUtils;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
 public class BlobId {
+    public static BlobId fromBytes(byte[] bytes) {
+        Preconditions.checkNotNull(bytes);
+        return new BlobId(DigestUtils.sha256Hex(bytes));
+    }
+
     public static BlobId fromString(String raw) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(raw));
         return new BlobId(raw);
@@ -55,7 +62,6 @@ public class BlobId {
     public final int hashCode() {
         return Objects.hash(id);
     }
-
 
     @Override
     public String toString() {

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/AttachmentIdTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/AttachmentIdTest.java
@@ -24,45 +24,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.UUID;
 
-import org.apache.james.util.ClassLoaderUtils;
 import org.junit.Test;
 
 public class AttachmentIdTest {
 
     @Test
-    public void forPayloadAndTypeShouldCalculateTheUnderlyingSha256() {
-        AttachmentId attachmentId = AttachmentId.forPayloadAndType("payload".getBytes(), "text/plain");
-        String expectedId = "d3a2642ee092a1b32c0a83cf94fc2499f7495b7b91b1bd434302a0a4c2aa4278";
-        assertThat(attachmentId.getId()).isEqualTo(expectedId);
-    }
-
-    @Test
-    public void forPayloadAndTypeShouldCalculateDifferentSha256WhenContentTypeIsDifferent() {
-        AttachmentId attachmentId = AttachmentId.forPayloadAndType("payload".getBytes(), "text/plain");
-        AttachmentId attachmentId2 = AttachmentId.forPayloadAndType("payload".getBytes(), "text/html");
+    public void randomShouldGenerateDifferentIds() {
+        AttachmentId attachmentId = AttachmentId.random();
+        AttachmentId attachmentId2 = AttachmentId.random();
         assertThat(attachmentId.getId()).isNotEqualTo(attachmentId2.getId());
-    }
-
-    @Test
-    public void forPayloadAndTypeShouldCalculateSameSha256WhenMimeTypeIsSameButNotParameters() {
-        AttachmentId attachmentId = AttachmentId.forPayloadAndType("payload".getBytes(), "text/html; charset=UTF-8");
-        AttachmentId attachmentId2 = AttachmentId.forPayloadAndType("payload".getBytes(), "text/html; charset=UTF-16");
-        assertThat(attachmentId.getId()).isEqualTo(attachmentId2.getId());
-    }
-    
-    @Test
-    public void forPayloadAndTypeShouldThrowWhenPayloadIsNull() {
-        assertThatThrownBy(() -> AttachmentId.forPayloadAndType(null, "text/plain")).isInstanceOf(NullPointerException.class);
-    }
-
-    @Test
-    public void forPayloadAndTypeShouldThrowWhenTypeIsNull() {
-        assertThatThrownBy(() -> AttachmentId.forPayloadAndType("payload".getBytes(), null)).isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    public void forPayloadAndTypeShouldThrowWhenTypeIsEmpty() {
-        assertThatThrownBy(() -> AttachmentId.forPayloadAndType("payload".getBytes(), "")).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -102,35 +72,5 @@ public class AttachmentIdTest {
 
         assertThat(attachmentId.asUUID())
             .isEqualTo(UUID.fromString("2f3a4fcc-ca64-36e3-9bcf-33e92dd93135"));
-    }
-
-    @Test
-    public void asMimeTypeShouldReturnOnlyMimeTypeFromContentTypeWhenContainingParameters() {
-        String mimeType = AttachmentId.asMimeType("text/html; charset=UTF-8");
-        
-        assertThat(mimeType).isEqualTo("text/html");
-    }
-
-    @Test
-    public void asMimeTypeShouldReturnOnlyMimeTypeFromContentTypeWhenNoParameters() {
-        String mimeType = AttachmentId.asMimeType("text/html");
-        
-        assertThat(mimeType).isEqualTo("text/html");
-    }
-
-    @Test
-    public void asMimeTypeShouldReturnDefaultMimeTypeWhenContentTypeIsUnparsable() {
-        String mimeType = AttachmentId.asMimeType("text");
-        
-        assertThat(mimeType).isEqualTo("application/octet-stream");
-    }
-
-    @Test
-    public void forPayloadAndTypeShouldCalculateDifferentHashesWhenCraftedSha1Collision() throws Exception {
-        byte[] payload1 = ClassLoaderUtils.getSystemResourceAsByteArray("shattered-1.pdf");
-        byte[] payload2 = ClassLoaderUtils.getSystemResourceAsByteArray("shattered-2.pdf");
-        AttachmentId attachmentId1 = AttachmentId.forPayloadAndType(payload1, "application/pdf");
-        AttachmentId attachmentId2 = AttachmentId.forPayloadAndType(payload2, "application/pdf");
-        assertThat(attachmentId1).isNotEqualTo(attachmentId2);
     }
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/AttachmentTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/AttachmentTest.java
@@ -47,7 +47,7 @@ public class AttachmentTest {
     }
 
     @Test
-    public void getByteShouldReturnByteArrayRepresentingTheAttachment() throws Exception {
+    public void getByteShouldReturnByteArrayRepresentingTheAttachment() {
         String input = "mystream";
         Attachment attachment = Attachment.builder()
             .bytes(input.getBytes(CHARSET))
@@ -104,33 +104,20 @@ public class AttachmentTest {
     @Test (expected = IllegalStateException.class)
     public void buildShouldThrowWhenBytesIsNotProvided() {
         Attachment.builder()
-            .attachmentId(AttachmentId.forPayloadAndType("mystream".getBytes(CHARSET), "type"))
+            .attachmentId(AttachmentId.random())
             .build();
     }
 
     @Test (expected = IllegalStateException.class)
     public void buildShouldThrowWhenTypeIsNotProvided() {
         Attachment.builder()
-            .attachmentId(AttachmentId.forPayloadAndType("mystream".getBytes(CHARSET), "type"))
+            .attachmentId(AttachmentId.random())
             .bytes("mystream".getBytes(CHARSET))
             .build();
     }
 
     @Test
-    public void buildShouldSetTheAttachmentId() throws Exception {
-        byte[] bytes = "mystream".getBytes(CHARSET);
-        String type = "content";
-        Attachment attachment = Attachment.builder()
-                .bytes(bytes)
-                .type(type)
-                .build();
-        AttachmentId expected = AttachmentId.forPayloadAndType(bytes, type);
-
-        assertThat(attachment.getAttachmentId()).isEqualTo(expected);
-    }
-
-    @Test
-    public void buildShouldSetTheSize() throws Exception {
+    public void buildShouldSetTheSize() {
         String input = "mystream";
         Attachment attachment = Attachment.builder()
                 .bytes(input.getBytes(CHARSET))
@@ -141,7 +128,7 @@ public class AttachmentTest {
     }
 
     @Test
-    public void toBlobShouldGenerateTheAttachmentBlob() throws Exception {
+    public void toBlobShouldGenerateTheAttachmentBlob() {
         byte[] bytes = "mystream".getBytes(CHARSET);
         String content = "content";
         Attachment attachment = Attachment.builder()
@@ -149,7 +136,7 @@ public class AttachmentTest {
             .type(content)
             .build();
         Blob expected = Blob.builder()
-            .id(BlobId.fromString(attachment.getAttachmentId().getId()))
+            .id(BlobId.fromBytes(bytes))
             .contentType(content)
             .payload(bytes)
             .build();

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/BlobIdTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/BlobIdTest.java
@@ -22,6 +22,8 @@ package org.apache.james.mailbox.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.nio.charset.StandardCharsets;
+
 import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -51,5 +53,19 @@ public class BlobIdTest {
     public void asStringShouldReturnUnderlyingId() {
         assertThat(BlobId.fromString("abc").asString())
             .isEqualTo("abc");
+    }
+
+    @Test
+    public void fromBytesShouldProduceASHA256() {
+        assertThat(BlobId.fromBytes("abc".getBytes(StandardCharsets.UTF_8)).asString())
+            .isEqualTo("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    }
+
+    @Test
+    public void fromBytesShouldCalculateSameSha256() {
+        byte[] bytes = "abc".getBytes(StandardCharsets.UTF_8);
+
+        assertThat(BlobId.fromBytes(bytes))
+            .isEqualTo(BlobId.fromBytes(bytes));
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
@@ -148,7 +148,7 @@ public class CassandraAttachmentMapper implements AttachmentMapper {
 
     @Override
     public Collection<Username> getOwners(AttachmentId attachmentId) throws MailboxException {
-        return ownerDAO.retrieveOwners(attachmentId).join();
+        return ownerDAO.retrieveOwners(attachmentId).join().collect(Guavate.toImmutableList());
     }
 
     public CompletableFuture<Void> storeAttachmentAsync(Attachment attachment, MessageId ownerMessageId) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentOwnerDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentOwnerDAO.java
@@ -28,7 +28,6 @@ import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentOwnerT
 import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentOwnerTable.OWNER;
 import static org.apache.james.mailbox.cassandra.table.CassandraAttachmentOwnerTable.TABLE_NAME;
 
-import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
@@ -42,8 +41,6 @@ import org.apache.james.mailbox.store.mail.model.Username;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
-import com.github.steveash.guavate.Guavate;
-import com.google.common.collect.ImmutableList;
 
 public class CassandraAttachmentOwnerDAO {
 
@@ -82,7 +79,7 @@ public class CassandraAttachmentOwnerDAO {
                 .setString(OWNER, owner.getValue()));
     }
 
-    public CompletableFuture<Collection<Username>> retrieveOwners(AttachmentId attachmentId) {
+    public CompletableFuture<Stream<Username>> retrieveOwners(AttachmentId attachmentId) {
         return executor.execute(
             selectStatement.bind()
                 .setUUID(ID, attachmentId.asUUID()))
@@ -90,9 +87,8 @@ public class CassandraAttachmentOwnerDAO {
             .thenApply(this::toOwners);
     }
 
-    private ImmutableList<Username> toOwners(Stream<Row> stream) {
+    private Stream<Username> toOwners(Stream<Row> stream) {
         return stream.map(row -> row.getString(OWNER))
-            .map(Username::fromRawValue)
-            .collect(Guavate.toImmutableList());
+            .map(Username::fromRawValue);
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentOwnerDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentOwnerDAOTest.java
@@ -21,6 +21,8 @@ package org.apache.james.mailbox.cassandra.mail;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.stream.IntStream;
+
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.DockerCassandraRule;
 import org.apache.james.backends.cassandra.utils.CassandraUtils;
@@ -72,5 +74,16 @@ public class CassandraAttachmentOwnerDAOTest {
 
         assertThat(testee.retrieveOwners(ATTACHMENT_ID).join())
             .containsOnly(OWNER_1, OWNER_2);
+    }
+
+    @Test
+    public void retrieveOwnersShouldNotThrowWhenMoreReferencesThanPaging() {
+        int referenceCountExceedingPaging = 5050;
+        IntStream.range(0, referenceCountExceedingPaging)
+            .boxed()
+            .forEach(i -> testee.addOwner(ATTACHMENT_ID, Username.fromRawValue("owner" + i)).join());
+
+        assertThat(testee.retrieveOwners(ATTACHMENT_ID).join())
+            .hasSize(referenceCountExceedingPaging);
     }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageIdManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageIdManager.java
@@ -131,9 +131,12 @@ public class StoreMessageIdManager implements MessageIdManager {
     public Set<MessageId> accessibleMessages(Collection<MessageId> messageIds, MailboxSession mailboxSession) throws MailboxException {
         MessageIdMapper messageIdMapper = mailboxSessionMapperFactory.getMessageIdMapper(mailboxSession);
         List<MailboxMessage> messageList = messageIdMapper.find(messageIds, MessageMapper.FetchType.Metadata);
+
+        ImmutableSet<MailboxId> allowedMailboxIds = getAllowedMailboxIds(mailboxSession, messageList, Right.Read);
+
         return messageList.stream()
-            .filter(hasRightsOn(mailboxSession, Right.Read))
-            .map(message -> message.getComposedMessageIdWithMetaData().getComposedMessageId().getMessageId())
+            .filter(message -> allowedMailboxIds.contains(message.getMailboxId()))
+            .map(MailboxMessage::getMessageId)
             .collect(Guavate.toImmutableSet());
     }
 
@@ -142,16 +145,20 @@ public class StoreMessageIdManager implements MessageIdManager {
         MessageIdMapper messageIdMapper = mailboxSessionMapperFactory.getMessageIdMapper(mailboxSession);
         List<MailboxMessage> messageList = messageIdMapper.find(messageIds, MessageMapper.FetchType.Full);
 
-        ImmutableSet<MailboxId> allowedMailboxIds = messageList.stream()
-            .map(MailboxMessage::getMailboxId)
-            .distinct()
-            .filter(hasRightsOnMailbox(mailboxSession, Right.Read))
-            .collect(Guavate.toImmutableSet());
+        ImmutableSet<MailboxId> allowedMailboxIds = getAllowedMailboxIds(mailboxSession, messageList, Right.Read);
 
         return messageList.stream()
             .filter(inMailboxes(allowedMailboxIds))
             .map(Throwing.function(messageResultConverter(fetchGroup)).sneakyThrow())
             .collect(Guavate.toImmutableList());
+    }
+
+    private ImmutableSet<MailboxId> getAllowedMailboxIds(MailboxSession mailboxSession, List<MailboxMessage> messageList, Right... rights) {
+        return messageList.stream()
+                .map(MailboxMessage::getMailboxId)
+                .distinct()
+                .filter(hasRightsOnMailbox(mailboxSession, rights))
+                .collect(Guavate.toImmutableSet());
     }
 
     @Override
@@ -212,9 +219,12 @@ public class StoreMessageIdManager implements MessageIdManager {
 
     private List<MailboxMessage> findRelatedMailboxMessages(MessageId messageId, MailboxSession mailboxSession) throws MailboxException {
         MessageIdMapper messageIdMapper = mailboxSessionMapperFactory.getMessageIdMapper(mailboxSession);
-        return messageIdMapper.find(ImmutableList.of(messageId), MessageMapper.FetchType.Full)
-            .stream()
-            .filter(hasRightsOn(mailboxSession, Right.Read))
+        List<MailboxMessage> messageList = messageIdMapper.find(ImmutableList.of(messageId), MessageMapper.FetchType.Full);
+
+        ImmutableSet<MailboxId> allowedMailboxIds = getAllowedMailboxIds(mailboxSession, messageList, Right.Read);
+
+        return messageList.stream()
+            .filter(message -> allowedMailboxIds.contains(message.getMailboxId()))
             .collect(Guavate.toImmutableList());
     }
 
@@ -332,10 +342,6 @@ public class StoreMessageIdManager implements MessageIdManager {
 
     private Predicate<MailboxMessage> inMailboxes(Collection<MailboxId> mailboxIds) {
         return mailboxMessage -> mailboxIds.contains(mailboxMessage.getMailboxId());
-    }
-
-    private Predicate<MailboxMessage> hasRightsOn(MailboxSession session, Right... rights) {
-        return message -> hasRightsOnMailbox(session, rights).test(message.getMailboxId());
     }
 
     private Predicate<MailboxId> hasRightsOnMailbox(MailboxSession session, Right... rights) {

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMailboxManagerAttachmentTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMailboxManagerAttachmentTest.java
@@ -181,34 +181,5 @@ public abstract class AbstractMailboxManagerAttachmentTest {
         List<MessageAttachment> attachments = messages.next().getAttachments();
         assertThat(attachments).hasSize(0);
     }
-
-    @Test
-    public void appendMessageShouldStoreOnceWhenDuplicateAttachment() throws Exception {
-        InputStream mailInputStream = ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml");
-        InputStream mailInputStream2 = ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml");
-        String user2 = "user2@domain.tld";
-        MailboxSession user2MailboxSession = new MockMailboxSession(user2);
-        MessageMapper user2MessageMapper = getMailboxSessionMapperFactory().getMessageMapper(user2MailboxSession);
-        MailboxMapper user2MailboxMapper = getMailboxSessionMapperFactory().getMailboxMapper(user2MailboxSession);
-        MailboxPath user2InboxPath = MailboxPath.forUser(user2, "INBOX");
-        mailboxManager.createMailbox(user2InboxPath, user2MailboxSession);
-        Mailbox user2Inbox = user2MailboxMapper.findMailboxByPath(user2InboxPath);
-        MessageManager user2InboxMessageManager = mailboxManager.getMailbox(user2InboxPath, user2MailboxSession);
-
-        inboxMessageManager.appendMessage(MessageManager.AppendCommand.builder()
-            .build(mailInputStream),
-            mailboxSession);
-        user2InboxMessageManager.appendMessage(MessageManager.AppendCommand.builder()
-                .build(mailInputStream2),
-            user2MailboxSession);
-        Iterator<MailboxMessage> messages = messageMapper.findInMailbox(inbox, MessageRange.all(), FetchType.Full, 1);
-        Iterator<MailboxMessage> user2Messages = user2MessageMapper.findInMailbox(user2Inbox, MessageRange.all(), FetchType.Full, 1);
-        assertThat(messages.hasNext()).isTrue();
-        List<MessageAttachment> attachments = messages.next().getAttachments();
-        assertThat(attachments).hasSize(1);
-        assertThat(user2Messages.hasNext()).isTrue();
-        List<MessageAttachment> user2Attachments = user2Messages.next().getAttachments();
-        assertThat(attachments.equals(user2Attachments)).isTrue();
-    }
 }
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreBlobManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreBlobManagerTest.java
@@ -82,7 +82,7 @@ public class StoreBlobManagerTest {
 
         assertThat(blobManager.retrieve(BLOB_ID_ATTACHMENT, session))
             .isEqualTo(Blob.builder()
-                .id(BLOB_ID_ATTACHMENT)
+                .id(BlobId.fromString("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"))
                 .contentType(CONTENT_TYPE)
                 .payload(BYTES)
                 .build());

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/AttachmentMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/AttachmentMapperTest.java
@@ -39,7 +39,7 @@ import org.junit.rules.ExpectedException;
 import com.google.common.collect.ImmutableList;
 
 public abstract class AttachmentMapperTest {
-    private static final AttachmentId UNKNOWN_ATTACHMENT_ID = AttachmentId.forPayloadAndType("unknown".getBytes(StandardCharsets.UTF_8), "type");
+    private static final AttachmentId UNKNOWN_ATTACHMENT_ID = AttachmentId.from("unknown");
     public static final Username OWNER = Username.fromRawValue("owner");
     public static final Username ADDITIONAL_OWNER = Username.fromRawValue("additionalOwner");
 
@@ -108,13 +108,13 @@ public abstract class AttachmentMapperTest {
     }
 
     @Test
-    public void getAttachmentsShouldThrowWhenNullAttachmentId() throws Exception {
+    public void getAttachmentsShouldThrowWhenNullAttachmentId() {
         expected.expect(IllegalArgumentException.class);
         attachmentMapper.getAttachments(null);
     }
 
     @Test
-    public void getAttachmentsShouldReturnEmptyListWhenNonReferencedAttachmentId() throws Exception {
+    public void getAttachmentsShouldReturnEmptyListWhenNonReferencedAttachmentId() {
         List<Attachment> attachments = attachmentMapper.getAttachments(ImmutableList.of(UNKNOWN_ATTACHMENT_ID));
 
         assertThat(attachments).isEmpty();

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
@@ -1910,7 +1910,7 @@ public abstract class SetMessagesMethodTest {
             .bytes("attachment".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
-        uploadAttachment(attachment);
+        String uploadedBlobId = uploadAttachment(attachment);
         String requestBody = "[" +
             "  [" +
             "    \"setMessages\"," +
@@ -1921,7 +1921,7 @@ public abstract class SetMessagesMethodTest {
             "        \"subject\": \"subject\"," +
             "        \"keywords\": {\"$Draft\": true}," +
             "        \"attachments\": [" +
-            "                {\"blobId\" : \"" + attachment.getAttachmentId().getId() + "\", " +
+            "                {\"blobId\" : \"" + uploadedBlobId + "\", " +
             "                 \"type\" : \"" + attachment.getType() + "\"," +
             "                 \"size\" : " + attachment.getSize() + "}" +
             "             ]," +
@@ -1949,11 +1949,6 @@ public abstract class SetMessagesMethodTest {
     @Test
     public void setMessagesShouldNotAllowDraftCreationInSomeoneElseMailbox() throws Exception {
         String messageCreationId = "creationId1337";
-        Attachment attachment = Attachment.builder()
-            .bytes("attachment".getBytes(StandardCharsets.UTF_8))
-            .type("application/octet-stream")
-            .build();
-        uploadAttachment(attachment);
         String requestBody = "[" +
             "  [" +
             "    \"setMessages\"," +
@@ -1987,11 +1982,6 @@ public abstract class SetMessagesMethodTest {
     @Test
     public void setMessagesShouldNotAllowDraftCreationInADelegatedMailbox() throws Exception {
         String messageCreationId = "creationId1337";
-        Attachment attachment = Attachment.builder()
-            .bytes("attachment".getBytes(StandardCharsets.UTF_8))
-            .type("application/octet-stream")
-            .build();
-        uploadAttachment(attachment);
 
         jmapServer.getProbe(ACLProbeImpl.class)
             .addRights(
@@ -3664,12 +3654,12 @@ public abstract class SetMessagesMethodTest {
             .bytes("attachment".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
-        uploadAttachment(attachment);
+        String uploadedAttachment1 = uploadAttachment(attachment);
         Attachment attachment2 = Attachment.builder()
             .bytes("attachment2".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
-        uploadAttachment(attachment2);
+        String uploadedAttachment2 = uploadAttachment(attachment2);
 
         String messageCreationId = "creationId";
         String fromAddress = USERNAME;
@@ -3685,10 +3675,10 @@ public abstract class SetMessagesMethodTest {
             "        \"textBody\": \"Test body\"," +
             "        \"mailboxIds\": [\"" + outboxId + "\"], " +
             "        \"attachments\": [" +
-            "               {\"blobId\" : \"" + attachment.getAttachmentId().getId() + "\", " +
+            "               {\"blobId\" : \"" + uploadedAttachment1 + "\", " +
             "               \"type\" : \"" + attachment.getType() + "\", " +
             "               \"size\" : " + attachment.getSize() + "}," +
-            "               {\"blobId\" : \"" + attachment2.getAttachmentId().getId() + "\", " +
+            "               {\"blobId\" : \"" + uploadedAttachment2 + "\", " +
             "               \"type\" : \"" + attachment2.getType() + "\", " +
             "               \"size\" : " + attachment2.getSize() + ", " +
             "               \"cid\" : \"123456789\", " +
@@ -3715,12 +3705,12 @@ public abstract class SetMessagesMethodTest {
             .body(ARGUMENTS + ".notCreated", aMapWithSize(0))
             .body(ARGUMENTS + ".created", aMapWithSize(1))
             .body(createdPath + ".attachments", hasSize(2))
-            .body(firstAttachment + ".blobId", equalTo(attachment.getAttachmentId().getId()))
+            .body(firstAttachment + ".blobId", equalTo(uploadedAttachment1))
             .body(firstAttachment + ".type", equalTo("application/octet-stream; charset=UTF-8"))
             .body(firstAttachment + ".size", equalTo((int) attachment.getSize()))
             .body(firstAttachment + ".cid", nullValue())
             .body(firstAttachment + ".isInline", equalTo(false))
-            .body(secondAttachment + ".blobId", equalTo(attachment2.getAttachmentId().getId()))
+            .body(secondAttachment + ".blobId", equalTo(uploadedAttachment2))
             .body(secondAttachment + ".type", equalTo("application/octet-stream; charset=UTF-8"))
             .body(secondAttachment + ".size", equalTo((int) attachment2.getSize()))
             .body(secondAttachment + ".cid", equalTo("123456789"))
@@ -3733,17 +3723,17 @@ public abstract class SetMessagesMethodTest {
             .bytes("attachment".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
-        uploadAttachment(attachment);
+        String uploadedAttachment1 = uploadAttachment(attachment);
         Attachment attachment2 = Attachment.builder()
             .bytes("attachment2".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
-        uploadAttachment(attachment2);
+        String uploadedAttachment2 = uploadAttachment(attachment2);
         Attachment attachment3 = Attachment.builder()
             .bytes("attachment3".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
-        uploadAttachment(attachment3);
+        String uploadedAttachment3 = uploadAttachment(attachment3);
 
         String messageCreationId = "creationId";
         String fromAddress = USERNAME;
@@ -3764,21 +3754,21 @@ public abstract class SetMessagesMethodTest {
             "          \"attachments\":" +
             "          [" +
             "            {" +
-            "              \"blobId\" : \"" + attachment.getAttachmentId().getId() + "\", " +
+            "              \"blobId\" : \"" + uploadedAttachment1 + "\", " +
             "              \"type\" : \"" + attachment.getType() + "\", " +
             "              \"size\" : " + attachment.getSize() + "," +
             "              \"name\" : \"ديناصور.png\", " +
             "              \"isInline\" : false" +
             "            }," +
             "            {" +
-            "              \"blobId\" : \"" + attachment2.getAttachmentId().getId() + "\", " +
+            "              \"blobId\" : \"" + uploadedAttachment2 + "\", " +
             "              \"type\" : \"" + attachment2.getType() + "\", " +
             "              \"size\" : " + attachment2.getSize() + "," +
             "              \"name\" : \"эволюционировать.png\", " +
             "              \"isInline\" : false" +
             "            }," +
             "            {" +
-            "              \"blobId\" : \"" + attachment3.getAttachmentId().getId() + "\", " +
+            "              \"blobId\" : \"" + uploadedAttachment3 + "\", " +
             "              \"type\" : \"" + attachment3.getType() + "\", " +
             "              \"size\" : " + attachment3.getSize() + "," +
             "              \"name\" : \"进化还是不.png\"," +
@@ -3819,19 +3809,19 @@ public abstract class SetMessagesMethodTest {
             .bytes("attachment".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
-        uploadAttachment(attachment);
+        String uploadedAttachment1 = uploadAttachment(attachment);
 
         Attachment attachment2 = Attachment.builder()
             .bytes("attachment2".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
-        uploadAttachment(attachment2);
+        String uploadedAttachment2 = uploadAttachment(attachment2);
 
         Attachment attachment3 = Attachment.builder()
             .bytes("attachment3".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
-        uploadAttachment(attachment3);
+        String uploadedAttachment3 = uploadAttachment(attachment3);
 
         String messageCreationId = "creationId";
         String fromAddress = USERNAME;
@@ -3852,21 +3842,21 @@ public abstract class SetMessagesMethodTest {
             "          \"attachments\":" +
             "          [" +
             "            {" +
-            "              \"blobId\" : \"" + attachment.getAttachmentId().getId() + "\", " +
+            "              \"blobId\" : \"" + uploadedAttachment1 + "\", " +
             "              \"type\" : \"" + attachment.getType() + "\", " +
             "              \"size\" : " + attachment.getSize() + "," +
             "              \"name\" : \"ديناصور.png\", " +
             "              \"isInline\" : false" +
             "            }," +
             "            {" +
-            "              \"blobId\" : \"" + attachment2.getAttachmentId().getId() + "\", " +
+            "              \"blobId\" : \"" + uploadedAttachment2 + "\", " +
             "              \"type\" : \"" + attachment2.getType() + "\", " +
             "              \"size\" : " + attachment2.getSize() + "," +
             "              \"name\" : \"эволюционировать.png\", " +
             "              \"isInline\" : false" +
             "            }," +
             "            {" +
-            "              \"blobId\" : \"" + attachment3.getAttachmentId().getId() + "\", " +
+            "              \"blobId\" : \"" + uploadedAttachment3 + "\", " +
             "              \"type\" : \"" + attachment3.getType() + "\", " +
             "              \"size\" : " + attachment3.getSize() + "," +
             "              \"name\" : \"进化还是不.png\"," +
@@ -3919,20 +3909,30 @@ public abstract class SetMessagesMethodTest {
             .body(thirdAttachment + ".name", equalTo("进化还是不.png"));
     }
 
-    private void uploadAttachment(Attachment attachment) throws IOException {
-        with()
+    private String uploadAttachment(Attachment attachment) throws IOException {
+        return with()
             .header("Authorization", accessToken.serialize())
             .contentType(attachment.getType())
             .content(attachment.getStream())
-            .post("/upload");
+            .post("/upload")
+        .then()
+            .extract()
+            .body()
+            .jsonPath()
+            .getString("blobId");
     }
 
-    private void uploadTextAttachment(Attachment attachment) throws IOException {
-        with()
+    private String uploadTextAttachment(Attachment attachment) throws IOException {
+        return with()
             .header("Authorization", accessToken.serialize())
             .contentType(attachment.getType())
             .content(new String(IOUtils.toByteArray(attachment.getStream()), StandardCharsets.UTF_8))
-            .post("/upload");
+            .post("/upload")
+        .then()
+            .extract()
+            .body()
+            .jsonPath()
+            .getString("blobId");
     }
 
     @Test
@@ -3948,8 +3948,7 @@ public abstract class SetMessagesMethodTest {
             .bytes(rawBytes)
             .type("application/octet-stream")
             .build();
-        uploadAttachment(attachment);
-        String expectedBlobId = attachment.getAttachmentId().getId();
+        String uploadedAttachment = uploadAttachment(attachment);
 
         String messageCreationId = "creationId";
         String fromAddress = USERNAME;
@@ -3965,7 +3964,7 @@ public abstract class SetMessagesMethodTest {
             "        \"textBody\": \"Test body\"," +
             "        \"mailboxIds\": [\"" + outboxId + "\"], " +
             "        \"attachments\": [" +
-            "               {\"blobId\" : \"" + attachment.getAttachmentId().getId() + "\", " +
+            "               {\"blobId\" : \"" + uploadedAttachment + "\", " +
             "               \"type\" : \"" + attachment.getType() + "\", " +
             "               \"size\" : " + attachment.getSize() + ", " +
             "               \"cid\" : \"123456789\", " +
@@ -3996,7 +3995,7 @@ public abstract class SetMessagesMethodTest {
 
         String firstMessage = ARGUMENTS + ".list[0]";
         String firstAttachment = firstMessage + ".attachments[0]";
-        given()
+        String blobId = given()
             .header("Authorization", accessToken.serialize())
             .body("[[\"getMessages\", {\"ids\": [\"" + receivedMessageId + "\"]}, \"#0\"]]")
         .when()
@@ -4006,21 +4005,25 @@ public abstract class SetMessagesMethodTest {
             .body(NAME, equalTo("messages"))
             .body(ARGUMENTS + ".list", hasSize(1))
             .body(firstMessage + ".attachments", hasSize(1))
-            .body(firstAttachment + ".blobId", equalTo(expectedBlobId))
             .body(firstAttachment + ".type", equalTo("application/octet-stream"))
             .body(firstAttachment + ".size", equalTo((int) attachment.getSize()))
             .body(firstAttachment + ".cid", equalTo("123456789"))
-            .body(firstAttachment + ".isInline", equalTo(true));
+            .body(firstAttachment + ".isInline", equalTo(true))
+            .extract()
+            .jsonPath()
+            .getString(firstAttachment + ".blobId");
+
+        checkBlobContent(blobId, rawBytes);
     }
 
     @Test
     public void attachmentsShouldBeRetrievedWhenChainingSetMessagesAndGetMessagesTextAttachment() throws Exception {
+        byte[] rawBytes = ByteStreams.toByteArray(new ZeroedInputStream(_1MB));
         Attachment attachment = Attachment.builder()
-            .bytes(ByteStreams.toByteArray(new ZeroedInputStream(_1MB)))
+            .bytes(rawBytes)
             .type("application/octet-stream")
             .build();
-        uploadAttachment(attachment);
-        String expectedBlobId = attachment.getAttachmentId().getId();
+        String uploadedAttachment = uploadAttachment(attachment);
 
         String messageCreationId = "creationId";
         String fromAddress = USERNAME;
@@ -4036,7 +4039,7 @@ public abstract class SetMessagesMethodTest {
             "        \"textBody\": \"Test body\"," +
             "        \"mailboxIds\": [\"" + outboxId + "\"], " +
             "        \"attachments\": [" +
-            "               {\"blobId\" : \"" + attachment.getAttachmentId().getId() + "\", " +
+            "               {\"blobId\" : \"" + uploadedAttachment + "\", " +
             "               \"type\" : \"" + attachment.getType() + "\", " +
             "               \"size\" : " + attachment.getSize() + ", " +
             "               \"cid\" : \"123456789\", " +
@@ -4068,7 +4071,7 @@ public abstract class SetMessagesMethodTest {
 
         String firstMessage = ARGUMENTS + ".list[0]";
         String firstAttachment = firstMessage + ".attachments[0]";
-        given()
+        String blobId = given()
             .header("Authorization", accessToken.serialize())
             .body("[[\"getMessages\", {\"ids\": [\"" + receivedMessageId + "\"]}, \"#0\"]]")
         .when()
@@ -4078,11 +4081,15 @@ public abstract class SetMessagesMethodTest {
             .body(NAME, equalTo("messages"))
             .body(ARGUMENTS + ".list", hasSize(1))
             .body(firstMessage + ".attachments", hasSize(1))
-            .body(firstAttachment + ".blobId", equalTo(expectedBlobId))
             .body(firstAttachment + ".type", equalTo("application/octet-stream"))
             .body(firstAttachment + ".size", equalTo((int) attachment.getSize()))
             .body(firstAttachment + ".cid", equalTo("123456789"))
-            .body(firstAttachment + ".isInline", equalTo(true));
+            .body(firstAttachment + ".isInline", equalTo(true))
+            .extract()
+            .jsonPath()
+            .getString(firstAttachment + ".blobId");
+
+        checkBlobContent(blobId, rawBytes);
     }
 
     private boolean isAnyMessageFoundInInbox(AccessToken recipientToken) {
@@ -4106,13 +4113,14 @@ public abstract class SetMessagesMethodTest {
 
     @Test
     public void attachmentsAndBodysShouldBeRetrievedWhenChainingSetMessagesAndGetMessagesWithMixedTextAndHtmlBodyAndHtmlAttachment() throws Exception {
+        byte[] rawBytes = ("<html>\n" +
+            "  <body>attachment</body>\n" + // needed indentation, else restassured is adding some
+            "</html>").getBytes(StandardCharsets.UTF_8);
         Attachment attachment = Attachment.builder()
-            .bytes(("<html>\n" +
-                    "  <body>attachment</body>\n" + // needed indentation, else restassured is adding some
-                    "</html>").getBytes(StandardCharsets.UTF_8))
+            .bytes(rawBytes)
             .type("text/html; charset=UTF-8")
             .build();
-        uploadTextAttachment(attachment);
+        String uploadedBlobId = uploadTextAttachment(attachment);
 
         String messageCreationId = "creationId";
         String fromAddress = USERNAME;
@@ -4129,7 +4137,7 @@ public abstract class SetMessagesMethodTest {
             "        \"htmlBody\": \"Test <b>body</b>, HTML version\"," +
             "        \"mailboxIds\": [\"" + outboxId + "\"], " +
             "        \"attachments\": [" +
-            "               {\"blobId\" : \"" + attachment.getAttachmentId().getId() + "\", " +
+            "               {\"blobId\" : \"" + uploadedBlobId + "\", " +
             "               \"type\" : \"" + attachment.getType() + "\", " +
             "               \"size\" : " + attachment.getSize() + ", " +
             "               \"isInline\" : false }" +
@@ -4160,7 +4168,7 @@ public abstract class SetMessagesMethodTest {
 
         String firstMessage = ARGUMENTS + ".list[0]";
         String firstAttachment = firstMessage + ".attachments[0]";
-        given()
+        String blobId = given()
             .header("Authorization", accessToken.serialize())
             .body("[[\"getMessages\", {\"ids\": [\"" + receivedMessageId + "\"]}, \"#0\"]]")
         .when()
@@ -4173,20 +4181,25 @@ public abstract class SetMessagesMethodTest {
             .body(firstMessage + ".textBody", equalTo("Test body, plain text version"))
             .body(firstMessage + ".htmlBody", equalTo("Test <b>body</b>, HTML version"))
             .body(firstMessage + ".attachments", hasSize(1))
-            .body(firstAttachment + ".blobId", equalTo(attachment.getAttachmentId().getId()))
             .body(firstAttachment + ".type", equalTo("text/html"))
-            .body(firstAttachment + ".size", equalTo((int) attachment.getSize()));
+            .body(firstAttachment + ".size", equalTo((int) attachment.getSize()))
+            .extract()
+            .jsonPath()
+            .getString(firstAttachment + ".blobId");
+
+        checkBlobContent(blobId, rawBytes);
     }
 
     @Test
     public void attachmentsAndBodyShouldBeRetrievedWhenChainingSetMessagesAndGetMessagesWithTextBodyAndHtmlAttachment() throws Exception {
+        byte[] rawBytes = ("<html>\n" +
+            "  <body>attachment</body>\n" + // needed indentation, else restassured is adding some
+            "</html>").getBytes(StandardCharsets.UTF_8);
         Attachment attachment = Attachment.builder()
-            .bytes(("<html>\n" +
-                    "  <body>attachment</body>\n" + // needed indentation, else restassured is adding some
-                    "</html>").getBytes(StandardCharsets.UTF_8))
+            .bytes(rawBytes)
             .type("text/html; charset=UTF-8")
             .build();
-        uploadTextAttachment(attachment);
+        String uploadedBlobId = uploadTextAttachment(attachment);
 
         String messageCreationId = "creationId";
         String fromAddress = USERNAME;
@@ -4202,7 +4215,7 @@ public abstract class SetMessagesMethodTest {
             "        \"textBody\": \"Test body, plain text version\"," +
             "        \"mailboxIds\": [\"" + outboxId + "\"], " +
             "        \"attachments\": [" +
-            "               {\"blobId\" : \"" + attachment.getAttachmentId().getId() + "\", " +
+            "               {\"blobId\" : \"" + uploadedBlobId + "\", " +
             "               \"type\" : \"" + attachment.getType() + "\", " +
             "               \"size\" : " + attachment.getSize() + ", " +
             "               \"isInline\" : false }" +
@@ -4233,7 +4246,7 @@ public abstract class SetMessagesMethodTest {
 
         String firstMessage = ARGUMENTS + ".list[0]";
         String firstAttachment = firstMessage + ".attachments[0]";
-        given()
+        String blobId = given()
             .header("Authorization", accessToken.serialize())
             .body("[[\"getMessages\", {\"ids\": [\"" + receivedMessageId + "\"]}, \"#0\"]]")
         .when()
@@ -4246,18 +4259,35 @@ public abstract class SetMessagesMethodTest {
             .body(firstMessage + ".textBody", equalTo("Test body, plain text version"))
             .body(firstMessage + ".htmlBody", isEmptyOrNullString())
             .body(firstMessage + ".attachments", hasSize(1))
-            .body(firstAttachment + ".blobId", equalTo(attachment.getAttachmentId().getId()))
             .body(firstAttachment + ".type", equalTo("text/html"))
-            .body(firstAttachment + ".size", equalTo((int) attachment.getSize()));
+            .body(firstAttachment + ".size", equalTo((int) attachment.getSize()))
+            .extract()
+            .jsonPath()
+            .getString(firstAttachment + ".blobId");
+
+        checkBlobContent(blobId, rawBytes);
     }
-    
+
+    public void checkBlobContent(String blobId, byte[] rawBytes) {
+        byte[] attachmentBytes = with()
+            .header("Authorization", accessToken.serialize())
+            .get("/download/" + blobId)
+        .then()
+            .extract()
+            .body()
+            .asByteArray();
+
+        assertThat(attachmentBytes).containsExactly(rawBytes);
+    }
+
     @Test
     public void attachmentAndEmptyBodyShouldBeRetrievedWhenChainingSetMessagesAndGetMessagesWithTextAttachmentWithoutMailBody() throws Exception {
+        byte[] rawBytes = ("some text").getBytes(StandardCharsets.UTF_8);
         Attachment attachment = Attachment.builder()
-            .bytes(("some text").getBytes(StandardCharsets.UTF_8))
+            .bytes(rawBytes)
             .type("text/plain; charset=UTF-8")
             .build();
-        uploadTextAttachment(attachment);
+        String uploadedBlobId = uploadTextAttachment(attachment);
 
         String messageCreationId = "creationId";
         String fromAddress = USERNAME;
@@ -4272,7 +4302,7 @@ public abstract class SetMessagesMethodTest {
             "        \"subject\": \"Message with an attachment\"," +
             "        \"mailboxIds\": [\"" + outboxId + "\"], " +
             "        \"attachments\": [" +
-            "               {\"blobId\" : \"" + attachment.getAttachmentId().getId() + "\", " +
+            "               {\"blobId\" : \"" + uploadedBlobId + "\", " +
             "               \"type\" : \"" + attachment.getType() + "\", " +
             "               \"size\" : " + attachment.getSize() + ", " +
             "               \"isInline\" : false }" +
@@ -4303,7 +4333,7 @@ public abstract class SetMessagesMethodTest {
 
         String firstMessage = ARGUMENTS + ".list[0]";
         String firstAttachment = firstMessage + ".attachments[0]";
-        given()
+        String blobId = given()
             .header("Authorization", accessToken.serialize())
             .body("[[\"getMessages\", {\"ids\": [\"" + receivedMessageId + "\"]}, \"#0\"]]")
         .when()
@@ -4316,9 +4346,13 @@ public abstract class SetMessagesMethodTest {
             .body(firstMessage + ".textBody", isEmptyOrNullString())
             .body(firstMessage + ".htmlBody", isEmptyOrNullString())
             .body(firstMessage + ".attachments", hasSize(1))
-            .body(firstAttachment + ".blobId", equalTo(attachment.getAttachmentId().getId()))
             .body(firstAttachment + ".type", equalTo("text/plain"))
-            .body(firstAttachment + ".size", equalTo((int) attachment.getSize()));
+            .body(firstAttachment + ".size", equalTo((int) attachment.getSize()))
+            .extract()
+            .jsonPath()
+            .getString(firstAttachment + ".blobId");
+
+        checkBlobContent(blobId, rawBytes);
     }
     
     @Test
@@ -5013,7 +5047,7 @@ public abstract class SetMessagesMethodTest {
                 .bytes(ClassLoaderUtils.getSystemResourceAsByteArray("attachment/nonIndexableAttachment.html"))
                 .type("text/html")
                 .build();
-        uploadTextAttachment(nonIndexableAttachment);
+        String uploadedBlobId = uploadTextAttachment(nonIndexableAttachment);
 
         String messageCreationId = "creationId";
         String fromAddress = USERNAME;
@@ -5029,7 +5063,7 @@ public abstract class SetMessagesMethodTest {
                 "        \"textBody\": \"Test body\"," +
                 "        \"mailboxIds\": [\"" + outboxId + "\"], " +
                 "        \"attachments\": [" +
-                "               {\"blobId\" : \"" + nonIndexableAttachment.getAttachmentId().getId() + "\", " +
+                "               {\"blobId\" : \"" + uploadedBlobId + "\", " +
                 "               \"type\" : \"" + nonIndexableAttachment.getType() + "\", " +
                 "               \"name\" : \"nonIndexableAttachment.html\", " +
                 "               \"size\" : " + nonIndexableAttachment.getSize() + "}" +
@@ -5054,7 +5088,7 @@ public abstract class SetMessagesMethodTest {
             .body(ARGUMENTS + ".notCreated", aMapWithSize(0))
             .body(ARGUMENTS + ".created", aMapWithSize(1))
             .body(createdPath + ".attachments", hasSize(1))
-            .body(singleAttachment + ".blobId", equalTo(nonIndexableAttachment.getAttachmentId().getId()))
+            .body(singleAttachment + ".blobId", equalTo(uploadedBlobId))
             .body(singleAttachment + ".type", equalTo("text/html; charset=UTF-8"))
             .body(singleAttachment + ".size", equalTo((int) nonIndexableAttachment.getSize()));
     }
@@ -5065,7 +5099,7 @@ public abstract class SetMessagesMethodTest {
                 .bytes(ClassLoaderUtils.getSystemResourceAsByteArray("attachment/nonIndexableAttachment.html"))
                 .type("text/html")
                 .build();
-        uploadTextAttachment(nonIndexableAttachment);
+        String uploadedBlobId = uploadTextAttachment(nonIndexableAttachment);
 
         String messageCreationId = "creationId";
         String fromAddress = USERNAME;
@@ -5081,7 +5115,7 @@ public abstract class SetMessagesMethodTest {
                 "        \"textBody\": \"Test body\"," +
                 "        \"mailboxIds\": [\"" + outboxId + "\"], " +
                 "        \"attachments\": [" +
-                "               {\"blobId\" : \"" + nonIndexableAttachment.getAttachmentId().getId() + "\", " +
+                "               {\"blobId\" : \"" + uploadedBlobId + "\", " +
                 "               \"type\" : \"" + nonIndexableAttachment.getType() + "\", " +
                 "               \"name\" : \"nonIndexableAttachment.html\", " +
                 "               \"size\" : " + nonIndexableAttachment.getSize() + "}" +
@@ -5125,7 +5159,7 @@ public abstract class SetMessagesMethodTest {
                 .bytes(ClassLoaderUtils.getSystemResourceAsByteArray("attachment/nonIndexableAttachment.html"))
                 .type("text/html")
                 .build();
-        uploadTextAttachment(nonIndexableAttachment);
+        String uploadedBlobId = uploadTextAttachment(nonIndexableAttachment);
 
         String messageCreationId = "creationId";
         String fromAddress = USERNAME;
@@ -5142,7 +5176,7 @@ public abstract class SetMessagesMethodTest {
                 "        \"textBody\": \"Test body\"," +
                 "        \"mailboxIds\": [\"" + outboxId + "\"], " +
                 "        \"attachments\": [" +
-                "               {\"blobId\" : \"" + nonIndexableAttachment.getAttachmentId().getId() + "\", " +
+                "               {\"blobId\" : \"" + uploadedBlobId + "\", " +
                 "               \"type\" : \"" + nonIndexableAttachment.getType() + "\", " +
                 "               \"name\" : \"nonIndexableAttachment.html\", " +
                 "               \"size\" : " + nonIndexableAttachment.getSize() + "}" +
@@ -5181,12 +5215,12 @@ public abstract class SetMessagesMethodTest {
             .bytes("attachment".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
-        uploadAttachment(attachment);
+        String uploadedAttachment1 = uploadAttachment(attachment);
         Attachment attachment2 = Attachment.builder()
             .bytes("attachment2".getBytes(StandardCharsets.UTF_8))
             .type("application/octet-stream")
             .build();
-        uploadAttachment(attachment2);
+        String uploadedAttachment2 = uploadAttachment(attachment2);
 
         String messageCreationId = "creationId";
         String fromAddress = USERNAME;
@@ -5202,10 +5236,10 @@ public abstract class SetMessagesMethodTest {
             "        \"textBody\": \"Test body\"," +
             "        \"mailboxIds\": [\"" + outboxId + "\"], " +
             "        \"attachments\": [" +
-            "               {\"blobId\" : \"" + attachment.getAttachmentId().getId() + "\", " +
+            "               {\"blobId\" : \"" + uploadedAttachment1 + "\", " +
             "               \"type\" : \"" + attachment.getType() + "\", " +
             "               \"size\" : " + attachment.getSize() + "}," +
-            "               {\"blobId\" : \"" + attachment2.getAttachmentId().getId() + "\", " +
+            "               {\"blobId\" : \"" + uploadedAttachment2 + "\", " +
             "               \"type\" : \"" + attachment2.getType() + "\", " +
             "               \"size\" : " + attachment2.getSize() + ", " +
             "               \"isInline\" : true }" +
@@ -5231,12 +5265,12 @@ public abstract class SetMessagesMethodTest {
             .body(ARGUMENTS + ".notCreated", aMapWithSize(0))
             .body(ARGUMENTS + ".created", aMapWithSize(1))
             .body(createdPath + ".attachments", hasSize(2))
-            .body(firstAttachment + ".blobId", equalTo(attachment.getAttachmentId().getId()))
+            .body(firstAttachment + ".blobId", equalTo(uploadedAttachment1))
             .body(firstAttachment + ".type", equalTo("application/octet-stream; charset=UTF-8"))
             .body(firstAttachment + ".size", equalTo((int) attachment.getSize()))
             .body(firstAttachment + ".cid", nullValue())
             .body(firstAttachment + ".isInline", equalTo(false))
-            .body(secondAttachment + ".blobId", equalTo(attachment2.getAttachmentId().getId()))
+            .body(secondAttachment + ".blobId", equalTo(uploadedAttachment2))
             .body(secondAttachment + ".type", equalTo("application/octet-stream; charset=UTF-8"))
             .body(secondAttachment + ".size", equalTo((int) attachment2.getSize()))
             .body(secondAttachment + ".cid", nullValue())

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/UploadStepdefs.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/cucumber/UploadStepdefs.java
@@ -54,7 +54,6 @@ import cucumber.runtime.java.guice.ScenarioScoped;
 
 @ScenarioScoped
 public class UploadStepdefs {
-    private static final String _1M_ZEROED_FILE_BLOB_ID = "35d87cc65060b896a0541713e7868f5cb5f8be3f563ccf82b72e61c2fee67404";
     private static final int _1M = 1024 * 1024;
     private static final int _10M = 10 * _1M;
 
@@ -193,7 +192,7 @@ public class UploadStepdefs {
             .containsExactly(
                 normalizeContentType(org.apache.http.entity.ContentType.APPLICATION_JSON.toString()));
         DocumentContext jsonPath = JsonPath.parse(response.getEntity().getContent());
-        assertThat(jsonPath.<String>read("blobId")).isEqualTo(_1M_ZEROED_FILE_BLOB_ID);
+        jsonPath.<String>read("blobId");
         assertThat(jsonPath.<String>read("type")).isEqualTo("application/octet-stream");
         assertThat(jsonPath.<Integer>read("size")).isEqualTo(_1M);
     }
@@ -205,7 +204,8 @@ public class UploadStepdefs {
     @Then("^\"([^\"]*)\" should be able to retrieve the content$")
     public void contentShouldBeRetrievable(String username) throws Exception {
         AccessToken accessToken = userStepdefs.authenticate(username);
-        Request request = Request.Get(baseUri(mainStepdefs.jmapServer).setPath("/download/" + _1M_ZEROED_FILE_BLOB_ID).build());
+        DocumentContext jsonPath = JsonPath.parse(response.getEntity().getContent());
+        Request request = Request.Get(baseUri(mainStepdefs.jmapServer).setPath("/download/" + jsonPath.<String>read("blobId")).build());
         if (accessToken != null) {
             request.addHeader("Authorization", accessToken.serialize());
         }

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/GetMessages.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/GetMessages.feature
@@ -164,14 +164,12 @@ Feature: GetMessages method
     And the list of attachments of the message contains 2 attachments
     And the first attachment is:
       |key      | value                                                             |
-      |blobId   |"81dad497ef270bd4537f5b43906aa88ad2e7168744c572be9a7414707727bf58" |
       |type     |"image/jpeg"                                                       |
       |size     |846                                                                |
       |cid      |null                                                               |
       |isInline |false                                                              |
     And the second attachment is:
       |key      | value                                                             |
-      |blobId   |"632b5341bbe044d26e0916b82a689282cc0891b806884b4d5a2339ea90b28e85" |
       |type     |"image/jpeg"                                                       |
       |size     |597                                                                |
       |cid      |"part1.37A15C92.A7C3488D@linagora.com"                             |


### PR DESCRIPTION
Most of the Cassandra failures are related to attachment downloads, and more precisely to attachment right checking.

![capture d ecran de 2018-05-06 19-32-31](https://user-images.githubusercontent.com/6928740/39674224-b5f0bc9e-5172-11e8-8d83-4ba304c54cb9.png)

![capture d ecran de 2018-05-06 19-35-02](https://user-images.githubusercontent.com/6928740/39674228-bdf3d99e-5172-11e8-853c-d1ac331ebb67.png)

Having a look at attached screenshots:
 - We can notice a lot of warnings are generated by JMAP attachment downloads.
 - That failure happens when reading meta-data, in order to retrieve the list of referencing messages to resolve rights.
 - Furthermore, we can notice failure is systematic for some attachments.

I spend a bit of time this weekend analysing this (unexpected!) performance issues. I've mostly found 2 intuitive performance improvements as well as one more complex.

  - 1. Upon checking whether a set of messages is accessible, the containing mailbox rights were checks on a per-mailbox base. This is sub-optimal as some messages might be in the same mailbox, whose rights will be needlessly checked several times.

This change inserts smoothly into the codebase, the tools for checking rights once per mailbox is already implemented. Just not used in that case.

 - 2. Paging and asynchronous code don't combine well as already proven by previous code. The mantra is *join then collect*. If the operation is done reverse and entries exceed paging size (~5000) an exception will be thrown by the Cassandra driver.

This explains the systematic failures for some specific attachments... The fix is trivial, and I added a test for demonstrating this.

 - 3. The given logs suggest that we have high cardinality rows in our database (IE an attachment referenced by several messages), as the number of referencing messages exceeds 5000 (to trigger paging issues)

Such a high cardinality has a massive read cost:
 - Reading such a row is a complex operation
 - Caching can not help as cache size per primary key is exceeded
 - Rights would be resolved for each referencing messages, generating an expensive read Cascade.

Note that deduplication is done at the Attachment level. By looking at the attachment names (cf screenshots) we can notice these "high cardinality" attachments look like inlined images in signature...

The stand here is that deduplicating is not a concern for attachments, but for blobs. We should further push this lower level constraint in the stack. That way, each blob would be deduplicated (storage cost reduction, higher FS cache efficiency, etc...) while avoiding *wide rows*.

We should ensure each newly generated AttachmentId is unique, then generate BlobId from the blob's content, to avoid wide rows while keeping deduplication in place.

Note that this being done just for newly received messages, this can be done transparently, without the needs for a migration.