### PR TITLE
JAMES-2464 ConcurrentTestRunner should use a builder

### DIFF
--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
@@ -67,8 +67,10 @@ public class CassandraMailboxMapperConcurrencyTest {
 
     @Test
     public void saveShouldBeThreadSafe() throws Exception {
-        boolean termination = new ConcurrentTestRunner(THREAD_COUNT, OPERATION_COUNT,
-            (a, b) -> testee.save(new SimpleMailbox(MAILBOX_PATH, UID_VALIDITY)))
+        boolean termination = ConcurrentTestRunner.builder()
+            .threadCount(THREAD_COUNT)
+            .operationCount(OPERATION_COUNT)
+            .build((a, b) -> testee.save(new SimpleMailbox(MAILBOX_PATH, UID_VALIDITY)))
             .run()
             .awaitTermination(1, TimeUnit.MINUTES);
 
@@ -83,8 +85,10 @@ public class CassandraMailboxMapperConcurrencyTest {
 
         mailbox.setName("newName");
 
-        boolean termination = new ConcurrentTestRunner(THREAD_COUNT, OPERATION_COUNT,
-            (a, b) -> testee.save(mailbox))
+        boolean termination = ConcurrentTestRunner.builder()
+            .threadCount(THREAD_COUNT)
+            .operationCount(OPERATION_COUNT)
+            .build((a, b) -> testee.save(mailbox))
             .run()
             .awaitTermination(1, TimeUnit.MINUTES);
 

--- a/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdMailingIntegrationTest.java
+++ b/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdMailingIntegrationTest.java
@@ -211,8 +211,9 @@ public interface QuotaThresholdMailingIntegrationTest {
                 .gracePeriod(GRACE_PERIOD)
                 .build());
 
-        new ConcurrentTestRunner(10, 1, (threadNb, step) ->
-            testee.event(new QuotaUsageUpdatedEvent(BOB_SESSION, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, NOW)))
+        ConcurrentTestRunner.builder()
+            .threadCount(10)
+            .build((threadNb, step) -> testee.event(new QuotaUsageUpdatedEvent(BOB_SESSION, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, NOW)))
             .run()
             .awaitTermination(1, TimeUnit.MINUTES);
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
@@ -677,8 +677,10 @@ public abstract class MessageIdMapperTest {
 
         int threadCount = 2;
         int updateCount = 10;
-        assertThat(new ConcurrentTestRunner(threadCount, updateCount,
-            (threadNumber, step) -> sut.setFlags(message1.getMessageId(),
+        assertThat(ConcurrentTestRunner.builder()
+            .threadCount(threadCount)
+            .operationCount(updateCount)
+            .build((threadNumber, step) -> sut.setFlags(message1.getMessageId(),
                 ImmutableList.of(message1.getMailboxId()),
                 new Flags("custom-" + threadNumber + "-" + step),
                 FlagsUpdateMode.ADD)).run()
@@ -697,10 +699,12 @@ public abstract class MessageIdMapperTest {
         message1.setModSeq(mapperProvider.generateModSeq(benwaInboxMailbox));
         sut.save(message1);
 
-        final int threadCount = 4;
-        final int updateCount = 20;
-        assertThat(new ConcurrentTestRunner(threadCount, updateCount,
-            (threadNumber, step) -> {
+        int threadCount = 4;
+        int updateCount = 20;
+        assertThat(ConcurrentTestRunner.builder()
+            .threadCount(threadCount)
+            .operationCount(updateCount)
+            .build((threadNumber, step) -> {
                 if (step  < updateCount / 2) {
                     sut.setFlags(message1.getMessageId(),
                         ImmutableList.of(message1.getMailboxId()),

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -796,8 +796,10 @@ public abstract class MessageMapperTest {
 
         int threadCount = 2;
         int updateCount = 10;
-        assertThat(new ConcurrentTestRunner(threadCount, updateCount,
-            (threadNumber, step) -> messageMapper.updateFlags(benwaInboxMailbox,
+        assertThat(ConcurrentTestRunner.builder()
+            .threadCount(threadCount)
+            .operationCount(updateCount)
+            .build((threadNumber, step) -> messageMapper.updateFlags(benwaInboxMailbox,
                 new FlagsUpdateCalculator(new Flags("custom-" + threadNumber + "-" + step), FlagsUpdateMode.ADD),
                 MessageRange.one(message1.getUid()))).run()
             .awaitTermination(1, TimeUnit.MINUTES))
@@ -814,10 +816,12 @@ public abstract class MessageMapperTest {
         Assume.assumeTrue(mapperProvider.getSupportedCapabilities().contains(MapperProvider.Capabilities.THREAD_SAFE_FLAGS_UPDATE));
         saveMessages();
 
-        final int threadCount = 4;
-        final int updateCount = 20;
-        assertThat(new ConcurrentTestRunner(threadCount, updateCount,
-            (threadNumber, step) -> {
+        int threadCount = 4;
+        int updateCount = 20;
+        assertThat(ConcurrentTestRunner.builder()
+            .threadCount(threadCount)
+            .operationCount(updateCount)
+            .build((threadNumber, step) -> {
                 if (step  < updateCount / 2) {
                     messageMapper.updateFlags(benwaInboxMailbox,
                         new FlagsUpdateCalculator(new Flags("custom-" + threadNumber + "-" + step), FlagsUpdateMode.ADD),

--- a/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/CachingTextExtractorTest.java
+++ b/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/CachingTextExtractorTest.java
@@ -185,10 +185,9 @@ public class CachingTextExtractorTest {
 
     @RepeatedTest(10)
     void concurrentValueComputationShouldNotLeadToDuplicatedBackendAccess() throws Exception {
-        int concurrentThreadCount = 10;
-        int operationCount = 1;
-        new ConcurrentTestRunner(concurrentThreadCount, operationCount,
-            (a, b) -> textExtractor.extractContent(INPUT_STREAM.get(), CONTENT_TYPE))
+        ConcurrentTestRunner.builder()
+            .threadCount(10)
+            .build((a, b) -> textExtractor.extractContent(INPUT_STREAM.get(), CONTENT_TYPE))
             .run()
             .awaitTermination(1, TimeUnit.MINUTES);
 

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
@@ -365,14 +365,15 @@ public class UidMsnConverterTest {
 
     @Test
     public void addAndRemoveShouldLeadToMonoticMSNToUIDConversionWhenMixed() throws Exception {
-        final int initialCount = 1000;
+        int initialCount = 1000;
         for (int i = 1; i <= initialCount; i++) {
             testee.addUid(MessageUid.of(i));
         }
 
-        int threadCount = 2;
-        ConcurrentTestRunner concurrentTestRunner = new ConcurrentTestRunner(threadCount, initialCount,
-            (threadNumber, step) -> {
+        ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
+            .threadCount(2)
+            .operationCount(initialCount)
+            .build((threadNumber, step) -> {
                 if (threadNumber == 0) {
                     testee.remove(MessageUid.of(step + 1));
                 } else {
@@ -392,11 +393,13 @@ public class UidMsnConverterTest {
 
     @Test
     public void addShouldLeadToMonoticMSNToUIDConversionWhenConcurrent() throws Exception {
-        final int operationCount = 1000;
+        int operationCount = 1000;
         int threadCount = 2;
 
-        ConcurrentTestRunner concurrentTestRunner = new ConcurrentTestRunner(threadCount, operationCount,
-            (threadNumber, step) -> testee.addUid(MessageUid.of((threadNumber * operationCount) + (step + 1))));
+        ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
+            .threadCount(threadCount)
+            .operationCount(operationCount)
+            .build((threadNumber, step) -> testee.addUid(MessageUid.of((threadNumber * operationCount) + (step + 1))));
         concurrentTestRunner.run();
         concurrentTestRunner.awaitTermination(10, TimeUnit.SECONDS);
 
@@ -410,14 +413,16 @@ public class UidMsnConverterTest {
 
     @Test
     public void removeShouldLeadToMonoticMSNToUIDConversionWhenConcurrent() throws Exception {
-        final int operationCount = 1000;
+        int operationCount = 1000;
         int threadCount = 2;
         for (int i = 1; i <= operationCount * (threadCount + 1); i++) {
             testee.addUid(MessageUid.of(i));
         }
 
-        ConcurrentTestRunner concurrentTestRunner = new ConcurrentTestRunner(threadCount, operationCount,
-            (threadNumber, step) -> testee.remove(MessageUid.of((threadNumber * operationCount) + (step + 1))));
+        ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
+            .threadCount(threadCount)
+            .operationCount(operationCount)
+            .build((threadNumber, step) -> testee.remove(MessageUid.of((threadNumber * operationCount) + (step + 1))));
         concurrentTestRunner.run();
         concurrentTestRunner.awaitTermination(10, TimeUnit.SECONDS);
 

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
@@ -99,13 +99,14 @@ public abstract class AbstractSMTPServerTest {
             server = createServer(createProtocol(hook));
             server.bind();
 
-            final ProtocolServer finalServer = server;
-            final InetSocketAddress bindedAddress = new ProtocolServerUtils(server).retrieveBindedAddress();
-            final String mailContent = CharStreams.toString(new InputStreamReader(ClassLoader.getSystemResourceAsStream("a50.eml"), StandardCharsets.US_ASCII));
-            int threadCount = 4;
-            int updateCount = 1;
-            assertThat(new ConcurrentTestRunner(threadCount, updateCount,
-                (threadNumber, step) -> send(finalServer, bindedAddress, mailContent)).run()
+            ProtocolServer finalServer = server;
+            InetSocketAddress bindedAddress = new ProtocolServerUtils(server).retrieveBindedAddress();
+            String mailContent = CharStreams.toString(new InputStreamReader(ClassLoader.getSystemResourceAsStream("a50.eml"), StandardCharsets.US_ASCII));
+
+            assertThat(ConcurrentTestRunner.builder()
+                .threadCount(4)
+                .build((threadNumber, step) -> send(finalServer, bindedAddress, mailContent))
+                .run()
                 .awaitTermination(1, TimeUnit.MINUTES))
                 .isTrue();
 

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/utils/InMemoryMailRepositoryStoreTest.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/utils/InMemoryMailRepositoryStoreTest.java
@@ -240,10 +240,10 @@ public class InMemoryMailRepositoryStoreTest {
     public void selectShouldNotReturnDifferentResultsWhenUsedInAConcurrentEnvironment() throws Exception {
         MailRepositoryUrl url = MailRepositoryUrl.from("memory://repo");
         int threadCount = 10;
-        int operationCount = 1;
 
-        ConcurrentTestRunner concurrentTestRunner = new ConcurrentTestRunner(threadCount, operationCount,
-            (threadNb, operationNb) -> repositoryStore.select(url)
+        ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
+            .threadCount(10)
+            .build((threadNb, operationNb) -> repositoryStore.select(url)
                 .store(FakeMail.builder()
                     .name("name" + threadNb)
                     .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()

--- a/server/data/data-api/src/test/java/org/apache/james/mailrepository/api/MailRepositoryUrlStoreContract.java
+++ b/server/data/data-api/src/test/java/org/apache/james/mailrepository/api/MailRepositoryUrlStoreContract.java
@@ -74,8 +74,10 @@ public interface MailRepositoryUrlStoreContract {
     default void addShouldWorkInConcurrentEnvironment(MailRepositoryUrlStore store) throws Exception {
         int operationCount = 10;
         int threadCount = 10;
-        ConcurrentTestRunner testRunner = new ConcurrentTestRunner(threadCount, operationCount,
-            (a, b) -> store.add(MailRepositoryUrl.from("proto://" + a + "/" + b)))
+        ConcurrentTestRunner testRunner = ConcurrentTestRunner.builder()
+            .threadCount(threadCount)
+            .operationCount(operationCount)
+            .build((a, b) -> store.add(MailRepositoryUrl.from("proto://" + a + "/" + b)))
             .run();
         testRunner.awaitTermination(1, TimeUnit.MINUTES);
         testRunner.assertNoException();
@@ -86,9 +88,10 @@ public interface MailRepositoryUrlStoreContract {
     @Test
     default void addShouldNotAddDuplicatesInConcurrentEnvironment(MailRepositoryUrlStore store) throws Exception {
         int operationCount = 10;
-        int threadCount = 10;
-        ConcurrentTestRunner testRunner = new ConcurrentTestRunner(threadCount, operationCount,
-            (a, b) -> store.add(MailRepositoryUrl.from("proto://" + b)))
+        ConcurrentTestRunner testRunner = ConcurrentTestRunner.builder()
+            .threadCount(10)
+            .operationCount(operationCount)
+            .build((a, b) -> store.add(MailRepositoryUrl.from("proto://" + b)))
             .run();
         testRunner.awaitTermination(1, TimeUnit.MINUTES);
         testRunner.assertNoException();

--- a/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
+++ b/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
@@ -381,8 +381,6 @@ public interface MailRepositoryContract {
     default void storingAndRemovingMessagesConcurrentlyShouldLeadToConsistentResult() throws Exception {
         MailRepository testee = retrieveRepository();
         int nbKeys = 20;
-        int nbIterations = 10;
-        int threadCount = 10;
         ConcurrentHashMap.KeySetView<MailKey, Boolean> expectedResult = ConcurrentHashMap.newKeySet();
         List<Object> locks = IntStream.range(0, 10)
             .boxed()
@@ -412,8 +410,10 @@ public interface MailRepositoryContract {
                 new DistributionEntry<>(add, 0.25),
                 new DistributionEntry<>(remove, 0.75)));
 
-        new ConcurrentTestRunner(threadCount, nbIterations,
-            (a, b) -> distribution.sample().run())
+        ConcurrentTestRunner.builder()
+            .threadCount(10)
+            .operationCount(10)
+            .build((a, b) -> distribution.sample().run())
             .run()
             .awaitTermination(1, TimeUnit.MINUTES);
 

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/ProvisioningTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/ProvisioningTest.java
@@ -78,8 +78,9 @@ public abstract class ProvisioningTest {
     public void provisionMailboxesShouldNotDuplicateMailboxByName() throws Exception {
         String token = authenticateJamesUser(baseUri(jmapServer), USER, PASSWORD).serialize();
 
-        boolean termination = new ConcurrentTestRunner(10, 1,
-            (a, b) -> with()
+        boolean termination = ConcurrentTestRunner.builder()
+            .threadCount(10)
+            .build((a, b) -> with()
                 .header("Authorization", token)
                 .body("[[\"getMailboxes\", {}, \"#0\"]]")
                 .post("/jmap"))

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/DefaultMailboxesProvisioningFilterTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/DefaultMailboxesProvisioningFilterTest.java
@@ -89,10 +89,9 @@ public class DefaultMailboxesProvisioningFilterTest {
 
     @Test
     public void createMailboxesIfNeededShouldNotGenerateExceptionsInConcurrentEnvironment() throws Exception {
-        int threadCount = 10;
-        int operationCount = 1;
-        new ConcurrentTestRunner(threadCount, operationCount,
-            (threadNumber, step) -> testee.createMailboxesIfNeeded(session))
+        ConcurrentTestRunner.builder()
+            .threadCount(10)
+            .build((threadNumber, step) -> testee.createMailboxesIfNeeded(session))
             .run()
             .assertNoException()
             .awaitTermination(10, TimeUnit.SECONDS);


### PR DESCRIPTION
This allows:
 - Removing the confusion between threadCount & operationCount
 - Allow a default value for operationCount (1)