### PR TITLE
JAMES-2477 Allow passing additional arguments to maven dockerized build

### DIFF
--- a/dockerfiles/compilation/java-8/compile.sh
+++ b/dockerfiles/compilation/java-8/compile.sh
@@ -6,6 +6,9 @@ printUsage() {
    echo "./compile.sh [-s | --skipTests] SHA1"
    echo "    -s: Skip test"
    echo "    SHA1: SHA1 to build (optional)"
+   echo ""
+   echo "Environment:"
+   echo " - MVN_ADDITIONAL_ARG_LINE: Allow passing additional command arguments to the maven command"
    exit 1
 }
 
@@ -47,9 +50,9 @@ git checkout $SHA1
 # Compilation
 
 if [ "$SKIPTESTS" = "skipTests" ]; then
-   mvn package -DskipTests
+   mvn package -DskipTests $MVN_ADDITIONAL_ARG_LINE
 else
-   mvn package
+   mvn package $MVN_ADDITIONAL_ARG_LINE
 fi
 
 # Retrieve result

--- a/dockerfiles/compilation/java-8/compile.sh
+++ b/dockerfiles/compilation/java-8/compile.sh
@@ -50,9 +50,9 @@ git checkout $SHA1
 # Compilation
 
 if [ "$SKIPTESTS" = "skipTests" ]; then
-   mvn package -DskipTests $MVN_ADDITIONAL_ARG_LINE
+   mvn package -DskipTests ${MVN_ADDITIONAL_ARG_LINE}
 else
-   mvn package $MVN_ADDITIONAL_ARG_LINE
+   mvn package ${MVN_ADDITIONAL_ARG_LINE}
 fi
 
 # Retrieve result


### PR DESCRIPTION
This should allow passing:

 - `-Dpartial-build` profile when needed
 - `-T 4` for parallel builds