### PR TITLE
MAILBOX-341 EventDeliver should report MailboxListener execution timings

### DIFF
--- a/mailbox/spring/src/main/resources/META-INF/spring/event-system.xml
+++ b/mailbox/spring/src/main/resources/META-INF/spring/event-system.xml
@@ -71,12 +71,15 @@
         <constructor-arg index="0" ref="mailbox-id-deserializer"/>
     </bean>
 
-    <bean id="synchronous-event-delivery" class="org.apache.james.mailbox.store.event.SynchronousEventDelivery" lazy-init="true"/>
+    <bean id="synchronous-event-delivery" class="org.apache.james.mailbox.store.event.SynchronousEventDelivery" lazy-init="true">
+        <constructor-arg index="0" ref="metricFactory"/>
+    </bean>
 
     <bean id="event-registry" class="org.apache.james.mailbox.store.event.MailboxListenerRegistry"/>
 
     <bean id="asynchronous-event-delivery" class="org.apache.james.mailbox.store.event.AsynchronousEventDelivery" lazy-init="true">
         <constructor-arg index="0" ref="${event.delivery.thread.count}"/>
+        <constructor-arg index="1" ref="synchronous-event-delivery"/>
     </bean>
 
     <bean id="mixed-event-delivery" class="org.apache.james.mailbox.store.event.MixedEventDelivery" lazy-init="true">

--- a/mailbox/spring/src/test/resources/META-INF/spring/event-alias.xml
+++ b/mailbox/spring/src/test/resources/META-INF/spring/event-alias.xml
@@ -29,4 +29,6 @@
         <constructor-arg index="0" ref="delegating-listener"/>
     </bean>
 
+    <bean id="metricFactory" class="org.apache.james.metrics.api.NoopMetricFactory"/>
+
 </beans>

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/AsynchronousEventDelivery.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/AsynchronousEventDelivery.java
@@ -32,9 +32,9 @@ public class AsynchronousEventDelivery implements EventDelivery {
     private final ExecutorService threadPoolExecutor;
     private final SynchronousEventDelivery synchronousEventDelivery;
 
-    public AsynchronousEventDelivery(int threadPoolSize) {
+    public AsynchronousEventDelivery(int threadPoolSize, SynchronousEventDelivery synchronousEventDelivery) {
         this.threadPoolExecutor = Executors.newFixedThreadPool(threadPoolSize);
-        this.synchronousEventDelivery = new SynchronousEventDelivery();
+        this.synchronousEventDelivery = synchronousEventDelivery;
     }
 
     @Override

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/DefaultDelegatingMailboxListener.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/DefaultDelegatingMailboxListener.java
@@ -28,6 +28,9 @@ import org.apache.james.mailbox.MailboxListener;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.metrics.api.NoopMetricFactory;
+
+import com.google.common.annotations.VisibleForTesting;
 
 /**
  * Receive a {@link org.apache.james.mailbox.MailboxListener.MailboxEvent} and delegate it to an other
@@ -45,8 +48,9 @@ public class DefaultDelegatingMailboxListener implements DelegatingMailboxListen
         return ListenerType.EACH_NODE;
     }
 
+    @VisibleForTesting
     public DefaultDelegatingMailboxListener() {
-        this(new SynchronousEventDelivery(),
+        this(new SynchronousEventDelivery(new NoopMetricFactory()),
             new MailboxListenerRegistry());
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/distributed/BroadcastDelegatingMailboxListener.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/distributed/BroadcastDelegatingMailboxListener.java
@@ -33,8 +33,11 @@ import org.apache.james.mailbox.store.event.SynchronousEventDelivery;
 import org.apache.james.mailbox.store.publisher.MessageConsumer;
 import org.apache.james.mailbox.store.publisher.Publisher;
 import org.apache.james.mailbox.store.publisher.Topic;
+import org.apache.james.metrics.api.NoopMetricFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
 
 public class BroadcastDelegatingMailboxListener implements DistributedDelegatingMailboxListener {
 
@@ -60,11 +63,12 @@ public class BroadcastDelegatingMailboxListener implements DistributedDelegating
         messageConsumer.init(this.globalTopic);
     }
 
+    @VisibleForTesting
     public BroadcastDelegatingMailboxListener(Publisher publisher,
                                               MessageConsumer messageConsumer,
                                               EventSerializer eventSerializer,
                                               String globalTopic) throws Exception {
-        this(publisher, messageConsumer, eventSerializer, new SynchronousEventDelivery(), globalTopic);
+        this(publisher, messageConsumer, eventSerializer, new SynchronousEventDelivery(new NoopMetricFactory()), globalTopic);
     }
 
     @Override

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/distributed/RegisteredDelegatingMailboxListener.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/distributed/RegisteredDelegatingMailboxListener.java
@@ -34,8 +34,11 @@ import org.apache.james.mailbox.store.event.SynchronousEventDelivery;
 import org.apache.james.mailbox.store.publisher.MessageConsumer;
 import org.apache.james.mailbox.store.publisher.Publisher;
 import org.apache.james.mailbox.store.publisher.Topic;
+import org.apache.james.metrics.api.NoopMetricFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
 
 public class RegisteredDelegatingMailboxListener implements DistributedDelegatingMailboxListener {
 
@@ -61,11 +64,12 @@ public class RegisteredDelegatingMailboxListener implements DistributedDelegatin
         messageConsumer.init(mailboxPathRegister.getLocalTopic());
     }
 
+    @VisibleForTesting
     public RegisteredDelegatingMailboxListener(EventSerializer eventSerializer,
                                                Publisher publisher,
                                                MessageConsumer messageConsumer,
                                                MailboxPathRegister mailboxPathRegister) throws Exception {
-        this(eventSerializer, publisher, messageConsumer, mailboxPathRegister, new SynchronousEventDelivery());
+        this(eventSerializer, publisher, messageConsumer, mailboxPathRegister, new SynchronousEventDelivery(new NoopMetricFactory()));
     }
 
     @Override

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/event/AsynchronousEventDeliveryTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/event/AsynchronousEventDeliveryTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.james.mailbox.MailboxListener;
 import org.apache.james.mailbox.mock.MockMailboxSession;
+import org.apache.james.metrics.api.NoopMetricFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,7 +42,8 @@ public class AsynchronousEventDeliveryTest {
     @Before
     public void setUp() {
         mailboxListener = mock(MailboxListener.class);
-        asynchronousEventDelivery = new AsynchronousEventDelivery(2);
+        asynchronousEventDelivery = new AsynchronousEventDelivery(2,
+            new SynchronousEventDelivery(new NoopMetricFactory()));
     }
 
     @After

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/event/SynchronousEventDeliveryTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/event/SynchronousEventDeliveryTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 
 import org.apache.james.mailbox.MailboxListener;
 import org.apache.james.mailbox.mock.MockMailboxSession;
+import org.apache.james.metrics.api.NoopMetricFactory;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -36,7 +37,7 @@ public class SynchronousEventDeliveryTest {
     @Before
     public void setUp() {
         mailboxListener = mock(MailboxListener.class);
-        synchronousEventDelivery = new SynchronousEventDelivery();
+        synchronousEventDelivery = new SynchronousEventDelivery(new NoopMetricFactory());
     }
 
     @Test

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/DefaultEventModule.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/DefaultEventModule.java
@@ -36,6 +36,7 @@ import org.apache.james.mailbox.store.event.MailboxListenerRegistry;
 import org.apache.james.mailbox.store.event.MixedEventDelivery;
 import org.apache.james.mailbox.store.event.SynchronousEventDelivery;
 import org.apache.james.mailbox.store.quota.ListeningCurrentQuotaUpdater;
+import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
 import org.apache.james.utils.ConfigurationPerformer;
 
@@ -69,12 +70,13 @@ public class DefaultEventModule extends AbstractModule {
 
     @Provides
     @Singleton
-    EventDelivery provideEventDelivery(ConfigurationProvider configurationProvider) {
+    EventDelivery provideEventDelivery(ConfigurationProvider configurationProvider, MetricFactory metricFactory) {
         int poolSize = retrievePoolSize(configurationProvider);
 
+        SynchronousEventDelivery synchronousEventDelivery = new SynchronousEventDelivery(metricFactory);
         return new MixedEventDelivery(
-            new AsynchronousEventDelivery(poolSize),
-            new SynchronousEventDelivery());
+            new AsynchronousEventDelivery(poolSize, synchronousEventDelivery),
+            synchronousEventDelivery);
     }
 
     private int retrievePoolSize(ConfigurationProvider configurationProvider) {


### PR DESCRIPTION
Interesting upcming new metrics names:

```
mailbox-listener-ElasticSearchListeningMessageSearchIndex
mailbox-listener-ElasticSearchQuotaMailboxListener
mailbox-listener-IdleMailboxListener
mailbox-listener-ListeningCurrentQuotaUpdater
mailbox-listener-MailboxAnnotationListener
mailbox-listener-MailboxOperationLoggingListener
mailbox-listener-PropagateLookupRightListener
mailbox-listener-QuotaThresholdCrossingListener
mailbox-listener-SelectedMailboxImpl
mailbox-listener-SpamAssassinListener
```