### PR TITLE
JAMES-2478 Upgrade Swagger

### DIFF
--- a/server/protocols/webadmin/webadmin-core/pom.xml
+++ b/server/protocols/webadmin/webadmin-core/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-jaxrs</artifactId>
-            <version>1.5.8</version>
+            <version>1.5.20</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/server/protocols/webadmin/webadmin-core/pom.xml
+++ b/server/protocols/webadmin/webadmin-core/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-jaxrs</artifactId>
-            <version>1.5.20</version>
+            <version>1.5.13</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>


### PR DESCRIPTION
```
io.swagger:swagger-jaxrs ............................. 1.5.8 -> 1.5.13 the lastest 1.5.20 is not compatible with guava 19.0
```