### PR TITLE
MIME4J-274 Communicating the MIME4J 0.8.2 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -580,7 +580,7 @@
         <deployTechnicalSiteDirectory />
 
         <activemq.version>5.15.2</activemq.version>
-        <apache-mime4j.version>0.8.2-SNAPSHOT</apache-mime4j.version>
+        <apache-mime4j.version>0.8.2</apache-mime4j.version>
         <camel.version>2.19.4</camel.version>
         <derby.version>10.9.1.0</derby.version>
         <hadoop.version>1.1.1</hadoop.version>

--- a/src/homepage/_posts/2018-05-07-mime4j-0.8.2.markdown
+++ b/src/homepage/_posts/2018-05-07-mime4j-0.8.2.markdown
@@ -1,0 +1,34 @@
+---
+layout: post
+title:  "Apache James Mime4J 0.8.2"
+date:   2018-05-07 11:30:00 +0700
+categories: james update
+---
+
+James Mime4J 0.8.2 has been released.
+
+This release solves the following bugs:
+
+ - MIME4J-267 MIME4J DOM parsing errors on specific formats
+ - MIME4J-273 Correcting encoder splitting point
+
+The following feature were added:
+
+ - MIME4J-269 Introduce a safe to use, PERMISSIVE configuration
+ - MIME4J-268 DefaultMessageWriter: expose a convenient *asBytes* method
+ - MIME4J-271 Make possible to define a Content-Type parameter
+ - MIME4J-272 Implicit DOM builder call
+
+The library is available as a maven artifact, for instance for mime4j core:
+
+```
+<dependency>
+    <groupId>org.apache.james</groupId>
+    <artifactId>apache-mime4j-core</artifactId>
+    <version>0.8.2</version>
+</dependency>
+```
+
+You can also download the release artifacts [here].
+
+[here]: https://www.apache.org/dist/james/mime4j/0.8.2/

--- a/src/site/xdoc/download.xml
+++ b/src/site/xdoc/download.xml
@@ -238,7 +238,7 @@ is found <a href='https://www.apache.org/licenses/exports/'>here</a>.
 
   <section name="Apache Mime4J">
   
-    <p>Apache Mime4J 0.8.1 is the latest stable version.</p>
+    <p>Apache Mime4J 0.8.2 is the latest stable version.</p>
 
     <p>You can directly use the core library with maven:</p>
 
@@ -247,16 +247,16 @@ is found <a href='https://www.apache.org/licenses/exports/'>here</a>.
   &lt;dependency&gt;
     &lt;groupId&gt;org.apache.james&lt;/groupId&gt;
     &lt;artifactId&gt;apache-mime4j-core&lt;/artifactId&gt;
-    &lt;version&gt;0.8.1&lt;/version&gt;
+    &lt;version&gt;0.8.2&lt;/version&gt;
   &lt;/dependency&gt;
      </code>
     </pre>
 
     <p>Direct download link:
-      <a href="https://www.apache.org/dist/james/mime4j/0.8.1/apache-mime4j-core-0.8.1.jar">(Jar)</a>
-      [<a href="https://www.apache.org/dist/james/mime4j/0.8.1/apache-mime4j-core-0.8.1.jar.md5">MD5</a>]
-      [<a href="https://www.apache.org/dist/james/mime4j/0.8.1/apache-mime4j-core-0.8.1.jar.sha1">SHA-1</a>]
-      [<a href="https://www.apache.org/dist/james/mime4j/0.8.1/apache-mime4j-core-0.8.1.jar.asc">PGP</a>]
+      <a href="https://www.apache.org/dist/james/mime4j/0.8.2/apache-mime4j-core-0.8.2.jar">(Jar)</a>
+      [<a href="https://www.apache.org/dist/james/mime4j/0.8.2/apache-mime4j-core-0.8.2.jar.md5">MD5</a>]
+      [<a href="https://www.apache.org/dist/james/mime4j/0.8.2/apache-mime4j-core-0.8.2.jar.sha1">SHA-1</a>]
+      [<a href="https://www.apache.org/dist/james/mime4j/0.8.2/apache-mime4j-core-0.8.2.jar.asc">PGP</a>]
       </p>
 
     <p>In order to use Mime-4j DOM:</p>
@@ -266,16 +266,16 @@ is found <a href='https://www.apache.org/licenses/exports/'>here</a>.
   &lt;dependency&gt;
     &lt;groupId&gt;org.apache.james&lt;/groupId&gt;
     &lt;artifactId&gt;apache-mime4j-dom&lt;/artifactId&gt;
-    &lt;version&gt;0.8.1&lt;/version&gt;
+    &lt;version&gt;0.8.2&lt;/version&gt;
   &lt;/dependency&gt;
      </code>
     </pre>
 
     <p>Direct download link:
-      <a href="https://www.apache.org/dist/james/mime4j/0.8.1/apache-mime4j-dom-0.8.1.jar">(Jar)</a>
-      [<a href="https://www.apache.org/dist/james/mime4j/0.8.1/apache-mime4j-dom-0.8.1.jar.md5">MD5</a>]
-      [<a href="https://www.apache.org/dist/james/mime4j/0.8.1/apache-mime4j-dom-0.8.1.jar.sha1">SHA-1</a>]
-      [<a href="https://www.apache.org/dist/james/mime4j/0.8.1/apache-mime4j-dom-0.8.1.jar.asc">PGP</a>]
+      <a href="https://www.apache.org/dist/james/mime4j/0.8.2/apache-mime4j-dom-0.8.2.jar">(Jar)</a>
+      [<a href="https://www.apache.org/dist/james/mime4j/0.8.2/apache-mime4j-dom-0.8.2.jar.md5">MD5</a>]
+      [<a href="https://www.apache.org/dist/james/mime4j/0.8.2/apache-mime4j-dom-0.8.2.jar.sha1">SHA-1</a>]
+      [<a href="https://www.apache.org/dist/james/mime4j/0.8.2/apache-mime4j-dom-0.8.2.jar.asc">PGP</a>]
     </p>
 
     <p>An aggregator project is also available:</p>
@@ -285,23 +285,23 @@ is found <a href='https://www.apache.org/licenses/exports/'>here</a>.
   &lt;dependency&gt;
     &lt;groupId&gt;org.apache.james&lt;/groupId&gt;
     &lt;artifactId&gt;apache-mime4j&lt;/artifactId&gt;
-    &lt;version&gt;0.8.1&lt;/version&gt;
+    &lt;version&gt;0.8.2&lt;/version&gt;
   &lt;/dependency&gt;
      </code>
     </pre>
 
     <p>Direct download link:
-      <a href="https://www.apache.org/dist/james/mime4j/0.8.1/apache-mime4j-0.8.1-bin.zip">(Zip)</a>
-      [<a href="https://www.apache.org/dist/james/mime4j/0.8.1/apache-mime4j-0.8.1-bin.zip.md5">MD5</a>]
-      [<a href="https://www.apache.org/dist/james/mime4j/0.8.1/apache-mime4j-0.8.1-bin.zip.sha1">SHA-1</a>]
-      [<a href="https://www.apache.org/dist/james/mime4j/0.8.1/apache-mime4j-0.8.1-bin.zip.asc">PGP</a>]
+      <a href="https://www.apache.org/dist/james/mime4j/0.8.2/apache-mime4j-0.8.2-bin.zip">(Zip)</a>
+      [<a href="https://www.apache.org/dist/james/mime4j/0.8.2/apache-mime4j-0.8.2-bin.zip.md5">MD5</a>]
+      [<a href="https://www.apache.org/dist/james/mime4j/0.8.2/apache-mime4j-0.8.2-bin.zip.sha1">SHA-1</a>]
+      [<a href="https://www.apache.org/dist/james/mime4j/0.8.2/apache-mime4j-0.8.2-bin.zip.asc">PGP</a>]
     </p>
 
     <p>Sources:
-      <a href="https://www.apache.org/dist/james/mime4j/0.8.1/james-mime4j-sources-0.8.1.zip">(Zip)</a>
-      [<a href="https://www.apache.org/dist/james/mime4j/0.8.1/james-mime4j-sources-0.8.1.zip.md5">MD5</a>]
-      [<a href="https://www.apache.org/dist/james/mime4j/0.8.1/james-mime4j-sources-0.8.1.zip.sha1">SHA-1</a>]
-      [<a href="https://www.apache.org/dist/james/mime4j/0.8.1/james-mime4j-sources-0.8.1.zip.asc">PGP</a>]
+      <a href="https://www.apache.org/dist/james/mime4j/0.8.2/james-mime4j-sources-0.8.2.zip">(Zip)</a>
+      [<a href="https://www.apache.org/dist/james/mime4j/0.8.2/james-mime4j-sources-0.8.2.zip.md5">MD5</a>]
+      [<a href="https://www.apache.org/dist/james/mime4j/0.8.2/james-mime4j-sources-0.8.2.zip.sha1">SHA-1</a>]
+      [<a href="https://www.apache.org/dist/james/mime4j/0.8.2/james-mime4j-sources-0.8.2.zip.asc">PGP</a>]
     </p>
   
   </section>


### PR DESCRIPTION
 - Download link update
 - Blog post.

Additional communication to be done:

 - Twitter:

```
The Apache James PMC is pleased to announce the 0.8.2 release of Apache MIME4J.

More information: https://link/to/blog/post
```

 - Apache announcements + Server user

```
The Apache James PMC is pleased to announce the 0.8.2 release of Apache MIME4J.

Apache MIME4J is a Java library for parsing, generating and modifying MIME messages.

This release solves the following bugs:

 - MIME4J-267 MIME4J DOM parsing errors on specific formats
 - MIME4J-273 Correcting encoder splitting point

The following feature were added:

 - MIME4J-269 Introduce a safe to use, PERMISSIVE configuration
 - MIME4J-268 DefaultMessageWriter: expose a convenient *asBytes* method
 - MIME4J-271 Make possible to define a Content-Type parameter
 - MIME4J-272 Implicit DOM builder call

More information: https://link/to/blog/post

Enjoy!

The Apache James team.
```

 - Gitter

```
Apache MIME4J 0.8.2 had just been released. Read more: https://link/to/blog/post
```