### PR TITLE
Adds mailet utilities

### DIFF
--- a/mailet/pom.xml
+++ b/mailet/pom.xml
@@ -51,8 +51,8 @@
         <module>crypto</module>
         <module>icalendar</module>
         <module>mailetdocs-maven-plugin</module>
-        <module>standard</module>
         <module>scala</module>
+        <module>standard</module>
         <module>test</module>
     </modules>
 

--- a/mailet/pom.xml
+++ b/mailet/pom.xml
@@ -52,6 +52,7 @@
         <module>icalendar</module>
         <module>mailetdocs-maven-plugin</module>
         <module>standard</module>
+        <module>scala</module>
         <module>test</module>
     </modules>
 

--- a/mailet/scala/pom.xml
+++ b/mailet/scala/pom.xml
@@ -17,9 +17,7 @@
   ~ specific language governing permissions and limitations     ~
   ~ under the License.                                          ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -34,8 +32,7 @@
 
     <name>Apache James :: Scala Mailets</name>
     <description>Apache James Scala Mailets is a small collection of general purpose mailets
-        with limited dependencies. These mailets can be used in any mailet container.
-    </description>
+        with limited dependencies. These mailets can be used in any mailet container.</description>
     <url>http://james.apache.org/mailet/standard/</url>
     <inceptionYear>2018</inceptionYear>
 
@@ -50,125 +47,23 @@
 
     <dependencies>
         <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>apache-mailet-base</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>apache-mailet-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>apache-mime4j-dom</artifactId>
-            <version>${apache-mime4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-mailets</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>james-server-dnsservice-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-util</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-testing</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>javax-mail-extension</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.rabbitmq</groupId>
-            <artifactId>amqp-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>net.javacrumbs.json-unit</groupId>
-            <artifactId>json-unit-assertj</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>nl.jqno.equalsverifier</groupId>
-            <artifactId>equalsverifier</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient-osgi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-guava</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-launcher</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>james-server-mailets</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <version>${scala.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_${scala.compat.version}</artifactId>
-            <version>3.0.5</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -194,8 +89,6 @@
     </dependencies>
 
     <build>
-        <sourceDirectory>src/main/scala</sourceDirectory>
-        <testSourceDirectory>src/test/scala</testSourceDirectory>
         <plugins>
             <plugin>
                 <!-- see http://davidb.github.com/scala-maven-plugin -->
@@ -229,10 +122,10 @@
                 <executions>
                     <execution>
                         <id>add-source</id>
-                        <phase>generate-sources</phase>
                         <goals>
                             <goal>add-source</goal>
                         </goals>
+                        <phase>generate-sources</phase>
                         <configuration>
                             <sources>
                                 <source>src/main/scala</source>
@@ -241,10 +134,10 @@
                     </execution>
                     <execution>
                         <id>add-test-source</id>
-                        <phase>generate-sources</phase>
                         <goals>
                             <goal>add-test-source</goal>
                         </goals>
+                        <phase>generate-sources</phase>
                         <configuration>
                             <sources>
                                 <source>src/test/scala</source>
@@ -254,5 +147,7 @@
                 </executions>
             </plugin>
         </plugins>
+        <sourceDirectory>src/main/scala</sourceDirectory>
+        <testSourceDirectory>src/test/scala</testSourceDirectory>
     </build>
 </project>

--- a/mailet/scala/pom.xml
+++ b/mailet/scala/pom.xml
@@ -186,6 +186,11 @@
             <version>${spec2.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.threeten</groupId>
+            <artifactId>threeten-extra</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/mailet/scala/pom.xml
+++ b/mailet/scala/pom.xml
@@ -1,0 +1,253 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Licensed to the Apache Software Foundation (ASF) under one  ~
+  ~ or more contributor license agreements.  See the NOTICE file~
+  ~ distributed with this work for additional information       ~
+  ~ regarding copyright ownership.  The ASF licenses this file  ~
+  ~ to you under the Apache License, Version 2.0 (the           ~
+  ~ "License"); you may not use this file except in compliance  ~
+  ~ with the License.  You may obtain a copy of the License at  ~
+  ~                                                             ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0                ~
+  ~                                                             ~
+  ~ Unless required by applicable law or agreed to in writing,  ~
+  ~ software distributed under the License is distributed on an ~
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY      ~
+  ~ KIND, either express or implied.  See the License for the   ~
+  ~ specific language governing permissions and limitations     ~
+  ~ under the License.                                          ~
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.james</groupId>
+        <artifactId>apache-mailet</artifactId>
+        <version>3.2.0-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>apache-mailet-scala</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>Apache James :: Scala Mailets</name>
+    <description>Apache James Scala Mailets is a small collection of general purpose mailets
+        with limited dependencies. These mailets can be used in any mailet container.
+    </description>
+    <url>http://james.apache.org/mailet/standard/</url>
+    <inceptionYear>2018</inceptionYear>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <encoding>UTF-8</encoding>
+        <scala.version>2.12.6</scala.version>
+        <scala.compat.version>2.12</scala.compat.version>
+        <spec2.version>4.2.0</spec2.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-mailet-base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-mailet-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-mime4j-dom</artifactId>
+            <version>${apache-mime4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-mailets</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-dnsservice-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>javax-mail-extension</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.rabbitmq</groupId>
+            <artifactId>amqp-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient-osgi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-guava</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_${scala.compat.version}</artifactId>
+            <version>3.0.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.compat.version}</artifactId>
+            <version>${spec2.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.compat.version}</artifactId>
+            <version>${spec2.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/scala</sourceDirectory>
+        <testSourceDirectory>src/test/scala</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <!-- see http://davidb.github.com/scala-maven-plugin -->
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>3.3.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <args>
+                                <arg>-dependencyfile</arg>
+                                <arg>${project.build.directory}/.scala_dependencies</arg>
+                            </args>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>${james.groupId}</groupId>
+                <artifactId>maven-mailetdocs-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/main/scala</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-test-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/test/scala</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/mailet/scala/src/main/scala/org/apache/james/transport/mailets/Throttler.scala
+++ b/mailet/scala/src/main/scala/org/apache/james/transport/mailets/Throttler.scala
@@ -1,0 +1,93 @@
+/** **************************************************************
+  * Licensed to the Apache Software Foundation (ASF) under one   *
+  * or more contributor license agreements.  See the NOTICE file *
+  * distributed with this work for additional information        *
+  * regarding copyright ownership.  The ASF licenses this file   *
+  * to you under the Apache License, Version 2.0 (the            *
+  * "License"); you may not use this file except in compliance   *
+  * with the License.  You may obtain a copy of the License at   *
+  * *
+  * http://www.apache.org/licenses/LICENSE-2.0                 *
+  * *
+  * Unless required by applicable law or agreed to in writing,   *
+  * software distributed under the License is distributed on an  *
+  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+  * KIND, either express or implied.  See the License for the    *
+  * specific language governing permissions and limitations      *
+  * under the License.                                           *
+  * ***************************************************************/
+
+package org.apache.james.transport.mailets
+
+import java.time.{Clock, Instant}
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.util.Try
+
+import org.apache.james.core.MailAddress
+import org.apache.mailet.{Mail, Mailet, MailetConfig, MailetException}
+
+object Throttler {
+  val PERIOD_PARAM = "period"
+  val COUNT_PARAM = "count"
+}
+
+class Throttler(clock: Clock = Clock.systemUTC()) extends Mailet {
+  private var config: MailetConfig = _
+  private val safeRates: AtomicReference[Map[MailAddress, Seq[Instant]]] =
+    new AtomicReference(Map.empty.withDefaultValue(Seq.empty))
+
+  private var period: FiniteDuration = _
+  private var count: Int = _
+
+  override def init(config: MailetConfig): Unit = {
+    this.period = parsePeriod(config)
+    this.count = parseCount(config)
+    this.config = config
+  }
+
+  private def parseCount(config: MailetConfig) = {
+    Try(config.getInitParameter(Throttler.COUNT_PARAM).toInt)
+      .getOrElse(
+        throw new MailetException(
+          s"Missing or invalid configuration parameter ${Throttler.COUNT_PARAM} " +
+            s"for mailet ${config.getMailetName} ($getMailetInfo)"))
+  }
+
+  private def parsePeriod(config: MailetConfig) = {
+    val duration = Try(Duration(config.getInitParameter(Throttler.PERIOD_PARAM)))
+      .getOrElse(
+        throw new MailetException(
+          s"Missing or invalid configuration parameter ${Throttler.PERIOD_PARAM} " +
+            s"for mailet ${config.getMailetName} ($getMailetInfo)"))
+    if (duration.isFinite()) {
+      FiniteDuration(duration.toMillis, TimeUnit.MILLISECONDS)
+    } else {
+      throw new MailetException(s"${Throttler.PERIOD_PARAM} must be a finite duration")
+    }
+  }
+
+  override def service(mail: Mail): Unit = {
+    val sender = mail.getSender
+    val now = Instant.now(clock)
+    val limit = now.minusMillis(period.toMillis)
+    val updatedRates = safeRates.updateAndGet(rates => {
+      val instants: Seq[Instant] = rates(sender)
+      rates + (sender -> (now +: instants.filter(_.isAfter(limit))))
+    })
+
+    if (updatedRates(sender).size > count) {
+      mail.setState(Mail.ERROR)
+      mail.setErrorMessage("454 Throttling – Maximum sending rate exceeded")
+    }
+
+  }
+
+  override def destroy(): Unit = ()
+
+  override def getMailetConfig: MailetConfig = config
+
+  override def getMailetInfo: String = "Email Throttler"
+}

--- a/mailet/scala/src/main/scala/org/apache/james/transport/mailets/Throttler.scala
+++ b/mailet/scala/src/main/scala/org/apache/james/transport/mailets/Throttler.scala
@@ -34,6 +34,52 @@ object Throttler {
   val COUNT_PARAM = "count"
 }
 
+/**
+  * <p>This mailet keeps track of the sending rate for each sender
+  * going through the email server (instance based). It rejects emails with
+  * <i>"454 Throttling – Maximum sending rate exceeded"</i> when the rate goes
+  * over a fixed limit.</p>
+  * <p/>
+  * <p>The tracking is done using a list of timestamps of messages previously
+  * seen for each individual sender. This means that allowing 3600 messages per
+  * hour may end up consuming more memory (upto 3600 java.time.Instant instances
+  * per sender if they continuously send emails) than 600 messages per 10
+  * minutes</p>
+  * <p/>
+  * <p>This mailet expects 2 configuration parameters :
+  * <ul>
+  * <li><i>count</i> is expected to be an integer
+  * <li><i>period</i> is expected to be an finite duration greater than 1ms.
+  * It can be expressed using the scala duration DSL.
+  * </ul>
+  *</p>
+  * <pre><code>
+  * &lt;mailet match=&quot;All&quot; class=&quot;&lt;Throttler&gt;&quot;&gt;
+  * &lt;period&gt;1 minute&lt;/period&gt;
+  * &lt;count&gt;10&lt;/count&gt;
+  * &lt;/mailet&gt;
+  * </code></pre>
+  *
+  * <p>The scala Duration dsl expects a number (integer or fractional) followed by
+  * a unit. The unit can be one of
+  *<ul>
+  * <li> d|day|days, h|hour|hours
+  * <li> min|minute|minutes
+  * <li> s|second|seconds
+  * <li> ms|milli|millis|millisecond|milliseconds
+  * <li> µs|micro|micros|microsecond|microseconds
+  * <li> ns|nano|nanos|nanosecond|nanoseconds
+  *</ul>
+  * for exemple the following strings are valid durations:</p>
+  *<pre><code>
+  * 10 seconds
+  * 1 day
+  * 8h
+  * 100ns
+  * 80millis
+  *</code></pre>
+  *
+  */
 class Throttler(clock: Clock = Clock.systemUTC()) extends Mailet {
   private var config: MailetConfig = _
   private val safeRates: AtomicReference[Map[MailAddress, Seq[Instant]]] =
@@ -48,24 +94,28 @@ class Throttler(clock: Clock = Clock.systemUTC()) extends Mailet {
     this.config = config
   }
 
-  private def parseCount(config: MailetConfig) = {
-    Try(config.getInitParameter(Throttler.COUNT_PARAM).toInt)
-      .getOrElse(
-        throw new MailetException(
-          s"Missing or invalid configuration parameter ${Throttler.COUNT_PARAM} " +
-            s"for mailet ${config.getMailetName} ($getMailetInfo)"))
-  }
+  private def parseCount(config: MailetConfig): Int = Try(config.getInitParameter(Throttler.COUNT_PARAM).toInt)
+    .getOrElse(
+      throw new MailetException(
+        s"Missing or invalid configuration parameter ${Throttler.COUNT_PARAM} " +
+          s"for mailet ${config.getMailetName} ($getMailetInfo)"))
 
-  private def parsePeriod(config: MailetConfig) = {
+  private def parsePeriod(config: MailetConfig): FiniteDuration = {
     val duration = Try(Duration(config.getInitParameter(Throttler.PERIOD_PARAM)))
       .getOrElse(
         throw new MailetException(
           s"Missing or invalid configuration parameter ${Throttler.PERIOD_PARAM} " +
             s"for mailet ${config.getMailetName} ($getMailetInfo)"))
     if (duration.isFinite()) {
-      FiniteDuration(duration.toMillis, TimeUnit.MILLISECONDS)
+      if (duration.toMillis > 0) {
+        FiniteDuration(duration.toMillis, TimeUnit.MILLISECONDS)
+      } else {
+        throw new MailetException(
+          s"${Throttler.PERIOD_PARAM} must be a finite duration greater or equal to 1ms")
+      }
     } else {
-      throw new MailetException(s"${Throttler.PERIOD_PARAM} must be a finite duration")
+      throw new MailetException(
+        s"${Throttler.PERIOD_PARAM} must be a finite duration greater or equal to 1ms")
     }
   }
 
@@ -74,7 +124,7 @@ class Throttler(clock: Clock = Clock.systemUTC()) extends Mailet {
     val now = Instant.now(clock)
     val limit = now.minusMillis(period.toMillis)
     val updatedRates = safeRates.updateAndGet(rates => {
-      val instants: Seq[Instant] = rates(sender)
+      val instants = rates(sender)
       rates + (sender -> (now +: instants.filter(_.isAfter(limit))))
     })
 
@@ -89,5 +139,5 @@ class Throttler(clock: Clock = Clock.systemUTC()) extends Mailet {
 
   override def getMailetConfig: MailetConfig = config
 
-  override def getMailetInfo: String = "Email Throttler"
+  override def getMailetInfo = "Email Throttler"
 }

--- a/mailet/scala/src/main/scala/org/apache/james/transport/mailets/XOriginatingIpInNetwork.scala
+++ b/mailet/scala/src/main/scala/org/apache/james/transport/mailets/XOriginatingIpInNetwork.scala
@@ -19,7 +19,7 @@
 
 package org.apache.james.transport.mailets
 
-import java.util.Collection
+import java.util.{Collection => JUCollection}
 
 import org.apache.james.core.MailAddress
 import org.apache.james.transport.matchers.AbstractNetworkMatcher
@@ -29,21 +29,24 @@ object XOriginatingIpInNetwork {
   val X_ORIGINATING_IP: String = "X-Originating-IP"
 }
 
+/**
+  * <p>
+  * Checks the first X_ORIGINATING_IP IP address against a comma- delimited list
+  * of IP addresses, domain names or sub-nets.
+  * </p>
+  * <p>
+  * See AbstractNetworkMatcher for details on how to specify entries.
+  * </p>
+  */
 class XOriginatingIpInNetwork extends AbstractNetworkMatcher {
-  override def `match`(mail: Mail): Collection[MailAddress] = {
-    matchOnOriginatingAddr(mail).orNull
-  }
+  override def `match`(mail: Mail): JUCollection[MailAddress] = matchOnOriginatingAddr(mail).orNull
 
-  def matchOnOriginatingAddr(mail: Mail): Option[Collection[MailAddress]] = {
-    Option(mail.getMessage
-      .getHeader(XOriginatingIpInNetwork.X_ORIGINATING_IP))
-      .flatMap(_.headOption)
-      .map(normalizeIP)
-      .filter(matchNetwork)
-      .map(_ => mail.getRecipients)
-  }
+  def matchOnOriginatingAddr(mail: Mail): Option[JUCollection[MailAddress]] = Option(mail.getMessage
+    .getHeader(XOriginatingIpInNetwork.X_ORIGINATING_IP))
+    .flatMap(_.headOption)
+    .map(normalizeIP)
+    .filter(matchNetwork)
+    .map(_ => mail.getRecipients)
 
-  private def normalizeIP(ip: String): String = {
-    ip.replace("[", "").replace("]", "")
-  }
+  private def normalizeIP(ip: String): String = ip.replace("[", "").replace("]", "")
 }

--- a/mailet/scala/src/main/scala/org/apache/james/transport/mailets/XOriginatingIpInNetwork.scala
+++ b/mailet/scala/src/main/scala/org/apache/james/transport/mailets/XOriginatingIpInNetwork.scala
@@ -1,0 +1,49 @@
+/** **************************************************************
+  * Licensed to the Apache Software Foundation (ASF) under one   *
+  * or more contributor license agreements.  See the NOTICE file *
+  * distributed with this work for additional information        *
+  * regarding copyright ownership.  The ASF licenses this file   *
+  * to you under the Apache License, Version 2.0 (the            *
+  * "License"); you may not use this file except in compliance   *
+  * with the License.  You may obtain a copy of the License at   *
+  * *
+  * http://www.apache.org/licenses/LICENSE-2.0                 *
+  * *
+  * Unless required by applicable law or agreed to in writing,   *
+  * software distributed under the License is distributed on an  *
+  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+  * KIND, either express or implied.  See the License for the    *
+  * specific language governing permissions and limitations      *
+  * under the License.                                           *
+  * ***************************************************************/
+
+package org.apache.james.transport.mailets
+
+import java.util.Collection
+
+import org.apache.james.core.MailAddress
+import org.apache.james.transport.matchers.AbstractNetworkMatcher
+import org.apache.mailet.Mail
+
+object XOriginatingIpInNetwork {
+  val X_ORIGINATING_IP: String = "X-Originating-IP"
+}
+
+class XOriginatingIpInNetwork extends AbstractNetworkMatcher {
+  override def `match`(mail: Mail): Collection[MailAddress] = {
+    matchOnOriginatingAddr(mail).orNull
+  }
+
+  def matchOnOriginatingAddr(mail: Mail): Option[Collection[MailAddress]] = {
+    Option(mail.getMessage
+      .getHeader(XOriginatingIpInNetwork.X_ORIGINATING_IP))
+      .flatMap(_.headOption)
+      .map(normalizeIP)
+      .filter(matchNetwork)
+      .map(_ => mail.getRecipients)
+  }
+
+  private def normalizeIP(ip: String): String = {
+    ip.replace("[", "").replace("]", "")
+  }
+}

--- a/mailet/scala/src/test/scala/org/apache/james/transport/mailets/ThrottlerSpec.scala
+++ b/mailet/scala/src/test/scala/org/apache/james/transport/mailets/ThrottlerSpec.scala
@@ -67,7 +67,16 @@ class ThrottlerSpec extends Specification {
       val defaultConfig = FakeMailetConfig.builder()
         .mailetName("throttler")
         .setProperty("period", "foo")
-        .setProperty("count", "a")
+        .setProperty("count", "1")
+        .build()
+      val throttler = new Throttler()
+      throttler.init(defaultConfig) should throwA[MailetException]
+    }
+    "not start if the period parameter is too small" in {
+      val defaultConfig = FakeMailetConfig.builder()
+        .mailetName("throttler")
+        .setProperty("period", "1ns")
+        .setProperty("count", "1")
         .build()
       val throttler = new Throttler()
       throttler.init(defaultConfig) should throwA[MailetException]

--- a/mailet/scala/src/test/scala/org/apache/james/transport/mailets/ThrottlerSpec.scala
+++ b/mailet/scala/src/test/scala/org/apache/james/transport/mailets/ThrottlerSpec.scala
@@ -1,0 +1,114 @@
+/** **************************************************************
+  * Licensed to the Apache Software Foundation (ASF) under one   *
+  * or more contributor license agreements.  See the NOTICE file *
+  * distributed with this work for additional information        *
+  * regarding copyright ownership.  The ASF licenses this file   *
+  * to you under the Apache License, Version 2.0 (the            *
+  * "License"); you may not use this file except in compliance   *
+  * with the License.  You may obtain a copy of the License at   *
+  * *
+  * http://www.apache.org/licenses/LICENSE-2.0                 *
+  * *
+  * Unless required by applicable law or agreed to in writing,   *
+  * software distributed under the License is distributed on an  *
+  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+  * KIND, either express or implied.  See the License for the    *
+  * specific language governing permissions and limitations      *
+  * under the License.                                           *
+  * ***************************************************************/
+
+package org.apache.james.transport.mailets
+
+import java.time.{Instant, ZoneOffset}
+
+import org.apache.mailet.base.test.{FakeMail, FakeMailetConfig}
+import org.apache.mailet.{Mail, MailetException}
+import org.specs2.mutable.Specification
+import org.threeten.extra.MutableClock
+
+class ThrottlerSpec extends Specification {
+  val defaultConfig = FakeMailetConfig.builder()
+    .mailetName("throttler")
+    .setProperty("period", "1s")
+    .setProperty("count", "1")
+    .build()
+
+  val JANE = "jane@example.com"
+  val JOHN = "john@example.com"
+
+  "Throttler " should {
+    "not start if the count parameter is absent from the config" in {
+      val defaultConfig = FakeMailetConfig.builder()
+        .mailetName("throttler")
+        .setProperty("period", "1s")
+        .build()
+      val throttler = new Throttler()
+      throttler.init(defaultConfig) should throwA[MailetException]
+
+    }
+    "not start if the period parameter is absent from the config" in {
+      val defaultConfig = FakeMailetConfig.builder()
+        .mailetName("throttler")
+        .setProperty("count", "1")
+        .build()
+      val throttler = new Throttler()
+      throttler.init(defaultConfig) should throwA[MailetException]
+    }
+    "not start if the count parameter is not a number" in {
+      val defaultConfig = FakeMailetConfig.builder()
+        .mailetName("throttler")
+        .setProperty("period", "1s")
+        .setProperty("count", "a")
+        .build()
+      val throttler = new Throttler()
+      throttler.init(defaultConfig) should throwA[MailetException]
+    }
+    "not start if the period parameter is not a duration" in {
+      val defaultConfig = FakeMailetConfig.builder()
+        .mailetName("throttler")
+        .setProperty("period", "foo")
+        .setProperty("count", "a")
+        .build()
+      val throttler = new Throttler()
+      throttler.init(defaultConfig) should throwA[MailetException]
+    }
+    "allow mail to pass if rate limit is not exceeded" in {
+      val clock = MutableClock.of(Instant.now(), ZoneOffset.UTC)
+      val throttler = new Throttler(clock)
+      throttler.init(defaultConfig)
+
+      val mail = FakeMail.builder()
+        .sender(JANE)
+        .recipient(JOHN)
+        .state(Mail.DEFAULT)
+        .build()
+
+      throttler.service(mail)
+
+      mail.getState must be_===(Mail.DEFAULT)
+    }
+    "allow mail to pass if rate limit is exceeded" in {
+      val clock = MutableClock.of(Instant.now(), ZoneOffset.UTC)
+      val throttler = new Throttler(clock)
+      throttler.init(defaultConfig)
+
+      val acceptedMail = FakeMail.builder()
+        .sender(JANE)
+        .recipient(JOHN)
+        .state(Mail.DEFAULT)
+        .build()
+      val rejectedMail = FakeMail.builder()
+        .sender(JANE)
+        .recipient(JOHN)
+        .state(Mail.DEFAULT)
+        .build()
+
+      throttler.service(acceptedMail)
+      throttler.service(rejectedMail)
+
+      acceptedMail.getState must be_===(Mail.DEFAULT)
+      rejectedMail.getState must be_===(Mail.ERROR)
+      rejectedMail.getErrorMessage must contain("454 Throttling")
+    }
+  }
+}

--- a/mailet/scala/src/test/scala/org/apache/james/transport/mailets/XOriginatingIpInNetworkSpec.scala
+++ b/mailet/scala/src/test/scala/org/apache/james/transport/mailets/XOriginatingIpInNetworkSpec.scala
@@ -1,0 +1,119 @@
+/** **************************************************************
+  * Licensed to the Apache Software Foundation (ASF) under one   *
+  * or more contributor license agreements.  See the NOTICE file *
+  * distributed with this work for additional information        *
+  * regarding copyright ownership.  The ASF licenses this file   *
+  * to you under the Apache License, Version 2.0 (the            *
+  * "License"); you may not use this file except in compliance   *
+  * with the License.  You may obtain a copy of the License at   *
+  * *
+  * http://www.apache.org/licenses/LICENSE-2.0                 *
+  * *
+  * Unless required by applicable law or agreed to in writing,   *
+  * software distributed under the License is distributed on an  *
+  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+  * KIND, either express or implied.  See the License for the    *
+  * specific language governing permissions and limitations      *
+  * under the License.                                           *
+  * ***************************************************************/
+
+package org.apache.james.transport.mailets
+
+import scala.collection.JavaConverters._
+
+import org.apache.james.core.MailAddress
+import org.apache.james.core.builder.MimeMessageBuilder
+import org.apache.james.dnsservice.api.{DNSService, InMemoryDNSService}
+import org.apache.james.transport.mailets.XOriginatingIpInNetwork.X_ORIGINATING_IP
+import org.apache.mailet.base.test.{FakeMail, FakeMatcherConfig}
+import org.junit.runner.RunWith
+import org.specs2.matcher.Matchers
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class XOriginatingIpInNetworkSpec extends Specification with Matchers {
+  val dnsServer: DNSService =
+    new InMemoryDNSService()
+      .registerMxRecord("192.168.0.1", "192.168.0.1")
+      .registerMxRecord("192.168.200.1", "192.168.200.1")
+      .registerMxRecord("192.168.200.0", "192.168.200.0")
+      .registerMxRecord("255.255.255.0", "255.255.255.0")
+  val matcherConfig: FakeMatcherConfig =
+    FakeMatcherConfig.builder
+      .matcherName("AllowedNetworkIs")
+      .condition("192.168.200.0/24")
+      .build
+
+  "RemoteAddrOrOriginatingIpInNetwork" should {
+    val testRecipient: MailAddress =
+      new MailAddress("test@james.apache.org")
+    val matcher = new XOriginatingIpInNetwork()
+    matcher.setDNSService(dnsServer)
+    matcher.init(matcherConfig)
+
+    s"match when ip of header $X_ORIGINATING_IP is on the same network" in {
+      val fakeMail =
+        FakeMail.builder
+          .recipient(testRecipient)
+          .remoteAddr("10.0.0.1")
+          .mimeMessage(
+            MimeMessageBuilder.mimeMessageBuilder()
+              .addToRecipient(testRecipient.toInternetAddress)
+              .addHeader(X_ORIGINATING_IP,"192.168.200.1")
+              .build())
+          .build
+
+      val actual = matcher.`match`(fakeMail).asScala
+
+      actual must contain(exactly(testRecipient))
+    }
+    s"match when ip of header $X_ORIGINATING_IP is between brackets" in {
+      val fakeMail =
+        FakeMail.builder
+          .recipient(testRecipient)
+          .remoteAddr("10.0.0.1")
+          .mimeMessage(
+            MimeMessageBuilder.mimeMessageBuilder()
+              .addToRecipient(testRecipient.toInternetAddress)
+              .addHeader(X_ORIGINATING_IP,"[192.168.200.1]")
+              .build())
+          .build
+
+      val actual = matcher.`match`(fakeMail).asScala
+
+      actual must contain(exactly(testRecipient))
+    }
+    s"not match when ip of header $X_ORIGINATING_IP is not on the same network" in {
+      val fakeMail =
+        FakeMail.builder
+          .recipient(testRecipient)
+          .remoteAddr("10.0.0.1")
+          .mimeMessage(
+            MimeMessageBuilder.mimeMessageBuilder()
+              .addToRecipient(testRecipient.toInternetAddress)
+              .addHeader(X_ORIGINATING_IP,"10.0.0.2")
+              .build())
+          .build
+
+      val actual = matcher.`match`(fakeMail)
+
+      actual must beNull
+    }
+    s"not match when header $X_ORIGINATING_IP is missing" in {
+      val fakeMail =
+        FakeMail.builder
+          .recipient(testRecipient)
+          .remoteAddr("10.0.0.1")
+          .mimeMessage(
+            MimeMessageBuilder.mimeMessageBuilder()
+              .addToRecipient(testRecipient.toInternetAddress)
+              .build())
+          .build
+
+      val actual = matcher.`match`(fakeMail)
+
+      actual must beNull
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds 2 utilities : 
- the XOriginatingIPInNetwork  matcher
This matcher is based on `RemoteAddrInNetwork` but instead of checking the `remoteAddr` it checks the `X-Originating-IP` header of the email. It is configured in the same way. 
It is best used in combination with `RemoteAddrInNetwork` to check that both `X-Originating-IP` and `remoteAddr` are in known networks. This will prevent relaying messages with forged `X-Originating-IP`.
- A Throttler Mailet
This mailet expects 2 configuration parameters : 
  * `count` is expected to be an integer
  * `period` is expected to be an finite duration. It can be expressed using the scala duration DSL[1]
The mailet enforces that no more than `count` emails are sent per `period`, emails exceeding this limit are rejected with the message `454 Throttling – Maximum sending rate exceeded`

[1] Duration dsl expects a number (integer or fractional) followed by a unit the unit can be one of 
- `d|day|days, h|hour|hours`
- `min|minute|minutes`
- `s|second|seconds`
- `ms|milli|millis|millisecond|milliseconds` 
- `µs|micro|micros|microsecond|microseconds` 
- `ns|nano|nanos|nanosecond|nanoseconds` 
for exemple the following strings are valid durations:
```
10 seconds
1 day
8h
100ns
80millis
```
