### PR TITLE
WIP Mailet jsonable attributes

### DIFF
--- a/mailet/api/pom.xml
+++ b/mailet/api/pom.xml
@@ -53,11 +53,6 @@
             <artifactId>javax.mail</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
             <scope>test</scope>
@@ -65,6 +60,21 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/mailet/api/pom.xml
+++ b/mailet/api/pom.xml
@@ -41,6 +41,22 @@
             <artifactId>james-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>james-server-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.steveash.guavate</groupId>
             <artifactId>guavate</artifactId>
         </dependency>
@@ -80,6 +96,11 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>de.ruedigermoeller</groupId>
+            <artifactId>fst</artifactId>
+            <version>2.56</version>
         </dependency>
     </dependencies>
 

--- a/mailet/api/src/main/java/org/apache/mailet/Attribute.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Attribute.java
@@ -1,0 +1,61 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.mailet;
+
+import java.util.Objects;
+
+/** 
+ * Attribute
+ * 
+ * @since Mailet API v3.2
+ */
+public class Attribute {
+    private final AttributeName name;
+    private final Object /*for the moment*/ value;
+
+    public Attribute(AttributeName name, Object value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public AttributeName getName() {
+        return name;
+    }
+
+    public Object /*for the moment*/ getValue() {
+        return value;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof Attribute) {
+            Attribute that = (Attribute) o;
+
+            return Objects.equals(this.name, that.name)
+                && Objects.equals(this.value, that.value);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(name, value);
+    }
+}

--- a/mailet/api/src/main/java/org/apache/mailet/Attribute.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Attribute.java
@@ -28,9 +28,9 @@ import java.util.Objects;
  */
 public class Attribute {
     private final AttributeName name;
-    private final Object /*for the moment*/ value;
+    private final AttributeValue<?> value;
 
-    public Attribute(AttributeName name, Object value) {
+    public Attribute(AttributeName name, AttributeValue<?> value) {
         this.name = name;
         this.value = value;
     }
@@ -39,8 +39,12 @@ public class Attribute {
         return name;
     }
 
-    public Object /*for the moment*/ getValue() {
+    public AttributeValue<?> getValue() {
         return value;
+    }
+
+    public Attribute duplicate() {
+        return new Attribute(name, value.duplicate());
     }
 
     @Override
@@ -53,9 +57,9 @@ public class Attribute {
         }
         return false;
     }
-
     @Override
     public final int hashCode() {
         return Objects.hash(name, value);
     }
+
 }

--- a/mailet/api/src/main/java/org/apache/mailet/AttributeName.java
+++ b/mailet/api/src/main/java/org/apache/mailet/AttributeName.java
@@ -1,0 +1,58 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.mailet;
+
+import java.util.Objects;
+
+/** 
+ * Strong typing for attribute name, which represent the name of an attribute store in a mail.
+ * 
+ * @since Mailet API v3.2
+ */
+public class AttributeName {
+    private final String name;
+
+    public static AttributeName of(String name) {
+        return new AttributeName(name);
+    }
+
+    private AttributeName(String name) {
+        this.name = name;
+    }
+
+    public String asString() {
+        return name;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof AttributeName) {
+            AttributeName that = (AttributeName) o;
+
+            return Objects.equals(this.name, that.name);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(name);
+    }
+}

--- a/mailet/api/src/main/java/org/apache/mailet/AttributeValue.java
+++ b/mailet/api/src/main/java/org/apache/mailet/AttributeValue.java
@@ -1,0 +1,188 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.mailet;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.james.util.streams.Iterators;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.github.steveash.guavate.Guavate;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+
+/** 
+ * Strong typing for attribute value, which represent the value of an attribute stored in a mail.
+ * 
+ * @since Mailet API v3.2
+ */
+public class AttributeValue<T> {
+
+    public static AttributeValue<Boolean> of(Boolean value) {
+        return new AttributeValue<>(value, Serializer.BOOLEAN_SERIALIZER);
+    }
+
+    public static AttributeValue<String> of(String value) {
+        return new AttributeValue<>(value, Serializer.STRING_SERIALIZER);
+    }
+
+    public static AttributeValue<Integer> of(Integer value) {
+        return new AttributeValue<>(value, Serializer.INT_SERIALIZER);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static AttributeValue<Collection<AttributeValue<?>>> of(Collection<AttributeValue<?>> value) {
+        return new AttributeValue<>(value, new Serializer.CollectionSerializer());
+    }
+
+    public static AttributeValue<Map<String, AttributeValue<?>>> of(Map<String, AttributeValue<?>> value) {
+        return new AttributeValue<>(value, new Serializer.MapSerializer());
+    }
+
+    public static AttributeValue<Serializable> ofSerializable(Serializable value) {
+        return new AttributeValue<>(value, new Serializer.FSTSerializer());
+    }
+
+    @SuppressWarnings("unchecked")
+    public static AttributeValue<?> of(Object value) {
+        if (value instanceof Boolean) {
+            return of((Boolean) value);
+        }
+        if (value instanceof String) {
+            return of((String) value);
+        }
+        if (value instanceof Integer) {
+            return of((Integer) value);
+        }
+        if (value instanceof Collection<?>) {
+            return of(((Collection<AttributeValue<?>>) value));
+        }
+        if (value instanceof Map<?,?>) {
+            return of(((Map<String, AttributeValue<?>>) value));
+        }
+        if (value instanceof Serializable) {
+            return ofSerializable((Serializable) value);
+        }
+        throw new IllegalArgumentException("input should at least be Serializable");
+    }
+
+    public static AttributeValue<?> fromJsonString(String json) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode tree = objectMapper.readTree(json);
+        return fromJson(tree);
+    }
+
+    @VisibleForTesting
+    static AttributeValue<?> fromJson(JsonNode input) {
+        if (input instanceof BooleanNode) {
+            return fromJson((BooleanNode) input);
+        }
+        if (input instanceof TextNode) {
+            return fromJson((TextNode) input);
+        }
+        if (input instanceof IntNode) {
+            return fromJson((IntNode) input);
+        }
+        if (input instanceof ArrayNode) {
+            return fromJson((ArrayNode) input);
+        }
+        //FIXME how are we supposed to choose between a Map and an Object Graph from FST
+        if (input instanceof ObjectNode) {
+            return fromJson((ObjectNode) input);
+        }
+        throw new IllegalStateException("unable to deserialize type " + input.getNodeType());
+    }
+
+    private static AttributeValue<Boolean> fromJson(BooleanNode booleanAsJson) {
+        return AttributeValue.of(booleanAsJson.asBoolean());
+    }
+
+    private static AttributeValue<String> fromJson(TextNode stringAsJson) {
+        return AttributeValue.of(stringAsJson.asText());
+    }
+
+    private static AttributeValue<Integer> fromJson(IntNode intAsJson) {
+        return AttributeValue.of(intAsJson.asInt());
+    }
+
+    private static AttributeValue<? extends Collection<?>> fromJson(ArrayNode arrayAsJson) {
+        return AttributeValue.of(
+            Iterators.toStream(arrayAsJson.elements())
+                .map(AttributeValue::fromJson)
+                .collect(ImmutableList.toImmutableList()));
+    }
+
+    private static AttributeValue<? extends Map<String, ?>> fromJson(ObjectNode mapAsJson) {
+        return AttributeValue.of(
+            Iterators.toStream(mapAsJson.fields())
+                .collect(Guavate.toImmutableMap(
+                    Map.Entry::getKey,
+                    entry -> fromJson(entry.getValue())
+                )));
+    }
+
+    private final T value;
+    private final Serializer<T> serializer;
+
+    private AttributeValue(T value, Serializer<T> serializer) {
+        this.value = value;
+        this.serializer = serializer;
+    }
+
+    public T value() {
+        return value;
+    }
+
+    //FIXME : poor performance
+    public AttributeValue<T> duplicate() {
+        return (AttributeValue<T>) fromJson(toJson());
+    }
+
+    public JsonNode toJson() {
+        return serializer.serialize(value);
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof AttributeValue) {
+            AttributeValue<?> that = (AttributeValue<?>) o;
+
+            return Objects.equals(this.value, that.value)
+                && Objects.equals(this.serializer, that.serializer);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(value, serializer);
+    }
+}

--- a/mailet/api/src/main/java/org/apache/mailet/Mail.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Mail.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.Optional;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
@@ -181,8 +182,12 @@ public interface Mail extends Serializable, Cloneable {
      * @param name the attribute name
      * @return the attribute value, or null if the attribute does not exist
      * @since Mailet API v2.1
+     * @deprecated see {@link #getAttribute(AttributeName)}
      */
+    @Deprecated
     Serializable getAttribute(String name);
+    
+    Optional<Attribute> getAttribute(AttributeName name);
     
     /**
      * Returns an Iterator over the names of all attributes which are set
@@ -193,8 +198,11 @@ public interface Mail extends Serializable, Cloneable {
      *
      * @return an Iterator (of Strings) over all attribute names
      * @since Mailet API v2.1
+     * @deprecated see {@link #attributeNames()}
      */
     Iterator<String> getAttributeNames();
+
+    Iterator<AttributeName> attributeNames();
 
     /**
      * Returns whether this Mail instance has any attributes set.
@@ -212,8 +220,11 @@ public interface Mail extends Serializable, Cloneable {
      *      if there was no such attribute (or if the attribute existed
      *      and its value was null)
      * @since Mailet API v2.1
+     * @deprecated see {@link #removeAttribute(AttributeName)
      */
     Serializable removeAttribute(String name);
+
+    Attribute removeAttribute(AttributeName attributeName);
     
     /**
      * Removes all attributes associated with this Mail instance. 
@@ -237,8 +248,11 @@ public interface Mail extends Serializable, Cloneable {
      *      or null if there was no such attribute (or if the attribute existed
      *      and its value was null)
      * @since Mailet API v2.1
+     * @deprecated see {@link #setAttribute(Attribute)
      */
     Serializable setAttribute(String name, Serializable object);
+
+    Attribute setAttribute(Attribute attribute);
 
     /**
      * Store a header (and its specific values) for a recipient

--- a/mailet/api/src/main/java/org/apache/mailet/Mail.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Mail.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
@@ -174,7 +175,9 @@ public interface Mail extends Serializable, Cloneable {
      * @param state the new state of this message
      */
     void setState(String state);
-    
+
+    Stream<Attribute> attributes();
+
     /**
      * Returns the value of the named Mail instance attribute,
      * or null if the attribute does not exist.

--- a/mailet/api/src/main/java/org/apache/mailet/Serializer.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Serializer.java
@@ -1,0 +1,141 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.mailet;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.UncheckedIOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.nustaq.serialization.FSTConfiguration;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+/** 
+ * Serializer
+ * 
+ * @since Mailet API v3.2
+ */
+public interface Serializer<T> {
+    JsonNode serialize(T object);
+
+    class BooleanSerializer implements Serializer<Boolean> {
+        @Override
+        public JsonNode serialize(Boolean object) {
+            return BooleanNode.valueOf(object);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this.getClass() == other.getClass();
+        }
+    }
+
+    Serializer<Boolean> BOOLEAN_SERIALIZER = new BooleanSerializer();
+
+    class StringSerializer implements Serializer<String> {
+        @Override
+        public JsonNode serialize(String object) {
+            return TextNode.valueOf(object);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this.getClass() == other.getClass();
+        }
+    }
+
+    Serializer<String> STRING_SERIALIZER = new StringSerializer();
+
+    class IntSerializer implements Serializer<Integer> {
+        @Override
+        public JsonNode serialize(Integer object) {
+            return IntNode.valueOf(object);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this.getClass() == other.getClass();
+        }
+    }
+
+    Serializer<Integer> INT_SERIALIZER = new IntSerializer();
+
+    class CollectionSerializer<U> implements Serializer<Collection<AttributeValue<U>>> {
+        @Override
+        public JsonNode serialize(Collection<AttributeValue<U>> object) {
+            List<JsonNode> jsons = object.stream()
+                .map(AttributeValue::toJson)
+                .collect(ImmutableList.toImmutableList());
+            return new ArrayNode(JsonNodeFactory.instance, jsons);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this.getClass() == other.getClass();
+        }
+    }
+
+    class MapSerializer<U> implements Serializer<Map<String, AttributeValue<U>>> {
+        @Override
+        public JsonNode serialize(Map<String, AttributeValue<U>> object) {
+            Map<String, JsonNode> jsonMap = object.entrySet().stream()
+                .collect(ImmutableMap.toImmutableMap(Entry::getKey, entry -> entry.getValue().toJson()));
+            return new ObjectNode(JsonNodeFactory.instance, jsonMap);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this.getClass() == other.getClass();
+        }
+    }
+
+    class FSTSerializer implements Serializer<Serializable> {
+        @Override
+        public JsonNode serialize(Serializable object) {
+            FSTConfiguration conf = FSTConfiguration.createJsonConfiguration();
+            String json = conf.asJsonString(object);
+            try {
+                return new ObjectMapper().reader().readTree(json);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this.getClass() == other.getClass();
+        }
+    }
+}

--- a/mailet/api/src/test/java/org/apache/mailet/AttributeNameTest.java
+++ b/mailet/api/src/test/java/org/apache/mailet/AttributeNameTest.java
@@ -1,0 +1,32 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.mailet;
+
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class AttributeNameTest {
+
+    @Test
+    void shouldRespectBeanContract() {
+        EqualsVerifier.forClass(AttributeName.class).verify();
+    }
+
+}

--- a/mailet/api/src/test/java/org/apache/mailet/AttributeTest.java
+++ b/mailet/api/src/test/java/org/apache/mailet/AttributeTest.java
@@ -1,0 +1,32 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.mailet;
+
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class AttributeTest {
+
+    @Test
+    void shouldRespectBeanContract() {
+        EqualsVerifier.forClass(Attribute.class).verify();
+    }
+
+}

--- a/mailet/api/src/test/java/org/apache/mailet/AttributeValueTest.java
+++ b/mailet/api/src/test/java/org/apache/mailet/AttributeValueTest.java
@@ -1,0 +1,141 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.mailet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class AttributeValueTest {
+    @Test
+    void shouldRespectBeanContract() {
+        EqualsVerifier.forClass(AttributeValue.class).verify();
+    }
+
+    @Test
+    void stringShouldBeSerializedAndBack() {
+        AttributeValue<String> expected = AttributeValue.of("value");
+        
+        JsonNode json = expected.toJson();
+        AttributeValue<?> actual = AttributeValue.fromJson(json);
+        
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void booleanShouldBeSerializedAndBack() {
+        AttributeValue<Boolean> expected = AttributeValue.of(true);
+
+        JsonNode json = expected.toJson();
+        AttributeValue<?> actual = AttributeValue.fromJson(json);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+
+    @Test
+    void intShouldBeSerializedAndBack() {
+        AttributeValue<Integer> expected = AttributeValue.of(42);
+        
+        JsonNode json = expected.toJson();
+        AttributeValue<?> actual = AttributeValue.fromJson(json);
+        
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void emptyStringListShouldBeSerializedAndBack() {
+        AttributeValue<?> expected = AttributeValue.of(ImmutableList.<String>of());
+        
+        JsonNode json = expected.toJson();
+        AttributeValue<?> actual = AttributeValue.fromJson(json);
+        
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void listShouldBeSerializedAndBack() {
+        AttributeValue<?> expected = AttributeValue.of(ImmutableList.of(AttributeValue.of("first"), AttributeValue.of("second")));
+        
+        JsonNode json = expected.toJson();
+        AttributeValue<?> actual = AttributeValue.fromJson(json);
+        
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void emptyMapShouldBeSerializedAndBack() {
+        AttributeValue<?> expected = AttributeValue.of(ImmutableMap.of());
+        JsonNode json = expected.toJson();
+        AttributeValue<?> actual = AttributeValue.fromJson(json);
+        
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void mapWithPrimitiveTypesShouldBeSerializedAndBack() {
+        AttributeValue<?> expected = AttributeValue.of(ImmutableMap.of("a", AttributeValue.of("value"), "b", AttributeValue.of(12)));
+        JsonNode json = expected.toJson();
+        AttributeValue<?> actual = AttributeValue.fromJson(json);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void fromJsonStringShouldReturnStringAttributeValueWhenString() throws Exception {
+        AttributeValue<String> expected = AttributeValue.of("value");
+
+        AttributeValue<?> actual = AttributeValue.fromJsonString("\"value\"");
+        
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void fromJsonStringShouldReturnIntAttributeValueWhenInt() throws Exception {
+        AttributeValue<Integer> expected = AttributeValue.of(42);
+
+        AttributeValue<?> actual = AttributeValue.fromJsonString("42");
+        
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void fromJsonStringShouldReturnEmptyListAttributeValueWhenEmptyArray() throws Exception {
+        AttributeValue<?> expected = AttributeValue.of(ImmutableList.of());
+
+        AttributeValue<?> actual = AttributeValue.fromJsonString("[]");
+        
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void fromJsonStringShouldReturnListAttributeValueWhenArray() throws Exception {
+        AttributeValue<?> expected = AttributeValue.of(ImmutableList.of(AttributeValue.of("first"), AttributeValue.of("second")));
+
+        AttributeValue<?> actual = AttributeValue.fromJsonString("[\"first\",\"second\"]");
+        
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/AmqpForwardAttribute.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/AmqpForwardAttribute.java
@@ -139,6 +139,9 @@ public class AmqpForwardAttribute extends GenericMailet {
     }
 
     private void sendContent(Stream<byte[]> content) throws IOException, TimeoutException {
+        //FIXME: we open a connection even when there's no contact to collect
+        //also, opening a connection for every mail looks like a bad idea, we should use
+        //our connection pool
         Connection connection = null;
         Channel channel = null;
         try {

--- a/server/container/core/src/main/java/org/apache/james/server/core/MailImpl.java
+++ b/server/container/core/src/main/java/org/apache/james/server/core/MailImpl.java
@@ -37,6 +37,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.mail.Address;
 import javax.mail.MessagingException;
@@ -46,10 +49,15 @@ import javax.mail.internet.MimeMessage;
 import javax.mail.internet.ParseException;
 
 import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.builder.MimeMessageBuilder;
 import org.apache.james.lifecycle.api.Disposable;
 import org.apache.james.lifecycle.api.LifecycleUtil;
+import org.apache.mailet.Attribute;
+import org.apache.mailet.AttributeName;
+import org.apache.mailet.AttributeValue;
 import org.apache.mailet.Mail;
 import org.apache.mailet.PerRecipientHeaders;
 import org.apache.mailet.PerRecipientHeaders.Header;
@@ -351,7 +359,7 @@ public class MailImpl implements Disposable, Mail {
     /**
      * Attributes added to this MailImpl instance
      */
-    private Map<String, Object> attributes;
+    private Map<AttributeName, AttributeValue<?>> attributes;
     /**
      * Specific headers for some recipients
      * These headers will be added at delivery time
@@ -394,21 +402,9 @@ public class MailImpl implements Disposable, Mail {
         setRemoteAddr(mail.getRemoteAddr());
         setLastUpdated(mail.getLastUpdated());
         setErrorMessage(mail.getErrorMessage());
-        try {
-            if (mail instanceof MailImpl) {
-                setAttributesRaw((HashMap<String, Object>) cloneSerializableObject(((MailImpl) mail).getAttributesRaw()));
-            } else {
-                HashMap<String, Object> attribs = new HashMap<>();
-                for (Iterator<String> i = mail.getAttributeNames(); i.hasNext(); ) {
-                    String hashKey = i.next();
-                    attribs.put(hashKey, cloneSerializableObject(mail.getAttribute(hashKey)));
-                }
-                setAttributesRaw(attribs);
-            }
-        } catch (IOException | ClassNotFoundException e) {
-            LOGGER.error("Error while deserializing attributes", e);
-            setAttributesRaw(new HashMap<>());
-        }
+        this.attributes = mail.attributes()
+            .map(attribute -> attribute.duplicate())
+            .collect(Collectors.toMap(Attribute::getName, Attribute::getValue));
     }
 
     /**
@@ -642,7 +638,7 @@ public class MailImpl implements Disposable, Mail {
         // the following is under try/catch to be backwards compatible
         // with messages created with James version <= 2.2.0a8
         try {
-            attributes = (HashMap<String, Object>) in.readObject();
+            setAttributesRaw((Map<String, Object>) in.readObject());
         } catch (OptionalDataException ode) {
             if (ode.eof) {
                 attributes = new HashMap<>();
@@ -668,7 +664,8 @@ public class MailImpl implements Disposable, Mail {
         out.writeObject(remoteHost);
         out.writeObject(remoteAddr);
         out.writeObject(lastUpdated);
-        out.writeObject(attributes);
+        //FIXME: are we supposed to serialize the new map ? (required by FileMailRepository for now)
+        out.writeObject(getAttributesRaw());
         out.writeObject(perRecipientSpecificHeaders);
     }
 
@@ -692,7 +689,11 @@ public class MailImpl implements Disposable, Mail {
      * @since 2.2.0
      */
     public Map<String, Object> getAttributesRaw() {
-        return attributes;
+        return attributes.entrySet().stream()
+            .collect(
+                Guavate.toImmutableMap(
+                    x -> x.getKey().asString(),
+                    x -> x.getValue().value()));
     }
 
     /**
@@ -708,24 +709,59 @@ public class MailImpl implements Disposable, Mail {
      * @param attr Serializable of the entire attributes collection
      * @since 2.2.0
      */
-    public void setAttributesRaw(HashMap<String, Object> attr) {
-        this.attributes = (attr == null) ? new HashMap<>() : attr;
+    public void setAttributesRaw(Map<String, Object> attr) {
+        this.attributes = Optional.ofNullable(attr)
+            .map(this::toStronglyTypedMap)
+            .orElse(new HashMap<>());
+    }
+
+    private Map<AttributeName, AttributeValue<?>> toStronglyTypedMap(Map<String, Object> input) {
+        return input
+            .entrySet()
+            .stream()
+            .collect(Collectors.toMap(
+                x -> AttributeName.of(x.getKey()),
+                x -> AttributeValue.of(x.getValue())));
+    }
+
+    @Override
+    public Stream<Attribute> attributes() {
+        return this.attributes.entrySet().stream().map(entry -> new Attribute(entry.getKey(), entry.getValue()));
     }
 
     @Override
     public Serializable getAttribute(String key) {
-        return (Serializable) attributes.get(key);
+        return (Serializable) Optional.ofNullable(attributes.get(AttributeName.of(key))).map(AttributeValue::value).orElse(null);
+    }
+
+    @Override
+    public Optional<Attribute> getAttribute(AttributeName name) {
+        return Optional.ofNullable(attributes.get(name)).map(value -> new Attribute(name, value));
     }
 
     @Override
     public Serializable setAttribute(String key, Serializable object) {
         Preconditions.checkNotNull(key, "Key of an attribute should not be null");
-        return (Serializable) attributes.put(key, object);
+        AttributeValue<?> previous = attributes.put(AttributeName.of(key), AttributeValue.of(object));
+        return Optional.ofNullable(previous).map(x -> (Serializable) x.value()).orElse(null);
+    }
+
+    @Override
+    public Attribute setAttribute(Attribute attribute) {
+        AttributeValue<?> previous = this.attributes.put(attribute.getName(), attribute.getValue());
+        return Optional.ofNullable(previous).map(value -> new Attribute(attribute.getName(), value)).orElse(null);
     }
 
     @Override
     public Serializable removeAttribute(String key) {
-        return (Serializable) attributes.remove(key);
+        AttributeValue<?> remove = attributes.remove(AttributeName.of(key));
+        return (Serializable) Optional.ofNullable(remove).map(AttributeValue::value).orElse(null);
+    }
+
+    @Override
+    public Attribute removeAttribute(AttributeName attributeName) {
+        AttributeValue<?> previous = attributes.remove(attributeName);
+        return Optional.ofNullable(previous).map(value -> new Attribute(attributeName, value)).orElse(null);
     }
 
     @Override
@@ -735,6 +771,11 @@ public class MailImpl implements Disposable, Mail {
 
     @Override
     public Iterator<String> getAttributeNames() {
+        return attributes.keySet().stream().map(AttributeName::asString).iterator();
+    }
+
+    @Override
+    public Iterator<AttributeName> attributeNames() {
         return attributes.keySet().iterator();
     }
 


### PR DESCRIPTION
We are not done yet, here is the list of things that are still required : 
* ensure that we don't confuse Map with Serializable (both are probably read from Json as ObjectNode)
* extract the Json handling part from mailet-api, it doesn't belong to this project, it's just one serialization implementation
* handle attributes duplication in an efficient way
* as FakeMail is becoming huge and duplicates a lot of MailImpl logic, we should rather invest in removing FakeMail in favor of MailImpl and its builder
* we should write tests to ensure we are able to read previously serialized Mail objects

Maybe there's more work than that but at least the compatibility layer should be ok as I ran almost all Mailet integration tests before pushing this PR.

If you want to read the non-squashed branch, you can find it here : https://github.com/mbaechler/james-project/tree/mailet-jsonable-attributes