### PR TITLE
MAILBOX-336 Only using tika for non textual attachments

### DIFF
--- a/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/json/MimePartContainerBuilder.java
+++ b/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/json/MimePartContainerBuilder.java
@@ -20,6 +20,7 @@
 package org.apache.james.mailbox.elasticsearch.json;
 
 import java.io.InputStream;
+import java.nio.charset.Charset;
 
 import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mime4j.stream.Field;
@@ -37,6 +38,8 @@ public interface MimePartContainerBuilder {
     MimePartContainerBuilder addChild(MimePart mimePart);
 
     MimePartContainerBuilder addFileName(String fileName);
+
+    MimePartContainerBuilder charset(Charset charset);
 
     MimePartContainerBuilder addMediaType(String mediaType);
 

--- a/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/json/RootMimePartContainerBuilder.java
+++ b/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/json/RootMimePartContainerBuilder.java
@@ -20,6 +20,7 @@
 package org.apache.james.mailbox.elasticsearch.json;
 
 import java.io.InputStream;
+import java.nio.charset.Charset;
 
 import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mime4j.stream.Field;
@@ -84,6 +85,12 @@ public class RootMimePartContainerBuilder implements MimePartContainerBuilder {
     @Override
     public MimePartContainerBuilder addContentDisposition(String contentDisposition) {
         LOGGER.warn("Trying to add content disposition to the Root MimePart container");
+        return this;
+    }
+
+    @Override
+    public MimePartContainerBuilder charset(Charset charset) {
+        LOGGER.warn("Trying to add content charset to the Root MimePart container");
         return this;
     }
 }

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/IndexableMessageTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/IndexableMessageTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.time.ZoneId;
+import java.util.Optional;
 
 import javax.mail.Flags;
 
@@ -470,8 +471,12 @@ public class IndexableMessageTest {
                 .build();
 
         // Then
-        assertThat(indexableMessage.getText()).contains("first attachment content");
-        assertThat(indexableMessage.getText()).contains("third attachment content");
+        assertThat(indexableMessage.getAttachments())
+            .extracting(MimePart::getTextualBody)
+            .contains(Optional.of("first attachment content"));
+        assertThat(indexableMessage.getAttachments())
+            .extracting(MimePart::getTextualBody)
+            .contains(Optional.of("third attachment content"));
     }
 
     @Test

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/MessageToElasticSearchJsonTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/MessageToElasticSearchJsonTest.java
@@ -25,7 +25,6 @@ import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.util.Date;
@@ -33,7 +32,6 @@ import java.util.Date;
 import javax.mail.Flags;
 import javax.mail.util.SharedByteArrayInputStream;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.james.mailbox.FlagsBuilder;
 import org.apache.james.mailbox.MailboxSession.User;
 import org.apache.james.mailbox.MessageUid;
@@ -68,7 +66,7 @@ public class MessageToElasticSearchJsonTest {
     public static final MessageId MESSAGE_ID = TestMessageId.of(184L);
     public static final long MOD_SEQ = 42L;
     public static final MessageUid UID = MessageUid.of(25);
-    public static final Charset CHARSET = StandardCharsets.UTF_8;
+    public static final MockMailboxSession MAILBOX_SESSION = new MockMailboxSession("username");
 
     private TextExtractor textExtractor;
 
@@ -95,7 +93,7 @@ public class MessageToElasticSearchJsonTest {
     }
 
     @Test
-    public void convertToJsonShouldThrowWhenNoUser() throws Exception {
+    public void convertToJsonShouldThrowWhenNoUser() {
         MessageToElasticSearchJson messageToElasticSearchJson = new MessageToElasticSearchJson(
                 new DefaultTextExtractor(),
                 ZoneId.of("Europe/Paris"), IndexAttachments.YES);
@@ -122,15 +120,15 @@ public class MessageToElasticSearchJsonTest {
                 date,
                 SIZE,
                 BODY_START_OCTET,
-                new SharedByteArrayInputStream(ClassLoaderUtils.getSystemResourceAsByteArray("eml/spamMail.eml")),
+                ClassLoaderUtils.getSystemResourceAsSharedStream("eml/spamMail.eml"),
                 new Flags(),
                 propertyBuilder,
                 MAILBOX_ID);
         spamMail.setUid(UID);
         spamMail.setModSeq(MOD_SEQ);
-        assertThatJson(messageToElasticSearchJson.convertToJson(spamMail, ImmutableList.of(new MockMailboxSession("username").getUser())))
+        assertThatJson(messageToElasticSearchJson.convertToJson(spamMail, ImmutableList.of(MAILBOX_SESSION.getUser())))
             .when(IGNORING_ARRAY_ORDER)
-            .isEqualTo(IOUtils.toString(ClassLoader.getSystemResource("eml/spamMail.json"), CHARSET));
+            .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/spamMail.json"));
     }
 
     @Test
@@ -142,15 +140,15 @@ public class MessageToElasticSearchJsonTest {
                 date,
                 SIZE,
                 BODY_START_OCTET,
-                new SharedByteArrayInputStream(ClassLoaderUtils.getSystemResourceAsByteArray("eml/htmlMail.eml")),
+                ClassLoaderUtils.getSystemResourceAsSharedStream("eml/htmlMail.eml"),
                 new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("social", "pocket-money").build(),
                 propertyBuilder,
                 MAILBOX_ID);
         htmlMail.setModSeq(MOD_SEQ);
         htmlMail.setUid(UID);
-        assertThatJson(messageToElasticSearchJson.convertToJson(htmlMail, ImmutableList.of(new MockMailboxSession("username").getUser())))
+        assertThatJson(messageToElasticSearchJson.convertToJson(htmlMail, ImmutableList.of(MAILBOX_SESSION.getUser())))
             .when(IGNORING_ARRAY_ORDER)
-            .isEqualTo(IOUtils.toString(ClassLoader.getSystemResource("eml/htmlMail.json"), CHARSET));
+            .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/htmlMail.json"));
     }
 
     @Test
@@ -162,15 +160,15 @@ public class MessageToElasticSearchJsonTest {
                 date,
                 SIZE,
                 BODY_START_OCTET,
-                new SharedByteArrayInputStream(ClassLoaderUtils.getSystemResourceAsByteArray("eml/pgpSignedMail.eml")),
+                ClassLoaderUtils.getSystemResourceAsSharedStream("eml/pgpSignedMail.eml"),
                 new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("debian", "security").build(),
                 propertyBuilder,
                 MAILBOX_ID);
         pgpSignedMail.setModSeq(MOD_SEQ);
         pgpSignedMail.setUid(UID);
-        assertThatJson(messageToElasticSearchJson.convertToJson(pgpSignedMail, ImmutableList.of(new MockMailboxSession("username").getUser())))
+        assertThatJson(messageToElasticSearchJson.convertToJson(pgpSignedMail, ImmutableList.of(MAILBOX_SESSION.getUser())))
             .when(IGNORING_ARRAY_ORDER)
-            .isEqualTo(IOUtils.toString(ClassLoader.getSystemResource("eml/pgpSignedMail.json"), CHARSET));
+            .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/pgpSignedMail.json"));
     }
 
     @Test
@@ -182,7 +180,7 @@ public class MessageToElasticSearchJsonTest {
                 date,
                 SIZE,
                 BODY_START_OCTET,
-                new SharedByteArrayInputStream(ClassLoaderUtils.getSystemResourceAsByteArray("eml/mail.eml")),
+                ClassLoaderUtils.getSystemResourceAsSharedStream("eml/mail.eml"),
                 new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("debian", "security").build(),
                 propertyBuilder,
                 MAILBOX_ID);
@@ -191,7 +189,7 @@ public class MessageToElasticSearchJsonTest {
         assertThatJson(messageToElasticSearchJson.convertToJson(mail,
                 ImmutableList.of(new MockMailboxSession("user1").getUser(), new MockMailboxSession("user2").getUser())))
             .when(IGNORING_ARRAY_ORDER).when(IGNORING_VALUES)
-            .isEqualTo(IOUtils.toString(ClassLoader.getSystemResource("eml/mail.json"), CHARSET));
+            .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/mail.json"));
     }
 
     @Test
@@ -203,15 +201,15 @@ public class MessageToElasticSearchJsonTest {
                 date,
                 SIZE,
                 BODY_START_OCTET,
-                new SharedByteArrayInputStream(ClassLoaderUtils.getSystemResourceAsByteArray("eml/recursiveMail.eml")),
+                ClassLoaderUtils.getSystemResourceAsSharedStream("eml/recursiveMail.eml"),
                 new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("debian", "security").build(),
                 propertyBuilder,
                 MAILBOX_ID);
         recursiveMail.setModSeq(MOD_SEQ);
         recursiveMail.setUid(UID);
-        assertThatJson(messageToElasticSearchJson.convertToJson(recursiveMail, ImmutableList.of(new MockMailboxSession("username").getUser())))
+        assertThatJson(messageToElasticSearchJson.convertToJson(recursiveMail, ImmutableList.of(MAILBOX_SESSION.getUser())))
             .when(IGNORING_ARRAY_ORDER).when(IGNORING_VALUES)
-            .isEqualTo(IOUtils.toString(ClassLoader.getSystemResource("eml/recursiveMail.json"), CHARSET));
+            .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/recursiveMail.json"));
     }
 
     @Test
@@ -223,16 +221,16 @@ public class MessageToElasticSearchJsonTest {
                 null,
                 SIZE,
                 BODY_START_OCTET,
-                new SharedByteArrayInputStream(ClassLoaderUtils.getSystemResourceAsByteArray("eml/recursiveMail.eml")),
+                ClassLoaderUtils.getSystemResourceAsSharedStream("eml/recursiveMail.eml"),
                 new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("debian", "security").build(),
                 propertyBuilder,
                 MAILBOX_ID);
         mailWithNoInternalDate.setModSeq(MOD_SEQ);
         mailWithNoInternalDate.setUid(UID);
-        assertThatJson(messageToElasticSearchJson.convertToJson(mailWithNoInternalDate, ImmutableList.of(new MockMailboxSession("username").getUser())))
+        assertThatJson(messageToElasticSearchJson.convertToJson(mailWithNoInternalDate, ImmutableList.of(MAILBOX_SESSION.getUser())))
             .when(IGNORING_ARRAY_ORDER)
             .when(IGNORING_VALUES)
-            .isEqualTo(IOUtils.toString(ClassLoader.getSystemResource("eml/recursiveMail.json"), CHARSET));
+            .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/recursiveMail.json"));
     }
 
     @Test
@@ -242,7 +240,7 @@ public class MessageToElasticSearchJsonTest {
                 null,
                 SIZE,
                 BODY_START_OCTET,
-                new SharedByteArrayInputStream(ClassLoaderUtils.getSystemResourceAsByteArray("eml/recursiveMail.eml")),
+                ClassLoaderUtils.getSystemResourceAsSharedStream("eml/recursiveMail.eml"),
                 new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("debian", "security").build(),
                 propertyBuilder,
                 MAILBOX_ID);
@@ -254,13 +252,13 @@ public class MessageToElasticSearchJsonTest {
             new DefaultTextExtractor(),
             ZoneId.of("Europe/Paris"),
             IndexAttachments.YES);
-        String convertToJson = messageToElasticSearchJson.convertToJson(mailWithNoInternalDate, ImmutableList.of(new MockMailboxSession("username").getUser()));
+        String convertToJson = messageToElasticSearchJson.convertToJson(mailWithNoInternalDate, ImmutableList.of(MAILBOX_SESSION.getUser()));
 
         // Then
         assertThatJson(convertToJson)
             .when(IGNORING_ARRAY_ORDER)
             .when(IGNORING_VALUES)
-            .isEqualTo(IOUtils.toString(ClassLoader.getSystemResource("eml/recursiveMail.json"), CHARSET));
+            .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/recursiveMail.json"));
     }
 
     @Test
@@ -270,7 +268,7 @@ public class MessageToElasticSearchJsonTest {
                 null,
                 SIZE,
                 BODY_START_OCTET,
-                new SharedByteArrayInputStream(ClassLoaderUtils.getSystemResourceAsByteArray("eml/recursiveMail.eml")),
+                ClassLoaderUtils.getSystemResourceAsSharedStream("eml/recursiveMail.eml"),
                 new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("debian", "security").build(),
                 propertyBuilder,
                 MAILBOX_ID);
@@ -282,13 +280,13 @@ public class MessageToElasticSearchJsonTest {
             new DefaultTextExtractor(),
             ZoneId.of("Europe/Paris"),
             IndexAttachments.NO);
-        String convertToJson = messageToElasticSearchJson.convertToJson(mailWithNoInternalDate, ImmutableList.of(new MockMailboxSession("username").getUser()));
+        String convertToJson = messageToElasticSearchJson.convertToJson(mailWithNoInternalDate, ImmutableList.of(MAILBOX_SESSION.getUser()));
 
         // Then
         assertThatJson(convertToJson)
             .when(IGNORING_ARRAY_ORDER)
             .when(IGNORING_VALUES)
-            .isEqualTo(IOUtils.toString(ClassLoader.getSystemResource("eml/recursiveMailWithoutAttachments.json"), CHARSET));
+            .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/recursiveMailWithoutAttachments.json"));
     }
 
     @Test(expected = NullPointerException.class)
@@ -301,7 +299,7 @@ public class MessageToElasticSearchJsonTest {
             mailWithNoMailboxId = new SimpleMailboxMessage(MESSAGE_ID, date,
                 SIZE,
                 BODY_START_OCTET,
-                new SharedByteArrayInputStream(ClassLoaderUtils.getSystemResourceAsByteArray("eml/recursiveMail.eml")),
+                ClassLoaderUtils.getSystemResourceAsSharedStream("eml/recursiveMail.eml"),
                 new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("debian", "security").build(),
                 propertyBuilder,
                 null);
@@ -310,7 +308,7 @@ public class MessageToElasticSearchJsonTest {
         } catch (Exception exception) {
             throw Throwables.propagate(exception);
         }
-        messageToElasticSearchJson.convertToJson(mailWithNoMailboxId, ImmutableList.of(new MockMailboxSession("username").getUser()));
+        messageToElasticSearchJson.convertToJson(mailWithNoMailboxId, ImmutableList.of(MAILBOX_SESSION.getUser()));
     }
 
     @Test
@@ -351,15 +349,17 @@ public class MessageToElasticSearchJsonTest {
         MailboxMessage spamMail = new SimpleMailboxMessage(MESSAGE_ID, date,
             SIZE,
             BODY_START_OCTET,
-            new SharedByteArrayInputStream(ClassLoaderUtils.getSystemResourceAsByteArray("eml/nonTextual.eml")),
+            ClassLoaderUtils.getSystemResourceAsSharedStream("eml/nonTextual.eml"),
             new Flags(),
             propertyBuilder,
             MAILBOX_ID);
         spamMail.setUid(UID);
         spamMail.setModSeq(MOD_SEQ);
-        assertThatJson(messageToElasticSearchJson.convertToJson(spamMail, ImmutableList.of(new MockMailboxSession("username").getUser())))
+
+        assertThatJson(messageToElasticSearchJson.convertToJson(spamMail, ImmutableList.of(MAILBOX_SESSION.getUser())))
             .when(IGNORING_ARRAY_ORDER)
-            .isEqualTo(IOUtils.toString(ClassLoader.getSystemResource("eml/nonTextual.json"), CHARSET));
+            .isEqualTo(
+                ClassLoaderUtils.getSystemResourceAsString("eml/nonTextual.json", StandardCharsets.UTF_8));
     }
 
     @Test
@@ -369,7 +369,7 @@ public class MessageToElasticSearchJsonTest {
             null,
             SIZE,
             BODY_START_OCTET,
-            new SharedByteArrayInputStream(ClassLoaderUtils.getSystemResourceAsByteArray("eml/emailWithNonIndexableAttachment.eml")),
+            ClassLoaderUtils.getSystemResourceAsSharedStream("eml/emailWithNonIndexableAttachment.eml"),
             new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("debian", "security").build(),
             propertyBuilder,
             MAILBOX_ID);
@@ -381,12 +381,12 @@ public class MessageToElasticSearchJsonTest {
                 new DefaultTextExtractor(),
                 ZoneId.of("Europe/Paris"),
                 IndexAttachments.NO);
-        String convertToJsonWithoutAttachment = messageToElasticSearchJson.convertToJsonWithoutAttachment(message, ImmutableList.of(new MockMailboxSession("username").getUser()));
+        String convertToJsonWithoutAttachment = messageToElasticSearchJson.convertToJsonWithoutAttachment(message, ImmutableList.of(MAILBOX_SESSION.getUser()));
 
         // Then
         assertThatJson(convertToJsonWithoutAttachment)
             .when(IGNORING_ARRAY_ORDER)
             .when(IGNORING_VALUES)
-            .isEqualTo(IOUtils.toString(ClassLoader.getSystemResource("eml/emailWithNonIndexableAttachmentWithoutAttachment.json"), CHARSET));
+            .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/emailWithNonIndexableAttachmentWithoutAttachment.json"));
     }
 }

--- a/mailbox/elasticsearch/src/test/resources/eml/emailWith3Attachments.eml
+++ b/mailbox/elasticsearch/src/test/resources/eml/emailWith3Attachments.eml
@@ -30,11 +30,11 @@ Content-Disposition: attachment;
 UEsDBBQAAAgAAGJVK0pexjIMJwAAACcAAAAIAAAAbWltZXR5cGVhcHBsaWNhdGlvbi92bmQu
 dC54bWxQSwUGAAAAABEAEQBwBAAAjyUAAAAA
 --------------36566F1E9D791340FFB75FF8
-Content-Type: text/html; charset=UTF-8;
+Content-Type: application/vnd.oasis.opendocument.text;
  name="attachment2-nonIndexableAttachment.html"
 Content-Transfer-Encoding: base64
 Content-Disposition: attachment;
- filename="attachment2-nonIndexableAttachment.html"
+ filename="attachment2-nonIndexableAttachment.odt"
 
 PCFET0NUWVBFIGh0bWw+CjxodG1sIGNsYXNzPSJtb3ppbGxhIiBsYW5nPSJlbiI+PGhlYWQ+
 CI+PC9kaXY+PC9kaXY+PC9ib2R5PjwvaHRtbD4=

--- a/mailbox/store/src/test/resources/eml/nonTextual.json
+++ b/mailbox/store/src/test/resources/eml/nonTextual.json
@@ -1,84 +1,5 @@
 {
-  "messageId":"184",
-  "uid":25,
-  "mailboxId":"18",
-  "modSeq":42,
-  "size":25,
-  "date":"2015-06-07T00:00:00+0200",
-  "mediaType":"plain",
-  "subtype":"text",
-  "userFlags":[],
-  "mimeMessageID": "<5582A0CE.4020801@linagora.com>",
-  "headers":{
-    "date":[
-      "Thu, 18 Jun 2015 12:43:26 +0200"
-    ],
-    "mime-version":[
-      "1.0"
-    ],
-    "x-sieve":[
-      "CMU Sieve 2.2"
-    ],
-    "return-path":[
-      "<btellier@linagora.com>"
-    ],
-    "subject":[
-      "Test message"
-    ],
-    "message-id":[
-      "<5582A0CE.4020801@linagora.com>"
-    ],
-    "received":[
-      "from alderaan.linagora.com (smtp.linagora.dc1 [172.16.18.53])\t by imap (Cyrus v2.2.13-Debian-2.2.13-19+squeeze3) with LMTPA;\t Thu, 18 Jun 2015 12:43:28 +0200","from [10.75.9.154] (unknown [92.103.166.6])\t(using TLSv1 with cipher DHE-RSA-AES128-SHA (128/128 bits))\t(No client certificate requested)\tby alderaan.linagora.com (Postfix) with ESMTPSA id 0EB1078A\tfor <btellier@linagora.com>; Thu, 18 Jun 2015 12:43:28 +0200 (CEST)"
-    ],
-    "from":[
-      "Benoit Tellier <btellier@linagora.com>"
-    ],
-    "content-type":[
-      "multipart/mixed; boundary=\"------------030000010109090603040500\""
-    ],
-    "to":[
-      "btellier@linagora.com"
-    ],
-    "user-agent":[
-      "Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Thunderbird/38.0.1"
-    ]
-  },
-  "from":[
-    {
-      "name":"Benoit Tellier",
-      "address":"btellier@linagora.com"
-    }
-  ],
-  "to":[
-    {
-      "name":"btellier@linagora.com",
-      "address":"btellier@linagora.com"
-    }
-  ],
-  "cc":[],
-  "bcc":[],
-  "replyTo":[],
-  "subject":["Test message"],
-  "sentDate":"2015-06-18T12:43:26+0200",
-  "properties":[
-    {
-      "namespace":"http://james.apache.org/rfc2045/Content-Type",
-      "localName":"type",
-      "value":"plain"
-    },
-    {
-      "namespace":"http://james.apache.org/rfc2045/Content-Type",
-      "localName":"subtype",
-      "value":"text"
-    },
-    {
-      "namespace":"http://james.apache.org/rfc2045",
-      "localName":"Content-Description",
-      "value":"An e-mail"
-    }
-  ],
-  "attachments":[
+  "attachments": [
     {
       "mediaType":"text",
       "subtype":"plain",
@@ -89,32 +10,62 @@
         "content-transfer-encoding":["7bit"],
         "content-type":["text/plain; charset=utf-8"]
       },
-      "textContent":"This mail have a non textual attachment !\r\n\n"
+      "textContent":"This mail have a non textual attachment !\r\n"
     },
     {
       "mediaType":"application",
       "subtype":"vnd.oasis.opendocument.text",
-      "fileName":"toto.odt",
-      "fileExtension":"odt",
+      "fileName":"toto.odt","fileExtension":"odt",
       "contentDisposition":"attachment",
       "headers":{
         "content-transfer-encoding":["base64"],
         "content-disposition":["attachment; filename=\"toto.odt\""],
         "content-type":["application/vnd.oasis.opendocument.text; name=\"toto.odt\""]
       },
-      "textContent":"Awesome document provided for text extraction !\n"}
+      "textContent":"Awesome document provided for text extraction !\n"
+    }
   ],
-  "textBody":"This mail have a non textual attachment !\r\n\n",
-  "htmlBody": null,
+  "bcc":[],
+  "htmlBody":null,
+  "textBody":"This mail have a non textual attachment !\r\n",
+  "cc":[],
+  "date":"2015-06-07T00:00:00+0200",
+  "from":[{"name":"Benoit Tellier","address":"btellier@linagora.com"}],
+  "hasAttachment":false,
+  "headers":{
+    "date":["Thu, 18 Jun 2015 12:43:26 +0200"],
+    "mime-version":["1.0"],
+    "x-sieve":["CMU Sieve 2.2"],
+    "return-path":["<btellier@linagora.com>"],
+    "subject":["Test message"],
+    "message-id":["<5582A0CE.4020801@linagora.com>"],
+    "received":["from alderaan.linagora.com (smtp.linagora.dc1 [172.16.18.53])\t by imap (Cyrus v2.2.13-Debian-2.2.13-19+squeeze3) with LMTPA;\t Thu, 18 Jun 2015 12:43:28 +0200","from [10.75.9.154] (unknown [92.103.166.6])\t(using TLSv1 with cipher DHE-RSA-AES128-SHA (128/128 bits))\t(No client certificate requested)\tby alderaan.linagora.com (Postfix) with ESMTPSA id 0EB1078A\tfor <btellier@linagora.com>; Thu, 18 Jun 2015 12:43:28 +0200 (CEST)"],
+    "from":["Benoit Tellier <btellier@linagora.com>"],
+    "content-type":["multipart/mixed; boundary=\"------------030000010109090603040500\""],
+    "to":["btellier@linagora.com"],
+    "user-agent":["Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Thunderbird/38.0.1"]},
+  "mailboxId":"18",
+  "mediaType":"plain",
+  "messageId":"184",
+  "modSeq":42,
+  "properties":[
+    {"namespace":"http://james.apache.org/rfc2045/Content-Type","localName":"type","value":"plain"},
+    {"namespace":"http://james.apache.org/rfc2045/Content-Type","localName":"subtype","value":"text"},
+    {"namespace":"http://james.apache.org/rfc2045","localName":"Content-Description","value":"An e-mail"}],
+  "replyTo":[],
+  "sentDate":"2015-06-18T12:43:26+0200",
+  "size":25,"subject":["Test message"],
+  "subtype":"text",
+  "text":"Benoit Tellier btellier@linagora.com btellier@linagora.com btellier@linagora.com Test message This mail have a non textual attachment !\r\n",
+  "to":[{"name":"btellier@linagora.com","address":"btellier@linagora.com"}],
+  "uid":25,
+  "userFlags":[],
+  "users":["username"],
+  "mimeMessageID":"<5582A0CE.4020801@linagora.com>",
   "isAnswered":false,
   "isDeleted":false,
   "isDraft":false,
   "isFlagged":false,
   "isRecent":false,
-  "hasAttachment":false,
-  "isUnread":true,
-  "users": [
-    "username"
-  ],
-  "text": "Benoit Tellier btellier@linagora.com btellier@linagora.com btellier@linagora.com Test message This mail have a non textual attachment !\r\n\n"
+  "isUnread":true
 }

--- a/server/container/util-java8/src/main/java/org/apache/james/util/ClassLoaderUtils.java
+++ b/server/container/util-java8/src/main/java/org/apache/james/util/ClassLoaderUtils.java
@@ -20,17 +20,24 @@
 package org.apache.james.util;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+
+import javax.mail.util.SharedByteArrayInputStream;
 
 import org.apache.commons.io.IOUtils;
 
 public class ClassLoaderUtils {
-    public static String getSystemResourceAsString(String filename) {
+    public static String getSystemResourceAsString(String filename, Charset charset) {
         try {
-            return IOUtils.toString(ClassLoader.getSystemResourceAsStream(filename), StandardCharsets.US_ASCII);
+            return IOUtils.toString(ClassLoader.getSystemResourceAsStream(filename), charset);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static String getSystemResourceAsString(String filename) {
+        return getSystemResourceAsString(filename, StandardCharsets.US_ASCII);
     }
 
     public static byte[] getSystemResourceAsByteArray(String filename) {
@@ -39,5 +46,9 @@ public class ClassLoaderUtils {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static SharedByteArrayInputStream getSystemResourceAsSharedStream(String filename) {
+        return new SharedByteArrayInputStream(getSystemResourceAsByteArray(filename));
     }
 }


### PR DESCRIPTION
Note that the content of nonTextual.json needed to be updated but the structure of the JSON did not change. I encountered some really stage bugs, spend my morning to try to understand why two
similar JSON strings were reported as different while printed the same way by the JSON assertion library.