### PR TITLE
JAMES-2457 replace embedded elasticsearch by docker elasticsearch in big jmap message test

### DIFF
--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/DockerCassandraTestExtension.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/DockerCassandraTestExtension.java
@@ -1,0 +1,94 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import org.apache.commons.text.RandomStringGenerator;
+import org.apache.james.backends.cassandra.DockerCassandraRule;
+import org.apache.james.backends.cassandra.init.configuration.ClusterConfiguration;
+import org.apache.james.util.Host;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.containers.GenericContainer;
+
+import com.google.inject.Module;
+
+public class DockerCassandraTestExtension implements BeforeEachCallback, AfterEachCallback, GuiceModuleTestExtension {
+
+    private DockerCassandraRule cassandraContainer;
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        cassandraContainer = new DockerCassandraRule();
+        cassandraContainer.start();
+
+        registerSelfToContext(context);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        cassandraContainer.stop();
+    }
+
+    @Override
+    public Module getModule() {
+        String keyspace = new RandomStringGenerator.Builder().withinRange('a', 'z').build().generate(12);
+        return (binder) -> binder.bind(ClusterConfiguration.class)
+            .toInstance(ClusterConfiguration.builder()
+                .host(cassandraContainer.getHost())
+                .keyspace(keyspace)
+                .replicationFactor(1)
+                .maxRetry(20)
+                .minDelay(5000)
+                .build());
+    }
+
+    public String getIp() {
+        return cassandraContainer.getIp();
+    }
+
+    public Host getHost() {
+        return cassandraContainer.getHost();
+    }
+
+    public Integer getMappedPort(int originalPort) {
+        return cassandraContainer.getBindingPort();
+    }
+
+    public void start() {
+        cassandraContainer.start();
+    }
+
+    public void stop() {
+        cassandraContainer.stop();
+    }
+
+    public GenericContainer<?> getRawContainer() {
+        return cassandraContainer.getRawContainer();
+    }
+
+    public void pause() {
+        cassandraContainer.pause();
+    }
+
+    public void unpause() {
+        cassandraContainer.unpause();
+    }
+}

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/DockerElasticSearchTestExtension.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/DockerElasticSearchTestExtension.java
@@ -1,0 +1,83 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import org.apache.james.mailbox.elasticsearch.IndexAttachments;
+import org.apache.james.modules.mailbox.ElasticSearchConfiguration;
+import org.apache.james.util.Host;
+import org.apache.james.util.docker.Images;
+import org.apache.james.util.docker.SwarmGenericContainer;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import com.google.inject.Module;
+
+public class DockerElasticSearchTestExtension implements BeforeEachCallback, AfterEachCallback, GuiceModuleTestExtension {
+
+    private static final int ELASTIC_SEARCH_PORT = 9300;
+    public static final int ELASTIC_SEARCH_HTTP_PORT = 9200;
+
+    private SwarmGenericContainer container = new SwarmGenericContainer(Images.ELASTICSEARCH)
+        .withExposedPorts(ELASTIC_SEARCH_HTTP_PORT, ELASTIC_SEARCH_PORT);
+
+    public ElasticSearchConfiguration getElasticSearchConfigurationForDocker() {
+        return ElasticSearchConfiguration.builder()
+            .addHost(Host.from(getIp(), container.getMappedPort(ELASTIC_SEARCH_PORT)))
+            .indexAttachment(IndexAttachments.NO)
+            .build();
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        container = new SwarmGenericContainer(Images.ELASTICSEARCH).withExposedPorts(9200, 9300);
+        container.start();
+
+        registerSelfToContext(extensionContext);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
+        container.stop();
+    }
+
+    @Override
+    public Module getModule() {
+        return (binder) ->
+                binder.bind(ElasticSearchConfiguration.class)
+                    .toInstance(getElasticSearchConfigurationForDocker());
+    }
+
+    public String getIp() {
+        return container.getHostIp();
+    }
+
+    public SwarmGenericContainer getElasticSearchContainer() {
+        return container;
+    }
+
+    public void pause() {
+        container.pause();
+    }
+
+    public void unpause() {
+        container.unpause();
+    }
+}

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/GuiceModuleTestExtension.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/GuiceModuleTestExtension.java
@@ -1,0 +1,33 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import com.google.inject.Module;
+
+public interface GuiceModuleTestExtension {
+
+    Module getModule();
+
+    default void registerSelfToContext(ExtensionContext context) {
+        context.getStore(ExtensionContext.Namespace.GLOBAL).put(this.getClass(), this);
+    }
+}

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/CassandraSetMessagesMethodWithBigMessageTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/CassandraSetMessagesMethodWithBigMessageTest.java
@@ -1,0 +1,33 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.cassandra;
+
+import org.apache.james.DockerCassandraTestExtension;
+import org.apache.james.DockerElasticSearchTestExtension;
+import org.apache.james.jmap.methods.integration.SetMessagesMethodWithBigMessageTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({
+    DockerCassandraTestExtension.class,
+    DockerElasticSearchTestExtension.class,
+    CassandraSetMessagesMethodWithBigMessageTestExtension.class
+})
+public class CassandraSetMessagesMethodWithBigMessageTest implements SetMessagesMethodWithBigMessageTest {
+}

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/CassandraSetMessagesMethodWithBigMessageTestExtension.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/CassandraSetMessagesMethodWithBigMessageTestExtension.java
@@ -1,0 +1,87 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.cassandra;
+
+import static org.apache.james.CassandraJamesServerMain.ALL_BUT_JMX_CASSANDRA_MODULE;
+
+import org.apache.james.DockerCassandraTestExtension;
+import org.apache.james.DockerElasticSearchTestExtension;
+import org.apache.james.GuiceJamesServer;
+import org.apache.james.jmap.methods.integration.SetMessagesMethodWithBigMessageTestSystem;
+import org.apache.james.modules.TestJMAPServerModule;
+import org.apache.james.server.core.configuration.Configuration;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.rules.TemporaryFolder;
+
+public class CassandraSetMessagesMethodWithBigMessageTestExtension implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
+
+    private static final int LIMIT_TO_10_MESSAGES = 10;
+
+    private SetMessagesMethodWithBigMessageTestSystem testSystem;
+    private TemporaryFolder temporaryFolder;
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        temporaryFolder = new TemporaryFolder();
+        temporaryFolder.create();
+
+        ExtensionContext.Store store = extensionContext.getStore(ExtensionContext.Namespace.GLOBAL);
+        DockerCassandraTestExtension cassandraExtension = store.get(DockerCassandraTestExtension.class, DockerCassandraTestExtension.class);
+        DockerElasticSearchTestExtension elasticSearchExtension = store.get(DockerElasticSearchTestExtension.class, DockerElasticSearchTestExtension.class);
+        GuiceJamesServer jamesServer = createJamesServer(cassandraExtension, elasticSearchExtension);
+        testSystem = new SetMessagesMethodWithBigMessageTestSystem(jamesServer);
+
+        testSystem.before();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
+        testSystem.after();
+        temporaryFolder.delete();
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return parameterContext.getParameter().getType() == SetMessagesMethodWithBigMessageTestSystem.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return testSystem;
+    }
+
+    private GuiceJamesServer createJamesServer(DockerCassandraTestExtension cassandra, DockerElasticSearchTestExtension es) {
+        Configuration configuration = Configuration.builder()
+            .workingDirectory(temporaryFolder.getRoot())
+            .configurationFromClasspath()
+            .build();
+
+        return new GuiceJamesServer(configuration)
+            .combineWith(ALL_BUT_JMX_CASSANDRA_MODULE)
+            .overrideWith(new TestJMAPServerModule(LIMIT_TO_10_MESSAGES))
+            .overrideWith(cassandra.getModule())
+            .overrideWith(es.getModule());
+    }
+}

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
@@ -1364,34 +1364,35 @@ public abstract class SetMessagesMethodTest {
         String messageCreationId = "creationId1337";
         String fromAddress = USERNAME;
         String body = Strings.repeat("d", BIG_MESSAGE_SIZE);
-        String requestBody = "[" +
-            "  [" +
-            "    \"setMessages\"," +
-            "    {" +
-            "      \"create\": { \"" + messageCreationId  + "\" : {" +
-            "        \"from\": { \"name\": \"Me\", \"email\": \"" + fromAddress + "\"}," +
-            "        \"to\": [{ \"name\": \"Me\", \"email\": \"" + fromAddress + "\"}]," +
-            "        \"subject\": \"Thank you for joining example.com!\"," +
-            "        \"textBody\": \"" + body + "\"," +
-            "        \"mailboxIds\": [\"" + getOutboxId(accessToken) + "\"]" +
-            "      }}" +
-            "    }," +
-            "    \"#0\"" +
-            "  ]" +
-            "]";
+        {
+            String requestBody = "[" +
+                "  [" +
+                "    \"setMessages\"," +
+                "    {" +
+                "      \"create\": { \"" + messageCreationId  + "\" : {" +
+                "        \"from\": { \"name\": \"Me\", \"email\": \"" + fromAddress + "\"}," +
+                "        \"to\": [{ \"name\": \"Me\", \"email\": \"" + fromAddress + "\"}]," +
+                "        \"subject\": \"Thank you for joining example.com!\"," +
+                "        \"textBody\": \"" + body + "\"," +
+                "        \"mailboxIds\": [\"" + getOutboxId(accessToken) + "\"]" +
+                "      }}" +
+                "    }," +
+                "    \"#0\"" +
+                "  ]" +
+                "]";
 
-        given()
-            .header("Authorization", accessToken.serialize())
-            .body(requestBody)
-        .when()
-            .post("/jmap")
-        .then()
-            .statusCode(200)
-            .body(NAME, equalTo("messagesSet"))
-            .body(ARGUMENTS + ".notCreated", aMapWithSize(0))
-            .body(ARGUMENTS + ".created", aMapWithSize(1))
-            .body(ARGUMENTS + ".created", hasEntry(equalTo(messageCreationId), hasEntry(equalTo("textBody"), equalTo(body))));
-        requestBody = null;
+            given()
+                .header("Authorization", accessToken.serialize())
+                .body(requestBody)
+            .when()
+                .post("/jmap")
+            .then()
+                .statusCode(200)
+                .body(NAME, equalTo("messagesSet"))
+                .body(ARGUMENTS + ".notCreated", aMapWithSize(0))
+                .body(ARGUMENTS + ".created", aMapWithSize(1))
+                .body(ARGUMENTS + ".created", hasEntry(equalTo(messageCreationId), hasEntry(equalTo("textBody"), equalTo(body))));
+        }
 
         calmlyAwait
             .pollDelay(Duration.FIVE_HUNDRED_MILLISECONDS)

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
@@ -119,7 +119,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.io.ByteStreams;
@@ -136,7 +135,6 @@ public abstract class SetMessagesMethodTest {
     private static final String PASSWORD = "password";
     private static final MailboxPath USER_MAILBOX = MailboxPath.forUser(USERNAME, "mailbox");
     private static final String NOT_UPDATED = ARGUMENTS + ".notUpdated";
-    private static final int BIG_MESSAGE_SIZE = 20 * 1024 * 1024;
 
     private AccessToken bobAccessToken;
 
@@ -1357,75 +1355,6 @@ public abstract class SetMessagesMethodTest {
             .body(ARGUMENTS + ".notCreated", aMapWithSize(1))
             .body(ARGUMENTS + ".created", aMapWithSize(0))
             .body(ARGUMENTS + ".notCreated[\"" + messageCreationId + "\"].type", equalTo("maxQuotaReached"));
-    }
-
-    @Test
-    public void setMessagesWithABigBodyShouldReturnCreatedMessageWhenSendingMessage() {
-        String messageCreationId = "creationId1337";
-        String fromAddress = USERNAME;
-        String body = Strings.repeat("d", BIG_MESSAGE_SIZE);
-        {
-            String requestBody = "[" +
-                "  [" +
-                "    \"setMessages\"," +
-                "    {" +
-                "      \"create\": { \"" + messageCreationId  + "\" : {" +
-                "        \"from\": { \"name\": \"Me\", \"email\": \"" + fromAddress + "\"}," +
-                "        \"to\": [{ \"name\": \"Me\", \"email\": \"" + fromAddress + "\"}]," +
-                "        \"subject\": \"Thank you for joining example.com!\"," +
-                "        \"textBody\": \"" + body + "\"," +
-                "        \"mailboxIds\": [\"" + getOutboxId(accessToken) + "\"]" +
-                "      }}" +
-                "    }," +
-                "    \"#0\"" +
-                "  ]" +
-                "]";
-
-            given()
-                .header("Authorization", accessToken.serialize())
-                .body(requestBody)
-            .when()
-                .post("/jmap")
-            .then()
-                .statusCode(200)
-                .body(NAME, equalTo("messagesSet"))
-                .body(ARGUMENTS + ".notCreated", aMapWithSize(0))
-                .body(ARGUMENTS + ".created", aMapWithSize(1))
-                .body(ARGUMENTS + ".created", hasEntry(equalTo(messageCreationId), hasEntry(equalTo("textBody"), equalTo(body))));
-        }
-
-        calmlyAwait
-            .pollDelay(Duration.FIVE_HUNDRED_MILLISECONDS)
-            .atMost(30, TimeUnit.SECONDS).until(() -> hasANewMailWithBody(accessToken, body));
-    }
-
-    private boolean hasANewMailWithBody(AccessToken recipientToken, String body) {
-        try {
-            String inboxId = getMailboxId(accessToken, Role.INBOX);
-            String receivedMessageId =
-                with()
-                    .header("Authorization", accessToken.serialize())
-                    .body("[[\"getMessageList\", {\"filter\":{\"inMailboxes\":[\"" + inboxId + "\"]}}, \"#0\"]]")
-                    .post("/jmap")
-                .then()
-                    .extract()
-                    .path(ARGUMENTS + ".messageIds[0]");
-
-            given()
-                .header("Authorization", accessToken.serialize())
-                .body("[[\"getMessages\", {\"ids\": [\"" + receivedMessageId + "\"]}, \"#0\"]]")
-            .when()
-                .post("/jmap")
-            .then()
-                .statusCode(200)
-                .body(NAME, equalTo("messages"))
-                .body(ARGUMENTS + ".list", hasSize(1))
-                .body(ARGUMENTS + ".list[0].textBody", equalTo(body));
-            return true;
-
-        } catch (AssertionError e) {
-            return false;
-        }
     }
 
     @Test

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
@@ -1416,7 +1416,6 @@ public abstract class SetMessagesMethodTest {
                 .post("/jmap")
             .then()
                 .statusCode(200)
-                .log().ifValidationFails()
                 .body(NAME, equalTo("messages"))
                 .body(ARGUMENTS + ".list", hasSize(1))
                 .body(ARGUMENTS + ".list[0].textBody", equalTo(body));

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
@@ -1391,6 +1391,7 @@ public abstract class SetMessagesMethodTest {
             .body(ARGUMENTS + ".notCreated", aMapWithSize(0))
             .body(ARGUMENTS + ".created", aMapWithSize(1))
             .body(ARGUMENTS + ".created", hasEntry(equalTo(messageCreationId), hasEntry(equalTo("textBody"), equalTo(body))));
+        requestBody = null;
 
         calmlyAwait
             .pollDelay(Duration.FIVE_HUNDRED_MILLISECONDS)

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodWithBigMessageTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodWithBigMessageTest.java
@@ -1,0 +1,124 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.methods.integration;
+
+import static com.jayway.restassured.RestAssured.given;
+import static com.jayway.restassured.RestAssured.with;
+import static org.apache.james.jmap.JmapCommonRequests.getMailboxId;
+import static org.apache.james.jmap.JmapCommonRequests.getOutboxId;
+import static org.apache.james.jmap.TestingConstants.ARGUMENTS;
+import static org.apache.james.jmap.TestingConstants.DOMAIN;
+import static org.apache.james.jmap.TestingConstants.NAME;
+import static org.apache.james.jmap.TestingConstants.calmlyAwait;
+import static org.apache.james.jmap.methods.integration.SetMessagesMethodWithBigMessageTest.Fixture.BIG_MESSAGE_SIZE;
+import static org.apache.james.jmap.methods.integration.SetMessagesMethodWithBigMessageTest.Fixture.USERNAME;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.james.jmap.api.access.AccessToken;
+import org.apache.james.mailbox.Role;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.base.Strings;
+import com.jayway.awaitility.Duration;
+
+public interface SetMessagesMethodWithBigMessageTest {
+
+    interface Fixture {
+        String USERNAME = "username@" + DOMAIN;
+        String PASSWORD = "password";
+        int BIG_MESSAGE_SIZE = 20 * 1024 * 1024;
+    }
+
+    @Test
+    default void setMessagesWithABigBodyShouldReturnCreatedMessageWhenSendingMessage(SetMessagesMethodWithBigMessageTestSystem testSystem) {
+        AccessToken accessToken = testSystem.getAccessToken();
+
+        String messageCreationId = "creationId1337";
+        String fromAddress = USERNAME;
+        String body = Strings.repeat("d", BIG_MESSAGE_SIZE);
+        {
+            String requestBody = "[" +
+                "  [" +
+                "    \"setMessages\"," +
+                "    {" +
+                "      \"create\": { \"" + messageCreationId  + "\" : {" +
+                "        \"from\": { \"name\": \"Me\", \"email\": \"" + fromAddress + "\"}," +
+                "        \"to\": [{ \"name\": \"Me\", \"email\": \"" + fromAddress + "\"}]," +
+                "        \"subject\": \"Thank you for joining example.com!\"," +
+                "        \"textBody\": \"" + body + "\"," +
+                "        \"mailboxIds\": [\"" + getOutboxId(accessToken) + "\"]" +
+                "      }}" +
+                "    }," +
+                "    \"#0\"" +
+                "  ]" +
+                "]";
+
+            given()
+                .header("Authorization", accessToken.serialize())
+                .body(requestBody)
+            .when()
+                .post("/jmap")
+            .then()
+                .statusCode(200)
+                .body(NAME, equalTo("messagesSet"))
+                .body(ARGUMENTS + ".notCreated", aMapWithSize(0))
+                .body(ARGUMENTS + ".created", aMapWithSize(1))
+                .body(ARGUMENTS + ".created", hasEntry(equalTo(messageCreationId), hasEntry(equalTo("textBody"), equalTo(body))));
+        }
+
+        calmlyAwait
+            .pollDelay(Duration.FIVE_HUNDRED_MILLISECONDS)
+            .atMost(30, TimeUnit.SECONDS).until(() -> hasANewMailWithBody(accessToken, body));
+    }
+
+    default boolean hasANewMailWithBody(AccessToken accessToken, String body) {
+        try {
+            String inboxId = getMailboxId(accessToken, Role.INBOX);
+            String receivedMessageId =
+                with()
+                    .header("Authorization", accessToken.serialize())
+                    .body("[[\"getMessageList\", {\"filter\":{\"inMailboxes\":[\"" + inboxId + "\"]}}, \"#0\"]]")
+                    .post("/jmap")
+                .then()
+                    .extract()
+                    .path(ARGUMENTS + ".messageIds[0]");
+
+            given()
+                .header("Authorization", accessToken.serialize())
+                .body("[[\"getMessages\", {\"ids\": [\"" + receivedMessageId + "\"]}, \"#0\"]]")
+            .when()
+                .post("/jmap")
+            .then()
+                .statusCode(200)
+                .body(NAME, equalTo("messages"))
+                .body(ARGUMENTS + ".list", hasSize(1))
+                .body(ARGUMENTS + ".list[0].textBody", equalTo(body));
+            return true;
+
+        } catch (AssertionError e) {
+            return false;
+        }
+    }
+}

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodWithBigMessageTestSystem.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodWithBigMessageTestSystem.java
@@ -1,0 +1,99 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.methods.integration;
+
+import static com.jayway.restassured.config.EncoderConfig.encoderConfig;
+import static com.jayway.restassured.config.RestAssuredConfig.newConfig;
+import static org.apache.james.jmap.JmapURIBuilder.baseUri;
+import static org.apache.james.jmap.TestingConstants.BOB;
+import static org.apache.james.jmap.TestingConstants.BOB_PASSWORD;
+import static org.apache.james.jmap.TestingConstants.DOMAIN;
+import static org.apache.james.jmap.methods.integration.SetMessagesMethodWithBigMessageTest.Fixture.PASSWORD;
+import static org.apache.james.jmap.methods.integration.SetMessagesMethodWithBigMessageTest.Fixture.USERNAME;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.james.GuiceJamesServer;
+import org.apache.james.jmap.HttpJmapAuthentication;
+import org.apache.james.jmap.api.access.AccessToken;
+import org.apache.james.mailbox.DefaultMailboxes;
+import org.apache.james.mailbox.model.MailboxConstants;
+import org.apache.james.mailbox.store.probe.MailboxProbe;
+import org.apache.james.modules.MailboxProbeImpl;
+import org.apache.james.probe.DataProbe;
+import org.apache.james.utils.DataProbeImpl;
+import org.apache.james.utils.JmapGuiceProbe;
+
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.builder.RequestSpecBuilder;
+import com.jayway.restassured.http.ContentType;
+import com.jayway.restassured.parsing.Parser;
+
+public class SetMessagesMethodWithBigMessageTestSystem {
+
+    private AccessToken accessToken;
+    private GuiceJamesServer jamesServer;
+    private MailboxProbe mailboxProbe;
+    private DataProbe dataProbe;
+
+    public SetMessagesMethodWithBigMessageTestSystem(GuiceJamesServer jamesServer) throws Exception {
+        this.jamesServer = jamesServer;
+
+        init();
+    }
+
+    private void init() throws Exception {
+
+        jamesServer.start();
+
+        mailboxProbe = jamesServer.getProbe(MailboxProbeImpl.class);
+        dataProbe = jamesServer.getProbe(DataProbeImpl.class);
+
+        RestAssured.requestSpecification = new RequestSpecBuilder()
+                .setContentType(ContentType.JSON)
+                .setAccept(ContentType.JSON)
+                .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
+                .setPort(jamesServer.getProbe(JmapGuiceProbe.class).getJmapPort())
+                .build();
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        RestAssured.defaultParser = Parser.JSON;
+    }
+
+    public void before() throws Exception {
+        dataProbe.addDomain(DOMAIN);
+        dataProbe.addUser(USERNAME, PASSWORD);
+        dataProbe.addUser(BOB, BOB_PASSWORD);
+        mailboxProbe.createMailbox("#private", USERNAME, DefaultMailboxes.INBOX);
+        accessToken = HttpJmapAuthentication.authenticateJamesUser(baseUri(jamesServer), USERNAME, PASSWORD);
+
+        mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, DefaultMailboxes.OUTBOX);
+        mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, DefaultMailboxes.TRASH);
+        mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, DefaultMailboxes.DRAFTS);
+        mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, DefaultMailboxes.SENT);
+    }
+
+    public void after() {
+        jamesServer.stop();
+    }
+
+    public AccessToken getAccessToken() {
+        return accessToken;
+    }
+}

--- a/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/java/org/apache/james/jmap/memory/MemorySetMessagesMethodWithBigMessageTest.java
+++ b/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/java/org/apache/james/jmap/memory/MemorySetMessagesMethodWithBigMessageTest.java
@@ -1,0 +1,29 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.memory;
+
+import org.apache.james.jmap.methods.integration.SetMessagesMethodWithBigMessageTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({
+    MemorySetMessagesMethodWithBigMessageTestExtension.class
+})
+public class MemorySetMessagesMethodWithBigMessageTest implements SetMessagesMethodWithBigMessageTest {
+}

--- a/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/java/org/apache/james/jmap/memory/MemorySetMessagesMethodWithBigMessageTestExtension.java
+++ b/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/java/org/apache/james/jmap/memory/MemorySetMessagesMethodWithBigMessageTestExtension.java
@@ -1,0 +1,91 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.memory;
+
+import java.io.IOException;
+
+import org.apache.activemq.store.PersistenceAdapter;
+import org.apache.activemq.store.memory.MemoryPersistenceAdapter;
+import org.apache.james.GuiceJamesServer;
+import org.apache.james.MemoryJamesServerMain;
+import org.apache.james.jmap.methods.integration.SetMessagesMethodWithBigMessageTestSystem;
+import org.apache.james.mailbox.extractor.TextExtractor;
+import org.apache.james.mailbox.store.search.MessageSearchIndex;
+import org.apache.james.mailbox.store.search.PDFTextExtractor;
+import org.apache.james.mailbox.store.search.SimpleMessageSearchIndex;
+import org.apache.james.modules.TestJMAPServerModule;
+import org.apache.james.server.core.configuration.Configuration;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.rules.TemporaryFolder;
+
+public class MemorySetMessagesMethodWithBigMessageTestExtension implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
+
+    private static final int LIMIT_TO_10_MESSAGES = 10;
+
+    private SetMessagesMethodWithBigMessageTestSystem testSystem;
+    private TemporaryFolder temporaryFolder;
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        temporaryFolder = new TemporaryFolder();
+        temporaryFolder.create();
+
+        GuiceJamesServer jamesServer = createJamesServer();
+        testSystem = new SetMessagesMethodWithBigMessageTestSystem(jamesServer);
+
+        testSystem.before();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
+        testSystem.after();
+        temporaryFolder.delete();
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return parameterContext.getParameter().getType() == SetMessagesMethodWithBigMessageTestSystem.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return testSystem;
+    }
+
+    private GuiceJamesServer createJamesServer() throws IOException {
+
+        Configuration configuration = Configuration.builder()
+            .workingDirectory(temporaryFolder.newFolder())
+            .configurationFromClasspath()
+            .build();
+
+        return new GuiceJamesServer(configuration)
+            .combineWith(MemoryJamesServerMain.IN_MEMORY_SERVER_AGGREGATE_MODULE)
+            .overrideWith(new TestJMAPServerModule(LIMIT_TO_10_MESSAGES))
+            .overrideWith(binder -> binder.bind(PersistenceAdapter.class).to(MemoryPersistenceAdapter.class))
+            .overrideWith(binder -> binder.bind(TextExtractor.class).to(PDFTextExtractor.class))
+            .overrideWith(binder -> binder.bind(MessageSearchIndex.class).to(SimpleMessageSearchIndex.class));
+    }
+}


### PR DESCRIPTION
- This help us eliminates big amount of memory in heap space then avoid OutOfMemory in this special test case
- Experiment multiple extensions sharing data by Store (a feature of junit 5)
In my new test, I did:
  - Replaced DockerCassandraRule by DockerCassandraTestExtension, then register it self to Junit global storage
  - Replaced DockerElasticSearchRule DockerElasticSearchTestExtension, then register it self to Junit global storage
  - Create CassandraSetMessagesMethodWithBigMessageTestExtension that retrive nessesary data from previous extensions by Junit global storage,
  	then create appropirate CassandraJamesServer on docker cassandra & docker elasticsearch