### PR TITLE
JAMES-2487 Remove deprecation warning

### DIFF
--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraDownloadCucumberTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraDownloadCucumberTest.java
@@ -29,7 +29,7 @@ import cucumber.api.junit.Cucumber;
 @RunWith(Cucumber.class)
 @CucumberOptions(features = {"classpath:cucumber/DownloadEndpoint.feature", "classpath:cucumber/DownloadGet.feature", "classpath:cucumber/DownloadPost.feature"},
                 glue = {"org.apache.james.jmap.methods.integration", "org.apache.james.jmap.cassandra.cucumber"},
-                tags = {"~@Ignore"},
+                tags = {"not @Ignore"},
                 strict = true)
 public class CassandraDownloadCucumberTest {
 

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraMailboxSharingTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraMailboxSharingTest.java
@@ -36,7 +36,7 @@ import cucumber.api.junit.Cucumber;
     "classpath:cucumber/sharing/MoveMailboxAndSharing.feature",
     "classpath:cucumber/sharing/RenamingMailboxAndSharing.feature" },
     glue = { "org.apache.james.jmap.methods.integration", "org.apache.james.jmap.cassandra.cucumber" },
-    tags = {"~@Ignore"},
+    tags = {"not @Ignore"},
     strict = true)
 public class CassandraMailboxSharingTest {
 

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraMessageSharingTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraMessageSharingTest.java
@@ -37,7 +37,7 @@ import cucumber.api.junit.Cucumber;
     "classpath:cucumber/sharing/SetFlagAndSharing.feature",
     "classpath:cucumber/sharing/CopyAndSharing.feature" },
     glue = { "org.apache.james.jmap.methods.integration", "org.apache.james.jmap.cassandra.cucumber" },
-    tags = {"~@Ignore"},
+    tags = {"not @Ignore"},
     strict = true)
 public class CassandraMessageSharingTest {
 

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraUploadCucumberTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraUploadCucumberTest.java
@@ -29,7 +29,7 @@ import cucumber.api.junit.Cucumber;
 @RunWith(Cucumber.class)
 @CucumberOptions(features = {"classpath:cucumber/UploadEndpoint.feature"},
                 glue = {"org.apache.james.jmap.methods.integration", "org.apache.james.jmap.cassandra.cucumber"},
-                tags = {"~@Ignore"},
+                tags = {"not @Ignore"},
                 strict = true)
 public class CassandraUploadCucumberTest {
 

--- a/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/java/org/apache/james/jmap/memory/cucumber/MemoryDownloadCucumberTest.java
+++ b/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/java/org/apache/james/jmap/memory/cucumber/MemoryDownloadCucumberTest.java
@@ -27,7 +27,7 @@ import cucumber.api.junit.Cucumber;
 @RunWith(Cucumber.class)
 @CucumberOptions(features = {"classpath:cucumber/DownloadEndpoint.feature", "classpath:cucumber/DownloadGet.feature", "classpath:cucumber/DownloadPost.feature"},
                 glue = {"org.apache.james.jmap.methods.integration", "org.apache.james.jmap.memory.cucumber"},
-                tags = {"~@Ignore"},
+                tags = {"not @Ignore"},
                 strict = true)
 public class MemoryDownloadCucumberTest {
 }

--- a/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/java/org/apache/james/jmap/memory/cucumber/MemorySharingTest.java
+++ b/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/java/org/apache/james/jmap/memory/cucumber/MemorySharingTest.java
@@ -42,7 +42,7 @@ import cucumber.api.junit.Cucumber;
     "classpath:cucumber/sharing/RenamingMailboxAndSharing.feature",
     "classpath:cucumber/sharing/CopyAndSharing.feature" },
     glue = { "org.apache.james.jmap.methods.integration", "org.apache.james.jmap.memory.cucumber" },
-    tags = {"~@Ignore"},
+    tags = {"not @Ignore"},
     strict = true)
 public class MemorySharingTest {
 }

--- a/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/java/org/apache/james/jmap/memory/cucumber/MemoryUploadCucumberTest.java
+++ b/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/java/org/apache/james/jmap/memory/cucumber/MemoryUploadCucumberTest.java
@@ -27,7 +27,7 @@ import cucumber.api.junit.Cucumber;
 @RunWith(Cucumber.class)
 @CucumberOptions(features = {"classpath:cucumber/UploadEndpoint.feature"},
                 glue = {"org.apache.james.jmap.methods.integration", "org.apache.james.jmap.memory.cucumber"},
-                tags = {"~@Ignore"},
+                tags = {"not @Ignore"},
                 strict = true)
 public class MemoryUploadCucumberTest {
 }

--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/MailQueueMetricContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/MailQueueMetricContract.java
@@ -64,11 +64,11 @@ public interface MailQueueMetricContract extends MailQueueContract {
     default void constructorShouldRegisterGetQueueSizeGauge(MailQueueMetricExtension.MailQueueMetricTestSystem testSystem) throws Exception {
         enQueueMail(3);
 
-        ArgumentCaptor<Gauge> gaugeCaptor = ArgumentCaptor.forClass(Gauge.class);
+        ArgumentCaptor<Gauge<?>> gaugeCaptor = ArgumentCaptor.forClass(Gauge.class);
         verify(testSystem.getSpyGaugeRegistry(), times(1)).register(any(), gaugeCaptor.capture());
         Mockito.verifyNoMoreInteractions(testSystem.getSpyGaugeRegistry());
 
-        Gauge registeredGauge = gaugeCaptor.getValue();
+        Gauge<?> registeredGauge = gaugeCaptor.getValue();
         Assertions.assertThat(registeredGauge.get()).isEqualTo(3L);
     }
 
@@ -123,6 +123,7 @@ public interface MailQueueMetricContract extends MailQueueContract {
         verify(testSystem.getSpyEnqueuedMailsTimeMetric(), times(2)).stopAndPublish();
         verifyNoMoreInteractions(testSystem.getSpyDequeuedMailsTimeMetric());
     }
+
     @Test
     default void dequeueShouldPublishDequeueTimeMetric(MailQueueMetricExtension.MailQueueMetricTestSystem testSystem) throws Exception {
         enQueueMail(2);

--- a/server/queue/queue-jms/src/test/java/org/apache/james/queue/jms/JMSMailQueueTest.java
+++ b/server/queue/queue-jms/src/test/java/org/apache/james/queue/jms/JMSMailQueueTest.java
@@ -25,7 +25,6 @@ import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.james.metrics.api.GaugeRegistry;
 import org.apache.james.metrics.api.MetricFactory;
-import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.james.queue.api.DelayedManageableMailQueueContract;
 import org.apache.james.queue.api.DelayedPriorityMailQueueContract;
 import org.apache.james.queue.api.MailQueue;


### PR DESCRIPTION
WARNING: Found tags option '\~@Ignore'. Support for '~@tag' will be removed from the next release of Cucumber-JVM. Please use 'not @tag' instead.