### PR TITLE
Blog post: Sprint 37 & 38 @Linagora

### DIFF
--- a/src/homepage/_posts/2018-06-06-linagora-june-nl.markdown
+++ b/src/homepage/_posts/2018-06-06-linagora-june-nl.markdown
@@ -7,7 +7,7 @@ categories: james update
 
 In the name of the James team @Linagora I will be presenting you what we did in the past few weeks, and plan to work on in the coming weeks.
 
-We need to work on some specific feature to make James easier to adopt for large organizations.
+We have to work on some specific features to make James easier to adopt for large organizations.
 
 # What was achieved in may
 
@@ -15,11 +15,10 @@ We need to work on some specific feature to make James easier to adopt for large
 
 > A mail needs to be sent to the user to warn him. This is an attempts to allow clients not implementing quota's RFCs to still get the warning.
 >
-> This is implemented with mailbox listeners (and not mailets), with event sourcing. We added the interfaces and implementation for implementing features in James using event sourcing with events being stored in Cassandra or in memory.
+> This is implemented with mailbox listeners (and not mailets), with event sourcing. We added the interfaces and implementations to achieve this feature in James using event sourcing with events being stored in Cassandra or in memory.
+> Such a technical solution might be very useful to implement other feature.
 >
 > This mailbox listener is optional. We allowed one to register his (potentially custom) mailbox listeners when working with Guice.
->
-> Most of the work was done during Sprint #36 but we finished this feature.
 
 ## Searching user by quota usage
 
@@ -43,8 +42,13 @@ We need to work on some specific feature to make James easier to adopt for large
 
 ### Exporting a mail account
 
-> As a user, I should be able to export the content of my mail account. This both allows easier migrations, comply with legal requirements as well as allow some forms of backups.
+> As an administrator, I should be able to export the content of my mail account. This both allows easier migrations, comply with legal requirements as well as allow some forms of backups.
 >
-> The chosen format is emls in a ZIP format, with the folder structure, and specific metadata to ease restoring a James account (flags, etc...) . An admin (via webamin) should be able to download/upload such backups in order to do export/restores.
+> The chosen format is EMLs in a ZIP format, with the folder structure described in archive meta-data, and specific metadata to ease restoring a James account (flags, etc...). An administrator (via webamin) should be able to download/upload such backups in order to do export/restores mail accounts.
+
+### Coming next
+
+Along side these features that turns out to be necessary for large organisations, our focus will be on having a distributed
+James server. To achieve this, we will propose soon a distributed mail queue based on RabbitMQ.
 
 [this issue]: https://github.com/apache/tika/pull/237

--- a/src/homepage/_posts/2018-06-06-linagora-june-nl.markdown
+++ b/src/homepage/_posts/2018-06-06-linagora-june-nl.markdown
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "Linagora Sprints 37 & 38"
+title:  "Linagora June newsletter"
 date:   2018-06-06 11:30:00 +0700
 categories: james update
 ---
@@ -9,9 +9,7 @@ In the name of the James team @Linagora I will be presenting you what we did in 
 
 We need to work on some specific feature to make James easier to adopt for large organizations.
 
-# Sprint 37
-
-Sprint #37 took place from the 16th of May to the 31st of May. During this sprint, we worked on the following topics:
+# What was achieved in may
 
 ## Notifications when soon over quota
 
@@ -35,9 +33,7 @@ Sprint #37 took place from the 16th of May to the 31st of May. During this sprin
 >
 > We also worked on improving massive JMAP operation performance (delete a large number of emails).
 
-# Sprint 38
-
-Sprint #38 will take place from the 5th of June to the 21st of June. We will work on the following topics:
+# What we will work on in June
 
 ## Data Loss Prevention
 
@@ -50,7 +46,5 @@ Sprint #38 will take place from the 5th of June to the 21st of June. We will wor
 > As a user, I should be able to export the content of my mail account. This both allows easier migrations, comply with legal requirements as well as allow some forms of backups.
 >
 > The chosen format is emls in a ZIP format, with the folder structure, and specific metadata to ease restoring a James account (flags, etc...) . An admin (via webamin) should be able to download/upload such backups in order to do export/restores.
->
-> Sadly, we won't be able to complete fully this feature as part of Sprint #38.
 
 [this issue]: https://github.com/apache/tika/pull/237

--- a/src/homepage/_posts/2018-06-06-linagora-june-nl.markdown
+++ b/src/homepage/_posts/2018-06-06-linagora-june-nl.markdown
@@ -9,7 +9,7 @@ In the name of the James team @Linagora I will be presenting you what we did in 
 
 We have to work on some specific features to make James easier to adopt for large organizations.
 
-# What was achieved in may
+# What was achieved in May
 
 ## Notifications when soon over quota
 
@@ -24,17 +24,19 @@ We have to work on some specific features to make James easier to adopt for larg
 
 > This would allow an admin to inspect per-user quota usage, via a webadmin interface.
 >
-> Again, we provided two implementations: a scrolling one, which naively enumerates mailboxes to compute occupation, and one where quota occupation is indexed in ElasticSearch.
+> Again, we provided two implementations: a scanning one, which naively enumerates mailboxes to compute occupation, and one where quota occupation is indexed in ElasticSearch.
 
 ## Performance enhancements
 
+> In order to have a very good mail search experience, it is possible to plug Apache Tika as a text extractor into James. We use Tika as an external service that we call with HTTP. When you use this Tika extractor with ElasticSearch indexing, you get a very powerful fulltext search even on complex attachment format like LibreOffice documents.
+>
 > We did experience slow requests with our Tika server. We contributed [this issue] which significantly enhanced Tika server performance, and we introduce a cache on James side to reduce calls to tika.
 >
 > We also worked on improving massive JMAP operation performance (delete a large number of emails).
 
 # What we will work on in June
 
-## Data Loss Prevention
+## Data Leak Prevention
 
 > We should have a matcher applying rules defined by the admin. This matcher will then store suspicious emails in specific mail repository for an admin review.
 >

--- a/src/homepage/_posts/2018-06-06-linagora-sprint-38.markdown
+++ b/src/homepage/_posts/2018-06-06-linagora-sprint-38.markdown
@@ -1,0 +1,56 @@
+---
+layout: post
+title:  "Linagora Sprints 37 & 38"
+date:   2018-06-06 11:30:00 +0700
+categories: james update
+---
+
+In the name of the James team @Linagora I will be presenting you what we did in the past few weeks, and plan to work on in the coming weeks.
+
+We need to work on some specific feature to make James easier to adopt for large organizations.
+
+# Sprint 37
+
+Sprint #37 took place from the 16th of May to the 31st of May. During this sprint, we worked on the following topics:
+
+## Notifications when soon over quota
+
+> A mail needs to be sent to the user to warn him. This is an attempts to allow clients not implementing quota's RFCs to still get the warning.
+>
+> This is implemented with mailbox listeners (and not mailets), with event sourcing. We added the interfaces and implementation for implementing features in James using event sourcing with events being stored in Cassandra or in memory.
+>
+> This mailbox listener is optional. We allowed one to register his (potentially custom) mailbox listeners when working with Guice.
+>
+> Most of the work was done during Sprint #36 but we finished this feature.
+
+## Searching user by quota usage
+
+> This would allow an admin to inspect per-user quota usage, via a webadmin interface.
+>
+> Again, we provided two implementations: a scrolling one, which naively enumerates mailboxes to compute occupation, and one where quota occupation is indexed in ElasticSearch.
+
+## Performance enhancements
+
+> We did experience slow requests with our Tika server. We contributed [this issue] which significantly enhanced Tika server performance, and we introduce a cache on James side to reduce calls to tika.
+>
+> We also worked on improving massive JMAP operation performance (delete a large number of emails).
+
+# Sprint 38
+
+Sprint #38 will take place from the 5th of June to the 21st of June. We will work on the following topics:
+
+## Data Loss Prevention
+
+> We should have a matcher applying rules defined by the admin. This matcher will then store suspicious emails in specific mail repository for an admin review.
+>
+> To implement this, we need to enhance browsing to MailRepository via WebAdmin. We need to allow storing such rules as well as updating them via webadmin. We need finally a mailet storing emails in a repository given its sender domain.
+
+### Exporting a mail account
+
+> As a user, I should be able to export the content of my mail account. This both allows easier migrations, comply with legal requirements as well as allow some forms of backups.
+>
+> The chosen format is emls in a ZIP format, with the folder structure, and specific metadata to ease restoring a James account (flags, etc...) . An admin (via webamin) should be able to download/upload such backups in order to do export/restores.
+>
+> Sadly, we won't be able to complete fully this feature as part of Sprint #38.
+
+[this issue]: https://github.com/apache/tika/pull/237


### PR DESCRIPTION
A bit sad but that is the best formatting I found.

I don't want to invest more on this, if you agree.

![capture d ecran de 2018-06-06 15-50-43](https://user-images.githubusercontent.com/6928740/41027554-85386862-69a1-11e8-93d4-a07d8bb27b70.png)

![capture d ecran de 2018-06-06 15-50-48](https://user-images.githubusercontent.com/6928740/41027557-8574a444-69a1-11e8-961e-e91b875858b4.png)

```
To users, devs
Subject: Use the James blog to communicate about your uses of James

Hi everyone,

We took the decision, @Linagora, to be communicating more on our Sprint contents (finished and to upcoming). We consider the best place to do so is to do it via a blog post, for it to be more durable.

Hence, you can be reading about our past Sprint #37 and our upcoming Sprint #38 works : https://XXX

Furthermore, anybody using James is encouraged to do some posts on the same medium about your uses of James and work on it. To do so add a file in this folder [1] then open a Pull Request on this repository [2].

Best regards,

Benoit Tellier

[1] https://github.com/apache/james-project/tree/master/src/homepage/_posts
[2] https://github.com/apache/james-project
```