### PR TITLE
JAMES-2450 GET quotas/domain/domain.tld should return scoped information

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/quota/MaxQuotaManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/quota/MaxQuotaManager.java
@@ -28,6 +28,9 @@ import org.apache.james.core.quota.QuotaSize;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Quota;
 import org.apache.james.mailbox.model.QuotaRoot;
+import org.apache.james.util.OptionalUtils;
+
+import com.github.fge.lambdas.Throwing;
 
 /**
  * This interface describe how to set the max quotas for users
@@ -136,4 +139,16 @@ public interface MaxQuotaManager {
     Optional<QuotaSize> getDomainMaxStorage(Domain domain);
 
     void removeDomainMaxStorage(Domain domain) throws MailboxException;
+
+    default Optional<QuotaCount> getComputedMaxMessage(Domain domain) throws MailboxException {
+        return OptionalUtils.orSuppliers(
+            Throwing.supplier(() -> getDomainMaxMessage(domain)).sneakyThrow(),
+            Throwing.supplier(this::getGlobalMaxMessage).sneakyThrow());
+    }
+
+    default Optional<QuotaSize> getComputedMaxStorage(Domain domain) throws MailboxException {
+        return OptionalUtils.orSuppliers(
+            Throwing.supplier(() -> getDomainMaxStorage(domain)).sneakyThrow(),
+            Throwing.supplier(this::getGlobalMaxStorage).sneakyThrow());
+    }
 }

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/dto/QuotaDomainDTO.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/dto/QuotaDomainDTO.java
@@ -1,0 +1,82 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+
+package org.apache.james.webadmin.dto;
+
+import java.util.Optional;
+
+public class QuotaDomainDTO {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Optional<QuotaDTO> global;
+        private Optional<QuotaDTO> domain;
+        private Optional<QuotaDTO> computed;
+
+        private Builder() {
+            global = Optional.empty();
+            computed = Optional.empty();
+        }
+
+        public Builder global(QuotaDTO.Builder global) {
+            this.global = Optional.of(global.build());
+            return this;
+        }
+
+        public Builder domain(QuotaDTO.Builder domain) {
+            this.domain = Optional.of(domain.build());
+            return this;
+        }
+
+        public Builder computed(QuotaDTO.Builder computed) {
+            this.computed = Optional.of(computed.build());
+            return this;
+        }
+
+        public QuotaDomainDTO build() {
+            return new QuotaDomainDTO(global, domain, computed);
+        }
+    }
+
+    private final Optional<QuotaDTO> global;
+    private final Optional<QuotaDTO> domain;
+    private final Optional<QuotaDTO> computed;
+
+    private QuotaDomainDTO(Optional<QuotaDTO> global, Optional<QuotaDTO> domain, Optional<QuotaDTO> computed) {
+        this.global = global;
+        this.domain = domain;
+        this.computed = computed;
+    }
+
+    public Optional<QuotaDTO> getGlobal() {
+        return global;
+    }
+
+    public Optional<QuotaDTO> getDomain() {
+        return domain;
+    }
+
+    public Optional<QuotaDTO> getComputed() {
+        return computed;
+    }
+}

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/DomainQuotaRoutes.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/DomainQuotaRoutes.java
@@ -39,6 +39,7 @@ import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.UsersRepositoryException;
 import org.apache.james.webadmin.Routes;
 import org.apache.james.webadmin.dto.QuotaDTO;
+import org.apache.james.webadmin.dto.QuotaDomainDTO;
 import org.apache.james.webadmin.service.DomainQuotaService;
 import org.apache.james.webadmin.utils.ErrorResponder;
 import org.apache.james.webadmin.utils.ErrorResponder.ErrorType;
@@ -137,7 +138,7 @@ public class DomainQuotaRoutes implements Routes {
         notes = "If there is no limitation for count and/or size, the returned value will be -1"
     )
     @ApiResponses(value = {
-            @ApiResponse(code = HttpStatus.OK_200, message = "OK", response = QuotaDTO.class),
+            @ApiResponse(code = HttpStatus.OK_200, message = "OK", response = QuotaDomainDTO.class),
             @ApiResponse(code = HttpStatus.NOT_FOUND_404, message = "The requested domain can not be found."),
             @ApiResponse(code = HttpStatus.METHOD_NOT_ALLOWED_405, message = "Domain Quota configuration not supported when virtual hosting is desactivated."),
             @ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = "Internal server error - Something went bad on the server side.")

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/DomainQuotaService.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/DomainQuotaService.java
@@ -29,6 +29,7 @@ import org.apache.james.core.quota.QuotaSize;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
 import org.apache.james.webadmin.dto.QuotaDTO;
+import org.apache.james.webadmin.dto.QuotaDomainDTO;
 
 import com.github.fge.lambdas.Throwing;
 
@@ -65,11 +66,20 @@ public class DomainQuotaService {
         maxQuotaManager.removeDomainMaxStorage(domain);
     }
 
-    public QuotaDTO getQuota(Domain domain) {
-        return QuotaDTO
-            .builder()
-            .count(maxQuotaManager.getDomainMaxMessage(domain))
-            .size(maxQuotaManager.getDomainMaxStorage(domain))
+    public QuotaDomainDTO getQuota(Domain domain) throws MailboxException {
+        return QuotaDomainDTO.builder()
+            .domain(QuotaDTO
+                .builder()
+                .count(maxQuotaManager.getDomainMaxMessage(domain))
+                .size(maxQuotaManager.getDomainMaxStorage(domain)))
+            .global(QuotaDTO
+                .builder()
+                .count(maxQuotaManager.getGlobalMaxMessage())
+                .size(maxQuotaManager.getGlobalMaxStorage()))
+            .computed(QuotaDTO
+                .builder()
+                .count(maxQuotaManager.getComputedMaxMessage(domain))
+                .size(maxQuotaManager.getComputedMaxStorage(domain)))
             .build();
     }
 

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/DomainQuotaRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/DomainQuotaRoutesTest.java
@@ -379,6 +379,31 @@ class DomainQuotaRoutesTest {
     }
 
     @Test
+    void getQuotaShouldDisplayScopesWhenUnlimited() throws Exception {
+        int maxMessage = 42;
+        maxQuotaManager.setGlobalMaxMessage(QuotaCount.unlimited());
+        maxQuotaManager.setGlobalMaxStorage(QuotaSize.size(42));
+        maxQuotaManager.setDomainMaxMessage(TROUVÉ_COM, QuotaCount.count(maxMessage));
+        maxQuotaManager.setDomainMaxStorage(TROUVÉ_COM, QuotaSize.unlimited());
+
+        String json =
+            given()
+                .get(QUOTA_DOMAINS + "/" + TROUVÉ_COM.name())
+            .then()
+                .statusCode(HttpStatus.OK_200)
+                .contentType(ContentType.JSON)
+                .extract()
+                .asString();
+
+        assertThatJson(json)
+            .isEqualTo("{" +
+                "\"global\":{\"count\":-1,\"size\":42}," +
+                "\"domain\":{\"count\":42,\"size\":-1}," +
+                "\"computed\":{\"count\":42,\"size\":-1}" +
+            "}");
+    }
+
+    @Test
     void getQuotaShouldDisplayScopedInformation() throws Exception {
         int maxMessage = 42;
         maxQuotaManager.setDomainMaxMessage(TROUVÉ_COM, QuotaCount.count(maxMessage));

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/DomainQuotaRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/DomainQuotaRoutesTest.java
@@ -21,6 +21,7 @@ package org.apache.james.webadmin.routes;
 
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.RestAssured.when;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
@@ -338,17 +339,21 @@ class DomainQuotaRoutesTest {
         int maxStorage = 42;
         maxQuotaManager.setDomainMaxStorage(TROUVÉ_COM, QuotaSize.size(maxStorage));
 
-        JsonPath jsonPath =
+        String json =
             given()
                 .get(QUOTA_DOMAINS + "/" + TROUVÉ_COM.name())
             .then()
                 .statusCode(HttpStatus.OK_200)
                 .contentType(ContentType.JSON)
                 .extract()
-                .jsonPath();
+                .asString();
 
-        assertThat(jsonPath.getLong(SIZE)).isEqualTo(maxStorage);
-        assertThat(jsonPath.getObject(COUNT, Long.class)).isNull();
+        assertThatJson(json)
+            .isEqualTo("{" +
+                "\"global\":{\"count\":null,\"size\":null}," +
+                "\"domain\":{\"count\":null,\"size\":42}," +
+                "\"computed\":{\"count\":null,\"size\":42}" +
+            "}");
     }
 
     @Test
@@ -356,18 +361,45 @@ class DomainQuotaRoutesTest {
         int maxMessage = 42;
         maxQuotaManager.setDomainMaxMessage(TROUVÉ_COM, QuotaCount.count(maxMessage));
 
-
-        JsonPath jsonPath =
+        String json =
             given()
                 .get(QUOTA_DOMAINS + "/" + TROUVÉ_COM.name())
             .then()
                 .statusCode(HttpStatus.OK_200)
                 .contentType(ContentType.JSON)
                 .extract()
-                .jsonPath();
+                .asString();
 
-        assertThat(jsonPath.getObject(SIZE, Long.class)).isNull();
-        assertThat(jsonPath.getLong(COUNT)).isEqualTo(maxMessage);
+        assertThatJson(json)
+            .isEqualTo("{" +
+                "\"global\":{\"count\":null,\"size\":null}," +
+                "\"domain\":{\"count\":42,\"size\":null}," +
+                "\"computed\":{\"count\":42,\"size\":null}" +
+            "}");
+    }
+
+    @Test
+    void getQuotaShouldDisplayScopedInformation() throws Exception {
+        int maxMessage = 42;
+        maxQuotaManager.setDomainMaxMessage(TROUVÉ_COM, QuotaCount.count(maxMessage));
+        maxQuotaManager.setGlobalMaxMessage(QuotaCount.count(32));
+        maxQuotaManager.setGlobalMaxStorage(QuotaSize.size(36));
+
+        String json =
+            given()
+                .get(QUOTA_DOMAINS + "/" + TROUVÉ_COM.name())
+            .then()
+                .statusCode(HttpStatus.OK_200)
+                .contentType(ContentType.JSON)
+                .extract()
+                .asString();
+
+        assertThatJson(json)
+            .isEqualTo("{" +
+                "\"global\":{\"count\":32,\"size\":36}," +
+                "\"domain\":{\"count\":42,\"size\":null}," +
+                "\"computed\":{\"count\":42,\"size\":36}" +
+            "}");
     }
 
     @Test

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -545,7 +545,30 @@ Resource name domainToBeUsed should be an existing domain. For example:
 curl -XGET http://ip:port/quota/domains/james.org
 ```
 
-The answer can contain a fixed value, an empty value (null) or an unlimited value (-1):
+The answer will detailed the default quota applied to users belonging to that domain:
+
+```
+{
+  "global": {
+    "count":252,
+    "size":null
+  },
+  "domain": {
+    "count":null,
+    "size":142
+  },
+  "computed": {
+    "count":252,
+    "size":142
+  }
+}
+```
+
+ - The `global` entry represent the quota limit defined on this James server by default.
+ - The `domain` entry represent the quota limit allowed for the user of that domain by default.
+ - The `computed` entry represent the quota limit applied for the users of that domain, by default, resolved from the upper values.
+
+Note that `quota` object can contain a fixed value, an empty value (null) or an unlimited value (-1):
 
 ```
 {"count":52,"size":42}

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -545,7 +545,7 @@ Resource name domainToBeUsed should be an existing domain. For example:
 curl -XGET http://ip:port/quota/domains/james.org
 ```
 
-The answer will detailed the default quota applied to users belonging to that domain:
+The answer will detail the default quota applied to users belonging to that domain:
 
 ```
 {
@@ -564,9 +564,9 @@ The answer will detailed the default quota applied to users belonging to that do
 }
 ```
 
- - The `global` entry represent the quota limit defined on this James server by default.
- - The `domain` entry represent the quota limit allowed for the user of that domain by default.
- - The `computed` entry represent the quota limit applied for the users of that domain, by default, resolved from the upper values.
+ - The `global` entry represents the quota limit defined on this James server by default.
+ - The `domain` entry represents the quota limit allowed for the user of that domain by default.
+ - The `computed` entry represents the quota limit applied for the users of that domain, by default, resolved from the upper values.
 
 Note that `quota` object can contain a fixed value, an empty value (null) or an unlimited value (-1):
 


### PR DESCRIPTION
This enables a smarter admin display, allowing:

 - Displaying effective limit for that domain
 - As well as defined limit for that domain

This distinction, done on the user endpoints but not on the domain one, would
have required fetching global endpoints as well as assuming scoping logic in client
code.