### PR TITLE
JAMES-2524 Upgrade to testcontainers 1.9.0

### DIFF
--- a/backends-common/rabbitmq/src/test/java/org/apache/james/backend/rabbitmq/DockerRabbitMQ.java
+++ b/backends-common/rabbitmq/src/test/java/org/apache/james/backend/rabbitmq/DockerRabbitMQ.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.apache.james.util.docker.Images;
+import org.apache.james.util.docker.RateLimiters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.DockerClientFactory;
@@ -63,7 +64,7 @@ public class DockerRabbitMQ {
                 .withCreateContainerCmdModifier(cmd -> cmd.withHostName(hostName.orElse(DEFAULT_RABBIT_NODE)))
                 .withExposedPorts(DEFAULT_RABBITMQ_PORT, DEFAULT_RABBITMQ_ADMIN_PORT)
                 .waitingFor(new WaitAllStrategy()
-                    .withStrategy(Wait.forHttp("").forPort(DEFAULT_RABBITMQ_ADMIN_PORT))
+                    .withStrategy(Wait.forHttp("").forPort(DEFAULT_RABBITMQ_ADMIN_PORT).withRateLimiter(RateLimiters.DEFAULT))
                     .withStrategy(RabbitMQWaitStrategy.withDefaultTimeout(this)))
                 .withLogConsumer(frame -> LOGGER.debug(frame.getUtf8String()))
                 .withCreateContainerCmdModifier(cmd -> cmd.getHostConfig()

--- a/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/TikaContainer.java
+++ b/mailbox/tika/src/test/java/org/apache/james/mailbox/tika/TikaContainer.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.james.util.docker.Images;
+import org.apache.james.util.docker.RateLimiters;
 import org.apache.james.util.docker.SwarmGenericContainer;
 import org.junit.rules.ExternalResource;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -38,7 +39,7 @@ public class TikaContainer extends ExternalResource {
     public TikaContainer() {
         tika = new SwarmGenericContainer(Images.TIKA)
                 .withExposedPorts(DEFAULT_TIKA_PORT)
-                .waitingFor(Wait.forHttp("/tika"))
+                .waitingFor(Wait.forHttp("/tika").withRateLimiter(RateLimiters.DEFAULT))
                 .withStartupTimeout(Duration.ofSeconds(30));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -633,7 +633,7 @@
         <jackson.version>2.9.6</jackson.version>
         <jetty.version>9.4.7.v20170914</jetty.version>
         <metrics.version>3.2.6</metrics.version>
-        <testcontainers.version>1.8.3</testcontainers.version>
+        <testcontainers.version>1.9.0</testcontainers.version>
         <assertj.version>3.3.0</assertj.version>
         <es.version>2.2.1</es.version>
         <es-reporter.version>2.2.0</es-reporter.version>

--- a/server/blob/blob-objectstorage/pom.xml
+++ b/server/blob/blob-objectstorage/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>james-server-util</artifactId>
         </dependency>
         <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/DockerSwiftTempAuthExtension.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/DockerSwiftTempAuthExtension.java
@@ -21,6 +21,7 @@ package org.apache.james.blob.objectstorage;
 
 import java.net.URI;
 
+import org.apache.james.util.docker.RateLimiters;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -28,12 +29,14 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 
 class DockerSwiftTempAuthExtension implements ParameterResolver, BeforeAllCallback, AfterAllCallback {
     public static final int SWIFT_PORT = 8080;
     private static GenericContainer<?> swiftContainer =
         new GenericContainer<>("bouncestorage/swift-aio:ea10837d")
-            .withExposedPorts(SWIFT_PORT);
+            .withExposedPorts(SWIFT_PORT)
+            .waitingFor(new HostPortWaitStrategy().withRateLimiter(RateLimiters.DEFAULT));
     private DockerSwift dockerSwift;
 
     @Override

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/DockerElasticSearchRule.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/DockerElasticSearchRule.java
@@ -23,9 +23,11 @@ import org.apache.james.mailbox.elasticsearch.IndexAttachments;
 import org.apache.james.modules.mailbox.ElasticSearchConfiguration;
 import org.apache.james.util.Host;
 import org.apache.james.util.docker.Images;
+import org.apache.james.util.docker.RateLimiters;
 import org.apache.james.util.docker.SwarmGenericContainer;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 
 import com.google.inject.Module;
 
@@ -42,7 +44,8 @@ public class DockerElasticSearchRule implements GuiceModuleTestRule {
     }
 
     private SwarmGenericContainer elasticSearchContainer = new SwarmGenericContainer(Images.ELASTICSEARCH)
-        .withExposedPorts(ELASTIC_SEARCH_HTTP_PORT, ELASTIC_SEARCH_PORT);
+        .withExposedPorts(ELASTIC_SEARCH_HTTP_PORT, ELASTIC_SEARCH_PORT)
+        .waitingFor(new HostPortWaitStrategy().withRateLimiter(RateLimiters.DEFAULT));
 
     @Override
     public Statement apply(Statement base, Description description) {

--- a/server/container/metrics/metrics-es-reporter/src/test/java/org/apache/james/metric/es/ESReporterTest.java
+++ b/server/container/metrics/metrics-es-reporter/src/test/java/org/apache/james/metric/es/ESReporterTest.java
@@ -32,6 +32,7 @@ import org.apache.james.metrics.dropwizard.DropWizardMetricFactory;
 import org.apache.james.metrics.es.ESMetricReporter;
 import org.apache.james.metrics.es.ESReporterConfiguration;
 import org.apache.james.util.docker.Images;
+import org.apache.james.util.docker.RateLimiters;
 import org.apache.james.util.docker.SwarmGenericContainer;
 import org.awaitility.Duration;
 import org.elasticsearch.client.Client;
@@ -40,6 +41,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 
 import com.codahale.metrics.MetricRegistry;
 
@@ -55,7 +57,8 @@ public class ESReporterTest {
     @Rule
     public SwarmGenericContainer esContainer = new SwarmGenericContainer(Images.ELASTICSEARCH)
         .withAffinityToContainer()
-        .withExposedPorts(ES_HTTP_PORT, ES_APPLICATIVE_PORT);
+        .withExposedPorts(ES_HTTP_PORT, ES_APPLICATIVE_PORT)
+        .waitingFor(new HostPortWaitStrategy().withRateLimiter(RateLimiters.DEFAULT));
 
     private ClientProvider clientProvider;
     private ESMetricReporter esMetricReporter;

--- a/server/data/data-ldap-integration-testing/src/test/java/org/apache/james/user/ldap/LdapGenericContainer.java
+++ b/server/data/data-ldap-integration-testing/src/test/java/org/apache/james/user/ldap/LdapGenericContainer.java
@@ -18,6 +18,7 @@
  ****************************************************************/
 package org.apache.james.user.ldap;
 
+import org.apache.james.util.docker.RateLimiters;
 import org.apache.james.util.docker.SwarmGenericContainer;
 import org.junit.rules.ExternalResource;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
@@ -68,7 +69,7 @@ public class LdapGenericContainer extends ExternalResource {
                 .withEnv("SLAPD_PASSWORD", password)
                 .withEnv("SLAPD_CONFIG_PASSWORD", password)
                 .withExposedPorts(LdapGenericContainer.DEFAULT_LDAP_PORT)
-                .waitingFor(new HostPortWaitStrategy());
+                .waitingFor(new HostPortWaitStrategy().withRateLimiter(RateLimiters.DEFAULT));
         }
     }
 

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/AmqpForwardAttachmentTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/AmqpForwardAttachmentTest.java
@@ -41,6 +41,7 @@ import org.apache.james.probe.DataProbe;
 import org.apache.james.transport.mailets.amqp.AmqpRule;
 import org.apache.james.transport.matchers.All;
 import org.apache.james.util.docker.Images;
+import org.apache.james.util.docker.RateLimiters;
 import org.apache.james.util.docker.SwarmGenericContainer;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.IMAPMessageReader;
@@ -68,10 +69,7 @@ public class AmqpForwardAttachmentTest {
     public SwarmGenericContainer rabbitMqContainer = new SwarmGenericContainer(Images.RABBITMQ)
         .withAffinityToContainer()
         .waitingFor(new HostPortWaitStrategy()
-            .withRateLimiter(RateLimiterBuilder.newBuilder()
-                .withRate(20, TimeUnit.SECONDS)
-                .withConstantThroughput()
-                .build()));
+            .withRateLimiter(RateLimiters.DEFAULT));
 
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
     public AmqpRule amqpRule = new AmqpRule(rabbitMqContainer, EXCHANGE_NAME, ROUTING_KEY);

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/AmqpForwardAttachmentTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/AmqpForwardAttachmentTest.java
@@ -26,7 +26,6 @@ import static org.apache.james.mailets.configuration.Constants.awaitAtMostOneMin
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.james.MemoryJamesServerMain;
 import org.apache.james.core.builder.MimeMessageBuilder;
@@ -53,7 +52,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
-import org.rnorth.ducttape.ratelimits.RateLimiterBuilder;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 
 public class AmqpForwardAttachmentTest {

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ContactExtractorTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ContactExtractorTest.java
@@ -40,6 +40,7 @@ import org.apache.james.transport.mailets.amqp.AmqpRule;
 import org.apache.james.transport.matchers.All;
 import org.apache.james.transport.matchers.SMTPAuthSuccessful;
 import org.apache.james.util.docker.Images;
+import org.apache.james.util.docker.RateLimiters;
 import org.apache.james.util.docker.SwarmGenericContainer;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.IMAPMessageReader;
@@ -51,6 +52,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 
 public class ContactExtractorTest {
     public static final String SENDER = "sender@" + DEFAULT_DOMAIN;
@@ -63,7 +65,8 @@ public class ContactExtractorTest {
     public static final String EXCHANGE = "collector:email";
     public static final String ROUTING_KEY = "";
 
-    public SwarmGenericContainer rabbit = new SwarmGenericContainer(Images.RABBITMQ);
+    public SwarmGenericContainer rabbit = new SwarmGenericContainer(Images.RABBITMQ)
+        .waitingFor(new HostPortWaitStrategy().withRateLimiter(RateLimiters.DEFAULT));
     public AmqpRule amqpRule = new AmqpRule(rabbit, EXCHANGE, ROUTING_KEY);
     public TemporaryFolder folder = new TemporaryFolder();
 

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ICSAttachmentWorkflowTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ICSAttachmentWorkflowTest.java
@@ -45,6 +45,7 @@ import org.apache.james.transport.mailets.amqp.AmqpRule;
 import org.apache.james.transport.matchers.All;
 import org.apache.james.util.MimeMessageUtil;
 import org.apache.james.util.docker.Images;
+import org.apache.james.util.docker.RateLimiters;
 import org.apache.james.util.docker.SwarmGenericContainer;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.IMAPMessageReader;
@@ -56,6 +57,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 
 import com.google.common.collect.ImmutableList;
 import com.jayway.jsonpath.Configuration;
@@ -428,7 +430,8 @@ public class ICSAttachmentWorkflowTest {
 
     @ClassRule
     public static SwarmGenericContainer rabbitMqContainer = new SwarmGenericContainer(Images.RABBITMQ)
-            .withAffinityToContainer();
+        .withAffinityToContainer()
+        .waitingFor(new HostPortWaitStrategy().withRateLimiter(RateLimiters.DEFAULT));;
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
     @Rule

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/SpamAssassinTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/SpamAssassinTest.java
@@ -41,6 +41,7 @@ import org.apache.james.modules.protocols.SmtpGuiceProbe;
 import org.apache.james.spamassassin.SpamAssassinResult;
 import org.apache.james.transport.matchers.All;
 import org.apache.james.util.docker.Images;
+import org.apache.james.util.docker.RateLimiters;
 import org.apache.james.util.docker.SwarmGenericContainer;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.IMAPMessageReader;
@@ -61,7 +62,7 @@ public class SpamAssassinTest {
     public static SwarmGenericContainer spamAssassinContainer = new SwarmGenericContainer(Images.SPAMASSASSIN)
         .withExposedPorts(783)
         .withAffinityToContainer()
-        .waitingFor(new HostPortWaitStrategy());
+        .waitingFor(new HostPortWaitStrategy().withRateLimiter(RateLimiters.DEFAULT));
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
     @Rule

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/ContainerTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/ContainerTest.java
@@ -27,6 +27,7 @@ import org.apache.http.client.fluent.Request;
 import org.apache.http.client.fluent.Response;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.james.util.docker.Images;
+import org.apache.james.util.docker.RateLimiters;
 import org.apache.james.util.docker.SwarmGenericContainer;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,7 +39,9 @@ public class ContainerTest {
     public SwarmGenericContainer container = new SwarmGenericContainer(Images.NGINX)
         .withAffinityToContainer()
         .withExposedPorts(80)
-        .waitingFor(new HttpWaitStrategy().forStatusCode(200));
+        .waitingFor(new HttpWaitStrategy()
+            .forStatusCode(200)
+            .withRateLimiter(RateLimiters.DEFAULT));
 
     @Test
     public void containerShouldBeReachableOnExposedPort() throws IOException, URISyntaxException {

--- a/server/testing/src/main/java/org/apache/james/util/docker/RateLimiters.java
+++ b/server/testing/src/main/java/org/apache/james/util/docker/RateLimiters.java
@@ -1,0 +1,32 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.util.docker;
+
+import java.util.concurrent.TimeUnit;
+
+import org.rnorth.ducttape.ratelimits.RateLimiter;
+import org.rnorth.ducttape.ratelimits.RateLimiterBuilder;
+
+public interface RateLimiters {
+    RateLimiter DEFAULT = RateLimiterBuilder.newBuilder()
+        .withRate(20, TimeUnit.SECONDS)
+        .withConstantThroughput()
+        .build();
+}

--- a/server/testing/src/main/java/org/apache/james/utils/FakeSmtp.java
+++ b/server/testing/src/main/java/org/apache/james/utils/FakeSmtp.java
@@ -24,6 +24,7 @@ import static io.restassured.config.EncoderConfig.encoderConfig;
 import static io.restassured.config.RestAssuredConfig.newConfig;
 
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import org.apache.james.util.docker.Images;
@@ -32,6 +33,7 @@ import org.awaitility.core.ConditionFactory;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+import org.rnorth.ducttape.ratelimits.RateLimiterBuilder;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 
 import io.restassured.builder.RequestSpecBuilder;
@@ -53,7 +55,11 @@ public class FakeSmtp implements TestRule {
     private static SwarmGenericContainer fakeSmtpContainer() {
         return new SwarmGenericContainer(Images.FAKE_SMTP)
             .withAffinityToContainer()
-            .waitingFor(new HostPortWaitStrategy());
+            .waitingFor(new HostPortWaitStrategy()
+            .withRateLimiter(RateLimiterBuilder.newBuilder()
+                .withRate(20, TimeUnit.SECONDS)
+                .withConstantThroughput()
+                .build()));
     }
 
     private static final int SMTP_PORT = 25;

--- a/server/testing/src/main/java/org/apache/james/utils/FakeSmtp.java
+++ b/server/testing/src/main/java/org/apache/james/utils/FakeSmtp.java
@@ -24,7 +24,6 @@ import static io.restassured.config.EncoderConfig.encoderConfig;
 import static io.restassured.config.RestAssuredConfig.newConfig;
 
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import org.apache.james.util.docker.Images;
@@ -34,7 +33,6 @@ import org.awaitility.core.ConditionFactory;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import org.rnorth.ducttape.ratelimits.RateLimiterBuilder;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 
 import io.restassured.builder.RequestSpecBuilder;

--- a/server/testing/src/main/java/org/apache/james/utils/FakeSmtp.java
+++ b/server/testing/src/main/java/org/apache/james/utils/FakeSmtp.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import org.apache.james.util.docker.Images;
+import org.apache.james.util.docker.RateLimiters;
 import org.apache.james.util.docker.SwarmGenericContainer;
 import org.awaitility.core.ConditionFactory;
 import org.junit.rules.TestRule;
@@ -56,10 +57,7 @@ public class FakeSmtp implements TestRule {
         return new SwarmGenericContainer(Images.FAKE_SMTP)
             .withAffinityToContainer()
             .waitingFor(new HostPortWaitStrategy()
-            .withRateLimiter(RateLimiterBuilder.newBuilder()
-                .withRate(20, TimeUnit.SECONDS)
-                .withConstantThroughput()
-                .build()));
+            .withRateLimiter(RateLimiters.DEFAULT));
     }
 
     private static final int SMTP_PORT = 25;


### PR DESCRIPTION
Rely on new feature allowing to specifiy rate limiter for retry strategies

Default is one call per second, leading to slow container startup