### PR TITLE
JAMES-2514 Improve configuration handling for guice Cassandra

### DIFF
--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
@@ -38,6 +38,7 @@ import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule
 import org.apache.james.lifecycle.api.Configurable;
 import org.apache.james.mailbox.store.BatchSizes;
 import org.apache.james.server.CassandraProbe;
+import org.apache.james.util.Host;
 import org.apache.james.utils.ConfigurationPerformer;
 import org.apache.james.utils.GuiceProbe;
 import org.apache.james.utils.PropertiesProvider;
@@ -62,7 +63,7 @@ public class CassandraSessionModule extends AbstractModule {
 
     private static final String LOCALHOST = "127.0.0.1";
     private static final String BATCHSIZES_FILE_NAME = "batchsizes";
-    private static final String CASSANDRA_NODES = "cassandra.nodes";
+    private static final String CASSANDRA_FILE_NAME = "cassandra";
 
     @Override
     protected void configure() {
@@ -120,23 +121,23 @@ public class CassandraSessionModule extends AbstractModule {
     @Provides
     @Singleton
     CassandraConfiguration provideCassandraConfiguration(PropertiesProvider propertiesProvider) throws ConfigurationException {
-        return CassandraConfiguration.from(getConfiguration(propertiesProvider));
+        try {
+            return CassandraConfiguration.from(propertiesProvider.getConfiguration(CASSANDRA_FILE_NAME));
+        } catch (FileNotFoundException e) {
+            return CassandraConfiguration.DEFAULT_CONFIGURATION;
+        }
     }
 
     @Provides
     @Singleton
     ClusterConfiguration provideClusterConfiguration(PropertiesProvider propertiesProvider) throws ConfigurationException {
-        return ClusterConfiguration.from(getConfiguration(propertiesProvider));
-    }
-
-    private PropertiesConfiguration getConfiguration(PropertiesProvider propertiesProvider) throws ConfigurationException {
         try {
-            return propertiesProvider.getConfiguration("cassandra");
+            return ClusterConfiguration.from(propertiesProvider.getConfiguration(CASSANDRA_FILE_NAME));
         } catch (FileNotFoundException e) {
             LOGGER.warn("Could not locate cassandra configuration file. Defaulting to node " + LOCALHOST + ":9042");
-            PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
-            propertiesConfiguration.addProperty(CASSANDRA_NODES, LOCALHOST);
-            return propertiesConfiguration;
+            return ClusterConfiguration.builder()
+                .host(Host.from(LOCALHOST, 9042))
+                .build();
         }
     }
 

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
@@ -64,6 +64,7 @@ public class CassandraSessionModule extends AbstractModule {
     private static final String LOCALHOST = "127.0.0.1";
     private static final String BATCHSIZES_FILE_NAME = "batchsizes";
     private static final String CASSANDRA_FILE_NAME = "cassandra";
+    private static final int CASSANDRA_PORT = 9042;
 
     @Override
     protected void configure() {
@@ -134,9 +135,9 @@ public class CassandraSessionModule extends AbstractModule {
         try {
             return ClusterConfiguration.from(propertiesProvider.getConfiguration(CASSANDRA_FILE_NAME));
         } catch (FileNotFoundException e) {
-            LOGGER.warn("Could not locate cassandra configuration file. Defaulting to node " + LOCALHOST + ":9042");
+            LOGGER.warn("Could not locate cassandra configuration file. Defaulting to node " + LOCALHOST + ":" + CASSANDRA_PORT);
             return ClusterConfiguration.builder()
-                .host(Host.from(LOCALHOST, 9042))
+                .host(Host.from(LOCALHOST, CASSANDRA_PORT))
                 .build();
         }
     }


### PR DESCRIPTION
 - A property file was crafted as a default. Using builder is cleaner.
 - The warning 'default to 127.0.0.1:9042' was issued twice

 Furthermore, tests were providing a ClusterConfiguration without a CassandraConfiguration.
 The warning was issued even if not applicable...