### PR TITLE
[JAMES-2525] Cryptographic support for object storage blob stores

### DIFF
--- a/server/blob/blob-objectstorage/pom.xml
+++ b/server/blob/blob-objectstorage/pom.xml
@@ -62,6 +62,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.crypto.tink</groupId>
+            <artifactId>tink</artifactId>
+            <version>1.2.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/AESPayloadCodec.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/AESPayloadCodec.java
@@ -58,7 +58,7 @@ public class AESPayloadCodec implements PayloadCodec {
                 }
             });
             copyThread.setUncaughtExceptionHandler((Thread t, Throwable e) ->
-                LOGGER.error("Unable to encrypt payload's input streal",e)
+                LOGGER.error("Unable to encrypt payload's input stream",e)
             );
             copyThread.start();
             return Payloads.newInputStreamPayload(snk);

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/AESPayloadCodec.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/AESPayloadCodec.java
@@ -1,0 +1,80 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.blob.objectstorage;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.security.GeneralSecurityException;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.james.blob.objectstorage.crypto.CryptoConfig;
+import org.apache.james.blob.objectstorage.crypto.PBKDF2StreamingAeadFactory;
+import org.jclouds.io.Payload;
+import org.jclouds.io.Payloads;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.crypto.tink.subtle.AesGcmHkdfStreaming;
+
+public class AESPayloadCodec implements PayloadCodec {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AESPayloadCodec.class);
+    private final AesGcmHkdfStreaming streamingAead;
+
+    public AESPayloadCodec(CryptoConfig cryptoConfig) {
+        streamingAead = PBKDF2StreamingAeadFactory.newAesGcmHkdfStreaming(cryptoConfig);
+    }
+
+    @Override
+    public Payload write(InputStream is) {
+        PipedInputStream snk = new PipedInputStream();
+        try {
+            PipedOutputStream src = new PipedOutputStream(snk);
+            OutputStream outputStream = streamingAead.newEncryptingStream(src, PBKDF2StreamingAeadFactory.EMPTY_ASSOCIATED_DATA);
+            Thread copyThread = new Thread(() -> {
+                try (OutputStream stream = outputStream) {
+                    IOUtils.copy(is, stream);
+                } catch (IOException e) {
+                    throw new RuntimeException("Stream copy failure ", e);
+                }
+            });
+            copyThread.setUncaughtExceptionHandler((Thread t, Throwable e) ->
+                LOGGER.error("Unable to encrypt payload's input streal",e)
+            );
+            copyThread.start();
+            return Payloads.newInputStreamPayload(snk);
+        } catch (IOException | GeneralSecurityException e) {
+            throw new RuntimeException("Unable to build payload for object storage, failed to " +
+                "encrypt", e);
+        }
+    }
+
+    @Override
+    public InputStream read(Payload payload) throws IOException {
+        try {
+            return streamingAead.newDecryptingStream(payload.openStream(), PBKDF2StreamingAeadFactory.EMPTY_ASSOCIATED_DATA);
+        } catch (GeneralSecurityException e) {
+            throw new IOException("Incorrect crypto setup", e);
+        }
+    }
+
+}

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/DefaultPayloadCodec.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/DefaultPayloadCodec.java
@@ -1,0 +1,38 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.blob.objectstorage;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.jclouds.io.Payload;
+import org.jclouds.io.Payloads;
+
+public class DefaultPayloadCodec implements PayloadCodec {
+    @Override
+    public Payload write(InputStream is) {
+        return Payloads.newInputStreamPayload(is);
+    }
+
+    @Override
+    public InputStream read(Payload payload) throws IOException {
+        return payload.openStream();
+    }
+}

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAO.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAO.java
@@ -34,6 +34,7 @@ import org.apache.james.blob.objectstorage.swift.SwiftTempAuthObjectStorage;
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.options.CopyOptions;
 import org.jclouds.domain.Location;
+import org.jclouds.io.Payload;
 
 import com.github.fge.lambdas.Throwing;
 import com.google.common.base.Preconditions;
@@ -49,12 +50,14 @@ public class ObjectStorageBlobsDAO implements BlobStore {
 
     private final ContainerName containerName;
     private final org.jclouds.blobstore.BlobStore blobStore;
+    private final PayloadCodec payloadCodec;
 
     ObjectStorageBlobsDAO(ContainerName containerName, BlobId.Factory blobIdFactory,
-                          org.jclouds.blobstore.BlobStore blobStore) {
+                          org.jclouds.blobstore.BlobStore blobStore, PayloadCodec payloadCodec) {
         this.blobIdFactory = blobIdFactory;
         this.containerName = containerName;
         this.blobStore = blobStore;
+        this.payloadCodec = payloadCodec;
     }
 
     public static ObjectStorageBlobsDAOBuilder builder(SwiftTempAuthObjectStorage.Configuration testConfig) {
@@ -106,7 +109,8 @@ public class ObjectStorageBlobsDAO implements BlobStore {
     private BlobId save(InputStream data, BlobId id) {
         String containerName = this.containerName.value();
         HashingInputStream hashingInputStream = new HashingInputStream(Hashing.sha256(), data);
-        Blob blob = blobStore.blobBuilder(id.asString()).payload(hashingInputStream).build();
+        Payload payload = payloadCodec.write(hashingInputStream);
+        Blob blob = blobStore.blobBuilder(id.asString()).payload(payload).build();
         blobStore.putBlob(containerName, blob);
         return blobIdFactory.from(hashingInputStream.hash().toString());
     }
@@ -123,13 +127,13 @@ public class ObjectStorageBlobsDAO implements BlobStore {
 
         try {
             if (blob != null) {
-                return blob.getPayload().openStream();
+                return payloadCodec.read(blob.getPayload());
             } else {
                 return EMPTY_STREAM;
             }
         } catch (IOException cause) {
             throw new ObjectStoreException(
-                "Failed to read blob " + blobId.asString(),
+                "Failed to readBytes blob " + blobId.asString(),
                 cause);
         }
 

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAOBuilder.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAOBuilder.java
@@ -53,6 +53,7 @@ public class ObjectStorageBlobsDAOBuilder {
         this.payloadCodec = Optional.of(payloadCodec);
         return this;
     }
+    
     public ObjectStorageBlobsDAOBuilder payloadCodec(Optional<PayloadCodec> payloadCodec) {
         this.payloadCodec = payloadCodec;
         return this;

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAOBuilder.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAOBuilder.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.blob.objectstorage;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.apache.james.blob.api.BlobId;
@@ -31,10 +32,10 @@ public class ObjectStorageBlobsDAOBuilder {
     private final Supplier<BlobStore> supplier;
     private ContainerName containerName;
     private BlobId.Factory blobIdFactory;
-    private PayloadCodec payloadCodec;
+    private Optional<PayloadCodec> payloadCodec;
 
     public ObjectStorageBlobsDAOBuilder(Supplier<BlobStore> supplier) {
-        this.payloadCodec = PayloadCodec.DEFAULT_CODEC;
+        this.payloadCodec = Optional.empty();
         this.supplier = supplier;
     }
 
@@ -49,6 +50,10 @@ public class ObjectStorageBlobsDAOBuilder {
     }
 
     public ObjectStorageBlobsDAOBuilder payloadCodec(PayloadCodec payloadCodec) {
+        this.payloadCodec = Optional.of(payloadCodec);
+        return this;
+    }
+    public ObjectStorageBlobsDAOBuilder payloadCodec(Optional<PayloadCodec> payloadCodec) {
         this.payloadCodec = payloadCodec;
         return this;
     }
@@ -57,7 +62,7 @@ public class ObjectStorageBlobsDAOBuilder {
         Preconditions.checkState(containerName != null);
         Preconditions.checkState(blobIdFactory != null);
 
-        return new ObjectStorageBlobsDAO(containerName, blobIdFactory, supplier.get(), payloadCodec);
+        return new ObjectStorageBlobsDAO(containerName, blobIdFactory, supplier.get(), payloadCodec.orElse(PayloadCodec.DEFAULT_CODEC));
     }
 
     @VisibleForTesting

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAOBuilder.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAOBuilder.java
@@ -31,8 +31,10 @@ public class ObjectStorageBlobsDAOBuilder {
     private final Supplier<BlobStore> supplier;
     private ContainerName containerName;
     private BlobId.Factory blobIdFactory;
+    private PayloadCodec payloadCodec;
 
     public ObjectStorageBlobsDAOBuilder(Supplier<BlobStore> supplier) {
+        this.payloadCodec = PayloadCodec.DEFAULT_CODEC;
         this.supplier = supplier;
     }
 
@@ -46,10 +48,16 @@ public class ObjectStorageBlobsDAOBuilder {
         return this;
     }
 
+    public ObjectStorageBlobsDAOBuilder payloadCodec(PayloadCodec payloadCodec) {
+        this.payloadCodec = payloadCodec;
+        return this;
+    }
+
     public ObjectStorageBlobsDAO build() {
         Preconditions.checkState(containerName != null);
         Preconditions.checkState(blobIdFactory != null);
-        return new ObjectStorageBlobsDAO(containerName, blobIdFactory, supplier.get());
+
+        return new ObjectStorageBlobsDAO(containerName, blobIdFactory, supplier.get(), payloadCodec);
     }
 
     @VisibleForTesting

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/PayloadCodec.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/PayloadCodec.java
@@ -1,0 +1,33 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.blob.objectstorage;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.jclouds.io.Payload;
+
+public interface PayloadCodec {
+    Payload write(InputStream is);
+
+    InputStream read(Payload payload) throws IOException;
+
+    PayloadCodec DEFAULT_CODEC = new DefaultPayloadCodec();
+}

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/crypto/CryptoConfig.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/crypto/CryptoConfig.java
@@ -1,0 +1,40 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.blob.objectstorage.crypto;
+
+import com.google.crypto.tink.subtle.Hex;
+
+public class CryptoConfig {
+    private final String salt;
+    private final String password;
+
+    public CryptoConfig(String salt, String password) {
+        this.salt = salt;
+        this.password = password;
+    }
+
+    public byte[] salt() {
+        return Hex.decode(salt);
+    }
+
+    public String password() {
+        return password;
+    }
+}

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/crypto/CryptoConfig.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/crypto/CryptoConfig.java
@@ -28,9 +28,9 @@ public class CryptoConfig {
     }
 
     private final String salt;
-    private final String password;
+    private final char[] password;
 
-    public CryptoConfig(String salt, String password) {
+    public CryptoConfig(String salt, char[] password) {
         this.salt = salt;
         this.password = password;
     }
@@ -39,7 +39,7 @@ public class CryptoConfig {
         return Hex.decode(salt);
     }
 
-    public String password() {
+    public char[] password() {
         return password;
     }
 }

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/crypto/CryptoConfig.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/crypto/CryptoConfig.java
@@ -22,6 +22,11 @@ package org.apache.james.blob.objectstorage.crypto;
 import com.google.crypto.tink.subtle.Hex;
 
 public class CryptoConfig {
+
+    public static CryptoConfigBuilder builder() {
+        return new CryptoConfigBuilder();
+    }
+
     private final String salt;
     private final String password;
 

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/crypto/CryptoConfigBuilder.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/crypto/CryptoConfigBuilder.java
@@ -17,30 +17,32 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.blob.objectstorage;
+package org.apache.james.blob.objectstorage.crypto;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import com.amazonaws.util.StringUtils;
+import com.google.common.base.Preconditions;
+import com.google.crypto.tink.subtle.Hex;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
+public class CryptoConfigBuilder {
+    private String salt;
+    private String password;
 
-import org.junit.jupiter.api.Test;
-
-public interface PayloadCodecContract {
-    byte[] SOME_BYTES = "james".getBytes(StandardCharsets.UTF_8);
-
-    @Test
-    default void shouldBeAbleToReadFromWrittenPayload() throws Exception {
-        PayloadCodec codec = codec();
-        InputStream actual = codec.read(codec.write(expected()));
-        assertThat(actual).hasSameContentAs(expected());
+    CryptoConfigBuilder() {
     }
 
-    default ByteArrayInputStream expected() {
-        return new ByteArrayInputStream(SOME_BYTES);
+    public CryptoConfigBuilder salt(String salt) {
+        this.salt = salt;
+        return this;
     }
 
-    PayloadCodec codec();
+    public CryptoConfigBuilder password(String password) {
+        this.password = password;
+        return this;
+    }
 
+    public CryptoConfig build() {
+        Preconditions.checkState(!StringUtils.isNullOrEmpty(salt));
+        Preconditions.checkState(!StringUtils.isNullOrEmpty(password));
+        return new CryptoConfig(Hex.encode(Hex.decode(salt)), password);
+    }
 }

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/crypto/CryptoConfigBuilder.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/crypto/CryptoConfigBuilder.java
@@ -25,7 +25,7 @@ import com.google.crypto.tink.subtle.Hex;
 
 public class CryptoConfigBuilder {
     private String salt;
-    private String password;
+    private char[] password;
 
     CryptoConfigBuilder() {
     }
@@ -35,14 +35,14 @@ public class CryptoConfigBuilder {
         return this;
     }
 
-    public CryptoConfigBuilder password(String password) {
+    public CryptoConfigBuilder password(char[] password) {
         this.password = password;
         return this;
     }
 
     public CryptoConfig build() {
         Preconditions.checkState(!StringUtils.isNullOrEmpty(salt));
-        Preconditions.checkState(!StringUtils.isNullOrEmpty(password));
+        Preconditions.checkState(password != null && password.length > 0);
         return new CryptoConfig(Hex.encode(Hex.decode(salt)), password);
     }
 }

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/crypto/CryptoException.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/crypto/CryptoException.java
@@ -1,0 +1,34 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.blob.objectstorage.crypto;
+
+public class CryptoException extends RuntimeException {
+    public CryptoException() {
+        super();
+    }
+
+    public CryptoException(String message) {
+        super(message);
+    }
+
+    public CryptoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/crypto/PBKDF2StreamingAeadFactory.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/crypto/PBKDF2StreamingAeadFactory.java
@@ -53,7 +53,7 @@ public class PBKDF2StreamingAeadFactory {
             throws NoSuchAlgorithmException, InvalidKeySpecException {
         byte[] saltBytes = cryptoConfig.salt();
         SecretKeyFactory skf = SecretKeyFactory.getInstance(SECRET_KEY_FACTORY_ALGORITHM);
-        PBEKeySpec spec = new PBEKeySpec(cryptoConfig.password().toCharArray(), saltBytes, PBKDF2_ITERATIONS, KEY_SIZE);
+        PBEKeySpec spec = new PBEKeySpec(cryptoConfig.password(), saltBytes, PBKDF2_ITERATIONS, KEY_SIZE);
         return skf.generateSecret(spec);
     }
 }

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/crypto/PBKDF2StreamingAeadFactory.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/crypto/PBKDF2StreamingAeadFactory.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.blob.objectstorage.crypto;
 
-import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
@@ -44,19 +43,17 @@ public class PBKDF2StreamingAeadFactory {
         try {
             SecretKey secretKey = deriveKey(config);
             return new AesGcmHkdfStreaming(secretKey.getEncoded(), HKDF_ALGO, KEY_SIZE_IN_BYTES, SEGMENT_SIZE, OFFSET);
-        } catch (GeneralSecurityException | UnsupportedEncodingException e) {
+        } catch (GeneralSecurityException e) {
             throw new CryptoException("Incorrect crypto setup", e);
 
         }
     }
 
-    private static SecretKey deriveKey(CryptoConfig cryptoConfig) throws UnsupportedEncodingException,
-        NoSuchAlgorithmException,
-        InvalidKeySpecException {
+    private static SecretKey deriveKey(CryptoConfig cryptoConfig)
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
         byte[] saltBytes = cryptoConfig.salt();
         SecretKeyFactory skf = SecretKeyFactory.getInstance(SECRET_KEY_FACTORY_ALGORITHM);
-        PBEKeySpec spec = new PBEKeySpec(cryptoConfig.password().toCharArray(), saltBytes,
-            PBKDF2_ITERATIONS, KEY_SIZE);
+        PBEKeySpec spec = new PBEKeySpec(cryptoConfig.password().toCharArray(), saltBytes, PBKDF2_ITERATIONS, KEY_SIZE);
         return skf.generateSecret(spec);
     }
 }

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/crypto/PBKDF2StreamingAeadFactory.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/crypto/PBKDF2StreamingAeadFactory.java
@@ -1,0 +1,62 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.blob.objectstorage.crypto;
+
+import java.io.UnsupportedEncodingException;
+import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
+import com.google.crypto.tink.subtle.AesGcmHkdfStreaming;
+
+public class PBKDF2StreamingAeadFactory {
+    private static final int PBKDF2_ITERATIONS = 65536;
+    private static final int KEY_SIZE = 256;
+    private static final String SECRET_KEY_FACTORY_ALGORITHM = "PBKDF2WithHmacSHA1";
+    private static final String HKDF_ALGO = "HmacSha256";
+    private static final int KEY_SIZE_IN_BYTES = 32;
+    private static final int SEGMENT_SIZE = 4096;
+    private static final int OFFSET = 0;
+    public static final byte[] EMPTY_ASSOCIATED_DATA = new byte[0];
+
+    public static AesGcmHkdfStreaming newAesGcmHkdfStreaming(CryptoConfig config) {
+        try {
+            SecretKey secretKey = deriveKey(config);
+            return new AesGcmHkdfStreaming(secretKey.getEncoded(), HKDF_ALGO, KEY_SIZE_IN_BYTES, SEGMENT_SIZE, OFFSET);
+        } catch (GeneralSecurityException | UnsupportedEncodingException e) {
+            throw new CryptoException("Incorrect crypto setup", e);
+
+        }
+    }
+
+    private static SecretKey deriveKey(CryptoConfig cryptoConfig) throws UnsupportedEncodingException,
+        NoSuchAlgorithmException,
+        InvalidKeySpecException {
+        byte[] saltBytes = cryptoConfig.salt();
+        SecretKeyFactory skf = SecretKeyFactory.getInstance(SECRET_KEY_FACTORY_ALGORITHM);
+        PBEKeySpec spec = new PBEKeySpec(cryptoConfig.password().toCharArray(), saltBytes,
+            PBKDF2_ITERATIONS, KEY_SIZE);
+        return skf.generateSecret(spec);
+    }
+}

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/AESPayloadCodecTest.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/AESPayloadCodecTest.java
@@ -44,7 +44,7 @@ class AESPayloadCodecTest implements PayloadCodecContract {
         return new AESPayloadCodec(
             new CryptoConfig(
                 "c603a7327ee3dcbc031d8d34b1096c605feca5e1",
-                "foobar"));
+                "foobar".toCharArray()));
     }
 
     @Test

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/AESPayloadCodecTest.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/AESPayloadCodecTest.java
@@ -1,0 +1,64 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.blob.objectstorage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.james.blob.objectstorage.crypto.CryptoConfig;
+import org.jclouds.io.Payload;
+import org.jclouds.io.Payloads;
+import org.junit.jupiter.api.Test;
+
+import com.google.crypto.tink.subtle.Hex;
+
+class AESPayloadCodecTest implements PayloadCodecContract {
+    private static final byte[] ENCRYPTED_BYTES = Hex.decode("28cdfb53c283185598ec7c49c415c6b56e85d3d74af89740270c2d2cd8006e1265a301436d919ed7acfc14586b5bd193e34c744ef1641230457dae3475");
+
+    @Override
+    public PayloadCodec codec() {
+        return new AESPayloadCodec(
+            new CryptoConfig(
+                "c603a7327ee3dcbc031d8d34b1096c605feca5e1",
+                "foobar"));
+    }
+
+    @Test
+    void aesCodecShouldEncryptPayloadContentWhenWriting() throws Exception {
+        Payload payload = codec().write(expected());
+        byte[] bytes = IOUtils.toByteArray(payload.openStream());
+        // authenticated encryption uses a random salt for the authentication
+        // header all we can say for sure is that the output is not the same as
+        // the input.
+        assertThat(bytes).isNotEqualTo(SOME_BYTES);
+    }
+
+    @Test
+    void aesCodecShouldDecryptPayloadContentWhenReading() throws Exception {
+        Payload payload = Payloads.newInputStreamPayload(new ByteArrayInputStream(ENCRYPTED_BYTES));
+
+        InputStream actual = codec().read(payload);
+
+        assertThat(actual).hasSameContentAs(expected());
+    }
+}

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/AESPayloadCodecTest.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/AESPayloadCodecTest.java
@@ -20,14 +20,18 @@
 package org.apache.james.blob.objectstorage;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.james.blob.objectstorage.crypto.CryptoConfig;
 import org.jclouds.io.Payload;
 import org.jclouds.io.Payloads;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import com.google.crypto.tink.subtle.Hex;
@@ -60,5 +64,28 @@ class AESPayloadCodecTest implements PayloadCodecContract {
         InputStream actual = codec().read(payload);
 
         assertThat(actual).hasSameContentAs(expected());
+    }
+
+    @Test
+    void aesCodecShouldRaiseExceptionWhenUnderliyingInputStreamFails() throws Exception {
+        Payload payload =
+            Payloads.newInputStreamPayload(new FilterInputStream(new ByteArrayInputStream(ENCRYPTED_BYTES)) {
+                private int readCount = 0;
+
+                @Override
+                public int read(@NotNull byte[] b, int off, int len) throws IOException {
+                    if (readCount >= ENCRYPTED_BYTES.length / 2) {
+                        throw new IOException();
+                    } else {
+                        readCount += len;
+                        return super.read(b, off, len);
+                    }
+                }
+            });
+        int i = ENCRYPTED_BYTES.length / 2;
+        byte[] bytes = new byte[i];
+        InputStream is = codec().read(payload);
+        assertThatThrownBy(() -> is.read(bytes, 0, i)).isInstanceOf(IOException.class);
+
     }
 }

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/DefaultPayloadCodecTest.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/DefaultPayloadCodecTest.java
@@ -1,0 +1,52 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.blob.objectstorage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+
+import org.jclouds.io.Payload;
+import org.jclouds.io.Payloads;
+import org.junit.jupiter.api.Test;
+
+class DefaultPayloadCodecTest implements PayloadCodecContract {
+    @Override
+    public PayloadCodec codec() {
+        return new DefaultPayloadCodec();
+    }
+
+    @Test
+    void defaultCodecShouldNotChangePayloadContentWhenWriting() throws Exception {
+        Payload payload = codec().write(expected());
+
+        assertThat(payload.openStream()).hasSameContentAs(expected());
+    }
+
+    @Test
+    void defaultCodecShouldNotChangePayloadContentWhenReading() throws Exception {
+        Payload payload = Payloads.newInputStreamPayload(expected());
+
+        InputStream actual = codec().read(payload);
+
+        assertThat(actual).hasSameContentAs(expected());
+    }
+
+}

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAOTest.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAOTest.java
@@ -60,7 +60,7 @@ public class ObjectStorageBlobsDAOTest implements BlobStoreContract {
     private ObjectStorageBlobsDAO testee;
     public static final CryptoConfig CRYPTO_CONFIG = CryptoConfig.builder()
         .salt(SAMPLE_SALT)
-        .password(PASSWORD.value())
+        .password(PASSWORD.value().toCharArray())
         .build();
 
     @BeforeEach

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAOTest.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAOTest.java
@@ -22,13 +22,17 @@ package org.apache.james.blob.objectstorage;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BlobStoreContract;
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.ObjectStoreException;
+import org.apache.james.blob.objectstorage.crypto.CryptoConfig;
 import org.apache.james.blob.objectstorage.swift.Credentials;
 import org.apache.james.blob.objectstorage.swift.Identity;
 import org.apache.james.blob.objectstorage.swift.PassHeaderName;
@@ -64,12 +68,12 @@ public class ObjectStorageBlobsDAOTest implements BlobStoreContract {
             .tempAuthHeaderPassName(PassHeaderName.of("X-Storage-Pass"))
             .build();
         BlobId.Factory blobIdFactory = blobIdFactory();
-        blobStore = ObjectStorageBlobsDAO
+        ObjectStorageBlobsDAOBuilder daoBuilder = ObjectStorageBlobsDAO
             .builder(testConfig)
             .container(containerName)
-            .blobIdFactory(blobIdFactory)
-            .getSupplier().get();
-        testee = new ObjectStorageBlobsDAO(containerName, blobIdFactory, blobStore);
+            .blobIdFactory(blobIdFactory);
+        blobStore = daoBuilder.getSupplier().get();
+        testee = daoBuilder.build();
         testee.createContainer(containerName);
     }
 
@@ -103,6 +107,24 @@ public class ObjectStorageBlobsDAOTest implements BlobStoreContract {
         assertThatThrownBy(() -> testee.createContainer(containerName).get())
             .hasCauseInstanceOf(ObjectStoreException.class)
             .hasMessageContaining("Unable to create container");
+    }
+
+    @Test
+    void supportsEncryptionWithCustomPayloadCodec() throws Exception {
+        ObjectStorageBlobsDAO encryptedDao = ObjectStorageBlobsDAO
+            .builder(testConfig)
+            .container(containerName)
+            .blobIdFactory(blobIdFactory())
+            .payloadCodec(new AESPayloadCodec(new CryptoConfig(
+                "c603a7327ee3dcbc031d8d34b1096c605feca5e1", "foobar")))
+            .build();
+        byte[] bytes = "James is the best!".getBytes(StandardCharsets.UTF_8);
+        BlobId blobId = encryptedDao.save(bytes).join();
+
+        InputStream read = testee.read(blobId);
+        assertThat(read).isNotNull();
+        byte[] encryptedBytes = IOUtils.toByteArray(read);
+        assertThat(encryptedBytes).isNotEqualTo(bytes);
     }
 }
 

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAOTest.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAOTest.java
@@ -22,6 +22,7 @@ package org.apache.james.blob.objectstorage;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
@@ -51,11 +52,16 @@ public class ObjectStorageBlobsDAOTest implements BlobStoreContract {
     private static final UserName USER_NAME = UserName.of("tester");
     private static final Credentials PASSWORD = Credentials.of("testing");
     private static final Identity SWIFT_IDENTITY = Identity.of(TENANT_NAME, USER_NAME);
+    public static final String SAMPLE_SALT = "c603a7327ee3dcbc031d8d34b1096c605feca5e1";
 
     private ContainerName containerName;
     private org.jclouds.blobstore.BlobStore blobStore;
     private SwiftTempAuthObjectStorage.Configuration testConfig;
     private ObjectStorageBlobsDAO testee;
+    public static final CryptoConfig CRYPTO_CONFIG = CryptoConfig.builder()
+        .salt(SAMPLE_SALT)
+        .password(PASSWORD.value())
+        .build();
 
     @BeforeEach
     void setUp(DockerSwift dockerSwift) throws Exception {
@@ -115,16 +121,33 @@ public class ObjectStorageBlobsDAOTest implements BlobStoreContract {
             .builder(testConfig)
             .container(containerName)
             .blobIdFactory(blobIdFactory())
-            .payloadCodec(new AESPayloadCodec(new CryptoConfig(
-                "c603a7327ee3dcbc031d8d34b1096c605feca5e1", "foobar")))
+            .payloadCodec(new AESPayloadCodec(CRYPTO_CONFIG))
             .build();
         byte[] bytes = "James is the best!".getBytes(StandardCharsets.UTF_8);
         BlobId blobId = encryptedDao.save(bytes).join();
 
-        InputStream read = testee.read(blobId);
-        assertThat(read).isNotNull();
-        byte[] encryptedBytes = IOUtils.toByteArray(read);
+        InputStream read = encryptedDao.read(blobId);
+        assertThat(read).hasSameContentAs(new ByteArrayInputStream(bytes));
+    }
+
+    @Test
+    void encryptionWithCustomPayloadCodeCannotBeReadFromUnencryptedDAO() throws Exception {
+        ObjectStorageBlobsDAO encryptedDao = ObjectStorageBlobsDAO
+            .builder(testConfig)
+            .container(containerName)
+            .blobIdFactory(blobIdFactory())
+            .payloadCodec(new AESPayloadCodec(CRYPTO_CONFIG))
+            .build();
+        byte[] bytes = "James is the best!".getBytes(StandardCharsets.UTF_8);
+        BlobId blobId = encryptedDao.save(bytes).join();
+
+        InputStream encryptedIs = testee.read(blobId);
+        assertThat(encryptedIs).isNotNull();
+        byte[] encryptedBytes = IOUtils.toByteArray(encryptedIs);
         assertThat(encryptedBytes).isNotEqualTo(bytes);
+
+        InputStream clearTextIs = encryptedDao.read(blobId);
+        assertThat(clearTextIs).hasSameContentAs(new ByteArrayInputStream(bytes));
     }
 }
 

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/PayloadCodecContract.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/PayloadCodecContract.java
@@ -1,0 +1,48 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.blob.objectstorage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+public interface PayloadCodecContract {
+    byte[] SOME_BYTES = "james".getBytes(StandardCharsets.UTF_8);
+
+    @Test
+    default void shouldBeAbleToReadFromWrittenPayload() throws Exception {
+        PayloadCodec codec = codec();
+        InputStream actual = codec.read(codec.write(expected()));
+        assertThat(actual).hasSameContentAs(expected());
+    }
+
+    @NotNull
+    default ByteArrayInputStream expected() {
+        return new ByteArrayInputStream(SOME_BYTES);
+    }
+
+    PayloadCodec codec();
+
+}

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/crypto/CryptoConfigBuilderTest.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/crypto/CryptoConfigBuilderTest.java
@@ -1,0 +1,82 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.blob.objectstorage.crypto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.crypto.tink.subtle.Hex;
+
+class CryptoConfigBuilderTest {
+
+    public static final String PASSWORD = "password";
+    public static final String SALT = "0123456789abcdef";
+
+    @Test
+    void should_not_build_crypto_config_if_salt_missing() {
+        CryptoConfigBuilder builder = new CryptoConfigBuilder();
+        builder.password(PASSWORD);
+        assertThatThrownBy(builder::build).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void should_not_build_crypto_config_if_salt_empty() {
+        CryptoConfigBuilder builder = new CryptoConfigBuilder();
+        builder.password(PASSWORD);
+        builder.salt("");
+        assertThatThrownBy(builder::build).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void should_not_build_crypto_config_if_salt_not_hex() {
+        CryptoConfigBuilder builder = new CryptoConfigBuilder();
+        builder.password(PASSWORD);
+        builder.salt("ghijk");
+        assertThatThrownBy(builder::build).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_not_build_crypto_config_if_password_missing() {
+        CryptoConfigBuilder builder = new CryptoConfigBuilder();
+        builder.salt(SALT);
+        assertThatThrownBy(builder::build).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void should_not_build_crypto_config_if_password_empty() {
+        CryptoConfigBuilder builder = new CryptoConfigBuilder();
+        builder.salt(SALT);
+        builder.password("");
+        assertThatThrownBy(builder::build).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void should_build_crypto_config() {
+        CryptoConfigBuilder builder = new CryptoConfigBuilder();
+        builder.salt(SALT);
+        builder.password(PASSWORD);
+        CryptoConfig actual = builder.build();
+        assertThat(actual.password()).isEqualTo(PASSWORD);
+        assertThat(actual.salt()).isEqualTo(Hex.decode(SALT));
+    }
+
+}

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/crypto/CryptoConfigBuilderTest.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/crypto/CryptoConfigBuilderTest.java
@@ -32,14 +32,14 @@ class CryptoConfigBuilderTest {
     public static final String SALT = "0123456789abcdef";
 
     @Test
-    void should_not_build_crypto_config_if_salt_missing() {
+    void shouldNotBuildCryptoConfigIfSaltMissing() {
         CryptoConfigBuilder builder = new CryptoConfigBuilder();
         builder.password(PASSWORD);
         assertThatThrownBy(builder::build).isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    void should_not_build_crypto_config_if_salt_empty() {
+    void shouldNotBuildCryptoConfigIfSaltEmpty() {
         CryptoConfigBuilder builder = new CryptoConfigBuilder();
         builder.password(PASSWORD);
         builder.salt("");
@@ -47,7 +47,7 @@ class CryptoConfigBuilderTest {
     }
 
     @Test
-    void should_not_build_crypto_config_if_salt_not_hex() {
+    void shouldNotBuildCryptoConfigIfSaltNotHex() {
         CryptoConfigBuilder builder = new CryptoConfigBuilder();
         builder.password(PASSWORD);
         builder.salt("ghijk");
@@ -55,14 +55,14 @@ class CryptoConfigBuilderTest {
     }
 
     @Test
-    void should_not_build_crypto_config_if_password_missing() {
+    void shouldNotBuildCryptoConfigIfPasswordMissing() {
         CryptoConfigBuilder builder = new CryptoConfigBuilder();
         builder.salt(SALT);
         assertThatThrownBy(builder::build).isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    void should_not_build_crypto_config_if_password_empty() {
+    void shouldNotBuildCryptoConfigIfPasswordEmpty() {
         CryptoConfigBuilder builder = new CryptoConfigBuilder();
         builder.salt(SALT);
         builder.password("".toCharArray());
@@ -70,7 +70,7 @@ class CryptoConfigBuilderTest {
     }
 
     @Test
-    void should_build_crypto_config() {
+    void shouldBuildCryptoConfig() {
         CryptoConfigBuilder builder = new CryptoConfigBuilder();
         builder.salt(SALT);
         builder.password(PASSWORD);

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/crypto/CryptoConfigBuilderTest.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/crypto/CryptoConfigBuilderTest.java
@@ -28,7 +28,7 @@ import com.google.crypto.tink.subtle.Hex;
 
 class CryptoConfigBuilderTest {
 
-    public static final String PASSWORD = "password";
+    public static final char[] PASSWORD = "password".toCharArray();
     public static final String SALT = "0123456789abcdef";
 
     @Test
@@ -65,7 +65,7 @@ class CryptoConfigBuilderTest {
     void should_not_build_crypto_config_if_password_empty() {
         CryptoConfigBuilder builder = new CryptoConfigBuilder();
         builder.salt(SALT);
-        builder.password("");
+        builder.password("".toCharArray());
         assertThatThrownBy(builder::build).isInstanceOf(IllegalStateException.class);
     }
 

--- a/server/container/guice/blob-objectstorage-guice/pom.xml
+++ b/server/container/guice/blob-objectstorage-guice/pom.xml
@@ -57,6 +57,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/ObjectStorageBlobStoreModule.java
+++ b/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/ObjectStorageBlobStoreModule.java
@@ -21,6 +21,7 @@ package org.apache.james.modules.objectstorage;
 
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.objectstorage.ObjectStorageBlobsDAO;
+import org.apache.james.blob.objectstorage.PayloadCodec;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
@@ -29,7 +30,8 @@ public class ObjectStorageBlobStoreModule extends AbstractModule {
 
     @Override
     protected void configure() {
+        bind(PayloadCodec.class).toProvider(PayloadCodecProvider.class).in(Scopes.SINGLETON);
         bind(ObjectStorageBlobsDAO.class).toProvider(ObjectStorageBlobsDAOProvider.class).in(Scopes.SINGLETON);
-        bind(BlobStore.class).to(ObjectStorageBlobsDAO.class);
+        bind(BlobStore.class).toProvider(ObjectStorageBlobsDAOProvider.class).in(Scopes.SINGLETON);
     }
 }

--- a/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/ObjectStorageBlobsDAOProvider.java
+++ b/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/ObjectStorageBlobsDAOProvider.java
@@ -39,11 +39,11 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
 public class ObjectStorageBlobsDAOProvider implements Provider<ObjectStorageBlobsDAO> {
-    private static final String OBJECTSTORAGE_CONFIGURATION_NAME = "objectstorage";
+    static final String OBJECTSTORAGE_CONFIGURATION_NAME = "objectstorage";
 
-    private static final String OBJECTSTORAGE_NAMESPACE = "objectstorage.namespace";
-    private static final String OBJECTSTORAGE_PROVIDER = "objectstorage.provider";
-    private static final String OBJECTSTORAGE_SWIFT_AUTH_API = "objectstorage.swift.authapi";
+    static final String OBJECTSTORAGE_NAMESPACE = "objectstorage.namespace";
+    static final String OBJECTSTORAGE_PROVIDER = "objectstorage.provider";
+    static final String OBJECTSTORAGE_SWIFT_AUTH_API = "objectstorage.swift.authapi";
 
     public static final String OBJECTSTORAGE_PROVIDER_SWIFT = "swift";
 

--- a/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/PayloadCodecProvider.java
+++ b/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/PayloadCodecProvider.java
@@ -33,8 +33,9 @@ import com.amazonaws.util.StringUtils;
 import com.google.common.base.Preconditions;
 
 public class PayloadCodecProvider implements Provider<PayloadCodec> {
+    static final String OBJECTSTORAGE_PAYLOAD_CODEC = "objectstorage.payload.codec";
+
     private static final String OBJECTSTORAGE_CONFIGURATION_NAME = "objectstorage";
-    private static final String OBJECTSTORAGE_PAYLOAD_CODEC = "objectstorage.payload.codec";
 
     private final Configuration configuration;
 

--- a/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/PayloadCodecProvider.java
+++ b/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/PayloadCodecProvider.java
@@ -29,6 +29,7 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.blob.objectstorage.PayloadCodec;
 import org.apache.james.utils.PropertiesProvider;
 
+import com.amazonaws.util.StringUtils;
 import com.google.common.base.Preconditions;
 
 public class PayloadCodecProvider implements Provider<PayloadCodec> {
@@ -50,9 +51,9 @@ public class PayloadCodecProvider implements Provider<PayloadCodec> {
 
     @Override
     public PayloadCodec get() {
-        String endpointStr = configuration.getString(OBJECTSTORAGE_PAYLOAD_CODEC, null);
-        Preconditions.checkArgument(endpointStr != null,
-            OBJECTSTORAGE_PAYLOAD_CODEC + "is a mandatory configuration value");
-        return PayloadCodecs.valueOf(endpointStr).codec(configuration);
+        String codecName = configuration.getString(OBJECTSTORAGE_PAYLOAD_CODEC, null);
+        Preconditions.checkArgument(!StringUtils.isNullOrEmpty(codecName),
+            OBJECTSTORAGE_PAYLOAD_CODEC + " is a mandatory configuration value");
+        return PayloadCodecs.valueOf(codecName).codec(configuration);
     }
 }

--- a/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/PayloadCodecProvider.java
+++ b/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/PayloadCodecProvider.java
@@ -40,7 +40,7 @@ public class PayloadCodecProvider implements Provider<PayloadCodec> {
 
     @Inject
     public PayloadCodecProvider(PropertiesProvider propertiesProvider)
-        throws ConfigurationException {
+            throws ConfigurationException {
         try {
             this.configuration =
                 propertiesProvider.getConfiguration(OBJECTSTORAGE_CONFIGURATION_NAME);

--- a/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/PayloadCodecProvider.java
+++ b/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/PayloadCodecProvider.java
@@ -1,0 +1,58 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.objectstorage;
+
+import java.io.FileNotFoundException;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.james.blob.objectstorage.PayloadCodec;
+import org.apache.james.utils.PropertiesProvider;
+
+import com.google.common.base.Preconditions;
+
+public class PayloadCodecProvider implements Provider<PayloadCodec> {
+    private static final String OBJECTSTORAGE_CONFIGURATION_NAME = "objectstorage";
+    private static final String OBJECTSTORAGE_PAYLOAD_CODEC = "objectstorage.payload.codec";
+
+    private final Configuration configuration;
+
+    @Inject
+    public PayloadCodecProvider(PropertiesProvider propertiesProvider)
+        throws ConfigurationException {
+        try {
+            this.configuration =
+                propertiesProvider.getConfiguration(OBJECTSTORAGE_CONFIGURATION_NAME);
+        } catch (FileNotFoundException e) {
+            throw new ConfigurationException(OBJECTSTORAGE_CONFIGURATION_NAME + "configuration was not found");
+        }
+    }
+
+    @Override
+    public PayloadCodec get() {
+        String endpointStr = configuration.getString(OBJECTSTORAGE_PAYLOAD_CODEC, null);
+        Preconditions.checkArgument(endpointStr != null,
+            OBJECTSTORAGE_PAYLOAD_CODEC + "is a mandatory configuration value");
+        return PayloadCodecs.valueOf(endpointStr).codec(configuration);
+    }
+}

--- a/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/PayloadCodecs.java
+++ b/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/PayloadCodecs.java
@@ -40,12 +40,12 @@ public enum PayloadCodecs {
         public PayloadCodec codec(Configuration configuration) {
             String salt = configuration.getString(OBJECTSTORAGE_AES256_HEXSALT);
             String password = configuration.getString(OBJECTSTORAGE_AES256_PASSWORD);
-            Preconditions.checkArgument(!StringUtils.isNullOrEmpty(salt) ,
+            Preconditions.checkArgument(!StringUtils.isNullOrEmpty(salt),
                 OBJECTSTORAGE_AES256_HEXSALT + " is a " +
-                "mandatory configuration value");
+                    "mandatory configuration value");
             Preconditions.checkArgument(!StringUtils.isNullOrEmpty(password),
                 OBJECTSTORAGE_AES256_PASSWORD + " is a " +
-                "mandatory configuration value");
+                    "mandatory configuration value");
             return new AESPayloadCodec(new CryptoConfig(salt, password));
         }
     };

--- a/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/PayloadCodecs.java
+++ b/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/PayloadCodecs.java
@@ -25,6 +25,7 @@ import org.apache.james.blob.objectstorage.DefaultPayloadCodec;
 import org.apache.james.blob.objectstorage.PayloadCodec;
 import org.apache.james.blob.objectstorage.crypto.CryptoConfig;
 
+import com.amazonaws.util.StringUtils;
 import com.google.common.base.Preconditions;
 
 public enum PayloadCodecs {
@@ -39,9 +40,11 @@ public enum PayloadCodecs {
         public PayloadCodec codec(Configuration configuration) {
             String salt = configuration.getString(OBJECTSTORAGE_AES256_HEXSALT);
             String password = configuration.getString(OBJECTSTORAGE_AES256_PASSWORD);
-            Preconditions.checkArgument(salt != null, OBJECTSTORAGE_AES256_HEXSALT + "is a " +
+            Preconditions.checkArgument(!StringUtils.isNullOrEmpty(salt) ,
+                OBJECTSTORAGE_AES256_HEXSALT + " is a " +
                 "mandatory configuration value");
-            Preconditions.checkArgument(password != null, OBJECTSTORAGE_AES256_PASSWORD + "is a " +
+            Preconditions.checkArgument(!StringUtils.isNullOrEmpty(password),
+                OBJECTSTORAGE_AES256_PASSWORD + " is a " +
                 "mandatory configuration value");
             return new AESPayloadCodec(new CryptoConfig(salt, password));
         }

--- a/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/PayloadCodecs.java
+++ b/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/PayloadCodecs.java
@@ -1,0 +1,56 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.objectstorage;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.james.blob.objectstorage.AESPayloadCodec;
+import org.apache.james.blob.objectstorage.DefaultPayloadCodec;
+import org.apache.james.blob.objectstorage.PayloadCodec;
+import org.apache.james.blob.objectstorage.crypto.CryptoConfig;
+
+import com.google.common.base.Preconditions;
+
+public enum PayloadCodecs {
+    DEFAULT {
+        @Override
+        public PayloadCodec codec(Configuration configuration) {
+            return new DefaultPayloadCodec();
+        }
+    },
+    AES256 {
+        @Override
+        public PayloadCodec codec(Configuration configuration) {
+            String salt = configuration.getString(OBJECTSTORAGE_AES256_HEXSALT);
+            String password = configuration.getString(OBJECTSTORAGE_AES256_PASSWORD);
+            Preconditions.checkArgument(salt != null, OBJECTSTORAGE_AES256_HEXSALT + "is a " +
+                "mandatory configuration value");
+            Preconditions.checkArgument(password != null, OBJECTSTORAGE_AES256_PASSWORD + "is a " +
+                "mandatory configuration value");
+            return new AESPayloadCodec(new CryptoConfig(salt, password));
+        }
+    };
+
+    private static final String OBJECTSTORAGE_AES256_HEXSALT = "objectstorage.aes256.hexsalt";
+    private static final String OBJECTSTORAGE_AES256_PASSWORD = "objectstorage.aes256.password";
+
+    public abstract PayloadCodec codec(Configuration configuration);
+
+
+}

--- a/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/PayloadCodecs.java
+++ b/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/PayloadCodecs.java
@@ -46,7 +46,7 @@ public enum PayloadCodecs {
             Preconditions.checkArgument(!StringUtils.isNullOrEmpty(password),
                 OBJECTSTORAGE_AES256_PASSWORD + " is a " +
                     "mandatory configuration value");
-            return new AESPayloadCodec(new CryptoConfig(salt, password));
+            return new AESPayloadCodec(new CryptoConfig(salt, password.toCharArray()));
         }
     };
 

--- a/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/PayloadCodecs.java
+++ b/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/PayloadCodecs.java
@@ -47,8 +47,8 @@ public enum PayloadCodecs {
         }
     };
 
-    private static final String OBJECTSTORAGE_AES256_HEXSALT = "objectstorage.aes256.hexsalt";
-    private static final String OBJECTSTORAGE_AES256_PASSWORD = "objectstorage.aes256.password";
+    public static final String OBJECTSTORAGE_AES256_HEXSALT = "objectstorage.aes256.hexsalt";
+    public static final String OBJECTSTORAGE_AES256_PASSWORD = "objectstorage.aes256.password";
 
     public abstract PayloadCodec codec(Configuration configuration);
 

--- a/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/SwiftKeystone2ConfigurationReader.java
+++ b/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/SwiftKeystone2ConfigurationReader.java
@@ -34,9 +34,9 @@ import com.google.common.base.Preconditions;
 
 public class SwiftKeystone2ConfigurationReader implements SwiftConfigurationReader {
 
-    private static final String OBJECTSTORAGE_SWIFT_KEYSTONE_2_USERNAME =
+    static final String OBJECTSTORAGE_SWIFT_KEYSTONE_2_USERNAME =
         "objectstorage.swift.keystone2.username";
-    private static final String OBJECTSTORAGE_SWIFT_KEYSTONE_2_TENANTNAME =
+    static final String OBJECTSTORAGE_SWIFT_KEYSTONE_2_TENANTNAME =
         "objectstorage.swift.keystone2.tenantname";
 
     public static SwiftKeystone2ObjectStorage.Configuration readSwiftConfiguration(Configuration configuration) {

--- a/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/SwiftKeystone3ConfigurationReader.java
+++ b/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/SwiftKeystone3ConfigurationReader.java
@@ -43,16 +43,16 @@ import com.google.common.base.Preconditions;
  */
 public class SwiftKeystone3ConfigurationReader implements SwiftConfigurationReader {
 
-    private static final String OBJECTSTORAGE_SWIFT_KEYSTONE_3_USER_NAME =
+    static final String OBJECTSTORAGE_SWIFT_KEYSTONE_3_USER_NAME =
         "objectstorage.swift.keystone3.user.name";
 
-    private static final String OBJECTSTORAGE_SWIFT_KEYSTONE_3_USER_DOMAIN =
+    static final String OBJECTSTORAGE_SWIFT_KEYSTONE_3_USER_DOMAIN =
         "objectstorage.swift.keystone3.user.domain";
 
     private static final String OBJECTSTORAGE_SWIFT_KEYSTONE_3_DOMAIN_ID =
         "objectstorage.swift.keystone3.scope.domainid";
 
-    private static final String OBJECTSTORAGE_SWIFT_KEYSTONE_3_PROJECT_NAME =
+    static final String OBJECTSTORAGE_SWIFT_KEYSTONE_3_PROJECT_NAME =
         "objectstorage.swift.keystone3.scope.project.name";
 
     private static final String OBJECTSTORAGE_SWIFT_KEYSTONE_3_PROJECT_DOMAIN_NAME =

--- a/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/SwiftTmpAuthConfigurationReader.java
+++ b/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/SwiftTmpAuthConfigurationReader.java
@@ -36,13 +36,13 @@ import com.google.common.base.Preconditions;
 
 public class SwiftTmpAuthConfigurationReader implements SwiftConfigurationReader {
 
-    private static final String OBJECTSTORAGE_SWIFT_TEMPAUTH_USERNAME =
+    static final String OBJECTSTORAGE_SWIFT_TEMPAUTH_USERNAME =
         "objectstorage.swift.tempauth.username";
-    private static final String OBJECTSTORAGE_SWIFT_TEMPAUTH_TENANTNAME =
+    static final String OBJECTSTORAGE_SWIFT_TEMPAUTH_TENANTNAME =
         "objectstorage.swift.tempauth.tenantname";
-    private static final String OBJECTSTORAGE_SWIFT_TEMPAUTH_PASS_HEADER_NAME =
+    static final String OBJECTSTORAGE_SWIFT_TEMPAUTH_PASS_HEADER_NAME =
         "objectstorage.swift.tempauth.passheadername";
-    private static final String OBJECTSTORAGE_SWIFT_TEMPAUTH_USER_HEADER_NAME =
+    static final String OBJECTSTORAGE_SWIFT_TEMPAUTH_USER_HEADER_NAME =
         "objectstorage.swift.tempauth.userheadername";
 
     public static SwiftTempAuthObjectStorage.Configuration readSwiftConfiguration(Configuration configuration) {

--- a/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/FakePropertiesProvider.java
+++ b/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/FakePropertiesProvider.java
@@ -1,0 +1,75 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.objectstorage;
+
+import java.io.FileNotFoundException;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.james.utils.PropertiesProvider;
+
+import com.google.common.collect.ImmutableMap;
+
+public class FakePropertiesProvider extends PropertiesProvider {
+    private ImmutableMap<String, Configuration> configurations;
+
+    public FakePropertiesProvider(ImmutableMap<String, Configuration> configurations) {
+        super(null);
+        this.configurations = configurations;
+    }
+
+
+    @Override
+    public Configuration getConfiguration(String fileName) throws FileNotFoundException, ConfigurationException {
+        if (configurations.containsKey(fileName)) {
+            return configurations.get(fileName);
+        } else {
+            throw new FileNotFoundException(
+                "no configuration defined for " +
+                    fileName +
+                    " know configurations are (" +
+                    StringUtils.join(configurations.keySet(), ",") +
+                    ")");
+        }
+    }
+
+    public static FakePropertiesProviderBuilder builder() {
+        return new FakePropertiesProviderBuilder();
+    }
+
+    static class FakePropertiesProviderBuilder {
+        private final ImmutableMap.Builder<String, Configuration> configurations;
+
+        public FakePropertiesProviderBuilder() {
+            configurations = new ImmutableMap.Builder<>();
+        }
+
+        public FakePropertiesProviderBuilder register(String filename,
+                                                      Configuration configuration) {
+            configurations.put(filename, configuration);
+            return this;
+        }
+
+        public FakePropertiesProvider build() {
+            return new FakePropertiesProvider(configurations.build());
+        }
+    }
+}

--- a/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/MapConfigurationBuilder.java
+++ b/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/MapConfigurationBuilder.java
@@ -20,7 +20,8 @@
 package org.apache.james.modules.objectstorage;
 
 import org.apache.commons.configuration.MapConfiguration;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+
+import com.google.common.collect.ImmutableMap;
 
 class MapConfigurationBuilder {
     private ImmutableMap.Builder<String, Object> config;

--- a/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/MapConfigurationBuilder.java
+++ b/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/MapConfigurationBuilder.java
@@ -1,0 +1,40 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.objectstorage;
+
+import org.apache.commons.configuration.MapConfiguration;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+
+class MapConfigurationBuilder {
+    private ImmutableMap.Builder<String, Object> config;
+
+    public MapConfigurationBuilder() {
+        this.config = new ImmutableMap.Builder<>();
+    }
+
+    public MapConfigurationBuilder put(String key, Object value) {
+        config.put(key, value);
+        return this;
+    }
+
+    public MapConfiguration build() {
+        return new MapConfiguration(config.build());
+    }
+}

--- a/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/ObjectStorageBlobsDAOProviderTest.java
+++ b/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/ObjectStorageBlobsDAOProviderTest.java
@@ -100,7 +100,7 @@ class ObjectStorageBlobsDAOProviderTest {
     }
 
     @Test
-    void provides_a_tempauth_backed_blobstore_dao() throws ConfigurationException {
+    void providesTempauthBackedBlobstoreDao() throws ConfigurationException {
         ObjectStorageBlobsDAOProvider objectStorageBlobsDAOProvider =
             new ObjectStorageBlobsDAOProvider(tempAuthPropertiesProvider(), BLOB_ID_FACTORY);
         ObjectStorageBlobsDAO objectStorageBlobsDAO = objectStorageBlobsDAOProvider.get();
@@ -108,7 +108,7 @@ class ObjectStorageBlobsDAOProviderTest {
     }
 
     @Test
-    void provides_a_keystone2_backed_blobstore_dao() throws ConfigurationException {
+    void providesKeystone2BackedBlobstoreDao() throws ConfigurationException {
         ObjectStorageBlobsDAOProvider objectStorageBlobsDAOProvider =
             new ObjectStorageBlobsDAOProvider(keystone2PropertiesProvider(),
                 BLOB_ID_FACTORY);
@@ -117,7 +117,7 @@ class ObjectStorageBlobsDAOProviderTest {
     }
 
     @Test
-    void provides_a_keystone3_backed_blobstore_dao() throws ConfigurationException {
+    void providesKeystone3BackedBlobstoreDao() throws ConfigurationException {
         ObjectStorageBlobsDAOProvider objectStorageBlobsDAOProvider =
             new ObjectStorageBlobsDAOProvider(keystone3PropertiesProvider(),
                 BLOB_ID_FACTORY);

--- a/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/ObjectStorageBlobsDAOProviderTest.java
+++ b/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/ObjectStorageBlobsDAOProviderTest.java
@@ -1,0 +1,138 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.objectstorage;
+
+import static org.apache.james.modules.objectstorage.ObjectStorageBlobsDAOProvider.OBJECTSTORAGE_CONFIGURATION_NAME;
+import static org.apache.james.modules.objectstorage.ObjectStorageBlobsDAOProvider.OBJECTSTORAGE_NAMESPACE;
+import static org.apache.james.modules.objectstorage.ObjectStorageBlobsDAOProvider.OBJECTSTORAGE_PROVIDER;
+import static org.apache.james.modules.objectstorage.ObjectStorageBlobsDAOProvider.OBJECTSTORAGE_PROVIDER_SWIFT;
+import static org.apache.james.modules.objectstorage.ObjectStorageBlobsDAOProvider.OBJECTSTORAGE_SWIFT_AUTH_API;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.objectstorage.ContainerName;
+import org.apache.james.blob.objectstorage.DockerSwift;
+import org.apache.james.blob.objectstorage.DockerSwiftExtension;
+import org.apache.james.blob.objectstorage.ObjectStorageBlobsDAO;
+import org.apache.james.blob.objectstorage.swift.SwiftKeystone2ObjectStorage;
+import org.apache.james.blob.objectstorage.swift.SwiftKeystone3ObjectStorage;
+import org.apache.james.blob.objectstorage.swift.SwiftTempAuthObjectStorage;
+import org.apache.james.utils.PropertiesProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(DockerSwiftExtension.class)
+class ObjectStorageBlobsDAOProviderTest {
+
+    private ContainerName containerName;
+    private DockerSwift dockerSwift;
+
+    @BeforeEach
+    void setUp(DockerSwift dockerSwift) throws Exception {
+        this.dockerSwift = dockerSwift;
+        containerName = ContainerName.of(UUID.randomUUID().toString());
+    }
+
+    public static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
+
+
+    private PropertiesProvider tempAuthPropertiesProvider() {
+        return FakePropertiesProvider.builder()
+            .register(OBJECTSTORAGE_CONFIGURATION_NAME,
+                swiftConfigBuilder()
+                    .put(OBJECTSTORAGE_SWIFT_AUTH_API, SwiftTempAuthObjectStorage.AUTH_API_NAME)
+                    .put(SwiftConfigurationReader.OBJECTSTORAGE_SWIFT_ENDPOINT, dockerSwift.swiftEndpoint().toString())
+                    .put(SwiftConfigurationReader.OBJECTSTORAGE_SWIFT_CREDENTIALS, "testing")
+                    .put(SwiftTmpAuthConfigurationReader.OBJECTSTORAGE_SWIFT_TEMPAUTH_USERNAME, "tester")
+                    .put(SwiftTmpAuthConfigurationReader.OBJECTSTORAGE_SWIFT_TEMPAUTH_TENANTNAME, "test")
+                    .put(SwiftTmpAuthConfigurationReader.OBJECTSTORAGE_SWIFT_TEMPAUTH_PASS_HEADER_NAME, "X-Storage-Pass")
+                    .put(SwiftTmpAuthConfigurationReader.OBJECTSTORAGE_SWIFT_TEMPAUTH_USER_HEADER_NAME, "X-Storage-User")
+                    .build())
+            .build();
+    }
+
+    private PropertiesProvider keystone2PropertiesProvider() {
+        return FakePropertiesProvider.builder()
+            .register(OBJECTSTORAGE_CONFIGURATION_NAME,
+                swiftConfigBuilder()
+                    .put(OBJECTSTORAGE_SWIFT_AUTH_API, SwiftKeystone2ObjectStorage.AUTH_API_NAME)
+                    .put(SwiftConfigurationReader.OBJECTSTORAGE_SWIFT_ENDPOINT, dockerSwift.keystoneV2Endpoint().toString())
+                    .put(SwiftConfigurationReader.OBJECTSTORAGE_SWIFT_CREDENTIALS, "demo")
+                    .put(SwiftKeystone2ConfigurationReader.OBJECTSTORAGE_SWIFT_KEYSTONE_2_USERNAME, "demo")
+                    .put(SwiftKeystone2ConfigurationReader.OBJECTSTORAGE_SWIFT_KEYSTONE_2_TENANTNAME, "test")
+                    .build())
+            .build();
+    }
+
+    private final PropertiesProvider keystone3PropertiesProvider() {
+        return FakePropertiesProvider.builder()
+            .register(OBJECTSTORAGE_CONFIGURATION_NAME,
+                swiftConfigBuilder()
+                    .put(OBJECTSTORAGE_SWIFT_AUTH_API, SwiftKeystone3ObjectStorage.AUTH_API_NAME)
+                    .put(SwiftConfigurationReader.OBJECTSTORAGE_SWIFT_ENDPOINT, dockerSwift.keystoneV3Endpoint().toString())
+                    .put(SwiftConfigurationReader.OBJECTSTORAGE_SWIFT_CREDENTIALS, "demo")
+                    .put(SwiftKeystone3ConfigurationReader.OBJECTSTORAGE_SWIFT_KEYSTONE_3_USER_NAME, "demo")
+                    .put(SwiftKeystone3ConfigurationReader.OBJECTSTORAGE_SWIFT_KEYSTONE_3_USER_DOMAIN, "Default")
+                    .put(SwiftKeystone3ConfigurationReader.OBJECTSTORAGE_SWIFT_KEYSTONE_3_PROJECT_NAME, "test")
+                    .build())
+            .build();
+    }
+
+    @Test
+    void provides_a_tempauth_backed_blobstore_dao() throws ConfigurationException {
+        ObjectStorageBlobsDAOProvider objectStorageBlobsDAOProvider =
+            new ObjectStorageBlobsDAOProvider(tempAuthPropertiesProvider(), BLOB_ID_FACTORY);
+        ObjectStorageBlobsDAO objectStorageBlobsDAO = objectStorageBlobsDAOProvider.get();
+        assertThat(objectStorageBlobsDAO).isNotNull();
+    }
+
+    @Test
+    void provides_a_keystone2_backed_blobstore_dao() throws ConfigurationException {
+        ObjectStorageBlobsDAOProvider objectStorageBlobsDAOProvider =
+            new ObjectStorageBlobsDAOProvider(keystone2PropertiesProvider(),
+                BLOB_ID_FACTORY);
+        ObjectStorageBlobsDAO objectStorageBlobsDAO = objectStorageBlobsDAOProvider.get();
+        assertThat(objectStorageBlobsDAO).isNotNull();
+    }
+
+    @Test
+    void provides_a_keystone3_backed_blobstore_dao() throws ConfigurationException {
+        ObjectStorageBlobsDAOProvider objectStorageBlobsDAOProvider =
+            new ObjectStorageBlobsDAOProvider(keystone3PropertiesProvider(),
+                BLOB_ID_FACTORY);
+        ObjectStorageBlobsDAO objectStorageBlobsDAO = objectStorageBlobsDAOProvider.get();
+        assertThat(objectStorageBlobsDAO).isNotNull();
+    }
+
+    private static MapConfigurationBuilder swiftConfigBuilder() {
+        return newConfigBuilder()
+            .put(PayloadCodecProvider.OBJECTSTORAGE_PAYLOAD_CODEC, PayloadCodecs.DEFAULT.name())
+            .put(OBJECTSTORAGE_PROVIDER, OBJECTSTORAGE_PROVIDER_SWIFT)
+            .put(OBJECTSTORAGE_NAMESPACE, "foo");
+    }
+
+    private static MapConfigurationBuilder newConfigBuilder() {
+        return new MapConfigurationBuilder();
+    }
+}

--- a/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/PayloadCodecProviderTest.java
+++ b/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/PayloadCodecProviderTest.java
@@ -22,18 +22,10 @@ package org.apache.james.modules.objectstorage;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.FileNotFoundException;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.MapConfiguration;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.james.blob.objectstorage.AESPayloadCodec;
 import org.apache.james.blob.objectstorage.DefaultPayloadCodec;
 import org.apache.james.blob.objectstorage.PayloadCodec;
-import org.apache.james.utils.PropertiesProvider;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
@@ -155,51 +147,6 @@ class PayloadCodecProviderTest {
 
     private static MapConfigurationBuilder newConfigBuilder() {
         return new MapConfigurationBuilder();
-    }
-
-    private static class FakePropertiesProvider extends PropertiesProvider {
-        private Map<String, Configuration> configurations;
-
-        public FakePropertiesProvider(Map<String, Configuration> configurations) {
-            super(null);
-            this.configurations = configurations;
-        }
-
-
-        @Override
-        public Configuration getConfiguration(String fileName) throws FileNotFoundException, ConfigurationException {
-            if (configurations.containsKey(fileName)) {
-                return configurations.get(fileName);
-            } else {
-                throw new FileNotFoundException(
-                    "no configuration defined for " +
-                        fileName +
-                        " know configurations are (" +
-                        StringUtils.join(configurations.keySet(), ",") +
-                        ")");
-            }
-        }
-
-        public static FakePropertiesProviderBuilder builder() {
-            return new FakePropertiesProviderBuilder();
-        }
-
-        static class FakePropertiesProviderBuilder {
-            private final Map<String, Configuration> configurations;
-
-            public FakePropertiesProviderBuilder() {
-                configurations = new HashMap<>();
-            }
-
-            public FakePropertiesProviderBuilder register(String objectstorage, Configuration configuration) {
-                configurations.put(objectstorage, configuration);
-                return this;
-            }
-
-            public FakePropertiesProvider build() {
-                return new FakePropertiesProvider(configurations);
-            }
-        }
     }
 
     private static class MapConfigurationBuilder {

--- a/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/PayloadCodecProviderTest.java
+++ b/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/PayloadCodecProviderTest.java
@@ -1,0 +1,175 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.objectstorage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.FileNotFoundException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.MapConfiguration;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.james.blob.objectstorage.AESPayloadCodec;
+import org.apache.james.blob.objectstorage.DefaultPayloadCodec;
+import org.apache.james.blob.objectstorage.PayloadCodec;
+import org.apache.james.utils.PropertiesProvider;
+import org.junit.jupiter.api.Test;
+
+class PayloadCodecProviderTest {
+
+
+    private static final FakePropertiesProvider DEFAULT_PROPERTIES_PROVIDER =
+        FakePropertiesProvider.builder()
+            .register("objectstorage",
+                newConfigBuilder()
+                    .put("objectstorage.payload.codec", PayloadCodecs.DEFAULT.name())
+                    .build())
+            .build();
+    private static final FakePropertiesProvider EMPTY_PROPERTIES_PROVIDER =
+        FakePropertiesProvider.builder()
+            .register("objectstorage",
+                newConfigBuilder().build()
+            ).build();
+
+    private static final FakePropertiesProvider AES_PROPERTIES_PROVIDER =
+        FakePropertiesProvider.builder()
+            .register("objectstorage",
+                newConfigBuilder()
+                    .put("objectstorage.payload.codec", PayloadCodecs.AES256.name())
+                    .put("objectstorage.aes256.hexsalt", "12345123451234512345")
+                    .put("objectstorage.aes256.password", "james is great")
+                    .build())
+            .build();
+    private static final FakePropertiesProvider MISSING_SALT_PROPERTIES_PROVIDER =
+        FakePropertiesProvider.builder()
+            .register("objectstorage",
+                newConfigBuilder()
+                    .put("objectstorage.payload.codec", PayloadCodecs.AES256.name())
+                    .put("objectstorage.aes256.password", "james is great")
+                    .build())
+            .build();
+    private static final FakePropertiesProvider MISSING_PASSWORD_PROPERTIES_PROVIDER =
+        FakePropertiesProvider.builder()
+            .register("objectstorage",
+                newConfigBuilder()
+                    .put("objectstorage.payload.codec", PayloadCodecs.AES256.name())
+                    .put("objectstorage.aes256.hexsalt", "12345123451234512345")
+                    .build())
+            .build();
+
+    @Test
+    void shouldBuildADefaultPayloadCodecForDefaultConfig() throws Exception {
+        PayloadCodec payloadCodec = new PayloadCodecProvider(DEFAULT_PROPERTIES_PROVIDER).get();
+        assertThat(payloadCodec).isInstanceOf(DefaultPayloadCodec.class);
+    }
+
+    @Test
+    void shouldBuildAnAESPayloadCodecForAESConfig() throws Exception {
+        PayloadCodec payloadCodec = new PayloadCodecProvider(AES_PROPERTIES_PROVIDER).get();
+        assertThat(payloadCodec).isInstanceOf(AESPayloadCodec.class);
+    }
+
+    @Test
+    void shouldFailIfCodeKeyIsMissing() throws Exception {
+        assertThatThrownBy(() -> new PayloadCodecProvider(EMPTY_PROPERTIES_PROVIDER).get()).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldFailForAESCodecWhenSaltKeyIsMissing() throws Exception {
+        assertThatThrownBy(() -> new PayloadCodecProvider(MISSING_SALT_PROPERTIES_PROVIDER).get()).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldFailForAESCodecWhenPasswordKeyIsMissing() throws Exception {
+
+        assertThatThrownBy(() -> new PayloadCodecProvider(MISSING_PASSWORD_PROPERTIES_PROVIDER).get()).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static MapConfigurationBuilder newConfigBuilder() {
+        return new MapConfigurationBuilder();
+    }
+
+    private static class FakePropertiesProvider extends PropertiesProvider {
+        private Map<String, Configuration> configurations;
+
+        public FakePropertiesProvider(Map<String, Configuration> configurations) {
+            super(null);
+            this.configurations = configurations;
+        }
+
+
+        @Override
+        public Configuration getConfiguration(String fileName) throws FileNotFoundException, ConfigurationException {
+            if (configurations.containsKey(fileName)) {
+                return configurations.get(fileName);
+            } else {
+                throw new FileNotFoundException(
+                    "no configuration defined for " +
+                        fileName +
+                        " know configurations are (" +
+                        StringUtils.join(configurations.keySet(), ",") +
+                        ")");
+            }
+        }
+
+        public static FakePropertiesProviderBuilder builder() {
+            return new FakePropertiesProviderBuilder();
+        }
+
+        static class FakePropertiesProviderBuilder {
+            private final Map<String, Configuration> configurations;
+
+            public FakePropertiesProviderBuilder() {
+                configurations = new HashMap<>();
+            }
+
+            public FakePropertiesProviderBuilder register(String objectstorage, Configuration configuration) {
+                configurations.put(objectstorage, configuration);
+                return this;
+            }
+
+            public FakePropertiesProvider build() {
+                return new FakePropertiesProvider(configurations);
+            }
+        }
+    }
+
+    private static class MapConfigurationBuilder {
+        private Map<String, Object> config;
+
+        public MapConfigurationBuilder() {
+            this.config = new HashMap<>();
+        }
+
+        public MapConfigurationBuilder put(String key, Object value) {
+            config.put(key, value);
+            return this;
+        }
+
+        public MapConfiguration build() {
+            return new MapConfiguration(config);
+        }
+    }
+}
+

--- a/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/PayloadCodecProviderTest.java
+++ b/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/PayloadCodecProviderTest.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.Test;
 
 class PayloadCodecProviderTest {
 
-
     private static final FakePropertiesProvider DEFAULT_PROPERTIES_PROVIDER =
         FakePropertiesProvider.builder()
             .register("objectstorage",
@@ -46,6 +45,7 @@ class PayloadCodecProviderTest {
                     .put("objectstorage.payload.codec", PayloadCodecs.DEFAULT.name())
                     .build())
             .build();
+
     private static final FakePropertiesProvider EMPTY_PROPERTIES_PROVIDER =
         FakePropertiesProvider.builder()
             .register("objectstorage",
@@ -61,6 +61,7 @@ class PayloadCodecProviderTest {
                     .put("objectstorage.aes256.password", "james is great")
                     .build())
             .build();
+
     private static final FakePropertiesProvider MISSING_SALT_PROPERTIES_PROVIDER =
         FakePropertiesProvider.builder()
             .register("objectstorage",
@@ -69,6 +70,7 @@ class PayloadCodecProviderTest {
                     .put("objectstorage.aes256.password", "james is great")
                     .build())
             .build();
+
     private static final FakePropertiesProvider MISSING_PASSWORD_PROPERTIES_PROVIDER =
         FakePropertiesProvider.builder()
             .register("objectstorage",
@@ -91,8 +93,20 @@ class PayloadCodecProviderTest {
     }
 
     @Test
-    void shouldFailIfCodeKeyIsMissing() throws Exception {
+    void shouldFailIfCodecKeyIsMissing() throws Exception {
         assertThatThrownBy(() -> new PayloadCodecProvider(EMPTY_PROPERTIES_PROVIDER).get()).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldFailIfCodecKeyIsIncorrect() throws Exception {
+        FakePropertiesProvider typoed_properties = FakePropertiesProvider.builder()
+            .register("objectstorage",
+                newConfigBuilder()
+                    .put("objectstorage.payload.codec", "aes255")
+                    .put("objectstorage.aes256.password", "james is great")
+                    .build())
+            .build();
+        assertThatThrownBy(()->new PayloadCodecProvider(typoed_properties).get()).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/PayloadCodecProviderTest.java
+++ b/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/PayloadCodecProviderTest.java
@@ -35,6 +35,7 @@ import org.apache.james.blob.objectstorage.DefaultPayloadCodec;
 import org.apache.james.blob.objectstorage.PayloadCodec;
 import org.apache.james.utils.PropertiesProvider;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 class PayloadCodecProviderTest {
 
@@ -71,12 +72,32 @@ class PayloadCodecProviderTest {
                     .build())
             .build();
 
+    private static final FakePropertiesProvider EMPTY_SALT_PROPERTIES_PROVIDER =
+        FakePropertiesProvider.builder()
+            .register("objectstorage",
+                newConfigBuilder()
+                    .put("objectstorage.payload.codec", PayloadCodecs.AES256.name())
+                    .put("objectstorage.aes256.hexsalt", "")
+                    .put("objectstorage.aes256.password", "james is great")
+                    .build())
+            .build();
+
     private static final FakePropertiesProvider MISSING_PASSWORD_PROPERTIES_PROVIDER =
         FakePropertiesProvider.builder()
             .register("objectstorage",
                 newConfigBuilder()
                     .put("objectstorage.payload.codec", PayloadCodecs.AES256.name())
                     .put("objectstorage.aes256.hexsalt", "12345123451234512345")
+                    .build())
+            .build();
+
+    private static final FakePropertiesProvider EMPTY_PASSWORD_PROPERTIES_PROVIDER =
+        FakePropertiesProvider.builder()
+            .register("objectstorage",
+                newConfigBuilder()
+                    .put("objectstorage.payload.codec", PayloadCodecs.AES256.name())
+                    .put("objectstorage.aes256.hexsalt", "12345123451234512345")
+                    .put("objectstorage.aes256.password", "")
                     .build())
             .build();
 
@@ -115,9 +136,20 @@ class PayloadCodecProviderTest {
     }
 
     @Test
+    void shouldFailForAESCodecWhenSaltKeyIsEmpty() throws Exception {
+        assertThatThrownBy(() -> new PayloadCodecProvider(EMPTY_SALT_PROPERTIES_PROVIDER).get()).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     void shouldFailForAESCodecWhenPasswordKeyIsMissing() throws Exception {
 
         assertThatThrownBy(() -> new PayloadCodecProvider(MISSING_PASSWORD_PROPERTIES_PROVIDER).get()).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldFailForAESCodecWhenPasswordKeyIsEmpty() throws Exception {
+
+        assertThatThrownBy(() -> new PayloadCodecProvider(EMPTY_PASSWORD_PROPERTIES_PROVIDER).get()).isInstanceOf(IllegalArgumentException.class);
     }
 
     private static MapConfigurationBuilder newConfigBuilder() {
@@ -170,10 +202,10 @@ class PayloadCodecProviderTest {
     }
 
     private static class MapConfigurationBuilder {
-        private Map<String, Object> config;
+        private ImmutableMap.Builder<String, Object> config;
 
         public MapConfigurationBuilder() {
-            this.config = new HashMap<>();
+            this.config = new ImmutableMap.Builder<>();
         }
 
         public MapConfigurationBuilder put(String key, Object value) {
@@ -182,7 +214,7 @@ class PayloadCodecProviderTest {
         }
 
         public MapConfiguration build() {
-            return new MapConfiguration(config);
+            return new MapConfiguration(config.build());
         }
     }
 }

--- a/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/PayloadCodecProviderTest.java
+++ b/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/PayloadCodecProviderTest.java
@@ -49,8 +49,8 @@ class PayloadCodecProviderTest {
     private static final FakePropertiesProvider EMPTY_PROPERTIES_PROVIDER =
         FakePropertiesProvider.builder()
             .register("objectstorage",
-                newConfigBuilder().build()
-            ).build();
+                newConfigBuilder().build())
+            .build();
 
     private static final FakePropertiesProvider AES_PROPERTIES_PROVIDER =
         FakePropertiesProvider.builder()

--- a/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/PayloadCodecProviderTest.java
+++ b/server/container/guice/blob-objectstorage-guice/src/test/java/org/apache/james/modules/objectstorage/PayloadCodecProviderTest.java
@@ -35,7 +35,8 @@ import org.apache.james.blob.objectstorage.DefaultPayloadCodec;
 import org.apache.james.blob.objectstorage.PayloadCodec;
 import org.apache.james.utils.PropertiesProvider;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+
+import com.google.common.collect.ImmutableMap;
 
 class PayloadCodecProviderTest {
 
@@ -120,14 +121,14 @@ class PayloadCodecProviderTest {
 
     @Test
     void shouldFailIfCodecKeyIsIncorrect() throws Exception {
-        FakePropertiesProvider typoed_properties = FakePropertiesProvider.builder()
+        FakePropertiesProvider propertiesWithTypo = FakePropertiesProvider.builder()
             .register("objectstorage",
                 newConfigBuilder()
                     .put("objectstorage.payload.codec", "aes255")
                     .put("objectstorage.aes256.password", "james is great")
                     .build())
             .build();
-        assertThatThrownBy(()->new PayloadCodecProvider(typoed_properties).get()).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new PayloadCodecProvider(propertiesWithTypo).get()).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CucumberSwiftSingleton.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CucumberSwiftSingleton.java
@@ -18,10 +18,11 @@
  ****************************************************************/
 package org.apache.james.jmap.cassandra.cucumber;
 
+import org.apache.james.modules.objectstorage.PayloadCodecs;
 import org.apache.james.modules.objectstorage.guice.DockerSwiftTestRule;
 
 public class CucumberSwiftSingleton {
 
     public static DockerSwiftTestRule swiftServer = new DockerSwiftTestRule();
-
+    public static DockerSwiftTestRule encryptedSwiftServer = new DockerSwiftTestRule(PayloadCodecs.AES256);
 }


### PR DESCRIPTION
This commits adds a simple cryptographic support for blobstores backed by object storage. stores configured to use encryption will apply AES256/GCM/NoPadding encryption to the blobs before uploading them and will decrypt them when read from the store.

The capability configurability is fairly limited at this point, it will only be one of no encryption or use the authenticated encryption AES256/GCM/NoPadding. 
The 256 bits key is derived from a provided salt and password using PBKDF2 with the maximum possible iterations of PBKDF2WithHmacSHA1.