### PR TITLE
JAMES-2439 Allow to disable unsecured JMX server with Guice

### DIFF
--- a/dockerfiles/run/guice/cassandra-ldap/destination/conf/jmx.properties
+++ b/dockerfiles/run/guice/cassandra-ldap/destination/conf/jmx.properties
@@ -24,5 +24,6 @@
 
 # See http://james.apache.org/server/3/config.html for usage
 
+jmx.enabled=true
 jmx.address=127.0.0.1
 jmx.port=9999

--- a/dockerfiles/run/guice/cassandra/destination/conf/jmx.properties
+++ b/dockerfiles/run/guice/cassandra/destination/conf/jmx.properties
@@ -24,5 +24,6 @@
 
 # See http://james.apache.org/server/3/config.html for usage
 
+jmx.enabled=true
 jmx.address=127.0.0.1
 jmx.port=9999

--- a/dockerfiles/run/guice/jpa/destination/conf/jmx.properties
+++ b/dockerfiles/run/guice/jpa/destination/conf/jmx.properties
@@ -24,5 +24,6 @@
 
 # See http://james.apache.org/server/3/config.html for usage
 
+jmx.enabled=true
 jmx.address=127.0.0.1
 jmx.port=9999

--- a/server/container/guice/jmx/pom.xml
+++ b/server/container/guice/jmx/pom.xml
@@ -77,6 +77,26 @@
             <artifactId>guice-multibindings</artifactId>
         </dependency>
         <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JMXServer.java
+++ b/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JMXServer.java
@@ -57,6 +57,9 @@ public class JMXServer {
 
     public void start() {
         synchronized (lock) {
+            if (!jmxConfiguration.isEnabled()) {
+                return;
+            }
             if (isStarted) {
                 return;
             }

--- a/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JmxConfiguration.java
+++ b/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JmxConfiguration.java
@@ -1,0 +1,75 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.server;
+
+import java.util.Objects;
+
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.james.util.Host;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+
+public class JmxConfiguration {
+
+    public static final String LOCALHOST = "localhost";
+    public static final int DEFAULT_PORT = 9999;
+
+    public static final JmxConfiguration DEFAULT_CONFIGURATION = new JmxConfiguration(Host.from(LOCALHOST, DEFAULT_PORT));
+
+    public static JmxConfiguration fromProperties(PropertiesConfiguration configuration) {
+        String address = configuration.getString("jmx.address", LOCALHOST);
+        int port = configuration.getInt("jmx.port", DEFAULT_PORT);
+        return new JmxConfiguration(Host.from(address, port));
+    }
+
+    private final Host host;
+
+    @VisibleForTesting
+    JmxConfiguration(Host host) {
+        this.host = host;
+    }
+
+    public Host getHost() {
+        return host;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof JmxConfiguration) {
+            JmxConfiguration that = (JmxConfiguration) o;
+
+            return Objects.equals(this.host, that.host);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(host);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("host", host)
+            .toString();
+    }
+}

--- a/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JmxConfiguration.java
+++ b/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JmxConfiguration.java
@@ -20,35 +20,48 @@
 package org.apache.james.modules.server;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.james.util.Host;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
 
 public class JmxConfiguration {
 
     public static final String LOCALHOST = "localhost";
     public static final int DEFAULT_PORT = 9999;
 
-    public static final JmxConfiguration DEFAULT_CONFIGURATION = new JmxConfiguration(Host.from(LOCALHOST, DEFAULT_PORT));
+    public static final JmxConfiguration DEFAULT_CONFIGURATION = new JmxConfiguration(Optional.of(Host.from(LOCALHOST, DEFAULT_PORT)));
+    public static final JmxConfiguration DISABLED = new JmxConfiguration(Optional.empty());
 
     public static JmxConfiguration fromProperties(PropertiesConfiguration configuration) {
+        boolean jmxEnabled = configuration.getBoolean("jmx.enabled", true);
+        if (!jmxEnabled) {
+            return DISABLED;
+        }
+
         String address = configuration.getString("jmx.address", LOCALHOST);
         int port = configuration.getInt("jmx.port", DEFAULT_PORT);
-        return new JmxConfiguration(Host.from(address, port));
+        return new JmxConfiguration(Optional.of(Host.from(address, port)));
     }
 
-    private final Host host;
+    private final Optional<Host> host;
 
     @VisibleForTesting
-    JmxConfiguration(Host host) {
+    JmxConfiguration(Optional<Host> host) {
         this.host = host;
     }
 
+    public boolean isEnabled() {
+        return host.isPresent();
+    }
+
     public Host getHost() {
-        return host;
+        Preconditions.checkState(isEnabled(), "Trying to access JMX host while JMX is not enabled");
+        return host.get();
     }
 
     @Override

--- a/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JmxConfiguration.java
+++ b/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JmxConfiguration.java
@@ -33,9 +33,10 @@ public class JmxConfiguration {
 
     public static final String LOCALHOST = "localhost";
     public static final int DEFAULT_PORT = 9999;
+    public static final boolean ENABLED = true;
 
-    public static final JmxConfiguration DEFAULT_CONFIGURATION = new JmxConfiguration(Optional.of(Host.from(LOCALHOST, DEFAULT_PORT)));
-    public static final JmxConfiguration DISABLED = new JmxConfiguration(Optional.empty());
+    public static final JmxConfiguration DEFAULT_CONFIGURATION = new JmxConfiguration(ENABLED, Optional.of(Host.from(LOCALHOST, DEFAULT_PORT)));
+    public static final JmxConfiguration DISABLED = new JmxConfiguration(!ENABLED, Optional.empty());
 
     public static JmxConfiguration fromProperties(PropertiesConfiguration configuration) {
         boolean jmxEnabled = configuration.getBoolean("jmx.enabled", true);
@@ -45,18 +46,25 @@ public class JmxConfiguration {
 
         String address = configuration.getString("jmx.address", LOCALHOST);
         int port = configuration.getInt("jmx.port", DEFAULT_PORT);
-        return new JmxConfiguration(Optional.of(Host.from(address, port)));
+        return new JmxConfiguration(ENABLED, Optional.of(Host.from(address, port)));
     }
 
+    private final boolean enabled;
     private final Optional<Host> host;
 
     @VisibleForTesting
-    JmxConfiguration(Optional<Host> host) {
+    JmxConfiguration(boolean enabled, Optional<Host> host) {
+        Preconditions.checkArgument(disabledOrHasHost(enabled, host), "Specifying a host is compulsory when JMX is enabled");
+        this.enabled = enabled;
         this.host = host;
     }
 
+    private boolean disabledOrHasHost(boolean enabled, Optional<Host> host) {
+        return !enabled || host.isPresent();
+    }
+
     public boolean isEnabled() {
-        return host.isPresent();
+        return enabled;
     }
 
     public Host getHost() {
@@ -69,14 +77,15 @@ public class JmxConfiguration {
         if (o instanceof JmxConfiguration) {
             JmxConfiguration that = (JmxConfiguration) o;
 
-            return Objects.equals(this.host, that.host);
+            return Objects.equals(this.host, that.host)
+                && Objects.equals(this.enabled, that.enabled);
         }
         return false;
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(host);
+        return Objects.hash(host, enabled);
     }
 
     @Override

--- a/server/container/guice/jmx/src/test/java/org/apache/james/modules/server/JmxConfigurationTest.java
+++ b/server/container/guice/jmx/src/test/java/org/apache/james/modules/server/JmxConfigurationTest.java
@@ -1,0 +1,55 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringReader;
+
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.james.util.Host;
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class JmxConfigurationTest {
+    @Test
+    void shouldMatchBeanContract() {
+        EqualsVerifier.forClass(JmxConfiguration.class)
+            .verify();
+    }
+
+    @Test
+    void fromPropertiesShouldReturnDefaultWhenEmpty() {
+        assertThat(JmxConfiguration.fromProperties(new PropertiesConfiguration()))
+            .isEqualTo(JmxConfiguration.DEFAULT_CONFIGURATION);
+    }
+
+    @Test
+    void fromPropertiesShouldReturnConfiguredValues() throws Exception {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.load(new StringReader(
+                "jmx.address=172.0.0.5\n" +
+                "jmx.port=889\n"));
+
+        assertThat(JmxConfiguration.fromProperties(configuration))
+            .isEqualTo(new JmxConfiguration(Host.from("172.0.0.5", 889)));
+    }
+}

--- a/server/container/guice/jmx/src/test/java/org/apache/james/modules/server/JmxConfigurationTest.java
+++ b/server/container/guice/jmx/src/test/java/org/apache/james/modules/server/JmxConfigurationTest.java
@@ -51,7 +51,7 @@ public class JmxConfigurationTest {
                 "jmx.port=889\n"));
 
         assertThat(JmxConfiguration.fromProperties(configuration))
-            .isEqualTo(new JmxConfiguration(Optional.of(Host.from("172.0.0.5", 889))));
+            .isEqualTo(new JmxConfiguration(JmxConfiguration.ENABLED, Optional.of(Host.from("172.0.0.5", 889))));
     }
 
     @Test

--- a/server/container/guice/jmx/src/test/java/org/apache/james/modules/server/JmxConfigurationTest.java
+++ b/server/container/guice/jmx/src/test/java/org/apache/james/modules/server/JmxConfigurationTest.java
@@ -22,6 +22,7 @@ package org.apache.james.modules.server;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.StringReader;
+import java.util.Optional;
 
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.james.util.Host;
@@ -50,6 +51,28 @@ public class JmxConfigurationTest {
                 "jmx.port=889\n"));
 
         assertThat(JmxConfiguration.fromProperties(configuration))
-            .isEqualTo(new JmxConfiguration(Host.from("172.0.0.5", 889)));
+            .isEqualTo(new JmxConfiguration(Optional.of(Host.from("172.0.0.5", 889))));
+    }
+
+    @Test
+    void fromPropertiesShouldReturnDisabledWhenConfiguredAsDisabled() throws Exception {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.load(new StringReader(
+                    "jmx.enabled=false\n"));
+
+        assertThat(JmxConfiguration.fromProperties(configuration))
+            .isEqualTo(JmxConfiguration.DISABLED);
+    }
+
+    @Test
+    void fromPropertiesShouldReturnDisabledWhenConfiguredAsDisabledWithHost() throws Exception {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.load(new StringReader(
+                    "jmx.enabled=false\n" +
+                "jmx.address=172.0.0.5\n" +
+                "jmx.port=889\n"));
+
+        assertThat(JmxConfiguration.fromProperties(configuration))
+            .isEqualTo(JmxConfiguration.DISABLED);
     }
 }

--- a/server/container/guice/memory-guice/sample-configuration/jmx.properties
+++ b/server/container/guice/memory-guice/sample-configuration/jmx.properties
@@ -24,5 +24,6 @@
 
 # See http://james.apache.org/server/3/config.html for usage
 
+jmx.enabled=true
 jmx.address=127.0.0.1
 jmx.port=9999

--- a/src/site/xdoc/server/config-system.xml
+++ b/src/site/xdoc/server/config-system.xml
@@ -117,6 +117,8 @@
                 <p>This is used to configure the JMX MBean server via which all management is achieved (also used by via the james-cli).</p>
 
                 <dl>
+                    <dt><strong>jmx.enabled</strong></dt>
+                    <dd>(Guice only). Boolean. Should the JMX server de enabled? Defaults to `true`.</dd>
                     <dt><strong>jmx.address</strong></dt>
                     <dd>The IP address (host name) the MBean Server will bind/listen to.</dd>
                     <dt><strong>jmx.port</strong></dt>

--- a/src/site/xdoc/server/config-system.xml
+++ b/src/site/xdoc/server/config-system.xml
@@ -118,7 +118,7 @@
 
                 <dl>
                     <dt><strong>jmx.enabled</strong></dt>
-                    <dd>(Guice only). Boolean. Should the JMX server de enabled? Defaults to `true`.</dd>
+                    <dd>(Guice only). Boolean. Should the JMX server be enabled? Defaults to `true`.</dd>
                     <dt><strong>jmx.address</strong></dt>
                     <dd>The IP address (host name) the MBean Server will bind/listen to.</dd>
                     <dt><strong>jmx.port</strong></dt>


### PR DESCRIPTION
This should be allowed via the configuration.

This would allow a full answer to `CVE-2017-12628`.