### PR TITLE
JAMES-2546 Add nullSender support to MailRepository contract

### DIFF
--- a/server/data/data-jdbc/src/test/java/org/apache/james/mailrepository/jdbc/JDBCMailRepositoryTest.java
+++ b/server/data/data-jdbc/src/test/java/org/apache/james/mailrepository/jdbc/JDBCMailRepositoryTest.java
@@ -75,7 +75,7 @@ public class JDBCMailRepositoryTest implements MailRepositoryContract {
     }
 
     @Override
-    @Disabled("JAMES-2546 This mail repository do not support null sender")
+    @Disabled("JAMES-2546 This mail repository does not support null sender")
     public void storeRegularMailShouldNotFailWhenNullSender() {
 
     }

--- a/server/data/data-jdbc/src/test/java/org/apache/james/mailrepository/jdbc/JDBCMailRepositoryTest.java
+++ b/server/data/data-jdbc/src/test/java/org/apache/james/mailrepository/jdbc/JDBCMailRepositoryTest.java
@@ -32,6 +32,7 @@ import org.apache.james.mailrepository.MailRepositoryContract;
 import org.apache.james.mailrepository.api.MailRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 
 public class JDBCMailRepositoryTest implements MailRepositoryContract {
 
@@ -71,5 +72,11 @@ public class JDBCMailRepositoryTest implements MailRepositoryContract {
         ds.setUsername("james");
         ds.setPassword("james");
         return ds;
+    }
+
+    @Override
+    @Disabled("JAMES-2546 This mail repository do not support null sender")
+    public void storeRegularMailShouldNotFailWhenNullSender() {
+
     }
 }

--- a/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
+++ b/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
@@ -43,6 +43,8 @@ import org.apache.james.utils.DiscreteDistribution;
 import org.apache.james.utils.DiscreteDistribution.DistributionEntry;
 import org.apache.mailet.Mail;
 import org.apache.mailet.PerRecipientHeaders;
+import org.apache.mailet.base.MailAddressFixture;
+import org.apache.mailet.base.test.FakeMail;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
@@ -133,6 +135,21 @@ public interface MailRepositoryContract {
         testee.remove(MAIL_1);
 
         assertThat(testee.size()).isEqualTo(0L);
+    }
+
+    @Test
+    default void storeRegularMailShouldNotFailWhenNullSender() throws Exception {
+        MailRepository testee = retrieveRepository();
+        Mail mail = FakeMail.builder()
+            .sender(MailAddress.nullSender())
+            .recipient(MailAddressFixture.RECIPIENT1)
+            .name(MAIL_1.asString())
+            .mimeMessage(generateMailContent("String body"))
+            .build();
+
+        testee.store(mail);
+
+        assertThat(testee.retrieve(MAIL_1).getSender()).isEqualTo(MailAddress.nullSender());
     }
 
     @Test

--- a/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryMailDAO.java
+++ b/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryMailDAO.java
@@ -174,7 +174,7 @@ public class CassandraMailRepositoryMailDAO {
 
     private MailDTO toMail(Row row) {
         MailAddress sender = Optional.ofNullable(row.getString(SENDER))
-            .map(Throwing.function(MailAddress::new))
+            .map(MailAddress::getMailSender)
             .orElse(null);
         List<MailAddress> recipients = row.getList(RECIPIENTS, String.class)
             .stream()


### PR DESCRIPTION
Spotted while refactoring https://github.com/linagora/james-project/pull/1736