### PR TITLE
JAMES-2488 Upgrade netflix curator & openjpa & jasypt(crypto)

### DIFF
--- a/backends-common/jpa/pom.xml
+++ b/backends-common/jpa/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.apache.openjpa</groupId>
             <artifactId>openjpa</artifactId>
-            <version>2.4.2</version>
+            <version>${apache.openjpa.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/dockerfiles/run/guice/jpa/Dockerfile
+++ b/dockerfiles/run/guice/jpa/Dockerfile
@@ -27,4 +27,4 @@ ADD destination/conf /root/conf
 
 VOLUME /logs
 
-ENTRYPOINT java -classpath '/root/james-server.jar:/root/james-server-jpa-guice.lib/*' -javaagent:/root/james-server-cli.lib/openjpa-2.4.2.jar -Dlogback.configurationFile=/root/conf/logback.xml -Dworking.directory=/root/ org.apache.james.JPAJamesServerMain
+ENTRYPOINT java -classpath '/root/james-server.jar:/root/james-server-jpa-guice.lib/*' -javaagent:/root/james-server-cli.lib/openjpa-3.0.0.jar -Dlogback.configurationFile=/root/conf/logback.xml -Dworking.directory=/root/ org.apache.james.JPAJamesServerMain

--- a/mailbox/jpa/pom.xml
+++ b/mailbox/jpa/pom.xml
@@ -111,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.openjpa</groupId>
                 <artifactId>openjpa-maven-plugin</artifactId>
-                <version>2.4.2</version>
+                <version>${apache.openjpa.version}</version>
                 <configuration>
                     <includes>org/apache/james/mailbox/jpa/*/model/**/*.class</includes>
                     <excludes>org/apache/james/mailbox/jpa/mail/model/openjpa/EncryptDecryptHelper.class</excludes>

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/JPAMailboxSessionMapperFactory.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/JPAMailboxSessionMapperFactory.java
@@ -22,7 +22,7 @@ import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.jpa.mail.JPAAnnotationMapper;
@@ -68,7 +68,7 @@ public class JPAMailboxSessionMapperFactory extends MailboxSessionMapperFactory 
 
     @Override
     public MessageIdMapper createMessageIdMapper(MailboxSession session) throws MailboxException {
-        throw new NotImplementedException();
+        throw new NotImplementedException("not implemented");
     }
 
     @Override

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAModSeqProvider.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAModSeqProvider.java
@@ -23,7 +23,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.PersistenceException;
 
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.mailbox.MailboxPathLocker;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -91,6 +91,6 @@ public class JPAModSeqProvider extends AbstractLockingModSeqProvider {
 
     @Override
     public long highestModSeq(MailboxSession session, MailboxId mailboxId) throws MailboxException {
-        throw new NotImplementedException();
+        throw new NotImplementedException("not implemented");
     }
 }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAMapperProvider.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JPAMapperProvider.java
@@ -24,7 +24,7 @@ import java.util.Random;
 
 import javax.persistence.EntityManagerFactory;
 
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.backends.jpa.JpaTestCluster;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -73,7 +73,7 @@ public class JPAMapperProvider implements MapperProvider {
 
     @Override
     public AttachmentMapper createAttachmentMapper() throws MailboxException {
-        throw new NotImplementedException();
+        throw new NotImplementedException("not implemented");
     }
 
     @Override
@@ -108,22 +108,22 @@ public class JPAMapperProvider implements MapperProvider {
 
     @Override
     public MessageIdMapper createMessageIdMapper() throws MailboxException {
-        throw new NotImplementedException();
+        throw new NotImplementedException("not implemented");
     }
 
     @Override
     public MessageUid generateMessageUid() {
-        throw new NotImplementedException();
+        throw new NotImplementedException("not implemented");
     }
 
     @Override
     public long generateModSeq(Mailbox mailbox) throws MailboxException {
-        throw new NotImplementedException();
+        throw new NotImplementedException("not implemented");
     }
 
     @Override
     public long highestModSeq(Mailbox mailbox) throws MailboxException {
-        throw new NotImplementedException();
+        throw new NotImplementedException("not implemented");
     }
 
 }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalAnnotationMapper.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalAnnotationMapper.java
@@ -22,7 +22,7 @@ package org.apache.james.mailbox.jpa.mail;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.MailboxAnnotation;
 import org.apache.james.mailbox.model.MailboxAnnotationKey;
@@ -39,12 +39,12 @@ public class TransactionalAnnotationMapper implements AnnotationMapper {
 
     @Override
     public void endRequest() {
-        throw new NotImplementedException();
+        throw new NotImplementedException("not implemented");
     }
 
     @Override
     public <T> T execute(Transaction<T> transaction) {
-        throw new NotImplementedException();
+        throw new NotImplementedException("not implemented");
     }
 
     @Override

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMailboxMapper.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMailboxMapper.java
@@ -21,7 +21,7 @@ package org.apache.james.mailbox.jpa.mail;
 
 import java.util.List;
 
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.mailbox.acl.ACLDiff;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.MailboxNotFoundException;
@@ -42,12 +42,12 @@ public class TransactionalMailboxMapper implements MailboxMapper {
 
     @Override
     public void endRequest() {
-        throw new NotImplementedException();
+        throw new NotImplementedException("not implemented");
     }
 
     @Override
     public <T> T execute(Transaction<T> transaction) throws MailboxException {
-        throw new NotImplementedException();
+        throw new NotImplementedException("not implemented");
     }
 
     @Override

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMessageMapper.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMessageMapper.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 
 import javax.mail.Flags;
 
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.MailboxCounters;
@@ -48,7 +48,7 @@ public class TransactionalMessageMapper implements MessageMapper {
     
     @Override
     public void endRequest() {
-        throw new NotImplementedException();
+        throw new NotImplementedException("not implemented");
     }
 
     @Override
@@ -66,7 +66,7 @@ public class TransactionalMessageMapper implements MessageMapper {
 
     @Override
     public <T> T execute(Transaction<T> transaction) throws MailboxException {
-        throw new NotImplementedException();
+        throw new NotImplementedException("not implemented");
     }
 
     @Override

--- a/mailbox/zoo-seq-provider/pom.xml
+++ b/mailbox/zoo-seq-provider/pom.xml
@@ -33,7 +33,7 @@
     <description>High performance distribuited sequence provider based on ZooKeepr</description>
 
     <properties>
-        <curator.version>1.3.2</curator.version>
+        <curator.version>4.0.1</curator.version>
     </properties>
 
     <dependencies>
@@ -55,22 +55,22 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.netflix.curator</groupId>
+            <groupId>org.apache.curator</groupId>
             <artifactId>curator-client</artifactId>
             <version>${curator.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.netflix.curator</groupId>
+            <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
             <version>${curator.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.netflix.curator</groupId>
+            <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
             <version>${curator.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.netflix.curator</groupId>
+            <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
             <version>${curator.version}</version>
             <scope>test</scope>

--- a/mailbox/zoo-seq-provider/src/main/java/org/apache/james/mailbox/store/mail/ZooUidProvider.java
+++ b/mailbox/zoo-seq-provider/src/main/java/org/apache/james/mailbox/store/mail/ZooUidProvider.java
@@ -21,6 +21,12 @@ package org.apache.james.mailbox.store.mail;
 import java.util.Optional;
 
 import org.apache.commons.lang3.NotImplementedException;
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.imps.CuratorFrameworkState;
+import org.apache.curator.framework.recipes.atomic.AtomicValue;
+import org.apache.curator.framework.recipes.atomic.DistributedAtomicLong;
+import org.apache.curator.retry.RetryOneTime;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -28,12 +34,6 @@ import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
 
 import com.google.common.base.Preconditions;
-import com.netflix.curator.RetryPolicy;
-import com.netflix.curator.framework.CuratorFramework;
-import com.netflix.curator.framework.imps.CuratorFrameworkState;
-import com.netflix.curator.framework.recipes.atomic.AtomicValue;
-import com.netflix.curator.framework.recipes.atomic.DistributedAtomicLong;
-import com.netflix.curator.retry.RetryOneTime;
 
 /**
  * ZooKeeper based implementation of a distributed sequential UID generator.
@@ -42,6 +42,8 @@ public class ZooUidProvider implements UidProvider {
     // TODO: use ZK paths to store uid and modSeq, etc.
 
     public static final String UID_PATH_SUFFIX = "-uid";
+    public static final String PATH_PREFIX = "/";
+
     private final CuratorFramework client;
     private final RetryPolicy retryPolicy;
 
@@ -99,6 +101,6 @@ public class ZooUidProvider implements UidProvider {
     }
 
     public static <E extends MailboxId> String pathForMailbox(Mailbox mailbox) {
-        return mailbox.getMailboxId().serialize() + UID_PATH_SUFFIX;
+        return PATH_PREFIX + mailbox.getMailboxId().serialize() + UID_PATH_SUFFIX;
     }
 }

--- a/mailbox/zoo-seq-provider/src/test/java/org/apache/james/mailbox/store/mail/ZooUidProviderTest.java
+++ b/mailbox/zoo-seq-provider/src/test/java/org/apache/james/mailbox/store/mail/ZooUidProviderTest.java
@@ -24,6 +24,11 @@ import java.io.Serializable;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.TestingServer;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
@@ -32,11 +37,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.netflix.curator.RetryPolicy;
-import com.netflix.curator.framework.CuratorFramework;
-import com.netflix.curator.framework.CuratorFrameworkFactory;
-import com.netflix.curator.retry.RetryOneTime;
-import com.netflix.curator.test.TestingServer;
 
 /**
  * Test for UID provider.
@@ -137,73 +137,72 @@ public class ZooUidProviderTest {
 
     }
 
+    private static TestingServer testServer;
+    private static final int ZOO_TEST_PORT = 3123;
+    private final RetryPolicy retryPolicy = new RetryOneTime(1);
+    private CuratorFramework client;
+    private ZooUidProvider uuidProvider;
+    private ZooUidProvider longProvider;
+    private SimpleMailbox mailboxUUID;
+    private SimpleMailbox mailboxLong;
+    private UUID randomUUID = UUID.randomUUID();
 
-        private static TestingServer testServer;
-        private static final int ZOO_TEST_PORT = 3123;
-        private final RetryPolicy retryPolicy = new RetryOneTime(1);
-        private CuratorFramework client;
-        private ZooUidProvider uuidProvider;
-        private ZooUidProvider longProvider;
-        private SimpleMailbox mailboxUUID;
-        private SimpleMailbox mailboxLong;
-        private UUID randomUUID = UUID.randomUUID();
-
-        @Before
-        public void setUp() throws Exception {
-            testServer = new TestingServer(ZOO_TEST_PORT);
-            client = CuratorFrameworkFactory.builder().connectString("localhost:" + ZOO_TEST_PORT)
-                    .retryPolicy(retryPolicy)
-                    .namespace("JAMES").build();
-            client.start();
-            uuidProvider = new ZooUidProvider(client, retryPolicy);
-            longProvider = new ZooUidProvider(client, retryPolicy);
-            MailboxPath path1 = new MailboxPath("namespacetest", "namespaceuser", "UUID");
-            MailboxPath path2 = new MailboxPath("namespacetest", "namespaceuser", "Long");
-            mailboxUUID = new SimpleMailbox(path1, 1L);
-            mailboxUUID.setMailboxId(UUIDId.of(randomUUID));
-            mailboxLong = new SimpleMailbox(path2, 2L);
-            mailboxLong.setMailboxId(new LongId(123L));
-        }
-
-        @After
-        public void tearDown() throws Exception {
-            client.close();
-            testServer.close();
-        }
-
-        /**
-         * Test of nextUid method, of class ZooUidProvider.
-         */
-        @Test
-        public void testNextUid() throws Exception {
-            System.out.println("Testing nextUid");
-            MessageUid result = uuidProvider.nextUid(null, mailboxUUID);
-            assertEquals("Next UID is 1", 1, result.asLong());
-            result = longProvider.nextUid(null, mailboxLong);
-            assertEquals("Next UID is 1", 1, result.asLong());
-        }
-
-        /**
-         * Test of lastUid method, of class ZooUidProvider.
-         */
-        @Test
-        public void testLastUid() throws Exception {
-            System.out.println("Testing lastUid");
-            Optional<MessageUid> result = uuidProvider.lastUid(null, mailboxUUID);
-            assertEquals("Next UID is empty", Optional.empty(), result);
-            MessageUid nextResult = uuidProvider.nextUid(null, mailboxUUID);
-            assertEquals("Next UID is 1", 1, nextResult.asLong());
-        }
-
-        /**
-         * Test of lastUid method, of class ZooUidProvider.
-         */
-        @Test
-        public void testLongLastUid() throws Exception {
-            System.out.println("Testing long lastUid");
-            Optional<MessageUid> result = longProvider.lastUid(null, mailboxLong);
-            assertEquals("Next UID is empty", Optional.empty(), result);
-            MessageUid nextResult = longProvider.nextUid(null, mailboxLong);
-            assertEquals("Next UID is 1", 1, nextResult.asLong());
-        }
+    @Before
+    public void setUp() throws Exception {
+        testServer = new TestingServer(ZOO_TEST_PORT);
+        client = CuratorFrameworkFactory.builder().connectString("localhost:" + ZOO_TEST_PORT)
+                .retryPolicy(retryPolicy)
+                .namespace("JAMES").build();
+        client.start();
+        uuidProvider = new ZooUidProvider(client, retryPolicy);
+        longProvider = new ZooUidProvider(client, retryPolicy);
+        MailboxPath path1 = new MailboxPath("namespacetest", "namespaceuser", "UUID");
+        MailboxPath path2 = new MailboxPath("namespacetest", "namespaceuser", "Long");
+        mailboxUUID = new SimpleMailbox(path1, 1L);
+        mailboxUUID.setMailboxId(UUIDId.of(randomUUID));
+        mailboxLong = new SimpleMailbox(path2, 2L);
+        mailboxLong.setMailboxId(new LongId(123L));
     }
+
+    @After
+    public void tearDown() throws Exception {
+        client.close();
+        testServer.close();
+    }
+
+    /**
+     * Test of nextUid method, of class ZooUidProvider.
+     */
+    @Test
+    public void testNextUid() throws Exception {
+        System.out.println("Testing nextUid");
+        MessageUid result = uuidProvider.nextUid(null, mailboxUUID);
+        assertEquals("Next UID is 1", 1, result.asLong());
+        result = longProvider.nextUid(null, mailboxLong);
+        assertEquals("Next UID is 1", 1, result.asLong());
+    }
+
+    /**
+     * Test of lastUid method, of class ZooUidProvider.
+     */
+    @Test
+    public void testLastUid() throws Exception {
+        System.out.println("Testing lastUid");
+        Optional<MessageUid> result = uuidProvider.lastUid(null, mailboxUUID);
+        assertEquals("Next UID is empty", Optional.empty(), result);
+        MessageUid nextResult = uuidProvider.nextUid(null, mailboxUUID);
+        assertEquals("Next UID is 1", 1, nextResult.asLong());
+    }
+
+    /**
+     * Test of lastUid method, of class ZooUidProvider.
+     */
+    @Test
+    public void testLongLastUid() throws Exception {
+        System.out.println("Testing long lastUid");
+        Optional<MessageUid> result = longProvider.lastUid(null, mailboxLong);
+        assertEquals("Next UID is empty", Optional.empty(), result);
+        MessageUid nextResult = longProvider.nextUid(null, mailboxLong);
+        assertEquals("Next UID is 1", 1, nextResult.asLong());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -583,6 +583,7 @@
 
         <activemq.version>5.15.4</activemq.version>
         <apache-mime4j.version>0.8.2</apache-mime4j.version>
+        <apache.openjpa.version>3.0.0</apache.openjpa.version>
         <camel.version>2.22.0</camel.version>
         <derby.version>10.9.1.0</derby.version>
         <hadoop.version>1.1.1</hadoop.version>

--- a/pom.xml
+++ b/pom.xml
@@ -661,7 +661,7 @@
         <xml-apis.version>1.3.04</xml-apis.version>
         <geronimo-activation-spec.version>1.1</geronimo-activation-spec.version>
         <mockito-core.version>1.9.0</mockito-core.version>
-        <jasypt.version>1.9.0</jasypt.version>
+        <jasypt.version>1.9.2</jasypt.version>
         <jackson-databinding.version>2.6.3</jackson-databinding.version>
         <guice.version>4.0</guice.version>
         <jackrabbit-core.version>2.5.2</jackrabbit-core.version>

--- a/server/data/data-jpa/pom.xml
+++ b/server/data/data-jpa/pom.xml
@@ -147,7 +147,7 @@
             <plugin>
                 <groupId>org.apache.openjpa</groupId>
                 <artifactId>openjpa-maven-plugin</artifactId>
-                <version>2.4.2</version>
+                <version>${apache.openjpa.version}</version>
                 <configuration>
                     <includes>org/apache/james/user/jpa/model/JPAUser.class,
                         org/apache/james/rrt/jpa/model/JPARecipientRewrite.class,


### PR DESCRIPTION
```
com.netflix.curator:curator-client .................... 1.3.2 -> 1.3.3 GDF [zookeeper] Moved to org.apache.curator
com.netflix.curator:curator-framework ................. 1.3.2 -> 1.3.3 GDF [zookeeper] Moved to org.apache.curator
com.netflix.curator:curator-recipes ................... 1.3.2 -> 1.3.3 GDF [zookeeper] Moved to org.apache.curator
com.netflix.curator:curator-test ...................... 1.3.2 -> 1.3.3 GDF [zookeeper] Moved to org.apache.curator

org.apache.openjpa:openjpa ............................ 2.4.2 -> 3.0.0 MBA [db] 3.0.0 released one month ago, migration guide : http://openjpa.apache.org/builds/3.0.0/apache-openjpa/docs/main.html
org.jasypt:jasypt ..................................... 1.9.0 -> 1.9.2 MBA [crypto] use to store crypted messages into JPA, could probably be replaced by bouncycastle // low priority

```