### PR TITLE
Revert "JAMES-2404 Use programmatically registered extensions"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -617,7 +617,7 @@
 
         <dnsjava.version>2.1.1</dnsjava.version>
         <junit.version>4.11</junit.version>
-        <junit.jupiter.version>5.2.0</junit.jupiter.version>
+        <junit.jupiter.version>5.0.2</junit.jupiter.version>
         <junit.plateform.version>1.0.2</junit.plateform.version>
         <junit.vintage.version>4.12.2</junit.vintage.version>
         <jmock.version>2.6.0</jmock.version>

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/WebAdminUtils.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/WebAdminUtils.java
@@ -24,13 +24,11 @@ import static com.jayway.restassured.config.RestAssuredConfig.newConfig;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.util.Port;
 import org.apache.james.webadmin.authentication.NoAuthenticationFilter;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.jayway.restassured.builder.RequestSpecBuilder;
 import com.jayway.restassured.http.ContentType;
@@ -38,12 +36,6 @@ import com.jayway.restassured.http.ContentType;
 public class WebAdminUtils {
 
     public static WebAdminServer createWebAdminServer(MetricFactory metricFactory, Routes... routes) throws IOException {
-        return createWebAdminServer(
-            metricFactory,
-            ImmutableList.copyOf(routes));
-    }
-
-    public static WebAdminServer createWebAdminServer(MetricFactory metricFactory, List<Routes> routes) throws IOException {
         return new WebAdminServer(WebAdminConfiguration.TEST_CONFIGURATION,
             ImmutableSet.copyOf(routes),
             new NoAuthenticationFilter(),

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/DomainQuotaRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/DomainQuotaRoutesTest.java
@@ -29,34 +29,17 @@ import org.apache.james.core.Domain;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
 import org.apache.james.mailbox.quota.QuotaCount;
 import org.apache.james.mailbox.quota.QuotaSize;
-import org.apache.james.quota.search.QuotaSearchTestSystem;
-import org.apache.james.webadmin.jackson.QuotaModule;
-import org.apache.james.webadmin.service.DomainQuotaService;
-import org.apache.james.webadmin.utils.JsonTransformer;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.Extension;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import com.google.common.collect.ImmutableSet;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.http.ContentType;
 import com.jayway.restassured.path.json.JsonPath;
 
+@ExtendWith(ScanningQuotaSearchExtension.class)
 class DomainQuotaRoutesTest {
-    @RegisterExtension
-    Extension scanningExtension = new ScanningQuotaSearchExtension(this::createDomainQuotaRoutes);
-
-    private DomainQuotaRoutes createDomainQuotaRoutes(QuotaSearchTestSystem testSystem) {
-        QuotaModule quotaModule = new QuotaModule();
-        return new DomainQuotaRoutes(
-            testSystem.getDomainList(),
-            new DomainQuotaService(testSystem.getMaxQuotaManager()),
-            testSystem.getUsersRepository(),
-            new JsonTransformer(quotaModule),
-            ImmutableSet.of(quotaModule));
-    }
 
     private static final String QUOTA_DOMAINS = "/quota/domains";
     private static final String PERDU_COM = "perdu.com";

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/ElasticSearchQuotaSearchExtension.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/ElasticSearchQuotaSearchExtension.java
@@ -38,9 +38,6 @@ import org.apache.james.quota.search.elasticsearch.QuotaSearchIndexCreationUtil;
 import org.apache.james.quota.search.elasticsearch.events.ElasticSearchQuotaMailboxListener;
 import org.apache.james.quota.search.elasticsearch.json.QuotaRatioToElasticSearchJson;
 import org.apache.james.user.memory.MemoryUsersRepository;
-import org.apache.james.webadmin.jackson.QuotaModule;
-import org.apache.james.webadmin.service.UserQuotaService;
-import org.apache.james.webadmin.utils.JsonTransformer;
 import org.elasticsearch.client.Client;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -49,9 +46,6 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.rules.TemporaryFolder;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 public class ElasticSearchQuotaSearchExtension implements ParameterResolver, BeforeEachCallback, AfterEachCallback {
 
@@ -97,17 +91,7 @@ public class ElasticSearchQuotaSearchExtension implements ParameterResolver, Bef
                 resources.getCurrentQuotaManager(),
                 () -> embeddedElasticSearch.awaitForElasticSearch());
 
-            UserQuotaRoutes routes = new UserQuotaRoutes(
-                quotaSearchTestSystem.getUsersRepository(),
-                new UserQuotaService(
-                    quotaSearchTestSystem.getMaxQuotaManager(),
-                    quotaSearchTestSystem.getQuotaManager(),
-                    quotaSearchTestSystem.getQuotaRootResolver(),
-                    quotaSearchTestSystem.getQuotaSearcher()),
-                new JsonTransformer(new QuotaModule()),
-                ImmutableSet.of(new QuotaModule()));
-
-            restQuotaSearchTestSystem = new WebAdminQuotaSearchTestSystem(quotaSearchTestSystem, ImmutableList.of(routes));
+            restQuotaSearchTestSystem = new WebAdminQuotaSearchTestSystem(quotaSearchTestSystem);
         } catch (Exception e) {
             throw new ParameterResolutionException("Error while resolving parameter", e);
         }

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/GlobalQuotaRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/GlobalQuotaRoutesTest.java
@@ -28,31 +28,18 @@ import java.util.Map;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
 import org.apache.james.mailbox.quota.QuotaCount;
 import org.apache.james.mailbox.quota.QuotaSize;
-import org.apache.james.quota.search.QuotaSearchTestSystem;
-import org.apache.james.webadmin.jackson.QuotaModule;
-import org.apache.james.webadmin.service.GlobalQuotaService;
-import org.apache.james.webadmin.utils.JsonTransformer;
 import org.assertj.core.api.SoftAssertions;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.Extension;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.http.ContentType;
 import com.jayway.restassured.path.json.JsonPath;
 
+@ExtendWith(ScanningQuotaSearchExtension.class)
 class GlobalQuotaRoutesTest {
-    @RegisterExtension
-    Extension scanningExtension = new ScanningQuotaSearchExtension(this::createGlobalQuotaRoutes);
-
-    private GlobalQuotaRoutes createGlobalQuotaRoutes(QuotaSearchTestSystem testSystem) {
-        return new GlobalQuotaRoutes(
-            new GlobalQuotaService(testSystem.getMaxQuotaManager()),
-            new JsonTransformer(new QuotaModule()));
-    }
-
     private MaxQuotaManager maxQuotaManager;
 
     @BeforeEach

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/ScanningQuotaSearchExtension.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/ScanningQuotaSearchExtension.java
@@ -21,9 +21,6 @@ package org.apache.james.webadmin.routes;
 
 import static org.mockito.Mockito.mock;
 
-import java.util.List;
-import java.util.function.Function;
-
 import org.apache.commons.configuration.DefaultConfigurationBuilder;
 import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.domainlist.memory.MemoryDomainList;
@@ -33,7 +30,6 @@ import org.apache.james.quota.search.QuotaSearchTestSystem;
 import org.apache.james.quota.search.scanning.ClauseConverter;
 import org.apache.james.quota.search.scanning.ScanningQuotaSearcher;
 import org.apache.james.user.memory.MemoryUsersRepository;
-import org.apache.james.webadmin.Routes;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -41,21 +37,10 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
-import com.github.steveash.guavate.Guavate;
-import com.google.common.collect.ImmutableList;
-import com.jayway.restassured.specification.RequestSpecification;
-
 public class ScanningQuotaSearchExtension implements ParameterResolver, BeforeEachCallback, AfterEachCallback {
     private static final Runnable NO_AWAIT = () -> { };
 
-    private final List<Function<QuotaSearchTestSystem, Routes>> routesGenerators;
     private WebAdminQuotaSearchTestSystem restQuotaSearchTestSystem;
-    private QuotaSearchTestSystem quotaSearchTestSystem;
-
-    @SafeVarargs
-    public ScanningQuotaSearchExtension(Function<QuotaSearchTestSystem, Routes>... routesGenerators) {
-        this.routesGenerators = ImmutableList.copyOf(routesGenerators);
-    }
 
     @Override
     public void beforeEach(ExtensionContext context) {
@@ -69,7 +54,7 @@ public class ScanningQuotaSearchExtension implements ParameterResolver, BeforeEa
             domainList.configure(new DefaultConfigurationBuilder());
             usersRepository.setDomainList(domainList);
 
-            quotaSearchTestSystem = new QuotaSearchTestSystem(
+            QuotaSearchTestSystem quotaSearchTestSystem = new QuotaSearchTestSystem(
                 resources.getMaxQuotaManager(),
                 resources.getMailboxManager(),
                 resources.getQuotaManager(),
@@ -81,11 +66,7 @@ public class ScanningQuotaSearchExtension implements ParameterResolver, BeforeEa
                 resources.getCurrentQuotaManager(),
                 NO_AWAIT);
 
-            List<Routes> routes = routesGenerators.stream()
-                .map(generator -> generator.apply(quotaSearchTestSystem))
-                .collect(Guavate.toImmutableList());
-
-            restQuotaSearchTestSystem = new WebAdminQuotaSearchTestSystem(quotaSearchTestSystem, routes);
+            restQuotaSearchTestSystem = new WebAdminQuotaSearchTestSystem(quotaSearchTestSystem);
         } catch (Exception e) {
             throw new ParameterResolutionException("Error while resolving parameter", e);
         }
@@ -104,13 +85,5 @@ public class ScanningQuotaSearchExtension implements ParameterResolver, BeforeEa
     @Override
     public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
         return restQuotaSearchTestSystem;
-    }
-
-    public QuotaSearchTestSystem getQuotaSearchTestSystem() {
-        return quotaSearchTestSystem;
-    }
-
-    public RequestSpecification getRequestSpecification() {
-        return restQuotaSearchTestSystem.getRequestSpecification();
     }
 }

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserQuotaRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserQuotaRoutesTest.java
@@ -48,20 +48,15 @@ import org.apache.james.mailbox.quota.QuotaSize;
 import org.apache.james.mailbox.quota.UserQuotaRootResolver;
 import org.apache.james.quota.search.QuotaSearchTestSystem;
 import org.apache.james.user.api.UsersRepository;
-import org.apache.james.webadmin.jackson.QuotaModule;
-import org.apache.james.webadmin.service.UserQuotaService;
-import org.apache.james.webadmin.utils.JsonTransformer;
 import org.assertj.core.api.SoftAssertions;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.Extension;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSet;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.http.ContentType;
 import com.jayway.restassured.path.json.JsonPath;
@@ -79,20 +74,6 @@ class UserQuotaRoutesTest {
     private static final String PASSWORD = "secret";
     private static final String COUNT = "count";
     private static final String SIZE = "size";
-
-    private final ScanningQuotaSearchExtension scanningExtension = new ScanningQuotaSearchExtension(this::createUserQuotaRoutes);
-
-    private UserQuotaRoutes createUserQuotaRoutes(QuotaSearchTestSystem testSystem) {
-        QuotaModule quotaModule = new QuotaModule();
-        return new UserQuotaRoutes(testSystem.getUsersRepository(),
-            new UserQuotaService(
-                testSystem.getMaxQuotaManager(),
-                testSystem.getQuotaManager(),
-                testSystem.getQuotaRootResolver(),
-                testSystem.getQuotaSearcher()),
-            new JsonTransformer(quotaModule),
-            ImmutableSet.of(quotaModule));
-    }
 
     @BeforeEach
     public void setUp(WebAdminQuotaSearchTestSystem testSystem) throws Exception {
@@ -469,21 +450,20 @@ class UserQuotaRoutesTest {
     }
 
     @Nested
+    @ExtendWith(ScanningQuotaSearchExtension.class)
     class ScanningGetUsersQuotaRouteTest implements GetUsersQuotaRouteContract {
-        @RegisterExtension
-        Extension registeredExtension = scanningExtension;
+
     }
 
     @Nested
+    @ExtendWith(ElasticSearchQuotaSearchExtension.class)
     class ElasticSearchGetUsersQuotaRouteTest implements GetUsersQuotaRouteContract {
-        @RegisterExtension
-        Extension registeredExtension = new ElasticSearchQuotaSearchExtension();
+
     }
 
     @Nested
+    @ExtendWith(ScanningQuotaSearchExtension.class)
     class GetCount {
-        @RegisterExtension
-        Extension registeredExtension = scanningExtension;
 
         @Test
         void getCountShouldReturnNotFoundWhenUserDoesntExist() {
@@ -523,10 +503,8 @@ class UserQuotaRoutesTest {
     }
 
     @Nested
+    @ExtendWith(ScanningQuotaSearchExtension.class)
     class GetSize {
-        @RegisterExtension
-        Extension registeredExtension = scanningExtension;
-
         @Test
         void getSizeShouldReturnNotFoundWhenUserDoesntExist() {
             when()
@@ -566,10 +544,8 @@ class UserQuotaRoutesTest {
     }
 
     @Nested
+    @ExtendWith(ScanningQuotaSearchExtension.class)
     class PutCount {
-        @RegisterExtension
-        Extension registeredExtension = scanningExtension;
-
         @Test
         void putCountShouldReturnNotFoundWhenUserDoesntExist() {
             given()
@@ -674,10 +650,8 @@ class UserQuotaRoutesTest {
     }
 
     @Nested
+    @ExtendWith(ScanningQuotaSearchExtension.class)
     class PutSize {
-        @RegisterExtension
-        Extension registeredExtension = scanningExtension;
-
         @Test
         void putSizeAcceptEscapedUsers() {
             given()
@@ -768,9 +742,8 @@ class UserQuotaRoutesTest {
     }
 
     @Nested
+    @ExtendWith(ScanningQuotaSearchExtension.class)
     class DeleteCount {
-        @RegisterExtension
-        Extension registeredExtension = scanningExtension;
 
         @Test
         void deleteCountShouldReturnNotFoundWhenUserDoesntExist() {
@@ -796,10 +769,8 @@ class UserQuotaRoutesTest {
     }
 
     @Nested
+    @ExtendWith(ScanningQuotaSearchExtension.class)
     class DeleteSize {
-        @RegisterExtension
-        Extension registeredExtension = scanningExtension;
-
         @Test
         void deleteSizeShouldReturnNotFoundWhenUserDoesntExist() {
             when()
@@ -825,10 +796,8 @@ class UserQuotaRoutesTest {
     }
 
     @Nested
+    @ExtendWith(ScanningQuotaSearchExtension.class)
     class GetQuota {
-        @RegisterExtension
-        Extension registeredExtension = scanningExtension;
-
         @Test
         void getQuotaShouldReturnNotFoundWhenUserDoesntExist() {
             when()
@@ -1073,9 +1042,8 @@ class UserQuotaRoutesTest {
     }
 
     @Nested
+    @ExtendWith(ScanningQuotaSearchExtension.class)
     class PutQuota {
-        @RegisterExtension
-        Extension registeredExtension = scanningExtension;
 
         @Test
         void putQuotaShouldReturnNotFoundWhenUserDoesntExist() {

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/WebAdminQuotaSearchTestSystem.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/WebAdminQuotaSearchTestSystem.java
@@ -21,14 +21,17 @@ package org.apache.james.webadmin.routes;
 
 import static org.apache.james.webadmin.WebAdminServer.NO_CONFIGURATION;
 
-import java.util.List;
-
 import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.james.quota.search.QuotaSearchTestSystem;
-import org.apache.james.webadmin.Routes;
 import org.apache.james.webadmin.WebAdminServer;
 import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.jackson.QuotaModule;
+import org.apache.james.webadmin.service.DomainQuotaService;
+import org.apache.james.webadmin.service.GlobalQuotaService;
+import org.apache.james.webadmin.service.UserQuotaService;
+import org.apache.james.webadmin.utils.JsonTransformer;
 
+import com.google.common.collect.ImmutableSet;
 import com.jayway.restassured.specification.RequestSpecification;
 
 public class WebAdminQuotaSearchTestSystem {
@@ -36,9 +39,34 @@ public class WebAdminQuotaSearchTestSystem {
     private final WebAdminServer webAdminServer;
     private final RequestSpecification requestSpecBuilder;
 
-    public WebAdminQuotaSearchTestSystem(QuotaSearchTestSystem quotaSearchTestSystem, List<Routes> routes) throws Exception {
+    public WebAdminQuotaSearchTestSystem(QuotaSearchTestSystem quotaSearchTestSystem) throws Exception {
         this.quotaSearchTestSystem = quotaSearchTestSystem;
-        this.webAdminServer = WebAdminUtils.createWebAdminServer(new NoopMetricFactory(), routes);
+
+        UserQuotaService userQuotaService = new UserQuotaService(quotaSearchTestSystem.getMaxQuotaManager(),
+            quotaSearchTestSystem.getQuotaManager(),
+            quotaSearchTestSystem.getQuotaRootResolver(),
+            quotaSearchTestSystem.getQuotaSearcher());
+
+        QuotaModule quotaModule = new QuotaModule();
+        JsonTransformer jsonTransformer = new JsonTransformer(quotaModule);
+        UserQuotaRoutes userQuotaRoutes = new UserQuotaRoutes(quotaSearchTestSystem.getUsersRepository(),
+            userQuotaService, jsonTransformer,
+            ImmutableSet.of(quotaModule));
+        DomainQuotaRoutes domainQuotaRoutes = new DomainQuotaRoutes(
+            quotaSearchTestSystem.getDomainList(),
+            new DomainQuotaService(quotaSearchTestSystem.getMaxQuotaManager()),
+            quotaSearchTestSystem.getUsersRepository(),
+            jsonTransformer,
+            ImmutableSet.of(quotaModule));
+        GlobalQuotaRoutes globalQuotaRoutes = new GlobalQuotaRoutes(
+            new GlobalQuotaService(quotaSearchTestSystem.getMaxQuotaManager()),
+            jsonTransformer);
+
+        this.webAdminServer = WebAdminUtils.createWebAdminServer(
+            new NoopMetricFactory(),
+            userQuotaRoutes,
+            domainQuotaRoutes,
+            globalQuotaRoutes);
         this.webAdminServer.configure(NO_CONFIGURATION);
         this.webAdminServer.await();
 


### PR DESCRIPTION
This reverts commit f8faf50e8cb76cdd1931ddcebb0f3e4865028eaf.

This commit introduced a move toward JUNIT 5.2.0 in order to use programmatically registered extensions, which looked very promissing.
However, JUNIT 5.2.0 is not stable yet, and that lead to many tests being skept. As such, we failed finding a satisfying solution, so we have to revert, in order to get all tests played.