### PR TITLE
 Experiment: reduce surefire XMS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2800,7 +2800,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.0</version>
                     <configuration>
-                        <argLine>-Xms512m -Xmx1024m</argLine>
+                        <argLine>-Xms128m -Xmx1024m</argLine>
                         <reuseForks>false</reuseForks>
                         <!-- Fail tests longer than 2 hours, prevent form random locking tests -->
                         <forkedProcessTimeoutInSeconds>7200</forkedProcessTimeoutInSeconds>


### PR DESCRIPTION
I suspect virtualized environment to create a high cost to memory allocation on new CI be it because of:

 - More memory checks while allocating
 - Or memory is more fragmented due to shared environment

I'd like to see build time reduction
