### PR TITLE
James 2436 Handle mailboxes in archives

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,7 @@ import java.util.Optional;
 
 import javax.mail.Flags;
 
+import org.apache.james.mailbox.MailboxManager.MessageCapabilities;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.UnsupportedCriteriaException;
 import org.apache.james.mailbox.model.ComposedMessageId;
@@ -268,6 +270,7 @@ public interface MessageManager {
      */
     MessageResultIterator getMessages(MessageRange set, FetchGroup fetchGroup, MailboxSession mailboxSession) throws MailboxException;
 
+    EnumSet<MessageCapabilities> getSupportedMessageCapabilities();
 
     /**
      * Gets the id of the referenced mailbox

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Backup.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Backup.java
@@ -20,11 +20,15 @@ package org.apache.james.mailbox.backup;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.List;
+import java.util.stream.Stream;
 
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 
 public interface Backup {
 
-    void archive(List<MailboxMessage> messages, OutputStream destination) throws IOException;
+    /**
+     * @param messages a stream of MailboxMessages that will be consumed
+     * @param destination an OutputStream in which the zip will be written
+     */
+    void archive(Stream<MailboxMessage> messages, OutputStream destination) throws IOException;
 }

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Backup.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Backup.java
@@ -20,15 +20,18 @@ package org.apache.james.mailbox.backup;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.List;
 import java.util.stream.Stream;
 
+import org.apache.james.mailbox.store.mail.model.Mailbox;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 
 public interface Backup {
 
     /**
+     * @param mailboxes list of mailboxes to be stored in the archive
      * @param messages a stream of MailboxMessages that will be consumed
      * @param destination an OutputStream in which the zip will be written
      */
-    void archive(Stream<MailboxMessage> messages, OutputStream destination) throws IOException;
+    void archive(List<Mailbox> mailboxes, Stream<MailboxMessage> messages, OutputStream destination) throws IOException;
 }

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Directory.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Directory.java
@@ -1,0 +1,33 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.mailbox.backup;
+
+import java.io.File;
+
+public class Directory extends File {
+
+    public Directory(String pathname) {
+        super(pathname);
+    }
+
+    @Override
+    public boolean isDirectory() {
+        return true;
+    }
+}

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/InternalDateExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/InternalDateExtraField.java
@@ -1,0 +1,55 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.backup;
+
+import java.util.Date;
+import java.util.Optional;
+
+import org.apache.commons.compress.archivers.zip.ZipShort;
+
+public class InternalDateExtraField extends LongExtraField {
+
+    public static final ZipShort ID = new ZipShort(0x6F61); // "ao" in little-endian
+
+    public InternalDateExtraField() {
+        super();
+    }
+
+    public InternalDateExtraField(long time) {
+        super(time);
+    }
+
+    public InternalDateExtraField(Date date) {
+        super(date.getTime());
+    }
+
+    public InternalDateExtraField(Optional<Date> date) {
+        super(date.map(Date::getTime));
+    }
+
+    @Override
+    public ZipShort getHeaderId() {
+        return ID;
+    }
+
+    public Optional<Date> getDateValue() {
+        return getValue().map(Date::new);
+    }
+}

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/InternalDateExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/InternalDateExtraField.java
@@ -19,12 +19,14 @@
 
 package org.apache.james.mailbox.backup;
 
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Optional;
 
 import org.apache.commons.compress.archivers.zip.ZipShort;
 
-public class InternalDateExtraField extends LongExtraField {
+public class InternalDateExtraField extends StringExtraField {
 
     public static final ZipShort ID = new ZipShort(0x6F61); // "ao" in little-endian
 
@@ -32,16 +34,14 @@ public class InternalDateExtraField extends LongExtraField {
         super();
     }
 
-    public InternalDateExtraField(long time) {
-        super(time);
-    }
-
     public InternalDateExtraField(Date date) {
-        super(date.getTime());
+        super(Optional.of(date.toInstant().toString()));
     }
 
     public InternalDateExtraField(Optional<Date> date) {
-        super(date.map(Date::getTime));
+        super(date
+            .map(Date::toInstant)
+            .map(Instant::toString));
     }
 
     @Override
@@ -50,6 +50,9 @@ public class InternalDateExtraField extends LongExtraField {
     }
 
     public Optional<Date> getDateValue() {
-        return getValue().map(Date::new);
+        return getValue()
+            .map(ZonedDateTime::parse)
+            .map(ZonedDateTime::toInstant)
+            .map(Date::from);
     }
 }

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/InternalDateExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/InternalDateExtraField.java
@@ -19,9 +19,6 @@
 
 package org.apache.james.mailbox.backup;
 
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Optional;
 
@@ -37,11 +34,7 @@ public class InternalDateExtraField extends LongExtraField {
 
     public InternalDateExtraField(Optional<Date> date) {
         super(date
-            .map(Date::toInstant)
-            .map(instant -> ZonedDateTime.ofInstant(instant, ZoneId.systemDefault()))
-            .map(locateZonedDateTime -> locateZonedDateTime.withZoneSameInstant(ZoneId.of("UTC")))
-            .map(ZonedDateTime::toInstant)
-            .map(Instant::toEpochMilli));
+            .map(Date::getTime));
     }
 
     public InternalDateExtraField(Date date) {
@@ -59,14 +52,5 @@ public class InternalDateExtraField extends LongExtraField {
 
     public Optional<Date> getDateValue() {
         return getValue().map(Date::new);
-    }
-
-    public Optional<Date> getLocalDateValue() {
-        return getValue()
-            .map(Instant::ofEpochMilli)
-            .map(instant -> ZonedDateTime.ofInstant(instant, ZoneId.of("UTC")))
-            .map(utcTime -> utcTime.withZoneSameInstant(ZoneId.systemDefault()))
-            .map(ZonedDateTime::toInstant)
-            .map(Date::from);
     }
 }

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/InternalDateExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/InternalDateExtraField.java
@@ -37,11 +37,11 @@ public class InternalDateExtraField extends LongExtraField {
 
     public InternalDateExtraField(Optional<Date> date) {
         super(date
-            .map(Date::toInstant) // convert to Instant, prepare to synchronize Instant to UTC
-            .map(instant -> ZonedDateTime.ofInstant(instant, ZoneId.of("UTC")))  // convert to UTC time
-            .map(ZonedDateTime::toInstant) // get UTC Instant
-            .map(Date::from) // get time in millisecond of UTC time
-            .map(Date::getTime));
+            .map(Date::toInstant)
+            .map(instant -> ZonedDateTime.ofInstant(instant, ZoneId.systemDefault()))
+            .map(locateZonedDateTime -> locateZonedDateTime.withZoneSameInstant(ZoneId.of("UTC")))
+            .map(ZonedDateTime::toInstant)
+            .map(Instant::toEpochMilli));
     }
 
     public InternalDateExtraField(Date date) {
@@ -57,14 +57,15 @@ public class InternalDateExtraField extends LongExtraField {
         return ID;
     }
 
-    public Optional<Date> getUTCDateValue() {
+    public Optional<Date> getDateValue() {
         return getValue().map(Date::new);
     }
 
     public Optional<Date> getLocalDateValue() {
         return getValue()
-            .map(Instant::ofEpochMilli) // now instant is UTC based by default
-            .map(instant -> ZonedDateTime.ofInstant(instant, ZoneId.systemDefault())) // convert UTC time to local time
+            .map(Instant::ofEpochMilli)
+            .map(instant -> ZonedDateTime.ofInstant(instant, ZoneId.of("UTC")))
+            .map(utcTime -> utcTime.withZoneSameInstant(ZoneId.systemDefault()))
             .map(ZonedDateTime::toInstant)
             .map(Date::from);
     }

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/InternalDateExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/InternalDateExtraField.java
@@ -19,8 +19,9 @@
 
 package org.apache.james.mailbox.backup;
 
-import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Optional;
 
@@ -34,14 +35,15 @@ public class InternalDateExtraField extends StringExtraField {
         super();
     }
 
-    public InternalDateExtraField(Date date) {
-        super(Optional.of(date.toInstant().toString()));
-    }
-
     public InternalDateExtraField(Optional<Date> date) {
         super(date
             .map(Date::toInstant)
-            .map(Instant::toString));
+            .map(instant -> ZonedDateTime.ofInstant(instant, ZoneId.systemDefault()))
+            .map(DateTimeFormatter.ISO_OFFSET_DATE_TIME::format));
+    }
+
+    public InternalDateExtraField(Date date) {
+        this(Optional.of(date));
     }
 
     @Override
@@ -51,7 +53,7 @@ public class InternalDateExtraField extends StringExtraField {
 
     public Optional<Date> getDateValue() {
         return getValue()
-            .map(ZonedDateTime::parse)
+            .map(time -> ZonedDateTime.parse(time, DateTimeFormatter.ISO_OFFSET_DATE_TIME))
             .map(ZonedDateTime::toInstant)
             .map(Date::from);
     }

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/InternalDateExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/InternalDateExtraField.java
@@ -38,7 +38,7 @@ public class InternalDateExtraField extends StringExtraField {
     public InternalDateExtraField(Optional<Date> date) {
         super(date
             .map(Date::toInstant)
-            .map(instant -> ZonedDateTime.ofInstant(instant, ZoneId.systemDefault()))
+            .map(instant -> ZonedDateTime.ofInstant(instant, ZoneId.of("UTC")))
             .map(DateTimeFormatter.ISO_OFFSET_DATE_TIME::format));
     }
 

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/LongExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/LongExtraField.java
@@ -1,0 +1,105 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.backup;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.zip.ZipException;
+
+import org.apache.commons.compress.archivers.zip.ZipExtraField;
+import org.apache.commons.compress.archivers.zip.ZipShort;
+
+public abstract class LongExtraField implements ZipExtraField {
+
+    private Optional<Long> value;
+
+    public LongExtraField() {
+        this(Optional.empty());
+    }
+
+    public LongExtraField(long value) {
+        this(Optional.of(value));
+    }
+
+    public LongExtraField(Optional<Long> value) {
+        this.value = value;
+    }
+
+    @Override
+    public ZipShort getLocalFileDataLength() {
+        return new ZipShort(Long.BYTES);
+    }
+
+    @Override
+    public ZipShort getCentralDirectoryLength() {
+        return getLocalFileDataLength();
+    }
+
+    @Override
+    public byte[] getLocalFileDataData() {
+        long value = this.value.orElseThrow(() -> new RuntimeException("Value must by initialized"));
+        return ByteBuffer.allocate(Long.BYTES)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .putLong(value)
+            .array();
+    }
+
+    @Override
+    public byte[] getCentralDirectoryData() {
+        return getLocalFileDataData();
+    }
+
+    @Override
+    public void parseFromLocalFileData(byte[] buffer, int offset, int length) throws ZipException {
+        if (length != Long.BYTES) {
+            throw new ZipException("Unexpected data length for ExtraField. Expected " + Long.BYTES + " but got " + length + ".");
+        }
+        value = Optional.of(ByteBuffer
+                .wrap(buffer, offset, Long.BYTES)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .getLong());
+    }
+
+    @Override
+    public void parseFromCentralDirectoryData(byte[] buffer, int offset, int length) throws ZipException {
+        parseFromLocalFileData(buffer, offset, length);
+    }
+
+    public Optional<Long> getValue() {
+        return value;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof LongExtraField) {
+            LongExtraField that = (LongExtraField) o;
+
+            return Objects.equals(this.value, that.value);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/LongExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/LongExtraField.java
@@ -90,7 +90,7 @@ public abstract class LongExtraField implements ZipExtraField {
 
     @Override
     public final boolean equals(Object o) {
-        if (this.getClass() == o.getClass()) {
+        if (o instanceof LongExtraField) {
             LongExtraField that = (LongExtraField) o;
 
             return Objects.equals(this.value, that.value)
@@ -101,6 +101,6 @@ public abstract class LongExtraField implements ZipExtraField {
 
     @Override
     public final int hashCode() {
-        return Objects.hash(value);
+        return Objects.hash(value, getHeaderId());
     }
 }

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/MailboxIdExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/MailboxIdExtraField.java
@@ -1,0 +1,105 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.backup;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.commons.compress.archivers.zip.ZipExtraField;
+import org.apache.commons.compress.archivers.zip.ZipShort;
+
+public class MailboxIdExtraField implements ZipExtraField {
+
+    public static final ZipShort ID = new ZipShort(0x6D61); // "am" in little-endian
+
+    private Optional<String> mailboxId;
+
+    public MailboxIdExtraField() {
+        this(Optional.empty());
+    }
+
+    public MailboxIdExtraField(String mailboxId) {
+        this(Optional.of(mailboxId));
+    }
+
+    public MailboxIdExtraField(Optional<String> mailboxId) {
+        this.mailboxId = mailboxId;
+    }
+
+    @Override
+    public ZipShort getHeaderId() {
+        return ID;
+    }
+
+    @Override
+    public ZipShort getLocalFileDataLength() {
+        return mailboxId
+            .map(value -> value.getBytes(StandardCharsets.UTF_8).length)
+            .map(ZipShort::new)
+            .orElseThrow(() -> new RuntimeException("Value must by initialized"));
+    }
+
+    @Override
+    public ZipShort getCentralDirectoryLength() {
+        return getLocalFileDataLength();
+    }
+
+    @Override
+    public byte[] getLocalFileDataData() {
+        return mailboxId
+            .map(value -> value.getBytes(StandardCharsets.UTF_8))
+            .orElseThrow(() -> new RuntimeException("Value must by initialized"));
+    }
+
+    @Override
+    public byte[] getCentralDirectoryData() {
+        return getLocalFileDataData();
+    }
+
+    @Override
+    public void parseFromLocalFileData(byte[] buffer, int offset, int length) {
+        mailboxId = Optional.of(new String(buffer, offset, length, StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public void parseFromCentralDirectoryData(byte[] buffer, int offset, int length) {
+        parseFromLocalFileData(buffer, offset, length);
+    }
+
+    public Optional<String> getMailboxId() {
+        return mailboxId;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof MailboxIdExtraField) {
+            MailboxIdExtraField that = (MailboxIdExtraField) o;
+
+            return Objects.equals(this.mailboxId, that.mailboxId);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(mailboxId);
+    }
+}

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/MailboxIdExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/MailboxIdExtraField.java
@@ -33,7 +33,7 @@ public class MailboxIdExtraField extends StringExtraField {
     }
 
     public MailboxIdExtraField(String value) {
-        super(value);
+        super(Optional.of(value));
     }
 
     public MailboxIdExtraField(Optional<String> value) {
@@ -41,7 +41,7 @@ public class MailboxIdExtraField extends StringExtraField {
     }
 
     public MailboxIdExtraField(MailboxId mailboxId) {
-        super(mailboxId.serialize());
+        super(Optional.of(mailboxId.serialize()));
     }
 
     @Override

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/MailboxIdExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/MailboxIdExtraField.java
@@ -19,87 +19,33 @@
 
 package org.apache.james.mailbox.backup;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Objects;
 import java.util.Optional;
 
-import org.apache.commons.compress.archivers.zip.ZipExtraField;
 import org.apache.commons.compress.archivers.zip.ZipShort;
+import org.apache.james.mailbox.model.MailboxId;
 
-public class MailboxIdExtraField implements ZipExtraField {
+public class MailboxIdExtraField extends StringExtraField {
 
     public static final ZipShort ID = new ZipShort(0x6D61); // "am" in little-endian
 
-    private Optional<String> mailboxId;
-
     public MailboxIdExtraField() {
-        this(Optional.empty());
+        super();
     }
 
-    public MailboxIdExtraField(String mailboxId) {
-        this(Optional.of(mailboxId));
+    public MailboxIdExtraField(String value) {
+        super(value);
     }
 
-    public MailboxIdExtraField(Optional<String> mailboxId) {
-        this.mailboxId = mailboxId;
+    public MailboxIdExtraField(Optional<String> value) {
+        super(value);
+    }
+
+    public MailboxIdExtraField(MailboxId mailboxId) {
+        super(mailboxId.serialize());
     }
 
     @Override
     public ZipShort getHeaderId() {
         return ID;
-    }
-
-    @Override
-    public ZipShort getLocalFileDataLength() {
-        return mailboxId
-            .map(value -> value.getBytes(StandardCharsets.UTF_8).length)
-            .map(ZipShort::new)
-            .orElseThrow(() -> new RuntimeException("Value must by initialized"));
-    }
-
-    @Override
-    public ZipShort getCentralDirectoryLength() {
-        return getLocalFileDataLength();
-    }
-
-    @Override
-    public byte[] getLocalFileDataData() {
-        return mailboxId
-            .map(value -> value.getBytes(StandardCharsets.UTF_8))
-            .orElseThrow(() -> new RuntimeException("Value must by initialized"));
-    }
-
-    @Override
-    public byte[] getCentralDirectoryData() {
-        return getLocalFileDataData();
-    }
-
-    @Override
-    public void parseFromLocalFileData(byte[] buffer, int offset, int length) {
-        mailboxId = Optional.of(new String(buffer, offset, length, StandardCharsets.UTF_8));
-    }
-
-    @Override
-    public void parseFromCentralDirectoryData(byte[] buffer, int offset, int length) {
-        parseFromLocalFileData(buffer, offset, length);
-    }
-
-    public Optional<String> getMailboxId() {
-        return mailboxId;
-    }
-
-    @Override
-    public final boolean equals(Object o) {
-        if (o instanceof MailboxIdExtraField) {
-            MailboxIdExtraField that = (MailboxIdExtraField) o;
-
-            return Objects.equals(this.mailboxId, that.mailboxId);
-        }
-        return false;
-    }
-
-    @Override
-    public final int hashCode() {
-        return Objects.hash(mailboxId);
     }
 }

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/MessageIdExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/MessageIdExtraField.java
@@ -1,0 +1,105 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.backup;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.commons.compress.archivers.zip.ZipExtraField;
+import org.apache.commons.compress.archivers.zip.ZipShort;
+
+public class MessageIdExtraField implements ZipExtraField {
+
+    public static final ZipShort ID = new ZipShort(0x6C61); // "al" in little-endian
+
+    private Optional<String> messageId;
+
+    public MessageIdExtraField() {
+        this(Optional.empty());
+    }
+
+    public MessageIdExtraField(String messageId) {
+        this(Optional.of(messageId));
+    }
+
+    public MessageIdExtraField(Optional<String> messageId) {
+        this.messageId = messageId;
+    }
+
+    @Override
+    public ZipShort getHeaderId() {
+        return ID;
+    }
+
+    @Override
+    public ZipShort getLocalFileDataLength() {
+        return messageId
+            .map(value -> value.getBytes(StandardCharsets.UTF_8).length)
+            .map(ZipShort::new)
+            .orElseThrow(() -> new RuntimeException("Value must by initialized"));
+    }
+
+    @Override
+    public ZipShort getCentralDirectoryLength() {
+        return getLocalFileDataLength();
+    }
+
+    @Override
+    public byte[] getLocalFileDataData() {
+        return messageId
+            .map(value -> value.getBytes(StandardCharsets.UTF_8))
+            .orElseThrow(() -> new RuntimeException("Value must by initialized"));
+    }
+
+    @Override
+    public byte[] getCentralDirectoryData() {
+        return getLocalFileDataData();
+    }
+
+    @Override
+    public void parseFromLocalFileData(byte[] buffer, int offset, int length) {
+        messageId = Optional.of(new String(buffer, offset, length, StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public void parseFromCentralDirectoryData(byte[] buffer, int offset, int length) {
+        parseFromLocalFileData(buffer, offset, length);
+    }
+
+    public Optional<String> getMessageId() {
+        return messageId;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof MessageIdExtraField) {
+            MessageIdExtraField that = (MessageIdExtraField) o;
+
+            return Objects.equals(this.messageId, that.messageId);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(messageId);
+    }
+}

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/MessageIdExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/MessageIdExtraField.java
@@ -33,7 +33,7 @@ public class MessageIdExtraField extends StringExtraField {
     }
 
     public MessageIdExtraField(String value) {
-        super(value);
+        super(Optional.of(value));
     }
 
     public MessageIdExtraField(Optional<String> value) {
@@ -41,7 +41,7 @@ public class MessageIdExtraField extends StringExtraField {
     }
 
     public MessageIdExtraField(MessageId messageId) {
-        super(messageId.serialize());
+        super(Optional.of(messageId.serialize()));
     }
 
     @Override

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/MessageIdExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/MessageIdExtraField.java
@@ -19,87 +19,33 @@
 
 package org.apache.james.mailbox.backup;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Objects;
 import java.util.Optional;
 
-import org.apache.commons.compress.archivers.zip.ZipExtraField;
 import org.apache.commons.compress.archivers.zip.ZipShort;
+import org.apache.james.mailbox.model.MessageId;
 
-public class MessageIdExtraField implements ZipExtraField {
+public class MessageIdExtraField extends StringExtraField {
 
     public static final ZipShort ID = new ZipShort(0x6C61); // "al" in little-endian
 
-    private Optional<String> messageId;
-
     public MessageIdExtraField() {
-        this(Optional.empty());
+        super();
     }
 
-    public MessageIdExtraField(String messageId) {
-        this(Optional.of(messageId));
+    public MessageIdExtraField(String value) {
+        super(value);
     }
 
-    public MessageIdExtraField(Optional<String> messageId) {
-        this.messageId = messageId;
+    public MessageIdExtraField(Optional<String> value) {
+        super(value);
+    }
+
+    public MessageIdExtraField(MessageId messageId) {
+        super(messageId.serialize());
     }
 
     @Override
     public ZipShort getHeaderId() {
         return ID;
-    }
-
-    @Override
-    public ZipShort getLocalFileDataLength() {
-        return messageId
-            .map(value -> value.getBytes(StandardCharsets.UTF_8).length)
-            .map(ZipShort::new)
-            .orElseThrow(() -> new RuntimeException("Value must by initialized"));
-    }
-
-    @Override
-    public ZipShort getCentralDirectoryLength() {
-        return getLocalFileDataLength();
-    }
-
-    @Override
-    public byte[] getLocalFileDataData() {
-        return messageId
-            .map(value -> value.getBytes(StandardCharsets.UTF_8))
-            .orElseThrow(() -> new RuntimeException("Value must by initialized"));
-    }
-
-    @Override
-    public byte[] getCentralDirectoryData() {
-        return getLocalFileDataData();
-    }
-
-    @Override
-    public void parseFromLocalFileData(byte[] buffer, int offset, int length) {
-        messageId = Optional.of(new String(buffer, offset, length, StandardCharsets.UTF_8));
-    }
-
-    @Override
-    public void parseFromCentralDirectoryData(byte[] buffer, int offset, int length) {
-        parseFromLocalFileData(buffer, offset, length);
-    }
-
-    public Optional<String> getMessageId() {
-        return messageId;
-    }
-
-    @Override
-    public final boolean equals(Object o) {
-        if (o instanceof MessageIdExtraField) {
-            MessageIdExtraField that = (MessageIdExtraField) o;
-
-            return Objects.equals(this.messageId, that.messageId);
-        }
-        return false;
-    }
-
-    @Override
-    public final int hashCode() {
-        return Objects.hash(messageId);
     }
 }

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/SizeExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/SizeExtraField.java
@@ -18,93 +18,27 @@
  ****************************************************************/
 package org.apache.james.mailbox.backup;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.zip.ZipException;
 
-import org.apache.commons.compress.archivers.zip.ZipExtraField;
 import org.apache.commons.compress.archivers.zip.ZipShort;
 
-public class SizeExtraField implements ZipExtraField {
+public class SizeExtraField extends LongExtraField {
     public static final ZipShort ID = new ZipShort(0x6A61); // "aj" in little-endian
 
-    private Optional<Long> size;
-
     public SizeExtraField() {
-        this(Optional.empty());
+        super();
     }
 
-    public SizeExtraField(long size) {
-        this(Optional.of(size));
+    public SizeExtraField(long value) {
+        super(value);
     }
 
-    public SizeExtraField(Optional<Long> size) {
-        this.size = size;
+    public SizeExtraField(Optional<Long> value) {
+        super(value);
     }
 
     @Override
     public ZipShort getHeaderId() {
         return ID;
-    }
-
-    @Override
-    public ZipShort getLocalFileDataLength() {
-        return new ZipShort(Long.BYTES);
-    }
-
-    @Override
-    public ZipShort getCentralDirectoryLength() {
-        return getLocalFileDataLength();
-    }
-
-    @Override
-    public byte[] getLocalFileDataData() {
-        long value = size.orElseThrow(() -> new RuntimeException("Value must by initialized"));
-        return ByteBuffer.allocate(Long.BYTES)
-            .order(ByteOrder.LITTLE_ENDIAN)
-            .putLong(value)
-            .array();
-    }
-
-    @Override
-    public byte[] getCentralDirectoryData() {
-        return getLocalFileDataData();
-    }
-
-    @Override
-    public void parseFromLocalFileData(byte[] buffer, int offset, int length) throws ZipException {
-        if (length != Long.BYTES) {
-            throw new ZipException("Unexpected data length for SizeExtraField. Expected " + Long.BYTES + " but got " + length + ".");
-        }
-        size = Optional.of(ByteBuffer
-                .wrap(buffer, offset, Long.BYTES)
-                .order(ByteOrder.LITTLE_ENDIAN)
-                .getLong());
-    }
-
-    @Override
-    public void parseFromCentralDirectoryData(byte[] buffer, int offset, int length) throws ZipException {
-        parseFromLocalFileData(buffer, offset, length);
-    }
-
-    public Optional<Long> getSize() {
-        return size;
-    }
-
-    @Override
-    public final boolean equals(Object o) {
-        if (o instanceof SizeExtraField) {
-            SizeExtraField that = (SizeExtraField) o;
-
-            return Objects.equals(this.size, that.size);
-        }
-        return false;
-    }
-
-    @Override
-    public final int hashCode() {
-        return Objects.hash(size);
     }
 }

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/StringExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/StringExtraField.java
@@ -34,10 +34,6 @@ public abstract class StringExtraField implements ZipExtraField {
         this(Optional.empty());
     }
 
-    public StringExtraField(String value) {
-        this(Optional.of(value));
-    }
-
     public StringExtraField(Optional<String> value) {
         this.value = value;
     }
@@ -83,12 +79,17 @@ public abstract class StringExtraField implements ZipExtraField {
 
     @Override
     public final boolean equals(Object o) {
-        if (this.getClass() == o.getClass()) {
+        if (o instanceof StringExtraField) {
             StringExtraField that = (StringExtraField) o;
 
             return Objects.equals(this.getValue(), that.getValue())
                 && Objects.equals(this.getHeaderId(), that.getHeaderId());
         }
         return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(value, getHeaderId());
     }
 }

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/StringExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/StringExtraField.java
@@ -19,34 +19,35 @@
 
 package org.apache.james.mailbox.backup;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.zip.ZipException;
 
 import org.apache.commons.compress.archivers.zip.ZipExtraField;
 import org.apache.commons.compress.archivers.zip.ZipShort;
 
-public abstract class LongExtraField implements ZipExtraField {
+public abstract class StringExtraField implements ZipExtraField {
 
-    private Optional<Long> value;
+    private Optional<String> value;
 
-    public LongExtraField() {
+    public StringExtraField() {
         this(Optional.empty());
     }
 
-    public LongExtraField(long value) {
+    public StringExtraField(String value) {
         this(Optional.of(value));
     }
 
-    public LongExtraField(Optional<Long> value) {
+    public StringExtraField(Optional<String> value) {
         this.value = value;
     }
 
     @Override
     public ZipShort getLocalFileDataLength() {
-        return new ZipShort(Long.BYTES);
+        return value
+            .map(value -> value.getBytes(StandardCharsets.UTF_8).length)
+            .map(ZipShort::new)
+            .orElseThrow(() -> new RuntimeException("Value must by initialized"));
     }
 
     @Override
@@ -56,11 +57,9 @@ public abstract class LongExtraField implements ZipExtraField {
 
     @Override
     public byte[] getLocalFileDataData() {
-        long value = this.value.orElseThrow(() -> new RuntimeException("Value must by initialized"));
-        return ByteBuffer.allocate(Long.BYTES)
-            .order(ByteOrder.LITTLE_ENDIAN)
-            .putLong(value)
-            .array();
+        return value
+            .map(value -> value.getBytes(StandardCharsets.UTF_8))
+            .orElseThrow(() -> new RuntimeException("Value must by initialized"));
     }
 
     @Override
@@ -69,38 +68,27 @@ public abstract class LongExtraField implements ZipExtraField {
     }
 
     @Override
-    public void parseFromLocalFileData(byte[] buffer, int offset, int length) throws ZipException {
-        if (length != Long.BYTES) {
-            throw new ZipException("Unexpected data length for ExtraField. Expected " + Long.BYTES + " but got " + length + ".");
-        }
-        value = Optional.of(ByteBuffer
-                .wrap(buffer, offset, Long.BYTES)
-                .order(ByteOrder.LITTLE_ENDIAN)
-                .getLong());
+    public void parseFromLocalFileData(byte[] buffer, int offset, int length) {
+        value = Optional.of(new String(buffer, offset, length, StandardCharsets.UTF_8));
     }
 
     @Override
-    public void parseFromCentralDirectoryData(byte[] buffer, int offset, int length) throws ZipException {
+    public void parseFromCentralDirectoryData(byte[] buffer, int offset, int length) {
         parseFromLocalFileData(buffer, offset, length);
     }
 
-    public Optional<Long> getValue() {
+    public Optional<String> getValue() {
         return value;
     }
 
     @Override
     public final boolean equals(Object o) {
         if (this.getClass() == o.getClass()) {
-            LongExtraField that = (LongExtraField) o;
+            StringExtraField that = (StringExtraField) o;
 
-            return Objects.equals(this.value, that.value)
+            return Objects.equals(this.getValue(), that.getValue())
                 && Objects.equals(this.getHeaderId(), that.getHeaderId());
         }
         return false;
-    }
-
-    @Override
-    public final int hashCode() {
-        return Objects.hash(value);
     }
 }

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/UidExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/UidExtraField.java
@@ -1,0 +1,112 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.backup;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.zip.ZipException;
+
+import org.apache.commons.compress.archivers.zip.ZipExtraField;
+import org.apache.commons.compress.archivers.zip.ZipShort;
+
+public class UidExtraField implements ZipExtraField {
+
+    public static final ZipShort ID = new ZipShort(0x6B61); // "ak" in little-endian
+
+    private Optional<Long> uid;
+
+    public UidExtraField() {
+        this(Optional.empty());
+    }
+
+    public UidExtraField(long uid) {
+        this(Optional.of(uid));
+    }
+
+    public UidExtraField(Optional<Long> uid) {
+        this.uid = uid;
+    }
+
+    @Override
+    public ZipShort getHeaderId() {
+        return ID;
+    }
+
+    @Override
+    public ZipShort getLocalFileDataLength() {
+        return new ZipShort(Long.BYTES);
+    }
+
+    @Override
+    public ZipShort getCentralDirectoryLength() {
+        return getLocalFileDataLength();
+    }
+
+    @Override
+    public byte[] getLocalFileDataData() {
+        long value = uid.orElseThrow(() -> new RuntimeException("Value must by initialized"));
+        return ByteBuffer.allocate(Long.BYTES)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .putLong(value)
+            .array();
+    }
+
+    @Override
+    public byte[] getCentralDirectoryData() {
+        return getLocalFileDataData();
+    }
+
+    @Override
+    public void parseFromLocalFileData(byte[] buffer, int offset, int length) throws ZipException {
+        if (length != Long.BYTES) {
+            throw new ZipException("Unexpected data length for UidExtraField. Expected " + Long.BYTES + " but got " + length + ".");
+        }
+        uid = Optional.of(ByteBuffer
+                .wrap(buffer, offset, Long.BYTES)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .getLong());
+    }
+
+    @Override
+    public void parseFromCentralDirectoryData(byte[] buffer, int offset, int length) throws ZipException {
+        parseFromLocalFileData(buffer, offset, length);
+    }
+
+    public Optional<Long> getUid() {
+        return uid;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof UidExtraField) {
+            UidExtraField that = (UidExtraField) o;
+
+            return Objects.equals(this.uid, that.uid);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(uid);
+    }
+}

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/UidExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/UidExtraField.java
@@ -19,94 +19,28 @@
 
 package org.apache.james.mailbox.backup;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.zip.ZipException;
 
-import org.apache.commons.compress.archivers.zip.ZipExtraField;
 import org.apache.commons.compress.archivers.zip.ZipShort;
 
-public class UidExtraField implements ZipExtraField {
+public class UidExtraField extends LongExtraField {
 
     public static final ZipShort ID = new ZipShort(0x6B61); // "ak" in little-endian
 
-    private Optional<Long> uid;
-
     public UidExtraField() {
-        this(Optional.empty());
+        super();
     }
 
-    public UidExtraField(long uid) {
-        this(Optional.of(uid));
+    public UidExtraField(long value) {
+        super(value);
     }
 
-    public UidExtraField(Optional<Long> uid) {
-        this.uid = uid;
+    public UidExtraField(Optional<Long> value) {
+        super(value);
     }
 
     @Override
     public ZipShort getHeaderId() {
         return ID;
-    }
-
-    @Override
-    public ZipShort getLocalFileDataLength() {
-        return new ZipShort(Long.BYTES);
-    }
-
-    @Override
-    public ZipShort getCentralDirectoryLength() {
-        return getLocalFileDataLength();
-    }
-
-    @Override
-    public byte[] getLocalFileDataData() {
-        long value = uid.orElseThrow(() -> new RuntimeException("Value must by initialized"));
-        return ByteBuffer.allocate(Long.BYTES)
-            .order(ByteOrder.LITTLE_ENDIAN)
-            .putLong(value)
-            .array();
-    }
-
-    @Override
-    public byte[] getCentralDirectoryData() {
-        return getLocalFileDataData();
-    }
-
-    @Override
-    public void parseFromLocalFileData(byte[] buffer, int offset, int length) throws ZipException {
-        if (length != Long.BYTES) {
-            throw new ZipException("Unexpected data length for UidExtraField. Expected " + Long.BYTES + " but got " + length + ".");
-        }
-        uid = Optional.of(ByteBuffer
-                .wrap(buffer, offset, Long.BYTES)
-                .order(ByteOrder.LITTLE_ENDIAN)
-                .getLong());
-    }
-
-    @Override
-    public void parseFromCentralDirectoryData(byte[] buffer, int offset, int length) throws ZipException {
-        parseFromLocalFileData(buffer, offset, length);
-    }
-
-    public Optional<Long> getUid() {
-        return uid;
-    }
-
-    @Override
-    public final boolean equals(Object o) {
-        if (o instanceof UidExtraField) {
-            UidExtraField that = (UidExtraField) o;
-
-            return Objects.equals(this.uid, that.uid);
-        }
-        return false;
-    }
-
-    @Override
-    public final int hashCode() {
-        return Objects.hash(uid);
     }
 }

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/UidValidityExtraField.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/UidValidityExtraField.java
@@ -1,0 +1,44 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.mailbox.backup;
+
+import java.util.Optional;
+
+import org.apache.commons.compress.archivers.zip.ZipShort;
+
+public class UidValidityExtraField extends LongExtraField {
+    public static final ZipShort ID = new ZipShort(0x6E61); // "an" in little-endian
+
+    public UidValidityExtraField() {
+        super();
+    }
+
+    public UidValidityExtraField(long value) {
+        super(value);
+    }
+
+    public UidValidityExtraField(Optional<Long> value) {
+        super(value);
+    }
+
+    @Override
+    public ZipShort getHeaderId() {
+        return ID;
+    }
+}

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Zipper.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Zipper.java
@@ -36,6 +36,9 @@ import com.github.fge.lambdas.Throwing;
 public class Zipper implements Backup {
     public Zipper() {
         ExtraFieldUtils.register(SizeExtraField.class);
+        ExtraFieldUtils.register(UidExtraField.class);
+        ExtraFieldUtils.register(MessageIdExtraField.class);
+        ExtraFieldUtils.register(MailboxIdExtraField.class);
     }
 
     @Override
@@ -61,7 +64,12 @@ public class Zipper implements Backup {
     private void storeInArchive(MailboxMessage message, ZipArchiveOutputStream archiveOutputStream) throws IOException {
         String entryId = message.getMessageId().serialize();
         ZipArchiveEntry archiveEntry = (ZipArchiveEntry) archiveOutputStream.createArchiveEntry(new File(entryId), entryId);
+
         archiveEntry.addExtraField(new SizeExtraField(message.getFullContentOctets()));
+        archiveEntry.addExtraField(new UidExtraField(message.getUid().asLong()));
+        archiveEntry.addExtraField(new MessageIdExtraField(message.getMessageId().serialize()));
+        archiveEntry.addExtraField(new MailboxIdExtraField(message.getMailboxId().serialize()));
+
         archiveOutputStream.putArchiveEntry(archiveEntry);
         IOUtils.copy(message.getFullContent(), archiveOutputStream);
         archiveOutputStream.closeArchiveEntry();

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Zipper.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Zipper.java
@@ -46,14 +46,22 @@ public class Zipper implements Backup {
     @Override
     public void archive(List<Mailbox> mailboxes, Stream<MailboxMessage> messages, OutputStream destination) throws IOException {
         try (ZipArchiveOutputStream archiveOutputStream = new ZipArchiveOutputStream(destination)) {
-            for (Mailbox mailbox: mailboxes) {
-                storeInArchive(mailbox, archiveOutputStream);
-            }
-            messages.forEach(Throwing.<MailboxMessage>consumer(message -> {
-                storeInArchive(message, archiveOutputStream);
-            }).sneakyThrow());
+            storeMailboxes(mailboxes, archiveOutputStream);
+            storeMessages(messages, archiveOutputStream);
             archiveOutputStream.finish();
         }
+    }
+
+    private void storeMailboxes(List<Mailbox> mailboxes, ZipArchiveOutputStream archiveOutputStream) throws IOException {
+        for (Mailbox mailbox: mailboxes) {
+            storeInArchive(mailbox, archiveOutputStream);
+        }
+    }
+
+    private void storeMessages(Stream<MailboxMessage> messages, ZipArchiveOutputStream archiveOutputStream) {
+        messages.forEach(Throwing.<MailboxMessage>consumer(message -> {
+            storeInArchive(message, archiveOutputStream);
+        }).sneakyThrow());
     }
 
     private void storeInArchive(Mailbox mailbox, ZipArchiveOutputStream archiveOutputStream) throws IOException {

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Zipper.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Zipper.java
@@ -60,8 +60,8 @@ public class Zipper implements Backup {
 
     private void storeMessages(Stream<MailboxMessage> messages, ZipArchiveOutputStream archiveOutputStream) {
         messages.forEach(Throwing.<MailboxMessage>consumer(message -> {
-            storeInArchive(message, archiveOutputStream);
-        }).sneakyThrow());
+                storeInArchive(message, archiveOutputStream);
+            }).sneakyThrow());
     }
 
     private void storeInArchive(Mailbox mailbox, ZipArchiveOutputStream archiveOutputStream) throws IOException {

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Zipper.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Zipper.java
@@ -57,6 +57,9 @@ public class Zipper implements Backup {
     private void storeInArchive(Mailbox mailbox, ZipArchiveOutputStream archiveOutputStream) throws IOException {
         String name = mailbox.getName();
         ZipArchiveEntry archiveEntry = (ZipArchiveEntry) archiveOutputStream.createArchiveEntry(new Directory(name), name);
+
+        archiveEntry.addExtraField(new MailboxIdExtraField(mailbox.getMailboxId().serialize()));
+
         archiveOutputStream.putArchiveEntry(archiveEntry);
         archiveOutputStream.closeArchiveEntry();
     }

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Zipper.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Zipper.java
@@ -21,7 +21,7 @@ package org.apache.james.mailbox.backup;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.List;
+import java.util.stream.Stream;
 
 import org.apache.commons.compress.archivers.zip.ExtraFieldUtils;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
@@ -29,17 +29,19 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.apache.commons.io.IOUtils;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 
+import com.github.fge.lambdas.Throwing;
+
 public class Zipper implements Backup {
     public Zipper() {
         ExtraFieldUtils.register(SizeExtraField.class);
     }
 
     @Override
-    public void archive(List<MailboxMessage> messages, OutputStream destination) throws IOException {
+    public void archive(Stream<MailboxMessage> messages, OutputStream destination) throws IOException {
         try (ZipArchiveOutputStream archiveOutputStream = new ZipArchiveOutputStream(destination)) {
-            for (MailboxMessage message: messages) {
+            messages.forEach(Throwing.<MailboxMessage>consumer(message -> {
                 storeInArchive(message, archiveOutputStream);
-            }
+            }).sneakyThrow());
             archiveOutputStream.finish();
         }
     }

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Zipper.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Zipper.java
@@ -40,6 +40,7 @@ public class Zipper implements Backup {
         ExtraFieldUtils.register(MessageIdExtraField.class);
         ExtraFieldUtils.register(MailboxIdExtraField.class);
         ExtraFieldUtils.register(UidValidityExtraField.class);
+        ExtraFieldUtils.register(InternalDateExtraField.class);
     }
 
     @Override
@@ -74,6 +75,7 @@ public class Zipper implements Backup {
         archiveEntry.addExtraField(new UidExtraField(message.getUid().asLong()));
         archiveEntry.addExtraField(new MessageIdExtraField(message.getMessageId().serialize()));
         archiveEntry.addExtraField(new MailboxIdExtraField(message.getMailboxId().serialize()));
+        archiveEntry.addExtraField(new InternalDateExtraField(message.getInternalDate()));
 
         archiveOutputStream.putArchiveEntry(archiveEntry);
         IOUtils.copy(message.getFullContent(), archiveOutputStream);

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Zipper.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/Zipper.java
@@ -39,6 +39,7 @@ public class Zipper implements Backup {
         ExtraFieldUtils.register(UidExtraField.class);
         ExtraFieldUtils.register(MessageIdExtraField.class);
         ExtraFieldUtils.register(MailboxIdExtraField.class);
+        ExtraFieldUtils.register(UidValidityExtraField.class);
     }
 
     @Override
@@ -59,6 +60,7 @@ public class Zipper implements Backup {
         ZipArchiveEntry archiveEntry = (ZipArchiveEntry) archiveOutputStream.createArchiveEntry(new Directory(name), name);
 
         archiveEntry.addExtraField(new MailboxIdExtraField(mailbox.getMailboxId().serialize()));
+        archiveEntry.addExtraField(new UidValidityExtraField(mailbox.getUidValidity()));
 
         archiveOutputStream.putArchiveEntry(archiveEntry);
         archiveOutputStream.closeArchiveEntry();

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/DirectoryTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/DirectoryTest.java
@@ -1,0 +1,31 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.mailbox.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class DirectoryTest {
+
+    @Test
+    void isDirectoryShouldReturnTrue() {
+        assertThat(new Directory("myPath").isDirectory()).isTrue();
+    }
+}

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/InternalDateExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/InternalDateExtraFieldTest.java
@@ -1,0 +1,297 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Date;
+import java.util.zip.ZipException;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.bouncycastle.util.Arrays;
+
+import com.google.common.base.Charsets;
+
+public class InternalDateExtraFieldTest {
+    private static final byte[] ZERO_AS_BYTE_ARRAY = {0, 0, 0, 0, 0, 0, 0, 0};
+    private static final byte[] _123456789ABCDEF0_AS_LE_BYTE_ARRAY = new byte[] {(byte) 0xF0, (byte) 0xDE, (byte) 0xBC, (byte) 0x9A, 0x78, 0x56, 0x34, 0x12};
+    private static final byte[] FEDCBA9876543210_AS_LE_BYTE_ARRAY = new byte[] {0x10, 0x32, 0x54, 0x76, (byte) 0x98, (byte) 0xBA, (byte) 0xDC, (byte) 0xFE};
+    private static final byte[] UNUSED = new byte[] {(byte) 0xDE, (byte) 0xAD};
+
+    private static final byte[] DEFAULT_DATE_BYTE_ARRAY = {(byte) 0xdd, (byte) 0xf2, (byte) 0xdc, 0x20, 0x64, 0x01, 0x00, 0x00 };
+    private static final long DEFAULT_DATE_TIMESTAMP = 1529559708381L;
+    private static final Date DEFAULT_DATE = new Date(DEFAULT_DATE_TIMESTAMP);
+
+    @Nested
+    class GetHeaderId {
+
+        @Test
+        void getHeaderIdShouldReturnSpecificStringInLittleEndian() {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            ByteBuffer byteBuffer = ByteBuffer.wrap(testee.getHeaderId().getBytes())
+                .order(ByteOrder.LITTLE_ENDIAN);
+            assertThat(Charsets.US_ASCII.decode(byteBuffer).toString())
+                .isEqualTo("ao");
+        }
+    }
+
+    @Nested
+    class GetLocalFileDataLength {
+        @Test
+        void getLocalFileDataLengthShouldReturnIntegerSize() {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            assertThat(testee.getLocalFileDataLength().getValue())
+                .isEqualTo(Long.BYTES);
+        }
+    }
+
+    @Nested
+    class GetCentralDirectoryLength {
+
+        @Test
+        void getCentralDirectoryLengthShouldReturnIntegerSize() {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            assertThat(testee.getCentralDirectoryLength().getValue())
+                .isEqualTo(Long.BYTES);
+        }
+
+
+        @Test
+        void getCentralDirectoryDataShouldThrowWhenNoValue() {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            assertThatThrownBy(() -> testee.getCentralDirectoryData())
+                .isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        void getCentralDirectoryDataShouldReturnZeroWhenZero() {
+            byte[] actual = new InternalDateExtraField(0).getCentralDirectoryData();
+            assertThat(actual).isEqualTo(ZERO_AS_BYTE_ARRAY);
+        }
+
+        @Test
+        void getCentralDirectoryDataShouldReturnValueInLittleIndianWhen123456789ABCDEF0() {
+            byte[] actual = new InternalDateExtraField(0x123456789ABCDEF0L).getCentralDirectoryData();
+            assertThat(actual).isEqualTo(_123456789ABCDEF0_AS_LE_BYTE_ARRAY);
+        }
+
+        @Test
+        void getCentralDirectoryDataShouldReturnValueInLittleIndianWhenFEDCBA9876543210() {
+            byte[] actual = new InternalDateExtraField(0xFEDCBA9876543210L).getCentralDirectoryData();
+            assertThat(actual).isEqualTo(FEDCBA9876543210_AS_LE_BYTE_ARRAY);
+        }
+    }
+
+    @Nested
+    class GetLocalFileDataData {
+
+        @Test
+        void getLocalFileDataDataShouldThrowWhenNoValue() {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            assertThatThrownBy(() -> testee.getLocalFileDataData())
+                .isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        void getLocalFileDataDataShouldReturnZeroWhenZero() {
+            byte[] actual = new InternalDateExtraField(0).getLocalFileDataData();
+            assertThat(actual).isEqualTo(ZERO_AS_BYTE_ARRAY);
+        }
+
+        @Test
+        void getLocalFileDataDataShouldReturnValueInLittleIndianWhen123456789ABCDEF0() {
+            byte[] actual = new InternalDateExtraField(0x123456789ABCDEF0L).getLocalFileDataData();
+            assertThat(actual).isEqualTo(_123456789ABCDEF0_AS_LE_BYTE_ARRAY);
+        }
+
+        @Test
+        void getLocalFileDataDataShouldReturnValueInLittleIndianWhenFEDCBA9876543210() {
+            byte[] actual = new InternalDateExtraField(0xFEDCBA9876543210L).getLocalFileDataData();
+            assertThat(actual).isEqualTo(FEDCBA9876543210_AS_LE_BYTE_ARRAY);
+        }
+    }
+
+    @Nested
+    class ParseFromLocalFileData {
+
+        @Test
+        void parseFromLocalFileDataShouldThrownWhenLengthIsSmallerThan8() {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            byte[] input = new byte[] {0, 0, 0, 0, 0, 0, 0};
+            assertThatThrownBy(() -> testee.parseFromLocalFileData(input, 0, 7))
+                .isInstanceOf(ZipException.class);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldThrownWhenLengthIsBiggerThan8() {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            byte[] input = new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0};
+            assertThatThrownBy(() -> testee.parseFromLocalFileData(input, 0, 9))
+                .isInstanceOf(ZipException.class);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldParseWhenZero() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            testee.parseFromLocalFileData(ZERO_AS_BYTE_ARRAY, 0, 8);
+            assertThat(testee.getValue())
+                .contains(0L);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldParseWhen123456789ABCDEF0InLittleEndian() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            testee.parseFromLocalFileData(_123456789ABCDEF0_AS_LE_BYTE_ARRAY, 0, 8);
+            assertThat(testee.getValue())
+                .contains(0x123456789ABCDEF0L);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldParseWhenFEDCBA9876543210InLittleEndian() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            byte[] input = FEDCBA9876543210_AS_LE_BYTE_ARRAY;
+            testee.parseFromLocalFileData(input, 0, 8);
+            assertThat(testee.getValue())
+                .contains(0xFEDCBA9876543210L);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldHandleOffset() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            byte[] input = Arrays.concatenate(UNUSED, _123456789ABCDEF0_AS_LE_BYTE_ARRAY);
+            testee.parseFromLocalFileData(input, 2, 8);
+            assertThat(testee.getValue())
+                .contains(0x123456789ABCDEF0L);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldReturnZeroDayWhenZero() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            testee.parseFromLocalFileData(ZERO_AS_BYTE_ARRAY, 0, 8);
+
+            assertThat(testee.getDateValue())
+                .contains(new Date(0L));
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldReturnDefaultDateWhenPassDefaultDateByteArray() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField(new Date());
+            testee.parseFromLocalFileData(DEFAULT_DATE_BYTE_ARRAY, 0, 8);
+
+            assertThat(testee.getDateValue())
+                .contains(DEFAULT_DATE);
+        }
+    }
+
+    @Nested
+    class ParseFromCentralDirectoryData {
+
+        @Test
+        void parseFromCentralDirectoryDataShouldThrownWhenLengthIsSmallerThan8() {
+            InternalDateExtraField testee = new InternalDateExtraField();
+            byte[] input = new byte[7];
+
+            assertThatThrownBy(() -> testee.parseFromCentralDirectoryData(input, 0, 7))
+                .isInstanceOf(ZipException.class);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldThrownWhenLengthIsBiggerThan8() {
+            InternalDateExtraField testee = new InternalDateExtraField();
+            byte[] input = new byte[9];
+
+            assertThatThrownBy(() -> testee.parseFromCentralDirectoryData(input, 0, 9))
+                .isInstanceOf(ZipException.class);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldParseWhenZero() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            testee.parseFromCentralDirectoryData(ZERO_AS_BYTE_ARRAY, 0, 8);
+            assertThat(testee.getValue())
+                .contains(0L);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldParseWhen123456789ABCDEF0InLittleEndian() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            testee.parseFromCentralDirectoryData(_123456789ABCDEF0_AS_LE_BYTE_ARRAY, 0, 8);
+            assertThat(testee.getValue())
+                .contains(0x123456789ABCDEF0L);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldParseWhenFEDCBA9876543210InLittleEndian() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+            byte[] input = FEDCBA9876543210_AS_LE_BYTE_ARRAY;
+
+            testee.parseFromCentralDirectoryData(input, 0, 8);
+            assertThat(testee.getValue())
+                .contains(0xFEDCBA9876543210L);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldHandleOffset() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+            byte[] input = Arrays.concatenate(UNUSED, _123456789ABCDEF0_AS_LE_BYTE_ARRAY);
+
+            testee.parseFromCentralDirectoryData(input, 2, 8);
+            assertThat(testee.getValue())
+                .contains(0x123456789ABCDEF0L);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldReturnZeroDayWhenZero() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            testee.parseFromCentralDirectoryData(ZERO_AS_BYTE_ARRAY, 0, 8);
+
+            assertThat(testee.getDateValue())
+                .contains(new Date(0L));
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldReturnDefaultDateWhenPassDefaultDateByteArray() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField(new Date());
+            testee.parseFromCentralDirectoryData(DEFAULT_DATE_BYTE_ARRAY, 0, 8);
+
+            assertThat(testee.getDateValue())
+                .contains(DEFAULT_DATE);
+        }
+    }
+}

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/InternalDateExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/InternalDateExtraFieldTest.java
@@ -20,14 +20,14 @@
 package org.apache.james.mailbox.backup;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.apache.james.mailbox.backup.MailboxMessageFixture.DATE_1;
-import static org.apache.james.mailbox.backup.MailboxMessageFixture.DATE_STRING_1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 import org.junit.jupiter.api.Nested;
@@ -40,6 +40,8 @@ import nl.jqno.equalsverifier.Warning;
 
 public class InternalDateExtraFieldTest {
 
+    public static final String DATE_STRING_1 = "2018-02-15T22:54:02+07:00";
+    private static final ZonedDateTime DATE_1 = ZonedDateTime.parse(DATE_STRING_1, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
     private static final byte[] DATE_STRING_1_BYTE_ARRAY = DATE_STRING_1.getBytes(StandardCharsets.UTF_8);
 
     private static final String DEFAULT_MAILBOX_ID = "123456789ABCDEF0";
@@ -208,7 +210,7 @@ public class InternalDateExtraFieldTest {
         void parseFromLocalFileDataShouldReturnDateWhenPassDateByteArray() {
             InternalDateExtraField testee = new InternalDateExtraField();
 
-            testee.parseFromLocalFileData(DATE_STRING_1_BYTE_ARRAY, 0, 20);
+            testee.parseFromLocalFileData(DATE_STRING_1_BYTE_ARRAY, 0, 25);
 
             assertThat(testee.getDateValue())
                 .contains(Date.from(DATE_1.toInstant()));
@@ -252,7 +254,7 @@ public class InternalDateExtraFieldTest {
         void parseFromCentralDirectoryDataShouldReturnDateWhenPassDateByteArray() {
             InternalDateExtraField testee = new InternalDateExtraField();
 
-            testee.parseFromCentralDirectoryData(DATE_STRING_1_BYTE_ARRAY, 0, 20);
+            testee.parseFromCentralDirectoryData(DATE_STRING_1_BYTE_ARRAY, 0, 25);
 
             assertThat(testee.getDateValue())
                 .contains(Date.from(DATE_1.toInstant()));

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/InternalDateExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/InternalDateExtraFieldTest.java
@@ -46,7 +46,10 @@ public class InternalDateExtraFieldTest {
 
     private static final long DEFAULT_DATE_TIMESTAMP = 1529559708381L;
     private static final byte[] DEFAULT_DATE_BYTE_ARRAY = {(byte) 0xdd, (byte) 0xf2, (byte) 0xdc, 0x20, 0x64, 0x01, 0x00, 0x00 };
-    private static final Date DEFAULT_DATE = new Date(DEFAULT_DATE_TIMESTAMP);
+    private static final Date DEFAULT_DATE_LOCAL = new Date(DEFAULT_DATE_TIMESTAMP);
+    private static final Date DEFAULT_DATE_UTC = Date.from(ZonedDateTime
+            .ofInstant(DEFAULT_DATE_LOCAL.toInstant(), ZoneId.systemDefault())
+            .withZoneSameInstant(ZoneId.of("UTC")).toInstant());
 
     @Test
     public void shouldMatchBeanContract() {
@@ -214,17 +217,17 @@ public class InternalDateExtraFieldTest {
 
             testee.parseFromLocalFileData(ZERO_AS_BYTE_ARRAY, 0, 8);
 
-            assertThat(testee.getUTCDateValue())
+            assertThat(testee.getDateValue())
                 .contains(new Date(0L));
         }
 
         @Test
-        void parseFromLocalFileDataShouldReturnDefaultDateWhenPassDefaultDateByteArray() throws Exception {
-            InternalDateExtraField testee = new InternalDateExtraField(new Date());
+        void parseFromLocalFileDataShouldReturnDefaultDateWhenPassDefaultUTCDateByteArray() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
             testee.parseFromLocalFileData(DEFAULT_DATE_BYTE_ARRAY, 0, 8);
 
-            assertThat(testee.getUTCDateValue())
-                .contains(DEFAULT_DATE);
+            assertThat(testee.getDateValue())
+                .contains(DEFAULT_DATE_UTC);
         }
 
         @Test
@@ -232,12 +235,8 @@ public class InternalDateExtraFieldTest {
             InternalDateExtraField testee = new InternalDateExtraField();
             testee.parseFromLocalFileData(DEFAULT_DATE_BYTE_ARRAY, 0, 8);
 
-            Date expectedTimeZonedDate = Date.from(ZonedDateTime
-                .ofInstant(DEFAULT_DATE.toInstant(), ZoneId.systemDefault())
-                .toInstant());
-
             assertThat(testee.getLocalDateValue())
-                .contains(expectedTimeZonedDate);
+                .contains(DEFAULT_DATE_LOCAL);
         }
     }
 
@@ -306,17 +305,17 @@ public class InternalDateExtraFieldTest {
 
             testee.parseFromCentralDirectoryData(ZERO_AS_BYTE_ARRAY, 0, 8);
 
-            assertThat(testee.getUTCDateValue())
+            assertThat(testee.getDateValue())
                 .contains(new Date(0L));
         }
 
         @Test
-        void parseFromCentralDirectoryDataShouldReturnDefaultDateWhenPassDefaultDateByteArray() throws Exception {
+        void parseFromCentralDirectoryDataShouldReturnDefaultDateWhenPassDefaultUTCDateByteArray() throws Exception {
             InternalDateExtraField testee = new InternalDateExtraField();
             testee.parseFromCentralDirectoryData(DEFAULT_DATE_BYTE_ARRAY, 0, 8);
 
-            assertThat(testee.getUTCDateValue())
-                .contains(DEFAULT_DATE);
+            assertThat(testee.getDateValue())
+                .contains(DEFAULT_DATE_UTC);
         }
 
         @Test
@@ -324,12 +323,8 @@ public class InternalDateExtraFieldTest {
             InternalDateExtraField testee = new InternalDateExtraField();
             testee.parseFromCentralDirectoryData(DEFAULT_DATE_BYTE_ARRAY, 0, 8);
 
-            Date expectedTimeZonedDate = Date.from(ZonedDateTime
-                .ofInstant(DEFAULT_DATE.toInstant(), ZoneId.systemDefault())
-                .toInstant());
-
             assertThat(testee.getLocalDateValue())
-                .contains(expectedTimeZonedDate);
+                .contains(DEFAULT_DATE_LOCAL);
         }
     }
 }

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/InternalDateExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/InternalDateExtraFieldTest.java
@@ -19,19 +19,19 @@
 
 package org.apache.james.mailbox.backup;
 
-import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
+import java.util.zip.ZipException;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.bouncycastle.util.Arrays;
 
 import com.google.common.base.Charsets;
 
@@ -39,18 +39,18 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 
 public class InternalDateExtraFieldTest {
+    private static final byte[] ZERO_AS_BYTE_ARRAY = {0, 0, 0, 0, 0, 0, 0, 0};
+    private static final byte[] _123456789ABCDEF0_AS_LE_BYTE_ARRAY = new byte[] {(byte) 0xF0, (byte) 0xDE, (byte) 0xBC, (byte) 0x9A, 0x78, 0x56, 0x34, 0x12};
+    private static final byte[] FEDCBA9876543210_AS_LE_BYTE_ARRAY = new byte[] {0x10, 0x32, 0x54, 0x76, (byte) 0x98, (byte) 0xBA, (byte) 0xDC, (byte) 0xFE};
+    private static final byte[] UNUSED = new byte[] {(byte) 0xDE, (byte) 0xAD};
 
-    public static final String DATE_STRING_1 = "2018-02-15T22:54:02Z";
-    private static final ZonedDateTime DATE_1 = ZonedDateTime.parse(DATE_STRING_1, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-    private static final byte[] DATE_STRING_1_BYTE_ARRAY = DATE_STRING_1.getBytes(StandardCharsets.UTF_8);
-
-    private static final String DEFAULT_MAILBOX_ID = "123456789ABCDEF0";
-    private static final byte[] DEFAULT_MAILBOX_ID_BYTE_ARRAY = new byte[] {0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x30};
-    private static final byte [] EMPTY_BYTE_ARRAY = {};
+    private static final long DEFAULT_DATE_TIMESTAMP = 1529559708381L;
+    private static final byte[] DEFAULT_DATE_BYTE_ARRAY = {(byte) 0xdd, (byte) 0xf2, (byte) 0xdc, 0x20, 0x64, 0x01, 0x00, 0x00 };
+    private static final Date DEFAULT_DATE = new Date(DEFAULT_DATE_TIMESTAMP);
 
     @Test
     public void shouldMatchBeanContract() {
-        EqualsVerifier.forClass(MailboxIdExtraField.class)
+        EqualsVerifier.forClass(InternalDateExtraField.class)
             .suppress(Warning.NONFINAL_FIELDS)
             .verify();
     }
@@ -60,31 +60,23 @@ public class InternalDateExtraFieldTest {
 
         @Test
         void getHeaderIdShouldReturnSpecificStringInLittleEndian() {
-            MailboxIdExtraField testee = new MailboxIdExtraField();
+            InternalDateExtraField testee = new InternalDateExtraField();
+
             ByteBuffer byteBuffer = ByteBuffer.wrap(testee.getHeaderId().getBytes())
                 .order(ByteOrder.LITTLE_ENDIAN);
-
             assertThat(Charsets.US_ASCII.decode(byteBuffer).toString())
-                .isEqualTo("am");
+                .isEqualTo("ao");
         }
     }
 
     @Nested
     class GetLocalFileDataLength {
-
-        @Test
-        void getLocalFileDataLengthShouldThrowWhenNoValue() {
-            MailboxIdExtraField testee = new MailboxIdExtraField();
-            assertThatThrownBy(() -> testee.getLocalFileDataLength().getValue())
-                .isInstanceOf(RuntimeException.class);
-        }
-
         @Test
         void getLocalFileDataLengthShouldReturnIntegerSize() {
-            MailboxIdExtraField testee = new MailboxIdExtraField(DEFAULT_MAILBOX_ID);
+            InternalDateExtraField testee = new InternalDateExtraField();
 
             assertThat(testee.getLocalFileDataLength().getValue())
-                .isEqualTo(16);
+                .isEqualTo(Long.BYTES);
         }
     }
 
@@ -92,18 +84,38 @@ public class InternalDateExtraFieldTest {
     class GetCentralDirectoryLength {
 
         @Test
-        void getCentralDirectoryLengthShouldThrowWhenNoValue() {
-            MailboxIdExtraField testee = new MailboxIdExtraField();
-            assertThatThrownBy(() -> testee.getCentralDirectoryLength().getValue())
+        void getCentralDirectoryLengthShouldReturnIntegerSize() {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            assertThat(testee.getCentralDirectoryLength().getValue())
+                .isEqualTo(Long.BYTES);
+        }
+
+
+        @Test
+        void getCentralDirectoryDataShouldThrowWhenNoValue() {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            assertThatThrownBy(() -> testee.getCentralDirectoryData())
                 .isInstanceOf(RuntimeException.class);
         }
 
         @Test
-        void getCentralDirectoryLengthShouldReturnIntegerSize() {
-            MailboxIdExtraField testee = new MailboxIdExtraField(DEFAULT_MAILBOX_ID);
+        void getCentralDirectoryDataShouldReturnZeroWhenZero() {
+            byte[] actual = new InternalDateExtraField(0).getCentralDirectoryData();
+            assertThat(actual).isEqualTo(ZERO_AS_BYTE_ARRAY);
+        }
 
-            assertThat(testee.getCentralDirectoryLength().getValue())
-                .isEqualTo(16);
+        @Test
+        void getCentralDirectoryDataShouldReturnValueInLittleIndianWhen123456789ABCDEF0() {
+            byte[] actual = new InternalDateExtraField(0x123456789ABCDEF0L).getCentralDirectoryData();
+            assertThat(actual).isEqualTo(_123456789ABCDEF0_AS_LE_BYTE_ARRAY);
+        }
+
+        @Test
+        void getCentralDirectoryDataShouldReturnValueInLittleIndianWhenFEDCBA9876543210() {
+            byte[] actual = new InternalDateExtraField(0xFEDCBA9876543210L).getCentralDirectoryData();
+            assertThat(actual).isEqualTo(FEDCBA9876543210_AS_LE_BYTE_ARRAY);
         }
     }
 
@@ -112,64 +124,28 @@ public class InternalDateExtraFieldTest {
 
         @Test
         void getLocalFileDataDataShouldThrowWhenNoValue() {
-            MailboxIdExtraField testee = new MailboxIdExtraField();
+            InternalDateExtraField testee = new InternalDateExtraField();
 
             assertThatThrownBy(() -> testee.getLocalFileDataData())
                 .isInstanceOf(RuntimeException.class);
         }
 
         @Test
-        void getLocalFileDataDataShouldReturnEmptyArrayWhenValueIsEmpty() {
-            byte[] actual = new MailboxIdExtraField(EMPTY).getLocalFileDataData();
-            assertThat(actual).isEqualTo(EMPTY_BYTE_ARRAY);
+        void getLocalFileDataDataShouldReturnZeroWhenZero() {
+            byte[] actual = new InternalDateExtraField(0).getLocalFileDataData();
+            assertThat(actual).isEqualTo(ZERO_AS_BYTE_ARRAY);
         }
 
         @Test
-        void getLocalFileDataDataShouldReturnValueInByteArray() {
-            byte[] actual = new MailboxIdExtraField(DEFAULT_MAILBOX_ID).getLocalFileDataData();
-            assertThat(actual).isEqualTo(DEFAULT_MAILBOX_ID_BYTE_ARRAY);
+        void getLocalFileDataDataShouldReturnValueInLittleIndianWhen123456789ABCDEF0() {
+            byte[] actual = new InternalDateExtraField(0x123456789ABCDEF0L).getLocalFileDataData();
+            assertThat(actual).isEqualTo(_123456789ABCDEF0_AS_LE_BYTE_ARRAY);
         }
 
         @Test
-        void getLocalFileDataShouldReturnDateByteArrayWhenPassDate() {
-            byte[] actual = new InternalDateExtraField(Date.from(DATE_1.toInstant()))
-                .getLocalFileDataData();
-
-            assertThat(actual)
-                .isEqualTo(DATE_STRING_1_BYTE_ARRAY);
-        }
-    }
-
-    @Nested
-    class GetCentralDirectoryData {
-
-        @Test
-        void getCentralDirectoryDataShouldThrowWhenNoValue() {
-            MailboxIdExtraField testee = new MailboxIdExtraField();
-
-            assertThatThrownBy(() -> testee.getCentralDirectoryData())
-                .isInstanceOf(RuntimeException.class);
-        }
-
-        @Test
-        void getCentralDirectoryDataShouldReturnEmptyArrayWhenValueIsEmpty() {
-            byte[] actual = new MailboxIdExtraField(EMPTY).getCentralDirectoryData();
-            assertThat(actual).isEqualTo(EMPTY_BYTE_ARRAY);
-        }
-
-        @Test
-        void getCentralDirectoryDataShouldReturnValueInByteArray() {
-            byte[] actual = new MailboxIdExtraField(DEFAULT_MAILBOX_ID).getCentralDirectoryData();
-            assertThat(actual).isEqualTo(DEFAULT_MAILBOX_ID_BYTE_ARRAY);
-        }
-
-        @Test
-        void getCentralDirectoryDataShouldReturnDateByteArrayWhenPassDate() {
-            byte[] actual = new InternalDateExtraField(Date.from(DATE_1.toInstant()))
-                .getCentralDirectoryData();
-
-            assertThat(actual)
-                .isEqualTo(DATE_STRING_1_BYTE_ARRAY);
+        void getLocalFileDataDataShouldReturnValueInLittleIndianWhenFEDCBA9876543210() {
+            byte[] actual = new InternalDateExtraField(0xFEDCBA9876543210L).getLocalFileDataData();
+            assertThat(actual).isEqualTo(FEDCBA9876543210_AS_LE_BYTE_ARRAY);
         }
     }
 
@@ -177,43 +153,91 @@ public class InternalDateExtraFieldTest {
     class ParseFromLocalFileData {
 
         @Test
-        void parseFromLocalFileDataShouldParseWhenZero() {
-            MailboxIdExtraField testee = new MailboxIdExtraField();
-
-            testee.parseFromLocalFileData(EMPTY_BYTE_ARRAY, 0, 0);
-
-            assertThat(testee.getValue())
-                .contains(EMPTY);
-        }
-
-        @Test
-        void parseFromLocalFileDataShouldParseByteArray() {
-            MailboxIdExtraField testee = new MailboxIdExtraField();
-
-            testee.parseFromLocalFileData(DEFAULT_MAILBOX_ID_BYTE_ARRAY, 0, 16);
-
-            assertThat(testee.getValue())
-                .contains(DEFAULT_MAILBOX_ID);
-        }
-
-        @Test
-        void parseFromLocalFileDataShouldHandleOffset() {
-            MailboxIdExtraField testee = new MailboxIdExtraField();
-
-            testee.parseFromLocalFileData(DEFAULT_MAILBOX_ID_BYTE_ARRAY, 2, 14);
-
-            assertThat(testee.getValue())
-                .contains("3456789ABCDEF0");
-        }
-
-        @Test
-        void parseFromLocalFileDataShouldReturnDateWhenPassDateByteArray() {
+        void parseFromLocalFileDataShouldThrownWhenLengthIsSmallerThan8() {
             InternalDateExtraField testee = new InternalDateExtraField();
 
-            testee.parseFromLocalFileData(DATE_STRING_1_BYTE_ARRAY, 0, 20);
+            byte[] input = new byte[] {0, 0, 0, 0, 0, 0, 0};
+            assertThatThrownBy(() -> testee.parseFromLocalFileData(input, 0, 7))
+                .isInstanceOf(ZipException.class);
+        }
 
-            assertThat(testee.getDateValue())
-                .contains(Date.from(DATE_1.toInstant()));
+        @Test
+        void parseFromLocalFileDataShouldThrownWhenLengthIsBiggerThan8() {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            byte[] input = new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0};
+            assertThatThrownBy(() -> testee.parseFromLocalFileData(input, 0, 9))
+                .isInstanceOf(ZipException.class);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldParseWhenZero() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            testee.parseFromLocalFileData(ZERO_AS_BYTE_ARRAY, 0, 8);
+            assertThat(testee.getValue())
+                .contains(0L);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldParseWhen123456789ABCDEF0InLittleEndian() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            testee.parseFromLocalFileData(_123456789ABCDEF0_AS_LE_BYTE_ARRAY, 0, 8);
+            assertThat(testee.getValue())
+                .contains(0x123456789ABCDEF0L);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldParseWhenFEDCBA9876543210InLittleEndian() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            byte[] input = FEDCBA9876543210_AS_LE_BYTE_ARRAY;
+            testee.parseFromLocalFileData(input, 0, 8);
+            assertThat(testee.getValue())
+                .contains(0xFEDCBA9876543210L);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldHandleOffset() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            byte[] input = Arrays.concatenate(UNUSED, _123456789ABCDEF0_AS_LE_BYTE_ARRAY);
+            testee.parseFromLocalFileData(input, 2, 8);
+            assertThat(testee.getValue())
+                .contains(0x123456789ABCDEF0L);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldReturnZeroDayWhenZero() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            testee.parseFromLocalFileData(ZERO_AS_BYTE_ARRAY, 0, 8);
+
+            assertThat(testee.getUTCDateValue())
+                .contains(new Date(0L));
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldReturnDefaultDateWhenPassDefaultDateByteArray() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField(new Date());
+            testee.parseFromLocalFileData(DEFAULT_DATE_BYTE_ARRAY, 0, 8);
+
+            assertThat(testee.getUTCDateValue())
+                .contains(DEFAULT_DATE);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldReturnLocalDateWhenPassDefaultDateByteArray() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+            testee.parseFromLocalFileData(DEFAULT_DATE_BYTE_ARRAY, 0, 8);
+
+            Date expectedTimeZonedDate = Date.from(ZonedDateTime
+                .ofInstant(DEFAULT_DATE.toInstant(), ZoneId.systemDefault())
+                .toInstant());
+
+            assertThat(testee.getLocalDateValue())
+                .contains(expectedTimeZonedDate);
         }
     }
 
@@ -221,43 +245,91 @@ public class InternalDateExtraFieldTest {
     class ParseFromCentralDirectoryData {
 
         @Test
-        void parseFromCentralDirectoryDataShouldParseWhenZero() {
-            MailboxIdExtraField testee = new MailboxIdExtraField();
+        void parseFromCentralDirectoryDataShouldThrownWhenLengthIsSmallerThan8() {
+            InternalDateExtraField testee = new InternalDateExtraField();
+            byte[] input = new byte[7];
 
-            testee.parseFromCentralDirectoryData(EMPTY_BYTE_ARRAY, 0, 0);
-
-            assertThat(testee.getValue())
-                .contains(EMPTY);
+            assertThatThrownBy(() -> testee.parseFromCentralDirectoryData(input, 0, 7))
+                .isInstanceOf(ZipException.class);
         }
 
         @Test
-        void parseFromCentralDirectoryDataShouldParseByteArray() {
-            MailboxIdExtraField testee = new MailboxIdExtraField();
+        void parseFromCentralDirectoryDataShouldThrownWhenLengthIsBiggerThan8() {
+            InternalDateExtraField testee = new InternalDateExtraField();
+            byte[] input = new byte[9];
 
-            testee.parseFromCentralDirectoryData(DEFAULT_MAILBOX_ID_BYTE_ARRAY, 0, 16);
-
-            assertThat(testee.getValue())
-                .contains(DEFAULT_MAILBOX_ID);
+            assertThatThrownBy(() -> testee.parseFromCentralDirectoryData(input, 0, 9))
+                .isInstanceOf(ZipException.class);
         }
 
         @Test
-        void parseFromCentralDirectoryDataShouldHandleOffset() {
-            MailboxIdExtraField testee = new MailboxIdExtraField();
-
-            testee.parseFromCentralDirectoryData(DEFAULT_MAILBOX_ID_BYTE_ARRAY, 2, 14);
-
-            assertThat(testee.getValue())
-                .contains("3456789ABCDEF0");
-        }
-
-        @Test
-        void parseFromCentralDirectoryDataShouldReturnDateWhenPassDateByteArray() {
+        void parseFromCentralDirectoryDataShouldParseWhenZero() throws Exception {
             InternalDateExtraField testee = new InternalDateExtraField();
 
-            testee.parseFromCentralDirectoryData(DATE_STRING_1_BYTE_ARRAY, 0, 20);
+            testee.parseFromCentralDirectoryData(ZERO_AS_BYTE_ARRAY, 0, 8);
+            assertThat(testee.getValue())
+                .contains(0L);
+        }
 
-            assertThat(testee.getDateValue())
-                .contains(Date.from(DATE_1.toInstant()));
+        @Test
+        void parseFromCentralDirectoryDataShouldParseWhen123456789ABCDEF0InLittleEndian() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            testee.parseFromCentralDirectoryData(_123456789ABCDEF0_AS_LE_BYTE_ARRAY, 0, 8);
+            assertThat(testee.getValue())
+                .contains(0x123456789ABCDEF0L);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldParseWhenFEDCBA9876543210InLittleEndian() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+            byte[] input = FEDCBA9876543210_AS_LE_BYTE_ARRAY;
+
+            testee.parseFromCentralDirectoryData(input, 0, 8);
+            assertThat(testee.getValue())
+                .contains(0xFEDCBA9876543210L);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldHandleOffset() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+            byte[] input = Arrays.concatenate(UNUSED, _123456789ABCDEF0_AS_LE_BYTE_ARRAY);
+
+            testee.parseFromCentralDirectoryData(input, 2, 8);
+            assertThat(testee.getValue())
+                .contains(0x123456789ABCDEF0L);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldReturnZeroDayWhenZero() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+
+            testee.parseFromCentralDirectoryData(ZERO_AS_BYTE_ARRAY, 0, 8);
+
+            assertThat(testee.getUTCDateValue())
+                .contains(new Date(0L));
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldReturnDefaultDateWhenPassDefaultDateByteArray() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+            testee.parseFromCentralDirectoryData(DEFAULT_DATE_BYTE_ARRAY, 0, 8);
+
+            assertThat(testee.getUTCDateValue())
+                .contains(DEFAULT_DATE);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldReturnLocalDateWhenPassDefaultDateByteArray() throws Exception {
+            InternalDateExtraField testee = new InternalDateExtraField();
+            testee.parseFromCentralDirectoryData(DEFAULT_DATE_BYTE_ARRAY, 0, 8);
+
+            Date expectedTimeZonedDate = Date.from(ZonedDateTime
+                .ofInstant(DEFAULT_DATE.toInstant(), ZoneId.systemDefault())
+                .toInstant());
+
+            assertThat(testee.getLocalDateValue())
+                .contains(expectedTimeZonedDate);
         }
     }
 }

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/InternalDateExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/InternalDateExtraFieldTest.java
@@ -24,8 +24,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.zip.ZipException;
 
@@ -45,11 +43,8 @@ public class InternalDateExtraFieldTest {
     private static final byte[] UNUSED = new byte[] {(byte) 0xDE, (byte) 0xAD};
 
     private static final long DEFAULT_DATE_TIMESTAMP = 1529559708381L;
-    private static final byte[] DEFAULT_DATE_BYTE_ARRAY = {(byte) 0xdd, (byte) 0xf2, (byte) 0xdc, 0x20, 0x64, 0x01, 0x00, 0x00 };
-    private static final Date DEFAULT_DATE_LOCAL = new Date(DEFAULT_DATE_TIMESTAMP);
-    private static final Date DEFAULT_DATE_UTC = Date.from(ZonedDateTime
-            .ofInstant(DEFAULT_DATE_LOCAL.toInstant(), ZoneId.systemDefault())
-            .withZoneSameInstant(ZoneId.of("UTC")).toInstant());
+    private static final byte[] DEFAULT_DATE_LE_BYTE_ARRAY = {(byte) 0xdd, (byte) 0xf2, (byte) 0xdc, 0x20, 0x64, 0x01, 0x00, 0x00 };
+    private static final Date DEFAULT_DATE = new Date(DEFAULT_DATE_TIMESTAMP);
 
     @Test
     public void shouldMatchBeanContract() {
@@ -120,6 +115,13 @@ public class InternalDateExtraFieldTest {
             byte[] actual = new InternalDateExtraField(0xFEDCBA9876543210L).getCentralDirectoryData();
             assertThat(actual).isEqualTo(FEDCBA9876543210_AS_LE_BYTE_ARRAY);
         }
+
+        @Test
+        void getCentralDirectoryDataShouldReturnDefaultDateWhenPassDefaultDateInByteArray() {
+            byte[] actual = new InternalDateExtraField(DEFAULT_DATE).getCentralDirectoryData();
+
+            assertThat(actual).isEqualTo(DEFAULT_DATE_LE_BYTE_ARRAY);
+        }
     }
 
     @Nested
@@ -149,6 +151,13 @@ public class InternalDateExtraFieldTest {
         void getLocalFileDataDataShouldReturnValueInLittleIndianWhenFEDCBA9876543210() {
             byte[] actual = new InternalDateExtraField(0xFEDCBA9876543210L).getLocalFileDataData();
             assertThat(actual).isEqualTo(FEDCBA9876543210_AS_LE_BYTE_ARRAY);
+        }
+
+        @Test
+        void getLocalFileDataDataShouldReturnDefaultDateWhenPassDefaultDateInByteArray() {
+            byte[] actual = new InternalDateExtraField(DEFAULT_DATE).getLocalFileDataData();
+
+            assertThat(actual).isEqualTo(DEFAULT_DATE_LE_BYTE_ARRAY);
         }
     }
 
@@ -224,19 +233,10 @@ public class InternalDateExtraFieldTest {
         @Test
         void parseFromLocalFileDataShouldReturnDefaultDateWhenPassDefaultUTCDateByteArray() throws Exception {
             InternalDateExtraField testee = new InternalDateExtraField();
-            testee.parseFromLocalFileData(DEFAULT_DATE_BYTE_ARRAY, 0, 8);
+            testee.parseFromLocalFileData(DEFAULT_DATE_LE_BYTE_ARRAY, 0, 8);
 
             assertThat(testee.getDateValue())
-                .contains(DEFAULT_DATE_UTC);
-        }
-
-        @Test
-        void parseFromLocalFileDataShouldReturnLocalDateWhenPassDefaultDateByteArray() throws Exception {
-            InternalDateExtraField testee = new InternalDateExtraField();
-            testee.parseFromLocalFileData(DEFAULT_DATE_BYTE_ARRAY, 0, 8);
-
-            assertThat(testee.getLocalDateValue())
-                .contains(DEFAULT_DATE_LOCAL);
+                .contains(DEFAULT_DATE);
         }
     }
 
@@ -312,19 +312,10 @@ public class InternalDateExtraFieldTest {
         @Test
         void parseFromCentralDirectoryDataShouldReturnDefaultDateWhenPassDefaultUTCDateByteArray() throws Exception {
             InternalDateExtraField testee = new InternalDateExtraField();
-            testee.parseFromCentralDirectoryData(DEFAULT_DATE_BYTE_ARRAY, 0, 8);
+            testee.parseFromCentralDirectoryData(DEFAULT_DATE_LE_BYTE_ARRAY, 0, 8);
 
             assertThat(testee.getDateValue())
-                .contains(DEFAULT_DATE_UTC);
-        }
-
-        @Test
-        void parseFromCentralDirectoryDataShouldReturnLocalDateWhenPassDefaultDateByteArray() throws Exception {
-            InternalDateExtraField testee = new InternalDateExtraField();
-            testee.parseFromCentralDirectoryData(DEFAULT_DATE_BYTE_ARRAY, 0, 8);
-
-            assertThat(testee.getLocalDateValue())
-                .contains(DEFAULT_DATE_LOCAL);
+                .contains(DEFAULT_DATE);
         }
     }
 }

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/InternalDateExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/InternalDateExtraFieldTest.java
@@ -40,7 +40,7 @@ import nl.jqno.equalsverifier.Warning;
 
 public class InternalDateExtraFieldTest {
 
-    public static final String DATE_STRING_1 = "2018-02-15T22:54:02+07:00";
+    public static final String DATE_STRING_1 = "2018-02-15T22:54:02Z";
     private static final ZonedDateTime DATE_1 = ZonedDateTime.parse(DATE_STRING_1, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
     private static final byte[] DATE_STRING_1_BYTE_ARRAY = DATE_STRING_1.getBytes(StandardCharsets.UTF_8);
 
@@ -210,7 +210,7 @@ public class InternalDateExtraFieldTest {
         void parseFromLocalFileDataShouldReturnDateWhenPassDateByteArray() {
             InternalDateExtraField testee = new InternalDateExtraField();
 
-            testee.parseFromLocalFileData(DATE_STRING_1_BYTE_ARRAY, 0, 25);
+            testee.parseFromLocalFileData(DATE_STRING_1_BYTE_ARRAY, 0, 20);
 
             assertThat(testee.getDateValue())
                 .contains(Date.from(DATE_1.toInstant()));
@@ -254,7 +254,7 @@ public class InternalDateExtraFieldTest {
         void parseFromCentralDirectoryDataShouldReturnDateWhenPassDateByteArray() {
             InternalDateExtraField testee = new InternalDateExtraField();
 
-            testee.parseFromCentralDirectoryData(DATE_STRING_1_BYTE_ARRAY, 0, 25);
+            testee.parseFromCentralDirectoryData(DATE_STRING_1_BYTE_ARRAY, 0, 20);
 
             assertThat(testee.getDateValue())
                 .contains(Date.from(DATE_1.toInstant()));

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/InternalDateExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/InternalDateExtraFieldTest.java
@@ -33,6 +33,9 @@ import org.testcontainers.shaded.org.bouncycastle.util.Arrays;
 
 import com.google.common.base.Charsets;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
 public class InternalDateExtraFieldTest {
     private static final byte[] ZERO_AS_BYTE_ARRAY = {0, 0, 0, 0, 0, 0, 0, 0};
     private static final byte[] _123456789ABCDEF0_AS_LE_BYTE_ARRAY = new byte[] {(byte) 0xF0, (byte) 0xDE, (byte) 0xBC, (byte) 0x9A, 0x78, 0x56, 0x34, 0x12};
@@ -42,6 +45,13 @@ public class InternalDateExtraFieldTest {
     private static final byte[] DEFAULT_DATE_BYTE_ARRAY = {(byte) 0xdd, (byte) 0xf2, (byte) 0xdc, 0x20, 0x64, 0x01, 0x00, 0x00 };
     private static final long DEFAULT_DATE_TIMESTAMP = 1529559708381L;
     private static final Date DEFAULT_DATE = new Date(DEFAULT_DATE_TIMESTAMP);
+
+    @Test
+    public void shouldMatchBeanContract() {
+        EqualsVerifier.forClass(InternalDateExtraField.class)
+            .suppress(Warning.NONFINAL_FIELDS)
+            .verify();
+    }
 
     @Nested
     class GetHeaderId {

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/InternalDateExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/InternalDateExtraFieldTest.java
@@ -19,17 +19,19 @@
 
 package org.apache.james.mailbox.backup;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.james.mailbox.backup.MailboxMessageFixture.DATE_1;
+import static org.apache.james.mailbox.backup.MailboxMessageFixture.DATE_STRING_1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
-import java.util.zip.ZipException;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.org.bouncycastle.util.Arrays;
 
 import com.google.common.base.Charsets;
 
@@ -37,18 +39,16 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 
 public class InternalDateExtraFieldTest {
-    private static final byte[] ZERO_AS_BYTE_ARRAY = {0, 0, 0, 0, 0, 0, 0, 0};
-    private static final byte[] _123456789ABCDEF0_AS_LE_BYTE_ARRAY = new byte[] {(byte) 0xF0, (byte) 0xDE, (byte) 0xBC, (byte) 0x9A, 0x78, 0x56, 0x34, 0x12};
-    private static final byte[] FEDCBA9876543210_AS_LE_BYTE_ARRAY = new byte[] {0x10, 0x32, 0x54, 0x76, (byte) 0x98, (byte) 0xBA, (byte) 0xDC, (byte) 0xFE};
-    private static final byte[] UNUSED = new byte[] {(byte) 0xDE, (byte) 0xAD};
 
-    private static final byte[] DEFAULT_DATE_BYTE_ARRAY = {(byte) 0xdd, (byte) 0xf2, (byte) 0xdc, 0x20, 0x64, 0x01, 0x00, 0x00 };
-    private static final long DEFAULT_DATE_TIMESTAMP = 1529559708381L;
-    private static final Date DEFAULT_DATE = new Date(DEFAULT_DATE_TIMESTAMP);
+    private static final byte[] DATE_STRING_1_BYTE_ARRAY = DATE_STRING_1.getBytes(StandardCharsets.UTF_8);
+
+    private static final String DEFAULT_MAILBOX_ID = "123456789ABCDEF0";
+    private static final byte[] DEFAULT_MAILBOX_ID_BYTE_ARRAY = new byte[] {0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x30};
+    private static final byte [] EMPTY_BYTE_ARRAY = {};
 
     @Test
     public void shouldMatchBeanContract() {
-        EqualsVerifier.forClass(InternalDateExtraField.class)
+        EqualsVerifier.forClass(MailboxIdExtraField.class)
             .suppress(Warning.NONFINAL_FIELDS)
             .verify();
     }
@@ -58,23 +58,31 @@ public class InternalDateExtraFieldTest {
 
         @Test
         void getHeaderIdShouldReturnSpecificStringInLittleEndian() {
-            InternalDateExtraField testee = new InternalDateExtraField();
-
+            MailboxIdExtraField testee = new MailboxIdExtraField();
             ByteBuffer byteBuffer = ByteBuffer.wrap(testee.getHeaderId().getBytes())
                 .order(ByteOrder.LITTLE_ENDIAN);
+
             assertThat(Charsets.US_ASCII.decode(byteBuffer).toString())
-                .isEqualTo("ao");
+                .isEqualTo("am");
         }
     }
 
     @Nested
     class GetLocalFileDataLength {
+
+        @Test
+        void getLocalFileDataLengthShouldThrowWhenNoValue() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
+            assertThatThrownBy(() -> testee.getLocalFileDataLength().getValue())
+                .isInstanceOf(RuntimeException.class);
+        }
+
         @Test
         void getLocalFileDataLengthShouldReturnIntegerSize() {
-            InternalDateExtraField testee = new InternalDateExtraField();
+            MailboxIdExtraField testee = new MailboxIdExtraField(DEFAULT_MAILBOX_ID);
 
             assertThat(testee.getLocalFileDataLength().getValue())
-                .isEqualTo(Long.BYTES);
+                .isEqualTo(16);
         }
     }
 
@@ -82,38 +90,18 @@ public class InternalDateExtraFieldTest {
     class GetCentralDirectoryLength {
 
         @Test
-        void getCentralDirectoryLengthShouldReturnIntegerSize() {
-            InternalDateExtraField testee = new InternalDateExtraField();
-
-            assertThat(testee.getCentralDirectoryLength().getValue())
-                .isEqualTo(Long.BYTES);
-        }
-
-
-        @Test
-        void getCentralDirectoryDataShouldThrowWhenNoValue() {
-            InternalDateExtraField testee = new InternalDateExtraField();
-
-            assertThatThrownBy(() -> testee.getCentralDirectoryData())
+        void getCentralDirectoryLengthShouldThrowWhenNoValue() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
+            assertThatThrownBy(() -> testee.getCentralDirectoryLength().getValue())
                 .isInstanceOf(RuntimeException.class);
         }
 
         @Test
-        void getCentralDirectoryDataShouldReturnZeroWhenZero() {
-            byte[] actual = new InternalDateExtraField(0).getCentralDirectoryData();
-            assertThat(actual).isEqualTo(ZERO_AS_BYTE_ARRAY);
-        }
+        void getCentralDirectoryLengthShouldReturnIntegerSize() {
+            MailboxIdExtraField testee = new MailboxIdExtraField(DEFAULT_MAILBOX_ID);
 
-        @Test
-        void getCentralDirectoryDataShouldReturnValueInLittleIndianWhen123456789ABCDEF0() {
-            byte[] actual = new InternalDateExtraField(0x123456789ABCDEF0L).getCentralDirectoryData();
-            assertThat(actual).isEqualTo(_123456789ABCDEF0_AS_LE_BYTE_ARRAY);
-        }
-
-        @Test
-        void getCentralDirectoryDataShouldReturnValueInLittleIndianWhenFEDCBA9876543210() {
-            byte[] actual = new InternalDateExtraField(0xFEDCBA9876543210L).getCentralDirectoryData();
-            assertThat(actual).isEqualTo(FEDCBA9876543210_AS_LE_BYTE_ARRAY);
+            assertThat(testee.getCentralDirectoryLength().getValue())
+                .isEqualTo(16);
         }
     }
 
@@ -122,28 +110,64 @@ public class InternalDateExtraFieldTest {
 
         @Test
         void getLocalFileDataDataShouldThrowWhenNoValue() {
-            InternalDateExtraField testee = new InternalDateExtraField();
+            MailboxIdExtraField testee = new MailboxIdExtraField();
 
             assertThatThrownBy(() -> testee.getLocalFileDataData())
                 .isInstanceOf(RuntimeException.class);
         }
 
         @Test
-        void getLocalFileDataDataShouldReturnZeroWhenZero() {
-            byte[] actual = new InternalDateExtraField(0).getLocalFileDataData();
-            assertThat(actual).isEqualTo(ZERO_AS_BYTE_ARRAY);
+        void getLocalFileDataDataShouldReturnEmptyArrayWhenValueIsEmpty() {
+            byte[] actual = new MailboxIdExtraField(EMPTY).getLocalFileDataData();
+            assertThat(actual).isEqualTo(EMPTY_BYTE_ARRAY);
         }
 
         @Test
-        void getLocalFileDataDataShouldReturnValueInLittleIndianWhen123456789ABCDEF0() {
-            byte[] actual = new InternalDateExtraField(0x123456789ABCDEF0L).getLocalFileDataData();
-            assertThat(actual).isEqualTo(_123456789ABCDEF0_AS_LE_BYTE_ARRAY);
+        void getLocalFileDataDataShouldReturnValueInByteArray() {
+            byte[] actual = new MailboxIdExtraField(DEFAULT_MAILBOX_ID).getLocalFileDataData();
+            assertThat(actual).isEqualTo(DEFAULT_MAILBOX_ID_BYTE_ARRAY);
         }
 
         @Test
-        void getLocalFileDataDataShouldReturnValueInLittleIndianWhenFEDCBA9876543210() {
-            byte[] actual = new InternalDateExtraField(0xFEDCBA9876543210L).getLocalFileDataData();
-            assertThat(actual).isEqualTo(FEDCBA9876543210_AS_LE_BYTE_ARRAY);
+        void getLocalFileDataShouldReturnDateByteArrayWhenPassDate() {
+            byte[] actual = new InternalDateExtraField(Date.from(DATE_1.toInstant()))
+                .getLocalFileDataData();
+
+            assertThat(actual)
+                .isEqualTo(DATE_STRING_1_BYTE_ARRAY);
+        }
+    }
+
+    @Nested
+    class GetCentralDirectoryData {
+
+        @Test
+        void getCentralDirectoryDataShouldThrowWhenNoValue() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
+
+            assertThatThrownBy(() -> testee.getCentralDirectoryData())
+                .isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        void getCentralDirectoryDataShouldReturnEmptyArrayWhenValueIsEmpty() {
+            byte[] actual = new MailboxIdExtraField(EMPTY).getCentralDirectoryData();
+            assertThat(actual).isEqualTo(EMPTY_BYTE_ARRAY);
+        }
+
+        @Test
+        void getCentralDirectoryDataShouldReturnValueInByteArray() {
+            byte[] actual = new MailboxIdExtraField(DEFAULT_MAILBOX_ID).getCentralDirectoryData();
+            assertThat(actual).isEqualTo(DEFAULT_MAILBOX_ID_BYTE_ARRAY);
+        }
+
+        @Test
+        void getCentralDirectoryDataShouldReturnDateByteArrayWhenPassDate() {
+            byte[] actual = new InternalDateExtraField(Date.from(DATE_1.toInstant()))
+                .getCentralDirectoryData();
+
+            assertThat(actual)
+                .isEqualTo(DATE_STRING_1_BYTE_ARRAY);
         }
     }
 
@@ -151,78 +175,43 @@ public class InternalDateExtraFieldTest {
     class ParseFromLocalFileData {
 
         @Test
-        void parseFromLocalFileDataShouldThrownWhenLengthIsSmallerThan8() {
-            InternalDateExtraField testee = new InternalDateExtraField();
+        void parseFromLocalFileDataShouldParseWhenZero() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
 
-            byte[] input = new byte[] {0, 0, 0, 0, 0, 0, 0};
-            assertThatThrownBy(() -> testee.parseFromLocalFileData(input, 0, 7))
-                .isInstanceOf(ZipException.class);
-        }
+            testee.parseFromLocalFileData(EMPTY_BYTE_ARRAY, 0, 0);
 
-        @Test
-        void parseFromLocalFileDataShouldThrownWhenLengthIsBiggerThan8() {
-            InternalDateExtraField testee = new InternalDateExtraField();
-
-            byte[] input = new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0};
-            assertThatThrownBy(() -> testee.parseFromLocalFileData(input, 0, 9))
-                .isInstanceOf(ZipException.class);
-        }
-
-        @Test
-        void parseFromLocalFileDataShouldParseWhenZero() throws Exception {
-            InternalDateExtraField testee = new InternalDateExtraField();
-
-            testee.parseFromLocalFileData(ZERO_AS_BYTE_ARRAY, 0, 8);
             assertThat(testee.getValue())
-                .contains(0L);
+                .contains(EMPTY);
         }
 
         @Test
-        void parseFromLocalFileDataShouldParseWhen123456789ABCDEF0InLittleEndian() throws Exception {
-            InternalDateExtraField testee = new InternalDateExtraField();
+        void parseFromLocalFileDataShouldParseByteArray() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
 
-            testee.parseFromLocalFileData(_123456789ABCDEF0_AS_LE_BYTE_ARRAY, 0, 8);
+            testee.parseFromLocalFileData(DEFAULT_MAILBOX_ID_BYTE_ARRAY, 0, 16);
+
             assertThat(testee.getValue())
-                .contains(0x123456789ABCDEF0L);
+                .contains(DEFAULT_MAILBOX_ID);
         }
 
         @Test
-        void parseFromLocalFileDataShouldParseWhenFEDCBA9876543210InLittleEndian() throws Exception {
-            InternalDateExtraField testee = new InternalDateExtraField();
+        void parseFromLocalFileDataShouldHandleOffset() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
 
-            byte[] input = FEDCBA9876543210_AS_LE_BYTE_ARRAY;
-            testee.parseFromLocalFileData(input, 0, 8);
+            testee.parseFromLocalFileData(DEFAULT_MAILBOX_ID_BYTE_ARRAY, 2, 14);
+
             assertThat(testee.getValue())
-                .contains(0xFEDCBA9876543210L);
+                .contains("3456789ABCDEF0");
         }
 
         @Test
-        void parseFromLocalFileDataShouldHandleOffset() throws Exception {
+        void parseFromLocalFileDataShouldReturnDateWhenPassDateByteArray() {
             InternalDateExtraField testee = new InternalDateExtraField();
 
-            byte[] input = Arrays.concatenate(UNUSED, _123456789ABCDEF0_AS_LE_BYTE_ARRAY);
-            testee.parseFromLocalFileData(input, 2, 8);
-            assertThat(testee.getValue())
-                .contains(0x123456789ABCDEF0L);
-        }
-
-        @Test
-        void parseFromLocalFileDataShouldReturnZeroDayWhenZero() throws Exception {
-            InternalDateExtraField testee = new InternalDateExtraField();
-
-            testee.parseFromLocalFileData(ZERO_AS_BYTE_ARRAY, 0, 8);
+            testee.parseFromLocalFileData(DATE_STRING_1_BYTE_ARRAY, 0, 20);
 
             assertThat(testee.getDateValue())
-                .contains(new Date(0L));
-        }
-
-        @Test
-        void parseFromLocalFileDataShouldReturnDefaultDateWhenPassDefaultDateByteArray() throws Exception {
-            InternalDateExtraField testee = new InternalDateExtraField(new Date());
-            testee.parseFromLocalFileData(DEFAULT_DATE_BYTE_ARRAY, 0, 8);
-
-            assertThat(testee.getDateValue())
-                .contains(DEFAULT_DATE);
+                .contains(Date.from(DATE_1.toInstant()));
         }
     }
 
@@ -230,78 +219,43 @@ public class InternalDateExtraFieldTest {
     class ParseFromCentralDirectoryData {
 
         @Test
-        void parseFromCentralDirectoryDataShouldThrownWhenLengthIsSmallerThan8() {
-            InternalDateExtraField testee = new InternalDateExtraField();
-            byte[] input = new byte[7];
+        void parseFromCentralDirectoryDataShouldParseWhenZero() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
 
-            assertThatThrownBy(() -> testee.parseFromCentralDirectoryData(input, 0, 7))
-                .isInstanceOf(ZipException.class);
-        }
+            testee.parseFromCentralDirectoryData(EMPTY_BYTE_ARRAY, 0, 0);
 
-        @Test
-        void parseFromCentralDirectoryDataShouldThrownWhenLengthIsBiggerThan8() {
-            InternalDateExtraField testee = new InternalDateExtraField();
-            byte[] input = new byte[9];
-
-            assertThatThrownBy(() -> testee.parseFromCentralDirectoryData(input, 0, 9))
-                .isInstanceOf(ZipException.class);
-        }
-
-        @Test
-        void parseFromCentralDirectoryDataShouldParseWhenZero() throws Exception {
-            InternalDateExtraField testee = new InternalDateExtraField();
-
-            testee.parseFromCentralDirectoryData(ZERO_AS_BYTE_ARRAY, 0, 8);
             assertThat(testee.getValue())
-                .contains(0L);
+                .contains(EMPTY);
         }
 
         @Test
-        void parseFromCentralDirectoryDataShouldParseWhen123456789ABCDEF0InLittleEndian() throws Exception {
-            InternalDateExtraField testee = new InternalDateExtraField();
+        void parseFromCentralDirectoryDataShouldParseByteArray() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
 
-            testee.parseFromCentralDirectoryData(_123456789ABCDEF0_AS_LE_BYTE_ARRAY, 0, 8);
+            testee.parseFromCentralDirectoryData(DEFAULT_MAILBOX_ID_BYTE_ARRAY, 0, 16);
+
             assertThat(testee.getValue())
-                .contains(0x123456789ABCDEF0L);
+                .contains(DEFAULT_MAILBOX_ID);
         }
 
         @Test
-        void parseFromCentralDirectoryDataShouldParseWhenFEDCBA9876543210InLittleEndian() throws Exception {
-            InternalDateExtraField testee = new InternalDateExtraField();
-            byte[] input = FEDCBA9876543210_AS_LE_BYTE_ARRAY;
+        void parseFromCentralDirectoryDataShouldHandleOffset() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
 
-            testee.parseFromCentralDirectoryData(input, 0, 8);
+            testee.parseFromCentralDirectoryData(DEFAULT_MAILBOX_ID_BYTE_ARRAY, 2, 14);
+
             assertThat(testee.getValue())
-                .contains(0xFEDCBA9876543210L);
+                .contains("3456789ABCDEF0");
         }
 
         @Test
-        void parseFromCentralDirectoryDataShouldHandleOffset() throws Exception {
-            InternalDateExtraField testee = new InternalDateExtraField();
-            byte[] input = Arrays.concatenate(UNUSED, _123456789ABCDEF0_AS_LE_BYTE_ARRAY);
-
-            testee.parseFromCentralDirectoryData(input, 2, 8);
-            assertThat(testee.getValue())
-                .contains(0x123456789ABCDEF0L);
-        }
-
-        @Test
-        void parseFromCentralDirectoryDataShouldReturnZeroDayWhenZero() throws Exception {
+        void parseFromCentralDirectoryDataShouldReturnDateWhenPassDateByteArray() {
             InternalDateExtraField testee = new InternalDateExtraField();
 
-            testee.parseFromCentralDirectoryData(ZERO_AS_BYTE_ARRAY, 0, 8);
+            testee.parseFromCentralDirectoryData(DATE_STRING_1_BYTE_ARRAY, 0, 20);
 
             assertThat(testee.getDateValue())
-                .contains(new Date(0L));
-        }
-
-        @Test
-        void parseFromCentralDirectoryDataShouldReturnDefaultDateWhenPassDefaultDateByteArray() throws Exception {
-            InternalDateExtraField testee = new InternalDateExtraField(new Date());
-            testee.parseFromCentralDirectoryData(DEFAULT_DATE_BYTE_ARRAY, 0, 8);
-
-            assertThat(testee.getDateValue())
-                .contains(DEFAULT_DATE);
+                .contains(Date.from(DATE_1.toInstant()));
         }
     }
 }

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxIdExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxIdExtraFieldTest.java
@@ -1,0 +1,207 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.backup;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.base.Charsets;
+
+public class MailboxIdExtraFieldTest {
+
+    private static final String DEFAULT_MAILBOX_ID = "123456789ABCDEF0";
+    private static final byte[] DEFAULT_MAILBOX_ID_BYTE_ARRAY = new byte[] {0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x30};
+    private static final byte [] EMPTY_BYTE_ARRAY = {};
+
+    @Nested
+    class GetHeaderId {
+
+        @Test
+        void getHeaderIdShouldReturnSpecificStringInLittleEndian() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
+            ByteBuffer byteBuffer = ByteBuffer.wrap(testee.getHeaderId().getBytes())
+                .order(ByteOrder.LITTLE_ENDIAN);
+
+            assertThat(Charsets.US_ASCII.decode(byteBuffer).toString())
+                .isEqualTo("am");
+        }
+    }
+
+    @Nested
+    class GetLocalFileDataLength {
+
+        @Test
+        void getLocalFileDataLengthShouldThrowWhenNoValue() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
+            assertThatThrownBy(() -> testee.getLocalFileDataLength().getValue())
+                .isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        void getLocalFileDataLengthShouldReturnIntegerSize() {
+            MailboxIdExtraField testee = new MailboxIdExtraField(DEFAULT_MAILBOX_ID);
+
+            assertThat(testee.getLocalFileDataLength().getValue())
+                .isEqualTo(16);
+        }
+    }
+
+    @Nested
+    class GetCentralDirectoryLength {
+
+        @Test
+        void getCentralDirectoryLengthShouldThrowWhenNoValue() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
+            assertThatThrownBy(() -> testee.getCentralDirectoryLength().getValue())
+                .isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        void getCentralDirectoryLengthShouldReturnIntegerSize() {
+            MailboxIdExtraField testee = new MailboxIdExtraField(DEFAULT_MAILBOX_ID);
+
+            assertThat(testee.getCentralDirectoryLength().getValue())
+                .isEqualTo(16);
+        }
+    }
+
+    @Nested
+    class GetLocalFileDataData {
+
+        @Test
+        void getLocalFileDataDataShouldThrowWhenNoValue() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
+
+            assertThatThrownBy(() -> testee.getLocalFileDataData())
+                .isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        void getLocalFileDataDataShouldReturnEmptyArrayWhenValueIsEmpty() {
+            byte[] actual = new MailboxIdExtraField(EMPTY).getLocalFileDataData();
+            assertThat(actual).isEqualTo(EMPTY_BYTE_ARRAY);
+        }
+
+        @Test
+        void getLocalFileDataDataShouldReturnValueInByteArray() {
+            byte[] actual = new MailboxIdExtraField(DEFAULT_MAILBOX_ID).getLocalFileDataData();
+            assertThat(actual).isEqualTo(DEFAULT_MAILBOX_ID_BYTE_ARRAY);
+        }
+    }
+
+    @Nested
+    class GetCentralDirectoryData {
+
+        @Test
+        void getCentralDirectoryDataShouldThrowWhenNoValue() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
+
+            assertThatThrownBy(() -> testee.getCentralDirectoryData())
+                .isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        void getCentralDirectoryDataShouldReturnEmptyArrayWhenValueIsEmpty() {
+            byte[] actual = new MailboxIdExtraField(EMPTY).getCentralDirectoryData();
+            assertThat(actual).isEqualTo(EMPTY_BYTE_ARRAY);
+        }
+
+        @Test
+        void getCentralDirectoryDataShouldReturnValueInByteArray() {
+            byte[] actual = new MailboxIdExtraField(DEFAULT_MAILBOX_ID).getCentralDirectoryData();
+            assertThat(actual).isEqualTo(DEFAULT_MAILBOX_ID_BYTE_ARRAY);
+        }
+    }
+
+    @Nested
+    class ParseFromLocalFileData {
+
+        @Test
+        void parseFromLocalFileDataShouldParseWhenZero() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
+
+            testee.parseFromLocalFileData(EMPTY_BYTE_ARRAY, 0, 0);
+
+            assertThat(testee.getMailboxId())
+                .contains(EMPTY);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldParseByteArray() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
+
+            testee.parseFromLocalFileData(DEFAULT_MAILBOX_ID_BYTE_ARRAY, 0, 16);
+
+            assertThat(testee.getMailboxId())
+                .contains(DEFAULT_MAILBOX_ID);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldHandleOffset() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
+
+            testee.parseFromLocalFileData(DEFAULT_MAILBOX_ID_BYTE_ARRAY, 2, 14);
+
+            assertThat(testee.getMailboxId())
+                .contains("3456789ABCDEF0");
+        }
+    }
+
+    @Nested
+    class ParseFromCentralDirectoryData {
+
+        @Test
+        void parseFromCentralDirectoryDataShouldParseWhenZero() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
+
+            testee.parseFromCentralDirectoryData(EMPTY_BYTE_ARRAY, 0, 0);
+
+            assertThat(testee.getMailboxId())
+                .contains(EMPTY);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldParseByteArray() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
+
+            testee.parseFromCentralDirectoryData(DEFAULT_MAILBOX_ID_BYTE_ARRAY, 0, 16);
+
+            assertThat(testee.getMailboxId())
+                .contains(DEFAULT_MAILBOX_ID);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldHandleOffset() {
+            MailboxIdExtraField testee = new MailboxIdExtraField();
+
+            testee.parseFromCentralDirectoryData(DEFAULT_MAILBOX_ID_BYTE_ARRAY, 2, 14);
+
+            assertThat(testee.getMailboxId())
+                .contains("3456789ABCDEF0");
+        }
+    }
+}

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxIdExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxIdExtraFieldTest.java
@@ -146,7 +146,7 @@ public class MailboxIdExtraFieldTest {
 
             testee.parseFromLocalFileData(EMPTY_BYTE_ARRAY, 0, 0);
 
-            assertThat(testee.getMailboxId())
+            assertThat(testee.getValue())
                 .contains(EMPTY);
         }
 
@@ -156,7 +156,7 @@ public class MailboxIdExtraFieldTest {
 
             testee.parseFromLocalFileData(DEFAULT_MAILBOX_ID_BYTE_ARRAY, 0, 16);
 
-            assertThat(testee.getMailboxId())
+            assertThat(testee.getValue())
                 .contains(DEFAULT_MAILBOX_ID);
         }
 
@@ -166,7 +166,7 @@ public class MailboxIdExtraFieldTest {
 
             testee.parseFromLocalFileData(DEFAULT_MAILBOX_ID_BYTE_ARRAY, 2, 14);
 
-            assertThat(testee.getMailboxId())
+            assertThat(testee.getValue())
                 .contains("3456789ABCDEF0");
         }
     }
@@ -180,7 +180,7 @@ public class MailboxIdExtraFieldTest {
 
             testee.parseFromCentralDirectoryData(EMPTY_BYTE_ARRAY, 0, 0);
 
-            assertThat(testee.getMailboxId())
+            assertThat(testee.getValue())
                 .contains(EMPTY);
         }
 
@@ -190,7 +190,7 @@ public class MailboxIdExtraFieldTest {
 
             testee.parseFromCentralDirectoryData(DEFAULT_MAILBOX_ID_BYTE_ARRAY, 0, 16);
 
-            assertThat(testee.getMailboxId())
+            assertThat(testee.getValue())
                 .contains(DEFAULT_MAILBOX_ID);
         }
 
@@ -200,7 +200,7 @@ public class MailboxIdExtraFieldTest {
 
             testee.parseFromCentralDirectoryData(DEFAULT_MAILBOX_ID_BYTE_ARRAY, 2, 14);
 
-            assertThat(testee.getMailboxId())
+            assertThat(testee.getValue())
                 .contains("3456789ABCDEF0");
         }
     }

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxIdExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxIdExtraFieldTest.java
@@ -31,11 +31,21 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Charsets;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
 public class MailboxIdExtraFieldTest {
 
     private static final String DEFAULT_MAILBOX_ID = "123456789ABCDEF0";
     private static final byte[] DEFAULT_MAILBOX_ID_BYTE_ARRAY = new byte[] {0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x30};
     private static final byte [] EMPTY_BYTE_ARRAY = {};
+
+    @Test
+    public void shouldMatchBeanContract() {
+        EqualsVerifier.forClass(MailboxIdExtraField.class)
+            .suppress(Warning.NONFINAL_FIELDS)
+            .verify();
+    }
 
     @Nested
     class GetHeaderId {

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxMessageFixture.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxMessageFixture.java
@@ -27,10 +27,13 @@ import java.util.Date;
 import javax.mail.Flags;
 import javax.mail.util.SharedByteArrayInputStream;
 
+import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.TestId;
 import org.apache.james.mailbox.model.TestMessageId;
+import org.apache.james.mailbox.store.mail.model.Mailbox;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailbox;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 
 public interface MailboxMessageFixture {
@@ -48,6 +51,9 @@ public interface MailboxMessageFixture {
     MessageId MESSAGE_ID_2 = MESSAGE_ID_FACTORY.generate();
     long SIZE_1 = 1000;
     long SIZE_2 = 2000;
+
+    Mailbox MAILBOX_1 = new SimpleMailbox(MailboxPath.forUser("user", "mailbox1"), 42, TestId.of(1L));
+    Mailbox MAILBOX_2 = new SimpleMailbox(MailboxPath.forUser("user", "mailbox2"), 43, TestId.of(2L));
 
     SimpleMailboxMessage MESSAGE_1 = SimpleMailboxMessage.builder()
         .messageId(MESSAGE_ID_1)

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxMessageFixture.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxMessageFixture.java
@@ -27,6 +27,8 @@ import java.util.Date;
 import javax.mail.Flags;
 import javax.mail.util.SharedByteArrayInputStream;
 
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.mock.MockMailboxSession;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.TestId;
@@ -52,7 +54,10 @@ public interface MailboxMessageFixture {
     long SIZE_1 = 1000;
     long SIZE_2 = 2000;
 
+    MailboxSession MAILBOX_SESSION = new MockMailboxSession("user");
+    
     Mailbox MAILBOX_1 = new SimpleMailbox(MailboxPath.forUser("user", "mailbox1"), 42, TestId.of(1L));
+    Mailbox MAILBOX_1_SUB_1 = new SimpleMailbox(MailboxPath.forUser("user", "mailbox1" + MAILBOX_SESSION.getPathDelimiter() + "sub1"), 420, TestId.of(11L));
     Mailbox MAILBOX_2 = new SimpleMailbox(MailboxPath.forUser("user", "mailbox2"), 43, TestId.of(2L));
 
     SimpleMailboxMessage MESSAGE_1 = SimpleMailboxMessage.builder()

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxMessageFixture.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxMessageFixture.java
@@ -42,8 +42,10 @@ import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 
 public interface MailboxMessageFixture {
 
-    ZonedDateTime DATE_1 = ZonedDateTime.parse("2018-02-15T15:54:02Z");
-    ZonedDateTime DATE_2 = ZonedDateTime.parse("2018-03-15T15:54:02Z");
+    String DATE_STRING_1 = "2018-02-15T15:54:02Z";
+    String DATE_STRING_2 = "2018-03-15T15:54:02Z";
+    ZonedDateTime DATE_1 = ZonedDateTime.parse(DATE_STRING_1);
+    ZonedDateTime DATE_2 = ZonedDateTime.parse(DATE_STRING_2);
 
     MessageId.Factory MESSAGE_ID_FACTORY = new TestMessageId.Factory();
     Charset MESSAGE_CHARSET = StandardCharsets.UTF_8;

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxMessageFixture.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxMessageFixture.java
@@ -30,6 +30,8 @@ import javax.mail.util.SharedByteArrayInputStream;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.mock.MockMailboxSession;
 import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.TestId;
 import org.apache.james.mailbox.model.TestMessageId;
@@ -53,6 +55,11 @@ public interface MailboxMessageFixture {
     MessageId MESSAGE_ID_2 = MESSAGE_ID_FACTORY.generate();
     long SIZE_1 = 1000;
     long SIZE_2 = 2000;
+    long MESSAGE_UID_1_VALUE = 1111L;
+    long MESSAGE_UID_2_VALUE = 2222L;
+    MessageUid MESSAGE_UID_1 = MessageUid.of(MESSAGE_UID_1_VALUE);
+    MessageUid MESSAGE_UID_2 = MessageUid.of(MESSAGE_UID_2_VALUE);
+    MailboxId MAILBOX_ID_1 = TestId.of(1L);
 
     MailboxSession MAILBOX_SESSION = new MockMailboxSession("user");
     
@@ -62,23 +69,25 @@ public interface MailboxMessageFixture {
 
     SimpleMailboxMessage MESSAGE_1 = SimpleMailboxMessage.builder()
         .messageId(MESSAGE_ID_1)
+        .uid(MESSAGE_UID_1)
         .content(CONTENT_STREAM_1)
         .size(SIZE_1)
         .internalDate(new Date(DATE_1.toEpochSecond()))
         .bodyStartOctet(0)
         .flags(new Flags())
         .propertyBuilder(new PropertyBuilder())
-        .mailboxId(TestId.of(1L))
+        .mailboxId(MAILBOX_ID_1)
         .build();
     SimpleMailboxMessage MESSAGE_2 = SimpleMailboxMessage.builder()
         .messageId(MESSAGE_ID_2)
+        .uid(MESSAGE_UID_2)
         .content(CONTENT_STREAM_2)
         .size(SIZE_2)
         .internalDate(new Date(DATE_2.toEpochSecond()))
         .bodyStartOctet(0)
         .flags(new Flags())
         .propertyBuilder(new PropertyBuilder())
-        .mailboxId(TestId.of(1L))
+        .mailboxId(MAILBOX_ID_1)
         .build();
 
 }

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxMessageFixture.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxMessageFixture.java
@@ -21,8 +21,7 @@ package org.apache.james.mailbox.backup;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.ZonedDateTime;
 import java.util.Date;
 
 import javax.mail.Flags;
@@ -36,10 +35,8 @@ import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 
 public interface MailboxMessageFixture {
 
-    SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
-
-    Date DATE_1 = parseDate("2018-02-15 15:54:02");
-    Date DATE_2 = parseDate("2018-03-15 15:54:02");
+    ZonedDateTime DATE_1 = ZonedDateTime.parse("2018-02-15T15:54:02Z");
+    ZonedDateTime DATE_2 = ZonedDateTime.parse("2018-03-15T15:54:02Z");
 
     MessageId.Factory MESSAGE_ID_FACTORY = new TestMessageId.Factory();
     Charset MESSAGE_CHARSET = StandardCharsets.UTF_8;
@@ -56,7 +53,7 @@ public interface MailboxMessageFixture {
         .messageId(MESSAGE_ID_1)
         .content(CONTENT_STREAM_1)
         .size(SIZE_1)
-        .internalDate(DATE_1)
+        .internalDate(new Date(DATE_1.toEpochSecond()))
         .bodyStartOctet(0)
         .flags(new Flags())
         .propertyBuilder(new PropertyBuilder())
@@ -66,18 +63,11 @@ public interface MailboxMessageFixture {
         .messageId(MESSAGE_ID_2)
         .content(CONTENT_STREAM_2)
         .size(SIZE_2)
-        .internalDate(DATE_2)
+        .internalDate(new Date(DATE_2.toEpochSecond()))
         .bodyStartOctet(0)
         .flags(new Flags())
         .propertyBuilder(new PropertyBuilder())
         .mailboxId(TestId.of(1L))
         .build();
 
-    static Date parseDate(String input) {
-        try {
-            return SIMPLE_DATE_FORMAT.parse(input);
-        } catch (ParseException e) {
-            throw new RuntimeException(e);
-        }
-    }
 }

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MessageIdExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MessageIdExtraFieldTest.java
@@ -104,7 +104,6 @@ public class MessageIdExtraFieldTest {
 
         @Test
         void getLocalFileDataDataShouldReturnEmptyArrayWhenValueIsEmpty() {
-            MessageIdExtraField testee = new MessageIdExtraField();
             byte[] actual = new MessageIdExtraField(EMPTY).getLocalFileDataData();
 
             assertThat(actual).isEqualTo(EMPTY_BYTE_ARRAY);
@@ -112,7 +111,6 @@ public class MessageIdExtraFieldTest {
 
         @Test
         void getLocalFileDataDataShouldReturnValueInByteArray() {
-            MessageIdExtraField testee = new MessageIdExtraField();
             byte[] actual = new MessageIdExtraField(DEFAULT_MESSAGE_ID).getLocalFileDataData();
 
             assertThat(actual).isEqualTo(DEFAULT_MESSAGE_ID_BYTE_ARRAY);

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MessageIdExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MessageIdExtraFieldTest.java
@@ -1,0 +1,214 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.backup;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.base.Charsets;
+
+public class MessageIdExtraFieldTest {
+
+    private static final String DEFAULT_MESSAGE_ID = "123456789ABCDEF0";
+    private static final byte[] DEFAULT_MESSAGE_ID_BYTE_ARRAY = new byte[] {0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x30};
+    private static final byte [] EMPTY_BYTE_ARRAY = {};
+
+    @Nested
+    class GetHeaderId {
+
+        @Test
+        void getHeaderIdShouldReturnSpecificStringInLittleEndian() {
+            MessageIdExtraField testee = new MessageIdExtraField();
+            ByteBuffer byteBuffer = ByteBuffer.wrap(testee.getHeaderId().getBytes())
+                .order(ByteOrder.LITTLE_ENDIAN);
+
+            assertThat(Charsets.US_ASCII.decode(byteBuffer).toString())
+                .isEqualTo("al");
+        }
+    }
+
+    @Nested
+    class GetLocalFileDataLength {
+
+        @Test
+        void getLocalFileDataLengthShouldThrowWhenNoValue() {
+            MessageIdExtraField testee = new MessageIdExtraField();
+
+            assertThatThrownBy(() -> testee.getLocalFileDataLength().getValue())
+                .isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        void getLocalFileDataLengthShouldReturnIntegerSize() {
+            MessageIdExtraField testee = new MessageIdExtraField(DEFAULT_MESSAGE_ID);
+
+            assertThat(testee.getLocalFileDataLength().getValue())
+                .isEqualTo(16);
+        }
+    }
+
+    @Nested
+    class GetCentralDirectoryLength {
+
+        @Test
+        void getCentralDirectoryLengthShouldThrowWhenNoValue() {
+            MessageIdExtraField testee = new MessageIdExtraField();
+
+            assertThatThrownBy(() -> testee.getCentralDirectoryLength().getValue())
+                .isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        void getCentralDirectoryLengthShouldReturnIntegerSize() {
+            MessageIdExtraField testee = new MessageIdExtraField(DEFAULT_MESSAGE_ID);
+
+            assertThat(testee.getCentralDirectoryLength().getValue())
+                .isEqualTo(16);
+        }
+    }
+
+    @Nested
+    class GetLocalFileDataData {
+
+        @Test
+        void getLocalFileDataDataShouldThrowWhenNoValue() {
+            MessageIdExtraField testee = new MessageIdExtraField();
+
+            assertThatThrownBy(() -> testee.getLocalFileDataData())
+                .isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        void getLocalFileDataDataShouldReturnEmptyArrayWhenValueIsEmpty() {
+            MessageIdExtraField testee = new MessageIdExtraField();
+            byte[] actual = new MessageIdExtraField(EMPTY).getLocalFileDataData();
+
+            assertThat(actual).isEqualTo(EMPTY_BYTE_ARRAY);
+        }
+
+        @Test
+        void getLocalFileDataDataShouldReturnValueInByteArray() {
+            MessageIdExtraField testee = new MessageIdExtraField();
+            byte[] actual = new MessageIdExtraField(DEFAULT_MESSAGE_ID).getLocalFileDataData();
+
+            assertThat(actual).isEqualTo(DEFAULT_MESSAGE_ID_BYTE_ARRAY);
+        }
+    }
+
+    @Nested
+    class GetCentralDirectoryData {
+
+        @Test
+        void getCentralDirectoryDataShouldThrowWhenNoValue() {
+            MessageIdExtraField testee = new MessageIdExtraField();
+
+            assertThatThrownBy(() -> testee.getCentralDirectoryData())
+                .isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        void getCentralDirectoryDataShouldReturnEmptyArrayWhenValueIsEmpty() {
+            byte[] actual = new MessageIdExtraField(EMPTY).getCentralDirectoryData();
+            assertThat(actual).isEqualTo(EMPTY_BYTE_ARRAY);
+        }
+
+        @Test
+        void getCentralDirectoryDataShouldReturnValueInByteArray() {
+            byte[] actual = new MessageIdExtraField(DEFAULT_MESSAGE_ID).getCentralDirectoryData();
+            assertThat(actual).isEqualTo(DEFAULT_MESSAGE_ID_BYTE_ARRAY);
+        }
+    }
+
+    @Nested
+    class ParseFromLocalFileData {
+
+        @Test
+        void parseFromLocalFileDataShouldParseWhenZero() {
+            MessageIdExtraField testee = new MessageIdExtraField();
+
+            testee.parseFromLocalFileData(EMPTY_BYTE_ARRAY, 0, 0);
+
+            assertThat(testee.getMessageId())
+                .contains(EMPTY);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldParseByteArray() {
+            MessageIdExtraField testee = new MessageIdExtraField();
+
+            testee.parseFromLocalFileData(DEFAULT_MESSAGE_ID_BYTE_ARRAY, 0, 16);
+
+            assertThat(testee.getMessageId())
+                .contains(DEFAULT_MESSAGE_ID);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldHandleOffset() {
+            MessageIdExtraField testee = new MessageIdExtraField();
+
+            testee.parseFromLocalFileData(DEFAULT_MESSAGE_ID_BYTE_ARRAY, 2, 14);
+
+            assertThat(testee.getMessageId())
+                .contains("3456789ABCDEF0");
+        }
+    }
+
+    @Nested
+    class ParseFromCentralDirectoryData {
+
+        @Test
+        void parseFromCentralDirectoryDataShouldParseWhenZero() {
+            MessageIdExtraField testee = new MessageIdExtraField();
+
+            testee.parseFromCentralDirectoryData(EMPTY_BYTE_ARRAY, 0, 0);
+
+            assertThat(testee.getMessageId())
+                .contains(EMPTY);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldParseByteArray() {
+            MessageIdExtraField testee = new MessageIdExtraField();
+
+            testee.parseFromCentralDirectoryData(DEFAULT_MESSAGE_ID_BYTE_ARRAY, 0, 16);
+
+            assertThat(testee.getMessageId())
+                .contains(DEFAULT_MESSAGE_ID);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldHandleOffset() {
+            MessageIdExtraField testee = new MessageIdExtraField();
+
+            testee.parseFromCentralDirectoryData(DEFAULT_MESSAGE_ID_BYTE_ARRAY, 2, 14);
+
+            assertThat(testee.getMessageId())
+                .contains("3456789ABCDEF0");
+        }
+    }
+    
+}

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MessageIdExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MessageIdExtraFieldTest.java
@@ -31,11 +31,21 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Charsets;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
 public class MessageIdExtraFieldTest {
 
     private static final String DEFAULT_MESSAGE_ID = "123456789ABCDEF0";
     private static final byte[] DEFAULT_MESSAGE_ID_BYTE_ARRAY = new byte[] {0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x30};
     private static final byte [] EMPTY_BYTE_ARRAY = {};
+
+    @Test
+    public void shouldMatchBeanContract() {
+        EqualsVerifier.forClass(MessageIdExtraField.class)
+            .suppress(Warning.NONFINAL_FIELDS)
+            .verify();
+    }
 
     @Nested
     class GetHeaderId {

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MessageIdExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MessageIdExtraFieldTest.java
@@ -150,7 +150,7 @@ public class MessageIdExtraFieldTest {
 
             testee.parseFromLocalFileData(EMPTY_BYTE_ARRAY, 0, 0);
 
-            assertThat(testee.getMessageId())
+            assertThat(testee.getValue())
                 .contains(EMPTY);
         }
 
@@ -160,7 +160,7 @@ public class MessageIdExtraFieldTest {
 
             testee.parseFromLocalFileData(DEFAULT_MESSAGE_ID_BYTE_ARRAY, 0, 16);
 
-            assertThat(testee.getMessageId())
+            assertThat(testee.getValue())
                 .contains(DEFAULT_MESSAGE_ID);
         }
 
@@ -170,7 +170,7 @@ public class MessageIdExtraFieldTest {
 
             testee.parseFromLocalFileData(DEFAULT_MESSAGE_ID_BYTE_ARRAY, 2, 14);
 
-            assertThat(testee.getMessageId())
+            assertThat(testee.getValue())
                 .contains("3456789ABCDEF0");
         }
     }
@@ -184,7 +184,7 @@ public class MessageIdExtraFieldTest {
 
             testee.parseFromCentralDirectoryData(EMPTY_BYTE_ARRAY, 0, 0);
 
-            assertThat(testee.getMessageId())
+            assertThat(testee.getValue())
                 .contains(EMPTY);
         }
 
@@ -194,7 +194,7 @@ public class MessageIdExtraFieldTest {
 
             testee.parseFromCentralDirectoryData(DEFAULT_MESSAGE_ID_BYTE_ARRAY, 0, 16);
 
-            assertThat(testee.getMessageId())
+            assertThat(testee.getValue())
                 .contains(DEFAULT_MESSAGE_ID);
         }
 
@@ -204,7 +204,7 @@ public class MessageIdExtraFieldTest {
 
             testee.parseFromCentralDirectoryData(DEFAULT_MESSAGE_ID_BYTE_ARRAY, 2, 14);
 
-            assertThat(testee.getMessageId())
+            assertThat(testee.getValue())
                 .contains("3456789ABCDEF0");
         }
     }

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/SizeExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/SizeExtraFieldTest.java
@@ -129,14 +129,14 @@ public class SizeExtraFieldTest {
     @Test
     void parseFromLocalFileDataShouldParseWhenZero() throws Exception {
         testee.parseFromLocalFileData(ZERO_AS_BYTE_ARRAY, 0, 8);
-        assertThat(testee.getSize())
+        assertThat(testee.getValue())
             .contains(0L);
     }
 
     @Test
     void parseFromLocalFileDataShouldParseWhen123456789ABCDEF0InLittleEndian() throws Exception {
         testee.parseFromLocalFileData(_123456789ABCDEF0_AS_LE_BYTE_ARRAY, 0, 8);
-        assertThat(testee.getSize())
+        assertThat(testee.getValue())
             .contains(0x123456789ABCDEF0L);
     }
 
@@ -144,7 +144,7 @@ public class SizeExtraFieldTest {
     void parseFromLocalFileDataShouldParseWhenFEDCBA9876543210InLittleEndian() throws Exception {
         byte[] input = FEDCBA9876543210_AS_LE_BYTE_ARRAY;
         testee.parseFromLocalFileData(input, 0, 8);
-        assertThat(testee.getSize())
+        assertThat(testee.getValue())
             .contains(0xFEDCBA9876543210L);
     }
 
@@ -152,7 +152,7 @@ public class SizeExtraFieldTest {
     void parseFromLocalFileDataShouldHandleOffset() throws Exception {
         byte[] input = Arrays.concatenate(UNUSED, _123456789ABCDEF0_AS_LE_BYTE_ARRAY);
         testee.parseFromLocalFileData(input, 2, 8);
-        assertThat(testee.getSize())
+        assertThat(testee.getValue())
             .contains(0x123456789ABCDEF0L);
     }
 
@@ -173,14 +173,14 @@ public class SizeExtraFieldTest {
     @Test
     void parseFromCentralDirectoryDataShouldParseWhenZero() throws Exception {
         testee.parseFromCentralDirectoryData(ZERO_AS_BYTE_ARRAY, 0, 8);
-        assertThat(testee.getSize())
+        assertThat(testee.getValue())
             .contains(0L);
     }
 
     @Test
     void parseFromCentralDirectoryDataShouldParseWhen123456789ABCDEF0InLittleEndian() throws Exception {
         testee.parseFromCentralDirectoryData(_123456789ABCDEF0_AS_LE_BYTE_ARRAY, 0, 8);
-        assertThat(testee.getSize())
+        assertThat(testee.getValue())
             .contains(0x123456789ABCDEF0L);
     }
 
@@ -188,7 +188,7 @@ public class SizeExtraFieldTest {
     void parseFromCentralDirectoryDataShouldParseWhenFEDCBA9876543210InLittleEndian() throws Exception {
         byte[] input = FEDCBA9876543210_AS_LE_BYTE_ARRAY;
         testee.parseFromCentralDirectoryData(input, 0, 8);
-        assertThat(testee.getSize())
+        assertThat(testee.getValue())
             .contains(0xFEDCBA9876543210L);
     }
 
@@ -196,7 +196,7 @@ public class SizeExtraFieldTest {
     void parseFromCentralDirectoryDataShouldHandleOffset() throws Exception {
         byte[] input = Arrays.concatenate(UNUSED, _123456789ABCDEF0_AS_LE_BYTE_ARRAY);
         testee.parseFromCentralDirectoryData(input, 2, 8);
-        assertThat(testee.getSize())
+        assertThat(testee.getValue())
             .contains(0x123456789ABCDEF0L);
     }
 }

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/SizeExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/SizeExtraFieldTest.java
@@ -31,6 +31,9 @@ import org.testcontainers.shaded.org.bouncycastle.util.Arrays;
 
 import com.google.common.base.Charsets;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
 public class SizeExtraFieldTest {
     private static final byte[] ZERO_AS_BYTE_ARRAY = {0, 0, 0, 0, 0, 0, 0, 0};
     private static final byte[] _123456789ABCDEF0_AS_LE_BYTE_ARRAY = new byte[] {(byte) 0xF0, (byte) 0xDE, (byte) 0xBC, (byte) 0x9A, 0x78, 0x56, 0x34, 0x12};
@@ -42,6 +45,13 @@ public class SizeExtraFieldTest {
     @BeforeEach
     void setUp() {
         testee = new SizeExtraField();
+    }
+
+    @Test
+    public void shouldMatchBeanContract() {
+        EqualsVerifier.forClass(SizeExtraField.class)
+            .suppress(Warning.NONFINAL_FIELDS)
+            .verify();
     }
 
     @Test

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/UidExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/UidExtraFieldTest.java
@@ -158,7 +158,7 @@ public class UidExtraFieldTest {
             UidExtraField testee = new UidExtraField();
 
             testee.parseFromLocalFileData(ZERO_AS_BYTE_ARRAY, 0, 8);
-            assertThat(testee.getUid())
+            assertThat(testee.getValue())
                 .contains(0L);
         }
 
@@ -167,7 +167,7 @@ public class UidExtraFieldTest {
             UidExtraField testee = new UidExtraField();
 
             testee.parseFromLocalFileData(_123456789ABCDEF0_AS_LE_BYTE_ARRAY, 0, 8);
-            assertThat(testee.getUid())
+            assertThat(testee.getValue())
                 .contains(0x123456789ABCDEF0L);
         }
 
@@ -177,7 +177,7 @@ public class UidExtraFieldTest {
 
             byte[] input = FEDCBA9876543210_AS_LE_BYTE_ARRAY;
             testee.parseFromLocalFileData(input, 0, 8);
-            assertThat(testee.getUid())
+            assertThat(testee.getValue())
                 .contains(0xFEDCBA9876543210L);
         }
 
@@ -187,7 +187,7 @@ public class UidExtraFieldTest {
 
             byte[] input = Arrays.concatenate(UNUSED, _123456789ABCDEF0_AS_LE_BYTE_ARRAY);
             testee.parseFromLocalFileData(input, 2, 8);
-            assertThat(testee.getUid())
+            assertThat(testee.getValue())
                 .contains(0x123456789ABCDEF0L);
         }
     }
@@ -218,7 +218,7 @@ public class UidExtraFieldTest {
             UidExtraField testee = new UidExtraField();
 
             testee.parseFromCentralDirectoryData(ZERO_AS_BYTE_ARRAY, 0, 8);
-            assertThat(testee.getUid())
+            assertThat(testee.getValue())
                 .contains(0L);
         }
 
@@ -227,7 +227,7 @@ public class UidExtraFieldTest {
             UidExtraField testee = new UidExtraField();
 
             testee.parseFromCentralDirectoryData(_123456789ABCDEF0_AS_LE_BYTE_ARRAY, 0, 8);
-            assertThat(testee.getUid())
+            assertThat(testee.getValue())
                 .contains(0x123456789ABCDEF0L);
         }
 
@@ -237,7 +237,7 @@ public class UidExtraFieldTest {
             byte[] input = FEDCBA9876543210_AS_LE_BYTE_ARRAY;
 
             testee.parseFromCentralDirectoryData(input, 0, 8);
-            assertThat(testee.getUid())
+            assertThat(testee.getValue())
                 .contains(0xFEDCBA9876543210L);
         }
 
@@ -247,7 +247,7 @@ public class UidExtraFieldTest {
             byte[] input = Arrays.concatenate(UNUSED, _123456789ABCDEF0_AS_LE_BYTE_ARRAY);
 
             testee.parseFromCentralDirectoryData(input, 2, 8);
-            assertThat(testee.getUid())
+            assertThat(testee.getValue())
                 .contains(0x123456789ABCDEF0L);
         }
     }

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/UidExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/UidExtraFieldTest.java
@@ -1,0 +1,254 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.zip.ZipException;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.bouncycastle.util.Arrays;
+
+import com.google.common.base.Charsets;
+
+public class UidExtraFieldTest {
+    private static final byte[] ZERO_AS_BYTE_ARRAY = {0, 0, 0, 0, 0, 0, 0, 0};
+    private static final byte[] _123456789ABCDEF0_AS_LE_BYTE_ARRAY = new byte[] {(byte) 0xF0, (byte) 0xDE, (byte) 0xBC, (byte) 0x9A, 0x78, 0x56, 0x34, 0x12};
+    private static final byte[] FEDCBA9876543210_AS_LE_BYTE_ARRAY = new byte[] {0x10, 0x32, 0x54, 0x76, (byte) 0x98, (byte) 0xBA, (byte) 0xDC, (byte) 0xFE};
+    private static final byte[] UNUSED = new byte[] {(byte) 0xDE, (byte) 0xAD};
+
+    @Nested
+    class GetHeaderId {
+
+        @Test
+        void getHeaderIdShouldReturnSpecificStringInLittleEndian() {
+            UidExtraField testee = new UidExtraField();
+
+            ByteBuffer byteBuffer = ByteBuffer.wrap(testee.getHeaderId().getBytes())
+                .order(ByteOrder.LITTLE_ENDIAN);
+            assertThat(Charsets.US_ASCII.decode(byteBuffer).toString())
+                .isEqualTo("ak");
+        }
+    }
+
+    @Nested
+    class GetLocalFileDataLength {
+        @Test
+        void getLocalFileDataLengthShouldReturnIntegerSize() {
+            UidExtraField testee = new UidExtraField();
+
+            assertThat(testee.getLocalFileDataLength().getValue())
+                .isEqualTo(Long.BYTES);
+        }
+    }
+
+    @Nested
+    class GetCentralDirectoryLength {
+
+        @Test
+        void getCentralDirectoryLengthShouldReturnIntegerSize() {
+            UidExtraField testee = new UidExtraField();
+
+            assertThat(testee.getCentralDirectoryLength().getValue())
+                .isEqualTo(Long.BYTES);
+        }
+
+
+        @Test
+        void getCentralDirectoryDataShouldThrowWhenNoValue() {
+            UidExtraField testee = new UidExtraField();
+
+            assertThatThrownBy(() -> testee.getCentralDirectoryData())
+                .isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        void getCentralDirectoryDataShouldReturnZeroWhenZero() {
+            byte[] actual = new UidExtraField(0).getCentralDirectoryData();
+            assertThat(actual).isEqualTo(ZERO_AS_BYTE_ARRAY);
+        }
+
+        @Test
+        void getCentralDirectoryDataShouldReturnValueInLittleIndianWhen123456789ABCDEF0() {
+            byte[] actual = new UidExtraField(0x123456789ABCDEF0L).getCentralDirectoryData();
+            assertThat(actual).isEqualTo(_123456789ABCDEF0_AS_LE_BYTE_ARRAY);
+        }
+
+        @Test
+        void getCentralDirectoryDataShouldReturnValueInLittleIndianWhenFEDCBA9876543210() {
+            byte[] actual = new UidExtraField(0xFEDCBA9876543210L).getCentralDirectoryData();
+            assertThat(actual).isEqualTo(FEDCBA9876543210_AS_LE_BYTE_ARRAY);
+        }
+    }
+
+    @Nested
+    class GetLocalFileDataData {
+
+        @Test
+        void getLocalFileDataDataShouldThrowWhenNoValue() {
+            UidExtraField testee = new UidExtraField();
+
+            assertThatThrownBy(() -> testee.getLocalFileDataData())
+                .isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        void getLocalFileDataDataShouldReturnZeroWhenZero() {
+            byte[] actual = new UidExtraField(0).getLocalFileDataData();
+            assertThat(actual).isEqualTo(ZERO_AS_BYTE_ARRAY);
+        }
+
+        @Test
+        void getLocalFileDataDataShouldReturnValueInLittleIndianWhen123456789ABCDEF0() {
+            byte[] actual = new UidExtraField(0x123456789ABCDEF0L).getLocalFileDataData();
+            assertThat(actual).isEqualTo(_123456789ABCDEF0_AS_LE_BYTE_ARRAY);
+        }
+
+        @Test
+        void getLocalFileDataDataShouldReturnValueInLittleIndianWhenFEDCBA9876543210() {
+            byte[] actual = new UidExtraField(0xFEDCBA9876543210L).getLocalFileDataData();
+            assertThat(actual).isEqualTo(FEDCBA9876543210_AS_LE_BYTE_ARRAY);
+        }
+    }
+
+    @Nested
+    class ParseFromLocalFileData {
+
+        @Test
+        void parseFromLocalFileDataShouldThrownWhenLengthIsSmallerThan8() {
+            UidExtraField testee = new UidExtraField();
+
+            byte[] input = new byte[] {0, 0, 0, 0, 0, 0, 0};
+            assertThatThrownBy(() -> testee.parseFromLocalFileData(input, 0, 7))
+                .isInstanceOf(ZipException.class);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldThrownWhenLengthIsBiggerThan8() {
+            UidExtraField testee = new UidExtraField();
+
+            byte[] input = new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0};
+            assertThatThrownBy(() -> testee.parseFromLocalFileData(input, 0, 9))
+                .isInstanceOf(ZipException.class);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldParseWhenZero() throws Exception {
+            UidExtraField testee = new UidExtraField();
+
+            testee.parseFromLocalFileData(ZERO_AS_BYTE_ARRAY, 0, 8);
+            assertThat(testee.getUid())
+                .contains(0L);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldParseWhen123456789ABCDEF0InLittleEndian() throws Exception {
+            UidExtraField testee = new UidExtraField();
+
+            testee.parseFromLocalFileData(_123456789ABCDEF0_AS_LE_BYTE_ARRAY, 0, 8);
+            assertThat(testee.getUid())
+                .contains(0x123456789ABCDEF0L);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldParseWhenFEDCBA9876543210InLittleEndian() throws Exception {
+            UidExtraField testee = new UidExtraField();
+
+            byte[] input = FEDCBA9876543210_AS_LE_BYTE_ARRAY;
+            testee.parseFromLocalFileData(input, 0, 8);
+            assertThat(testee.getUid())
+                .contains(0xFEDCBA9876543210L);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldHandleOffset() throws Exception {
+            UidExtraField testee = new UidExtraField();
+
+            byte[] input = Arrays.concatenate(UNUSED, _123456789ABCDEF0_AS_LE_BYTE_ARRAY);
+            testee.parseFromLocalFileData(input, 2, 8);
+            assertThat(testee.getUid())
+                .contains(0x123456789ABCDEF0L);
+        }
+    }
+
+    @Nested
+    class ParseFromCentralDirectoryData {
+
+        @Test
+        void parseFromCentralDirectoryDataShouldThrownWhenLengthIsSmallerThan8() {
+            UidExtraField testee = new UidExtraField();
+            byte[] input = new byte[7];
+
+            assertThatThrownBy(() -> testee.parseFromCentralDirectoryData(input, 0, 7))
+                .isInstanceOf(ZipException.class);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldThrownWhenLengthIsBiggerThan8() {
+            UidExtraField testee = new UidExtraField();
+            byte[] input = new byte[9];
+
+            assertThatThrownBy(() -> testee.parseFromCentralDirectoryData(input, 0, 9))
+                .isInstanceOf(ZipException.class);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldParseWhenZero() throws Exception {
+            UidExtraField testee = new UidExtraField();
+
+            testee.parseFromCentralDirectoryData(ZERO_AS_BYTE_ARRAY, 0, 8);
+            assertThat(testee.getUid())
+                .contains(0L);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldParseWhen123456789ABCDEF0InLittleEndian() throws Exception {
+            UidExtraField testee = new UidExtraField();
+
+            testee.parseFromCentralDirectoryData(_123456789ABCDEF0_AS_LE_BYTE_ARRAY, 0, 8);
+            assertThat(testee.getUid())
+                .contains(0x123456789ABCDEF0L);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldParseWhenFEDCBA9876543210InLittleEndian() throws Exception {
+            UidExtraField testee = new UidExtraField();
+            byte[] input = FEDCBA9876543210_AS_LE_BYTE_ARRAY;
+
+            testee.parseFromCentralDirectoryData(input, 0, 8);
+            assertThat(testee.getUid())
+                .contains(0xFEDCBA9876543210L);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldHandleOffset() throws Exception {
+            UidExtraField testee = new UidExtraField();
+            byte[] input = Arrays.concatenate(UNUSED, _123456789ABCDEF0_AS_LE_BYTE_ARRAY);
+
+            testee.parseFromCentralDirectoryData(input, 2, 8);
+            assertThat(testee.getUid())
+                .contains(0x123456789ABCDEF0L);
+        }
+    }
+}

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/UidExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/UidExtraFieldTest.java
@@ -32,11 +32,21 @@ import org.testcontainers.shaded.org.bouncycastle.util.Arrays;
 
 import com.google.common.base.Charsets;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
 public class UidExtraFieldTest {
     private static final byte[] ZERO_AS_BYTE_ARRAY = {0, 0, 0, 0, 0, 0, 0, 0};
     private static final byte[] _123456789ABCDEF0_AS_LE_BYTE_ARRAY = new byte[] {(byte) 0xF0, (byte) 0xDE, (byte) 0xBC, (byte) 0x9A, 0x78, 0x56, 0x34, 0x12};
     private static final byte[] FEDCBA9876543210_AS_LE_BYTE_ARRAY = new byte[] {0x10, 0x32, 0x54, 0x76, (byte) 0x98, (byte) 0xBA, (byte) 0xDC, (byte) 0xFE};
     private static final byte[] UNUSED = new byte[] {(byte) 0xDE, (byte) 0xAD};
+
+    @Test
+    public void shouldMatchBeanContract() {
+        EqualsVerifier.forClass(UidExtraField.class)
+            .suppress(Warning.NONFINAL_FIELDS)
+            .verify();
+    }
 
     @Nested
     class GetHeaderId {

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/UidValidityExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/UidValidityExtraFieldTest.java
@@ -32,11 +32,21 @@ import org.testcontainers.shaded.org.bouncycastle.util.Arrays;
 
 import com.google.common.base.Charsets;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
 public class UidValidityExtraFieldTest {
     private static final byte[] ZERO_AS_BYTE_ARRAY = {0, 0, 0, 0, 0, 0, 0, 0};
     private static final byte[] _123456789ABCDEF0_AS_LE_BYTE_ARRAY = new byte[] {(byte) 0xF0, (byte) 0xDE, (byte) 0xBC, (byte) 0x9A, 0x78, 0x56, 0x34, 0x12};
     private static final byte[] FEDCBA9876543210_AS_LE_BYTE_ARRAY = new byte[] {0x10, 0x32, 0x54, 0x76, (byte) 0x98, (byte) 0xBA, (byte) 0xDC, (byte) 0xFE};
     private static final byte[] UNUSED = new byte[] {(byte) 0xDE, (byte) 0xAD};
+
+    @Test
+    public void shouldMatchBeanContract() {
+        EqualsVerifier.forClass(UidValidityExtraField.class)
+            .suppress(Warning.NONFINAL_FIELDS)
+            .verify();
+    }
 
     @Nested
     class GetHeaderId {

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/UidValidityExtraFieldTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/UidValidityExtraFieldTest.java
@@ -1,0 +1,254 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.zip.ZipException;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.bouncycastle.util.Arrays;
+
+import com.google.common.base.Charsets;
+
+public class UidValidityExtraFieldTest {
+    private static final byte[] ZERO_AS_BYTE_ARRAY = {0, 0, 0, 0, 0, 0, 0, 0};
+    private static final byte[] _123456789ABCDEF0_AS_LE_BYTE_ARRAY = new byte[] {(byte) 0xF0, (byte) 0xDE, (byte) 0xBC, (byte) 0x9A, 0x78, 0x56, 0x34, 0x12};
+    private static final byte[] FEDCBA9876543210_AS_LE_BYTE_ARRAY = new byte[] {0x10, 0x32, 0x54, 0x76, (byte) 0x98, (byte) 0xBA, (byte) 0xDC, (byte) 0xFE};
+    private static final byte[] UNUSED = new byte[] {(byte) 0xDE, (byte) 0xAD};
+
+    @Nested
+    class GetHeaderId {
+
+        @Test
+        void getHeaderIdShouldReturnSpecificStringInLittleEndian() {
+            UidValidityExtraField testee = new UidValidityExtraField();
+
+            ByteBuffer byteBuffer = ByteBuffer.wrap(testee.getHeaderId().getBytes())
+                .order(ByteOrder.LITTLE_ENDIAN);
+            assertThat(Charsets.US_ASCII.decode(byteBuffer).toString())
+                .isEqualTo("an");
+        }
+    }
+
+    @Nested
+    class GetLocalFileDataLength {
+        @Test
+        void getLocalFileDataLengthShouldReturnIntegerSize() {
+            UidValidityExtraField testee = new UidValidityExtraField();
+
+            assertThat(testee.getLocalFileDataLength().getValue())
+                .isEqualTo(Long.BYTES);
+        }
+    }
+
+    @Nested
+    class GetCentralDirectoryLength {
+
+        @Test
+        void getCentralDirectoryLengthShouldReturnIntegerSize() {
+            UidValidityExtraField testee = new UidValidityExtraField();
+
+            assertThat(testee.getCentralDirectoryLength().getValue())
+                .isEqualTo(Long.BYTES);
+        }
+
+
+        @Test
+        void getCentralDirectoryDataShouldThrowWhenNoValue() {
+            UidValidityExtraField testee = new UidValidityExtraField();
+
+            assertThatThrownBy(() -> testee.getCentralDirectoryData())
+                .isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        void getCentralDirectoryDataShouldReturnZeroWhenZero() {
+            byte[] actual = new UidValidityExtraField(0).getCentralDirectoryData();
+            assertThat(actual).isEqualTo(ZERO_AS_BYTE_ARRAY);
+        }
+
+        @Test
+        void getCentralDirectoryDataShouldReturnValueInLittleIndianWhen123456789ABCDEF0() {
+            byte[] actual = new UidValidityExtraField(0x123456789ABCDEF0L).getCentralDirectoryData();
+            assertThat(actual).isEqualTo(_123456789ABCDEF0_AS_LE_BYTE_ARRAY);
+        }
+
+        @Test
+        void getCentralDirectoryDataShouldReturnValueInLittleIndianWhenFEDCBA9876543210() {
+            byte[] actual = new UidValidityExtraField(0xFEDCBA9876543210L).getCentralDirectoryData();
+            assertThat(actual).isEqualTo(FEDCBA9876543210_AS_LE_BYTE_ARRAY);
+        }
+    }
+
+    @Nested
+    class GetLocalFileDataData {
+
+        @Test
+        void getLocalFileDataDataShouldThrowWhenNoValue() {
+            UidValidityExtraField testee = new UidValidityExtraField();
+
+            assertThatThrownBy(() -> testee.getLocalFileDataData())
+                .isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        void getLocalFileDataDataShouldReturnZeroWhenZero() {
+            byte[] actual = new UidValidityExtraField(0).getLocalFileDataData();
+            assertThat(actual).isEqualTo(ZERO_AS_BYTE_ARRAY);
+        }
+
+        @Test
+        void getLocalFileDataDataShouldReturnValueInLittleIndianWhen123456789ABCDEF0() {
+            byte[] actual = new UidValidityExtraField(0x123456789ABCDEF0L).getLocalFileDataData();
+            assertThat(actual).isEqualTo(_123456789ABCDEF0_AS_LE_BYTE_ARRAY);
+        }
+
+        @Test
+        void getLocalFileDataDataShouldReturnValueInLittleIndianWhenFEDCBA9876543210() {
+            byte[] actual = new UidValidityExtraField(0xFEDCBA9876543210L).getLocalFileDataData();
+            assertThat(actual).isEqualTo(FEDCBA9876543210_AS_LE_BYTE_ARRAY);
+        }
+    }
+
+    @Nested
+    class ParseFromLocalFileData {
+
+        @Test
+        void parseFromLocalFileDataShouldThrownWhenLengthIsSmallerThan8() {
+            UidValidityExtraField testee = new UidValidityExtraField();
+
+            byte[] input = new byte[] {0, 0, 0, 0, 0, 0, 0};
+            assertThatThrownBy(() -> testee.parseFromLocalFileData(input, 0, 7))
+                .isInstanceOf(ZipException.class);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldThrownWhenLengthIsBiggerThan8() {
+            UidValidityExtraField testee = new UidValidityExtraField();
+
+            byte[] input = new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0};
+            assertThatThrownBy(() -> testee.parseFromLocalFileData(input, 0, 9))
+                .isInstanceOf(ZipException.class);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldParseWhenZero() throws Exception {
+            UidValidityExtraField testee = new UidValidityExtraField();
+
+            testee.parseFromLocalFileData(ZERO_AS_BYTE_ARRAY, 0, 8);
+            assertThat(testee.getValue())
+                .contains(0L);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldParseWhen123456789ABCDEF0InLittleEndian() throws Exception {
+            UidValidityExtraField testee = new UidValidityExtraField();
+
+            testee.parseFromLocalFileData(_123456789ABCDEF0_AS_LE_BYTE_ARRAY, 0, 8);
+            assertThat(testee.getValue())
+                .contains(0x123456789ABCDEF0L);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldParseWhenFEDCBA9876543210InLittleEndian() throws Exception {
+            UidValidityExtraField testee = new UidValidityExtraField();
+
+            byte[] input = FEDCBA9876543210_AS_LE_BYTE_ARRAY;
+            testee.parseFromLocalFileData(input, 0, 8);
+            assertThat(testee.getValue())
+                .contains(0xFEDCBA9876543210L);
+        }
+
+        @Test
+        void parseFromLocalFileDataShouldHandleOffset() throws Exception {
+            UidValidityExtraField testee = new UidValidityExtraField();
+
+            byte[] input = Arrays.concatenate(UNUSED, _123456789ABCDEF0_AS_LE_BYTE_ARRAY);
+            testee.parseFromLocalFileData(input, 2, 8);
+            assertThat(testee.getValue())
+                .contains(0x123456789ABCDEF0L);
+        }
+    }
+
+    @Nested
+    class ParseFromCentralDirectoryData {
+
+        @Test
+        void parseFromCentralDirectoryDataShouldThrownWhenLengthIsSmallerThan8() {
+            UidValidityExtraField testee = new UidValidityExtraField();
+            byte[] input = new byte[7];
+
+            assertThatThrownBy(() -> testee.parseFromCentralDirectoryData(input, 0, 7))
+                .isInstanceOf(ZipException.class);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldThrownWhenLengthIsBiggerThan8() {
+            UidValidityExtraField testee = new UidValidityExtraField();
+            byte[] input = new byte[9];
+
+            assertThatThrownBy(() -> testee.parseFromCentralDirectoryData(input, 0, 9))
+                .isInstanceOf(ZipException.class);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldParseWhenZero() throws Exception {
+            UidValidityExtraField testee = new UidValidityExtraField();
+
+            testee.parseFromCentralDirectoryData(ZERO_AS_BYTE_ARRAY, 0, 8);
+            assertThat(testee.getValue())
+                .contains(0L);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldParseWhen123456789ABCDEF0InLittleEndian() throws Exception {
+            UidValidityExtraField testee = new UidValidityExtraField();
+
+            testee.parseFromCentralDirectoryData(_123456789ABCDEF0_AS_LE_BYTE_ARRAY, 0, 8);
+            assertThat(testee.getValue())
+                .contains(0x123456789ABCDEF0L);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldParseWhenFEDCBA9876543210InLittleEndian() throws Exception {
+            UidValidityExtraField testee = new UidValidityExtraField();
+            byte[] input = FEDCBA9876543210_AS_LE_BYTE_ARRAY;
+
+            testee.parseFromCentralDirectoryData(input, 0, 8);
+            assertThat(testee.getValue())
+                .contains(0xFEDCBA9876543210L);
+        }
+
+        @Test
+        void parseFromCentralDirectoryDataShouldHandleOffset() throws Exception {
+            UidValidityExtraField testee = new UidValidityExtraField();
+            byte[] input = Arrays.concatenate(UNUSED, _123456789ABCDEF0_AS_LE_BYTE_ARRAY);
+
+            testee.parseFromCentralDirectoryData(input, 2, 8);
+            assertThat(testee.getValue())
+                .contains(0x123456789ABCDEF0L);
+        }
+    }
+}

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipArchiveEntryAssert.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipArchiveEntryAssert.java
@@ -38,6 +38,10 @@ public class ZipArchiveEntryAssert extends AbstractAssert<ZipArchiveEntryAssert,
         return new ZipArchiveEntryAssert(zipFile, zipArchiveEntry);
     }
 
+    private static BasicErrorMessageFactory shouldBeADirectory(ZipArchiveEntry zipArchiveEntry) {
+        return new BasicErrorMessageFactory("%nExpecting %s to be a directory but was not", zipArchiveEntry);
+    }
+
     private static BasicErrorMessageFactory shouldHaveName(ZipArchiveEntry zipArchiveEntry, String expected) {
         return new BasicErrorMessageFactory("%nExpecting %s to have name %s but was %s", zipArchiveEntry, expected, zipArchiveEntry.getName());
     }
@@ -57,6 +61,14 @@ public class ZipArchiveEntryAssert extends AbstractAssert<ZipArchiveEntryAssert,
         super(zipArchiveEntry, ZipArchiveEntryAssert.class);
         this.zipFile = zipFile;
         this.actual = zipArchiveEntry;
+    }
+
+    public ZipArchiveEntryAssert isDirectory() {
+        isNotNull();
+        if (!actual.isDirectory()) {
+            throwAssertionError(shouldBeADirectory(actual));
+        }
+        return myself;
     }
 
     public ZipArchiveEntryAssert hasName(String name) {

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipAssert.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipAssert.java
@@ -61,8 +61,12 @@ public class ZipAssert extends AbstractAssert<ZipAssert, ZipFile> {
                 check.compose(additionalCheck));
         }
 
-        public EntryChecks hasStringContent(String stringConyent) {
-            return check(check.compose(assertion -> assertion.hasStringContent(stringConyent)));
+        public EntryChecks hasStringContent(String stringContent) {
+            return check(check.compose(assertion -> assertion.hasStringContent(stringContent)));
+        }
+
+        public EntryChecks isDirectory() {
+            return check(check.compose(assertion -> assertion.isDirectory()));
         }
 
         public EntryChecks containsExtraFields(ZipExtraField... expectedExtraFields) {
@@ -75,7 +79,7 @@ public class ZipAssert extends AbstractAssert<ZipAssert, ZipFile> {
     }
 
     private static BasicErrorMessageFactory shouldHaveSize(ZipFile zipFile, int expected, int actual) {
-        return new BasicErrorMessageFactory("%nExpecting %s to have side %s but was %s", zipFile, expected, actual);
+        return new BasicErrorMessageFactory("%nExpecting %s to have size %s but was %s", zipFile, expected, actual);
     }
 
     private static BasicErrorMessageFactory shouldBeEmpty(ZipFile zipFile) {

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipAssertTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipAssertTest.java
@@ -64,9 +64,11 @@ public class ZipAssertTest {
             archiveOutputStream.finish();
         }
 
-        assertThatCode(() -> assertThatZip(new ZipFile(destination))
-                .hasNoEntry())
-            .doesNotThrowAnyException();
+        try (ZipFile zipFile = new ZipFile(destination)) {
+            assertThatCode(() -> assertThatZip(zipFile)
+                    .hasNoEntry())
+                .doesNotThrowAnyException();
+        }
     }
 
     @Test
@@ -81,9 +83,11 @@ public class ZipAssertTest {
             archiveOutputStream.finish();
         }
 
-        assertThatThrownBy(() -> assertThatZip(new ZipFile(destination))
-                .hasNoEntry())
-            .isInstanceOf(AssertionError.class);
+        try (ZipFile zipFile = new ZipFile(destination)) {
+            assertThatThrownBy(() -> assertThatZip(zipFile)
+                    .hasNoEntry())
+                .isInstanceOf(AssertionError.class);
+        }
     }
 
     @Test
@@ -92,9 +96,11 @@ public class ZipAssertTest {
             archiveOutputStream.finish();
         }
 
-        assertThatCode(() -> assertThatZip(new ZipFile(destination))
-                .containsOnlyEntriesMatching())
-            .doesNotThrowAnyException();
+        try (ZipFile zipFile = new ZipFile(destination)) {
+            assertThatCode(() -> assertThatZip(zipFile)
+                    .containsOnlyEntriesMatching())
+                .doesNotThrowAnyException();
+        }
     }
 
     @Test
@@ -114,11 +120,13 @@ public class ZipAssertTest {
             archiveOutputStream.finish();
         }
 
-        assertThatCode(() -> assertThatZip(new ZipFile(destination))
-                .containsOnlyEntriesMatching(
-                    hasName(ENTRY_NAME),
-                    hasName(ENTRY_NAME_2)))
-            .doesNotThrowAnyException();
+        try (ZipFile zipFile = new ZipFile(destination)) {
+            assertThatCode(() -> assertThatZip(zipFile)
+                    .containsOnlyEntriesMatching(
+                        hasName(ENTRY_NAME),
+                        hasName(ENTRY_NAME_2)))
+                .doesNotThrowAnyException();
+        }
     }
 
     @Test
@@ -132,10 +140,12 @@ public class ZipAssertTest {
             archiveOutputStream.finish();
         }
 
-        assertThatThrownBy(() -> assertThatZip(new ZipFile(destination))
-                .containsOnlyEntriesMatching(
-                    hasName(ENTRY_NAME_2)))
-            .isInstanceOf(AssertionError.class);
+        try (ZipFile zipFile = new ZipFile(destination)) {
+            assertThatThrownBy(() -> assertThatZip(zipFile)
+                    .containsOnlyEntriesMatching(
+                        hasName(ENTRY_NAME_2)))
+                .isInstanceOf(AssertionError.class);
+        }
     }
 
     @Test
@@ -155,11 +165,13 @@ public class ZipAssertTest {
             archiveOutputStream.finish();
         }
 
-        assertThatCode(() -> assertThatZip(new ZipFile(destination))
-                .containsOnlyEntriesMatching(
-                    hasName(ENTRY_NAME),
-                    hasName(ENTRY_NAME_2)))
-            .doesNotThrowAnyException();
+        try (ZipFile zipFile = new ZipFile(destination)) {
+            assertThatCode(() -> assertThatZip(zipFile)
+                    .containsOnlyEntriesMatching(
+                        hasName(ENTRY_NAME),
+                        hasName(ENTRY_NAME_2)))
+                .doesNotThrowAnyException();
+        }
     }
 
     @Test
@@ -179,12 +191,14 @@ public class ZipAssertTest {
             archiveOutputStream.finish();
         }
 
-        assertThatThrownBy(() -> assertThatZip(new ZipFile(destination))
-                .containsOnlyEntriesMatching(
-                    hasName(ENTRY_NAME),
-                    hasName(ENTRY_NAME_2),
-                    hasName("extraEntry")))
-            .isInstanceOf(AssertionError.class);
+        try (ZipFile zipFile = new ZipFile(destination)) {
+            assertThatThrownBy(() -> assertThatZip(zipFile)
+                    .containsOnlyEntriesMatching(
+                        hasName(ENTRY_NAME),
+                        hasName(ENTRY_NAME_2),
+                        hasName("extraEntry")))
+                .isInstanceOf(AssertionError.class);
+        }
     }
 
     @Test
@@ -204,10 +218,12 @@ public class ZipAssertTest {
             archiveOutputStream.finish();
         }
 
-        assertThatThrownBy(() -> assertThatZip(new ZipFile(destination))
-                .containsOnlyEntriesMatching(
-                    hasName(ENTRY_NAME)))
-            .isInstanceOf(AssertionError.class);
+        try (ZipFile zipFile = new ZipFile(destination)) {
+            assertThatThrownBy(() -> assertThatZip(zipFile)
+                    .containsOnlyEntriesMatching(
+                        hasName(ENTRY_NAME)))
+                .isInstanceOf(AssertionError.class);
+        }
     }
 
     @Test
@@ -222,11 +238,13 @@ public class ZipAssertTest {
             archiveOutputStream.finish();
         }
 
-        assertThatCode(() -> assertThatZip(new ZipFile(destination))
-            .containsOnlyEntriesMatching(
-                hasName(ENTRY_NAME)
-                    .hasStringContent(STRING_ENTRY_CONTENT)))
-            .doesNotThrowAnyException();
+        try (ZipFile zipFile = new ZipFile(destination)) {
+            assertThatCode(() -> assertThatZip(zipFile)
+                .containsOnlyEntriesMatching(
+                    hasName(ENTRY_NAME)
+                        .hasStringContent(STRING_ENTRY_CONTENT)))
+                .doesNotThrowAnyException();
+        }
     }
 
     @Test
@@ -241,11 +259,13 @@ public class ZipAssertTest {
             archiveOutputStream.finish();
         }
 
-        assertThatThrownBy(() -> assertThatZip(new ZipFile(destination))
-            .containsOnlyEntriesMatching(
-                hasName(ENTRY_NAME)
-                    .hasStringContent(STRING_ENTRY_CONTENT_2)))
-            .isInstanceOf(AssertionError.class);
+        try (ZipFile zipFile = new ZipFile(destination)) {
+            assertThatThrownBy(() -> assertThatZip(zipFile)
+                .containsOnlyEntriesMatching(
+                    hasName(ENTRY_NAME)
+                        .hasStringContent(STRING_ENTRY_CONTENT_2)))
+                .isInstanceOf(AssertionError.class);
+        }
     }
 
     @Test
@@ -260,11 +280,13 @@ public class ZipAssertTest {
             archiveOutputStream.finish();
         }
 
-        assertThatCode(() -> assertThatZip(new ZipFile(destination))
-            .containsOnlyEntriesMatching(
-                hasName(ENTRY_NAME)
-                    .containsExtraFields()))
-            .doesNotThrowAnyException();
+        try (ZipFile zipFile = new ZipFile(destination)) {
+            assertThatCode(() -> assertThatZip(zipFile)
+                .containsOnlyEntriesMatching(
+                    hasName(ENTRY_NAME)
+                        .containsExtraFields()))
+                .doesNotThrowAnyException();
+        }
     }
 
     @Test
@@ -279,11 +301,13 @@ public class ZipAssertTest {
             archiveOutputStream.finish();
         }
 
-        assertThatThrownBy(() -> assertThatZip(new ZipFile(destination))
-            .containsOnlyEntriesMatching(
-                hasName(ENTRY_NAME)
-                    .containsExtraFields(EXTRA_FIELD)))
-            .isInstanceOf(AssertionError.class);
+        try (ZipFile zipFile = new ZipFile(destination)) {
+            assertThatThrownBy(() -> assertThatZip(zipFile)
+                .containsOnlyEntriesMatching(
+                    hasName(ENTRY_NAME)
+                        .containsExtraFields(EXTRA_FIELD)))
+                .isInstanceOf(AssertionError.class);
+        }
     }
 
     @Test
@@ -299,11 +323,13 @@ public class ZipAssertTest {
             archiveOutputStream.finish();
         }
 
-        assertThatCode(() -> assertThatZip(new ZipFile(destination))
-            .containsOnlyEntriesMatching(
-                hasName(ENTRY_NAME)
-                    .containsExtraFields()))
-            .doesNotThrowAnyException();
+        try (ZipFile zipFile = new ZipFile(destination)) {
+            assertThatCode(() -> assertThatZip(zipFile)
+                .containsOnlyEntriesMatching(
+                    hasName(ENTRY_NAME)
+                        .containsExtraFields()))
+                .doesNotThrowAnyException();
+        }
     }
 
     @Test
@@ -319,10 +345,12 @@ public class ZipAssertTest {
             archiveOutputStream.finish();
         }
 
-        assertThatCode(() -> assertThatZip(new ZipFile(destination))
-            .containsOnlyEntriesMatching(
-                hasName(ENTRY_NAME)
-                    .containsExtraFields(EXTRA_FIELD)))
-            .doesNotThrowAnyException();
+        try (ZipFile zipFile = new ZipFile(destination)) {
+            assertThatCode(() -> assertThatZip(zipFile)
+                .containsOnlyEntriesMatching(
+                    hasName(ENTRY_NAME)
+                        .containsExtraFields(EXTRA_FIELD)))
+                .doesNotThrowAnyException();
+        }
     }
 }

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipperTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipperTest.java
@@ -161,6 +161,18 @@ class ZipperTest {
         }
     }
 
+    @Test
+    void archiveShouldWriteMailboxMetadataWhenPresent() throws Exception {
+        testee.archive(ImmutableList.of(MAILBOX_1), Stream.of(), output);
+
+        try (ZipFile zipFile = new ZipFile(toSeekableByteChannel(output))) {
+            assertThatZip(zipFile)
+                .containsOnlyEntriesMatching(
+                    hasName(MAILBOX_1.getName() + "/")
+                        .containsExtraFields(new MailboxIdExtraField(MAILBOX_1.getMailboxId().serialize())));
+        }
+    }
+
     private SeekableInMemoryByteChannel toSeekableByteChannel(ByteArrayOutputStream output) {
         return new SeekableInMemoryByteChannel(output.toByteArray());
     }

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipperTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipperTest.java
@@ -19,6 +19,7 @@
 package org.apache.james.mailbox.backup;
 
 import static org.apache.james.mailbox.backup.MailboxMessageFixture.MAILBOX_1;
+import static org.apache.james.mailbox.backup.MailboxMessageFixture.MAILBOX_1_SUB_1;
 import static org.apache.james.mailbox.backup.MailboxMessageFixture.MAILBOX_2;
 import static org.apache.james.mailbox.backup.MailboxMessageFixture.MESSAGE_1;
 import static org.apache.james.mailbox.backup.MailboxMessageFixture.MESSAGE_2;
@@ -119,6 +120,36 @@ class ZipperTest {
             assertThatZip(zipFile)
                 .containsOnlyEntriesMatching(
                     hasName(MAILBOX_1.getName() + "/")
+                        .isDirectory(),
+                    hasName(MAILBOX_2.getName() + "/")
+                        .isDirectory());
+        }
+    }
+
+    @Test
+    void archiveShouldWriteMailboxHierarchyWhenPresent() throws Exception {
+        testee.archive(ImmutableList.of(MAILBOX_1, MAILBOX_1_SUB_1, MAILBOX_2), Stream.of(), output);
+
+        try (ZipFile zipFile = new ZipFile(toSeekableByteChannel(output))) {
+            assertThatZip(zipFile)
+                .containsOnlyEntriesMatching(
+                    hasName(MAILBOX_1.getName() + "/")
+                        .isDirectory(),
+                    hasName(MAILBOX_1_SUB_1.getName() + "/")
+                        .isDirectory(),
+                    hasName(MAILBOX_2.getName() + "/")
+                        .isDirectory());
+        }
+    }
+
+    @Test
+    void archiveShouldWriteMailboxHierarchyWhenMissingParent() throws Exception {
+        testee.archive(ImmutableList.of(MAILBOX_1_SUB_1, MAILBOX_2), Stream.of(), output);
+
+        try (ZipFile zipFile = new ZipFile(toSeekableByteChannel(output))) {
+            assertThatZip(zipFile)
+                .containsOnlyEntriesMatching(
+                    hasName(MAILBOX_1_SUB_1.getName() + "/")
                         .isDirectory(),
                     hasName(MAILBOX_2.getName() + "/")
                         .isDirectory());

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipperTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipperTest.java
@@ -31,7 +31,6 @@ import static org.apache.james.mailbox.backup.ZipAssert.assertThatZip;
 import java.io.File;
 import java.io.FileOutputStream;
 
-import org.apache.commons.compress.archivers.zip.ExtraFieldUtils;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.james.junit.TemporaryFolderExtension;
 import org.apache.james.junit.TemporaryFolderExtension.TemporaryFolder;
@@ -50,8 +49,6 @@ public class ZipperTest {
     void beforeEach(TemporaryFolder temporaryFolder) throws Exception {
         testee = new Zipper();
         destination = File.createTempFile("backup-test", ".zip", temporaryFolder.getTempDir());
-
-        ExtraFieldUtils.register(SizeExtraField.class);
     }
 
     @Test

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipperTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipperTest.java
@@ -30,6 +30,7 @@ import static org.apache.james.mailbox.backup.ZipAssert.assertThatZip;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.util.stream.Stream;
 
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.james.junit.TemporaryFolderExtension;
@@ -37,8 +38,6 @@ import org.apache.james.junit.TemporaryFolderExtension.TemporaryFolder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
-import com.google.common.collect.ImmutableList;
 
 @ExtendWith(TemporaryFolderExtension.class)
 public class ZipperTest {
@@ -53,7 +52,7 @@ public class ZipperTest {
 
     @Test
     void archiveShouldWriteEmptyValidArchiveWhenNoMessage() throws Exception {
-        testee.archive(ImmutableList.of(), new FileOutputStream(destination));
+        testee.archive(Stream.of(), new FileOutputStream(destination));
 
         try (ZipFile zipFile = new ZipFile(destination)) {
             assertThatZip(zipFile).hasNoEntry();
@@ -62,7 +61,7 @@ public class ZipperTest {
 
     @Test
     void archiveShouldWriteOneMessageWhenOne() throws Exception {
-        testee.archive(ImmutableList.of(MESSAGE_1), new FileOutputStream(destination));
+        testee.archive(Stream.of(MESSAGE_1), new FileOutputStream(destination));
 
         try (ZipFile zipFile = new ZipFile(destination)) {
             assertThatZip(zipFile)
@@ -74,7 +73,7 @@ public class ZipperTest {
 
     @Test
     void archiveShouldWriteTwoMessagesWhenTwo() throws Exception {
-        testee.archive(ImmutableList.of(MESSAGE_1, MESSAGE_2), new FileOutputStream(destination));
+        testee.archive(Stream.of(MESSAGE_1, MESSAGE_2), new FileOutputStream(destination));
 
         try (ZipFile zipFile = new ZipFile(destination)) {
             assertThatZip(zipFile)
@@ -88,8 +87,8 @@ public class ZipperTest {
 
     @Test
     void archiveShouldOverwriteContent() throws Exception {
-        testee.archive(ImmutableList.of(MESSAGE_1), new FileOutputStream(destination));
-        testee.archive(ImmutableList.of(MESSAGE_2), new FileOutputStream(destination));
+        testee.archive(Stream.of(MESSAGE_1), new FileOutputStream(destination));
+        testee.archive(Stream.of(MESSAGE_2), new FileOutputStream(destination));
 
         try (ZipFile zipFile = new ZipFile(destination)) {
             assertThatZip(zipFile)
@@ -101,7 +100,7 @@ public class ZipperTest {
 
     @Test
     void archiveShouldWriteSizeMetadata() throws Exception {
-        testee.archive(ImmutableList.of(MESSAGE_1), new FileOutputStream(destination));
+        testee.archive(Stream.of(MESSAGE_1), new FileOutputStream(destination));
 
         try (ZipFile zipFile = new ZipFile(destination)) {
             assertThatZip(zipFile)

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipperTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipperTest.java
@@ -21,12 +21,14 @@ package org.apache.james.mailbox.backup;
 import static org.apache.james.mailbox.backup.MailboxMessageFixture.MAILBOX_1;
 import static org.apache.james.mailbox.backup.MailboxMessageFixture.MAILBOX_1_SUB_1;
 import static org.apache.james.mailbox.backup.MailboxMessageFixture.MAILBOX_2;
+import static org.apache.james.mailbox.backup.MailboxMessageFixture.MAILBOX_ID_1;
 import static org.apache.james.mailbox.backup.MailboxMessageFixture.MESSAGE_1;
 import static org.apache.james.mailbox.backup.MailboxMessageFixture.MESSAGE_2;
 import static org.apache.james.mailbox.backup.MailboxMessageFixture.MESSAGE_CONTENT_1;
 import static org.apache.james.mailbox.backup.MailboxMessageFixture.MESSAGE_CONTENT_2;
 import static org.apache.james.mailbox.backup.MailboxMessageFixture.MESSAGE_ID_1;
 import static org.apache.james.mailbox.backup.MailboxMessageFixture.MESSAGE_ID_2;
+import static org.apache.james.mailbox.backup.MailboxMessageFixture.MESSAGE_UID_1_VALUE;
 import static org.apache.james.mailbox.backup.MailboxMessageFixture.SIZE_1;
 import static org.apache.james.mailbox.backup.ZipAssert.assertThatZip;
 import static org.apache.james.mailbox.backup.ZipAssert.EntryChecks.hasName;
@@ -89,14 +91,17 @@ class ZipperTest {
     }
 
     @Test
-    void archiveShouldWriteSizeMetadata() throws Exception {
+    void archiveShouldWriteMetadata() throws Exception {
         testee.archive(NO_MAILBOXES, Stream.of(MESSAGE_1), output);
 
         try (ZipFile zipFile = new ZipFile(toSeekableByteChannel(output))) {
             assertThatZip(zipFile)
                 .containsOnlyEntriesMatching(
                     hasName(MESSAGE_ID_1.serialize())
-                        .containsExtraFields(new SizeExtraField(SIZE_1)));
+                        .containsExtraFields(new SizeExtraField(SIZE_1))
+                        .containsExtraFields(new UidExtraField(MESSAGE_UID_1_VALUE))
+                        .containsExtraFields(new MessageIdExtraField(MESSAGE_ID_1.serialize()))
+                        .containsExtraFields(new MailboxIdExtraField(MAILBOX_ID_1.serialize())));
         }
     }
 

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipperTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipperTest.java
@@ -30,8 +30,8 @@ import static org.apache.james.mailbox.backup.MailboxMessageFixture.MESSAGE_ID_1
 import static org.apache.james.mailbox.backup.MailboxMessageFixture.MESSAGE_ID_2;
 import static org.apache.james.mailbox.backup.MailboxMessageFixture.MESSAGE_UID_1_VALUE;
 import static org.apache.james.mailbox.backup.MailboxMessageFixture.SIZE_1;
-import static org.apache.james.mailbox.backup.ZipAssert.assertThatZip;
 import static org.apache.james.mailbox.backup.ZipAssert.EntryChecks.hasName;
+import static org.apache.james.mailbox.backup.ZipAssert.assertThatZip;
 
 import java.io.ByteArrayOutputStream;
 import java.util.List;
@@ -100,8 +100,8 @@ class ZipperTest {
                     hasName(MESSAGE_ID_1.serialize())
                         .containsExtraFields(new SizeExtraField(SIZE_1))
                         .containsExtraFields(new UidExtraField(MESSAGE_UID_1_VALUE))
-                        .containsExtraFields(new MessageIdExtraField(MESSAGE_ID_1.serialize()))
-                        .containsExtraFields(new MailboxIdExtraField(MAILBOX_ID_1.serialize())));
+                        .containsExtraFields(new MessageIdExtraField(MESSAGE_ID_1))
+                        .containsExtraFields(new MailboxIdExtraField(MAILBOX_ID_1)));
         }
     }
 
@@ -170,7 +170,7 @@ class ZipperTest {
                 .containsOnlyEntriesMatching(
                     hasName(MAILBOX_1.getName() + "/")
                         .containsExtraFields(
-                            new MailboxIdExtraField(MAILBOX_1.getMailboxId().serialize()),
+                            new MailboxIdExtraField(MAILBOX_1.getMailboxId()),
                             new UidValidityExtraField(MAILBOX_1.getUidValidity())));
         }
     }

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipperTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipperTest.java
@@ -101,7 +101,8 @@ class ZipperTest {
                         .containsExtraFields(new SizeExtraField(SIZE_1))
                         .containsExtraFields(new UidExtraField(MESSAGE_UID_1_VALUE))
                         .containsExtraFields(new MessageIdExtraField(MESSAGE_ID_1))
-                        .containsExtraFields(new MailboxIdExtraField(MAILBOX_ID_1)));
+                        .containsExtraFields(new MailboxIdExtraField(MAILBOX_ID_1))
+                        .containsExtraFields(new InternalDateExtraField(MESSAGE_1.getInternalDate())));
         }
     }
 

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipperTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipperTest.java
@@ -169,7 +169,9 @@ class ZipperTest {
             assertThatZip(zipFile)
                 .containsOnlyEntriesMatching(
                     hasName(MAILBOX_1.getName() + "/")
-                        .containsExtraFields(new MailboxIdExtraField(MAILBOX_1.getMailboxId().serialize())));
+                        .containsExtraFields(
+                            new MailboxIdExtraField(MAILBOX_1.getMailboxId().serialize()),
+                            new UidValidityExtraField(MAILBOX_1.getUidValidity())));
         }
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/ImmutableMailboxMessage.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/ImmutableMailboxMessage.java
@@ -29,7 +29,6 @@ import javax.mail.Flags;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.ComposedMessageId;
@@ -46,12 +45,6 @@ import com.google.common.collect.ImmutableList;
 public class ImmutableMailboxMessage implements MailboxMessage {
 
     public static class Factory {
-
-        private final MailboxManager mailboxManager;
-
-        public Factory(MailboxManager mailboxManager) {
-            this.mailboxManager = mailboxManager;
-        }
 
         public ImmutableMailboxMessage from(MailboxId mailboxId, MailboxMessage message) throws MailboxException {
             try {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -156,7 +156,7 @@ public class StoreMailboxManager implements MailboxManager {
         this.messageIdFactory = messageIdFactory;
         this.delegatingListener = delegatingListener;
         this.dispatcher = mailboxEventDispatcher;
-        this.immutableMailboxMessageFactory = new ImmutableMailboxMessage.Factory(this);
+        this.immutableMailboxMessageFactory = new ImmutableMailboxMessage.Factory();
         this.storeRightManager = storeRightManager;
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -41,6 +41,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.TeeInputStream;
 import org.apache.james.mailbox.MailboxListener;
 import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MailboxManager.MessageCapabilities;
 import org.apache.james.mailbox.MailboxPathLocker;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageManager;
@@ -829,5 +830,10 @@ public class StoreMessageManager implements org.apache.james.mailbox.MessageMana
 
         return messageMapper.execute(
             () -> messageMapper.listAllMessageUids(mailbox));
+    }
+
+    @Override
+    public EnumSet<MessageCapabilities> getSupportedMessageCapabilities() {
+        return messageCapabilities;
     }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/ImmutableMailboxMessageTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/ImmutableMailboxMessageTest.java
@@ -52,7 +52,7 @@ public class ImmutableMailboxMessageTest {
         MailboxManager mailboxManager = mock(MailboxManager.class);
         when(mailboxManager.getSupportedMessageCapabilities()).thenReturn(EnumSet.noneOf(MessageCapabilities.class));
 
-        messageFactory = new ImmutableMailboxMessage.Factory(mailboxManager);
+        messageFactory = new ImmutableMailboxMessage.Factory();
     }
 
     @Test


### PR DESCRIPTION
Including uidvalidity and mailboxid metadata
Todo: store internalDate in messages metadata

Also some design notes: with Antoine we decided to not store folder hierarchy as a real hierarchy because it creates more problem than it solves. For the same reason, messages are not stored in their respective mailbox because if one day we want to store several mailboxIds for one message we won't be able to store messages in their mailboxes.
With this design we also do not need to care about checking that parent mailboxes are well created, nor that every mailboxes are created for every mail.