### PR TITLE
JAMES-2567 Upgrade RabbitMQ amqp-client from 5.3.0 to 5.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1841,7 +1841,7 @@
             <dependency>
                 <groupId>com.rabbitmq</groupId>
                 <artifactId>amqp-client</artifactId>
-                <version>5.3.0</version>
+                <version>5.4.3</version>
             </dependency>
             <dependency>
                 <groupId>com.sparkjava</groupId>


### PR DESCRIPTION
CVE-2018-11087 [More information](https://nvd.nist.gov/vuln/detail/CVE-2018-11087)
moderate severity
Vulnerable versions: >= 5.0.0, < 5.4.0
Patched version: 5.4.0
Pivotal Spring AMQP, 1.x versions prior to 1.7.10 and 2.x versions prior to 2.0.6, expose a man-in-the-middle vulnerability due to lack of hostname validation. A malicious user that has the ability to intercept traffic would be able to view data in transit.