### PR TITLE
JAMES-2557 SenderIs* does not support null sender

### DIFF
--- a/core/src/main/java/org/apache/james/core/MailAddress.java
+++ b/core/src/main/java/org/apache/james/core/MailAddress.java
@@ -381,15 +381,18 @@ public class MailAddress implements java.io.Serializable {
             String theString = (String) obj;
             return toString().equalsIgnoreCase(theString);
         } else if (obj instanceof MailAddress) {
-            MailAddress addr = (MailAddress) obj;
-            if (isNullSender() && addr.isNullSender()) {
+            MailAddress that = (MailAddress) obj;
+            boolean bothNullSender = this.isNullSender() && that.isNullSender();
+            boolean onlyOneIsNullSender = isNullSender() ^ that.isNullSender();
+
+            if (bothNullSender) {
                 return true;
             }
-            if (isNullSender() != addr.isNullSender()) {
+            if (onlyOneIsNullSender) {
                 return false;
             }
-            return equalsIgnoreCase(getLocalPart(), addr.getLocalPart())
-                && Objects.equals(getDomain(), addr.getDomain());
+            return equalsIgnoreCase(getLocalPart(), that.getLocalPart())
+                && Objects.equals(getDomain(), that.getDomain());
         }
         return false;
     }

--- a/core/src/main/java/org/apache/james/core/MailAddress.java
+++ b/core/src/main/java/org/apache/james/core/MailAddress.java
@@ -385,7 +385,7 @@ public class MailAddress implements java.io.Serializable {
             if (isNullSender() && addr.isNullSender()) {
                 return true;
             }
-            if (isNullSender() || addr.isNullSender()) {
+            if (isNullSender() != addr.isNullSender()) {
                 return false;
             }
             return equalsIgnoreCase(getLocalPart(), addr.getLocalPart())

--- a/core/src/main/java/org/apache/james/core/MailAddress.java
+++ b/core/src/main/java/org/apache/james/core/MailAddress.java
@@ -385,6 +385,9 @@ public class MailAddress implements java.io.Serializable {
             if (isNullSender() && addr.isNullSender()) {
                 return true;
             }
+            if (isNullSender() || addr.isNullSender()) {
+                return false;
+            }
             return equalsIgnoreCase(getLocalPart(), addr.getLocalPart())
                 && Objects.equals(getDomain(), addr.getDomain());
         }

--- a/core/src/test/java/org/apache/james/core/MailAddressTest.java
+++ b/core/src/test/java/org/apache/james/core/MailAddressTest.java
@@ -245,6 +245,18 @@ public class MailAddressTest {
     }
 
     @Test
+    public void equalsShouldReturnFalseWhenOnlyFirstMemberIsANullSender() {
+        assertThat(MailAddress.getMailSender(GOOD_ADDRESS))
+            .isNotEqualTo(MailAddress.nullSender());
+    }
+
+    @Test
+    public void equalsShouldReturnFalseWhenOnlySecondMemberIsANullSender() {
+        assertThat(MailAddress.nullSender())
+            .isNotEqualTo(MailAddress.getMailSender(GOOD_ADDRESS));
+    }
+
+    @Test
     public void shouldMatchBeanContract() {
         EqualsVerifier.forClass(MailAddress.class)
             .verify();

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderHostIs.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderHostIs.java
@@ -78,7 +78,7 @@ public class SenderHostIs extends GenericMatcher {
     @Override
     public Collection<MailAddress> match(Mail mail) {
         try {
-            if (mail.getSender() != null && senderHosts.contains(mail.getSender().getDomain())) {
+            if (!senderIsNull(mail) && senderHosts.contains(mail.getSender().getDomain())) {
                 return mail.getRecipients();
             }
         } catch (Exception e) {
@@ -86,5 +86,10 @@ public class SenderHostIs extends GenericMatcher {
         }
 
         return null;    //No match.
+    }
+
+    private boolean senderIsNull(Mail mail) {
+        return mail.getSender() == null
+            || mail.getSender().isNullSender();
     }
 }

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderHostIs.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderHostIs.java
@@ -78,7 +78,7 @@ public class SenderHostIs extends GenericMatcher {
     @Override
     public Collection<MailAddress> match(Mail mail) {
         try {
-            if (!senderIsNull(mail) && senderHosts.contains(mail.getSender().getDomain())) {
+            if (hasSender(mail) && senderHosts.contains(mail.getSender().getDomain())) {
                 return mail.getRecipients();
             }
         } catch (Exception e) {
@@ -88,8 +88,8 @@ public class SenderHostIs extends GenericMatcher {
         return null;    //No match.
     }
 
-    private boolean senderIsNull(Mail mail) {
-        return mail.getSender() == null
-            || mail.getSender().isNullSender();
+    private boolean hasSender(Mail mail) {
+        return mail.getSender() != null
+            && !mail.getSender().isNullSender();
     }
 }

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderHostIsLocal.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderHostIsLocal.java
@@ -47,6 +47,9 @@ public class SenderHostIsLocal extends GenericMatcher {
     }
 
     private boolean isLocalServer(Mail mail) {
+        if (mail.getSender().isNullSender()) {
+            return false;
+        }
         return this.getMailetContext().isLocalServer(mail.getSender().getDomain());
     }
 

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIs.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIs.java
@@ -20,6 +20,7 @@
 package org.apache.james.transport.matchers;
 
 import java.util.Collection;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.mail.MessagingException;
@@ -66,7 +67,8 @@ public class SenderIs extends GenericMatcher {
 
     @Override
     public Collection<MailAddress> match(Mail mail) {
-        if (senders.contains(mail.getSender())) {
+        MailAddress sanitizedSender = Optional.ofNullable(mail.getSender()).orElse(MailAddress.nullSender());
+        if (senders.contains(sanitizedSender)) {
             return mail.getRecipients();
         } else {
             return null;

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIsLocal.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIsLocal.java
@@ -20,8 +20,6 @@ package org.apache.james.transport.matchers;
 
 import java.util.Collection;
 
-import javax.mail.MessagingException;
-
 import org.apache.james.core.MailAddress;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMatcher;
@@ -32,7 +30,7 @@ import org.apache.mailet.base.GenericMatcher;
 public class SenderIsLocal extends GenericMatcher {
 
     @Override
-    public final Collection<MailAddress> match(Mail mail) throws MessagingException {
+    public final Collection<MailAddress> match(Mail mail) {
         if (isLocal(mail.getSender())) {
             return mail.getRecipients();
         }
@@ -40,6 +38,9 @@ public class SenderIsLocal extends GenericMatcher {
     }
 
     private boolean isLocal(MailAddress mailAddress) {
+        if (mailAddress.isNullSender()) {
+            return false;
+        }
         return getMailetContext().isLocalEmail(mailAddress);
     }
 

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIsLocal.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIsLocal.java
@@ -19,6 +19,7 @@
 package org.apache.james.transport.matchers;
 
 import java.util.Collection;
+import java.util.Optional;
 
 import org.apache.james.core.MailAddress;
 import org.apache.mailet.Mail;
@@ -38,10 +39,10 @@ public class SenderIsLocal extends GenericMatcher {
     }
 
     private boolean isLocal(MailAddress mailAddress) {
-        if (mailAddress.isNullSender()) {
-            return false;
-        }
-        return getMailetContext().isLocalEmail(mailAddress);
+        return Optional.ofNullable(mailAddress)
+            .filter(address -> !address.isNullSender())
+            .map(address -> getMailetContext().isLocalEmail(address))
+            .orElse(false);
     }
 
 }

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIsNull.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIsNull.java
@@ -38,10 +38,15 @@ public class SenderIsNull extends GenericMatcher {
 
     @Override
     public Collection<MailAddress> match(Mail mail) {
-        if (mail.getSender() == null) {
+        if (isNullSender(mail)) {
             return mail.getRecipients();
         } else {
             return null;
         }
+    }
+
+    private boolean isNullSender(Mail mail) {
+        return mail.getSender() == null
+            || mail.getSender().isNullSender();
     }
 }

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIsRegex.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIsRegex.java
@@ -78,7 +78,7 @@ public class SenderIsRegex extends GenericMatcher {
         if (mailAddress == null) {
             return null;
         }
-        String senderString = mailAddress.toString();
+        String senderString = mailAddress.asString();
         if (pattern.matcher(senderString).matches()) {
             return mail.getRecipients();
         }

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/utils/MailAddressCollectionReader.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/utils/MailAddressCollectionReader.java
@@ -38,12 +38,15 @@ public class MailAddressCollectionReader {
         return Splitter.onPattern("(,| |\t)").splitToList(condition)
             .stream()
             .filter(s -> !Strings.isNullOrEmpty(s))
-            .map(s -> getMailAddress(s))
+            .map(MailAddressCollectionReader::getMailAddress)
             .collect(Guavate.toImmutableSet());
     }
 
     private static MailAddress getMailAddress(String s) {
         try {
+            if (s.equals(MailAddress.NULL_SENDER_AS_STRING)) {
+                return MailAddress.nullSender();
+            }
             return new MailAddress(s);
         } catch (AddressException e) {
             throw new RuntimeException(e);

--- a/mailet/standard/src/test/java/org/apache/james/transport/matchers/SenderHostIsLocalTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/matchers/SenderHostIsLocalTest.java
@@ -87,4 +87,29 @@ public class SenderHostIsLocalTest {
         assertThat(actual).isNull();
     }
 
+    @Test
+    public void shouldNotMatchWhenNullSender() throws MessagingException {
+        //Given
+        Mail mail = FakeMail.builder()
+            .sender(MailAddress.nullSender())
+            .recipient(ANY_AT_JAMES)
+            .build();
+        //When
+        Collection<MailAddress> actual = matcher.match(mail);
+        //Then
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    public void shouldNotMatchWhenNoSender() throws MessagingException {
+        //Given
+        Mail mail = FakeMail.builder()
+            .recipient(ANY_AT_JAMES)
+            .build();
+        //When
+        Collection<MailAddress> actual = matcher.match(mail);
+        //Then
+        assertThat(actual).isNull();
+    }
+
 }

--- a/mailet/standard/src/test/java/org/apache/james/transport/matchers/SenderHostIsTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/matchers/SenderHostIsTest.java
@@ -116,6 +116,25 @@ public class SenderHostIsTest {
         matcher.init(FakeMatcherConfig.builder()
                 .matcherName("SenderHostIs")
                 .mailetContext(mailContext)
+                .condition("domain.tld")
+                .build());
+
+        Mail mail = FakeMail.builder()
+                .sender(ANY_AT_JAMES2)
+                .recipient(ANY_AT_JAMES2)
+                .build();
+        //When
+        Collection<MailAddress> actual = matcher.match(mail);
+        //Then
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    void shouldNotMatchWhenNoSender() throws MessagingException {
+        //Given
+        matcher.init(FakeMatcherConfig.builder()
+                .matcherName("SenderHostIs")
+                .mailetContext(mailContext)
                 .condition("")
                 .build());
 

--- a/mailet/standard/src/test/java/org/apache/james/transport/matchers/SenderIsLocalTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/matchers/SenderIsLocalTest.java
@@ -98,4 +98,17 @@ public class SenderIsLocalTest {
         assertThat(actual).isNull();
     }
 
+    @Test
+    public void shouldNotMatchWhenNullSender() throws MessagingException {
+        //Given
+        Mail mail = FakeMail.builder()
+            .sender(MailAddress.nullSender())
+            .recipient(ANY_AT_JAMES)
+            .build();
+        //When
+        Collection<MailAddress> actual = matcher.match(mail);
+        //Then
+        assertThat(actual).isNull();
+    }
+
 }

--- a/mailet/standard/src/test/java/org/apache/james/transport/matchers/SenderIsLocalTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/matchers/SenderIsLocalTest.java
@@ -111,4 +111,16 @@ public class SenderIsLocalTest {
         assertThat(actual).isNull();
     }
 
+    @Test
+    public void shouldNotMatchWhenNoSender() throws MessagingException {
+        //Given
+        Mail mail = FakeMail.builder()
+            .recipient(ANY_AT_JAMES)
+            .build();
+        //When
+        Collection<MailAddress> actual = matcher.match(mail);
+        //Then
+        assertThat(actual).isNull();
+    }
+
 }

--- a/mailet/standard/src/test/java/org/apache/james/transport/matchers/SenderIsNullTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/matchers/SenderIsNullTest.java
@@ -23,6 +23,7 @@ package org.apache.james.transport.matchers;
 import static org.apache.mailet.base.MailAddressFixture.ANY_AT_JAMES;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.james.core.MailAddress;
 import org.apache.mailet.base.test.FakeMail;
 import org.apache.mailet.base.test.FakeMatcherConfig;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,9 +42,19 @@ class SenderIsNullTest {
     }
 
     @Test
+    void shouldMatchWhenNoSender() throws Exception {
+        FakeMail fakeMail = FakeMail.builder()
+            .recipient(ANY_AT_JAMES)
+            .build();
+
+        assertThat(matcher.match(fakeMail)).containsExactly(ANY_AT_JAMES);
+    }
+
+    @Test
     void shouldMatchWhenNullSender() throws Exception {
         FakeMail fakeMail = FakeMail.builder()
             .recipient(ANY_AT_JAMES)
+            .sender(MailAddress.nullSender())
             .build();
 
         assertThat(matcher.match(fakeMail)).containsExactly(ANY_AT_JAMES);

--- a/mailet/standard/src/test/java/org/apache/james/transport/matchers/SenderIsRegexTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/matchers/SenderIsRegexTest.java
@@ -74,7 +74,7 @@ class SenderIsRegexTest {
     }
 
     @Test
-    void shouldNotMatchWhenNullSender() throws Exception {
+    void shouldNotMatchWhenNoSender() throws Exception {
         matcher.init(FakeMatcherConfig.builder()
                 .matcherName("SenderIsRegex")
                 .condition(".*@.*")
@@ -85,6 +85,36 @@ class SenderIsRegexTest {
             .build();
 
         assertThat(matcher.match(fakeMail)).isNull();
+    }
+
+    @Test
+    void shouldNotMatchWhenNullSender() throws Exception {
+        matcher.init(FakeMatcherConfig.builder()
+                .matcherName("SenderIsRegex")
+                .condition(".*@.*")
+                .build());
+
+        FakeMail fakeMail = FakeMail.builder()
+            .recipient(recipient)
+            .sender(MailAddress.nullSender())
+            .build();
+
+        assertThat(matcher.match(fakeMail)).isNull();
+    }
+
+    @Test
+    void shouldMatchNullSenderWhenConfigured() throws Exception {
+        matcher.init(FakeMatcherConfig.builder()
+                .matcherName("SenderIsRegex")
+                .condition("<>")
+                .build());
+
+        FakeMail fakeMail = FakeMail.builder()
+            .recipient(recipient)
+            .sender(MailAddress.nullSender())
+            .build();
+
+        assertThat(matcher.match(fakeMail)).containsExactly(recipient);
     }
 
     @Test

--- a/mailet/standard/src/test/java/org/apache/james/transport/matchers/SenderIsTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/matchers/SenderIsTest.java
@@ -75,6 +75,20 @@ class SenderIsTest {
     }
 
     @Test
+    void shouldMatchNotMatchWhenNoSender() throws Exception {
+        matcher.init(FakeMatcherConfig.builder()
+                .matcherName("SenderIs")
+                .condition(SENDER_NAME)
+                .build());
+
+        FakeMail fakeMail = FakeMail.builder()
+            .recipient(recipient)
+            .build();
+
+        assertThat(matcher.match(fakeMail)).isNull();
+    }
+
+    @Test
     void shouldMatchMatchWhenNullSenderWhenConfigured() throws Exception {
         matcher.init(FakeMatcherConfig.builder()
                 .matcherName("SenderIs")
@@ -84,6 +98,20 @@ class SenderIsTest {
         FakeMail fakeMail = FakeMail.builder()
             .recipient(recipient)
             .sender(MailAddress.nullSender())
+            .build();
+
+        assertThat(matcher.match(fakeMail)).containsExactly(recipient);
+    }
+
+    @Test
+    void shouldMatchMatchWhenNoSenderWhenConfigured() throws Exception {
+        matcher.init(FakeMatcherConfig.builder()
+                .matcherName("SenderIs")
+                .condition(MailAddress.NULL_SENDER_AS_STRING)
+                .build());
+
+        FakeMail fakeMail = FakeMail.builder()
+            .recipient(recipient)
             .build();
 
         assertThat(matcher.match(fakeMail)).containsExactly(recipient);

--- a/mailet/standard/src/test/java/org/apache/james/transport/matchers/SenderIsTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/matchers/SenderIsTest.java
@@ -60,6 +60,36 @@ class SenderIsTest {
     }
 
     @Test
+    void shouldMatchNotMatchWhenNullSender() throws Exception {
+        matcher.init(FakeMatcherConfig.builder()
+                .matcherName("SenderIs")
+                .condition(SENDER_NAME)
+                .build());
+
+        FakeMail fakeMail = FakeMail.builder()
+            .recipient(recipient)
+            .sender(MailAddress.nullSender())
+            .build();
+
+        assertThat(matcher.match(fakeMail)).isNull();
+    }
+
+    @Test
+    void shouldMatchMatchWhenNullSenderWhenConfigured() throws Exception {
+        matcher.init(FakeMatcherConfig.builder()
+                .matcherName("SenderIs")
+                .condition(MailAddress.NULL_SENDER_AS_STRING)
+                .build());
+
+        FakeMail fakeMail = FakeMail.builder()
+            .recipient(recipient)
+            .sender(MailAddress.nullSender())
+            .build();
+
+        assertThat(matcher.match(fakeMail)).containsExactly(recipient);
+    }
+
+    @Test
     void shouldNotMatchWhenWrongSender() throws Exception {
         matcher.init(FakeMatcherConfig.builder()
                 .matcherName("SenderIs")

--- a/mailet/standard/src/test/java/org/apache/james/transport/matchers/util/MailAddressCollectionReaderTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/matchers/util/MailAddressCollectionReaderTest.java
@@ -61,6 +61,12 @@ class MailAddressCollectionReaderTest {
     }
 
     @Test
+    void readShouldParseNullSender() {
+        assertThat(MailAddressCollectionReader.read("<>"))
+            .containsExactly(MailAddress.nullSender());
+    }
+
+    @Test
     void readShouldParseTwoEmailSeparatedByComaOnly() throws Exception {
         MailAddress mailAddress1 = new MailAddress("valid@apache.org");
         MailAddress mailAddress2 = new MailAddress("bis@apache.org");


### PR DESCRIPTION
While this PR does solve some encountered issues in production, https://ci.linagora.com/linagora/lgs/openpaas/james/issues/798 does a long term fix proposal.

This PR, while being a working fix for the provided matchers, serves also to highlight that it is a global problem.