### PR TITLE
Improve build stability

### DIFF
--- a/backends-common/rabbitmq/src/test/java/org/apache/james/backend/rabbitmq/DockerClusterRabbitMQExtension.java
+++ b/backends-common/rabbitmq/src/test/java/org/apache/james/backend/rabbitmq/DockerClusterRabbitMQExtension.java
@@ -21,6 +21,7 @@ package org.apache.james.backend.rabbitmq;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.james.util.Runnables;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -64,13 +65,14 @@ public class DockerClusterRabbitMQExtension implements BeforeEachCallback, After
             Throwing.runnable(() -> rabbitMQ2.join(rabbitMQ1)),
             Throwing.runnable(() -> rabbitMQ3.join(rabbitMQ1)));
 
-
-
         Runnables.runParallel(
             Throwing.runnable(rabbitMQ2::startApp),
             Throwing.runnable(rabbitMQ3::startApp));
 
         cluster = new DockerRabbitMQCluster(rabbitMQ1, rabbitMQ2, rabbitMQ3);
+
+        Awaitility.await().until(rabbitMQ1::isConnected);
+        Awaitility.await().until(rabbitMQ2::isConnected);
     }
 
     @Override

--- a/backends-common/rabbitmq/src/test/java/org/apache/james/backend/rabbitmq/DockerRabbitMQ.java
+++ b/backends-common/rabbitmq/src/test/java/org/apache/james/backend/rabbitmq/DockerRabbitMQ.java
@@ -18,12 +18,13 @@
  ****************************************************************/
 package org.apache.james.backend.rabbitmq;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeoutException;
 
-import com.rabbitmq.client.Address;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.james.util.docker.Images;
 import org.apache.james.util.docker.RateLimiters;
@@ -36,6 +37,8 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 
 import com.google.common.collect.ImmutableMap;
+import com.rabbitmq.client.Address;
+import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 
 public class DockerRabbitMQ {
@@ -188,5 +191,11 @@ public class DockerRabbitMQ {
                 .setHost(getHostIp())
                 .setPort(getAdminPort())
                 .build();
+    }
+
+    public boolean isConnected() throws IOException, TimeoutException {
+        try (Connection connection = connectionFactory().newConnection()) {
+            return connection.isOpen();
+        }
     }
 }

--- a/backends-common/rabbitmq/src/test/java/org/apache/james/backend/rabbitmq/RabbitMQWaitStrategy.java
+++ b/backends-common/rabbitmq/src/test/java/org/apache/james/backend/rabbitmq/RabbitMQWaitStrategy.java
@@ -19,17 +19,14 @@
 
 package org.apache.james.backend.rabbitmq;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import org.rnorth.ducttape.unreliables.Unreliables;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import org.testcontainers.containers.wait.strategy.WaitStrategyTarget;
 
 import com.google.common.primitives.Ints;
-import com.rabbitmq.client.Connection;
 
 public class RabbitMQWaitStrategy implements WaitStrategy {
 
@@ -51,13 +48,7 @@ public class RabbitMQWaitStrategy implements WaitStrategy {
     public void waitUntilReady(WaitStrategyTarget waitStrategyTarget) {
         int seconds = Ints.checkedCast(this.timeout.getSeconds());
 
-        Unreliables.retryUntilTrue(seconds, TimeUnit.SECONDS, this::isConnected);
-    }
-
-    private Boolean isConnected() throws IOException, TimeoutException {
-        try (Connection connection = rabbitMQ.connectionFactory().newConnection()) {
-            return connection.isOpen();
-        }
+        Unreliables.retryUntilTrue(seconds, TimeUnit.SECONDS, rabbitMQ::isConnected);
     }
 
     @Override

--- a/mpt/impl/smtp/core/src/main/java/org/apache/james/mpt/smtp/ForwardSmtpTest.java
+++ b/mpt/impl/smtp/core/src/main/java/org/apache/james/mpt/smtp/ForwardSmtpTest.java
@@ -78,10 +78,11 @@ public abstract class ForwardSmtpTest {
     public void forwardingAnEmailShouldWork() throws Exception {
         scriptedTest.run("helo");
 
-        calmlyAwait.untilAsserted(() -> fakeSmtp.isReceived(
-            response -> response
-                .body("[0].from", equalTo("matthieu@yopmail.com"))
-                .body("[0].subject", equalTo("test"))
-                .body("[0].text", equalTo("content"))));
+        calmlyAwait.atMost(ONE_MINUTE)
+            .untilAsserted(() -> fakeSmtp.isReceived(
+                response -> response
+                    .body("[0].from", equalTo("matthieu@yopmail.com"))
+                    .body("[0].subject", equalTo("test"))
+                    .body("[0].text", equalTo("content"))));
     }
 }

--- a/mpt/impl/smtp/core/src/main/java/org/apache/james/mpt/smtp/ForwardSmtpTest.java
+++ b/mpt/impl/smtp/core/src/main/java/org/apache/james/mpt/smtp/ForwardSmtpTest.java
@@ -78,8 +78,8 @@ public abstract class ForwardSmtpTest {
     public void forwardingAnEmailShouldWork() throws Exception {
         scriptedTest.run("helo");
 
-        calmlyAwait.atMost(ONE_MINUTE).until(() ->
-            fakeSmtp.isReceived(response -> response
+        calmlyAwait.untilAsserted(() -> fakeSmtp.isReceived(
+            response -> response
                 .body("[0].from", equalTo("matthieu@yopmail.com"))
                 .body("[0].subject", equalTo("test"))
                 .body("[0].text", equalTo("content"))));

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/GroupMappingRelayTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/GroupMappingRelayTest.java
@@ -50,7 +50,6 @@ import org.apache.james.utils.WebAdminGuiceProbe;
 import org.apache.james.webadmin.WebAdminUtils;
 import org.apache.james.webadmin.routes.GroupsRoutes;
 import org.apache.mailet.base.test.FakeMail;
-import org.awaitility.Duration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -159,9 +158,8 @@ public class GroupMappingRelayTest {
                 .sender(SENDER)
                 .recipient(GROUP_ON_DOMAIN1));
 
-        awaitAtMostOneMinute
-            .pollDelay(Duration.ONE_HUNDRED_MILLISECONDS)
-            .until(() -> fakeSmtp.isReceived(response -> response
+        awaitAtMostOneMinute.untilAsserted(() -> fakeSmtp.isReceived(
+            response -> response
                 .body("[0].from", equalTo(SENDER))
                 .body("[0].to[0]", equalTo(externalMail))
                 .body("[0].text", equalTo(MESSAGE_CONTENT))));

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/VacationRelayIntegrationTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/VacationRelayIntegrationTest.java
@@ -115,7 +115,7 @@ public abstract class VacationRelayIntegrationTest {
         smtpClient.sendShortMessageData("content");
 
         calmlyAwait.atMost(1, TimeUnit.MINUTES)
-            .until(() ->
+            .untilAsserted(() ->
                 fakeSmtp.isReceived(response -> response
                     .body("[0].from", equalTo(USER_WITH_DOMAIN))
                     .body("[0].to[0]", equalTo(externalMail))

--- a/server/testing/src/main/java/org/apache/james/utils/FakeSmtp.java
+++ b/server/testing/src/main/java/org/apache/james/utils/FakeSmtp.java
@@ -81,17 +81,16 @@ public class FakeSmtp implements TestRule {
         calmyAwait.until(() -> container.tryConnect(smtpPort));
     }
 
-    public boolean isReceived(Function<ValidatableResponse, ValidatableResponse> expectations) {
-        try {
-            expectations.apply(
-                given(requestSpecification(), RESPONSE_SPECIFICATION)
-                    .get("/api/email")
+    public void awaitReceived(ConditionFactory conditionFactory, Function<ValidatableResponse, ValidatableResponse> expectations) {
+        conditionFactory.untilAsserted(() -> isReceived(expectations));
+    }
+
+    public void isReceived(Function<ValidatableResponse, ValidatableResponse> expectations) {
+        expectations.apply(
+            given(requestSpecification(), RESPONSE_SPECIFICATION)
+                .get("/api/email")
                 .then()
-                    .statusCode(200));
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
+                .statusCode(200));
     }
 
     private RequestSpecification requestSpecification() {


### PR DESCRIPTION
```
[null] [ERROR] Tests run: 6, Failures: 0, Errors: 1, Skipped: 1, Time elapsed: 162.701 s <<< FAILURE! - in org.apache.james.backend.rabbitmq.RabbitMQClusterTest
[null] [ERROR] queuesShouldBeDeclarableOnAnotherNode  Time elapsed: 37.042 s  <<< ERROR!
[null] java.io.IOException
[null] 	at org.apache.james.backend.rabbitmq.RabbitMQClusterTest$ClusterSharing.setup(RabbitMQClusterTest.java:82)
[null] Caused by: com.rabbitmq.client.ShutdownSignalException: connection error
[null] 	at org.apache.james.backend.rabbitmq.RabbitMQClusterTest$ClusterSharing.setup(RabbitMQClusterTest.java:82)
[null] Caused by: java.net.SocketException: Connection reset
```

And 

```
[null] [ERROR]   GroupMappingRelayTest.lambda$sendMessageShouldSendAMessageToAnExternalGroupMember$1:164->lambda$null$0:165 1 expectation failed.
[null] JSON path [0].from doesn't match.
[null] Expected: fromuser@domain1.com
[null]   Actual: null
```