### PR TITLE
JAMES-2442 Integration tests for RemoteDelivery

### DIFF
--- a/server/container/util-java8/src/test/java/org/apache/james/util/docker/SwarmGenericContainer.java
+++ b/server/container/util-java8/src/test/java/org/apache/james/util/docker/SwarmGenericContainer.java
@@ -108,6 +108,11 @@ public class SwarmGenericContainer implements TestRule {
         return this;
     }
 
+    public SwarmGenericContainer withCommands(String... commands) {
+        container.withCommand(commands);
+        return this;
+    }
+
     public void start() {
         container.start();
     }

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/DirectResolutionRemoteDeliveryIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/DirectResolutionRemoteDeliveryIntegrationTest.java
@@ -21,15 +21,12 @@ package org.apache.james.mailets;
 
 import static org.apache.james.MemoryJamesServerMain.SMTP_AND_IMAP_MODULE;
 import static org.apache.james.MemoryJamesServerMain.SMTP_ONLY_MODULE;
-import static org.apache.james.mailets.configuration.Constants.DEFAULT_DOMAIN;
-import static org.apache.james.mailets.configuration.Constants.IMAP_PORT;
-import static org.apache.james.mailets.configuration.Constants.LOCALHOST_IP;
-import static org.apache.james.mailets.configuration.Constants.PASSWORD;
-import static org.apache.james.mailets.configuration.Constants.SMTP_PORT;
-import static org.apache.james.mailets.configuration.Constants.awaitAtMostOneMinute;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.apache.james.mailets.configuration.Constants.*;
+import static org.apache.james.mailets.configuration.MailetConfiguration.LOCAL_DELIVERY;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+
+import java.util.List;
 
 import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.dnsservice.api.InMemoryDNSService;
@@ -49,8 +46,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public class GatewayRemoteDeliveryIntegrationTest {
+import com.google.common.collect.ImmutableList;
+
+public class DirectResolutionRemoteDeliveryIntegrationTest {
     private static final String JAMES_ANOTHER_DOMAIN = "james.com";
+    private static final String JAMES_ANOTHER_MX_DOMAIN_1 = "mx1.james.com";
+    private static final String JAMES_ANOTHER_MX_DOMAIN_2 = "mx2.james.com";
+    private static final List<String> JAMES_ANOTHER_MX_DOMAINS = ImmutableList.of(JAMES_ANOTHER_MX_DOMAIN_1, JAMES_ANOTHER_MX_DOMAIN_2);
 
     private static final String FROM = "from@" + DEFAULT_DOMAIN;
     private static final String RECIPIENT = "touser@" + JAMES_ANOTHER_DOMAIN;
@@ -66,14 +68,10 @@ public class GatewayRemoteDeliveryIntegrationTest {
 
     private TemporaryJamesServer jamesServer;
     private DataProbe dataProbe;
-    private InMemoryDNSService inMemoryDNSService;
 
     @Before
-    public void setup() throws Exception {
+    public void setup() {
         fakeSmtp.awaitStarted(awaitAtMostOneMinute);
-
-        inMemoryDNSService = new InMemoryDNSService()
-            .registerMxRecord(JAMES_ANOTHER_DOMAIN, fakeSmtp.getContainer().getContainerIp());
     }
 
     @After
@@ -84,12 +82,18 @@ public class GatewayRemoteDeliveryIntegrationTest {
     }
 
     @Test
-    public void outgoingMailShouldTransitThroughGatewayWhenNoPort() throws Exception {
-        String gatewayProperty = fakeSmtp.getContainer().getContainerIp();
+    public void directResolutionShouldBeWellPerformed() throws Exception {
+        InMemoryDNSService inMemoryDNSService = new InMemoryDNSService()
+            .registerMxRecord(JAMES_ANOTHER_DOMAIN, fakeSmtp.getContainer().getContainerIp());
 
         jamesServer = TemporaryJamesServer.builder()
             .withBase(SMTP_ONLY_MODULE)
-            .withMailetContainer(generateMailetContainerConfiguration(gatewayProperty))
+            .withOverrides(binder -> binder.bind(DNSService.class).toInstance(inMemoryDNSService))
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(CommonProcessors.simpleRoot())
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(directResolutionTransport())
+                .putProcessor(CommonProcessors.bounces()))
             .build(temporaryFolder);
 
         dataProbe = jamesServer.getProbe(DataProbeImpl.class);
@@ -103,12 +107,20 @@ public class GatewayRemoteDeliveryIntegrationTest {
     }
 
     @Test
-    public void outgoingMailShouldTransitThroughGatewayWhenPort() throws Exception {
-        String gatewayProperty = fakeSmtp.getContainer().getContainerIp() + ":25";
+    public void directResolutionShouldFailoverOnSecondMxWhenFirstMxFailed() throws Exception {
+        InMemoryDNSService inMemoryDNSService = new InMemoryDNSService()
+            .registerRecord(JAMES_ANOTHER_DOMAIN, ImmutableList.of(), JAMES_ANOTHER_MX_DOMAINS, ImmutableList.of())
+            .registerMxRecord(JAMES_ANOTHER_MX_DOMAIN_1, LOCALHOST_IP) // TODO find another IP address
+            .registerMxRecord(JAMES_ANOTHER_MX_DOMAIN_2, fakeSmtp.getContainer().getContainerIp());
 
         jamesServer = TemporaryJamesServer.builder()
             .withBase(SMTP_ONLY_MODULE)
-            .withMailetContainer(generateMailetContainerConfiguration(gatewayProperty))
+            .withOverrides(binder -> binder.bind(DNSService.class).toInstance(inMemoryDNSService))
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(CommonProcessors.simpleRoot())
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(directResolutionTransport())
+                .putProcessor(CommonProcessors.bounces()))
             .build(temporaryFolder);
 
         dataProbe = jamesServer.getProbe(DataProbeImpl.class);
@@ -122,77 +134,18 @@ public class GatewayRemoteDeliveryIntegrationTest {
     }
 
     @Test
-    public void outgoingMailShouldTransitThroughGatewayWhenSeveralIps() throws Exception {
-        String gatewayProperty = fakeSmtp.getContainer().getContainerIp() + ",invalid.domain";
-
-        jamesServer = TemporaryJamesServer.builder()
-            .withBase(SMTP_ONLY_MODULE)
-            .withMailetContainer(generateMailetContainerConfiguration(gatewayProperty))
-            .build(temporaryFolder);
-
-        dataProbe = jamesServer.getProbe(DataProbeImpl.class);
-        dataProbe.addDomain(DEFAULT_DOMAIN);
-        dataProbe.addUser(FROM, PASSWORD);
-
-        messageSender.connect(LOCALHOST_IP, SMTP_PORT)
-            .sendMessage(FROM, RECIPIENT);
-
-        awaitAtMostOneMinute.until(this::messageIsReceivedByTheSmtpServer);
-    }
-
-    @Test
-    public void outgoingMailShouldFallbackToSecondGatewayWhenFirstInvalid() throws Exception {
-        String gatewayProperty = "invalid.domain," + fakeSmtp.getContainer().getContainerIp();
-
-        jamesServer = TemporaryJamesServer.builder()
-            .withBase(SMTP_ONLY_MODULE)
-            .withMailetContainer(generateMailetContainerConfiguration(gatewayProperty))
-            .build(temporaryFolder);
-
-        dataProbe = jamesServer.getProbe(DataProbeImpl.class);
-        dataProbe.addDomain(DEFAULT_DOMAIN);
-        dataProbe.addUser(FROM, PASSWORD);
-
-        messageSender.connect(LOCALHOST_IP, SMTP_PORT)
-            .sendMessage(FROM, RECIPIENT);
-
-        awaitAtMostOneMinute.until(this::messageIsReceivedByTheSmtpServer);
-    }
-
-    @Test
-    public void outgoingMailShouldNotBeSentDirectlyToTheHostWhenGatewayFails() throws Exception {
-        String gatewayProperty = "invalid.domain";
+    public void directResolutionShouldBounceUponUnreachableMxRecords() throws Exception {
+        InMemoryDNSService inMemoryDNSService = new InMemoryDNSService()
+            .registerRecord(JAMES_ANOTHER_DOMAIN, ImmutableList.of(), ImmutableList.of("unknown"), ImmutableList.of());
 
         jamesServer = TemporaryJamesServer.builder()
             .withBase(SMTP_AND_IMAP_MODULE)
             .withOverrides(binder -> binder.bind(DNSService.class).toInstance(inMemoryDNSService))
-            .withMailetContainer(generateMailetContainerConfiguration(gatewayProperty))
-            .build(temporaryFolder);
-
-        dataProbe = jamesServer.getProbe(DataProbeImpl.class);
-        dataProbe.addDomain(DEFAULT_DOMAIN);
-        dataProbe.addUser(FROM, PASSWORD);
-
-        messageSender.connect(LOCALHOST_IP, SMTP_PORT)
-            .sendMessage(FROM, RECIPIENT);
-
-        // Wait for bounce being sent before checking no email is sent
-        imapMessageReader.connect(LOCALHOST_IP, IMAP_PORT)
-            .login(FROM, PASSWORD)
-            .select(IMAPMessageReader.INBOX)
-            .awaitMessage(awaitAtMostOneMinute);
-        assertThat(fakeSmtp.isReceived(response -> response.body("", hasSize(0))))
-            .isTrue();
-    }
-
-    @Test
-    public void remoteDeliveryShouldBounceUponFailure() throws Exception {
-        String gatewayProperty = "invalid.domain";
-
-        jamesServer = TemporaryJamesServer.builder()
-            .withBase(SMTP_AND_IMAP_MODULE)
-            .withOverrides(binder -> binder.bind(DNSService.class).toInstance(inMemoryDNSService))
-            .withMailetContainer(generateMailetContainerConfiguration(gatewayProperty))
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(CommonProcessors.simpleRoot())
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(transport())
+                .putProcessor(CommonProcessors.bounces()))
             .build(temporaryFolder);
 
         dataProbe = jamesServer.getProbe(DataProbeImpl.class);
@@ -209,19 +162,18 @@ public class GatewayRemoteDeliveryIntegrationTest {
     }
 
     @Test
-    public void remoteDeliveryShouldBounceUponFailureWhenNoBounceProcessor() throws Exception {
-        String gatewayProperty = "invalid.domain";
+    public void directResolutionShouldBounceWhenNoMxRecord() throws Exception {
+        InMemoryDNSService inMemoryDNSService = new InMemoryDNSService()
+            .registerRecord(JAMES_ANOTHER_DOMAIN, ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
 
         jamesServer = TemporaryJamesServer.builder()
             .withBase(SMTP_AND_IMAP_MODULE)
             .withOverrides(binder -> binder.bind(DNSService.class).toInstance(inMemoryDNSService))
-            .withMailetContainer(TemporaryJamesServer.SIMPLE_MAILET_CONTAINER_CONFIGURATION
-                .putProcessor(ProcessorConfiguration.transport()
-                    .addMailet(MailetConfiguration.BCC_STRIPPER)
-                    .addMailet(MailetConfiguration.LOCAL_DELIVERY)
-                    .addMailet(MailetConfiguration.remoteDeliveryBuilderNoBounces()
-                        .matcher(All.class)
-                        .addProperty("gateway", gatewayProperty))))
+            .withMailetContainer(MailetContainer.builder()
+                .putProcessor(CommonProcessors.simpleRoot())
+                .putProcessor(CommonProcessors.error())
+                .putProcessor(transport())
+                .putProcessor(CommonProcessors.bounces()))
             .build(temporaryFolder);
 
         dataProbe = jamesServer.getProbe(DataProbeImpl.class);
@@ -244,16 +196,19 @@ public class GatewayRemoteDeliveryIntegrationTest {
             .body("[0].subject", equalTo("test")));
     }
 
-    private MailetContainer.Builder generateMailetContainerConfiguration(String gatewayProperty) {
-        return TemporaryJamesServer.SIMPLE_MAILET_CONTAINER_CONFIGURATION
-            .putProcessor(relayAndLocalDeliveryTransport(gatewayProperty));
-    }
-
-    private ProcessorConfiguration.Builder relayAndLocalDeliveryTransport(String gatewayProperty) {
+    private ProcessorConfiguration.Builder directResolutionTransport() {
         return ProcessorConfiguration.transport()
-            .addMailetsFrom(CommonProcessors.deliverOnlyTransport())
+            .addMailet(MailetConfiguration.BCC_STRIPPER)
             .addMailet(MailetConfiguration.remoteDeliveryBuilder()
-                .addProperty("gateway", gatewayProperty)
                 .matcher(All.class));
     }
+
+    private ProcessorConfiguration.Builder transport() {
+        return ProcessorConfiguration.transport()
+            .addMailet(MailetConfiguration.BCC_STRIPPER)
+            .addMailet(LOCAL_DELIVERY)
+            .addMailet(MailetConfiguration.remoteDeliveryBuilder()
+                .matcher(All.class));
+    }
+
 }

--- a/server/testing/src/main/java/org/apache/james/utils/FakeSmtp.java
+++ b/server/testing/src/main/java/org/apache/james/utils/FakeSmtp.java
@@ -42,15 +42,32 @@ import com.jayway.restassured.specification.RequestSpecification;
 import com.jayway.restassured.specification.ResponseSpecification;
 
 public class FakeSmtp implements TestRule {
+
+    public static FakeSmtp withSmtpPort(Integer smtpPort) {
+        SwarmGenericContainer container = new SwarmGenericContainer(Images.FAKE_SMTP)
+                .withAffinityToContainer()
+                .withCommands("node", "cli", "--listen", "80", "--smtp", smtpPort.toString())
+                .waitingFor(new HostPortWaitStrategy());
+
+        return new FakeSmtp(container, smtpPort);
+    }
+
     private static final int SMTP_PORT = 25;
     private static final ResponseSpecification RESPONSE_SPECIFICATION = new ResponseSpecBuilder().build();
     private final SwarmGenericContainer container;
+    private final Integer smtpPort;
 
     public FakeSmtp() {
-        container = new SwarmGenericContainer(Images.FAKE_SMTP)
-            .withExposedPorts(SMTP_PORT)
-            .withAffinityToContainer()
-            .waitingFor(new HostPortWaitStrategy());
+        this(new SwarmGenericContainer(Images.FAKE_SMTP)
+                .withExposedPorts(SMTP_PORT)
+                .withAffinityToContainer()
+                .waitingFor(new HostPortWaitStrategy()),
+            SMTP_PORT);
+    }
+
+    public FakeSmtp(SwarmGenericContainer container, Integer smtpPort) {
+        this.smtpPort = smtpPort;
+        this.container = container;
     }
 
     @Override
@@ -59,7 +76,7 @@ public class FakeSmtp implements TestRule {
     }
 
     public void awaitStarted(ConditionFactory calmyAwait) {
-        calmyAwait.until(() -> container.tryConnect(SMTP_PORT));
+        calmyAwait.until(() -> container.tryConnect(smtpPort));
     }
 
     public boolean isReceived(Function<ValidatableResponse, ValidatableResponse> expectations) {

--- a/server/testing/src/main/java/org/apache/james/utils/FakeSmtp.java
+++ b/server/testing/src/main/java/org/apache/james/utils/FakeSmtp.java
@@ -44,12 +44,16 @@ import com.jayway.restassured.specification.ResponseSpecification;
 public class FakeSmtp implements TestRule {
 
     public static FakeSmtp withSmtpPort(Integer smtpPort) {
-        SwarmGenericContainer container = new SwarmGenericContainer(Images.FAKE_SMTP)
-                .withAffinityToContainer()
-                .withCommands("node", "cli", "--listen", "80", "--smtp", smtpPort.toString())
-                .waitingFor(new HostPortWaitStrategy());
+        SwarmGenericContainer container = fakeSmtpContainer()
+            .withCommands("node", "cli", "--listen", "80", "--smtp", smtpPort.toString());
 
         return new FakeSmtp(container, smtpPort);
+    }
+
+    private static SwarmGenericContainer fakeSmtpContainer() {
+        return new SwarmGenericContainer(Images.FAKE_SMTP)
+            .withAffinityToContainer()
+            .waitingFor(new HostPortWaitStrategy());
     }
 
     private static final int SMTP_PORT = 25;
@@ -58,11 +62,7 @@ public class FakeSmtp implements TestRule {
     private final Integer smtpPort;
 
     public FakeSmtp() {
-        this(new SwarmGenericContainer(Images.FAKE_SMTP)
-                .withExposedPorts(SMTP_PORT)
-                .withAffinityToContainer()
-                .waitingFor(new HostPortWaitStrategy()),
-            SMTP_PORT);
+        this(fakeSmtpContainer().withExposedPorts(SMTP_PORT), SMTP_PORT);
     }
 
     public FakeSmtp(SwarmGenericContainer container, Integer smtpPort) {


### PR DESCRIPTION
- That an unreachable MX IP will generate a failover to the second MX when direct resolution
- If all (direct resolution) MX IPs are not reachable, a bounce is sent
- what happens when direct resolution to a domain with no mx records? a bounce is sent