### PR TITLE
JAMES-2404 Re-enable JUNIT vintage in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -618,8 +618,8 @@
         <dnsjava.version>2.1.1</dnsjava.version>
         <junit.version>4.11</junit.version>
         <junit.jupiter.version>5.2.0</junit.jupiter.version>
-        <junit.plateform.version>1.0.2</junit.plateform.version>
-        <junit.vintage.version>4.12.2</junit.vintage.version>
+        <junit.plateform.version>1.2.0</junit.plateform.version>
+        <junit.vintage.version>5.2.0</junit.vintage.version>
         <jmock.version>2.6.0</jmock.version>
         <concurrent.version>1.3.4</concurrent.version>
         <log4j.version>1.2.17</log4j.version>
@@ -2777,7 +2777,6 @@
                     <version>2.19.1</version>
                     <configuration>
                         <argLine>-Xms512m -Xmx1024m</argLine>
-                        <reuseForks>false</reuseForks>
                         <!-- Fail tests longer than 2 hours, prevent form random locking tests -->
                         <forkedProcessTimeoutInSeconds>7200</forkedProcessTimeoutInSeconds>
                     </configuration>


### PR DESCRIPTION
Note that if we care about `<reuseForks>false</reuseForks>` then we might need to follow https://github.com/junit-team/junit5/issues/1367#issuecomment-392253754 for now.