### PR TITLE
JAMES-2547 Make PropertiesProvider return the Configuration interface

### DIFF
--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/configuration/CassandraConfiguration.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/configuration/CassandraConfiguration.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration.Configuration;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
@@ -227,7 +227,7 @@ public class CassandraConfiguration {
         return new Builder();
     }
 
-    public static CassandraConfiguration from(PropertiesConfiguration propertiesConfiguration) {
+    public static CassandraConfiguration from(Configuration propertiesConfiguration) {
         return builder()
             .aclMaxRetry(Optional.ofNullable(
                 propertiesConfiguration.getInteger(MAILBOX_MAX_RETRY_ACL, null)))

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/configuration/ClusterConfiguration.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/configuration/ClusterConfiguration.java
@@ -25,7 +25,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.apache.commons.configuration.Configuration;
 import org.apache.james.backends.cassandra.init.ClusterBuilder;
 import org.apache.james.util.Host;
 
@@ -175,8 +176,8 @@ public class ClusterConfiguration {
         return new Builder();
     }
 
-    public static ClusterConfiguration from(PropertiesConfiguration configuration) {
-        PropertiesConfiguration.setDefaultListDelimiter(',');
+    public static ClusterConfiguration from(Configuration configuration) {
+        AbstractConfiguration.setDefaultListDelimiter(',');
         return ClusterConfiguration.builder()
             .hosts(listCassandraServers(configuration))
             .keyspace(Optional.ofNullable(configuration.getString(CASSANDRA_KEYSPACE, null)))
@@ -190,7 +191,7 @@ public class ClusterConfiguration {
             .build();
     }
 
-    private static List<Host> listCassandraServers(PropertiesConfiguration configuration) {
+    private static List<Host> listCassandraServers(Configuration configuration) {
         String[] ipAndPorts = configuration.getStringArray(CASSANDRA_NODES);
 
         return Arrays.stream(ipAndPorts)
@@ -198,7 +199,7 @@ public class ClusterConfiguration {
             .collect(Guavate.toImmutableList());
     }
 
-    private static Optional<PoolingOptions> readPoolingOptions(PropertiesConfiguration configuration) {
+    private static Optional<PoolingOptions> readPoolingOptions(Configuration configuration) {
         Optional<Integer> maxConnections = Optional.ofNullable(configuration.getInteger("cassandra.pooling.local.max.connections", null));
         Optional<Integer> maxRequests = Optional.ofNullable(configuration.getInteger("cassandra.pooling.local.max.requests", null));
         Optional<Integer> poolingTimeout = Optional.ofNullable(configuration.getInteger("cassandra.pooling.timeout", null));

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/configuration/QueryLoggerConfiguration.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/configuration/QueryLoggerConfiguration.java
@@ -22,7 +22,7 @@ package org.apache.james.backends.cassandra.init.configuration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration.Configuration;
 
 import com.datastax.driver.core.PerHostPercentileTracker;
 import com.datastax.driver.core.QueryLogger;
@@ -108,7 +108,7 @@ public class QueryLoggerConfiguration {
         return new Builder();
     }
 
-    public static QueryLoggerConfiguration from(PropertiesConfiguration configuration) {
+    public static QueryLoggerConfiguration from(Configuration configuration) {
         QueryLoggerConfiguration.Builder builder = QueryLoggerConfiguration.builder();
 
         Optional<Long> constantThreshold = getOptionalIntegerFromConf(configuration, "cassandra.query.logger.constant.threshold")
@@ -142,11 +142,11 @@ public class QueryLoggerConfiguration {
         return builder.build();
     }
 
-    private static Optional<Integer> getOptionalIntegerFromConf(PropertiesConfiguration configuration, String key) {
+    private static Optional<Integer> getOptionalIntegerFromConf(Configuration configuration, String key) {
         return Optional.ofNullable(configuration.getInteger(key, null));
     }
 
-    private static Optional<Double> getOptionalDoubleFromConf(PropertiesConfiguration configuration, String key) {
+    private static Optional<Double> getOptionalDoubleFromConf(Configuration configuration, String key) {
         return Optional.ofNullable(configuration.getDouble(key, null));
     }
 

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backend/rabbitmq/RabbitMQConfiguration.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backend/rabbitmq/RabbitMQConfiguration.java
@@ -22,7 +22,7 @@ import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration.Configuration;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -81,7 +81,7 @@ public class RabbitMQConfiguration {
         return amqpUri -> managementUri -> new Builder(amqpUri, managementUri);
     }
 
-    public static RabbitMQConfiguration from(PropertiesConfiguration configuration) {
+    public static RabbitMQConfiguration from(Configuration configuration) {
         String uriAsString = configuration.getString(URI_PROPERTY_NAME);
         Preconditions.checkState(!Strings.isNullOrEmpty(uriAsString), "You need to specify the URI of RabbitMQ");
         URI amqpUri = checkURI(uriAsString);

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
+import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.init.CassandraZonedDateTimeModule;
 import org.apache.james.backends.cassandra.init.SessionWithInitializedTablesFactory;
@@ -95,7 +95,7 @@ public class CassandraSessionModule extends AbstractModule {
     @Singleton
     BatchSizes getBatchSizesConfiguration(PropertiesProvider propertiesProvider) {
         try {
-            PropertiesConfiguration configuration = propertiesProvider.getConfiguration(BATCHSIZES_FILE_NAME);
+            Configuration configuration = propertiesProvider.getConfiguration(BATCHSIZES_FILE_NAME);
             BatchSizes batchSizes = BatchSizes.builder()
                     .fetchMetadata(configuration.getInt("fetch.metadata", BatchSizes.DEFAULT_BATCH_SIZE))
                     .fetchHeaders(configuration.getInt("fetch.headers", BatchSizes.DEFAULT_BATCH_SIZE))

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/ElasticSearchConfiguration.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/ElasticSearchConfiguration.java
@@ -25,8 +25,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.james.backends.es.IndexName;
 import org.apache.james.backends.es.ReadAliasName;
 import org.apache.james.backends.es.WriteAliasName;
@@ -216,7 +217,7 @@ public class ElasticSearchConfiguration {
         .addHost(Host.from(LOCALHOST, DEFAULT_PORT))
         .build();
 
-    public static ElasticSearchConfiguration fromProperties(PropertiesConfiguration configuration) throws ConfigurationException {
+    public static ElasticSearchConfiguration fromProperties(Configuration configuration) throws ConfigurationException {
         return builder()
             .addHosts(getHosts(configuration))
             .indexMailboxName(computeMailboxIndexName(configuration))
@@ -233,7 +234,7 @@ public class ElasticSearchConfiguration {
             .build();
     }
 
-    public static Optional<IndexName> computeMailboxIndexName(PropertiesConfiguration configuration) {
+    public static Optional<IndexName> computeMailboxIndexName(Configuration configuration) {
         return OptionalUtils.or(
             Optional.ofNullable(configuration.getString(ELASTICSEARCH_INDEX_MAILBOX_NAME))
                 .map(IndexName::new),
@@ -241,7 +242,7 @@ public class ElasticSearchConfiguration {
                 .map(IndexName::new));
     }
 
-    public static Optional<WriteAliasName> computeMailboxWriteAlias(PropertiesConfiguration configuration) {
+    public static Optional<WriteAliasName> computeMailboxWriteAlias(Configuration configuration) {
         return OptionalUtils.or(
             Optional.ofNullable(configuration.getString(ELASTICSEARCH_ALIAS_WRITE_MAILBOX_NAME))
                 .map(WriteAliasName::new),
@@ -249,7 +250,7 @@ public class ElasticSearchConfiguration {
                 .map(WriteAliasName::new));
     }
 
-    public static Optional<ReadAliasName> computeMailboxReadAlias(PropertiesConfiguration configuration) {
+    public static Optional<ReadAliasName> computeMailboxReadAlias(Configuration configuration) {
         return OptionalUtils.or(
             Optional.ofNullable(configuration.getString(ELASTICSEARCH_ALIAS_READ_MAILBOX_NAME))
                 .map(ReadAliasName::new),
@@ -257,30 +258,30 @@ public class ElasticSearchConfiguration {
                 .map(ReadAliasName::new));
     }
 
-    public static Optional<IndexName> computeQuotaSearchIndexName(PropertiesConfiguration configuration) {
+    public static Optional<IndexName> computeQuotaSearchIndexName(Configuration configuration) {
         return Optional.ofNullable(configuration.getString(ELASTICSEARCH_INDEX_QUOTA_RATIO_NAME))
             .map(IndexName::new);
     }
 
-    public static Optional<WriteAliasName> computeQuotaSearchWriteAlias(PropertiesConfiguration configuration) {
+    public static Optional<WriteAliasName> computeQuotaSearchWriteAlias(Configuration configuration) {
         return Optional.ofNullable(configuration.getString(ELASTICSEARCH_ALIAS_WRITE_QUOTA_RATIO_NAME))
             .map(WriteAliasName::new);
     }
 
-    public static Optional<ReadAliasName> computeQuotaSearchReadAlias(PropertiesConfiguration configuration) {
+    public static Optional<ReadAliasName> computeQuotaSearchReadAlias(Configuration configuration) {
         return Optional.ofNullable(configuration.getString(ELASTICSEARCH_ALIAS_READ_QUOTA_RATIO_NAME))
                 .map(ReadAliasName::new);
     }
 
-    private static IndexAttachments provideIndexAttachments(PropertiesConfiguration configuration) {
+    private static IndexAttachments provideIndexAttachments(Configuration configuration) {
         if (configuration.getBoolean(ELASTICSEARCH_INDEX_ATTACHMENTS, DEFAULT_INDEX_ATTACHMENTS)) {
             return IndexAttachments.YES;
         }
         return IndexAttachments.NO;
     }
 
-    private static ImmutableList<Host> getHosts(PropertiesConfiguration propertiesReader) throws ConfigurationException {
-        PropertiesConfiguration.setDefaultListDelimiter(',');
+    private static ImmutableList<Host> getHosts(Configuration propertiesReader) throws ConfigurationException {
+        AbstractConfiguration.setDefaultListDelimiter(',');
         Optional<String> masterHost = Optional.ofNullable(
             propertiesReader.getString(ELASTICSEARCH_MASTER_HOST, null));
         Optional<Integer> masterPort = Optional.ofNullable(

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/ElasticSearchMailboxModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/ElasticSearchMailboxModule.java
@@ -29,8 +29,8 @@ import java.util.concurrent.ExecutorService;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.james.backends.es.ClientProviderImpl;
 import org.apache.james.backends.es.ElasticSearchIndexer;
 import org.apache.james.mailbox.elasticsearch.IndexAttachments;
@@ -104,7 +104,7 @@ public class ElasticSearchMailboxModule extends AbstractModule {
     @Singleton
     private ElasticSearchConfiguration getElasticSearchConfiguration(PropertiesProvider propertiesProvider) throws ConfigurationException {
         try {
-            PropertiesConfiguration configuration = propertiesProvider.getConfiguration(ELASTICSEARCH_CONFIGURATION_NAME);
+            Configuration configuration = propertiesProvider.getConfiguration(ELASTICSEARCH_CONFIGURATION_NAME);
             return ElasticSearchConfiguration.fromProperties(configuration);
         } catch (FileNotFoundException e) {
             LOGGER.warn("Could not find " + ELASTICSEARCH_CONFIGURATION_NAME + " configuration file. Using 127.0.0.1:9300 as contact point");

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/TikaConfigurationReader.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/TikaConfigurationReader.java
@@ -22,7 +22,7 @@ package org.apache.james.modules.mailbox;
 import java.time.Duration;
 import java.util.Optional;
 
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration.Configuration;
 import org.apache.james.mailbox.tika.TikaConfiguration;
 import org.apache.james.util.Size;
 import org.apache.james.util.TimeConverter;
@@ -38,7 +38,7 @@ public class TikaConfigurationReader {
     public static final String TIKA_CACHE_EVICTION_PERIOD = "tika.cache.eviction.period";
     public static final String TIKA_CACHE_WEIGHT_MAX = "tika.cache.weight.max";
 
-    public static TikaConfiguration readTikaConfiguration(PropertiesConfiguration configuration) {
+    public static TikaConfiguration readTikaConfiguration(Configuration configuration) {
         Optional<Boolean> enabled = Optional.ofNullable(
             configuration.getBoolean(TIKA_ENABLED, null));
 

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/TikaMailboxModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/TikaMailboxModule.java
@@ -24,8 +24,8 @@ import java.net.URISyntaxException;
 
 import javax.inject.Singleton;
 
+import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mailbox.store.extractor.DefaultTextExtractor;
 import org.apache.james.mailbox.tika.CachingTextExtractor;
@@ -65,7 +65,7 @@ public class TikaMailboxModule extends AbstractModule {
     @Singleton
     private TikaConfiguration getTikaConfiguration(PropertiesProvider propertiesProvider) throws ConfigurationException {
         try {
-            PropertiesConfiguration configuration = propertiesProvider.getConfiguration(TIKA_CONFIGURATION_NAME);
+            Configuration configuration = propertiesProvider.getConfiguration(TIKA_CONFIGURATION_NAME);
 
             return TikaConfigurationReader.readTikaConfiguration(configuration);
         } catch (FileNotFoundException e) {

--- a/server/container/guice/configuration/src/main/java/org/apache/james/utils/PropertiesProvider.java
+++ b/server/container/guice/configuration/src/main/java/org/apache/james/utils/PropertiesProvider.java
@@ -24,6 +24,7 @@ import java.io.FileNotFoundException;
 
 import javax.inject.Inject;
 
+import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.james.filesystem.api.FileSystem;
@@ -40,7 +41,7 @@ public class PropertiesProvider {
         this.fileSystem = fileSystem;
     }
 
-    public PropertiesConfiguration getConfiguration(String fileName) throws FileNotFoundException, ConfigurationException {
+    public Configuration getConfiguration(String fileName) throws FileNotFoundException, ConfigurationException {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(fileName));
         File file = fileSystem.getFile(FileSystem.FILE_PROTOCOL_AND_CONF + fileName + ".properties");
         if (!file.exists()) {

--- a/server/container/guice/es-metric-reporter/src/main/java/org/apache/james/modules/server/ElasticSearchMetricReporterModule.java
+++ b/server/container/guice/es-metric-reporter/src/main/java/org/apache/james/modules/server/ElasticSearchMetricReporterModule.java
@@ -22,9 +22,9 @@ package org.apache.james.modules.server;
 import java.io.FileNotFoundException;
 import java.util.List;
 
+import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
-import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.james.lifecycle.api.Configurable;
 import org.apache.james.metrics.es.ESMetricReporter;
@@ -58,7 +58,7 @@ public class ElasticSearchMetricReporterModule extends AbstractModule {
     @Provides
     public ESReporterConfiguration provideConfiguration(PropertiesProvider propertiesProvider) throws ConfigurationException {
         try {
-            PropertiesConfiguration propertiesReader = propertiesProvider.getConfiguration(ELASTICSEARCH_CONFIGURATION_NAME);
+            Configuration propertiesReader = propertiesProvider.getConfiguration(ELASTICSEARCH_CONFIGURATION_NAME);
 
             if (isMetricEnable(propertiesReader)) {
                 return ESReporterConfiguration.builder()
@@ -77,12 +77,12 @@ public class ElasticSearchMetricReporterModule extends AbstractModule {
             .build();
     }
 
-    private String locateHost(PropertiesConfiguration propertiesReader) {
+    private String locateHost(Configuration propertiesReader) {
         return propertiesReader.getString("elasticsearch.http.host",
             propertiesReader.getString(ELASTICSEARCH_MASTER_HOST));
     }
 
-    private boolean isMetricEnable(PropertiesConfiguration propertiesReader) {
+    private boolean isMetricEnable(Configuration propertiesReader) {
         return propertiesReader.getBoolean("elasticsearch.metrics.reports.enabled", DEFAULT_DISABLE);
     }
 

--- a/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JmxConfiguration.java
+++ b/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JmxConfiguration.java
@@ -22,7 +22,7 @@ package org.apache.james.modules.server;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration.Configuration;
 import org.apache.james.util.Host;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -38,7 +38,7 @@ public class JmxConfiguration {
     public static final JmxConfiguration DEFAULT_CONFIGURATION = new JmxConfiguration(ENABLED, Optional.of(Host.from(LOCALHOST, DEFAULT_PORT)));
     public static final JmxConfiguration DISABLED = new JmxConfiguration(!ENABLED, Optional.empty());
 
-    public static JmxConfiguration fromProperties(PropertiesConfiguration configuration) {
+    public static JmxConfiguration fromProperties(Configuration configuration) {
         boolean jmxEnabled = configuration.getBoolean("jmx.enabled", true);
         if (!jmxEnabled) {
             return DISABLED;

--- a/server/container/guice/jpa-common-guice/src/main/java/org/apache/james/modules/data/JPAEntityManagerModule.java
+++ b/server/container/guice/jpa-common-guice/src/main/java/org/apache/james/modules/data/JPAEntityManagerModule.java
@@ -27,8 +27,8 @@ import javax.inject.Singleton;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
+import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.james.backends.jpa.JPAConstants;
 import org.apache.james.utils.PropertiesProvider;
 
@@ -66,7 +66,7 @@ public class JPAEntityManagerModule extends AbstractModule {
     @Provides
     @Singleton
     JPAConfiguration provideConfiguration(PropertiesProvider propertiesProvider) throws FileNotFoundException, ConfigurationException {
-        PropertiesConfiguration dataSource = propertiesProvider.getConfiguration("james-database");
+        Configuration dataSource = propertiesProvider.getConfiguration("james-database");
         return JPAConfiguration.builder()
                 .driverName(dataSource.getString("database.driverClassName"))
                 .driverURL(dataSource.getString("database.url"))

--- a/server/container/guice/mailbox-plugin-spamassassin/src/main/java/org/apache/james/modules/spamassassin/SpamAssassinConfigurationLoader.java
+++ b/server/container/guice/mailbox-plugin-spamassassin/src/main/java/org/apache/james/modules/spamassassin/SpamAssassinConfigurationLoader.java
@@ -21,7 +21,7 @@ package org.apache.james.modules.spamassassin;
 
 import java.util.Optional;
 
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration.Configuration;
 import org.apache.james.mailbox.spamassassin.SpamAssassinConfiguration;
 import org.apache.james.util.Host;
 
@@ -36,12 +36,12 @@ public class SpamAssassinConfigurationLoader {
         return new SpamAssassinConfiguration(Optional.empty());
     }
 
-    public static SpamAssassinConfiguration fromProperties(PropertiesConfiguration configuration) {
+    public static SpamAssassinConfiguration fromProperties(Configuration configuration) {
         Host host = getHost(configuration);
         return new SpamAssassinConfiguration(Optional.of(host));
     }
 
-    private static Host getHost(PropertiesConfiguration propertiesReader) {
+    private static Host getHost(Configuration propertiesReader) {
         return Host.from(propertiesReader.getString(SPAMASSASSIN_HOST, DEFAULT_HOST), 
                 propertiesReader.getInteger(SPAMASSASSIN_PORT, DEFAULT_PORT));
     }

--- a/server/container/guice/mailbox-plugin-spamassassin/src/main/java/org/apache/james/modules/spamassassin/SpamAssassinListenerModule.java
+++ b/server/container/guice/mailbox-plugin-spamassassin/src/main/java/org/apache/james/modules/spamassassin/SpamAssassinListenerModule.java
@@ -23,8 +23,8 @@ import java.io.FileNotFoundException;
 
 import javax.inject.Singleton;
 
+import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.james.mailbox.spamassassin.SpamAssassinConfiguration;
 import org.apache.james.utils.PropertiesProvider;
 import org.slf4j.Logger;
@@ -47,7 +47,7 @@ public class SpamAssassinListenerModule extends AbstractModule {
     @Singleton
     private SpamAssassinConfiguration getSpamAssassinConfiguration(PropertiesProvider propertiesProvider) throws ConfigurationException {
         try {
-            PropertiesConfiguration configuration = propertiesProvider.getConfiguration(SPAMASSASSIN_CONFIGURATION_NAME);
+            Configuration configuration = propertiesProvider.getConfiguration(SPAMASSASSIN_CONFIGURATION_NAME);
             return SpamAssassinConfigurationLoader.fromProperties(configuration);
         } catch (FileNotFoundException e) {
             LOGGER.warn("Could not find " + SPAMASSASSIN_CONFIGURATION_NAME + " configuration file. Disabling this service.");

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPModule.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPModule.java
@@ -25,8 +25,8 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.james.filesystem.api.FileSystem;
 import org.apache.james.jmap.event.PropagateLookupRightListener;
@@ -113,7 +113,7 @@ public class JMAPModule extends AbstractModule {
     @Singleton
     JMAPConfiguration provideConfiguration(PropertiesProvider propertiesProvider, FileSystem fileSystem) throws ConfigurationException, IOException {
         try {
-            PropertiesConfiguration configuration = propertiesProvider.getConfiguration("jmap");
+            Configuration configuration = propertiesProvider.getConfiguration("jmap");
             return JMAPConfiguration.builder()
                 .enabled(configuration.getBoolean("enabled", true))
                 .keystore(configuration.getString("tls.keystoreURL"))

--- a/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/WebAdminServerModule.java
+++ b/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/WebAdminServerModule.java
@@ -26,8 +26,8 @@ import java.io.FileNotFoundException;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.james.jwt.JwtTokenVerifier;
 import org.apache.james.lifecycle.api.Configurable;
 import org.apache.james.utils.ConfigurationPerformer;
@@ -83,7 +83,7 @@ public class WebAdminServerModule extends AbstractModule {
     @Provides
     public WebAdminConfiguration provideWebAdminConfiguration(PropertiesProvider propertiesProvider) throws Exception {
         try {
-            PropertiesConfiguration configurationFile = propertiesProvider.getConfiguration("webadmin");
+            Configuration configurationFile = propertiesProvider.getConfiguration("webadmin");
             return WebAdminConfiguration.builder()
                 .enable(configurationFile.getBoolean("enabled", DEFAULT_DISABLED))
                 .port(new FixedPortSupplier(configurationFile.getInt("port", WebAdminServer.DEFAULT_PORT)))
@@ -102,7 +102,7 @@ public class WebAdminServerModule extends AbstractModule {
     public AuthenticationFilter providesAuthenticationFilter(PropertiesProvider propertiesProvider,
                                                              JwtTokenVerifier jwtTokenVerifier) throws Exception {
         try {
-            PropertiesConfiguration configurationFile = propertiesProvider.getConfiguration("webadmin");
+            Configuration configurationFile = propertiesProvider.getConfiguration("webadmin");
             if (configurationFile.getBoolean("jwt.enabled", DEFAULT_JWT_DISABLED)) {
                 return new JwtFilter(jwtTokenVerifier);
             }
@@ -112,7 +112,7 @@ public class WebAdminServerModule extends AbstractModule {
         }
     }
 
-    private Optional<TlsConfiguration> readHttpsConfiguration(PropertiesConfiguration configurationFile) {
+    private Optional<TlsConfiguration> readHttpsConfiguration(Configuration configurationFile) {
         boolean enabled = configurationFile.getBoolean("https.enabled", DEFAULT_HTTPS_DISABLED);
         if (enabled) {
             return Optional.of(TlsConfiguration.builder()

--- a/server/container/guice/rabbitmq/src/main/java/org/apache/james/modules/rabbitmq/RabbitMQModule.java
+++ b/server/container/guice/rabbitmq/src/main/java/org/apache/james/modules/rabbitmq/RabbitMQModule.java
@@ -22,8 +22,8 @@ import java.io.FileNotFoundException;
 
 import javax.inject.Singleton;
 
+import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.james.backend.rabbitmq.RabbitMQConfiguration;
 import org.apache.james.utils.PropertiesProvider;
 import org.slf4j.Logger;
@@ -46,7 +46,7 @@ public class RabbitMQModule extends AbstractModule {
     @Singleton
     private RabbitMQConfiguration getMailQueueConfiguration(PropertiesProvider propertiesProvider) throws ConfigurationException {
         try {
-            PropertiesConfiguration configuration = propertiesProvider.getConfiguration(RABBITMQ_CONFIGURATION_NAME);
+            Configuration configuration = propertiesProvider.getConfiguration(RABBITMQ_CONFIGURATION_NAME);
             return RabbitMQConfiguration.from(configuration);
         } catch (FileNotFoundException e) {
             LOGGER.error("Could not find " + RABBITMQ_CONFIGURATION_NAME + " configuration file.");


### PR DESCRIPTION
This makes testing easier through subclassing of PropertiesProvider
by allowing to return an in memory configuration such as a
MapConfiguration instead of being bound to the concrete
PropertiesConfiguration implementation.