### PR TITLE
JAMES-2500 Upgrade cassandra driver & testcontainers & docker-client

### DIFF
--- a/backends-common/cassandra/pom.xml
+++ b/backends-common/cassandra/pom.xml
@@ -31,7 +31,7 @@
     <name>Apache James Cassandra backend</name>
 
     <properties>
-        <cassandra.driver.version>3.5.0</cassandra.driver.version>
+        <cassandra.driver.version>3.5.1</cassandra.driver.version>
     </properties>
 
     <dependencies>

--- a/mailbox/cassandra/pom.xml
+++ b/mailbox/cassandra/pom.xml
@@ -154,12 +154,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.cassandraunit</groupId>
-            <artifactId>cassandra-unit</artifactId>
-            <version>2.1.9.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>

--- a/mailbox/cassandra/pom.xml
+++ b/mailbox/cassandra/pom.xml
@@ -156,6 +156,7 @@
         <dependency>
             <groupId>org.cassandraunit</groupId>
             <artifactId>cassandra-unit</artifactId>
+            <version>2.1.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/mpt/impl/imap-mailbox/cyrus/pom.xml
+++ b/mpt/impl/imap-mailbox/cyrus/pom.xml
@@ -42,6 +42,12 @@
         <dependency>
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
+            <version>8.11.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>20.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/mpt/impl/imap-mailbox/cyrus/src/test/java/org/apache/james/mpt/imapmailbox/cyrus/host/Docker.java
+++ b/mpt/impl/imap-mailbox/cyrus/src/test/java/org/apache/james/mpt/imapmailbox/cyrus/host/Docker.java
@@ -27,9 +27,10 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.jayway.awaitility.Awaitility;
 import com.spotify.docker.client.DefaultDockerClient;
-import com.spotify.docker.client.DockerException;
+import com.spotify.docker.client.exceptions.DockerException;
 import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.ContainerCreation;
+import com.spotify.docker.client.messages.ExecCreation;
 import com.spotify.docker.client.messages.HostConfig;
 
 public class Docker {
@@ -114,7 +115,7 @@ public class Docker {
     
     public void createUser(ContainerCreation container, String user, String password) throws DockerException, InterruptedException {
         String createUserCommand = String.format("echo %s | saslpasswd2 -u test -c %s -p", password, user);
-        String execId = dockerClient.execCreate(container.id(), new String[] {"/bin/bash", "-c", createUserCommand});
-        dockerClient.execStart(execId);
+        ExecCreation execCreation = dockerClient.execCreate(container.id(), new String[]{"/bin/bash", "-c", createUserCommand});
+        dockerClient.execStart(execCreation.id());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -634,7 +634,7 @@
         <jackson-data.version>2.6.3</jackson-data.version>
         <jetty.version>9.4.7.v20170914</jetty.version>
         <assertj-guava.version>3.1.0</assertj-guava.version>
-        <testcontainers-version>1.7.3</testcontainers-version>
+        <testcontainers.version>1.8.1</testcontainers.version>
         <metrics.version>3.2.6</metrics.version>
         <joda.version>2.9.4</joda.version>
         <assertj.version>3.3.0</assertj.version>
@@ -2465,7 +2465,7 @@
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>
-                <version>${testcontainers-version}</version>
+                <version>${testcontainers.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.threeten</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1702,11 +1702,6 @@
                 <version>2.6.0</version>
             </dependency>
             <dependency>
-                <groupId>com.spotify</groupId>
-                <artifactId>docker-client</artifactId>
-                <version>3.5.10</version>
-            </dependency>
-            <dependency>
                 <groupId>com.sun.mail</groupId>
                 <artifactId>javax.mail</artifactId>
                 <version>1.6.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -633,7 +633,6 @@
         <pax-logging-api.version>1.6.4</pax-logging-api.version>
         <jackson-data.version>2.6.3</jackson-data.version>
         <jetty.version>9.4.7.v20170914</jetty.version>
-        <cassandra-unit.version>2.1.9.2</cassandra-unit.version>
         <assertj-guava.version>3.1.0</assertj-guava.version>
         <testcontainers-version>1.7.3</testcontainers-version>
         <metrics.version>3.2.6</metrics.version>
@@ -2247,11 +2246,6 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk15on</artifactId>
                 <version>1.60</version>
-            </dependency>
-            <dependency>
-                <groupId>org.cassandraunit</groupId>
-                <artifactId>cassandra-unit</artifactId>
-                <version>2.1.9.2</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>

--- a/server/container/guice/jpa-smtp-mariadb/pom.xml
+++ b/server/container/guice/jpa-smtp-mariadb/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mariadb</artifactId>
-            <version>1.7.3</version>
+            <version>1.8.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQClusterTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQClusterTest.java
@@ -217,10 +217,10 @@ class RabbitMQClusterTest {
         @Test
         void connectingToAClusterWithAFailedRabbit(DockerRabbitMQCluster cluster) throws Exception {
             ConnectionFactory node3ConnectionFactory = cluster.getRabbitMQ3().connectionFactory();
-            cluster.getRabbitMQ3().stop();
-
             try (Connection connection = node3ConnectionFactory.newConnection(cluster.getAddresses());
-                 Channel channel = connection.createChannel()) {
+                    Channel channel = connection.createChannel()) {
+
+                cluster.getRabbitMQ3().stop();
 
                 channel.exchangeDeclare(EXCHANGE_NAME, DIRECT, DURABLE);
                 channel.queueDeclare(QUEUE, DURABLE, !EXCLUSIVE, !AUTO_DELETE, ImmutableMap.of()).getQueue();


### PR DESCRIPTION
```
com.datastax.cassandra:cassandra-driver-core .......... 3.5.0 -> 3.5.1 GDF [cassandra] 3.5.1 // mostly doc
org.cassandraunit:cassandra-unit .................. 2.1.9.2 -> 3.5.0.1 MBA [cassandra] should be dropped entirely
org.testcontainers:mariadb ............................ 1.7.3 -> 1.8.1 MBA [test] 
org.testcontainers:testcontainers ..................... 1.1.7 -> 1.8.1 MBA [test] 
org.testcontainers:testcontainers ..................... 1.7.3 -> 1.8.1 MBA [test] 1.8.1 would be great to use cassandra support but rabbitmq tests were not happy last time we tried migration
com.spotify:docker-client ........................... 3.5.10 -> 8.11.7 GDF [docker] 8.11.7 // Will hurt // we may have a conflict with testcontainer
```