### PR TITLE
JAMES-2514 DateTieredCompactionStrategy is deprecated in Cassandra 3.0.8 & 3.8

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraRegistrationModule.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraRegistrationModule.java
@@ -36,7 +36,7 @@ public interface CassandraRegistrationModule {
         .table(CassandraMailboxPathRegisterTable.TABLE_NAME)
         .comment("Holds node mailboxPath registration for distributed events")
         .options(options -> options
-            .compactionOptions(SchemaBuilder.dateTieredStrategy()))
+            .compactionOptions(SchemaBuilder.timeWindowCompactionStrategy()))
         .statement(statement -> statement
             .addUDTPartitionKey(CassandraMailboxPathRegisterTable.MAILBOX_PATH, SchemaBuilder.frozen(CassandraMailboxPathRegisterTable.MAILBOX_PATH))
             .addClusteringColumn(CassandraMailboxPathRegisterTable.TOPIC, text()))

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/vacation/CassandraNotificationRegistryModule.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/vacation/CassandraNotificationRegistryModule.java
@@ -31,7 +31,7 @@ public interface CassandraNotificationRegistryModule {
     CassandraModule MODULE = CassandraModule.table(CassandraNotificationTable.TABLE_NAME)
         .comment("Stores registry of vacation notification being sent.")
         .options(options -> options
-            .compactionOptions(SchemaBuilder.dateTieredStrategy())
+            .compactionOptions(SchemaBuilder.timeWindowCompactionStrategy())
             .caching(SchemaBuilder.KeyCaching.ALL,
                 SchemaBuilder.rows(CassandraConstants.DEFAULT_CACHED_ROW_PER_PARTITION)))
         .statement(statement -> statement


### PR DESCRIPTION
See https://docs.datastax.com/en/cassandra/3.0/cassandra/operations/opsConfigureCompaction.html