### PR TITLE
migrate AbstractJamesServerTests to junit 5

### DIFF
--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraExtension.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraExtension.java
@@ -17,29 +17,32 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.util;
+package org.apache.james;
 
-import java.util.Arrays;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class Runnables {
-    public static void runParallel(Runnable... runnables) {
-        Stream<Runnable> stream = Arrays.stream(runnables);
-        runParrallelStream(stream);
+import com.google.inject.Module;
+
+class CassandraExtension implements GuiceModuleTestExtension {
+
+    private final DockerCassandraRule cassandra;
+
+    CassandraExtension() {
+        this.cassandra = new DockerCassandraRule();
     }
 
-    public static void runParrallelStream(Stream<Runnable> stream) {
-        FluentFutureStream.of(stream
-                .map(runnable -> CompletableFuture.supplyAsync(toVoidSupplier(runnable))))
-            .join();
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) {
+        cassandra.start();
     }
 
-    private static Supplier<Void> toVoidSupplier(Runnable runnable) {
-        return () -> {
-            runnable.run();
-            return null;
-        };
+    @Override
+    public void afterAll(ExtensionContext extensionContext) {
+        cassandra.stop();
+    }
+
+    @Override
+    public Module getModule() {
+        return cassandra.getModule();
     }
 }

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraJamesServerTest.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraJamesServerTest.java
@@ -31,8 +31,8 @@ class CassandraJamesServerTest implements JamesServerContract {
 
     @RegisterExtension
     static JamesServerExtension testExtension = new JamesServerExtensionBuilder()
-        .extension(EmbeddedElasticSearchExtension::new)
-        .extension(CassandraExtension::new)
+        .extension(new EmbeddedElasticSearchExtension())
+        .extension(new CassandraExtension())
         .server(configuration -> GuiceJamesServer.forConfiguration(configuration)
             .combineWith(ALL_BUT_JMX_CASSANDRA_MODULE)
             .overrideWith(binder -> binder.bind(TextExtractor .class).to(PDFTextExtractor.class))

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraJamesServerTest.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraJamesServerTest.java
@@ -35,7 +35,7 @@ class CassandraJamesServerTest implements JamesServerContract {
         .extension(new CassandraExtension())
         .server(configuration -> GuiceJamesServer.forConfiguration(configuration)
             .combineWith(ALL_BUT_JMX_CASSANDRA_MODULE)
-            .overrideWith(binder -> binder.bind(TextExtractor .class).to(PDFTextExtractor.class))
+            .overrideWith(binder -> binder.bind(TextExtractor.class).to(PDFTextExtractor.class))
             .overrideWith(new TestJMAPServerModule(LIMIT_TO_10_MESSAGES))
             .overrideWith(DOMAIN_LIST_CONFIGURATION_MODULE))
         .build();

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraJamesServerTest.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraJamesServerTest.java
@@ -23,15 +23,10 @@ import static org.apache.james.CassandraJamesServerMain.ALL_BUT_JMX_CASSANDRA_MO
 
 import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mailbox.store.search.PDFTextExtractor;
-import org.apache.james.modules.TestESMetricReporterModule;
 import org.apache.james.modules.TestJMAPServerModule;
-import org.apache.james.server.core.configuration.Configuration;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.google.inject.util.Modules;
-
 class CassandraJamesServerTest implements JamesServerContract {
-
     private static final int LIMIT_TO_10_MESSAGES = 10;
 
     @RegisterExtension
@@ -40,10 +35,8 @@ class CassandraJamesServerTest implements JamesServerContract {
         .extension(CassandraExtension::new)
         .server(configuration -> GuiceJamesServer.forConfiguration(configuration)
             .combineWith(ALL_BUT_JMX_CASSANDRA_MODULE)
-            .overrideWith(Modules.combine(
-                binder -> binder.bind(TextExtractor .class).to(PDFTextExtractor .class),
-                new TestJMAPServerModule(LIMIT_TO_10_MESSAGES),
-                new TestESMetricReporterModule()))
+            .overrideWith(binder -> binder.bind(TextExtractor .class).to(PDFTextExtractor.class))
+            .overrideWith(new TestJMAPServerModule(LIMIT_TO_10_MESSAGES))
             .overrideWith(DOMAIN_LIST_CONFIGURATION_MODULE))
         .build();
 }

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraWithTikaTest.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraWithTikaTest.java
@@ -21,17 +21,10 @@ package org.apache.james;
 
 import static org.apache.james.CassandraJamesServerMain.ALL_BUT_JMX_CASSANDRA_MODULE;
 
-import org.apache.james.mailbox.extractor.TextExtractor;
-import org.apache.james.mailbox.store.search.PDFTextExtractor;
-import org.apache.james.modules.TestESMetricReporterModule;
 import org.apache.james.modules.TestJMAPServerModule;
-import org.apache.james.server.core.configuration.Configuration;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.google.inject.util.Modules;
-
 class CassandraWithTikaTest implements JamesServerContract {
-
     private static final int LIMIT_TO_10_MESSAGES = 10;
 
     @RegisterExtension
@@ -42,10 +35,7 @@ class CassandraWithTikaTest implements JamesServerContract {
             .extension(EmbeddedElasticSearchExtension::new)
             .server(configuration -> GuiceJamesServer.forConfiguration(configuration)
                 .combineWith(ALL_BUT_JMX_CASSANDRA_MODULE)
-                .overrideWith(Modules.combine(
-                    binder -> binder.bind(TextExtractor.class).to(PDFTextExtractor.class),
-                    new TestJMAPServerModule(LIMIT_TO_10_MESSAGES),
-                    new TestESMetricReporterModule()))
+                .overrideWith(new TestJMAPServerModule(LIMIT_TO_10_MESSAGES))
                 .overrideWith(DOMAIN_LIST_CONFIGURATION_MODULE))
             .build();
 }

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraWithTikaTest.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraWithTikaTest.java
@@ -30,9 +30,9 @@ class CassandraWithTikaTest implements JamesServerContract {
     @RegisterExtension
     static JamesServerExtension testExtension =
         new JamesServerExtensionBuilder()
-            .extension(CassandraExtension::new)
-            .extension(TikaExtension::new)
-            .extension(EmbeddedElasticSearchExtension::new)
+            .extension(new CassandraExtension())
+            .extension(new  TikaExtension())
+            .extension(new EmbeddedElasticSearchExtension())
             .server(configuration -> GuiceJamesServer.forConfiguration(configuration)
                 .combineWith(ALL_BUT_JMX_CASSANDRA_MODULE)
                 .overrideWith(new TestJMAPServerModule(LIMIT_TO_10_MESSAGES))

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/EmbeddedElasticSearchExtension.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/EmbeddedElasticSearchExtension.java
@@ -19,29 +19,32 @@
 
 package org.apache.james;
 
-import java.io.File;
-
 import org.apache.james.backends.es.EmbeddedElasticSearch;
+import org.apache.james.junit.TemporaryFolderExtension;
 import org.apache.james.modules.TestElasticSearchModule;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import com.google.inject.Module;
 
 public class EmbeddedElasticSearchExtension implements GuiceModuleTestExtension {
-    private final EmbeddedElasticSearch embeddedElasticSearch;
+    private final TemporaryFolderExtension folderExtension;
+    private EmbeddedElasticSearch embeddedElasticSearch;
 
-    public EmbeddedElasticSearchExtension(File temporaryFolder) {
-        this.embeddedElasticSearch = new EmbeddedElasticSearch(temporaryFolder.toPath());
+    public EmbeddedElasticSearchExtension() {
+        this.folderExtension = new TemporaryFolderExtension();
     }
 
     @Override
-    public void beforeEach(ExtensionContext extensionContext) {
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        folderExtension.beforeEach(extensionContext);
+        embeddedElasticSearch = new EmbeddedElasticSearch(folderExtension.getTemporaryFolder().getTempDir().toPath());
         embeddedElasticSearch.before();
     }
 
     @Override
-    public void afterEach(ExtensionContext extensionContext) {
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
         embeddedElasticSearch.after();
+        folderExtension.afterEach(extensionContext);
     }
 
     @Override

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/EmbeddedElasticSearchExtension.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/EmbeddedElasticSearchExtension.java
@@ -51,8 +51,8 @@ public class EmbeddedElasticSearchExtension implements GuiceModuleTestExtension 
 
     @Override
     public Module getModule() {
-            return new TestElasticSearchModule(embeddedElasticSearch);
-        }
+        return new TestElasticSearchModule(embeddedElasticSearch);
+    }
 
     @Override
     public void await() {

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/EmbeddedElasticSearchExtension.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/EmbeddedElasticSearchExtension.java
@@ -24,28 +24,23 @@ import java.io.File;
 import org.apache.james.backends.es.EmbeddedElasticSearch;
 import org.apache.james.modules.TestElasticSearchModule;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.rules.TemporaryFolder;
 
 import com.google.inject.Module;
 
-
 public class EmbeddedElasticSearchExtension implements GuiceModuleTestExtension {
-
-    private final File temporaryFolder;
     private final EmbeddedElasticSearch embeddedElasticSearch;
 
     public EmbeddedElasticSearchExtension(File temporaryFolder) {
-        this.temporaryFolder = temporaryFolder;
         this.embeddedElasticSearch = new EmbeddedElasticSearch(temporaryFolder.toPath());
     }
 
     @Override
-    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+    public void beforeEach(ExtensionContext extensionContext) {
         embeddedElasticSearch.before();
     }
 
     @Override
-    public void afterAll(ExtensionContext extensionContext) throws Exception {
+    public void afterEach(ExtensionContext extensionContext) {
         embeddedElasticSearch.after();
     }
 

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/EmbeddedElasticSearchExtension.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/EmbeddedElasticSearchExtension.java
@@ -1,0 +1,65 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import java.io.File;
+
+import org.apache.james.backends.es.EmbeddedElasticSearch;
+import org.apache.james.modules.TestElasticSearchModule;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.rules.TemporaryFolder;
+
+import com.google.inject.Module;
+
+
+public class EmbeddedElasticSearchExtension implements GuiceModuleTestExtension {
+
+    private final File temporaryFolder;
+    private final EmbeddedElasticSearch embeddedElasticSearch;
+
+    public EmbeddedElasticSearchExtension(File temporaryFolder) {
+        this.temporaryFolder = temporaryFolder;
+        this.embeddedElasticSearch = new EmbeddedElasticSearch(temporaryFolder.toPath());
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        embeddedElasticSearch.before();
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) throws Exception {
+        embeddedElasticSearch.after();
+    }
+
+    @Override
+    public Module getModule() {
+            return new TestElasticSearchModule(embeddedElasticSearch);
+        }
+
+    @Override
+    public void await() {
+        embeddedElasticSearch.awaitForElasticSearch();
+    }
+
+    public EmbeddedElasticSearch getEmbeddedElasticSearch() {
+        return embeddedElasticSearch;
+    }
+}

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/TikaExtension.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/TikaExtension.java
@@ -18,32 +18,28 @@
  ****************************************************************/
 
 package org.apache.james;
+
 import org.apache.james.mailbox.tika.TikaContainer;
 import org.apache.james.modules.TestTikaModule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import com.google.inject.Module;
 
+class TikaExtension implements GuiceModuleTestExtension {
+    private final TikaContainer tika;
 
-public class GuiceTikaRule implements GuiceModuleTestRule {
-
-    private TikaContainer tika;
-
-    @Override
-    public Statement apply(Statement base, Description description) {
-        return new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                tika = new TikaContainer();
-                tika.start();
-                base.evaluate();
-            }
-        };
+    TikaExtension() {
+        this.tika = new TikaContainer();
     }
 
     @Override
-    public void await() {
+    public void beforeAll(ExtensionContext extensionContext) {
+        tika.start();
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) {
+        tika.stop();
     }
 
     @Override

--- a/server/container/guice/guice-common/pom.xml
+++ b/server/container/guice/guice-common/pom.xml
@@ -185,6 +185,11 @@
             <artifactId>awaitility</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/AggregateJunitExtension.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/AggregateJunitExtension.java
@@ -1,0 +1,67 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.apache.james.util.Runnables;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import com.github.fge.lambdas.Throwing;
+import com.google.common.collect.Lists;
+
+public class AggregateJunitExtension implements RegistrableExtension {
+
+    private final List<? extends RegistrableExtension> registrableExtensions;
+
+    public AggregateJunitExtension(List<? extends RegistrableExtension> registrableExtensions) {
+        this.registrableExtensions = registrableExtensions;
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) {
+        Runnables.runParrallelStream(registrableExtensions
+            .stream()
+            .map(ext -> Throwing.runnable(() -> ext.beforeAll(extensionContext))));
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        Runnables.runParrallelStream(registrableExtensions
+            .stream()
+            .map(ext -> Throwing.runnable(() -> ext.beforeEach(extensionContext))));
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) {
+        Runnables.runParrallelStream(Lists.reverse(registrableExtensions)
+            .stream()
+            .map(ext -> Throwing.runnable(() -> ext.afterEach(extensionContext))));
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) {
+        Runnables.runParrallelStream(Lists.reverse(registrableExtensions)
+            .stream()
+            .map(ext -> Throwing.runnable(() -> ext.afterAll(extensionContext))));
+    }
+
+}

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/GuiceModuleTestExtension.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/GuiceModuleTestExtension.java
@@ -17,29 +17,15 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.util;
+package org.apache.james;
 
-import java.util.Arrays;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
+import com.google.inject.Module;
 
-public class Runnables {
-    public static void runParallel(Runnable... runnables) {
-        Stream<Runnable> stream = Arrays.stream(runnables);
-        runParrallelStream(stream);
+public interface GuiceModuleTestExtension extends RegistrableExtension {
+
+    default Module getModule() {
+        return binder -> {};
     }
 
-    public static void runParrallelStream(Stream<Runnable> stream) {
-        FluentFutureStream.of(stream
-                .map(runnable -> CompletableFuture.supplyAsync(toVoidSupplier(runnable))))
-            .join();
-    }
-
-    private static Supplier<Void> toVoidSupplier(Runnable runnable) {
-        return () -> {
-            runnable.run();
-            return null;
-        };
-    }
+    default void await() {}
 }

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/JamesServerContract.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/JamesServerContract.java
@@ -64,38 +64,42 @@ public interface JamesServerContract {
 
     @Test
     default void connectIMAPServerShouldSendShabangOnConnect(GuiceJamesServer jamesServer) throws Exception {
-        SocketChannel socketChannel = SocketChannel.open();
-
-        socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort()));
-        assertThat(getServerConnectionResponse(socketChannel)).startsWith("* OK JAMES IMAP4rev1 Server");
+        try (SocketChannel socketChannel = SocketChannel.open()) {
+            socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort()));
+            assertThat(getServerConnectionResponse(socketChannel)).startsWith("* OK JAMES IMAP4rev1 Server");
+        }
     }
 
     @Test
     default void connectOnSecondaryIMAPServerIMAPServerShouldSendShabangOnConnect(GuiceJamesServer jamesServer) throws Exception {
-        SocketChannel socketChannel = SocketChannel.open();
-        socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, jamesServer.getProbe(ImapGuiceProbe.class).getImapsPort()));
-        assertThat(getServerConnectionResponse(socketChannel)).startsWith("* OK JAMES IMAP4rev1 Server");
+        try (SocketChannel socketChannel = SocketChannel.open()) {
+            socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, jamesServer.getProbe(ImapGuiceProbe.class).getImapsPort()));
+            assertThat(getServerConnectionResponse(socketChannel)).startsWith("* OK JAMES IMAP4rev1 Server");
+        }
     }
 
     @Test
     default void connectPOP3ServerShouldSendShabangOnConnect(GuiceJamesServer jamesServer) throws Exception {
-        SocketChannel socketChannel = SocketChannel.open();
-        socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, jamesServer.getProbe(Pop3GuiceProbe.class).getPop3Port()));
-        assertThat(getServerConnectionResponse(socketChannel)).contains("POP3 server (JAMES POP3 Server ) ready");
+        try (SocketChannel socketChannel = SocketChannel.open()) {
+            socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, jamesServer.getProbe(Pop3GuiceProbe.class).getPop3Port()));
+            assertThat(getServerConnectionResponse(socketChannel)).contains("POP3 server (JAMES POP3 Server ) ready");
+        }
     }
 
     @Test
     default void connectSMTPServerShouldSendShabangOnConnect(GuiceJamesServer jamesServer) throws Exception {
-        SocketChannel socketChannel = SocketChannel.open();
-        socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort()));
-        assertThat(getServerConnectionResponse(socketChannel)).startsWith("220 JAMES Linagora's SMTP awesome Server");
+        try (SocketChannel socketChannel = SocketChannel.open()) {
+            socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort()));
+            assertThat(getServerConnectionResponse(socketChannel)).startsWith("220 JAMES Linagora's SMTP awesome Server");
+        }
     }
 
     @Test
     default void connectLMTPServerShouldSendShabangOnConnect(GuiceJamesServer jamesServer) throws Exception {
-        SocketChannel socketChannel = SocketChannel.open();
-        socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, jamesServer.getProbe(LmtpGuiceProbe.class).getLmtpPort()));
-        assertThat(getServerConnectionResponse(socketChannel)).contains("LMTP Server (JAMES Protocols Server) ready");
+        try (SocketChannel socketChannel = SocketChannel.open()) {
+            socketChannel.connect(new InetSocketAddress(JAMES_SERVER_HOST, jamesServer.getProbe(LmtpGuiceProbe.class).getLmtpPort()));
+            assertThat(getServerConnectionResponse(socketChannel)).contains("LMTP Server (JAMES Protocols Server) ready");
+        }
     }
 
     static String getServerConnectionResponse(SocketChannel socketChannel) throws IOException {

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/JamesServerExtension.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/JamesServerExtension.java
@@ -34,16 +34,16 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 
 public class JamesServerExtension implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback, ParameterResolver {
 
-    interface ThrowingSupplier<T> {
-        T get(File file) throws Exception;
+    interface ThrowingFunction<P, T> {
+        T apply(P parameter) throws Exception;
     }
 
     private final TemporaryFolderRegistrableExtension folderRegistrableExtension;
-    private final ThrowingSupplier<GuiceJamesServer> serverSupplier;
+    private final ThrowingFunction<File, GuiceJamesServer> serverSupplier;
     private final RegistrableExtension registrableExtension;
     private GuiceJamesServer guiceJamesServer;
 
-    JamesServerExtension(RegistrableExtension registrableExtension, ThrowingSupplier<GuiceJamesServer> serverSupplier) {
+    JamesServerExtension(RegistrableExtension registrableExtension, ThrowingFunction<File, GuiceJamesServer> serverSupplier) {
         this.registrableExtension = registrableExtension;
         this.serverSupplier = serverSupplier;
         this.folderRegistrableExtension = new TemporaryFolderRegistrableExtension();
@@ -58,7 +58,7 @@ public class JamesServerExtension implements BeforeAllCallback, BeforeEachCallba
     public void beforeEach(ExtensionContext extensionContext) throws Exception {
         folderRegistrableExtension.beforeEach(extensionContext);
         registrableExtension.beforeEach(extensionContext);
-        guiceJamesServer = serverSupplier.get(createTmpDir());
+        guiceJamesServer = serverSupplier.apply(createTmpDir());
         guiceJamesServer.start();
     }
 

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/JamesServerExtension.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/JamesServerExtension.java
@@ -19,10 +19,10 @@
 
 package org.apache.james;
 
-import java.util.List;
-import java.util.function.Supplier;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 
-import org.apache.james.util.Runnables;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -32,15 +32,13 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
-import com.github.fge.lambdas.Throwing;
-import com.google.common.collect.Lists;
-
 public class JamesServerExtension implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback, ParameterResolver {
 
     interface ThrowingSupplier<T> {
-        T get() throws Exception;
+        T get(File file) throws Exception;
     }
 
+    private final TemporaryFolderRegistrableExtension folderRegistrableExtension;
     private final ThrowingSupplier<GuiceJamesServer> serverSupplier;
     private final RegistrableExtension registrableExtension;
     private GuiceJamesServer guiceJamesServer;
@@ -48,6 +46,7 @@ public class JamesServerExtension implements BeforeAllCallback, BeforeEachCallba
     JamesServerExtension(RegistrableExtension registrableExtension, ThrowingSupplier<GuiceJamesServer> serverSupplier) {
         this.registrableExtension = registrableExtension;
         this.serverSupplier = serverSupplier;
+        this.folderRegistrableExtension = new TemporaryFolderRegistrableExtension();
     }
 
     @Override
@@ -57,8 +56,9 @@ public class JamesServerExtension implements BeforeAllCallback, BeforeEachCallba
 
     @Override
     public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        folderRegistrableExtension.beforeEach(extensionContext);
         registrableExtension.beforeEach(extensionContext);
-        guiceJamesServer = serverSupplier.get();
+        guiceJamesServer = serverSupplier.get(createTmpDir());
         guiceJamesServer.start();
     }
 
@@ -66,6 +66,7 @@ public class JamesServerExtension implements BeforeAllCallback, BeforeEachCallba
     public void afterEach(ExtensionContext extensionContext) throws Exception {
         guiceJamesServer.stop();
         registrableExtension.afterEach(extensionContext);
+        folderRegistrableExtension.afterEach(extensionContext);
     }
 
     @Override
@@ -81,5 +82,13 @@ public class JamesServerExtension implements BeforeAllCallback, BeforeEachCallba
     @Override
     public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
         return guiceJamesServer;
+    }
+
+    private File createTmpDir() {
+        try {
+            return folderRegistrableExtension.getTemporaryFolder().newFolder();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/JamesServerExtension.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/JamesServerExtension.java
@@ -1,0 +1,85 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.apache.james.util.Runnables;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import com.github.fge.lambdas.Throwing;
+import com.google.common.collect.Lists;
+
+public class JamesServerExtension implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback, ParameterResolver {
+
+    interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+
+    private final ThrowingSupplier<GuiceJamesServer> serverSupplier;
+    private final RegistrableExtension registrableExtension;
+    private GuiceJamesServer guiceJamesServer;
+
+    JamesServerExtension(RegistrableExtension registrableExtension, ThrowingSupplier<GuiceJamesServer> serverSupplier) {
+        this.registrableExtension = registrableExtension;
+        this.serverSupplier = serverSupplier;
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        registrableExtension.beforeAll(extensionContext);
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        registrableExtension.beforeEach(extensionContext);
+        guiceJamesServer = serverSupplier.get();
+        guiceJamesServer.start();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
+        guiceJamesServer.stop();
+        registrableExtension.afterEach(extensionContext);
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) throws Exception {
+        registrableExtension.afterAll(extensionContext);
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return (parameterContext.getParameter().getType() == GuiceJamesServer.class);
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return guiceJamesServer;
+    }
+}

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/JamesServerExtensionBuilder.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/JamesServerExtensionBuilder.java
@@ -50,7 +50,6 @@ public class JamesServerExtensionBuilder {
     }
 
     private final ImmutableList.Builder<GuiceModuleTestExtension> extensions;
-    private final ImmutableList.Builder<Module> addedModules;
     private final TemporaryFolderRegistrableExtension folderRegistrableExtension;
     private ServerProvider server;
     private Optional<ConfigurationProvider> configuration;
@@ -58,7 +57,6 @@ public class JamesServerExtensionBuilder {
     JamesServerExtensionBuilder() {
         configuration = Optional.empty();
         extensions = ImmutableList.builder();
-        addedModules = ImmutableList.builder();
         folderRegistrableExtension = new TemporaryFolderRegistrableExtension();
     }
 

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/JamesServerExtensionBuilder.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/JamesServerExtensionBuilder.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.apache.james.server.core.configuration.Configuration;
@@ -57,6 +56,7 @@ public class JamesServerExtensionBuilder {
     private Optional<ConfigurationProvider> configuration;
 
     JamesServerExtensionBuilder() {
+        configuration = Optional.empty();
         extensions = ImmutableList.builder();
         addedModules = ImmutableList.builder();
         folderRegistrableExtension = new TemporaryFolderRegistrableExtension();

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/JamesServerExtensionBuilder.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/JamesServerExtensionBuilder.java
@@ -1,0 +1,126 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.apache.james.server.core.configuration.Configuration;
+
+import com.github.steveash.guavate.Guavate;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Module;
+
+public class JamesServerExtensionBuilder {
+
+    @FunctionalInterface
+    interface ExtensionProvider {
+        GuiceModuleTestExtension buildExtension(File tempDirectory);
+    }
+
+    @FunctionalInterface
+    interface ConfigurationProvider {
+        Configuration buildConfiguration(File tempDirectory);
+    }
+
+    @FunctionalInterface
+    interface ServerProvider {
+        GuiceJamesServer buildServer(Configuration configuration);
+    }
+
+    private final ImmutableList.Builder<GuiceModuleTestExtension> extensions;
+    private final ImmutableList.Builder<Module> addedModules;
+    private final TemporaryFolderRegistrableExtension folderRegistrableExtension;
+    private ServerProvider server;
+    private Optional<ConfigurationProvider> configuration;
+
+    JamesServerExtensionBuilder() {
+        extensions = ImmutableList.builder();
+        addedModules = ImmutableList.builder();
+        folderRegistrableExtension = new TemporaryFolderRegistrableExtension();
+    }
+
+    public JamesServerExtensionBuilder extensions(GuiceModuleTestExtension... extensions) {
+        this.extensions.add(extensions);
+        return this;
+    }
+
+    public JamesServerExtensionBuilder extension(Supplier<GuiceModuleTestExtension> extension) {
+        this.extensions.add(extension.get());
+        return this;
+    }
+
+    public JamesServerExtensionBuilder extension(ExtensionProvider extension) {
+        this.extensions.add(extension.buildExtension(createTmpDir()));
+        return this;
+    }
+
+    public JamesServerExtensionBuilder configuration(ConfigurationProvider configuration) throws UncheckedIOException {
+        this.configuration = Optional.of(configuration);
+        return this;
+    }
+
+    public JamesServerExtensionBuilder server(ServerProvider server) {
+        this.server = server;
+        return this;
+    }
+
+    public JamesServerExtension build() {
+        Preconditions.checkNotNull(server);
+        ConfigurationProvider configuration = this.configuration.orElse(defaultConfigurationProvider());
+        return new JamesServerExtension(buildAggregateJunitExtension(), () -> overrideServerWithExtensionsModules(configuration));
+    }
+
+    private ConfigurationProvider defaultConfigurationProvider() {
+        return tmpDir ->
+            Configuration.builder()
+                .workingDirectory(tmpDir)
+                .configurationFromClasspath()
+                .build();
+    }
+
+    private File createTmpDir() {
+        try {
+            return folderRegistrableExtension.getTemporaryFolder().newFolder();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private AggregateJunitExtension buildAggregateJunitExtension() {
+        ImmutableList<GuiceModuleTestExtension> extensions = this.extensions.build();
+        return new AggregateJunitExtension(
+            ImmutableList.<RegistrableExtension>builder()
+                .addAll(extensions)
+                .add(folderRegistrableExtension)
+                .build());
+    }
+
+    private GuiceJamesServer overrideServerWithExtensionsModules(ConfigurationProvider configurationProvider) {
+        ImmutableList<Module> modules = extensions.build().stream().map(x -> x.getModule()).collect(Guavate.toImmutableList());
+        return server.buildServer(configurationProvider.buildConfiguration(createTmpDir())).overrideWith(modules);
+    }
+
+}

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/RegistrableExtension.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/RegistrableExtension.java
@@ -17,29 +17,32 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.util;
+package org.apache.james;
 
-import java.util.Arrays;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class Runnables {
-    public static void runParallel(Runnable... runnables) {
-        Stream<Runnable> stream = Arrays.stream(runnables);
-        runParrallelStream(stream);
+public interface RegistrableExtension extends BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback {
+    @Override
+    default void afterAll(ExtensionContext extensionContext) throws Exception {
+
     }
 
-    public static void runParrallelStream(Stream<Runnable> stream) {
-        FluentFutureStream.of(stream
-                .map(runnable -> CompletableFuture.supplyAsync(toVoidSupplier(runnable))))
-            .join();
+    @Override
+    default void afterEach(ExtensionContext extensionContext) throws Exception {
+
     }
 
-    private static Supplier<Void> toVoidSupplier(Runnable runnable) {
-        return () -> {
-            runnable.run();
-            return null;
-        };
+    @Override
+    default void beforeAll(ExtensionContext extensionContext) throws Exception {
+
+    }
+
+    @Override
+    default void beforeEach(ExtensionContext extensionContext) throws Exception {
+
     }
 }

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/TemporaryFolderRegistrableExtension.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/TemporaryFolderRegistrableExtension.java
@@ -24,11 +24,10 @@ import org.junit.rules.TemporaryFolder;
 
 public class TemporaryFolderRegistrableExtension implements RegistrableExtension {
 
-    private TemporaryFolder temporaryFolder;
+    private TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Override
     public void beforeEach(ExtensionContext extensionContext) throws Exception {
-        temporaryFolder = new TemporaryFolder();
         temporaryFolder.create();
     }
 

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/TemporaryFolderRegistrableExtension.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/TemporaryFolderRegistrableExtension.java
@@ -17,29 +17,27 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.util;
+package org.apache.james;
 
-import java.util.Arrays;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.rules.TemporaryFolder;
 
-public class Runnables {
-    public static void runParallel(Runnable... runnables) {
-        Stream<Runnable> stream = Arrays.stream(runnables);
-        runParrallelStream(stream);
+public class TemporaryFolderRegistrableExtension implements RegistrableExtension {
+
+    private TemporaryFolder temporaryFolder;
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        temporaryFolder = new TemporaryFolder();
+        temporaryFolder.create();
     }
 
-    public static void runParrallelStream(Stream<Runnable> stream) {
-        FluentFutureStream.of(stream
-                .map(runnable -> CompletableFuture.supplyAsync(toVoidSupplier(runnable))))
-            .join();
+    @Override
+    public void afterEach(ExtensionContext extensionContext) {
+        temporaryFolder.delete();
     }
 
-    private static Supplier<Void> toVoidSupplier(Runnable runnable) {
-        return () -> {
-            runnable.run();
-            return null;
-        };
+    public TemporaryFolder getTemporaryFolder() {
+        return temporaryFolder;
     }
 }

--- a/server/container/guice/jpa-guice/src/test/java/org/apache/james/JPAJamesServerTest.java
+++ b/server/container/guice/jpa-guice/src/test/java/org/apache/james/JPAJamesServerTest.java
@@ -21,9 +21,8 @@ package org.apache.james;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
-
 import org.apache.james.core.quota.QuotaSize;
+import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mailbox.model.SerializableQuotaValue;
 import org.apache.james.modules.QuotaProbesImpl;
 import org.apache.james.modules.protocols.ImapGuiceProbe;
@@ -35,56 +34,50 @@ import org.apache.james.utils.SMTPMessageSender;
 import org.awaitility.Awaitility;
 import org.awaitility.Duration;
 import org.awaitility.core.ConditionFactory;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.base.Strings;
+import com.google.inject.util.Modules;
 
-public class JPAJamesServerTest extends AbstractJamesServerTest {
+class JPAJamesServerTest implements JamesServerContract {
+
+    @RegisterExtension
+    static JamesServerExtension jamesServerExtension = new JamesServerExtensionBuilder()
+        .server(configuration -> GuiceJamesServer.forConfiguration(configuration)
+            .combineWith(JPAJamesServerMain.JPA_SERVER_MODULE, JPAJamesServerMain.PROTOCOLS)
+            .overrideWith(new TestJPAConfigurationModule(), DOMAIN_LIST_CONFIGURATION_MODULE))
+        .build();
 
     private static final ConditionFactory AWAIT = Awaitility.await()
         .atMost(Duration.ONE_MINUTE)
         .with()
         .pollInterval(Duration.FIVE_HUNDRED_MILLISECONDS);
-    private static final String DOMAIN = "james.local";
+    static final String DOMAIN = "james.local";
     private static final String USER = "toto@" + DOMAIN;
     private static final String PASSWORD = "123456";
 
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
-    @Rule
-    public IMAPMessageReader imapMessageReader = new IMAPMessageReader();
-    @Rule
-    public SMTPMessageSender smtpMessageSender = new SMTPMessageSender(DOMAIN);
+    private IMAPMessageReader imapMessageReader;
+    private SMTPMessageSender smtpMessageSender;
 
-    @Override
-    protected GuiceJamesServer createJamesServer() throws IOException {
-        Configuration configuration = Configuration.builder()
-            .workingDirectory(temporaryFolder.newFolder())
-            .configurationFromClasspath()
-            .build();
-
-        return GuiceJamesServer.forConfiguration(configuration)
-            .combineWith(JPAJamesServerMain.JPA_SERVER_MODULE, JPAJamesServerMain.PROTOCOLS)
-            .overrideWith(new TestJPAConfigurationModule(), DOMAIN_LIST_CONFIGURATION_MODULE);
+    @BeforeEach
+    void setUp() {
+        this.imapMessageReader = new IMAPMessageReader();
+        this.smtpMessageSender = new SMTPMessageSender(DOMAIN);
     }
-
-    @Override
-    protected void clean() {
-    }
-
+    
     @Test
-    public void jpaGuiceServerShouldUpdateQuota() throws Exception {
-        server.getProbe(DataProbeImpl.class)
+    void jpaGuiceServerShouldUpdateQuota(GuiceJamesServer jamesServer) throws Exception {
+        jamesServer.getProbe(DataProbeImpl.class)
             .fluent()
             .addDomain(DOMAIN)
             .addUser(USER, PASSWORD);
-        server.getProbe(QuotaProbesImpl.class).setGlobalMaxStorage(new SerializableQuotaValue<>(QuotaSize.size(50 * 1024)));
+        jamesServer.getProbe(QuotaProbesImpl.class).setGlobalMaxStorage(new SerializableQuotaValue<>(QuotaSize.size(50 * 1024)));
 
         // ~ 12 KB email
-        int imapPort = server.getProbe(ImapGuiceProbe.class).getImapPort();
-        smtpMessageSender.connect(JAMES_SERVER_HOST, server.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+        int imapPort = jamesServer.getProbe(ImapGuiceProbe.class).getImapPort();
+        smtpMessageSender.connect(JAMES_SERVER_HOST, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
             .sendMessageWithHeaders(USER, USER, "header: toto\\r\\n\\r\\n" + Strings.repeat("0123456789\n", 1024));
         AWAIT.until(() -> imapMessageReader.connect(JAMES_SERVER_HOST, imapPort)
             .login(USER, PASSWORD)
@@ -99,5 +92,4 @@ public class JPAJamesServerTest extends AbstractJamesServerTest {
                 "* QUOTA #private&toto@james.local (STORAGE 12 50)\r\n")
             .endsWith("OK GETQUOTAROOT completed.\r\n");
     }
-
 }

--- a/server/container/guice/jpa-guice/src/test/java/org/apache/james/JPAJamesServerTest.java
+++ b/server/container/guice/jpa-guice/src/test/java/org/apache/james/JPAJamesServerTest.java
@@ -22,12 +22,10 @@ package org.apache.james;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.james.core.quota.QuotaSize;
-import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mailbox.model.SerializableQuotaValue;
 import org.apache.james.modules.QuotaProbesImpl;
 import org.apache.james.modules.protocols.ImapGuiceProbe;
 import org.apache.james.modules.protocols.SmtpGuiceProbe;
-import org.apache.james.server.core.configuration.Configuration;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.IMAPMessageReader;
 import org.apache.james.utils.SMTPMessageSender;
@@ -39,7 +37,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.base.Strings;
-import com.google.inject.util.Modules;
 
 class JPAJamesServerTest implements JamesServerContract {
 

--- a/server/container/guice/jpa-guice/src/test/java/org/apache/james/JPAJamesServerWithSqlValidationTest.java
+++ b/server/container/guice/jpa-guice/src/test/java/org/apache/james/JPAJamesServerWithSqlValidationTest.java
@@ -19,27 +19,21 @@
 
 package org.apache.james;
 
-import java.io.IOException;
-
 import org.apache.james.server.core.configuration.Configuration;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class JPAJamesServerWithSqlValidationTest extends JPAJamesServerTest {
+class JPAJamesServerWithSqlValidationTest extends JPAJamesServerTest {
 
-    @Override
-    protected GuiceJamesServer createJamesServer() throws IOException {
-        Configuration configuration = Configuration.builder()
-            .workingDirectory(temporaryFolder.newFolder())
-            .configurationFromClasspath()
-            .build();
-
-        return GuiceJamesServer.forConfiguration(configuration)
+    @RegisterExtension
+    static JamesServerExtension jamesServerExtension = new JamesServerExtensionBuilder()
+        .server(configuration -> GuiceJamesServer.forConfiguration(configuration)
             .combineWith(JPAJamesServerMain.JPA_SERVER_MODULE, JPAJamesServerMain.PROTOCOLS)
-            .overrideWith(new TestJPAConfigurationModuleWithSqlValidation(), DOMAIN_LIST_CONFIGURATION_MODULE);
-    }
+            .overrideWith(new TestJPAConfigurationModuleWithSqlValidation(), DOMAIN_LIST_CONFIGURATION_MODULE))
+        .build();
 
     @Override
-    @Ignore("Failing to create the domain: duplicate with test in JPAJamesServerTest")
-    public void jpaGuiceServerShouldUpdateQuota() {
+    @Disabled("Failing to create the domain: duplicate with test in JPAJamesServerTest")
+    void jpaGuiceServerShouldUpdateQuota(GuiceJamesServer jamesServer) {
     }
 }

--- a/server/container/guice/jpa-guice/src/test/java/org/apache/james/JPAJamesServerWithSqlValidationTest.java
+++ b/server/container/guice/jpa-guice/src/test/java/org/apache/james/JPAJamesServerWithSqlValidationTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.james;
 
-import org.apache.james.server.core.configuration.Configuration;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.RegisterExtension;
 

--- a/server/container/guice/memory-guice/pom.xml
+++ b/server/container/guice/memory-guice/pom.xml
@@ -153,8 +153,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/server/container/guice/memory-guice/src/test/java/org/apache/james/MemoryJamesServerTest.java
+++ b/server/container/guice/memory-guice/src/test/java/org/apache/james/MemoryJamesServerTest.java
@@ -19,23 +19,12 @@
 
 package org.apache.james;
 
-import java.util.List;
-
-import org.apache.activemq.store.PersistenceAdapter;
-import org.apache.activemq.store.memory.MemoryPersistenceAdapter;
 import org.apache.james.mailbox.extractor.TextExtractor;
-import org.apache.james.mailbox.store.search.MessageSearchIndex;
 import org.apache.james.mailbox.store.search.PDFTextExtractor;
-import org.apache.james.mailbox.store.search.SimpleMessageSearchIndex;
 import org.apache.james.modules.TestJMAPServerModule;
-import org.apache.james.server.core.configuration.Configuration;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.google.common.collect.ImmutableList;
-import com.google.inject.Module;
-
 class MemoryJamesServerTest implements JamesServerContract {
-
     private static final int LIMIT_TO_10_MESSAGES = 10;
 
     @RegisterExtension
@@ -43,10 +32,7 @@ class MemoryJamesServerTest implements JamesServerContract {
         .server(configuration -> GuiceJamesServer.forConfiguration(configuration)
             .combineWith(MemoryJamesServerMain.IN_MEMORY_SERVER_AGGREGATE_MODULE)
             .overrideWith(new TestJMAPServerModule(LIMIT_TO_10_MESSAGES))
-            .overrideWith(binder -> binder.bind(PersistenceAdapter.class).to(MemoryPersistenceAdapter.class))
             .overrideWith(binder -> binder.bind(TextExtractor.class).to(PDFTextExtractor.class))
-            .overrideWith(binder -> binder.bind(MessageSearchIndex.class).to(SimpleMessageSearchIndex.class))
             .overrideWith(DOMAIN_LIST_CONFIGURATION_MODULE))
         .build();
-
 }

--- a/server/testing/src/main/java/org/apache/james/junit/TemporaryFolderExtension.java
+++ b/server/testing/src/main/java/org/apache/james/junit/TemporaryFolderExtension.java
@@ -55,6 +55,10 @@ public class TemporaryFolderExtension implements ParameterResolver, BeforeEachCa
         FileUtils.deleteDirectory(temporaryFolder.getTempDir());
     }
 
+    public TemporaryFolder getTemporaryFolder() {
+        return temporaryFolder;
+    }
+
     public static class TemporaryFolder {
         private final File tempDir;
         private final String folderPath;


### PR DESCRIPTION
	This changeset leverage existing builders to create a JamesServerExtensionBuilder
	This JamesServerExtensionBuilder helps build a junit5 programmatic extension for
	Guice James and its related dependencies