### PR TITLE
JAMES-2448 Enhance jmap memory tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -582,7 +582,7 @@
 
         <activemq.version>5.15.2</activemq.version>
         <apache-mime4j.version>0.8.2</apache-mime4j.version>
-        <camel.version>2.19.4</camel.version>
+        <camel.version>2.21.1</camel.version>
         <derby.version>10.9.1.0</derby.version>
         <hadoop.version>1.1.1</hadoop.version>
         <hbase.version>0.94.27</hbase.version>

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraMailRepositoryIntegrationTest.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraMailRepositoryIntegrationTest.java
@@ -21,6 +21,8 @@ package org.apache.james;
 
 import static com.jayway.awaitility.Duration.FIVE_HUNDRED_MILLISECONDS;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.james.mailrepository.api.MailRepositoryUrl;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.MailRepositoryProbeImpl;
@@ -32,11 +34,13 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import com.jayway.awaitility.Awaitility;
+import com.jayway.awaitility.Duration;
 import com.jayway.awaitility.core.ConditionFactory;
 
 public class CassandraMailRepositoryIntegrationTest {
 
     private static final MailRepositoryUrl SENDER_DENIED_URL = MailRepositoryUrl.from("cassandra://var/mail/sender-denied/");
+    private static final Duration ONE_MILLISECOND = new Duration(1, TimeUnit.MILLISECONDS);
 
     @ClassRule
     public static DockerCassandraRule cassandra = new DockerCassandraRule();
@@ -57,7 +61,7 @@ public class CassandraMailRepositoryIntegrationTest {
             .pollInterval(FIVE_HUNDRED_MILLISECONDS)
             .and()
             .with()
-            .pollDelay(FIVE_HUNDRED_MILLISECONDS)
+            .pollDelay(ONE_MILLISECOND)
             .await();
     }
 

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/DirectResolutionRemoteDeliveryIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/DirectResolutionRemoteDeliveryIntegrationTest.java
@@ -48,6 +48,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import com.google.common.collect.ImmutableList;
+import com.jayway.awaitility.Duration;
 
 public class DirectResolutionRemoteDeliveryIntegrationTest {
     private static final String JAMES_ANOTHER_DOMAIN = "james.com";
@@ -110,7 +111,9 @@ public class DirectResolutionRemoteDeliveryIntegrationTest {
         messageSender.connect(LOCALHOST_IP, SMTP_PORT)
             .sendMessage(FROM, RECIPIENT);
 
-        awaitAtMostOneMinute.until(this::messageIsReceivedByTheSmtpServer);
+        awaitAtMostOneMinute
+            .pollDelay(Duration.FIVE_HUNDRED_MILLISECONDS)
+            .until(this::messageIsReceivedByTheSmtpServer);
     }
 
     @Test
@@ -137,7 +140,9 @@ public class DirectResolutionRemoteDeliveryIntegrationTest {
         messageSender.connect(LOCALHOST_IP, SMTP_PORT)
             .sendMessage(FROM, RECIPIENT);
 
-        awaitAtMostOneMinute.until(this::messageIsReceivedByTheSmtpServer);
+        awaitAtMostOneMinute
+            .pollDelay(Duration.FIVE_HUNDRED_MILLISECONDS)
+            .until(this::messageIsReceivedByTheSmtpServer);
     }
 
     @Test

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/GatewayRemoteDeliveryIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/GatewayRemoteDeliveryIntegrationTest.java
@@ -49,6 +49,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import com.jayway.awaitility.Duration;
+
 public class GatewayRemoteDeliveryIntegrationTest {
     private static final String JAMES_ANOTHER_DOMAIN = "james.com";
 
@@ -99,7 +101,9 @@ public class GatewayRemoteDeliveryIntegrationTest {
         messageSender.connect(LOCALHOST_IP, SMTP_PORT)
             .sendMessage(FROM, RECIPIENT);
 
-        awaitAtMostOneMinute.until(this::messageIsReceivedByTheSmtpServer);
+        awaitAtMostOneMinute
+            .pollDelay(Duration.FIVE_HUNDRED_MILLISECONDS)
+            .until(this::messageIsReceivedByTheSmtpServer);
     }
 
     @Test
@@ -137,7 +141,9 @@ public class GatewayRemoteDeliveryIntegrationTest {
         messageSender.connect(LOCALHOST_IP, SMTP_PORT)
             .sendMessage(FROM, RECIPIENT);
 
-        awaitAtMostOneMinute.until(this::messageIsReceivedByTheSmtpServer);
+        awaitAtMostOneMinute
+            .pollDelay(Duration.FIVE_HUNDRED_MILLISECONDS)
+            .until(this::messageIsReceivedByTheSmtpServer);
     }
 
     @Test
@@ -156,7 +162,9 @@ public class GatewayRemoteDeliveryIntegrationTest {
         messageSender.connect(LOCALHOST_IP, SMTP_PORT)
             .sendMessage(FROM, RECIPIENT);
 
-        awaitAtMostOneMinute.until(this::messageIsReceivedByTheSmtpServer);
+        awaitAtMostOneMinute
+            .pollDelay(Duration.FIVE_HUNDRED_MILLISECONDS)
+            .until(this::messageIsReceivedByTheSmtpServer);
     }
 
     @Test

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/configuration/Constants.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/configuration/Constants.java
@@ -19,20 +19,24 @@
 
 package org.apache.james.mailets.configuration;
 
-import static com.jayway.awaitility.Duration.FIVE_HUNDRED_MILLISECONDS;
+import static com.jayway.awaitility.Duration.ONE_HUNDRED_MILLISECONDS;
 import static com.jayway.awaitility.Duration.ONE_MINUTE;
+
+import java.util.concurrent.TimeUnit;
 
 import com.jayway.awaitility.Awaitility;
 import com.jayway.awaitility.Duration;
 import com.jayway.awaitility.core.ConditionFactory;
 
 public class Constants {
-    public static Duration slowPacedPollInterval = FIVE_HUNDRED_MILLISECONDS;
+    public static Duration slowPacedPollInterval = ONE_HUNDRED_MILLISECONDS;
+    public static Duration ONE_MILLISECOND = new Duration(1, TimeUnit.MILLISECONDS);
+
     public static ConditionFactory calmlyAwait = Awaitility.with()
         .pollInterval(slowPacedPollInterval)
         .and()
         .with()
-        .pollDelay(slowPacedPollInterval)
+        .pollDelay(ONE_MILLISECOND)
         .await();
     public static ConditionFactory awaitAtMostOneMinute = calmlyAwait.atMost(ONE_MINUTE);
 

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/smtp/SmtpAuthorizedAddressesTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/smtp/SmtpAuthorizedAddressesTest.java
@@ -50,6 +50,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import com.jayway.awaitility.Duration;
+
 public class SmtpAuthorizedAddressesTest {
     private static final String FROM = "fromuser@" + DEFAULT_DOMAIN;
     private static final String TO = "to@any.com";
@@ -134,10 +136,12 @@ public class SmtpAuthorizedAddressesTest {
             .authenticate(FROM, PASSWORD)
             .sendMessage(FROM, TO);
 
-        awaitAtMostOneMinute.until(() -> fakeSmtp.isReceived(response -> response
-            .body("", hasSize(1))
-            .body("[0].from", equalTo(FROM))
-            .body("[0].subject", equalTo("test"))));
+        awaitAtMostOneMinute
+            .pollDelay(Duration.FIVE_HUNDRED_MILLISECONDS)
+            .until(() -> fakeSmtp.isReceived(response -> response
+                .body("", hasSize(1))
+                .body("[0].from", equalTo(FROM))
+                .body("[0].subject", equalTo("test"))));
     }
 
     @Test

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/MatcherMailetPair.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/MatcherMailetPair.java
@@ -51,4 +51,9 @@ public class MatcherMailetPair {
         return mailet;
     }
 
+    public String getOnMatchException() {
+        return mailet.getMailetConfig()
+            .getInitParameter("onMatchException");
+    }
+
 }

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/CamelCompositeProcessor.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/CamelCompositeProcessor.java
@@ -72,14 +72,12 @@ public class CamelCompositeProcessor extends AbstractStateCompositeProcessor imp
     @Override
     @PostConstruct
     public void init() throws Exception {
-        super.init();
-
         // Make sure the camel context get started
         // See https://issues.apache.org/jira/browse/JAMES-1069
         if (getCamelContext().getStatus().isStopped()) {
             getCamelContext().start();
         }
-
+        super.init();
     }
 
     @PreDestroy

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/CamelMailetProcessor.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/CamelMailetProcessor.java
@@ -128,7 +128,6 @@ public class CamelMailetProcessor extends AbstractStateMailetProcessor implement
 
         private final List<MatcherMailetPair> pairs;
         private final MetricFactory metricFactory;
-        private boolean isMatched;
 
         private MailetContainerRouteBuilder(CamelMailetProcessor container, MetricFactory metricFactory, List<MatcherMailetPair> pairs) {
             this.container = container;
@@ -174,7 +173,7 @@ public class CamelMailetProcessor extends AbstractStateMailetProcessor implement
 
         private void handleMailet(Exchange exchange, CamelMailetProcessor container, CamelProcessor mailetProccessor) throws Exception {
             Mail mail = exchange.getIn().getBody(Mail.class);
-            isMatched = mail.removeAttribute(MatcherSplitter.MATCHER_MATCHED_ATTRIBUTE) != null;
+            boolean isMatched = mail.removeAttribute(MatcherSplitter.MATCHER_MATCHED_ATTRIBUTE) != null;
             if (isMatched) {
                 mailetProccessor.process(mail);
             }

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/CamelMailetProcessor.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/CamelMailetProcessor.java
@@ -28,17 +28,16 @@ import org.apache.camel.CamelContextAware;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
-import org.apache.camel.Processor;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.processor.aggregate.UseLatestAggregationStrategy;
+import org.apache.james.lifecycle.api.LifecycleUtil;
 import org.apache.james.mailetcontainer.impl.MatcherMailetPair;
 import org.apache.james.mailetcontainer.lib.AbstractStateMailetProcessor;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.mailet.Mail;
 import org.apache.mailet.Mailet;
-import org.apache.mailet.MailetConfig;
 import org.apache.mailet.Matcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,7 +55,6 @@ public class CamelMailetProcessor extends AbstractStateMailetProcessor implement
 
     private ProducerTemplate producerTemplate;
 
-    private final UseLatestAggregationStrategy aggr = new UseLatestAggregationStrategy();
     private final MetricFactory metricFactory;
     private List<MatcherMailetPair> pairs;
 
@@ -114,7 +112,7 @@ public class CamelMailetProcessor extends AbstractStateMailetProcessor implement
     protected void setupRouting(List<MatcherMailetPair> pairs) throws MessagingException {
         try {
             this.pairs = pairs;
-            context.addRoutes(new MailetContainerRouteBuilder(pairs));
+            context.addRoutes(new MailetContainerRouteBuilder(this, metricFactory, pairs));
         } catch (Exception e) {
             throw new MessagingException("Unable to setup routing for MailetMatcherPairs", e);
         }
@@ -124,84 +122,83 @@ public class CamelMailetProcessor extends AbstractStateMailetProcessor implement
      * {@link RouteBuilder} which construct the Matcher and Mailet routing use
      * Camel DSL
      */
-    private final class MailetContainerRouteBuilder extends RouteBuilder {
+    private static class MailetContainerRouteBuilder extends RouteBuilder {
+
+        private final CamelMailetProcessor container;
 
         private final List<MatcherMailetPair> pairs;
+        private final MetricFactory metricFactory;
+        private boolean isMatched;
 
-        public MailetContainerRouteBuilder(List<MatcherMailetPair> pairs) {
+        private MailetContainerRouteBuilder(CamelMailetProcessor container, MetricFactory metricFactory, List<MatcherMailetPair> pairs) {
+            this.container = container;
+            this.metricFactory = metricFactory;
             this.pairs = pairs;
         }
 
         @Override
         public void configure() {
-            Processor disposeProcessor = new DisposeProcessor();
-            Processor completeProcessor = new CompleteProcessor();
-            Processor stateChangedProcessor = new StateChangedProcessor();
+            String state = container.getState();
+            CamelProcessor terminatingMailetProcessor = new CamelProcessor(metricFactory, container, new TerminatingMailet());
 
-            String state = getState();
-
-            RouteDefinition processorDef = from(getEndpoint())
+            RouteDefinition processorDef = from(container.getEndpoint())
                 .routeId(state)
                 .setExchangePattern(ExchangePattern.InOnly);
 
             for (MatcherMailetPair pair : pairs) {
-                Matcher matcher = pair.getMatcher();
-                Mailet mailet = pair.getMailet();
-
-                MailetConfig mailetConfig = mailet.getMailetConfig();
-                String onMatchException = mailetConfig.getInitParameter("onMatchException");
-
-                CamelProcessor mailetProccessor = new CamelProcessor(metricFactory, mailet, CamelMailetProcessor.this);
-                // Store the matcher to use for splitter in properties
-                MatcherSplitter matcherSplitter = new MatcherSplitter(metricFactory, CamelMailetProcessor.this, matcher, onMatchException);
+                CamelProcessor mailetProccessor = new CamelProcessor(metricFactory, container, pair.getMailet());
+                MatcherSplitter matcherSplitter = new MatcherSplitter(metricFactory, container, pair);
 
                 processorDef
                         // do splitting of the mail based on the stored matcher
-                        .split().method(matcherSplitter).aggregationStrategy(aggr)
-
-                        .choice().when(new MatcherMatch()).process(mailetProccessor).end()
-
-                        .choice().when(new MailStateEquals(Mail.GHOST)).process(disposeProcessor).stop().end()
-
-                        .choice().when(new MailStateNotEquals(state)).process(stateChangedProcessor).process(completeProcessor).stop().end();
+                        .split().method(matcherSplitter)
+                            .aggregationStrategy(new UseLatestAggregationStrategy())
+                        .process(exchange -> handleMailet(exchange, container, mailetProccessor));
             }
-
-            Processor terminatingMailetProcessor = new CamelProcessor(metricFactory, new TerminatingMailet(), CamelMailetProcessor.this);
 
             processorDef
-                    // start choice
-                    .choice()
-
-                    // when the mail state did not change till yet ( the end of
-                    // the route) we need to call the TerminatingMailet to
-                    // make sure we don't fall into a endless loop
-                    .when(new MailStateEquals(state)).process(terminatingMailetProcessor).stop()
-
-                    // dispose when needed
-                    .when(new MailStateEquals(Mail.GHOST)).process(disposeProcessor).stop()
-
-                    // this container is complete
-                    .otherwise().process(completeProcessor).stop();
+                .process(exchange -> terminateSmoothly(exchange, container, terminatingMailetProcessor));
 
         }
 
-        private final class CompleteProcessor implements Processor {
+        private void terminateSmoothly(Exchange exchange, CamelMailetProcessor container, CamelProcessor terminatingMailetProcessor) throws Exception {
+            Mail mail = exchange.getIn().getBody(Mail.class);
+            if (mail.getState().equals(container.getState())) {
+                terminatingMailetProcessor.process(mail);
+            }
+            if (mail.getState().equals(Mail.GHOST)) {
+                dispose(exchange, mail);
+            }
+            complete(exchange, container);
+        }
 
-            @Override
-            public void process(Exchange ex) {
-                LOGGER.debug("End of mailetprocessor for state {} reached", getState());
-                ex.setProperty(Exchange.ROUTE_STOP, true);
+        private void handleMailet(Exchange exchange, CamelMailetProcessor container, CamelProcessor mailetProccessor) throws Exception {
+            Mail mail = exchange.getIn().getBody(Mail.class);
+            isMatched = mail.removeAttribute(MatcherSplitter.MATCHER_MATCHED_ATTRIBUTE) != null;
+            if (isMatched) {
+                mailetProccessor.process(mail);
+            }
+            if (mail.getState().equals(Mail.GHOST)) {
+                dispose(exchange, mail);
+                return;
+            }
+            if (!mail.getState().equals(container.getState())) {
+                container.toProcessor(mail);
+                complete(exchange, container);
             }
         }
 
-        private final class StateChangedProcessor implements Processor {
+        private void complete(Exchange exchange, CamelMailetProcessor container) {
+            LOGGER.debug("End of mailetprocessor for state {} reached", container.getState());
+            exchange.setProperty(Exchange.ROUTE_STOP, true);
+        }
 
-            @Override
-            public void process(Exchange arg0) throws Exception {
-                Mail mail = arg0.getIn().getBody(Mail.class);
-                toProcessor(mail);
-            }
+        private void dispose(Exchange exchange, Mail mail) throws MessagingException {
+            LifecycleUtil.dispose(mail.getMessage());
+            LifecycleUtil.dispose(mail);
 
+            // stop routing
+            exchange.setProperty(Exchange.ROUTE_STOP, true);
         }
 
     }

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/CamelProcessor.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/CamelProcessor.java
@@ -22,8 +22,6 @@ import java.io.Closeable;
 import java.util.List;
 import java.util.Locale;
 
-import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.james.mailetcontainer.impl.MailetConfigImpl;
 import org.apache.james.mailetcontainer.impl.ProcessorUtil;
 import org.apache.james.mailetcontainer.lib.AbstractStateMailetProcessor.MailetProcessorListener;
@@ -42,7 +40,7 @@ import com.google.common.collect.ImmutableList;
 /**
  * Mailet wrapper which execute a Mailet in a Processor
  */
-public class CamelProcessor implements Processor {
+public class CamelProcessor {
     private static final Logger LOGGER = LoggerFactory.getLogger(CamelProcessor.class);
 
     private final MetricFactory metricFactory;
@@ -51,22 +49,20 @@ public class CamelProcessor implements Processor {
 
     /**
      * Mailet to call on process
-     *
-     * @param metricFactory
+     *  @param metricFactory
+     * @param processor
      * @param mailet
      */
-    public CamelProcessor(MetricFactory metricFactory, Mailet mailet, CamelMailetProcessor processor) {
+    public CamelProcessor(MetricFactory metricFactory, CamelMailetProcessor processor, Mailet mailet) {
         this.metricFactory = metricFactory;
-        this.mailet = mailet;
         this.processor = processor;
+        this.mailet = mailet;
     }
 
     /**
      * Call the wrapped mailet for the exchange
      */
-    @Override
-    public void process(Exchange exchange) throws Exception {
-        Mail mail = exchange.getIn().getBody(Mail.class);
+    public void process(Mail mail) throws Exception {
         long start = System.currentTimeMillis();
         TimeMetric timeMetric = metricFactory.timer(mailet.getClass().getSimpleName());
         Exception ex = null;

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/MatcherSplitter.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/MatcherSplitter.java
@@ -32,6 +32,7 @@ import org.apache.camel.Body;
 import org.apache.camel.Handler;
 import org.apache.camel.InOnly;
 import org.apache.james.core.MailAddress;
+import org.apache.james.mailetcontainer.impl.MatcherMailetPair;
 import org.apache.james.mailetcontainer.impl.ProcessorUtil;
 import org.apache.james.mailetcontainer.lib.AbstractStateMailetProcessor.MailetProcessorListener;
 import org.apache.james.metrics.api.MetricFactory;
@@ -61,11 +62,11 @@ public class MatcherSplitter {
     private final Matcher matcher;
     private final String onMatchException;
 
-    public MatcherSplitter(MetricFactory metricFactory, CamelMailetProcessor container, Matcher matcher, String onMatchException) {
+    public MatcherSplitter(MetricFactory metricFactory, CamelMailetProcessor container, MatcherMailetPair pair) {
         this.metricFactory = metricFactory;
         this.container = container;
-        this.matcher = matcher;
-        this.onMatchException = Optional.ofNullable(onMatchException)
+        this.matcher = pair.getMatcher();
+        this.onMatchException = Optional.ofNullable(pair.getOnMatchException())
             .map(s -> s.trim().toLowerCase(Locale.US))
             .orElse(Mail.ERROR);
     }

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/lib/AbstractStateMailetProcessor.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/lib/AbstractStateMailetProcessor.java
@@ -383,7 +383,7 @@ public abstract class AbstractStateMailetProcessor implements MailProcessor, Con
      * Mailet which protect us to not fall into an endless loop caused by an
      * configuration error
      */
-    public final class TerminatingMailet extends GenericMailet {
+    public static class TerminatingMailet extends GenericMailet {
         /**
          * The name of the mailet used to terminate the mailet chain. The end of
          * the matcher/mailet chain must be a matcher that matches all mails and

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/TestingConstants.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/TestingConstants.java
@@ -23,6 +23,7 @@ import static com.jayway.restassured.config.EncoderConfig.encoderConfig;
 import static com.jayway.restassured.config.RestAssuredConfig.newConfig;
 
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 
 import com.jayway.awaitility.Awaitility;
 import com.jayway.awaitility.Duration;
@@ -31,12 +32,13 @@ import com.jayway.restassured.builder.RequestSpecBuilder;
 import com.jayway.restassured.http.ContentType;
 
 public interface TestingConstants {
-    Duration slowPacedPollInterval = Duration.FIVE_HUNDRED_MILLISECONDS;
+    Duration slowPacedPollInterval = Duration.ONE_HUNDRED_MILLISECONDS;
+    Duration ONE_MILLISECOND = new Duration(1, TimeUnit.MILLISECONDS);
 
     ConditionFactory calmlyAwait = Awaitility.with()
         .pollInterval(slowPacedPollInterval)
         .and().with()
-        .pollDelay(slowPacedPollInterval)
+        .pollDelay(ONE_MILLISECOND)
         .await();
 
     RequestSpecBuilder jmapRequestSpecBuilder = new RequestSpecBuilder()

--- a/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/resources/imapserver.xml
+++ b/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/resources/imapserver.xml
@@ -36,19 +36,4 @@ under the License.
         <connectionLimit>0</connectionLimit>
         <connectionLimitPerIP>0</connectionLimitPerIP>
     </imapserver>
-    <imapserver enabled="true">
-        <jmxName>imapserver-ssl</jmxName>
-        <bind>0.0.0.0:1993</bind>
-        <connectionBacklog>200</connectionBacklog>
-        <tls socketTLS="false" startTLS="false">
-            <!-- To create a new keystore execute:
-              keytool -genkey -alias james -keyalg RSA -keystore /path/to/james/conf/keystore
-             -->
-            <keystore>file://conf/keystore</keystore>
-            <secret>james72laBalle</secret>
-            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
-        </tls>
-        <connectionLimit>0</connectionLimit>
-        <connectionLimitPerIP>0</connectionLimitPerIP>
-    </imapserver>
 </imapservers>

--- a/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/resources/lmtpserver.xml
+++ b/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/resources/lmtpserver.xml
@@ -20,22 +20,4 @@
 
 <lmtpservers>
 
-    <lmtpserver enabled="true">
-        <jmxName>lmtpserver</jmxName>
-        <!-- LMTP should not be reachable from outside your network so bind it to loopback-->
-        <bind>127.0.0.1:1024</bind>
-        <connectionBacklog>200</connectionBacklog>
-        <connectiontimeout>1200</connectiontimeout>
-        <!-- Set the maximum simultaneous incoming connections for this service -->
-        <connectionLimit>0</connectionLimit>
-        <!-- Set the maximum simultaneous incoming connections per IP for this service -->
-        <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--  This sets the maximum allowed message size (in kilobytes) for this -->
-        <!--  LMTP service. If unspecified, the value defaults to 0, which means no limit. -->
-        <maxmessagesize>0</maxmessagesize>
-        <handlerchain>
-            <handler class="org.apache.james.lmtpserver.CoreCmdHandlerLoader"/>
-        </handlerchain>
-    </lmtpserver>
-
 </lmtpservers>

--- a/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/resources/managesieveserver.xml
+++ b/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/resources/managesieveserver.xml
@@ -27,39 +27,6 @@
 
 <managesieveservers>
 
-   <managesieveserver enabled="true">
-
-     <jmxName>managesieveserver</jmxName>
-
-     <bind>0.0.0.0:4190</bind>
-
-     <connectionBacklog>200</connectionBacklog>
-
-     <tls socketTLS="false" startTLS="false">
-       <!-- To create a new keystore execute:
-        keytool -genkey -alias james -keyalg RSA -keystore /path/to/james/conf/keystore
-         -->
-       <keystore>file://conf/keystore</keystore>
-       <secret>james72laBalle</secret>
-       <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
-       <!-- The algorithm is optional and only needs to be specified when using something other
-        than the Sun JCE provider - You could use IbmX509 with IBM Java runtime. -->
-       <algorithm>SunX509</algorithm>
-     </tls>
-         
-        <!-- connection timeout in secconds -->
-        <connectiontimeout>360</connectiontimeout>
-
-        <!-- Set the maximum simultaneous incoming connections for this service -->
-        <connectionLimit>0</connectionLimit>
-         
-        <!-- Set the maximum simultaneous incoming connections per IP for this service -->
-        <connectionLimitPerIP>0</connectionLimitPerIP>
-        <maxmessagesize>0</maxmessagesize>
-        <addressBracketsEnforcement>true</addressBracketsEnforcement>
-  
-   </managesieveserver>
-
 </managesieveservers>
 
 

--- a/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/resources/pop3server.xml
+++ b/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/resources/pop3server.xml
@@ -20,23 +20,4 @@
 
 
 <pop3servers>
-    <pop3server enabled="true">
-        <jmxName>pop3server</jmxName>
-        <bind>0.0.0.0:1110</bind>
-        <connectionBacklog>200</connectionBacklog>
-        <tls socketTLS="false" startTLS="false">
-            <!-- To create a new keystore execute:
-                  keytool -genkey -alias james -keyalg RSA -keystore /path/to/james/conf/keystore
-             -->
-            <keystore>file://conf/keystore</keystore>
-            <secret>james72laBalle</secret>
-            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
-        </tls>
-        <connectiontimeout>1200</connectiontimeout>
-        <connectionLimit>0</connectionLimit>
-        <connectionLimitPerIP>0</connectionLimitPerIP>
-        <handlerchain>
-            <handler class="org.apache.james.pop3server.core.CoreCmdHandlerLoader"/>
-        </handlerchain>
-    </pop3server>
 </pop3servers>

--- a/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/resources/smtpserver.xml
+++ b/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/resources/smtpserver.xml
@@ -43,60 +43,6 @@
             <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
         </handlerchain>
     </smtpserver>
-    <smtpserver enabled="true">
-        <jmxName>smtpserver-TLS</jmxName>
-        <bind>0.0.0.0:10465</bind>
-        <connectionBacklog>200</connectionBacklog>
-        <tls socketTLS="false" startTLS="false">
-            <keystore>file://conf/keystore</keystore>
-            <secret>james72laBalle</secret>
-            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
-            <algorithm>SunX509</algorithm>
-        </tls>
-        <connectiontimeout>360</connectiontimeout>
-        <connectionLimit>0</connectionLimit>
-        <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
-        <!-- Trust authenticated users -->
-        <verifyIdentity>false</verifyIdentity>
-        <maxmessagesize>0</maxmessagesize>
-        <addressBracketsEnforcement>true</addressBracketsEnforcement>
-        <smtpGreeting>JAMES Linagora's SMTP awesome Server</smtpGreeting>
-        <handlerchain>
-            <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
-            <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
-        </handlerchain>
-    </smtpserver>
-    <smtpserver enabled="true">
-        <jmxName>smtpserver-authenticated</jmxName>
-        <bind>0.0.0.0:1587</bind>
-        <connectionBacklog>200</connectionBacklog>
-        <tls socketTLS="false" startTLS="false">
-            <keystore>file://conf/keystore</keystore>
-            <secret>james72laBalle</secret>
-            <provider>org.bouncycastle.jce.provider.BouncyCastleProvider</provider>
-            <algorithm>SunX509</algorithm>
-        </tls>
-        <connectiontimeout>360</connectiontimeout>
-        <connectionLimit>0</connectionLimit>
-        <connectionLimitPerIP>0</connectionLimitPerIP>
-        <!--
-           Authorize only local users
-        -->
-        <authRequired>true</authRequired>
-        <!-- Trust authenticated users -->
-        <verifyIdentity>false</verifyIdentity>
-        <maxmessagesize>0</maxmessagesize>
-        <addressBracketsEnforcement>true</addressBracketsEnforcement>
-        <smtpGreeting>JAMES Linagora's SMTP awesome Server</smtpGreeting>
-        <handlerchain>
-            <handler class="org.apache.james.smtpserver.fastfail.ValidRcptHandler"/>
-            <handler class="org.apache.james.smtpserver.CoreCmdHandlerLoader"/>
-        </handlerchain>
-    </smtpserver>
 </smtpservers>
 
 


### PR DESCRIPTION
Before: 1 test = 2'' -> 2''400

Now: 1 test = 300ms -> 400ms

Actions taken:
 - Calmly await should get read of poll delay, and try directly (~1s gain)
 - Simplify logic pushed to camel, don't push inefficient choices. With other camel enhancements, this brings init time from 1s to ~200ms.

Performance tests demonstrating the impact on SMTP performance will  soon follow (I'm also expecting a gain).