### PR TITLE
JAMES-2541 Concurrency tests for mail queue

### DIFF
--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -983,10 +983,7 @@ public abstract class MailboxManagerTest {
         ConcurrentTestRunner.builder()
             .operation((a, b) -> mailboxManager.createMailbox(MailboxPath.forUser(USER_1, mailboxName + a), session))
             .threadCount(10)
-            .build()
-            .run()
-            .awaitTermination(1, TimeUnit.MINUTES)
-            .assertNoException();
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
     }
 
     @Test

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -980,13 +980,13 @@ public abstract class MailboxManagerTest {
         MailboxSession session = mailboxManager.createSystemSession(USER_1);
         String mailboxName = "a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z";
 
-        ConcurrentTestRunner testRunner = ConcurrentTestRunner.builder()
+        ConcurrentTestRunner.builder()
             .operation((a, b) -> mailboxManager.createMailbox(MailboxPath.forUser(USER_1, mailboxName + a), session))
             .threadCount(10)
             .build()
-            .run();
-        testRunner.awaitTermination(1, TimeUnit.MINUTES);
-        testRunner.assertNoException();
+            .run()
+            .awaitTermination(1, TimeUnit.MINUTES)
+            .assertNoException();
     }
 
     @Test

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -24,9 +24,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 import javax.mail.Flags;
 
@@ -983,7 +983,7 @@ public abstract class MailboxManagerTest {
         ConcurrentTestRunner.builder()
             .operation((a, b) -> mailboxManager.createMailbox(MailboxPath.forUser(USER_1, mailboxName + a), session))
             .threadCount(10)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
     }
 
     @Test

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -981,9 +981,9 @@ public abstract class MailboxManagerTest {
         String mailboxName = "a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z";
 
         ConcurrentTestRunner testRunner = ConcurrentTestRunner.builder()
+            .operation((a, b) -> mailboxManager.createMailbox(MailboxPath.forUser(USER_1, mailboxName + a), session))
             .threadCount(10)
-            .build(
-                (a, b) -> mailboxManager.createMailbox(MailboxPath.forUser(USER_1, mailboxName + a), session))
+            .build()
             .run();
         testRunner.awaitTermination(1, TimeUnit.MINUTES);
         testRunner.assertNoException();

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
@@ -21,8 +21,8 @@ package org.apache.james.mailbox.cassandra.mail;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
@@ -65,7 +65,7 @@ class CassandraMailboxMapperConcurrencyTest {
             .operation((a, b) -> testee.save(new SimpleMailbox(MAILBOX_PATH, UID_VALIDITY)))
             .threadCount(THREAD_COUNT)
             .operationCount(OPERATION_COUNT)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
 
         assertThat(testee.list()).hasSize(1);
     }
@@ -81,7 +81,7 @@ class CassandraMailboxMapperConcurrencyTest {
             .operation((a, b) -> testee.save(mailbox))
             .threadCount(THREAD_COUNT)
             .operationCount(OPERATION_COUNT)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
 
         List<Mailbox> list = testee.list();
         assertThat(list).hasSize(1);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
@@ -61,7 +61,7 @@ class CassandraMailboxMapperConcurrencyTest {
 
     @Test
     void saveShouldBeThreadSafe() throws Exception {
-        boolean termination = ConcurrentTestRunner.builder()
+        ConcurrentTestRunner.builder()
             .operation((a, b) -> testee.save(new SimpleMailbox(MAILBOX_PATH, UID_VALIDITY)))
             .threadCount(THREAD_COUNT)
             .operationCount(OPERATION_COUNT)
@@ -69,7 +69,6 @@ class CassandraMailboxMapperConcurrencyTest {
             .run()
             .awaitTermination(1, TimeUnit.MINUTES);
 
-        assertThat(termination).isTrue();
         assertThat(testee.list()).hasSize(1);
     }
 
@@ -80,7 +79,7 @@ class CassandraMailboxMapperConcurrencyTest {
 
         mailbox.setName("newName");
 
-        boolean termination = ConcurrentTestRunner.builder()
+        ConcurrentTestRunner.builder()
             .operation((a, b) -> testee.save(mailbox))
             .threadCount(THREAD_COUNT)
             .operationCount(OPERATION_COUNT)
@@ -88,7 +87,6 @@ class CassandraMailboxMapperConcurrencyTest {
             .run()
             .awaitTermination(1, TimeUnit.MINUTES);
 
-        assertThat(termination).isTrue();
         List<Mailbox> list = testee.list();
         assertThat(list).hasSize(1);
         assertThat(list.get(0)).isEqualToComparingFieldByField(mailbox);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
@@ -65,7 +65,7 @@ class CassandraMailboxMapperConcurrencyTest {
             .operation((a, b) -> testee.save(new SimpleMailbox(MAILBOX_PATH, UID_VALIDITY)))
             .threadCount(THREAD_COUNT)
             .operationCount(OPERATION_COUNT)
-            .runSuccessfullyWithin(Duration.ofMinutes(1));
+            .runAcceptErrorsWithin(Duration.ofMinutes(1));
 
         assertThat(testee.list()).hasSize(1);
     }
@@ -81,7 +81,7 @@ class CassandraMailboxMapperConcurrencyTest {
             .operation((a, b) -> testee.save(mailbox))
             .threadCount(THREAD_COUNT)
             .operationCount(OPERATION_COUNT)
-            .runSuccessfullyWithin(Duration.ofMinutes(1));
+            .runAcceptErrorsWithin(Duration.ofMinutes(1));
 
         List<Mailbox> list = testee.list();
         assertThat(list).hasSize(1);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
@@ -65,9 +65,7 @@ class CassandraMailboxMapperConcurrencyTest {
             .operation((a, b) -> testee.save(new SimpleMailbox(MAILBOX_PATH, UID_VALIDITY)))
             .threadCount(THREAD_COUNT)
             .operationCount(OPERATION_COUNT)
-            .build()
-            .run()
-            .awaitTermination(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
 
         assertThat(testee.list()).hasSize(1);
     }
@@ -83,9 +81,7 @@ class CassandraMailboxMapperConcurrencyTest {
             .operation((a, b) -> testee.save(mailbox))
             .threadCount(THREAD_COUNT)
             .operationCount(OPERATION_COUNT)
-            .build()
-            .run()
-            .awaitTermination(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
 
         List<Mailbox> list = testee.list();
         assertThat(list).hasSize(1);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
@@ -62,9 +62,10 @@ class CassandraMailboxMapperConcurrencyTest {
     @Test
     void saveShouldBeThreadSafe() throws Exception {
         boolean termination = ConcurrentTestRunner.builder()
+            .operation((a, b) -> testee.save(new SimpleMailbox(MAILBOX_PATH, UID_VALIDITY)))
             .threadCount(THREAD_COUNT)
             .operationCount(OPERATION_COUNT)
-            .build((a, b) -> testee.save(new SimpleMailbox(MAILBOX_PATH, UID_VALIDITY)))
+            .build()
             .run()
             .awaitTermination(1, TimeUnit.MINUTES);
 
@@ -80,9 +81,10 @@ class CassandraMailboxMapperConcurrencyTest {
         mailbox.setName("newName");
 
         boolean termination = ConcurrentTestRunner.builder()
+            .operation((a, b) -> testee.save(mailbox))
             .threadCount(THREAD_COUNT)
             .operationCount(OPERATION_COUNT)
-            .build((a, b) -> testee.save(mailbox))
+            .build()
             .run()
             .awaitTermination(1, TimeUnit.MINUTES);
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
@@ -65,7 +65,7 @@ class CassandraMailboxMapperConcurrencyTest {
             .operation((a, b) -> testee.save(new SimpleMailbox(MAILBOX_PATH, UID_VALIDITY)))
             .threadCount(THREAD_COUNT)
             .operationCount(OPERATION_COUNT)
-            .runAcceptErrorsWithin(Duration.ofMinutes(1));
+            .runAcceptingErrorsWithin(Duration.ofMinutes(1));
 
         assertThat(testee.list()).hasSize(1);
     }
@@ -81,7 +81,7 @@ class CassandraMailboxMapperConcurrencyTest {
             .operation((a, b) -> testee.save(mailbox))
             .threadCount(THREAD_COUNT)
             .operationCount(OPERATION_COUNT)
-            .runAcceptErrorsWithin(Duration.ofMinutes(1));
+            .runAcceptingErrorsWithin(Duration.ofMinutes(1));
 
         List<Mailbox> list = testee.list();
         assertThat(list).hasSize(1);

--- a/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdMailingIntegrationTest.java
+++ b/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdMailingIntegrationTest.java
@@ -214,9 +214,7 @@ public interface QuotaThresholdMailingIntegrationTest {
         ConcurrentTestRunner.builder()
             .operation((threadNb, step) -> testee.event(new QuotaUsageUpdatedEvent(BOB_SESSION, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, NOW)))
             .threadCount(10)
-            .build()
-            .run()
-            .awaitTermination(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
 
         assertThat(mailetContext.getSentMails())
             .hasSize(1);

--- a/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdMailingIntegrationTest.java
+++ b/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdMailingIntegrationTest.java
@@ -212,8 +212,9 @@ public interface QuotaThresholdMailingIntegrationTest {
                 .build());
 
         ConcurrentTestRunner.builder()
+            .operation((threadNb, step) -> testee.event(new QuotaUsageUpdatedEvent(BOB_SESSION, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, NOW)))
             .threadCount(10)
-            .build((threadNb, step) -> testee.event(new QuotaUsageUpdatedEvent(BOB_SESSION, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, NOW)))
+            .build()
             .run()
             .awaitTermination(1, TimeUnit.MINUTES);
 

--- a/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdMailingIntegrationTest.java
+++ b/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdMailingIntegrationTest.java
@@ -35,7 +35,7 @@ import static org.apache.james.mailbox.quota.model.QuotaThresholdFixture._80;
 import static org.apache.james.mailbox.quota.model.QuotaThresholdFixture.mailetContext;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import org.apache.james.eventsourcing.eventstore.EventStore;
 import org.apache.james.mailbox.MailboxListener.QuotaUsageUpdatedEvent;
@@ -214,7 +214,7 @@ public interface QuotaThresholdMailingIntegrationTest {
         ConcurrentTestRunner.builder()
             .operation((threadNb, step) -> testee.event(new QuotaUsageUpdatedEvent(BOB_SESSION, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, NOW)))
             .threadCount(10)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
 
         assertThat(mailetContext.getSentMails())
             .hasSize(1);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
@@ -678,12 +678,14 @@ public abstract class MessageIdMapperTest {
         int threadCount = 2;
         int updateCount = 10;
         assertThat(ConcurrentTestRunner.builder()
-            .threadCount(threadCount)
-            .operationCount(updateCount)
-            .build((threadNumber, step) -> sut.setFlags(message1.getMessageId(),
+            .operation((threadNumber, step) -> sut.setFlags(message1.getMessageId(),
                 ImmutableList.of(message1.getMailboxId()),
                 new Flags("custom-" + threadNumber + "-" + step),
-                FlagsUpdateMode.ADD)).run()
+                FlagsUpdateMode.ADD))
+            .threadCount(threadCount)
+            .operationCount(updateCount)
+            .build()
+            .run()
             .awaitTermination(1, TimeUnit.MINUTES))
             .isTrue();
 
@@ -702,9 +704,7 @@ public abstract class MessageIdMapperTest {
         int threadCount = 4;
         int updateCount = 20;
         assertThat(ConcurrentTestRunner.builder()
-            .threadCount(threadCount)
-            .operationCount(updateCount)
-            .build((threadNumber, step) -> {
+            .operation((threadNumber, step) -> {
                 if (step  < updateCount / 2) {
                     sut.setFlags(message1.getMessageId(),
                         ImmutableList.of(message1.getMailboxId()),
@@ -716,7 +716,11 @@ public abstract class MessageIdMapperTest {
                         new Flags("custom-" + threadNumber + "-" + (updateCount - step - 1)),
                         FlagsUpdateMode.REMOVE);
                 }
-            }).run()
+            })
+            .threadCount(threadCount)
+            .operationCount(updateCount)
+            .build()
+            .run()
             .awaitTermination(1, TimeUnit.MINUTES))
             .isTrue();
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
@@ -21,10 +21,10 @@ package org.apache.james.mailbox.store.mail.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import javax.mail.Flags;
 import javax.mail.Flags.Flag;
@@ -684,7 +684,7 @@ public abstract class MessageIdMapperTest {
                 FlagsUpdateMode.ADD))
             .threadCount(threadCount)
             .operationCount(updateCount)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
 
         List<MailboxMessage> messages = sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.Body);
         assertThat(messages).hasSize(1);
@@ -716,7 +716,7 @@ public abstract class MessageIdMapperTest {
             })
             .threadCount(threadCount)
             .operationCount(updateCount)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
 
         List<MailboxMessage> messages = sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.Body);
         assertThat(messages).hasSize(1);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
@@ -684,10 +684,7 @@ public abstract class MessageIdMapperTest {
                 FlagsUpdateMode.ADD))
             .threadCount(threadCount)
             .operationCount(updateCount)
-            .build()
-            .run()
-            .awaitTermination(1, TimeUnit.MINUTES)
-            .assertNoException();
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
 
         List<MailboxMessage> messages = sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.Body);
         assertThat(messages).hasSize(1);
@@ -719,9 +716,7 @@ public abstract class MessageIdMapperTest {
             })
             .threadCount(threadCount)
             .operationCount(updateCount)
-            .build()
-            .run()
-            .awaitTermination(1, TimeUnit.MINUTES)
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES)
             .assertNoException();
 
         List<MailboxMessage> messages = sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.Body);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
@@ -677,7 +677,7 @@ public abstract class MessageIdMapperTest {
 
         int threadCount = 2;
         int updateCount = 10;
-        assertThat(ConcurrentTestRunner.builder()
+        ConcurrentTestRunner.builder()
             .operation((threadNumber, step) -> sut.setFlags(message1.getMessageId(),
                 ImmutableList.of(message1.getMailboxId()),
                 new Flags("custom-" + threadNumber + "-" + step),
@@ -686,8 +686,8 @@ public abstract class MessageIdMapperTest {
             .operationCount(updateCount)
             .build()
             .run()
-            .awaitTermination(1, TimeUnit.MINUTES))
-            .isTrue();
+            .awaitTermination(1, TimeUnit.MINUTES)
+            .assertNoException();
 
         List<MailboxMessage> messages = sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.Body);
         assertThat(messages).hasSize(1);
@@ -703,7 +703,7 @@ public abstract class MessageIdMapperTest {
 
         int threadCount = 4;
         int updateCount = 20;
-        assertThat(ConcurrentTestRunner.builder()
+        ConcurrentTestRunner.builder()
             .operation((threadNumber, step) -> {
                 if (step  < updateCount / 2) {
                     sut.setFlags(message1.getMessageId(),
@@ -721,8 +721,8 @@ public abstract class MessageIdMapperTest {
             .operationCount(updateCount)
             .build()
             .run()
-            .awaitTermination(1, TimeUnit.MINUTES))
-            .isTrue();
+            .awaitTermination(1, TimeUnit.MINUTES)
+            .assertNoException();
 
         List<MailboxMessage> messages = sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.Body);
         assertThat(messages).hasSize(1);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
@@ -716,8 +716,7 @@ public abstract class MessageIdMapperTest {
             })
             .threadCount(threadCount)
             .operationCount(updateCount)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES)
-            .assertNoException();
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
 
         List<MailboxMessage> messages = sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.Body);
         assertThat(messages).hasSize(1);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -797,11 +797,13 @@ public abstract class MessageMapperTest {
         int threadCount = 2;
         int updateCount = 10;
         assertThat(ConcurrentTestRunner.builder()
+            .operation((threadNumber, step) -> messageMapper.updateFlags(benwaInboxMailbox,
+                new FlagsUpdateCalculator(new Flags("custom-" + threadNumber + "-" + step), FlagsUpdateMode.ADD),
+                MessageRange.one(message1.getUid())))
             .threadCount(threadCount)
             .operationCount(updateCount)
-            .build((threadNumber, step) -> messageMapper.updateFlags(benwaInboxMailbox,
-                new FlagsUpdateCalculator(new Flags("custom-" + threadNumber + "-" + step), FlagsUpdateMode.ADD),
-                MessageRange.one(message1.getUid()))).run()
+            .build()
+            .run()
             .awaitTermination(1, TimeUnit.MINUTES))
             .isTrue();
 
@@ -819,9 +821,7 @@ public abstract class MessageMapperTest {
         int threadCount = 4;
         int updateCount = 20;
         assertThat(ConcurrentTestRunner.builder()
-            .threadCount(threadCount)
-            .operationCount(updateCount)
-            .build((threadNumber, step) -> {
+            .operation((threadNumber, step) -> {
                 if (step  < updateCount / 2) {
                     messageMapper.updateFlags(benwaInboxMailbox,
                         new FlagsUpdateCalculator(new Flags("custom-" + threadNumber + "-" + step), FlagsUpdateMode.ADD),
@@ -832,7 +832,11 @@ public abstract class MessageMapperTest {
                             FlagsUpdateMode.REMOVE),
                         MessageRange.one(message1.getUid()));
                 }
-            }).run()
+            })
+            .threadCount(threadCount)
+            .operationCount(updateCount)
+            .build()
+            .run()
             .awaitTermination(1, TimeUnit.MINUTES))
             .isTrue();
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -796,7 +796,7 @@ public abstract class MessageMapperTest {
 
         int threadCount = 2;
         int updateCount = 10;
-        assertThat(ConcurrentTestRunner.builder()
+        ConcurrentTestRunner.builder()
             .operation((threadNumber, step) -> messageMapper.updateFlags(benwaInboxMailbox,
                 new FlagsUpdateCalculator(new Flags("custom-" + threadNumber + "-" + step), FlagsUpdateMode.ADD),
                 MessageRange.one(message1.getUid())))
@@ -804,8 +804,8 @@ public abstract class MessageMapperTest {
             .operationCount(updateCount)
             .build()
             .run()
-            .awaitTermination(1, TimeUnit.MINUTES))
-            .isTrue();
+            .awaitTermination(1, TimeUnit.MINUTES)
+            .assertNoException();
 
         Iterator<MailboxMessage> messages = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(message1.getUid()),
             FetchType.Metadata, 1);
@@ -820,7 +820,7 @@ public abstract class MessageMapperTest {
 
         int threadCount = 4;
         int updateCount = 20;
-        assertThat(ConcurrentTestRunner.builder()
+        ConcurrentTestRunner.builder()
             .operation((threadNumber, step) -> {
                 if (step  < updateCount / 2) {
                     messageMapper.updateFlags(benwaInboxMailbox,
@@ -837,8 +837,8 @@ public abstract class MessageMapperTest {
             .operationCount(updateCount)
             .build()
             .run()
-            .awaitTermination(1, TimeUnit.MINUTES))
-            .isTrue();
+            .awaitTermination(1, TimeUnit.MINUTES)
+            .assertNoException();
 
         Iterator<MailboxMessage> messages = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(message1.getUid()),
             FetchType.Metadata, 1);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -25,11 +25,11 @@ import static org.apache.james.mailbox.store.mail.model.MessageAssert.assertThat
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 import javax.mail.Flags;
 import javax.mail.Flags.Flag;
@@ -802,7 +802,7 @@ public abstract class MessageMapperTest {
                 MessageRange.one(message1.getUid())))
             .threadCount(threadCount)
             .operationCount(updateCount)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
 
         Iterator<MailboxMessage> messages = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(message1.getUid()),
             FetchType.Metadata, 1);
@@ -832,7 +832,7 @@ public abstract class MessageMapperTest {
             })
             .threadCount(threadCount)
             .operationCount(updateCount)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
 
         Iterator<MailboxMessage> messages = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(message1.getUid()),
             FetchType.Metadata, 1);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -802,10 +802,7 @@ public abstract class MessageMapperTest {
                 MessageRange.one(message1.getUid())))
             .threadCount(threadCount)
             .operationCount(updateCount)
-            .build()
-            .run()
-            .awaitTermination(1, TimeUnit.MINUTES)
-            .assertNoException();
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
 
         Iterator<MailboxMessage> messages = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(message1.getUid()),
             FetchType.Metadata, 1);
@@ -835,10 +832,7 @@ public abstract class MessageMapperTest {
             })
             .threadCount(threadCount)
             .operationCount(updateCount)
-            .build()
-            .run()
-            .awaitTermination(1, TimeUnit.MINUTES)
-            .assertNoException();
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
 
         Iterator<MailboxMessage> messages = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(message1.getUid()),
             FetchType.Metadata, 1);

--- a/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/CachingTextExtractorTest.java
+++ b/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/CachingTextExtractorTest.java
@@ -190,7 +190,8 @@ public class CachingTextExtractorTest {
             .threadCount(10)
             .build()
             .run()
-            .awaitTermination(1, TimeUnit.MINUTES);
+            .awaitTermination(1, TimeUnit.MINUTES)
+            .assertNoException();
 
         verify(wrappedTextExtractor, times(1)).extractContent(any(), any());
     }

--- a/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/CachingTextExtractorTest.java
+++ b/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/CachingTextExtractorTest.java
@@ -34,8 +34,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
@@ -188,7 +188,7 @@ public class CachingTextExtractorTest {
         ConcurrentTestRunner.builder()
             .operation((a, b) -> textExtractor.extractContent(INPUT_STREAM.get(), CONTENT_TYPE))
             .threadCount(10)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
 
         verify(wrappedTextExtractor, times(1)).extractContent(any(), any());
     }

--- a/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/CachingTextExtractorTest.java
+++ b/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/CachingTextExtractorTest.java
@@ -188,10 +188,7 @@ public class CachingTextExtractorTest {
         ConcurrentTestRunner.builder()
             .operation((a, b) -> textExtractor.extractContent(INPUT_STREAM.get(), CONTENT_TYPE))
             .threadCount(10)
-            .build()
-            .run()
-            .awaitTermination(1, TimeUnit.MINUTES)
-            .assertNoException();
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
 
         verify(wrappedTextExtractor, times(1)).extractContent(any(), any());
     }

--- a/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/CachingTextExtractorTest.java
+++ b/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/CachingTextExtractorTest.java
@@ -186,8 +186,9 @@ public class CachingTextExtractorTest {
     @RepeatedTest(10)
     void concurrentValueComputationShouldNotLeadToDuplicatedBackendAccess() throws Exception {
         ConcurrentTestRunner.builder()
+            .operation((a, b) -> textExtractor.extractContent(INPUT_STREAM.get(), CONTENT_TYPE))
             .threadCount(10)
-            .build((a, b) -> textExtractor.extractContent(INPUT_STREAM.get(), CONTENT_TYPE))
+            .build()
             .run()
             .awaitTermination(1, TimeUnit.MINUTES);
 

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
@@ -370,7 +370,7 @@ public class UidMsnConverterTest {
             testee.addUid(MessageUid.of(i));
         }
 
-        ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
+        ConcurrentTestRunner.builder()
             .operation((threadNumber, step) -> {
                 if (threadNumber == 0) {
                     testee.remove(MessageUid.of(step + 1));
@@ -380,9 +380,9 @@ public class UidMsnConverterTest {
             })
             .threadCount(2)
             .operationCount(initialCount)
-            .build();
-        concurrentTestRunner.run();
-        concurrentTestRunner.awaitTermination(10, TimeUnit.SECONDS);
+            .build()
+            .run()
+            .awaitTermination(10, TimeUnit.SECONDS);
 
         ImmutableMap.Builder<Integer, MessageUid> resultBuilder = ImmutableMap.builder();
         for (int i = 1; i <= initialCount; i++) {
@@ -397,13 +397,13 @@ public class UidMsnConverterTest {
         int operationCount = 1000;
         int threadCount = 2;
 
-        ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
+        ConcurrentTestRunner.builder()
             .operation((threadNumber, step) -> testee.addUid(MessageUid.of((threadNumber * operationCount) + (step + 1))))
             .threadCount(threadCount)
             .operationCount(operationCount)
-            .build();
-        concurrentTestRunner.run();
-        concurrentTestRunner.awaitTermination(10, TimeUnit.SECONDS);
+            .build()
+            .run()
+            .awaitTermination(10, TimeUnit.SECONDS);
 
         ImmutableMap.Builder<Integer, MessageUid> resultBuilder = ImmutableMap.builder();
         for (int i = 1; i <= threadCount * operationCount; i++) {
@@ -421,13 +421,13 @@ public class UidMsnConverterTest {
             testee.addUid(MessageUid.of(i));
         }
 
-        ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
+        ConcurrentTestRunner.builder()
             .operation((threadNumber, step) -> testee.remove(MessageUid.of((threadNumber * operationCount) + (step + 1))))
             .threadCount(threadCount)
             .operationCount(operationCount)
-            .build();
-        concurrentTestRunner.run();
-        concurrentTestRunner.awaitTermination(10, TimeUnit.SECONDS);
+            .build()
+            .run()
+            .awaitTermination(10, TimeUnit.SECONDS);
 
         ImmutableMap.Builder<Integer, MessageUid> resultBuilder = ImmutableMap.builder();
         for (int i = 1; i <= operationCount; i++) {

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
@@ -380,9 +380,7 @@ public class UidMsnConverterTest {
             })
             .threadCount(2)
             .operationCount(initialCount)
-            .build()
-            .run()
-            .awaitTermination(10, TimeUnit.SECONDS);
+            .runSuccessfullyWithin(10, TimeUnit.SECONDS);
 
         ImmutableMap.Builder<Integer, MessageUid> resultBuilder = ImmutableMap.builder();
         for (int i = 1; i <= initialCount; i++) {
@@ -401,9 +399,7 @@ public class UidMsnConverterTest {
             .operation((threadNumber, step) -> testee.addUid(MessageUid.of((threadNumber * operationCount) + (step + 1))))
             .threadCount(threadCount)
             .operationCount(operationCount)
-            .build()
-            .run()
-            .awaitTermination(10, TimeUnit.SECONDS);
+            .runSuccessfullyWithin(10, TimeUnit.SECONDS);
 
         ImmutableMap.Builder<Integer, MessageUid> resultBuilder = ImmutableMap.builder();
         for (int i = 1; i <= threadCount * operationCount; i++) {
@@ -425,9 +421,7 @@ public class UidMsnConverterTest {
             .operation((threadNumber, step) -> testee.remove(MessageUid.of((threadNumber * operationCount) + (step + 1))))
             .threadCount(threadCount)
             .operationCount(operationCount)
-            .build()
-            .run()
-            .awaitTermination(10, TimeUnit.SECONDS);
+            .runSuccessfullyWithin(10, TimeUnit.SECONDS);
 
         ImmutableMap.Builder<Integer, MessageUid> resultBuilder = ImmutableMap.builder();
         for (int i = 1; i <= operationCount; i++) {

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
@@ -371,15 +371,16 @@ public class UidMsnConverterTest {
         }
 
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
-            .threadCount(2)
-            .operationCount(initialCount)
-            .build((threadNumber, step) -> {
+            .operation((threadNumber, step) -> {
                 if (threadNumber == 0) {
                     testee.remove(MessageUid.of(step + 1));
                 } else {
                     testee.addUid(MessageUid.of(initialCount + step + 1));
                 }
-            });
+            })
+            .threadCount(2)
+            .operationCount(initialCount)
+            .build();
         concurrentTestRunner.run();
         concurrentTestRunner.awaitTermination(10, TimeUnit.SECONDS);
 
@@ -397,9 +398,10 @@ public class UidMsnConverterTest {
         int threadCount = 2;
 
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
+            .operation((threadNumber, step) -> testee.addUid(MessageUid.of((threadNumber * operationCount) + (step + 1))))
             .threadCount(threadCount)
             .operationCount(operationCount)
-            .build((threadNumber, step) -> testee.addUid(MessageUid.of((threadNumber * operationCount) + (step + 1))));
+            .build();
         concurrentTestRunner.run();
         concurrentTestRunner.awaitTermination(10, TimeUnit.SECONDS);
 
@@ -420,9 +422,10 @@ public class UidMsnConverterTest {
         }
 
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
+            .operation((threadNumber, step) -> testee.remove(MessageUid.of((threadNumber * operationCount) + (step + 1))))
             .threadCount(threadCount)
             .operationCount(operationCount)
-            .build((threadNumber, step) -> testee.remove(MessageUid.of((threadNumber * operationCount) + (step + 1))));
+            .build();
         concurrentTestRunner.run();
         concurrentTestRunner.awaitTermination(10, TimeUnit.SECONDS);
 

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/UidMsnConverterTest.java
@@ -21,8 +21,8 @@ package org.apache.james.imap.processor.base;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.util.concurrency.ConcurrentTestRunner;
@@ -380,7 +380,7 @@ public class UidMsnConverterTest {
             })
             .threadCount(2)
             .operationCount(initialCount)
-            .runSuccessfullyWithin(10, TimeUnit.SECONDS);
+            .runSuccessfullyWithin(Duration.ofSeconds(10));
 
         ImmutableMap.Builder<Integer, MessageUid> resultBuilder = ImmutableMap.builder();
         for (int i = 1; i <= initialCount; i++) {
@@ -399,7 +399,7 @@ public class UidMsnConverterTest {
             .operation((threadNumber, step) -> testee.addUid(MessageUid.of((threadNumber * operationCount) + (step + 1))))
             .threadCount(threadCount)
             .operationCount(operationCount)
-            .runSuccessfullyWithin(10, TimeUnit.SECONDS);
+            .runSuccessfullyWithin(Duration.ofSeconds(10));
 
         ImmutableMap.Builder<Integer, MessageUid> resultBuilder = ImmutableMap.builder();
         for (int i = 1; i <= threadCount * operationCount; i++) {
@@ -421,7 +421,7 @@ public class UidMsnConverterTest {
             .operation((threadNumber, step) -> testee.remove(MessageUid.of((threadNumber * operationCount) + (step + 1))))
             .threadCount(threadCount)
             .operationCount(operationCount)
-            .runSuccessfullyWithin(10, TimeUnit.SECONDS);
+            .runSuccessfullyWithin(Duration.ofSeconds(10));
 
         ImmutableMap.Builder<Integer, MessageUid> resultBuilder = ImmutableMap.builder();
         for (int i = 1; i <= operationCount; i++) {

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
@@ -104,8 +104,9 @@ public abstract class AbstractSMTPServerTest {
             String mailContent = CharStreams.toString(new InputStreamReader(ClassLoader.getSystemResourceAsStream("a50.eml"), StandardCharsets.US_ASCII));
 
             assertThat(ConcurrentTestRunner.builder()
+                .operation((threadNumber, step) -> send(finalServer, bindedAddress, mailContent))
                 .threadCount(4)
-                .build((threadNumber, step) -> send(finalServer, bindedAddress, mailContent))
+                .build()
                 .run()
                 .awaitTermination(1, TimeUnit.MINUTES))
                 .isTrue();

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
@@ -103,13 +103,13 @@ public abstract class AbstractSMTPServerTest {
             InetSocketAddress bindedAddress = new ProtocolServerUtils(server).retrieveBindedAddress();
             String mailContent = CharStreams.toString(new InputStreamReader(ClassLoader.getSystemResourceAsStream("a50.eml"), StandardCharsets.US_ASCII));
 
-            assertThat(ConcurrentTestRunner.builder()
+            ConcurrentTestRunner.builder()
                 .operation((threadNumber, step) -> send(finalServer, bindedAddress, mailContent))
                 .threadCount(4)
                 .build()
                 .run()
-                .awaitTermination(1, TimeUnit.MINUTES))
-                .isTrue();
+                .awaitTermination(1, TimeUnit.MINUTES)
+                .assertNoException();
 
             Iterator<MailEnvelope> queued = hook.getQueued().iterator();
             assertThat(queued.hasNext()).isTrue();

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
@@ -106,10 +106,7 @@ public abstract class AbstractSMTPServerTest {
             ConcurrentTestRunner.builder()
                 .operation((threadNumber, step) -> send(finalServer, bindedAddress, mailContent))
                 .threadCount(4)
-                .build()
-                .run()
-                .awaitTermination(1, TimeUnit.MINUTES)
-                .assertNoException();
+                .runSuccessfullyWithin(1, TimeUnit.MINUTES);
 
             Iterator<MailEnvelope> queued = hook.getQueued().iterator();
             assertThat(queued.hasNext()).isTrue();

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
@@ -26,6 +26,7 @@ import java.io.InputStreamReader;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -106,7 +107,7 @@ public abstract class AbstractSMTPServerTest {
             ConcurrentTestRunner.builder()
                 .operation((threadNumber, step) -> send(finalServer, bindedAddress, mailContent))
                 .threadCount(4)
-                .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+                .runSuccessfullyWithin(Duration.ofMinutes(1));
 
             Iterator<MailEnvelope> queued = hook.getQueued().iterator();
             assertThat(queued.hasNext()).isTrue();

--- a/server/container/util/src/main/java/org/apache/james/util/concurrency/ConcurrentTestRunner.java
+++ b/server/container/util/src/main/java/org/apache/james/util/concurrency/ConcurrentTestRunner.java
@@ -108,6 +108,10 @@ public class ConcurrentTestRunner {
         }
     }
 
+    public static class NotTerminatedException extends RuntimeException {
+
+    }
+
     private static final Logger LOGGER = LoggerFactory.getLogger(ConcurrentTestRunner.class);
 
     public static RequireOperation builder() {
@@ -144,8 +148,12 @@ public class ConcurrentTestRunner {
         return this;
     }
 
-    public boolean awaitTermination(long time, TimeUnit unit) throws InterruptedException {
+    public ConcurrentTestRunner awaitTermination(long time, TimeUnit unit) throws InterruptedException {
         executorService.shutdown();
-        return executorService.awaitTermination(time, unit);
+        boolean terminated = executorService.awaitTermination(time, unit);
+        if (!terminated) {
+            throw new NotTerminatedException();
+        }
+        return this;
     }
 }

--- a/server/container/util/src/main/java/org/apache/james/util/concurrency/ConcurrentTestRunner.java
+++ b/server/container/util/src/main/java/org/apache/james/util/concurrency/ConcurrentTestRunner.java
@@ -81,9 +81,9 @@ public class ConcurrentTestRunner {
                 .runSuccessfullyWithin(duration);
         }
 
-        public ConcurrentTestRunner runAcceptErrorsWithin(Duration duration) throws InterruptedException, ExecutionException {
+        public ConcurrentTestRunner runAcceptingErrorsWithin(Duration duration) throws InterruptedException, ExecutionException {
             return build()
-                .runAcceptErrorsWithin(duration);
+                .runAcceptingErrorsWithin(duration);
         }
     }
 
@@ -174,7 +174,7 @@ public class ConcurrentTestRunner {
             .assertNoException();
     }
 
-    public ConcurrentTestRunner runAcceptErrorsWithin(Duration duration) throws InterruptedException, ExecutionException {
+    public ConcurrentTestRunner runAcceptingErrorsWithin(Duration duration) throws InterruptedException, ExecutionException {
         return run()
             .awaitTermination(duration);
     }

--- a/server/container/util/src/main/java/org/apache/james/util/concurrency/ConcurrentTestRunner.java
+++ b/server/container/util/src/main/java/org/apache/james/util/concurrency/ConcurrentTestRunner.java
@@ -80,6 +80,11 @@ public class ConcurrentTestRunner {
             return build()
                 .runSuccessfullyWithin(duration);
         }
+
+        public ConcurrentTestRunner runAcceptErrorsWithin(Duration duration) throws InterruptedException, ExecutionException {
+            return build()
+                .runAcceptErrorsWithin(duration);
+        }
     }
 
     public interface ConcurrentOperation {
@@ -167,5 +172,10 @@ public class ConcurrentTestRunner {
         return run()
             .awaitTermination(duration)
             .assertNoException();
+    }
+
+    public ConcurrentTestRunner runAcceptErrorsWithin(Duration duration) throws InterruptedException, ExecutionException {
+        return run()
+            .awaitTermination(duration);
     }
 }

--- a/server/container/util/src/main/java/org/apache/james/util/concurrency/ConcurrentTestRunner.java
+++ b/server/container/util/src/main/java/org/apache/james/util/concurrency/ConcurrentTestRunner.java
@@ -68,7 +68,7 @@ public class ConcurrentTestRunner {
             return this;
         }
 
-        public ConcurrentTestRunner build() {
+        private ConcurrentTestRunner build() {
             return new ConcurrentTestRunner(
                 threadCount,
                 operationCount.orElse(DEFAULT_OPERATION_COUNT),

--- a/server/container/util/src/main/java/org/apache/james/util/concurrency/ConcurrentTestRunner.java
+++ b/server/container/util/src/main/java/org/apache/james/util/concurrency/ConcurrentTestRunner.java
@@ -74,6 +74,10 @@ public class ConcurrentTestRunner {
                 operationCount.orElse(DEFAULT_OPERATION_COUNT),
                 operation);
         }
+        public ConcurrentTestRunner runSuccessfullyWithin(long time, TimeUnit unit) throws InterruptedException, ExecutionException {
+            return build()
+                .runSuccessfullyWithin(time, unit);
+        }
     }
 
     public interface ConcurrentOperation {
@@ -155,5 +159,11 @@ public class ConcurrentTestRunner {
             throw new NotTerminatedException();
         }
         return this;
+    }
+
+    public ConcurrentTestRunner runSuccessfullyWithin(long time, TimeUnit unit) throws InterruptedException, ExecutionException {
+        return run()
+            .awaitTermination(time, unit)
+            .assertNoException();
     }
 }

--- a/server/container/util/src/main/java/org/apache/james/util/concurrency/ConcurrentTestRunner.java
+++ b/server/container/util/src/main/java/org/apache/james/util/concurrency/ConcurrentTestRunner.java
@@ -40,7 +40,7 @@ public class ConcurrentTestRunner {
 
     @FunctionalInterface
     public interface RequireOperation {
-        RequireThreadCount operation(BiConsumer operation);
+        RequireThreadCount operation(ConcurrentOperation operation);
     }
 
     @FunctionalInterface
@@ -50,10 +50,10 @@ public class ConcurrentTestRunner {
 
     public static class Builder {
         private final int threadCount;
-        private final BiConsumer operation;
-        private Optional<Integer>  operationCount;
+        private final ConcurrentOperation operation;
+        private Optional<Integer> operationCount;
 
-        public Builder(int threadCount, BiConsumer operation) {
+        public Builder(int threadCount, ConcurrentOperation operation) {
             Preconditions.checkArgument(threadCount > 0, "Thread count should be strictly positive");
             Preconditions.checkNotNull(operation);
 
@@ -76,18 +76,18 @@ public class ConcurrentTestRunner {
         }
     }
 
-    public interface BiConsumer {
-        void consume(int threadNumber, int step) throws Exception;
+    public interface ConcurrentOperation {
+        void execute(int threadNumber, int step) throws Exception;
     }
 
     private class ConcurrentRunnableTask implements Runnable {
         private final int threadNumber;
-        private final BiConsumer biConsumer;
+        private final ConcurrentOperation concurrentOperation;
         private Exception exception;
 
-        public ConcurrentRunnableTask(int threadNumber, BiConsumer biConsumer) {
+        public ConcurrentRunnableTask(int threadNumber, ConcurrentOperation concurrentOperation) {
             this.threadNumber = threadNumber;
-            this.biConsumer = biConsumer;
+            this.concurrentOperation = concurrentOperation;
         }
 
         @Override
@@ -96,7 +96,7 @@ public class ConcurrentTestRunner {
             countDownLatch.countDown();
             for (int i = 0; i < operationCount; i++) {
                 try {
-                    biConsumer.consume(threadNumber, i);
+                    concurrentOperation.execute(threadNumber, i);
                 } catch (Exception e) {
                     LOGGER.error("Error caught during concurrent testing", e);
                     exception = e;
@@ -117,11 +117,11 @@ public class ConcurrentTestRunner {
     private final int threadCount;
     private final int operationCount;
     private final CountDownLatch countDownLatch;
-    private final BiConsumer biConsumer;
+    private final ConcurrentOperation biConsumer;
     private final ExecutorService executorService;
     private final List<Future<?>> futures;
 
-    private ConcurrentTestRunner(int threadCount, int operationCount, BiConsumer biConsumer) {
+    private ConcurrentTestRunner(int threadCount, int operationCount, ConcurrentOperation biConsumer) {
         this.threadCount = threadCount;
         this.operationCount = operationCount;
         this.countDownLatch = new CountDownLatch(threadCount);

--- a/server/container/util/src/main/java/org/apache/james/util/concurrency/ConcurrentTestRunner.java
+++ b/server/container/util/src/main/java/org/apache/james/util/concurrency/ConcurrentTestRunner.java
@@ -74,6 +74,7 @@ public class ConcurrentTestRunner {
                 operationCount.orElse(DEFAULT_OPERATION_COUNT),
                 operation);
         }
+
         public ConcurrentTestRunner runSuccessfullyWithin(long time, TimeUnit unit) throws InterruptedException, ExecutionException {
             return build()
                 .runSuccessfullyWithin(time, unit);

--- a/server/container/util/src/main/java/org/apache/james/util/concurrency/ConcurrentTestRunner.java
+++ b/server/container/util/src/main/java/org/apache/james/util/concurrency/ConcurrentTestRunner.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.util.concurrency;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -75,9 +76,9 @@ public class ConcurrentTestRunner {
                 operation);
         }
 
-        public ConcurrentTestRunner runSuccessfullyWithin(long time, TimeUnit unit) throws InterruptedException, ExecutionException {
+        public ConcurrentTestRunner runSuccessfullyWithin(Duration duration) throws InterruptedException, ExecutionException {
             return build()
-                .runSuccessfullyWithin(time, unit);
+                .runSuccessfullyWithin(duration);
         }
     }
 
@@ -153,18 +154,18 @@ public class ConcurrentTestRunner {
         return this;
     }
 
-    public ConcurrentTestRunner awaitTermination(long time, TimeUnit unit) throws InterruptedException {
+    public ConcurrentTestRunner awaitTermination(Duration duration) throws InterruptedException {
         executorService.shutdown();
-        boolean terminated = executorService.awaitTermination(time, unit);
+        boolean terminated = executorService.awaitTermination(duration.toMillis(), TimeUnit.MILLISECONDS);
         if (!terminated) {
             throw new NotTerminatedException();
         }
         return this;
     }
 
-    public ConcurrentTestRunner runSuccessfullyWithin(long time, TimeUnit unit) throws InterruptedException, ExecutionException {
+    public ConcurrentTestRunner runSuccessfullyWithin(Duration duration) throws InterruptedException, ExecutionException {
         return run()
-            .awaitTermination(time, unit)
+            .awaitTermination(duration)
             .assertNoException();
     }
 }

--- a/server/container/util/src/main/java/org/apache/james/util/concurrency/ConcurrentTestRunner.java
+++ b/server/container/util/src/main/java/org/apache/james/util/concurrency/ConcurrentTestRunner.java
@@ -54,7 +54,7 @@ public class ConcurrentTestRunner {
         private final ConcurrentOperation operation;
         private Optional<Integer> operationCount;
 
-        public Builder(int threadCount, ConcurrentOperation operation) {
+        private Builder(int threadCount, ConcurrentOperation operation) {
             Preconditions.checkArgument(threadCount > 0, "Thread count should be strictly positive");
             Preconditions.checkNotNull(operation);
 

--- a/server/container/util/src/test/java/org/apache/james/util/concurrency/ConcurrentTestRunnerTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/concurrency/ConcurrentTestRunnerTest.java
@@ -26,7 +26,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.Duration;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
@@ -135,7 +134,7 @@ public class ConcurrentTestRunnerTest {
                 })
                 .threadCount(2)
                 .operationCount(2)
-                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME))
+                .runAcceptingErrorsWithin(DEFAULT_AWAIT_TIME))
             .doesNotThrowAnyException();
     }
 
@@ -164,18 +163,21 @@ public class ConcurrentTestRunnerTest {
     }
 
     @Test
-    public void runShouldPerformAllOperationsEvenOnExceptions() {
+    public void runShouldPerformAllOperationsEvenOnExceptions() throws Exception {
         ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
 
-        assertThatCode(() -> ConcurrentTestRunner.builder()
+        try {
+            ConcurrentTestRunner.builder()
                 .operation((threadNumber, step) -> {
                     queue.add(threadNumber + ":" + step);
                     throw new RuntimeException();
                 })
                 .threadCount(2)
                 .operationCount(2)
-                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME))
-            .doesNotThrowAnyException();
+                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME);
+        } catch (Exception e) {
+            // ignore
+        }
 
         assertThat(queue).containsOnly("0:0", "0:1", "1:0", "1:1");
     }
@@ -184,7 +186,8 @@ public class ConcurrentTestRunnerTest {
     public void runShouldPerformAllOperationsEvenOnOccasionalExceptions() {
         ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
 
-        assertThatCode(() -> ConcurrentTestRunner.builder()
+        try {
+            ConcurrentTestRunner.builder()
                 .operation((threadNumber, step) -> {
                     queue.add(threadNumber + ":" + step);
                     if ((threadNumber + step) % 2 == 0) {
@@ -193,8 +196,10 @@ public class ConcurrentTestRunnerTest {
                 })
                 .threadCount(2)
                 .operationCount(2)
-                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME))
-            .doesNotThrowAnyException();
+                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME);
+        } catch (Exception e) {
+            // ignore
+        }
 
         assertThat(queue).containsOnly("0:0", "0:1", "1:0", "1:1");
     }

--- a/server/container/util/src/test/java/org/apache/james/util/concurrency/ConcurrentTestRunnerTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/concurrency/ConcurrentTestRunnerTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.util.concurrency;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -83,18 +84,19 @@ public class ConcurrentTestRunnerTest {
     }
 
     @Test
-    public void awaitTerminationShouldReturnTrueWhenFinished() throws Exception {
+    public void awaitTerminationShouldNotThrowWhenFinished() {
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
             .operation(NOOP)
             .threadCount(1)
             .build()
             .run();
 
-        assertThat(concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS)).isTrue();
+        assertThatCode(() -> concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS))
+            .doesNotThrowAnyException();
     }
 
     @Test
-    public void awaitTerminationShouldReturnFalseWhenNotFinished() throws Exception {
+    public void awaitTerminationShouldThrowWhenNotFinished() {
         int sleepDelay = 50;
 
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
@@ -103,11 +105,12 @@ public class ConcurrentTestRunnerTest {
             .build()
             .run();
 
-        assertThat(concurrentTestRunner.awaitTermination(sleepDelay / 2, TimeUnit.MILLISECONDS)).isFalse();
+        assertThatThrownBy(() -> concurrentTestRunner.awaitTermination(sleepDelay / 2, TimeUnit.MILLISECONDS))
+            .isInstanceOf(ConcurrentTestRunner.NotTerminatedException.class);
     }
 
     @Test
-    public void runShouldPerformAllOperations() throws Exception {
+    public void runShouldPerformAllOperations() {
         ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
 
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
@@ -117,12 +120,13 @@ public class ConcurrentTestRunnerTest {
             .build()
             .run();
 
-        assertThat(concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS)).isTrue();
+        assertThatCode(() -> concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS))
+            .doesNotThrowAnyException();
         assertThat(queue).containsOnly("0:0", "0:1", "1:0", "1:1");
     }
 
     @Test
-    public void operationCountShouldDefaultToOne() throws Exception {
+    public void operationCountShouldDefaultToOne() {
         ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
 
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
@@ -131,12 +135,13 @@ public class ConcurrentTestRunnerTest {
             .build()
             .run();
 
-        assertThat(concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS)).isTrue();
+        assertThatCode(() -> concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS))
+            .doesNotThrowAnyException();
         assertThat(queue).containsOnly("0:0", "1:0");
     }
 
     @Test
-    public void runShouldNotThrowOnExceptions() throws Exception {
+    public void runShouldNotThrowOnExceptions() {
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
             .operation((threadNumber, step) -> {
                 throw new RuntimeException();
@@ -146,7 +151,8 @@ public class ConcurrentTestRunnerTest {
             .build()
             .run();
 
-        assertThat(concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS)).isTrue();
+        assertThatCode(() -> concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS))
+            .doesNotThrowAnyException();
     }
 
     @Test
@@ -180,7 +186,7 @@ public class ConcurrentTestRunnerTest {
     }
 
     @Test
-    public void runShouldPerformAllOperationsEvenOnExceptions() throws Exception {
+    public void runShouldPerformAllOperationsEvenOnExceptions() {
         ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
 
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
@@ -193,12 +199,13 @@ public class ConcurrentTestRunnerTest {
             .build()
             .run();
 
-        assertThat(concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS)).isTrue();
+        assertThatCode(() -> concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS))
+            .doesNotThrowAnyException();
         assertThat(queue).containsOnly("0:0", "0:1", "1:0", "1:1");
     }
 
     @Test
-    public void runShouldPerformAllOperationsEvenOnOccasionalExceptions() throws Exception {
+    public void runShouldPerformAllOperationsEvenOnOccasionalExceptions() {
         ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
 
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
@@ -213,7 +220,8 @@ public class ConcurrentTestRunnerTest {
             .build()
             .run();
 
-        assertThat(concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS)).isTrue();
+        assertThatCode(() -> concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS))
+            .doesNotThrowAnyException();
         assertThat(queue).containsOnly("0:0", "0:1", "1:0", "1:1");
     }
 }

--- a/server/container/util/src/test/java/org/apache/james/util/concurrency/ConcurrentTestRunnerTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/concurrency/ConcurrentTestRunnerTest.java
@@ -166,40 +166,32 @@ public class ConcurrentTestRunnerTest {
     public void runShouldPerformAllOperationsEvenOnExceptions() throws Exception {
         ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
 
-        try {
-            ConcurrentTestRunner.builder()
-                .operation((threadNumber, step) -> {
-                    queue.add(threadNumber + ":" + step);
-                    throw new RuntimeException();
-                })
-                .threadCount(2)
-                .operationCount(2)
-                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME);
-        } catch (Exception e) {
-            // ignore
-        }
+        ConcurrentTestRunner.builder()
+            .operation((threadNumber, step) -> {
+                queue.add(threadNumber + ":" + step);
+                throw new RuntimeException();
+            })
+            .threadCount(2)
+            .operationCount(2)
+            .runAcceptingErrorsWithin(DEFAULT_AWAIT_TIME);
 
         assertThat(queue).containsOnly("0:0", "0:1", "1:0", "1:1");
     }
 
     @Test
-    public void runShouldPerformAllOperationsEvenOnOccasionalExceptions() {
+    public void runShouldPerformAllOperationsEvenOnOccasionalExceptions() throws Exception {
         ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
 
-        try {
-            ConcurrentTestRunner.builder()
-                .operation((threadNumber, step) -> {
-                    queue.add(threadNumber + ":" + step);
-                    if ((threadNumber + step) % 2 == 0) {
-                        throw new RuntimeException();
-                    }
-                })
-                .threadCount(2)
-                .operationCount(2)
-                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME);
-        } catch (Exception e) {
-            // ignore
-        }
+        ConcurrentTestRunner.builder()
+            .operation((threadNumber, step) -> {
+                queue.add(threadNumber + ":" + step);
+                if ((threadNumber + step) % 2 == 0) {
+                    throw new RuntimeException();
+                }
+            })
+            .threadCount(2)
+            .operationCount(2)
+            .runAcceptingErrorsWithin(DEFAULT_AWAIT_TIME);
 
         assertThat(queue).containsOnly("0:0", "0:1", "1:0", "1:1");
     }

--- a/server/container/util/src/test/java/org/apache/james/util/concurrency/ConcurrentTestRunnerTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/concurrency/ConcurrentTestRunnerTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 public class ConcurrentTestRunnerTest {
-    public static final ConcurrentTestRunner.BiConsumer EMPTY_BI_CONSUMER = (threadNumber, step) -> { };
+    public static final ConcurrentTestRunner.ConcurrentOperation EMPTY_BI_CONSUMER = (threadNumber, step) -> { };
     public static final int DEFAULT_AWAIT_TIME = 100;
 
     @Test

--- a/server/container/util/src/test/java/org/apache/james/util/concurrency/ConcurrentTestRunnerTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/concurrency/ConcurrentTestRunnerTest.java
@@ -29,14 +29,14 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 public class ConcurrentTestRunnerTest {
-    public static final ConcurrentTestRunner.ConcurrentOperation EMPTY_BI_CONSUMER = (threadNumber, step) -> { };
+    public static final ConcurrentTestRunner.ConcurrentOperation NOOP = (threadNumber, step) -> { };
     public static final int DEFAULT_AWAIT_TIME = 100;
 
     @Test
     public void constructorShouldThrowOnNegativeThreadCount() {
         assertThatThrownBy(() ->
             ConcurrentTestRunner.builder()
-                .operation(EMPTY_BI_CONSUMER)
+                .operation(NOOP)
                 .threadCount(-1)
                 .build())
             .isInstanceOf(IllegalArgumentException.class);
@@ -46,7 +46,7 @@ public class ConcurrentTestRunnerTest {
     public void constructorShouldThrowOnNegativeOperationCount() {
         assertThatThrownBy(() ->
             ConcurrentTestRunner.builder()
-                .operation(EMPTY_BI_CONSUMER)
+                .operation(NOOP)
                 .threadCount(1)
                 .operationCount(-1))
             .isInstanceOf(IllegalArgumentException.class);
@@ -56,7 +56,7 @@ public class ConcurrentTestRunnerTest {
     public void constructorShouldThrowOnZeroThreadCount() {
         assertThatThrownBy(() ->
             ConcurrentTestRunner.builder()
-                .operation(EMPTY_BI_CONSUMER)
+                .operation(NOOP)
                 .threadCount(0)
                 .build())
             .isInstanceOf(IllegalArgumentException.class);
@@ -66,7 +66,7 @@ public class ConcurrentTestRunnerTest {
     public void constructorShouldThrowOnZeroOperationCount() {
         assertThatThrownBy(() ->
             ConcurrentTestRunner.builder()
-                .operation(EMPTY_BI_CONSUMER)
+                .operation(NOOP)
                 .threadCount(1)
                 .operationCount(0))
             .isInstanceOf(IllegalArgumentException.class);
@@ -85,7 +85,7 @@ public class ConcurrentTestRunnerTest {
     @Test
     public void awaitTerminationShouldReturnTrueWhenFinished() throws Exception {
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
-            .operation(EMPTY_BI_CONSUMER)
+            .operation(NOOP)
             .threadCount(1)
             .build()
             .run();
@@ -152,7 +152,7 @@ public class ConcurrentTestRunnerTest {
     @Test
     public void noExceptionsShouldNotThrowWhenNoExceptionGenerated() throws Exception {
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
-            .operation(EMPTY_BI_CONSUMER)
+            .operation(NOOP)
             .threadCount(2)
             .operationCount(2)
             .build()

--- a/server/container/util/src/test/java/org/apache/james/util/concurrency/ConcurrentTestRunnerTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/concurrency/ConcurrentTestRunnerTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Duration;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -31,7 +32,7 @@ import org.junit.Test;
 
 public class ConcurrentTestRunnerTest {
     public static final ConcurrentTestRunner.ConcurrentOperation NOOP = (threadNumber, step) -> { };
-    public static final int DEFAULT_AWAIT_TIME = 100;
+    public static final Duration DEFAULT_AWAIT_TIME = Duration.ofMillis(100);
 
     @Test
     public void constructorShouldThrowOnNegativeThreadCount() {
@@ -39,7 +40,7 @@ public class ConcurrentTestRunnerTest {
             ConcurrentTestRunner.builder()
                 .operation(NOOP)
                 .threadCount(-1)
-                .runSuccessfullyWithin(1, TimeUnit.SECONDS))
+                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -59,7 +60,7 @@ public class ConcurrentTestRunnerTest {
             ConcurrentTestRunner.builder()
                 .operation(NOOP)
                 .threadCount(0)
-                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS))
+                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -79,7 +80,7 @@ public class ConcurrentTestRunnerTest {
             ConcurrentTestRunner.builder()
                 .operation(null)
                 .threadCount(1)
-                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS))
+                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME))
             .isInstanceOf(NullPointerException.class);
     }
 
@@ -88,7 +89,7 @@ public class ConcurrentTestRunnerTest {
         assertThatCode(() ->  ConcurrentTestRunner.builder()
                 .operation(NOOP)
                 .threadCount(1)
-                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS))
+                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME))
             .doesNotThrowAnyException();
     }
 
@@ -97,7 +98,7 @@ public class ConcurrentTestRunnerTest {
         assertThatThrownBy(() -> ConcurrentTestRunner.builder()
                 .operation((threadNumber, step) -> Thread.sleep(50))
                 .threadCount(1)
-                .runSuccessfullyWithin(25, TimeUnit.MILLISECONDS))
+                .runSuccessfullyWithin(Duration.ofMillis(25)))
             .isInstanceOf(ConcurrentTestRunner.NotTerminatedException.class);
     }
 
@@ -109,7 +110,7 @@ public class ConcurrentTestRunnerTest {
                 .operation((threadNumber, step) -> queue.add(threadNumber + ":" + step))
                 .threadCount(2)
                 .operationCount(2)
-                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS))
+                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME))
             .doesNotThrowAnyException();
 
         assertThat(queue).containsOnly("0:0", "0:1", "1:0", "1:1");
@@ -122,7 +123,7 @@ public class ConcurrentTestRunnerTest {
         assertThatCode(() -> ConcurrentTestRunner.builder()
                 .operation((threadNumber, step) -> queue.add(threadNumber + ":" + step))
                 .threadCount(2)
-                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS))
+                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME))
             .doesNotThrowAnyException();
     }
 
@@ -134,7 +135,7 @@ public class ConcurrentTestRunnerTest {
                 })
                 .threadCount(2)
                 .operationCount(2)
-                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS))
+                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME))
             .doesNotThrowAnyException();
     }
 
@@ -144,7 +145,7 @@ public class ConcurrentTestRunnerTest {
             .operation(NOOP)
             .threadCount(2)
             .operationCount(2)
-            .runSuccessfullyWithin(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS)
+            .runSuccessfullyWithin(DEFAULT_AWAIT_TIME)
             .assertNoException();
     }
 
@@ -157,7 +158,7 @@ public class ConcurrentTestRunnerTest {
                     })
                     .threadCount(2)
                     .operationCount(2)
-                    .runSuccessfullyWithin(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS)
+                    .runSuccessfullyWithin(DEFAULT_AWAIT_TIME)
                     .assertNoException())
             .isInstanceOf(ExecutionException.class);
     }
@@ -173,7 +174,7 @@ public class ConcurrentTestRunnerTest {
                 })
                 .threadCount(2)
                 .operationCount(2)
-                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS))
+                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME))
             .doesNotThrowAnyException();
 
         assertThat(queue).containsOnly("0:0", "0:1", "1:0", "1:1");
@@ -192,7 +193,7 @@ public class ConcurrentTestRunnerTest {
                 })
                 .threadCount(2)
                 .operationCount(2)
-                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS))
+                .runSuccessfullyWithin(DEFAULT_AWAIT_TIME))
             .doesNotThrowAnyException();
 
         assertThat(queue).containsOnly("0:0", "0:1", "1:0", "1:1");

--- a/server/container/util/src/test/java/org/apache/james/util/concurrency/ConcurrentTestRunnerTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/concurrency/ConcurrentTestRunnerTest.java
@@ -36,7 +36,9 @@ public class ConcurrentTestRunnerTest {
     public void constructorShouldThrowOnNegativeThreadCount() {
         assertThatThrownBy(() ->
             ConcurrentTestRunner.builder()
-                .threadCount(-1))
+                .operation(EMPTY_BI_CONSUMER)
+                .threadCount(-1)
+                .build())
             .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -44,6 +46,8 @@ public class ConcurrentTestRunnerTest {
     public void constructorShouldThrowOnNegativeOperationCount() {
         assertThatThrownBy(() ->
             ConcurrentTestRunner.builder()
+                .operation(EMPTY_BI_CONSUMER)
+                .threadCount(1)
                 .operationCount(-1))
             .isInstanceOf(IllegalArgumentException.class);
     }
@@ -52,7 +56,9 @@ public class ConcurrentTestRunnerTest {
     public void constructorShouldThrowOnZeroThreadCount() {
         assertThatThrownBy(() ->
             ConcurrentTestRunner.builder()
-                .threadCount(0))
+                .operation(EMPTY_BI_CONSUMER)
+                .threadCount(0)
+                .build())
             .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -60,6 +66,8 @@ public class ConcurrentTestRunnerTest {
     public void constructorShouldThrowOnZeroOperationCount() {
         assertThatThrownBy(() ->
             ConcurrentTestRunner.builder()
+                .operation(EMPTY_BI_CONSUMER)
+                .threadCount(1)
                 .operationCount(0))
             .isInstanceOf(IllegalArgumentException.class);
     }
@@ -68,16 +76,18 @@ public class ConcurrentTestRunnerTest {
     public void constructorShouldThrowOnNullBiConsumer() {
         assertThatThrownBy(() ->
             ConcurrentTestRunner.builder()
+                .operation(null)
                 .threadCount(1)
-                .build(null))
+                .build())
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     public void awaitTerminationShouldReturnTrueWhenFinished() throws Exception {
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
+            .operation(EMPTY_BI_CONSUMER)
             .threadCount(1)
-            .build(EMPTY_BI_CONSUMER)
+            .build()
             .run();
 
         assertThat(concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS)).isTrue();
@@ -88,8 +98,9 @@ public class ConcurrentTestRunnerTest {
         int sleepDelay = 50;
 
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
+            .operation((threadNumber, step) -> Thread.sleep(sleepDelay))
             .threadCount(1)
-            .build((threadNumber, step) -> Thread.sleep(sleepDelay))
+            .build()
             .run();
 
         assertThat(concurrentTestRunner.awaitTermination(sleepDelay / 2, TimeUnit.MILLISECONDS)).isFalse();
@@ -100,9 +111,10 @@ public class ConcurrentTestRunnerTest {
         ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
 
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
+            .operation((threadNumber, step) -> queue.add(threadNumber + ":" + step))
             .threadCount(2)
             .operationCount(2)
-            .build((threadNumber, step) -> queue.add(threadNumber + ":" + step))
+            .build()
             .run();
 
         assertThat(concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS)).isTrue();
@@ -114,8 +126,9 @@ public class ConcurrentTestRunnerTest {
         ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
 
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
+            .operation((threadNumber, step) -> queue.add(threadNumber + ":" + step))
             .threadCount(2)
-            .build((threadNumber, step) -> queue.add(threadNumber + ":" + step))
+            .build()
             .run();
 
         assertThat(concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS)).isTrue();
@@ -125,11 +138,12 @@ public class ConcurrentTestRunnerTest {
     @Test
     public void runShouldNotThrowOnExceptions() throws Exception {
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
-            .threadCount(2)
-            .operationCount(2)
-            .build((threadNumber, step) -> {
+            .operation((threadNumber, step) -> {
                 throw new RuntimeException();
             })
+            .threadCount(2)
+            .operationCount(2)
+            .build()
             .run();
 
         assertThat(concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS)).isTrue();
@@ -138,9 +152,10 @@ public class ConcurrentTestRunnerTest {
     @Test
     public void noExceptionsShouldNotThrowWhenNoExceptionGenerated() throws Exception {
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
+            .operation(EMPTY_BI_CONSUMER)
             .threadCount(2)
             .operationCount(2)
-            .build(EMPTY_BI_CONSUMER)
+            .build()
             .run();
 
         concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS);
@@ -151,11 +166,12 @@ public class ConcurrentTestRunnerTest {
     @Test
     public void assertNoExceptionShouldThrowOnExceptions() throws Exception {
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
-            .threadCount(2)
-            .operationCount(2)
-            .build((threadNumber, step) -> {
+            .operation((threadNumber, step) -> {
                 throw new RuntimeException();
             })
+            .threadCount(2)
+            .operationCount(2)
+            .build()
             .run();
         concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS);
 
@@ -168,12 +184,13 @@ public class ConcurrentTestRunnerTest {
         ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
 
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
-            .threadCount(2)
-            .operationCount(2)
-            .build((threadNumber, step) -> {
+            .operation((threadNumber, step) -> {
                 queue.add(threadNumber + ":" + step);
                 throw new RuntimeException();
             })
+            .threadCount(2)
+            .operationCount(2)
+            .build()
             .run();
 
         assertThat(concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS)).isTrue();
@@ -185,14 +202,15 @@ public class ConcurrentTestRunnerTest {
         ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
 
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
-            .threadCount(2)
-            .operationCount(2)
-            .build((threadNumber, step) -> {
+            .operation((threadNumber, step) -> {
                 queue.add(threadNumber + ":" + step);
                 if ((threadNumber + step) % 2 == 0) {
                     throw new RuntimeException();
                 }
             })
+            .threadCount(2)
+            .operationCount(2)
+            .build()
             .run();
 
         assertThat(concurrentTestRunner.awaitTermination(DEFAULT_AWAIT_TIME, TimeUnit.MILLISECONDS)).isTrue();

--- a/server/data/data-api/src/test/java/org/apache/james/mailrepository/api/MailRepositoryUrlStoreContract.java
+++ b/server/data/data-api/src/test/java/org/apache/james/mailrepository/api/MailRepositoryUrlStoreContract.java
@@ -75,9 +75,10 @@ public interface MailRepositoryUrlStoreContract {
         int operationCount = 10;
         int threadCount = 10;
         ConcurrentTestRunner testRunner = ConcurrentTestRunner.builder()
+            .operation((a, b) -> store.add(MailRepositoryUrl.from("proto://" + a + "/" + b)))
             .threadCount(threadCount)
             .operationCount(operationCount)
-            .build((a, b) -> store.add(MailRepositoryUrl.from("proto://" + a + "/" + b)))
+            .build()
             .run();
         testRunner.awaitTermination(1, TimeUnit.MINUTES);
         testRunner.assertNoException();
@@ -89,9 +90,10 @@ public interface MailRepositoryUrlStoreContract {
     default void addShouldNotAddDuplicatesInConcurrentEnvironment(MailRepositoryUrlStore store) throws Exception {
         int operationCount = 10;
         ConcurrentTestRunner testRunner = ConcurrentTestRunner.builder()
+            .operation((a, b) -> store.add(MailRepositoryUrl.from("proto://" + b)))
             .threadCount(10)
             .operationCount(operationCount)
-            .build((a, b) -> store.add(MailRepositoryUrl.from("proto://" + b)))
+            .build()
             .run();
         testRunner.awaitTermination(1, TimeUnit.MINUTES);
         testRunner.assertNoException();

--- a/server/data/data-api/src/test/java/org/apache/james/mailrepository/api/MailRepositoryUrlStoreContract.java
+++ b/server/data/data-api/src/test/java/org/apache/james/mailrepository/api/MailRepositoryUrlStoreContract.java
@@ -74,14 +74,15 @@ public interface MailRepositoryUrlStoreContract {
     default void addShouldWorkInConcurrentEnvironment(MailRepositoryUrlStore store) throws Exception {
         int operationCount = 10;
         int threadCount = 10;
-        ConcurrentTestRunner testRunner = ConcurrentTestRunner.builder()
+
+        ConcurrentTestRunner.builder()
             .operation((a, b) -> store.add(MailRepositoryUrl.from("proto://" + a + "/" + b)))
             .threadCount(threadCount)
             .operationCount(operationCount)
             .build()
-            .run();
-        testRunner.awaitTermination(1, TimeUnit.MINUTES);
-        testRunner.assertNoException();
+            .run()
+            .awaitTermination(1, TimeUnit.MINUTES)
+            .assertNoException();
 
         assertThat(store.listDistinct()).hasSize(threadCount * operationCount);
     }
@@ -89,14 +90,15 @@ public interface MailRepositoryUrlStoreContract {
     @Test
     default void addShouldNotAddDuplicatesInConcurrentEnvironment(MailRepositoryUrlStore store) throws Exception {
         int operationCount = 10;
-        ConcurrentTestRunner testRunner = ConcurrentTestRunner.builder()
+
+        ConcurrentTestRunner.builder()
             .operation((a, b) -> store.add(MailRepositoryUrl.from("proto://" + b)))
             .threadCount(10)
             .operationCount(operationCount)
             .build()
-            .run();
-        testRunner.awaitTermination(1, TimeUnit.MINUTES);
-        testRunner.assertNoException();
+            .run()
+            .awaitTermination(1, TimeUnit.MINUTES)
+            .assertNoException();
 
         assertThat(store.listDistinct()).hasSize(operationCount);
     }

--- a/server/data/data-api/src/test/java/org/apache/james/mailrepository/api/MailRepositoryUrlStoreContract.java
+++ b/server/data/data-api/src/test/java/org/apache/james/mailrepository/api/MailRepositoryUrlStoreContract.java
@@ -79,10 +79,7 @@ public interface MailRepositoryUrlStoreContract {
             .operation((a, b) -> store.add(MailRepositoryUrl.from("proto://" + a + "/" + b)))
             .threadCount(threadCount)
             .operationCount(operationCount)
-            .build()
-            .run()
-            .awaitTermination(1, TimeUnit.MINUTES)
-            .assertNoException();
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
 
         assertThat(store.listDistinct()).hasSize(threadCount * operationCount);
     }
@@ -95,10 +92,7 @@ public interface MailRepositoryUrlStoreContract {
             .operation((a, b) -> store.add(MailRepositoryUrl.from("proto://" + b)))
             .threadCount(10)
             .operationCount(operationCount)
-            .build()
-            .run()
-            .awaitTermination(1, TimeUnit.MINUTES)
-            .assertNoException();
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
 
         assertThat(store.listDistinct()).hasSize(operationCount);
     }

--- a/server/data/data-api/src/test/java/org/apache/james/mailrepository/api/MailRepositoryUrlStoreContract.java
+++ b/server/data/data-api/src/test/java/org/apache/james/mailrepository/api/MailRepositoryUrlStoreContract.java
@@ -21,7 +21,7 @@ package org.apache.james.mailrepository.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import org.apache.james.util.concurrency.ConcurrentTestRunner;
 import org.junit.jupiter.api.Test;
@@ -79,7 +79,7 @@ public interface MailRepositoryUrlStoreContract {
             .operation((a, b) -> store.add(MailRepositoryUrl.from("proto://" + a + "/" + b)))
             .threadCount(threadCount)
             .operationCount(operationCount)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
 
         assertThat(store.listDistinct()).hasSize(threadCount * operationCount);
     }
@@ -92,7 +92,7 @@ public interface MailRepositoryUrlStoreContract {
             .operation((a, b) -> store.add(MailRepositoryUrl.from("proto://" + b)))
             .threadCount(10)
             .operationCount(operationCount)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
 
         assertThat(store.listDistinct()).hasSize(operationCount);
     }

--- a/server/data/data-memory/src/test/java/org/apache/james/mailrepository/memory/MemoryMailRepositoryStoreTest.java
+++ b/server/data/data-memory/src/test/java/org/apache/james/mailrepository/memory/MemoryMailRepositoryStoreTest.java
@@ -22,7 +22,7 @@ package org.apache.james.mailrepository.memory;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
@@ -239,7 +239,7 @@ public class MemoryMailRepositoryStoreTest {
                         .setText("Any body"))
                     .build()))
             .threadCount(10)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
 
         long actualSize = repositoryStore.get(url).get().size();
 

--- a/server/data/data-memory/src/test/java/org/apache/james/mailrepository/memory/MemoryMailRepositoryStoreTest.java
+++ b/server/data/data-memory/src/test/java/org/apache/james/mailrepository/memory/MemoryMailRepositoryStoreTest.java
@@ -232,13 +232,14 @@ public class MemoryMailRepositoryStoreTest {
         int threadCount = 10;
 
         ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
-            .threadCount(10)
-            .build((threadNb, operationNb) -> repositoryStore.select(url)
+            .operation((threadNb, operationNb) -> repositoryStore.select(url)
                 .store(FakeMail.builder()
                     .name("name" + threadNb)
                     .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
                         .setText("Any body"))
-                    .build()));
+                    .build()))
+            .threadCount(10)
+            .build();
         concurrentTestRunner.run().awaitTermination(1, TimeUnit.MINUTES);
         concurrentTestRunner.assertNoException();
 

--- a/server/data/data-memory/src/test/java/org/apache/james/mailrepository/memory/MemoryMailRepositoryStoreTest.java
+++ b/server/data/data-memory/src/test/java/org/apache/james/mailrepository/memory/MemoryMailRepositoryStoreTest.java
@@ -239,10 +239,7 @@ public class MemoryMailRepositoryStoreTest {
                         .setText("Any body"))
                     .build()))
             .threadCount(10)
-            .build()
-            .run()
-            .awaitTermination(1, TimeUnit.MINUTES)
-            .assertNoException();
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
 
         long actualSize = repositoryStore.get(url).get().size();
 

--- a/server/data/data-memory/src/test/java/org/apache/james/mailrepository/memory/MemoryMailRepositoryStoreTest.java
+++ b/server/data/data-memory/src/test/java/org/apache/james/mailrepository/memory/MemoryMailRepositoryStoreTest.java
@@ -231,7 +231,7 @@ public class MemoryMailRepositoryStoreTest {
         MailRepositoryUrl url = MailRepositoryUrl.from("memory1://repo");
         int threadCount = 10;
 
-        ConcurrentTestRunner concurrentTestRunner = ConcurrentTestRunner.builder()
+        ConcurrentTestRunner.builder()
             .operation((threadNb, operationNb) -> repositoryStore.select(url)
                 .store(FakeMail.builder()
                     .name("name" + threadNb)
@@ -239,9 +239,10 @@ public class MemoryMailRepositoryStoreTest {
                         .setText("Any body"))
                     .build()))
             .threadCount(10)
-            .build();
-        concurrentTestRunner.run().awaitTermination(1, TimeUnit.MINUTES);
-        concurrentTestRunner.assertNoException();
+            .build()
+            .run()
+            .awaitTermination(1, TimeUnit.MINUTES)
+            .assertNoException();
 
         long actualSize = repositoryStore.get(url).get().size();
 

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/MailboxAppenderTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/MailboxAppenderTest.java
@@ -126,8 +126,9 @@ public class MailboxAppenderTest {
     @RepeatedTest(20)
     void appendShouldNotFailInConcurrentEnvironment() throws Exception {
         ConcurrentTestRunner.builder()
+            .operation((a, b) -> testee.append(mimeMessage, USER, FOLDER + "/any"))
             .threadCount(100)
-            .build((a, b) -> testee.append(mimeMessage, USER, FOLDER + "/any"))
+            .build()
             .run()
             .assertNoException();
     }

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/MailboxAppenderTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/MailboxAppenderTest.java
@@ -22,7 +22,7 @@ package org.apache.james.transport.mailets.delivery;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
@@ -130,6 +130,6 @@ public class MailboxAppenderTest {
         ConcurrentTestRunner.builder()
             .operation((a, b) -> testee.append(mimeMessage, USER, FOLDER + "/any"))
             .threadCount(100)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
     }
 }

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/MailboxAppenderTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/MailboxAppenderTest.java
@@ -22,6 +22,8 @@ package org.apache.james.transport.mailets.delivery;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.concurrent.TimeUnit;
+
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
@@ -128,8 +130,6 @@ public class MailboxAppenderTest {
         ConcurrentTestRunner.builder()
             .operation((a, b) -> testee.append(mimeMessage, USER, FOLDER + "/any"))
             .threadCount(100)
-            .build()
-            .run()
-            .assertNoException();
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
     }
 }

--- a/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
+++ b/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
@@ -422,13 +422,13 @@ public interface MailRepositoryContract {
         MailRepository testee = retrieveRepository();
         int nbKeys = 20;
         ConcurrentHashMap.KeySetView<MailKey, Boolean> expectedResult = ConcurrentHashMap.newKeySet();
-        List<Object> locks = IntStream.range(0, 10)
+        List<Object> locks = IntStream.range(0, nbKeys)
             .boxed()
             .collect(Guavate.toImmutableList());
 
         Random random = new Random();
         ThrowingRunnable add = () -> {
-            int keyIndex = computeKeyIndex(nbKeys, random.nextInt());
+            int keyIndex = computeKeyIndex(nbKeys, Math.abs(random.nextInt()));
             MailKey key =  computeKey(keyIndex);
             synchronized (locks.get(keyIndex)) {
                 testee.store(createMail(key));
@@ -437,7 +437,7 @@ public interface MailRepositoryContract {
         };
 
         ThrowingRunnable remove = () -> {
-            int keyIndex = computeKeyIndex(nbKeys, random.nextInt());
+            int keyIndex = computeKeyIndex(nbKeys, Math.abs(random.nextInt()));
             MailKey key =  computeKey(keyIndex);
             synchronized (locks.get(keyIndex)) {
                 testee.remove(key);
@@ -454,9 +454,7 @@ public interface MailRepositoryContract {
             .operation((a, b) -> distribution.sample().run())
             .threadCount(10)
             .operationCount(10)
-            .build()
-            .run()
-            .awaitTermination(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
 
         assertThat(testee.list()).containsOnlyElementsOf(expectedResult);
     }

--- a/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
+++ b/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
@@ -23,11 +23,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Date;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 import javax.mail.MessagingException;
@@ -454,7 +454,7 @@ public interface MailRepositoryContract {
             .operation((a, b) -> distribution.sample().run())
             .threadCount(10)
             .operationCount(10)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
 
         assertThat(testee.list()).containsOnlyElementsOf(expectedResult);
     }

--- a/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
+++ b/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
@@ -451,9 +451,10 @@ public interface MailRepositoryContract {
                 new DistributionEntry<>(remove, 0.75)));
 
         ConcurrentTestRunner.builder()
+            .operation((a, b) -> distribution.sample().run())
             .threadCount(10)
             .operationCount(10)
-            .build((a, b) -> distribution.sample().run())
+            .build()
             .run()
             .awaitTermination(1, TimeUnit.MINUTES);
 

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/ProvisioningTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/ProvisioningTest.java
@@ -79,11 +79,12 @@ public abstract class ProvisioningTest {
         String token = authenticateJamesUser(baseUri(jmapServer), USER, PASSWORD).serialize();
 
         boolean termination = ConcurrentTestRunner.builder()
-            .threadCount(10)
-            .build((a, b) -> with()
+            .operation((a, b) -> with()
                 .header("Authorization", token)
                 .body("[[\"getMailboxes\", {}, \"#0\"]]")
                 .post("/jmap"))
+            .threadCount(10)
+            .build()
             .run()
             .awaitTermination(1, TimeUnit.MINUTES);
 

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/ProvisioningTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/ProvisioningTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import org.apache.james.GuiceJamesServer;
 import org.apache.james.mailbox.DefaultMailboxes;
@@ -84,7 +84,7 @@ public abstract class ProvisioningTest {
                 .body("[[\"getMailboxes\", {}, \"#0\"]]")
                 .post("/jmap"))
             .threadCount(10)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
 
         given()
             .header("Authorization", token)

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/ProvisioningTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/ProvisioningTest.java
@@ -78,7 +78,7 @@ public abstract class ProvisioningTest {
     public void provisionMailboxesShouldNotDuplicateMailboxByName() throws Exception {
         String token = authenticateJamesUser(baseUri(jmapServer), USER, PASSWORD).serialize();
 
-        boolean termination = ConcurrentTestRunner.builder()
+        ConcurrentTestRunner.builder()
             .operation((a, b) -> with()
                 .header("Authorization", token)
                 .body("[[\"getMailboxes\", {}, \"#0\"]]")
@@ -87,8 +87,6 @@ public abstract class ProvisioningTest {
             .build()
             .run()
             .awaitTermination(1, TimeUnit.MINUTES);
-
-        assertThat(termination).isTrue();
 
         given()
             .header("Authorization", token)

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/ProvisioningTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/ProvisioningTest.java
@@ -84,9 +84,7 @@ public abstract class ProvisioningTest {
                 .body("[[\"getMailboxes\", {}, \"#0\"]]")
                 .post("/jmap"))
             .threadCount(10)
-            .build()
-            .run()
-            .awaitTermination(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
 
         given()
             .header("Authorization", token)

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/DefaultMailboxesProvisioningFilterTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/DefaultMailboxesProvisioningFilterTest.java
@@ -90,8 +90,9 @@ public class DefaultMailboxesProvisioningFilterTest {
     @Test
     public void createMailboxesIfNeededShouldNotGenerateExceptionsInConcurrentEnvironment() throws Exception {
         ConcurrentTestRunner.builder()
+            .operation((threadNumber, step) -> testee.createMailboxesIfNeeded(session))
             .threadCount(10)
-            .build((threadNumber, step) -> testee.createMailboxesIfNeeded(session))
+            .build()
             .run()
             .assertNoException()
             .awaitTermination(10, TimeUnit.SECONDS);

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/DefaultMailboxesProvisioningFilterTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/DefaultMailboxesProvisioningFilterTest.java
@@ -94,8 +94,8 @@ public class DefaultMailboxesProvisioningFilterTest {
             .threadCount(10)
             .build()
             .run()
-            .assertNoException()
-            .awaitTermination(10, TimeUnit.SECONDS);
+            .awaitTermination(10, TimeUnit.SECONDS)
+            .assertNoException();
 
         assertThat(mailboxManager.list(session))
             .containsOnlyElementsOf(DefaultMailboxes.DEFAULT_MAILBOXES

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/DefaultMailboxesProvisioningFilterTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/DefaultMailboxesProvisioningFilterTest.java
@@ -92,10 +92,7 @@ public class DefaultMailboxesProvisioningFilterTest {
         ConcurrentTestRunner.builder()
             .operation((threadNumber, step) -> testee.createMailboxesIfNeeded(session))
             .threadCount(10)
-            .build()
-            .run()
-            .awaitTermination(10, TimeUnit.SECONDS)
-            .assertNoException();
+            .runSuccessfullyWithin(10, TimeUnit.SECONDS);
 
         assertThat(mailboxManager.list(session))
             .containsOnlyElementsOf(DefaultMailboxes.DEFAULT_MAILBOXES

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/DefaultMailboxesProvisioningFilterTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/DefaultMailboxesProvisioningFilterTest.java
@@ -20,7 +20,7 @@ package org.apache.james.jmap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import org.apache.james.mailbox.DefaultMailboxes;
 import org.apache.james.mailbox.MailboxSession;
@@ -92,7 +92,7 @@ public class DefaultMailboxesProvisioningFilterTest {
         ConcurrentTestRunner.builder()
             .operation((threadNumber, step) -> testee.createMailboxesIfNeeded(session))
             .threadCount(10)
-            .runSuccessfullyWithin(10, TimeUnit.SECONDS);
+            .runSuccessfullyWithin(Duration.ofSeconds(10));
 
         assertThat(mailboxManager.list(session))
             .containsOnlyElementsOf(DefaultMailboxes.DEFAULT_MAILBOXES

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/DefaultMailboxesProvisioningFilterThreadTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/DefaultMailboxesProvisioningFilterThreadTest.java
@@ -25,8 +25,8 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
@@ -68,6 +68,6 @@ public class DefaultMailboxesProvisioningFilterThreadTest {
             .builder()
             .operation((threadNumber, step) -> sut.createMailboxesIfNeeded(session))
             .threadCount(2)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
     }
 }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/DefaultMailboxesProvisioningFilterThreadTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/DefaultMailboxesProvisioningFilterThreadTest.java
@@ -65,8 +65,9 @@ public class DefaultMailboxesProvisioningFilterThreadTest {
 
         ConcurrentTestRunner
             .builder()
+            .operation((threadNumber, step) -> sut.createMailboxesIfNeeded(session))
             .threadCount(2)
-            .build((threadNumber, step) -> sut.createMailboxesIfNeeded(session))
+            .build()
             .run()
             .assertNoException();
     }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/DefaultMailboxesProvisioningFilterThreadTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/DefaultMailboxesProvisioningFilterThreadTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
@@ -67,8 +68,6 @@ public class DefaultMailboxesProvisioningFilterThreadTest {
             .builder()
             .operation((threadNumber, step) -> sut.createMailboxesIfNeeded(session))
             .threadCount(2)
-            .build()
-            .run()
-            .assertNoException();
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
     }
 }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/UserProvisioningFilterThreadTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/UserProvisioningFilterThreadTest.java
@@ -18,8 +18,8 @@
  ****************************************************************/
 package org.apache.james.jmap;
 
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.mock.MockMailboxSession;
@@ -48,7 +48,7 @@ public class UserProvisioningFilterThreadTest {
             .builder()
             .operation((threadNumber, step) -> sut.createAccountIfNeeded(session))
             .threadCount(2)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
     }
 }
 

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/UserProvisioningFilterThreadTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/UserProvisioningFilterThreadTest.java
@@ -45,8 +45,9 @@ public class UserProvisioningFilterThreadTest {
     public void testConcurrentAccessToFilterShouldNotThrow() throws ExecutionException, InterruptedException {
         ConcurrentTestRunner
             .builder()
+            .operation((threadNumber, step) -> sut.createAccountIfNeeded(session))
             .threadCount(2)
-            .build((threadNumber, step) -> sut.createAccountIfNeeded(session))
+            .build()
             .run()
             .assertNoException();
     }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/UserProvisioningFilterThreadTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/UserProvisioningFilterThreadTest.java
@@ -19,6 +19,7 @@
 package org.apache.james.jmap;
 
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.mock.MockMailboxSession;
@@ -47,9 +48,7 @@ public class UserProvisioningFilterThreadTest {
             .builder()
             .operation((threadNumber, step) -> sut.createAccountIfNeeded(session))
             .threadCount(2)
-            .build()
-            .run()
-            .assertNoException();
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
     }
 }
 

--- a/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueBlobTest.java
+++ b/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueBlobTest.java
@@ -124,6 +124,13 @@ public class ActiveMQMailQueueBlobTest implements DelayedManageableMailQueueCont
     }
 
     @Test
+    @Override
+    @Disabled("JAMES-2544 Mixing concurrent ack/nack might lead to a deadlock")
+    public void concurrentEnqueueDequeueWithAckNackShouldNotFail() {
+
+    }
+
+    @Test
     void computeNextDeliveryTimestampShouldReturnLongMaxWhenOverflow() {
         long deliveryTimestamp = mailQueue.computeNextDeliveryTimestamp(Long.MAX_VALUE, TimeUnit.DAYS);
 

--- a/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueTest.java
+++ b/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueTest.java
@@ -126,4 +126,11 @@ public class ActiveMQMailQueueTest implements DelayedManageableMailQueueContract
     public void clearShouldRemoveAllElements() {
 
     }
+
+    @Test
+    @Override
+    @Disabled("JAMES-2544 Mixing concurrent ack/nack might lead to a deadlock")
+    public void concurrentEnqueueDequeueWithAckNackShouldNotFail() {
+
+    }
 }

--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/MailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/MailQueueContract.java
@@ -349,6 +349,7 @@ public interface MailQueueContract {
 
         int threadCount = 10;
         int operationCount = 100;
+        int totalDequeuedMessages = 500;
         ConcurrentTestRunner.builder()
             .operation((threadNumber, step) -> {
                 if (step % 2 == 0) {
@@ -369,7 +370,7 @@ public interface MailQueueContract {
             dequeuedMails.stream()
                 .map(Mail::getName)
                 .distinct())
-            .hasSize(threadCount * operationCount / 2);
+            .hasSize(totalDequeuedMessages);
     }
 
     class SerializableAttribute implements Serializable {

--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/MailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/MailQueueContract.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -42,6 +43,7 @@ import javax.mail.internet.MimeMessage;
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.builder.MimeMessageBuilder;
 import org.apache.james.junit.ExecutorExtension;
+import org.apache.james.util.concurrency.ConcurrentTestRunner;
 import org.apache.mailet.Mail;
 import org.apache.mailet.PerRecipientHeaders;
 import org.apache.mailet.base.test.FakeMail;
@@ -319,7 +321,7 @@ public interface MailQueueContract {
     }
 
     @Test
-    default void deQueueShouldBlockWhenNoMail(ExecutorService executorService) throws Exception {
+    default void deQueueShouldBlockWhenNoMail(ExecutorService executorService) {
         Future<?> future = executorService.submit(Throwing.runnable(() -> getMailQueue().deQueue()));
 
         assertThatThrownBy(() -> future.get(2, TimeUnit.SECONDS))
@@ -339,10 +341,41 @@ public interface MailQueueContract {
         assertThat(tryDequeue.get().getMail().getName()).isEqualTo("name");
     }
 
+    @Test
+    default void concurrentEnqueueDequeueShouldNotFail() throws Exception {
+        MailQueue testee = getMailQueue();
+
+        ConcurrentLinkedDeque<Mail> dequeuedMails = new ConcurrentLinkedDeque<>();
+
+        int threadCount = 10;
+        int operationCount = 100;
+        ConcurrentTestRunner.builder()
+            .operation((threadNumber, step) -> {
+                if (step % 2 == 0) {
+                    testee.enQueue(defaultMail()
+                        .name("name" + threadNumber + "-" + step)
+                        .build());
+                } else {
+                    MailQueue.MailQueueItem mailQueueItem = testee.deQueue();
+                    dequeuedMails.add(mailQueueItem.getMail());
+                    mailQueueItem.done(true);
+                }
+            })
+            .threadCount(threadCount)
+            .operationCount(operationCount)
+            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+
+        assertThat(
+            dequeuedMails.stream()
+                .map(Mail::getName)
+                .distinct())
+            .hasSize(threadCount * operationCount / 2);
+    }
+
     class SerializableAttribute implements Serializable {
         private final String value;
 
-        public SerializableAttribute(String value) {
+        SerializableAttribute(String value) {
             this.value = value;
         }
 

--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/MailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/MailQueueContract.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.Serializable;
+import java.time.Duration;
 import java.util.Date;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -364,7 +365,7 @@ public interface MailQueueContract {
             })
             .threadCount(threadCount)
             .operationCount(operationCount)
-            .runSuccessfullyWithin(1, TimeUnit.MINUTES);
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
 
         assertThat(
             dequeuedMails.stream()

--- a/server/queue/queue-file/src/test/java/org/apache/james/queue/file/FileMailQueueTest.java
+++ b/server/queue/queue-file/src/test/java/org/apache/james/queue/file/FileMailQueueTest.java
@@ -97,4 +97,13 @@ public class FileMailQueueTest implements DelayedManageableMailQueueContract {
     public void removeByRecipientShouldRemoveSpecificEmailWhenMultipleRecipients() {
 
     }
+
+
+
+    @Test
+    @Override
+    @Disabled("JAMES-2544 Mixing concurent operation might lead to a deadlock and missing fiels")
+    public void concurrentEnqueueDequeueWithAckNackShouldNotFail() {
+
+    }
 }

--- a/server/queue/queue-jms/src/test/java/org/apache/james/queue/jms/JMSMailQueueTest.java
+++ b/server/queue/queue-jms/src/test/java/org/apache/james/queue/jms/JMSMailQueueTest.java
@@ -99,4 +99,18 @@ public class JMSMailQueueTest implements DelayedManageableMailQueueContract, Pri
     public void clearShouldRemoveAllElements() {
 
     }
+
+    @Test
+    @Override
+    @Disabled("JAMES-2544 Mixing concurrent operations might lead to a missing file and errors upon dequeue")
+    public void concurrentEnqueueDequeueShouldNotFail() {
+
+    }
+
+    @Test
+    @Override
+    @Disabled("JAMES-2544 Mixing concurrent operations might lead to a missing file and errors upon dequeue")
+    public void concurrentEnqueueDequeueWithAckNackShouldNotFail() {
+
+    }
 }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitClient.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitClient.java
@@ -22,11 +22,13 @@ package org.apache.james.queue.rabbitmq;
 import java.io.IOException;
 import java.util.Optional;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.backend.rabbitmq.RabbitChannelPool;
 import org.apache.james.queue.api.MailQueue;
 
 import com.google.common.collect.ImmutableMap;
 import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.GetResponse;
 
 class RabbitClient {
@@ -78,9 +80,10 @@ class RabbitClient {
         channelPool.execute(consumer);
     }
 
-    Optional<GetResponse> poll(MailQueueName name) throws IOException {
-        RabbitChannelPool.RabbitFunction<Optional<GetResponse>, IOException> f = channel ->
-            Optional.ofNullable(channel.basicGet(name.toWorkQueueName().asString(), !AUTO_ACK));
+    Optional<Pair<Channel, GetResponse>> poll(MailQueueName name) throws IOException {
+        RabbitChannelPool.RabbitFunction<Optional<Pair<Channel, GetResponse>>, IOException> f = channel ->
+            Optional.ofNullable(channel.basicGet(name.toWorkQueueName().asString(), !AUTO_ACK))
+                .map(res -> Pair.of(channel, res));
         return channelPool.execute(f);
     }
 }


### PR DESCRIPTION
I took that opportunity to revisit (again...) ConcurrentTestRunner:

 - Use cascading lambdas for compulsory values, and explicitly name operation
 - Make calling "awaitTermination" throwing if not finished to avoid the caller to have to check the return value
 - Provide a helper method for common call pattern build -> run -> await -> assertNoException that got duplicated everywhere in the code base
 - Solve issues in MailRepositoryContract concurrent testing

The result is IMO a way better API that should be easy for anyone to use.