### PR TITLE
[RabbitMQTest] avoid starting many dockers rabbitmq while only need one

### DIFF
--- a/backends-common/rabbitmq/src/test/java/org/apache/james/backend/rabbitmq/RabbitMQTest.java
+++ b/backends-common/rabbitmq/src/test/java/org/apache/james/backend/rabbitmq/RabbitMQTest.java
@@ -37,11 +37,14 @@ import java.util.Queue;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.IntStream;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.github.fge.lambdas.Throwing;
 import com.github.steveash.guavate.Guavate;
@@ -52,8 +55,39 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 
-@ExtendWith(RabbitMQExtension.class)
 class RabbitMQTest {
+
+    private static class RabbitMQTestExtension extends RabbitMQExtension {
+
+        @Override
+        public void beforeAll(ExtensionContext context) {
+        }
+
+        void beforeAll() {
+            super.beforeAll(null);
+        }
+
+        @Override
+        public void afterAll(ExtensionContext extensionContext) {
+        }
+
+        void afterAll() {
+            super.afterAll(null);
+        }
+    }
+
+    @RegisterExtension
+    static RabbitMQTestExtension testExtension = new RabbitMQTestExtension();
+
+    @BeforeAll
+    static void setup() {
+        testExtension.beforeAll();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        testExtension.afterAll();
+    }
 
     @Nested
     class SingleConsumerTest {

--- a/backends-common/rabbitmq/src/test/java/org/apache/james/backend/rabbitmq/RabbitMQTest.java
+++ b/backends-common/rabbitmq/src/test/java/org/apache/james/backend/rabbitmq/RabbitMQTest.java
@@ -57,7 +57,7 @@ import com.rabbitmq.client.ConnectionFactory;
 
 class RabbitMQTest {
 
-    private static class RabbitMQTestExtension extends RabbitMQExtension {
+    private static class RabbitMQNestedTestExtension extends RabbitMQExtension {
 
         @Override
         public void beforeAll(ExtensionContext context) {
@@ -77,7 +77,7 @@ class RabbitMQTest {
     }
 
     @RegisterExtension
-    static RabbitMQTestExtension testExtension = new RabbitMQTestExtension();
+    static RabbitMQNestedTestExtension testExtension = new RabbitMQNestedTestExtension();
 
     @BeforeAll
     static void setup() {


### PR DESCRIPTION
[small improvement]

RabbitMQTest and each nested class invokes rabbitMQExtension.beforeAll()
for their own. This leads to starting each different docker rabbit for each test class.
Some moments, there are 3 dockers rabbit are up.

This commit addresses this issue by starting only one docker rabbit for
whole test. I reused RabbitMQExtension and ignore beforeAll, afterAll callbacks
 and move them to RabbitMQTest level.