### PR TITLE
JAMES-2291 Invalid CassandraMailRepository size 

### DIFF
--- a/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
+++ b/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
@@ -334,6 +334,18 @@ public interface MailRepositoryContract {
     }
 
     @Test
+    default void removeShouldHaveNoEffectOnSizeWhenUnknownKeys() throws Exception {
+        MailRepository testee = retrieveRepository();
+
+        Mail mail1 = createMail(MAIL_1);
+        testee.store(mail1);
+
+        testee.remove(ImmutableList.of(createMail(UNKNOWN_KEY)));
+
+        assertThat(testee.size()).isEqualTo(1);
+    }
+
+    @Test
     default void removeShouldHaveNoEffectForUnknownMail() throws Exception {
         MailRepository testee = retrieveRepository();
 

--- a/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
+++ b/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
@@ -346,6 +346,17 @@ public interface MailRepositoryContract {
     }
 
     @Test
+    default void storeShouldHaveNoEffectOnSizeWhenAlreadyStoredMail() throws Exception {
+        MailRepository testee = retrieveRepository();
+
+        Mail mail1 = createMail(MAIL_1);
+        testee.store(mail1);
+        testee.store(mail1);
+
+        assertThat(testee.size()).isEqualTo(1);
+    }
+
+    @Test
     default void removeShouldHaveNoEffectForUnknownMail() throws Exception {
         MailRepository testee = retrieveRepository();
 

--- a/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryKeysDAO.java
+++ b/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryKeysDAO.java
@@ -68,6 +68,7 @@ public class CassandraMailRepositoryKeysDAO {
     private PreparedStatement prepareDelete(Session session) {
         return session.prepare(delete()
             .from(KEYS_TABLE_NAME)
+            .ifExists()
             .where(eq(REPOSITORY_NAME, bindMarker(REPOSITORY_NAME)))
             .and(eq(MAIL_KEY, bindMarker(MAIL_KEY))));
     }
@@ -91,8 +92,8 @@ public class CassandraMailRepositoryKeysDAO {
             .thenApply(stream -> stream.map(row -> new MailKey(row.getString(MAIL_KEY))));
     }
 
-    public CompletableFuture<Void> remove(MailRepositoryUrl url, MailKey key) {
-        return executor.executeVoid(deleteKey.bind()
+    public CompletableFuture<Boolean> remove(MailRepositoryUrl url, MailKey key) {
+        return executor.executeReturnApplied(deleteKey.bind()
             .setString(REPOSITORY_NAME, url.asString())
             .setString(MAIL_KEY, key.asString()));
     }

--- a/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryKeysDAO.java
+++ b/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryKeysDAO.java
@@ -75,12 +75,13 @@ public class CassandraMailRepositoryKeysDAO {
 
     private PreparedStatement prepareInsert(Session session) {
         return session.prepare(insertInto(KEYS_TABLE_NAME)
+            .ifNotExists()
             .value(REPOSITORY_NAME, bindMarker(REPOSITORY_NAME))
             .value(MAIL_KEY, bindMarker(MAIL_KEY)));
     }
 
-    public CompletableFuture<Void> store(MailRepositoryUrl url, MailKey key) {
-        return executor.executeVoid(insertKey.bind()
+    public CompletableFuture<Boolean> store(MailRepositoryUrl url, MailKey key) {
+        return executor.executeReturnApplied(insertKey.bind()
             .setString(REPOSITORY_NAME, url.asString())
             .setString(MAIL_KEY, key.asString()));
     }

--- a/server/mailrepository/mailrepository-cassandra/src/test/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryKeysDAOTest.java
+++ b/server/mailrepository/mailrepository-cassandra/src/test/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryKeysDAOTest.java
@@ -140,4 +140,21 @@ class CassandraMailRepositoryKeysDAOTest {
         assertThat(isDeleted).isFalse();
     }
 
+
+    @Test
+    void storeShouldReturnTrueWhenNotPreviouslyStored() {
+        boolean isStored = testee.store(URL, KEY_1).join();
+
+        assertThat(isStored).isTrue();
+    }
+
+    @Test
+    void storeShouldReturnFalseWhenPreviouslyStored() {
+        testee.store(URL, KEY_1).join();
+
+        boolean isStored = testee.store(URL, KEY_1).join();
+
+        assertThat(isStored).isFalse();
+    }
+
 }

--- a/server/mailrepository/mailrepository-cassandra/src/test/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryKeysDAOTest.java
+++ b/server/mailrepository/mailrepository-cassandra/src/test/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryKeysDAOTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(DockerCassandraExtension.class)
-public class CassandraMailRepositoryKeysDAOTest {
+class CassandraMailRepositoryKeysDAOTest {
 
     static final MailRepositoryUrl URL = MailRepositoryUrl.from("proto://url");
     static final MailRepositoryUrl URL2 = MailRepositoryUrl.from("proto://url2");
@@ -51,7 +51,7 @@ public class CassandraMailRepositoryKeysDAOTest {
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         testee = new CassandraMailRepositoryKeysDAO(cassandra.getConf(), CassandraUtils.WITH_DEFAULT_CONFIGURATION);
     }
 
@@ -66,13 +66,13 @@ public class CassandraMailRepositoryKeysDAOTest {
     }
 
     @Test
-    public void test() {
+    void listShouldBeEmptyByDefault() {
         assertThat(testee.list(URL).join())
             .isEmpty();
     }
 
     @Test
-    public void listShouldReturnEmptyByDefault() {
+    void listShouldReturnEmptyByDefault() {
         testee.store(URL, KEY_1).join();
 
         assertThat(testee.list(URL).join())
@@ -80,7 +80,7 @@ public class CassandraMailRepositoryKeysDAOTest {
     }
 
     @Test
-    public void listShouldNotReturnElementsOfOtherRepositories() {
+    void listShouldNotReturnElementsOfOtherRepositories() {
         testee.store(URL, KEY_1).join();
 
         assertThat(testee.list(URL2).join())
@@ -88,7 +88,7 @@ public class CassandraMailRepositoryKeysDAOTest {
     }
 
     @Test
-    public void listShouldReturnSeveralElements() {
+    void listShouldReturnSeveralElements() {
         testee.store(URL, KEY_1).join();
         testee.store(URL, KEY_2).join();
         testee.store(URL, KEY_3).join();
@@ -98,7 +98,7 @@ public class CassandraMailRepositoryKeysDAOTest {
     }
 
     @Test
-    public void listShouldNotReturnRemovedElements() {
+    void listShouldNotReturnRemovedElements() {
         testee.store(URL, KEY_1).join();
         testee.store(URL, KEY_2).join();
         testee.store(URL, KEY_3).join();
@@ -110,18 +110,34 @@ public class CassandraMailRepositoryKeysDAOTest {
     }
 
     @Test
-    public void removeShouldBeIdempotent() {
+    void removeShouldBeIdempotent() {
         testee.remove(URL, KEY_2).join();
     }
 
     @Test
-    public void removeShouldNotAffectOtherRepositories() {
+    void removeShouldNotAffectOtherRepositories() {
         testee.store(URL, KEY_1).join();
 
         testee.remove(URL2, KEY_2).join();
 
         assertThat(testee.list(URL).join())
             .containsOnly(KEY_1);
+    }
+
+    @Test
+    void removeShouldReturnTrueWhenKeyDeleted() {
+        testee.store(URL, KEY_1).join();
+
+        boolean isDeleted = testee.remove(URL, KEY_1).join();
+
+        assertThat(isDeleted).isTrue();
+    }
+
+    @Test
+    void removeShouldReturnFalseWhenKeyNotDeleted() {
+        boolean isDeleted = testee.remove(URL2, KEY_2).join();
+
+        assertThat(isDeleted).isFalse();
     }
 
 }


### PR DESCRIPTION
Deleting a non-stored mail decreased the size.

Storing an already stored mail increased the size.

These clearly incorrect behaviour needs transactionality to be solved.