### PR TITLE
JAMES-2426 Update commons-compress to 1.18

### DIFF
--- a/mailbox/backup/pom.xml
+++ b/mailbox/backup/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.17</version>
+            <version>1.18</version>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>


### PR DESCRIPTION
This fixes CVE-2018-11771 which reported a denial of service.

From CVE announcement:

When reading a specially crafted ZIP archive, the read method of
ZipArchiveInputStream can fail to return the correct EOF indication
after the end of the stream has been reached.  When combined with a
java.io.InputStreamReader this can lead to an infinite stream, which
can be used to mount a denial of service attack against services that
use Compress' zip package.