### PR TITLE
JAMES-2470 Various backend reuse improvments

### DIFF
--- a/mailbox/elasticsearch/pom.xml
+++ b/mailbox/elasticsearch/pom.xml
@@ -178,4 +178,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <reuseForks>true</reuseForks>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/ElasticSearchIntegrationTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/ElasticSearchIntegrationTest.java
@@ -44,7 +44,7 @@ import org.apache.james.mailbox.model.SearchQuery;
 import org.apache.james.mailbox.store.StoreMessageIdManager;
 import org.apache.james.mailbox.store.search.AbstractMessageSearchIndexTest;
 import org.apache.james.mailbox.tika.TikaConfiguration;
-import org.apache.james.mailbox.tika.TikaContainer;
+import org.apache.james.mailbox.tika.TikaContainerStaticRule;
 import org.apache.james.mailbox.tika.TikaHttpClientImpl;
 import org.apache.james.mailbox.tika.TikaTextExtractor;
 import org.apache.james.metrics.api.NoopMetricFactory;
@@ -70,7 +70,7 @@ public class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest
     public RuleChain ruleChain = RuleChain.outerRule(temporaryFolder).around(embeddedElasticSearch);
 
     @ClassRule
-    public static TikaContainer tika = new TikaContainer();
+    public static TikaContainerStaticRule tika = TikaContainerStaticRule.rule;
     private TikaTextExtractor textExtractor;
 
     @Override

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/ElasticSearchIntegrationTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/ElasticSearchIntegrationTest.java
@@ -44,7 +44,7 @@ import org.apache.james.mailbox.model.SearchQuery;
 import org.apache.james.mailbox.store.StoreMessageIdManager;
 import org.apache.james.mailbox.store.search.AbstractMessageSearchIndexTest;
 import org.apache.james.mailbox.tika.TikaConfiguration;
-import org.apache.james.mailbox.tika.TikaContainerStaticRule;
+import org.apache.james.mailbox.tika.TikaContainerSingletonRule;
 import org.apache.james.mailbox.tika.TikaHttpClientImpl;
 import org.apache.james.mailbox.tika.TikaTextExtractor;
 import org.apache.james.metrics.api.NoopMetricFactory;
@@ -70,7 +70,7 @@ public class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest
     public RuleChain ruleChain = RuleChain.outerRule(temporaryFolder).around(embeddedElasticSearch);
 
     @ClassRule
-    public static TikaContainerStaticRule tika = TikaContainerStaticRule.rule;
+    public static TikaContainerSingletonRule tika = TikaContainerSingletonRule.rule;
     private TikaTextExtractor textExtractor;
 
     @Override

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/IndexableMessageTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/IndexableMessageTest.java
@@ -33,6 +33,7 @@ import javax.mail.Flags;
 
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.elasticsearch.IndexAttachments;
+import org.apache.james.mailbox.tika.TikaContainerStaticRule;
 import org.apache.james.mailbox.extractor.ParsedContent;
 import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mailbox.inmemory.InMemoryMessageId;
@@ -44,7 +45,6 @@ import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleProperty;
 import org.apache.james.mailbox.tika.TikaConfiguration;
-import org.apache.james.mailbox.tika.TikaContainer;
 import org.apache.james.mailbox.tika.TikaHttpClientImpl;
 import org.apache.james.mailbox.tika.TikaTextExtractor;
 import org.apache.james.metrics.api.NoopMetricFactory;
@@ -61,7 +61,7 @@ public class IndexableMessageTest {
     public static final MessageUid MESSAGE_UID = MessageUid.of(154);
 
     @ClassRule
-    public static TikaContainer tika = new TikaContainer();
+    public static TikaContainerStaticRule tika = TikaContainerStaticRule.rule;
 
     private TikaTextExtractor textExtractor;
 

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/IndexableMessageTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/IndexableMessageTest.java
@@ -33,7 +33,7 @@ import javax.mail.Flags;
 
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.elasticsearch.IndexAttachments;
-import org.apache.james.mailbox.tika.TikaContainerStaticRule;
+import org.apache.james.mailbox.tika.TikaContainerSingletonRule;
 import org.apache.james.mailbox.extractor.ParsedContent;
 import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mailbox.inmemory.InMemoryMessageId;
@@ -61,7 +61,7 @@ public class IndexableMessageTest {
     public static final MessageUid MESSAGE_UID = MessageUid.of(154);
 
     @ClassRule
-    public static TikaContainerStaticRule tika = TikaContainerStaticRule.rule;
+    public static TikaContainerSingletonRule tika = TikaContainerSingletonRule.rule;
 
     private TikaTextExtractor textExtractor;
 

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/MessageToElasticSearchJsonTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/MessageToElasticSearchJsonTest.java
@@ -36,6 +36,7 @@ import org.apache.james.mailbox.FlagsBuilder;
 import org.apache.james.mailbox.MailboxSession.User;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.elasticsearch.IndexAttachments;
+import org.apache.james.mailbox.tika.TikaContainerStaticRule;
 import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mailbox.mock.MockMailboxSession;
 import org.apache.james.mailbox.model.MessageId;
@@ -46,7 +47,6 @@ import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 import org.apache.james.mailbox.tika.TikaConfiguration;
-import org.apache.james.mailbox.tika.TikaContainer;
 import org.apache.james.mailbox.tika.TikaHttpClientImpl;
 import org.apache.james.mailbox.tika.TikaTextExtractor;
 import org.apache.james.metrics.api.NoopMetricFactory;
@@ -73,7 +73,7 @@ public class MessageToElasticSearchJsonTest {
     private PropertyBuilder propertyBuilder;
 
     @ClassRule
-    public static TikaContainer tika = new TikaContainer();
+    public static TikaContainerStaticRule tika = TikaContainerStaticRule.rule;
 
     @Before
     public void setUp() throws Exception {

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/MessageToElasticSearchJsonTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/MessageToElasticSearchJsonTest.java
@@ -36,7 +36,7 @@ import org.apache.james.mailbox.FlagsBuilder;
 import org.apache.james.mailbox.MailboxSession.User;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.elasticsearch.IndexAttachments;
-import org.apache.james.mailbox.tika.TikaContainerStaticRule;
+import org.apache.james.mailbox.tika.TikaContainerSingletonRule;
 import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mailbox.mock.MockMailboxSession;
 import org.apache.james.mailbox.model.MessageId;
@@ -73,7 +73,7 @@ public class MessageToElasticSearchJsonTest {
     private PropertyBuilder propertyBuilder;
 
     @ClassRule
-    public static TikaContainerStaticRule tika = TikaContainerStaticRule.rule;
+    public static TikaContainerSingletonRule tika = TikaContainerSingletonRule.rule;
 
     @Before
     public void setUp() throws Exception {

--- a/mailbox/hbase/pom.xml
+++ b/mailbox/hbase/pom.xml
@@ -133,4 +133,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <reuseForks>true</reuseForks>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/TikaContainerSingletonRule.java
+++ b/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/TikaContainerSingletonRule.java
@@ -23,13 +23,13 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-public class TikaContainerStaticRule implements TestRule {
+public class TikaContainerSingletonRule implements TestRule {
 
-    public static final TikaContainerStaticRule rule = new TikaContainerStaticRule(new TikaContainer());
+    public static final TikaContainerSingletonRule rule = new TikaContainerSingletonRule(new TikaContainer());
 
     private final TikaContainer tikaContainer;
 
-    public TikaContainerStaticRule(TikaContainer tikaContainer) {
+    private TikaContainerSingletonRule(TikaContainer tikaContainer) {
         this.tikaContainer = tikaContainer;
         this.tikaContainer.start();
     }

--- a/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/TikaContainerStaticRule.java
+++ b/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/TikaContainerStaticRule.java
@@ -16,59 +16,38 @@
  * specific language governing permissions and limitations      *
  * under the License.                                           *
  ****************************************************************/
+
 package org.apache.james.mailbox.tika;
 
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
-import org.apache.james.util.docker.Images;
-import org.apache.james.util.docker.SwarmGenericContainer;
-import org.junit.rules.ExternalResource;
-import org.testcontainers.containers.wait.strategy.Wait;
+public class TikaContainerStaticRule implements TestRule {
 
-import com.google.common.primitives.Ints;
+    public static final TikaContainerStaticRule rule = new TikaContainerStaticRule(new TikaContainer());
 
-public class TikaContainer extends ExternalResource {
-    
-    private static final int DEFAULT_TIKA_PORT = 9998;
-    private static final int DEFAULT_TIMEOUT_IN_MS = Ints.checkedCast(TimeUnit.MINUTES.toMillis(3));
+    private final TikaContainer tikaContainer;
 
-    private final SwarmGenericContainer tika;
-
-    public TikaContainer() {
-        tika = new SwarmGenericContainer(Images.TIKA)
-                .withExposedPorts(DEFAULT_TIKA_PORT)
-                .waitingFor(Wait.forHttp("/tika"))
-                .withStartupTimeout(Duration.ofSeconds(30));
+    public TikaContainerStaticRule(TikaContainer tikaContainer) {
+        this.tikaContainer = tikaContainer;
+        this.tikaContainer.start();
     }
 
     @Override
-    protected void before() throws Throwable {
-        start();
-    }
-
-    public void start() {
-        tika.start();
-    }
-
-    @Override
-    protected void after() {
-        stop();
-    }
-
-    public void stop() {
-        tika.stop();
+    public Statement apply(Statement statement, Description description) {
+        return statement;
     }
 
     public String getIp() {
-        return tika.getHostIp();
+        return tikaContainer.getIp();
     }
 
     public int getPort() {
-        return tika.getMappedPort(DEFAULT_TIKA_PORT);
+        return tikaContainer.getPort();
     }
 
     public int getTimeoutInMillis() {
-        return DEFAULT_TIMEOUT_IN_MS;
+        return tikaContainer.getTimeoutInMillis();
     }
 }

--- a/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/TikaContainerStaticRule.java
+++ b/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/TikaContainerStaticRule.java
@@ -50,4 +50,7 @@ public class TikaContainerStaticRule implements TestRule {
     public int getTimeoutInMillis() {
         return tikaContainer.getTimeoutInMillis();
     }
+    
+    // Cleanup will be performed by test container resource reaper
+
 }

--- a/server/data/data-hbase/pom.xml
+++ b/server/data/data-hbase/pom.xml
@@ -173,10 +173,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <forkMode>pertest</forkMode>
-                    <argLine>-Xms256m -Xmx512m</argLine>
-                    <testFailureIgnore>false</testFailureIgnore>
-                    <skip>false</skip>
+                    <reuseForks>true</reuseForks>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Some small improvements:

 - Allow HBase cluster reuse across classes
 - Allow Tika docker container reuse across class

```
[INFO] Apache James :: Mailbox :: ElasticSearch ........... SUCCESS [01:28 min]
[INFO] Apache James :: Mailbox :: HBase ................... SUCCESS [01:22 min]
[INFO] Apache James :: Server :: Data :: HBase Persistence  SUCCESS [01:21 min]
```

After:

```
[INFO] Apache James :: Mailbox :: ElasticSearch ........... SUCCESS [01:02 min]
[INFO] Apache James :: Mailbox :: HBase ................... SUCCESS [ 17.385 s]
[INFO] Apache James :: Server :: Data :: HBase Persistence  SUCCESS [ 27.267 s]
```

Gain: **2 min 23**