### PR TITLE
JAMES-2449 MailQueue::browse should not snapshot isolated

### DIFF
--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/ManageableMailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/ManageableMailQueueContract.java
@@ -226,26 +226,6 @@ public interface ManageableMailQueueContract extends MailQueueContract {
     }
 
     @Test
-    default void concurrentEnqueueShouldNotAlterBrowsing() throws Exception {
-        getManageableMailQueue().enQueue(defaultMail()
-            .name("name1")
-            .build());
-        getManageableMailQueue().enQueue(defaultMail()
-            .name("name2")
-            .build());
-
-        ManageableMailQueue.MailQueueIterator items = getManageableMailQueue().browse();
-
-        getManageableMailQueue().enQueue(defaultMail()
-            .name("name3")
-            .build());
-
-        assertThat(items).extracting(ManageableMailQueue.MailQueueItemView::getMail)
-            .extracting(Mail::getName)
-            .containsExactly("name1", "name2");
-    }
-
-    @Test
     default void concurrentFlushShouldNotAlterBrowsingWhenDequeueWhileIterating() throws Exception {
         getManageableMailQueue().enQueue(defaultMail()
             .name("name1")

--- a/server/queue/queue-file/src/test/java/org/apache/james/queue/file/FileMailQueueTest.java
+++ b/server/queue/queue-file/src/test/java/org/apache/james/queue/file/FileMailQueueTest.java
@@ -94,13 +94,6 @@ public class FileMailQueueTest implements DelayedManageableMailQueueContract {
     @Test
     @Override
     @Disabled("JAMES-2299 No snapshot isolation")
-    public void concurrentEnqueueShouldNotAlterBrowsing() {
-
-    }
-
-    @Test
-    @Override
-    @Disabled("JAMES-2299 No snapshot isolation")
     public void concurrentDequeueShouldNotAlterBrowsingWhenDequeueWhileIterating() {
 
     }


### PR DESCRIPTION
solves : 

```
[285300a26fb7415700403e3a6ce46ee827375259] 
[285300a26fb7415700403e3a6ce46ee827375259] Failed tests: 
[285300a26fb7415700403e3a6ce46ee827375259]   ManageableMailQueueContract.concurrentEnqueueShouldNotAlterBrowsing:245 
[285300a26fb7415700403e3a6ce46ee827375259] Actual and expected should have same size but actual size was:
[285300a26fb7415700403e3a6ce46ee827375259]   <3>
[285300a26fb7415700403e3a6ce46ee827375259] while expected size was:
[285300a26fb7415700403e3a6ce46ee827375259]   <2>
[285300a26fb7415700403e3a6ce46ee827375259] Actual was:
[285300a26fb7415700403e3a6ce46ee827375259]   <["name1", "name2", "name3"]>
[285300a26fb7415700403e3a6ce46ee827375259] Expected was:
[285300a26fb7415700403e3a6ce46ee827375259]   <["name1", "name2"]>
```
