### PR TITLE
JAMES-2557 Mail::getSenderAsOptional & MailAddress::nullSender() deprecation

### DIFF
--- a/core/src/main/java/org/apache/james/core/MailAddress.java
+++ b/core/src/main/java/org/apache/james/core/MailAddress.java
@@ -391,6 +391,7 @@ public class MailAddress implements java.io.Serializable {
      * @returns true if the given object is equal to this one, false otherwise
      */
     @Override
+    @SuppressWarnings("deprecated")
     public final boolean equals(Object obj) {
         if (obj == null) {
             return false;
@@ -683,8 +684,9 @@ public class MailAddress implements java.io.Serializable {
     /**
      * Return <code>true</code> if the {@link MailAddress} should represent a null sender (<>)
      *
-     * @return nullsender
+     * @Deprecated You should use an Optional&lt;MailAddress&gt; representation of a MailAddress rather than relying on a NULL object
      */
+    @Deprecated
     public boolean isNullSender() {
         return false;
     }

--- a/core/src/main/java/org/apache/james/core/MailAddress.java
+++ b/core/src/main/java/org/apache/james/core/MailAddress.java
@@ -80,6 +80,9 @@ public class MailAddress implements java.io.Serializable {
 
     public static final String NULL_SENDER_AS_STRING = "<>";
 
+    /**
+     * @deprecated Prefer using Optional&lt;MailAddress&gt; for representing missing values
+     */
     @Deprecated
     private static final MailAddress NULL_SENDER = new MailAddress() {
 
@@ -110,7 +113,10 @@ public class MailAddress implements java.io.Serializable {
 
     };
 
-
+    /**
+     * @deprecated Prefer using Optional&lt;MailAddress&gt; for representing missing values
+     */
+    @Deprecated
     public static MailAddress nullSender() {
         return NULL_SENDER;
     }

--- a/core/src/main/java/org/apache/james/core/MailAddress.java
+++ b/core/src/main/java/org/apache/james/core/MailAddress.java
@@ -80,6 +80,7 @@ public class MailAddress implements java.io.Serializable {
 
     public static final String NULL_SENDER_AS_STRING = "<>";
 
+    @Deprecated
     private static final MailAddress NULL_SENDER = new MailAddress() {
 
         @Override
@@ -109,23 +110,33 @@ public class MailAddress implements java.io.Serializable {
 
     };
 
+
     public static MailAddress nullSender() {
         return NULL_SENDER;
     }
 
-    public static  MailAddress getMailSender(String sender) {
+    /**
+     * @deprecated Use {@link MailAddress#getMailSenderAsOptional(String)} instead
+     */
+    @Deprecated
+    public static MailAddress getMailSender(String sender) {
+        return getMailSenderAsOptional(sender)
+            .orElse(nullSender());
+    }
+
+    public static Optional<MailAddress> getMailSenderAsOptional(String sender) {
         if (sender == null || sender.trim().length() <= 0) {
-            return null;
+            return Optional.empty();
         }
         if (sender.equals(MailAddress.NULL_SENDER_AS_STRING)) {
-            return MailAddress.nullSender();
+            return Optional.empty();
         }
         try {
-            return new MailAddress(sender);
+            return Optional.of(new MailAddress(sender));
         } catch (AddressException e) {
             // Should never happen as long as the user does not modify the header by himself
             LOGGER.error("Unable to parse the sender address {}, so we fallback to a null sender", sender, e);
-            return MailAddress.nullSender();
+            return Optional.empty();
         }
     }
 

--- a/examples/custom-mailets/src/main/java/org/apache/james/examples/custom/mailets/SendPromotionCode.java
+++ b/examples/custom-mailets/src/main/java/org/apache/james/examples/custom/mailets/SendPromotionCode.java
@@ -23,6 +23,7 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.util.OptionalUtils;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMailet;
 
@@ -45,7 +46,7 @@ public class SendPromotionCode extends GenericMailet {
             "Here is the following promotion code that you can use on your next order: " + promotionCode);
 
         MailAddress sender = getMailetContext().getPostmaster();
-        ImmutableList<MailAddress> recipients = ImmutableList.of(mail.getSender());
+        ImmutableList<MailAddress> recipients = OptionalUtils.toList(mail.getSenderAsOptional());
 
         getMailetContext()
             .sendMail(sender, recipients, response);

--- a/mailet/ai/src/main/java/org/apache/james/ai/classic/BayesianAnalysis.java
+++ b/mailet/ai/src/main/java/org/apache/james/ai/classic/BayesianAnalysis.java
@@ -316,12 +316,9 @@ public class BayesianAnalysis extends GenericMailet {
             probabilityForm.applyPattern("##0.##%");
             String probabilityString = probabilityForm.format(probability);
 
-            String senderString;
-            if (mail.getSender() == null) {
-                senderString = "null";
-            } else {
-                senderString = mail.getSender().toString();
-            }
+            String senderString = mail.getSenderAsOptional()
+                .map(MailAddress::asString)
+                .orElse("null");
             if (probability > 0.1) {
                 final Collection<MailAddress> recipients = mail.getRecipients();
                 if (LOGGER.isDebugEnabled()) {
@@ -343,7 +340,7 @@ public class BayesianAnalysis extends GenericMailet {
     }
 
     private boolean isSenderLocal(Mail mail) {
-        return mail.getSender() != null && getMailetContext().isLocalServer(mail.getSender().getDomain());
+        return mail.hasSender() && getMailetContext().isLocalServer(mail.getSenderAsOptional().get().getDomain());
     }
 
     void loadData(Connection conn) throws java.sql.SQLException {

--- a/mailet/api/src/main/java/org/apache/mailet/Mail.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Mail.java
@@ -146,6 +146,17 @@ public interface Mail extends Serializable, Cloneable {
         return Optional.ofNullable(getSender())
             .filter(mailAddress -> !mailAddress.isNullSender());
     }
+
+    /**
+     * Returns if this message has a sender.
+     *
+     * 'null' or {@link MailAddress#nullSender()} will be considered as no sender.
+     *
+     * @since Mailet API v3.2.0
+     */
+    default boolean hasSender() {
+        return getSenderAsOptional().isPresent();
+    }
     
     /**
      * Returns the current state of the message, such as GHOST, ERROR or DEFAULT.

--- a/mailet/api/src/main/java/org/apache/mailet/Mail.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Mail.java
@@ -148,6 +148,12 @@ public interface Mail extends Serializable, Cloneable {
     }
 
     /**
+     * @since Mailet API v3.2.0
+     * @return A copy of this email. Name might differ.
+     */
+    Mail duplicate() throws MessagingException;
+
+    /**
      * Returns if this message has a sender.
      *
      * 'null' or {@link MailAddress#nullSender()} will be considered as no sender.

--- a/mailet/api/src/main/java/org/apache/mailet/Mail.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Mail.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.Optional;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
@@ -121,9 +122,30 @@ public interface Mail extends Serializable, Cloneable {
      * Returns the sender of the message, as specified by the SMTP "MAIL FROM" command,
      * or internally defined.
      *
+     * @deprecated @see {@link #getSenderAsOptional()}
+     *
+     * Note that SMTP null sender ( "&lt;&gt;" ) needs to be implicitly handled by the caller under the form of 'null' or
+     * {@link MailAddress#nullSender()}. Replacement method adds type safety on this operation.
+     *
      * @return the sender of this message
      */
+    @Deprecated
     MailAddress getSender();
+
+    /**
+     * Returns the sender of the message, as specified by the SMTP "MAIL FROM" command,
+     * or internally defined.
+     *
+     * 'null' or {@link MailAddress#nullSender()} are handled with an empty optional.
+     *
+     * @since Mailet API v3.2.0
+     * @return the sender of this message wrapped in an optional
+     */
+    @SuppressWarnings("deprecated")
+    default Optional<MailAddress> getSenderAsOptional() {
+        return Optional.ofNullable(getSender())
+            .filter(mailAddress -> !mailAddress.isNullSender());
+    }
     
     /**
      * Returns the current state of the message, such as GHOST, ERROR or DEFAULT.

--- a/mailet/base/src/main/java/org/apache/mailet/base/AutomaticallySentMailDetectorImpl.java
+++ b/mailet/base/src/main/java/org/apache/mailet/base/AutomaticallySentMailDetectorImpl.java
@@ -48,7 +48,7 @@ public class AutomaticallySentMailDetectorImpl implements AutomaticallySentMailD
 
     @Override
     public boolean isAutomaticallySent(Mail mail) throws MessagingException {
-        return mail.getSender() == null ||
+        return !mail.hasSender() ||
             isMailingList(mail) ||
             isAutoSubmitted(mail) ||
             isMdnSentAutomatically(mail);
@@ -61,17 +61,14 @@ public class AutomaticallySentMailDetectorImpl implements AutomaticallySentMailD
     }
 
     private boolean senderIsMailingList(Mail mail) {
-        MailAddress sender = mail.getSender();
-        if (sender == null) {
-            return false;
-        }
-
-        String localPart = sender.getLocalPart();
-        return localPart.startsWith("owner-")
-            || localPart.endsWith("-request")
-            || localPart.equalsIgnoreCase("MAILER-DAEMON")
-            || localPart.equalsIgnoreCase("LISTSERV")
-            || localPart.equalsIgnoreCase("majordomo");
+        return mail.getSenderAsOptional()
+            .map(MailAddress::getLocalPart)
+            .map(localPart ->  localPart.startsWith("owner-")
+                || localPart.endsWith("-request")
+                || localPart.equalsIgnoreCase("MAILER-DAEMON")
+                || localPart.equalsIgnoreCase("LISTSERV")
+                || localPart.equalsIgnoreCase("majordomo"))
+            .orElse(false);
     }
 
     private boolean headerIsMailingList(Mail mail) throws MessagingException {

--- a/mailet/crypto/src/main/java/org/apache/james/transport/mailets/AbstractSign.java
+++ b/mailet/crypto/src/main/java/org/apache/james/transport/mailets/AbstractSign.java
@@ -24,6 +24,7 @@ package org.apache.james.transport.mailets;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.util.Enumeration;
+import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.mail.MessagingException;
@@ -495,7 +496,7 @@ public abstract class AbstractSign extends GenericMailet {
   
             if (isRebuildFrom()) {
                 // builds a new "mixed" "From:" header
-                InternetAddress modifiedFromIA = new InternetAddress(getKeyHolder().getSignerAddress(), mail.getSender().toString());
+                InternetAddress modifiedFromIA = new InternetAddress(getKeyHolder().getSignerAddress(), mail.getSenderAsOptional().get().toString());
                 newMessage.setFrom(modifiedFromIA);
                 
                 // if the original "ReplyTo:" header is missing sets it to the original "From:" header
@@ -521,7 +522,7 @@ public abstract class AbstractSign extends GenericMailet {
             mail.setAttribute(SMIMEAttributeNames.SMIME_SIGNER_ADDRESS, getKeyHolder().getSignerAddress());
             
             if (isDebug()) {
-                LOGGER.debug("Message signed, reverse-path: {}, Id: {}", mail.getSender(), messageId);
+                LOGGER.debug("Message signed, reverse-path: {}, Id: {}", mail.getSenderAsOptional(), messageId);
             }
             
         } catch (MessagingException me) {
@@ -554,19 +555,19 @@ public abstract class AbstractSign extends GenericMailet {
      * @return True if can be signed.
      */
     protected boolean isOkToSign(Mail mail) throws MessagingException {
-
-        MailAddress reversePath = mail.getSender();
-        
         // Is it a bounce?
-        if (reversePath == null) {
+        if (!mail.hasSender()) {
             LOGGER.info("Can not sign: no sender");
             return false;
         }
+
+        MailAddress reversePath = mail.getSenderAsOptional().get();
+
         
         String authUser = (String) mail.getAttribute(Mail.SMTP_AUTH_USER_ATTRIBUTE_NAME);
         // was the sender user SMTP authorized?
         if (authUser == null) {
-            LOGGER.info("Can not sign mail for sender <{}> as he is not a SMTP authenticated user", mail.getSender());
+            LOGGER.info("Can not sign mail for sender <{}> as he is not a SMTP authenticated user", mail.getSenderAsOptional());
             return false;
         }
         
@@ -627,9 +628,9 @@ public abstract class AbstractSign extends GenericMailet {
      */    
     protected final boolean fromAddressSameAsReverse(Mail mail) {
         
-        MailAddress reversePath = mail.getSender();
+        Optional<MailAddress> reversePath = mail.getSenderAsOptional();
         
-        if (reversePath == null) {
+        if (!reversePath.isPresent()) {
             return false;
         }
         
@@ -644,7 +645,7 @@ public abstract class AbstractSign extends GenericMailet {
                         LOGGER.info("Unable to parse a \"FROM\" header address: {}; ignoring.", aFromArray);
                         continue;
                     }
-                    if (mailAddress.equals(reversePath)) {
+                    if (mailAddress.equals(reversePath.get())) {
                         return true;
                     }
                 }

--- a/mailet/crypto/src/main/java/org/apache/james/transport/mailets/SMIMESign.java
+++ b/mailet/crypto/src/main/java/org/apache/james/transport/mailets/SMIMESign.java
@@ -28,6 +28,7 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
+import org.apache.james.core.MailAddress;
 import org.apache.mailet.Mail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -202,7 +203,7 @@ public class SMIMESign extends Sign {
             signatureReason.setText(getReplacedExplanationText(getExplanationText(),
                                                                getSignerName(),
                                                                getKeyHolder().getSignerAddress(),
-                                                               mail.getSender().toString(),
+                                                               mail.getSenderAsOptional().map(MailAddress::asString).orElse(MailAddress.NULL_SENDER_AS_STRING),
                                                                headers));
             
             signatureReason.setFileName("SignatureExplanation.txt");

--- a/mailet/crypto/src/main/java/org/apache/james/transport/mailets/Sign.java
+++ b/mailet/crypto/src/main/java/org/apache/james/transport/mailets/Sign.java
@@ -28,6 +28,7 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
+import org.apache.james.core.MailAddress;
 import org.apache.mailet.Mail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -192,7 +193,7 @@ public class Sign extends AbstractSign {
             signatureReason.setText(getReplacedExplanationText(getExplanationText(),
                                                                getSignerName(),
                                                                getKeyHolder().getSignerAddress(),
-                                                               mail.getSender().toString(),
+                                                               mail.getSenderAsOptional().map(MailAddress::asString).orElse(MailAddress.NULL_SENDER_AS_STRING),
                                                                headers));
             
             signatureReason.setFileName("SignatureExplanation.txt");

--- a/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/ICALToJsonAttribute.java
+++ b/mailet/icalendar/src/main/java/org/apache/james/transport/mailets/ICALToJsonAttribute.java
@@ -220,7 +220,7 @@ public class ICALToJsonAttribute extends GenericMailet {
             .map(address -> (InternetAddress) address)
             .map(InternetAddress::getAddress)
             .findFirst();
-        Optional<String> fromEnvelope = Optional.ofNullable(mail.getSender())
+        Optional<String> fromEnvelope = mail.getSenderAsOptional()
             .map(MailAddress::asString);
 
         return OptionalUtils.or(

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/ClamAVScan.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/ClamAVScan.java
@@ -821,7 +821,9 @@ public class ClamAVScan extends GenericMailet {
             PrintWriter out = new PrintWriter(sout, true);
 
             out.print("Mail details:");
-            out.print(" MAIL FROM: " + mail.getSender());
+            out.print(" MAIL FROM: " + mail.getSenderAsOptional()
+                .map(MailAddress::asString)
+                .orElse(MailAddress.NULL_SENDER_AS_STRING));
             Iterator<MailAddress> rcptTo = mail.getRecipients().iterator();
             out.print(", RCPT TO: " + rcptTo.next());
             while (rcptTo.hasNext()) {

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/ContactExtractor.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/ContactExtractor.java
@@ -18,7 +18,6 @@
  ****************************************************************/
 package org.apache.james.transport.mailets;
 
-import java.io.IOException;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -101,11 +100,11 @@ public class ContactExtractor extends GenericMailet implements Mailet {
     }
 
     @VisibleForTesting
-    Optional<String> extractContacts(Mail mail) throws MessagingException, IOException {
+    Optional<String> extractContacts(Mail mail) throws MessagingException {
         ImmutableList<String> allRecipients = getAllRecipients(mail.getMessage());
 
         if (hasRecipient(allRecipients)) {
-            return Optional.of(mail.getSender())
+            return mail.getSenderAsOptional()
                 .map(MailAddress::asString)
                 .map(sender -> new ExtractedContacts(sender, allRecipients))
                 .map(Throwing.function(extractedContacts -> objectMapper.writeValueAsString(extractedContacts)));

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/ServerTime.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/ServerTime.java
@@ -46,6 +46,10 @@ public class ServerTime extends GenericMailet {
      */
     @Override
     public void service(Mail mail) throws javax.mail.MessagingException {
+        if (!mail.hasSender()) {
+            return;
+        }
+
         MimeMessage response = (MimeMessage)mail.getMessage().reply(false);
         response.setSubject("The time is now...");
         String textBuffer = "This mail server thinks it's " + (new java.util.Date()).toString() + ".";
@@ -61,7 +65,7 @@ public class ServerTime extends GenericMailet {
         }
 
         if (response.getAllRecipients() == null) {
-            response.setRecipients(MimeMessage.RecipientType.TO, mail.getSender().toString());
+            response.setRecipients(MimeMessage.RecipientType.TO, mail.getSenderAsOptional().get().toString());
         }
 
         response.saveChanges();

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/UseHeaderRecipients.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/UseHeaderRecipients.java
@@ -106,7 +106,7 @@ public class UseHeaderRecipients extends GenericMailet {
         }
 
         // Return email to the "root" process.
-        getMailetContext().sendMail(mail.getSender(), mail.getRecipients(), mail.getMessage());
+        getMailetContext().sendMail(mail.duplicate());
         mail.setState(Mail.GHOST);
     }
 

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/AbstractQuotaMatcher.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/AbstractQuotaMatcher.java
@@ -98,9 +98,7 @@ public abstract class AbstractQuotaMatcher extends GenericMatcher {
      * @param sender the sender to check
      */
     private boolean isSenderChecked(Optional<MailAddress> sender) {
-        return sender.filter(mailAddress -> getMailetContext().getPostmaster().equals(mailAddress))
-            .map(any -> true)
-            .orElse(false);
+        return sender.filter(mailAddress -> !getMailetContext().getPostmaster().equals(mailAddress)).isPresent();
     }
 
     /** 

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/AbstractQuotaMatcher.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/AbstractQuotaMatcher.java
@@ -17,12 +17,11 @@
  * under the License.                                           *
  ****************************************************************/
 
-
-
 package org.apache.james.transport.matchers;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Optional;
 
 import javax.mail.MessagingException;
 
@@ -57,7 +56,7 @@ public abstract class AbstractQuotaMatcher extends GenericMatcher {
     @Override
     public final Collection<MailAddress> match(Mail mail) throws MessagingException {
         Collection<MailAddress> matching = null;
-        if (isSenderChecked(mail.getSender())) {
+        if (isSenderChecked(mail.getSenderAsOptional())) {
             matching = new ArrayList<>();
             for (MailAddress recipient : mail.getRecipients()) {
                 if (isRecipientChecked(recipient) && isOverQuota(recipient, mail)) {
@@ -97,9 +96,11 @@ public abstract class AbstractQuotaMatcher extends GenericMatcher {
      * to its check.
      *
      * @param sender the sender to check
-     */    
-    protected boolean isSenderChecked(MailAddress sender) throws MessagingException {
-        return !(sender == null || getMailetContext().getPostmaster().equals(sender));
+     */
+    private boolean isSenderChecked(Optional<MailAddress> sender) {
+        return sender.filter(mailAddress -> getMailetContext().getPostmaster().equals(mailAddress))
+            .map(any -> true)
+            .orElse(false);
     }
 
     /** 

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/RecipientIs.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/RecipientIs.java
@@ -20,6 +20,7 @@
 package org.apache.james.transport.matchers;
 
 import java.util.Collection;
+import java.util.Optional;
 
 import javax.mail.MessagingException;
 
@@ -43,7 +44,7 @@ import com.google.common.base.Strings;
  */
 public class RecipientIs extends GenericRecipientMatcher {
 
-    private Collection<MailAddress> recipients;
+    private Collection<Optional<MailAddress>> recipients;
 
     @Override
     public void init() throws javax.mail.MessagingException {
@@ -58,6 +59,6 @@ public class RecipientIs extends GenericRecipientMatcher {
 
     @Override
     public boolean matchRecipient(MailAddress recipient) {
-        return recipients.contains(recipient);
+        return recipients.contains(Optional.of(recipient));
     }
 }

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderHostIs.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderHostIs.java
@@ -78,7 +78,9 @@ public class SenderHostIs extends GenericMatcher {
     @Override
     public Collection<MailAddress> match(Mail mail) {
         try {
-            if (hasSender(mail) && senderHosts.contains(mail.getSender().getDomain())) {
+            if (mail.getSenderAsOptional()
+                    .map(mailAddress -> senderHosts.contains(mailAddress.getDomain()))
+                    .orElse(false)) {
                 return mail.getRecipients();
             }
         } catch (Exception e) {
@@ -86,10 +88,5 @@ public class SenderHostIs extends GenericMatcher {
         }
 
         return null;    //No match.
-    }
-
-    private boolean hasSender(Mail mail) {
-        return mail.getSender() != null
-            && !mail.getSender().isNullSender();
     }
 }

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderHostIsLocal.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderHostIsLocal.java
@@ -39,18 +39,17 @@ import org.apache.mailet.base.GenericMatcher;
 public class SenderHostIsLocal extends GenericMatcher {
     @Override
     public Collection<MailAddress> match(Mail mail) {
-        if (mail.getSender() != null && isLocalServer(mail)) {
+        if (mail.getSenderAsOptional()
+                .map(this::isLocalServer)
+                .orElse(false)) {
             return mail.getRecipients();
         }
         return null;
         
     }
 
-    private boolean isLocalServer(Mail mail) {
-        if (mail.getSender().isNullSender()) {
-            return false;
-        }
-        return this.getMailetContext().isLocalServer(mail.getSender().getDomain());
+    private boolean isLocalServer(MailAddress sender) {
+        return this.getMailetContext().isLocalServer(sender.getDomain());
     }
 
 }

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIs.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIs.java
@@ -47,10 +47,10 @@ import com.google.common.base.Strings;
  */
 public class SenderIs extends GenericMatcher {
 
-    private Set<MailAddress> senders;
+    private Set<Optional<MailAddress>> senders;
 
     @VisibleForTesting
-    Set<MailAddress> getSenders() {
+    Set<Optional<MailAddress>> getSenders() {
         return senders;
     }
 
@@ -67,8 +67,7 @@ public class SenderIs extends GenericMatcher {
 
     @Override
     public Collection<MailAddress> match(Mail mail) {
-        MailAddress sanitizedSender = Optional.ofNullable(mail.getSender()).orElse(MailAddress.nullSender());
-        if (senders.contains(sanitizedSender)) {
+        if (senders.contains(mail.getSenderAsOptional())) {
             return mail.getRecipients();
         } else {
             return null;

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIsLocal.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIsLocal.java
@@ -19,7 +19,6 @@
 package org.apache.james.transport.matchers;
 
 import java.util.Collection;
-import java.util.Optional;
 
 import org.apache.james.core.MailAddress;
 import org.apache.mailet.Mail;

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIsLocal.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIsLocal.java
@@ -32,17 +32,16 @@ public class SenderIsLocal extends GenericMatcher {
 
     @Override
     public final Collection<MailAddress> match(Mail mail) {
-        if (isLocal(mail.getSender())) {
+        if (mail.getSenderAsOptional()
+                .map(this::isLocal)
+                .orElse(false)) {
             return mail.getRecipients();
         }
         return null;
     }
 
     private boolean isLocal(MailAddress mailAddress) {
-        return Optional.ofNullable(mailAddress)
-            .filter(address -> !address.isNullSender())
-            .map(address -> getMailetContext().isLocalEmail(address))
-            .orElse(false);
+        return getMailetContext().isLocalEmail(mailAddress);
     }
 
 }

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIsNull.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIsNull.java
@@ -35,18 +35,12 @@ import org.apache.mailet.base.GenericMatcher;
  * @since 2.2.0
  */
 public class SenderIsNull extends GenericMatcher {
-
     @Override
     public Collection<MailAddress> match(Mail mail) {
-        if (isNullSender(mail)) {
-            return mail.getRecipients();
-        } else {
+        if (mail.hasSender()) {
             return null;
+        } else {
+            return mail.getRecipients();
         }
-    }
-
-    private boolean isNullSender(Mail mail) {
-        return mail.getSender() == null
-            || mail.getSender().isNullSender();
     }
 }

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIsRegex.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/SenderIsRegex.java
@@ -74,11 +74,7 @@ public class SenderIsRegex extends GenericMatcher {
 
     @Override
     public Collection<MailAddress> match(Mail mail) {
-        MailAddress mailAddress = mail.getSender();
-        if (mailAddress == null) {
-            return null;
-        }
-        String senderString = mailAddress.asString();
+        String senderString = mail.getSenderAsOptional().map(MailAddress::asString).orElse(MailAddress.NULL_SENDER_AS_STRING);
         if (pattern.matcher(senderString).matches()) {
             return mail.getRecipients();
         }

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/utils/MailAddressCollectionReader.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/utils/MailAddressCollectionReader.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.transport.matchers.utils;
 
+import java.util.Optional;
 import java.util.Set;
 
 import javax.mail.internet.AddressException;
@@ -33,7 +34,7 @@ import com.google.common.base.Strings;
 
 public class MailAddressCollectionReader {
 
-    public static Set<MailAddress> read(String condition) {
+    public static Set<Optional<MailAddress>> read(String condition) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(condition));
         return Splitter.onPattern("(,| |\t)").splitToList(condition)
             .stream()
@@ -42,12 +43,12 @@ public class MailAddressCollectionReader {
             .collect(Guavate.toImmutableSet());
     }
 
-    private static MailAddress getMailAddress(String s) {
+    private static Optional<MailAddress> getMailAddress(String s) {
         try {
             if (s.equals(MailAddress.NULL_SENDER_AS_STRING)) {
-                return MailAddress.nullSender();
+                return Optional.empty();
             }
-            return new MailAddress(s);
+            return Optional.of(new MailAddress(s));
         } catch (AddressException e) {
             throw new RuntimeException(e);
         }

--- a/mailet/standard/src/test/java/org/apache/james/transport/matchers/SenderIsTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/matchers/SenderIsTest.java
@@ -23,6 +23,8 @@ package org.apache.james.transport.matchers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Optional;
+
 import javax.mail.MessagingException;
 
 import org.apache.james.core.MailAddress;
@@ -154,7 +156,8 @@ class SenderIsTest {
                 .condition(mailAddress + ", " + SENDER_NAME)
                 .build());
 
-        assertThat(matcher.getSenders()).containsExactly(new MailAddress(mailAddress), new MailAddress(SENDER_NAME));
+        assertThat(matcher.getSenders()).containsExactly(Optional.of(new MailAddress(mailAddress)),
+            Optional.of(new MailAddress(SENDER_NAME)));
     }
 
     @Test

--- a/mailet/standard/src/test/java/org/apache/james/transport/matchers/util/MailAddressCollectionReaderTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/matchers/util/MailAddressCollectionReaderTest.java
@@ -22,6 +22,8 @@ package org.apache.james.transport.matchers.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Optional;
+
 import org.apache.james.core.MailAddress;
 import org.apache.james.transport.matchers.utils.MailAddressCollectionReader;
 import org.junit.jupiter.api.Test;
@@ -57,13 +59,13 @@ class MailAddressCollectionReaderTest {
         MailAddress mailAddress = new MailAddress("valid@apache.org");
 
         assertThat(MailAddressCollectionReader.read(mailAddress.toString()))
-            .containsExactly(mailAddress);
+            .containsExactly(Optional.of(mailAddress));
     }
 
     @Test
     void readShouldParseNullSender() {
         assertThat(MailAddressCollectionReader.read("<>"))
-            .containsExactly(MailAddress.nullSender());
+            .containsExactly(Optional.empty());
     }
 
     @Test
@@ -72,7 +74,7 @@ class MailAddressCollectionReaderTest {
         MailAddress mailAddress2 = new MailAddress("bis@apache.org");
 
         assertThat(MailAddressCollectionReader.read(mailAddress1.toString() + "," + mailAddress2.toString()))
-            .containsExactly(mailAddress1, mailAddress2);
+            .containsExactly(Optional.of(mailAddress1), Optional.of(mailAddress2));
     }
 
     @Test
@@ -81,7 +83,7 @@ class MailAddressCollectionReaderTest {
         MailAddress mailAddress2 = new MailAddress("bis@apache.org");
 
         assertThat(MailAddressCollectionReader.read(mailAddress1.toString() + " " + mailAddress2.toString()))
-            .containsExactly(mailAddress1, mailAddress2);
+            .containsExactly(Optional.of(mailAddress1), Optional.of(mailAddress2));
     }
 
     @Test
@@ -90,7 +92,7 @@ class MailAddressCollectionReaderTest {
         MailAddress mailAddress2 = new MailAddress("bis@apache.org");
 
         assertThat(MailAddressCollectionReader.read(mailAddress1.toString() + "\t" + mailAddress2.toString()))
-            .containsExactly(mailAddress1, mailAddress2);
+            .containsExactly(Optional.of(mailAddress1), Optional.of(mailAddress2));
     }
 
 
@@ -100,7 +102,7 @@ class MailAddressCollectionReaderTest {
         MailAddress mailAddress2 = new MailAddress("bis@apache.org");
 
         assertThat(MailAddressCollectionReader.read(mailAddress1.toString() + ",\t  \t,\t \t " + mailAddress2.toString()))
-            .containsExactly(mailAddress1, mailAddress2);
+            .containsExactly(Optional.of(mailAddress1), Optional.of(mailAddress2));
     }
 
     @Test
@@ -108,7 +110,7 @@ class MailAddressCollectionReaderTest {
         MailAddress mailAddress = new MailAddress("valid@apache.org");
 
         assertThat(MailAddressCollectionReader.read(mailAddress.toString() + ", " + mailAddress.toString()))
-            .containsExactly(mailAddress);
+            .containsExactly(Optional.of(mailAddress));
     }
 
 

--- a/mailet/test/src/main/java/org/apache/mailet/base/test/FakeMail.java
+++ b/mailet/test/src/main/java/org/apache/mailet/base/test/FakeMail.java
@@ -166,12 +166,20 @@ public class FakeMail implements Mail, Serializable {
         }
 
         public Builder name(String name) {
-            this.name = Optional.of(name);
+            return this.name(Optional.of(name));
+        }
+
+        public Builder name(Optional<String> name) {
+            this.name = name;
             return this;
         }
 
         public Builder sender(MailAddress sender) {
-            this.sender = Optional.of(sender);
+            return this.sender(Optional.of(sender));
+        }
+
+        public Builder sender(Optional<MailAddress> sender) {
+            this.sender = sender;
             return this;
         }
 
@@ -180,17 +188,29 @@ public class FakeMail implements Mail, Serializable {
         }
 
         public Builder state(String state) {
-            this.state = Optional.of(state);
+            return this.state(Optional.of(state));
+        }
+
+        public Builder state(Optional<String> state) {
+            this.state = state;
             return this;
         }
 
         public Builder errorMessage(String errorMessage) {
-            this.errorMessage = Optional.of(errorMessage);
+            return this.errorMessage(Optional.of(errorMessage));
+        }
+
+        public Builder errorMessage(Optional<String> errorMessage) {
+            this.errorMessage = errorMessage;
             return this;
         }
 
         public Builder lastUpdated(Date lastUpdated) {
-            this.lastUpdated = Optional.of(lastUpdated);
+            return this.lastUpdated(Optional.of(lastUpdated));
+        }
+
+        public Builder lastUpdated(Optional<Date> lastUpdated) {
+            this.lastUpdated = lastUpdated;
             return this;
         }
 
@@ -272,6 +292,23 @@ public class FakeMail implements Mail, Serializable {
         this.remoteAddr = remoteAddr;
         this.perRecipientHeaders = perRecipientHeaders;
         this.remoteHost = remoteHost;
+    }
+
+    @Override
+    public Mail duplicate() throws MessagingException {
+        return builder()
+            .mimeMessage(msg)
+            .recipients(ImmutableList.copyOf(recipients))
+            .name(Optional.ofNullable(name))
+            .sender(Optional.ofNullable(sender))
+            .state(Optional.ofNullable(state))
+            .errorMessage(Optional.ofNullable(errorMessage))
+            .lastUpdated(Optional.ofNullable(lastUpdated))
+            .attributes(attributes)
+            .size(size)
+            .remoteAddr(remoteAddr)
+            .remoteHost(remoteHost)
+            .build();
     }
 
     @Override

--- a/mailet/test/src/main/java/org/apache/mailet/base/test/FakeMail.java
+++ b/mailet/test/src/main/java/org/apache/mailet/base/test/FakeMail.java
@@ -72,21 +72,6 @@ public class FakeMail implements Mail, Serializable {
                 .build();
     }
 
-    public static FakeMail fromMail(Mail mail) throws MessagingException {
-        return new FakeMail(mail.getMessage(),
-            Lists.newArrayList(mail.getRecipients()),
-            mail.getName(),
-            mail.getSender(),
-            mail.getState(),
-            mail.getErrorMessage(),
-            mail.getLastUpdated(),
-            attributes(mail),
-            mail.getMessageSize(),
-            mail.getRemoteAddr(),
-            mail.getRemoteHost(),
-            mail.getPerRecipientSpecificHeaders());
-    }
-
     public static FakeMail from(MimeMessage message) throws MessagingException {
         return builder()
                 .mimeMessage(message)

--- a/mailet/test/src/main/java/org/apache/mailet/base/test/FakeMailContext.java
+++ b/mailet/test/src/main/java/org/apache/mailet/base/test/FakeMailContext.java
@@ -64,7 +64,7 @@ public class FakeMailContext implements MailetContext {
 
     public static SentMail.Builder fromMail(Mail mail) throws MessagingException {
         return sentMailBuilder()
-            .sender(mail.getSender())
+            .sender(mail.getSenderAsOptional())
             .recipients(mail.getRecipients())
             .message(mail.getMessage())
             .state(mail.getState())
@@ -130,6 +130,11 @@ public class FakeMailContext implements MailetContext {
 
             public Builder sender(MailAddress sender) {
                 this.sender = sender;
+                return this;
+            }
+
+            public Builder sender(Optional<MailAddress> sender) {
+                sender.ifPresent(this::sender);
                 return this;
             }
 

--- a/mailet/test/src/main/java/org/apache/mailet/base/test/FakeMailContext.java
+++ b/mailet/test/src/main/java/org/apache/mailet/base/test/FakeMailContext.java
@@ -497,7 +497,7 @@ public class FakeMailContext implements MailetContext {
 
     @Override
     public void sendMail(Mail mail) throws MessagingException {
-        sendMail(mail, Mail.DEFAULT);
+        sendMail(mail, Optional.ofNullable(mail.getState()).orElse(Mail.DEFAULT));
     }
 
     @Override

--- a/protocols/smtp/pom.xml
+++ b/protocols/smtp/pom.xml
@@ -61,7 +61,8 @@
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/MailEnvelope.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/MailEnvelope.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.james.core.MailAddress;
 
@@ -51,10 +52,31 @@ public interface MailEnvelope {
     /**
      * Return the sender of the mail which was supplied int the MAIL FROM:
      * command. If its a "null" sender, null will get returned
-     * 
+     *
+     * @deprecated @see {@link #getSenderAsOptional()}
+     *
+     * Note that SMTP null sender ( "&lt;&gt;" ) needs to be implicitly handled by the caller under the form of 'null' or
+     * {@link MailAddress#nullSender()}. Replacement method adds type safety on this operation.
+     *
      * @return sender
      */
+    @Deprecated
     MailAddress getSender();
+
+    /**
+     * Returns the sender of the message, as specified by the SMTP "MAIL FROM" command,
+     * or internally defined.
+     *
+     * 'null' or {@link MailAddress#nullSender()} are handled with an empty optional.
+     *
+     * @since Mailet API v3.2.0
+     * @return the sender of this message wrapped in an optional
+     */
+    @SuppressWarnings("deprecated")
+    default Optional<MailAddress> getSenderAsOptional() {
+        return Optional.ofNullable(getSender())
+            .filter(mailAddress -> !mailAddress.isNullSender());
+    }
 
     /**
      * Return the OutputStream of the message

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/MailEnvelopeImpl.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/MailEnvelopeImpl.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.james.core.MailAddress;
 
@@ -37,7 +38,7 @@ public class MailEnvelopeImpl implements MailEnvelope {
 
     private List<MailAddress> recipients;
 
-    private MailAddress sender;
+    private Optional<MailAddress> sender;
 
     private ByteArrayOutputStream outputStream;
 
@@ -56,6 +57,11 @@ public class MailEnvelopeImpl implements MailEnvelope {
 
     @Override
     public MailAddress getSender() {
+        return sender.orElse(null);
+    }
+
+    @Override
+    public Optional<MailAddress> getSenderAsOptional() {
         return sender;
     }
 
@@ -74,7 +80,7 @@ public class MailEnvelopeImpl implements MailEnvelope {
      * @param sender
      */
     public void setSender(MailAddress sender) {
-        this.sender = sender;
+        this.sender = Optional.of(sender);
     }
 
     @Override

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractAuthRequiredToRelayRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractAuthRequiredToRelayRcptHook.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.protocols.smtp.core;
 
+import java.util.Optional;
+
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
 import org.apache.james.protocols.smtp.SMTPRetCode;
@@ -48,7 +50,7 @@ public abstract class AbstractAuthRequiredToRelayRcptHook implements RcptHook {
         .build();
     
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender,
+    public HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender,
                              MailAddress rcpt) {
         if (!session.isRelayingAllowed()) {
             Domain toDomain = rcpt.getDomain();

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
@@ -19,6 +19,7 @@
 package org.apache.james.protocols.smtp.core;
 
 import java.util.Locale;
+import java.util.Optional;
 
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
@@ -42,7 +43,7 @@ public abstract class AbstractSenderAuthIdentifyVerificationRcptHook implements 
         .build();
     
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender,
+    public HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender,
                              MailAddress rcpt) {
         if (session.getUser() != null) {
             String authUser = (session.getUser()).toLowerCase(Locale.US);
@@ -62,8 +63,8 @@ public abstract class AbstractSenderAuthIdentifyVerificationRcptHook implements 
         return HookResult.DECLINED;
     }
 
-    public String retrieveSender(MailAddress sender, MailAddress senderAddress) {
-        if (senderAddress != null && !sender.isNullSender()) {
+    public String retrieveSender(Optional<MailAddress> sender, MailAddress senderAddress) {
+        if (senderAddress != null && !sender.isPresent()) {
             return getUser(senderAddress);
         }
         return null;

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AcceptRecipientIfRelayingIsAllowed.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AcceptRecipientIfRelayingIsAllowed.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.protocols.smtp.core;
 
+import java.util.Optional;
+
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.MailAddress;
@@ -31,7 +33,7 @@ import org.apache.james.protocols.smtp.hook.RcptHook;
 public class AcceptRecipientIfRelayingIsAllowed implements RcptHook {
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender,
+    public HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender,
                              MailAddress rcpt) {
         if (session.isRelayingAllowed()) {
             return HookResult.OK;

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/DataCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/DataCmdHandler.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -171,17 +172,20 @@ public class DataCmdHandler implements CommandHandler<SMTPSession>, ExtensibleHa
      */
     @SuppressWarnings("unchecked")
     protected Response doDATA(SMTPSession session, String argument) {
-        MailEnvelope env = createEnvelope(session, (MailAddress) session.getAttachment(SMTPSession.SENDER,ProtocolSession.State.Transaction), new ArrayList<>((Collection<MailAddress>) session.getAttachment(SMTPSession.RCPT_LIST, ProtocolSession.State.Transaction)));
+        Optional<MailAddress> sender = (Optional<MailAddress>) session.getAttachment(SMTPSession.SENDER, ProtocolSession.State.Transaction);
+        ArrayList<MailAddress> recipients = new ArrayList<>((Collection<MailAddress>) session.getAttachment(SMTPSession.RCPT_LIST, ProtocolSession.State.Transaction));
+
+        MailEnvelope env = createEnvelope(session, sender, recipients);
         session.setAttachment(MAILENV, env,ProtocolSession.State.Transaction);
         session.pushLineHandler(lineHandler);
         
         return DATA_READY;
     }
     
-    protected MailEnvelope createEnvelope(SMTPSession session, MailAddress sender, List<MailAddress> recipients) {
+    protected MailEnvelope createEnvelope(SMTPSession session, Optional<MailAddress> sender, List<MailAddress> recipients) {
         MailEnvelopeImpl env = new MailEnvelopeImpl();
         env.setRecipients(recipients);
-        env.setSender(sender);
+        sender.ifPresent(env::setSender);
         return env;
     }
     

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/MailCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/MailCmdHandler.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.StringTokenizer;
 
 import javax.inject.Inject;
@@ -260,7 +261,7 @@ public class MailCmdHandler extends AbstractHookableCmdHandler<MailHook> {
         if (sender.isNullSender()) {
             sender = null;
         }
-        return rawHook.doMail(session, sender);
+        return rawHook.doMail(session, Optional.ofNullable(sender));
     }
 
     

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/PostmasterAbuseRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/PostmasterAbuseRcptHook.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.protocols.smtp.core;
 
+import java.util.Optional;
+
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.MailAddress;
@@ -34,7 +36,7 @@ public class PostmasterAbuseRcptHook implements RcptHook {
     private static final Logger LOGGER = LoggerFactory.getLogger(PostmasterAbuseRcptHook.class);
     
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender, MailAddress rcpt) {
         if (rcpt.getLocalPart().equalsIgnoreCase("postmaster") || rcpt.getLocalPart().equalsIgnoreCase("abuse")) {
             LOGGER.debug("Sender allowed");
             return HookResult.OK;

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/RcptCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/RcptCmdHandler.java
@@ -211,9 +211,9 @@ public class RcptCmdHandler extends AbstractHookableCmdHandler<RcptHook> impleme
         } else if (null != recipient) {
             sb.append(" [to:").append(recipient).append(']');
         }
-        if (null != session.getAttachment(SMTPSession.SENDER, State.Transaction)) {
-            MailAddress mailAddress = (MailAddress) session.getAttachment(SMTPSession.SENDER, State.Transaction);
-            sb.append(" [from:").append(mailAddress.asString()).append(']');
+        Optional<MailAddress> sender = (Optional<MailAddress>) session.getAttachment(SMTPSession.SENDER, State.Transaction);
+        if (null != sender && sender.isPresent()) {
+            sb.append(" [from:").append(sender.get().asString()).append(']');
         }
         return sb.toString();
     }
@@ -231,9 +231,8 @@ public class RcptCmdHandler extends AbstractHookableCmdHandler<RcptHook> impleme
     @Override
     protected HookResult callHook(RcptHook rawHook, SMTPSession session,
                                   String parameters) {
-        MailAddress sender = (MailAddress) session.getAttachment(SMTPSession.SENDER, State.Transaction);
-        return rawHook.doRcpt(session,
-                Optional.ofNullable(sender).filter(address -> !address.isNullSender()),
+        Optional<MailAddress> sender = (Optional<MailAddress>) session.getAttachment(SMTPSession.SENDER, State.Transaction);
+        return rawHook.doRcpt(session, sender,
                 (MailAddress) session.getAttachment(CURRENT_RECIPIENT, State.Transaction));
     }
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/RcptCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/RcptCmdHandler.java
@@ -22,6 +22,7 @@ package org.apache.james.protocols.smtp.core;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.StringTokenizer;
 
 import javax.inject.Inject;
@@ -230,8 +231,9 @@ public class RcptCmdHandler extends AbstractHookableCmdHandler<RcptHook> impleme
     @Override
     protected HookResult callHook(RcptHook rawHook, SMTPSession session,
                                   String parameters) {
+        MailAddress sender = (MailAddress) session.getAttachment(SMTPSession.SENDER, State.Transaction);
         return rawHook.doRcpt(session,
-                (MailAddress) session.getAttachment(SMTPSession.SENDER, State.Transaction),
+                Optional.ofNullable(sender).filter(address -> !address.isNullSender()),
                 (MailAddress) session.getAttachment(CURRENT_RECIPIENT, State.Transaction));
     }
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/MailSizeEsmtpExtension.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/esmtp/MailSizeEsmtpExtension.java
@@ -23,9 +23,12 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.james.core.MailAddress;
 import org.apache.james.protocols.api.ProtocolSession.State;
 import org.apache.james.protocols.api.Response;
 import org.apache.james.protocols.api.handler.LineHandler;
@@ -79,8 +82,10 @@ public class MailSizeEsmtpExtension implements MailParametersHook, EhloExtension
     @Override
     public HookResult doMailParameter(SMTPSession session, String paramName,
                                       String paramValue) {
+        Optional<MailAddress> tempSender = (Optional<MailAddress>) session.getAttachment(SMTPSession.SENDER, State.Transaction);
         return doMailSize(session, paramValue,
-                (String) session.getAttachment(SMTPSession.SENDER, State.Transaction));
+            Optional.ofNullable(tempSender).flatMap(Function.identity())
+                .map(MailAddress::asString).orElse(MailAddress.NULL_SENDER_AS_STRING));
     }
 
     @Override

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractGreylistHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractGreylistHandler.java
@@ -20,6 +20,7 @@
 package org.apache.james.protocols.smtp.core.fastfail;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.protocols.smtp.SMTPRetCode;
@@ -76,15 +77,15 @@ public abstract class AbstractGreylistHandler implements RcptHook {
     }
 
 
-    private HookResult doGreyListCheck(SMTPSession session, MailAddress senderAddress, MailAddress recipAddress) {
+    private HookResult doGreyListCheck(SMTPSession session, Optional<MailAddress> senderAddress, MailAddress recipAddress) {
         String recip = "";
         String sender = "";
 
         if (recipAddress != null) {
             recip = recipAddress.toString();
         }
-        if (senderAddress != null) {
-            sender = senderAddress.toString();
+        if (senderAddress.isPresent()) {
+            sender = senderAddress.map(MailAddress::asString).get();
         }
     
         long time = System.currentTimeMillis();
@@ -219,7 +220,7 @@ public abstract class AbstractGreylistHandler implements RcptHook {
   
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender, MailAddress rcpt) {
         if (!session.isRelayingAllowed()) {
             return doGreyListCheck(session, sender,rcpt);
         } else {

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractValidRcptHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractValidRcptHandler.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.protocols.smtp.core.fastfail;
 
+import java.util.Optional;
+
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
 import org.apache.james.protocols.smtp.SMTPRetCode;
@@ -37,7 +39,7 @@ public abstract class AbstractValidRcptHandler implements RcptHook {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractValidRcptHandler.class);
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender, MailAddress rcpt) {
         if (!isLocalDomain(session, rcpt.getDomain())) {
             return HookResult.DECLINED;
         }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandler.java
@@ -22,6 +22,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.StringTokenizer;
 
 import org.apache.commons.configuration.Configuration;
@@ -178,7 +179,7 @@ public class DNSRBLHandler implements RcptHook {
     }
     
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender, MailAddress rcpt) {
         checkDNSRBL(session, session.getRemoteAddress().getAddress().getHostAddress());
     
         if (!session.isRelayingAllowed()) {

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/MaxRcptHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/MaxRcptHandler.java
@@ -21,6 +21,8 @@
 
 package org.apache.james.protocols.smtp.core.fastfail;
 
+import java.util.Optional;
+
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.MailAddress;
@@ -56,7 +58,7 @@ public class MaxRcptHandler implements RcptHook {
     }
    
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender, MailAddress rcpt) {
         if ((session.getRcptCount() + 1) > maxRcpt) {
             LOGGER.info("Maximum recipients of {} reached", maxRcpt);
             

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandler.java
@@ -21,6 +21,7 @@ package org.apache.james.protocols.smtp.core.fastfail;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Optional;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
@@ -93,7 +94,7 @@ public class ResolvableEhloHeloHandler implements RcptHook, HeloHook {
     }
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender, MailAddress rcpt) {
         if (check(session,rcpt)) {
             return HookResult.builder()
                 .hookReturnCode(HookReturnCode.deny())

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/SpamTrapHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/SpamTrapHandler.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
@@ -69,7 +70,7 @@ public class SpamTrapHandler implements RcptHook {
     }
     
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender, MailAddress rcpt) {
         String address = session.getRemoteAddress().getAddress().getHostAddress();
         if (isBlocked(address, session)) {
             return HookResult.DENY;

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/SupressDuplicateRcptHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/SupressDuplicateRcptHandler.java
@@ -20,6 +20,7 @@
 package org.apache.james.protocols.smtp.core.fastfail;
 
 import java.util.Collection;
+import java.util.Optional;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
@@ -52,7 +53,7 @@ public class SupressDuplicateRcptHandler implements RcptHook {
 
     @Override
     @SuppressWarnings("unchecked")
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender, MailAddress rcpt) {
         Collection<MailAddress> rcptList = (Collection<MailAddress>) session.getAttachment(SMTPSession.RCPT_LIST, State.Transaction);
     
         // Check if the recipient is already in the rcpt list

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandler.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.protocols.smtp.core.fastfail;
 
+import java.util.Optional;
+
 import org.apache.james.core.MailAddress;
 import org.apache.james.protocols.smtp.SMTPRetCode;
 import org.apache.james.protocols.smtp.SMTPSession;
@@ -34,8 +36,8 @@ public abstract class ValidSenderDomainHandler implements MailHook {
 
 
     @Override
-    public HookResult doMail(SMTPSession session, MailAddress sender) {
-        if (sender != null  && !hasMXRecord(session,sender.getDomain().name())) {
+    public HookResult doMail(SMTPSession session, Optional<MailAddress> sender) {
+        if (sender.isPresent()  && !hasMXRecord(session,sender.get().getDomain().name())) {
             return HookResult.builder()
                 .hookReturnCode(HookReturnCode.deny())
                 .smtpReturnCode(SMTPRetCode.SYNTAX_ERROR_ARGUMENTS)

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/MailHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/MailHook.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.protocols.smtp.hook;
 
+import java.util.Optional;
+
 import org.apache.james.core.MailAddress;
 import org.apache.james.protocols.smtp.SMTPSession;
 
@@ -33,7 +35,25 @@ public interface MailHook extends Hook {
      * 
      * @param session the SMTPSession
      * @param sender the sender MailAddress
+     * @deprecated See {@link MailHook#doMail(SMTPSession, Optional)}
      * @return HockResult
      */
-    HookResult doMail(SMTPSession session, MailAddress sender);
+    @Deprecated
+    default HookResult doMail(SMTPSession session, MailAddress sender) {
+        return doMail(session, Optional.ofNullable(sender).filter(address -> !address.isNullSender()));
+    }
+
+    /**
+     * Return the HookResult after run the hook
+     *
+     * This strongly typed version of do mail is safer to use.
+     *
+     * @param session the SMTPSession
+     * @param sender the sender MailAddress
+     * @since James 3.2.0
+     * @return HockResult
+     */
+    default HookResult doMail(SMTPSession session, Optional<MailAddress> sender) {
+        return doMail(session, sender.orElse(null));
+    }
 }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/RcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/RcptHook.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.protocols.smtp.hook;
 
+import java.util.Optional;
+
 import org.apache.james.core.MailAddress;
 import org.apache.james.protocols.smtp.SMTPSession;
 
@@ -34,6 +36,14 @@ public interface RcptHook extends Hook {
      * @param rcpt the recipient MailAddress
      * @return HookResult
      */
-    HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt);
+    @SuppressWarnings("deprecated")
+    default HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender, MailAddress rcpt) {
+        return doRcpt(session, sender.orElse(null), rcpt);
+    }
+
+    @Deprecated
+    default HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+        return doRcpt(session, Optional.ofNullable(sender).filter(address -> !address.isNullSender()), rcpt);
+    }
 
 }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/SimpleHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/SimpleHook.java
@@ -67,7 +67,7 @@ public class SimpleHook implements HeloHook, MailHook, RcptHook, MessageHook {
      * Return {@link HookResult} with {@link HookReturnCode#DECLINED}
      */
     @Override
-    public HookResult doMail(SMTPSession session, MailAddress sender) {
+    public HookResult doMail(SMTPSession session, Optional<MailAddress> sender) {
         return HookResult.DECLINED;
 
     }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/SimpleHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/SimpleHook.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.protocols.smtp.hook;
 
+import java.util.Optional;
+
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.MailAddress;
@@ -56,7 +58,7 @@ public class SimpleHook implements HeloHook, MailHook, RcptHook, MessageHook {
      * Return {@link HookResult} with {@link HookReturnCode#DECLINED}
      */
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender, MailAddress rcpt) {
         return HookResult.DECLINED;
 
     }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
@@ -594,7 +594,7 @@ public abstract class AbstractSMTPServerTest {
             }
 
             @Override
-            public HookResult doMail(SMTPSession session, MailAddress sender) {
+            public HookResult doMail(SMTPSession session, Optional<MailAddress> sender) {
                 return HookResult.DENY;
             }
         };
@@ -644,7 +644,7 @@ public abstract class AbstractSMTPServerTest {
             }
 
             @Override
-            public HookResult doMail(SMTPSession session, MailAddress sender) {
+            public HookResult doMail(SMTPSession session, Optional<MailAddress> sender) {
                 return HookResult.DENYSOFT;
             }
         };

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
@@ -1114,7 +1114,7 @@ public abstract class AbstractSMTPServerTest {
     }
     
     protected static void checkEnvelope(MailEnvelope env, String sender, List<String> recipients, String msg) throws IOException {
-        assertThat(env.getSender().toString()).isEqualTo(sender);
+        assertThat(env.getSenderAsOptional().map(MailAddress::asString)).contains(sender);
 
         List<MailAddress> envRecipients = env.getRecipients();
         assertThat(envRecipients.size()).isEqualTo(recipients.size());

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
@@ -30,6 +30,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.configuration.Configuration;
@@ -694,7 +695,7 @@ public abstract class AbstractSMTPServerTest {
             }
 
             @Override
-            public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+            public HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender, MailAddress rcpt) {
                 if (RCPT1.equals(rcpt.toString())) {
                     return HookResult.DENY;
                 } else {
@@ -758,7 +759,7 @@ public abstract class AbstractSMTPServerTest {
             }
 
             @Override
-            public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+            public HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender, MailAddress rcpt) {
                 if (RCPT1.equals(rcpt.toString())) {
                     return HookResult.DENYSOFT;
                 } else {

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandlerTest.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.protocols.api.ProtocolSession.State;
@@ -183,7 +184,7 @@ public class DNSRBLHandlerTest {
 
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
-        rbl.doRcpt(mockedSMTPSession, null, new MailAddress("test@localhost"));
+        rbl.doRcpt(mockedSMTPSession, Optional.empty(), new MailAddress("test@localhost"));
         assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, State.Connection)).describedAs("Details").isEqualTo("Blocked - see http://www.spamcop.net/bl.shtml?127.0.0.2");
         assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Blocked").isNotNull();
     }
@@ -196,7 +197,7 @@ public class DNSRBLHandlerTest {
 
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(false);
-        rbl.doRcpt(mockedSMTPSession, null, new MailAddress("test@localhost"));
+        rbl.doRcpt(mockedSMTPSession, Optional.empty(), new MailAddress("test@localhost"));
         assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("No details").isNull();
         assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Blocked").isNotNull();
     }
@@ -210,7 +211,7 @@ public class DNSRBLHandlerTest {
 
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
-        rbl.doRcpt(mockedSMTPSession, null, new MailAddress("test@localhost"));
+        rbl.doRcpt(mockedSMTPSession, Optional.empty(), new MailAddress("test@localhost"));
         assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("No details").isNull();
         assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Not blocked").isNull();
     }
@@ -225,7 +226,7 @@ public class DNSRBLHandlerTest {
 
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
-        rbl.doRcpt(mockedSMTPSession, null, new MailAddress("test@localhost"));
+        rbl.doRcpt(mockedSMTPSession, Optional.empty(), new MailAddress("test@localhost"));
         assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("No details").isNull();
         assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Not blocked").isNull();
     }
@@ -240,7 +241,7 @@ public class DNSRBLHandlerTest {
 
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
-        rbl.doRcpt(mockedSMTPSession, null, new MailAddress("test@localhost"));
+        rbl.doRcpt(mockedSMTPSession, Optional.empty(), new MailAddress("test@localhost"));
         assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).isNull();
         assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Blocked").isNotNull();
     }
@@ -255,7 +256,7 @@ public class DNSRBLHandlerTest {
 
         rbl.setWhitelist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
-        rbl.doRcpt(mockedSMTPSession, null, new MailAddress("test@localhost"));
+        rbl.doRcpt(mockedSMTPSession, Optional.empty(), new MailAddress("test@localhost"));
         assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).isNull();
         assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Not blocked").isNull();
     }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/MaxRcptHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/MaxRcptHandlerTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.protocols.smtp.SMTPSession;
@@ -60,7 +61,7 @@ public class MaxRcptHandlerTest {
         MaxRcptHandler handler = new MaxRcptHandler();
         
         handler.setMaxRcpt(2);
-        HookReturnCode resp = handler.doRcpt(session,null,new MailAddress("test@test")).getResult();
+        HookReturnCode resp = handler.doRcpt(session, Optional.empty(), new MailAddress("test@test")).getResult();
     
         assertThat(HookReturnCode.deny()).describedAs("Rejected.. To many recipients").isEqualTo(resp);
     }
@@ -72,7 +73,7 @@ public class MaxRcptHandlerTest {
         MaxRcptHandler handler = new MaxRcptHandler();    
 
         handler.setMaxRcpt(4);
-        HookReturnCode resp = handler.doRcpt(session,null,new MailAddress("test@test")).getResult();
+        HookReturnCode resp = handler.doRcpt(session, Optional.empty(), new MailAddress("test@test")).getResult();
         
         assertThat(HookReturnCode.declined()).describedAs("Not Rejected..").isEqualTo(resp);
     }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandlerTest.java
@@ -27,6 +27,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.protocols.smtp.SMTPSession;
@@ -126,7 +127,7 @@ public class ResolvableEhloHeloHandlerTest {
         handler.doHelo(session, INVALID_HOST);
         assertThat(session.getAttachment(BAD_EHLO_HELO, Transaction)).withFailMessage("Invalid HELO").isNotNull();
 
-        HookReturnCode result = handler.doRcpt(session,null, mailAddress).getResult();
+        HookReturnCode result = handler.doRcpt(session, Optional.empty(), mailAddress).getResult();
         assertThat(HookReturnCode.deny()).describedAs("Reject").isEqualTo(result);
     }
     
@@ -140,7 +141,7 @@ public class ResolvableEhloHeloHandlerTest {
         handler.doHelo(session, VALID_HOST);
         assertThat(session.getAttachment(BAD_EHLO_HELO, Transaction)).withFailMessage("Valid HELO").isNull();
 
-        HookReturnCode result = handler.doRcpt(session,null, mailAddress).getResult();
+        HookReturnCode result = handler.doRcpt(session, Optional.empty(), mailAddress).getResult();
         assertThat(HookReturnCode.declined()).describedAs("Not reject").isEqualTo(result);
     }
    
@@ -155,7 +156,7 @@ public class ResolvableEhloHeloHandlerTest {
         assertThat(session.getAttachment(BAD_EHLO_HELO, Transaction)).withFailMessage("Value stored").isNotNull();
 
 
-        HookReturnCode result = handler.doRcpt(session,null, mailAddress).getResult();
+        HookReturnCode result = handler.doRcpt(session, Optional.empty(), mailAddress).getResult();
         assertThat(HookReturnCode.deny()).describedAs("Reject").isEqualTo(result);
     }
     
@@ -171,7 +172,7 @@ public class ResolvableEhloHeloHandlerTest {
         assertThat(session.getAttachment(BAD_EHLO_HELO, Transaction)).withFailMessage("Value stored").isNotNull();
 
 
-        HookReturnCode result = handler.doRcpt(session,null, mailAddress).getResult();
+        HookReturnCode result = handler.doRcpt(session, Optional.empty(), mailAddress).getResult();
         assertThat(HookReturnCode.deny()).describedAs("Reject").isEqualTo(result);
     }
 }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/SpamTrapHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/SpamTrapHandlerTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Fail.fail;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Optional;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.protocols.smtp.SMTPSession;
@@ -63,17 +64,17 @@ public class SpamTrapHandlerTest {
         handler.setBlockTime(blockTime);
         handler.setSpamTrapRecipients(rcpts);
 
-        HookReturnCode result = handler.doRcpt(setUpSMTPSession(ip),null,new MailAddress(SPAM_TRAP_RECIP1)).getResult();
+        HookReturnCode result = handler.doRcpt(setUpSMTPSession(ip), Optional.empty(), new MailAddress(SPAM_TRAP_RECIP1)).getResult();
     
         assertThat(result).describedAs("Blocked on first connect").isEqualTo(HookReturnCode.deny());
     
 
-        result = handler.doRcpt(setUpSMTPSession(ip),null,new MailAddress(RECIP1)).getResult();
+        result = handler.doRcpt(setUpSMTPSession(ip), Optional.empty(), new MailAddress(RECIP1)).getResult();
     
         assertThat(result).describedAs("Blocked on second connect").isEqualTo(HookReturnCode.deny());
     
         
-        result = handler.doRcpt(setUpSMTPSession(ip2),null,new MailAddress(RECIP1)).getResult();
+        result = handler.doRcpt(setUpSMTPSession(ip2), Optional.empty(), new MailAddress(RECIP1)).getResult();
     
         assertThat(result).describedAs("Not Blocked").isEqualTo(HookReturnCode.declined());
     
@@ -84,7 +85,7 @@ public class SpamTrapHandlerTest {
             fail("Failed to sleep for " + blockTime + " ms");
         }
     
-        result = handler.doRcpt(setUpSMTPSession(ip),null,new MailAddress(RECIP1)).getResult();
+        result = handler.doRcpt(setUpSMTPSession(ip), Optional.empty(), new MailAddress(RECIP1)).getResult();
     
         assertThat(result).describedAs("Not blocked. BlockTime exceeded").isEqualTo(HookReturnCode.declined());
     }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandlerTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
@@ -106,7 +107,7 @@ public class ValidSenderDomainHandlerTest {
     @Test
     public void testNullSenderNotReject() {
         ValidSenderDomainHandler handler = createHandler();
-        HookReturnCode response = handler.doMail(setupMockedSession(null),null).getResult();
+        HookReturnCode response = handler.doMail(setupMockedSession(null), Optional.empty()).getResult();
         
         assertThat(HookReturnCode.declined()).describedAs("Not blocked cause its a nullsender").isEqualTo(response);
     }
@@ -115,7 +116,8 @@ public class ValidSenderDomainHandlerTest {
     public void testInvalidSenderDomainReject() throws Exception {
         ValidSenderDomainHandler handler = createHandler();
         SMTPSession session = setupMockedSession(new MailAddress("invalid@invalid"));
-        HookReturnCode response = handler.doMail(session,(MailAddress) session.getAttachment(SMTPSession.SENDER, State.Transaction)).getResult();
+        Optional<MailAddress> sender = Optional.of((MailAddress) session.getAttachment(SMTPSession.SENDER, State.Transaction));
+        HookReturnCode response = handler.doMail(session, sender).getResult();
         
         assertThat(HookReturnCode.deny()).describedAs("Blocked cause we use reject action").isEqualTo(response);
     }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandlerTest.java
@@ -66,7 +66,7 @@ public class ValidSenderDomainHandlerTest {
             @Override
             public Map<String,Object> getState() {
 
-                map.put(SMTPSession.SENDER, sender);
+                map.put(SMTPSession.SENDER, Optional.of(sender));
 
                 return map;
             }
@@ -116,7 +116,7 @@ public class ValidSenderDomainHandlerTest {
     public void testInvalidSenderDomainReject() throws Exception {
         ValidSenderDomainHandler handler = createHandler();
         SMTPSession session = setupMockedSession(new MailAddress("invalid@invalid"));
-        Optional<MailAddress> sender = Optional.of((MailAddress) session.getAttachment(SMTPSession.SENDER, State.Transaction));
+        Optional<MailAddress> sender = (Optional<MailAddress>) session.getAttachment(SMTPSession.SENDER, State.Transaction);
         HookReturnCode response = handler.doMail(session, sender).getResult();
         
         assertThat(HookReturnCode.deny()).describedAs("Blocked cause we use reject action").isEqualTo(response);

--- a/server/container/core/src/main/java/org/apache/james/server/core/MailImpl.java
+++ b/server/container/core/src/main/java/org/apache/james/server/core/MailImpl.java
@@ -176,7 +176,11 @@ public class MailImpl implements Disposable, Mail {
         }
 
         public Builder sender(MailAddress sender) {
-            this.sender = Optional.ofNullable(sender);
+            return sender(Optional.ofNullable(sender));
+        }
+
+        public Builder sender(Optional<MailAddress> sender) {
+            this.sender = sender;
             return this;
         }
 
@@ -387,7 +391,7 @@ public class MailImpl implements Disposable, Mail {
         }
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "deprecated"})
     private MailImpl(Mail mail, String newName) throws MessagingException {
         this(newName, mail.getSender(), mail.getRecipients(), mail.getMessage());
         setRemoteHost(mail.getRemoteHost());

--- a/server/container/core/src/main/java/org/apache/james/server/core/MailImpl.java
+++ b/server/container/core/src/main/java/org/apache/james/server/core/MailImpl.java
@@ -790,4 +790,9 @@ public class MailImpl implements Disposable, Mail {
     public void addAllSpecificHeaderForRecipient(PerRecipientHeaders perRecipientHeaders) {
         perRecipientSpecificHeaders.addAll(perRecipientHeaders);
     }
+
+    @Override
+    public Mail duplicate() throws MessagingException {
+        return MailImpl.duplicate(this);
+    }
 }

--- a/server/container/core/src/main/java/org/apache/james/server/core/MailImpl.java
+++ b/server/container/core/src/main/java/org/apache/james/server/core/MailImpl.java
@@ -391,6 +391,17 @@ public class MailImpl implements Disposable, Mail {
         }
     }
 
+    public MailImpl(String name, Optional<MailAddress> sender, Collection<MailAddress> recipients) {
+        this();
+        setName(name);
+        sender.ifPresent(this::setSender);
+
+        // Copy the recipient list
+        if (recipients != null) {
+            setRecipients(recipients);
+        }
+    }
+
     @SuppressWarnings({"unchecked", "deprecated"})
     private MailImpl(Mail mail, String newName) throws MessagingException {
         this(newName, mail.getSender(), mail.getRecipients(), mail.getMessage());

--- a/server/container/core/src/test/java/org/apache/james/server/core/MailImplTest.java
+++ b/server/container/core/src/test/java/org/apache/james/server/core/MailImplTest.java
@@ -63,7 +63,7 @@ public class MailImplTest {
         assertThat(mail.getRemoteHost()).describedAs("initial remote host is localhost").isEqualTo("localhost");
         assertThat(mail.getState()).describedAs("default initial state").isEqualTo(Mail.DEFAULT);
         assertThat(mail.getMessage()).isNull();
-        assertThat(mail.getSender()).isNull();
+        assertThat(mail.getSenderAsOptional()).isEmpty();
         assertThat(mail.getName()).isNull();
     }
 
@@ -96,7 +96,7 @@ public class MailImplTest {
         MailAddress senderMailAddress = new MailAddress(sender);
         MailImpl mail = new MailImpl(name, senderMailAddress, recipients);
 
-        assertThat(mail.getSender().asString()).isEqualTo(sender);
+        assertThat(mail.getSenderAsOptional().get().asString()).isEqualTo(sender);
         assertThat(mail.getName()).isEqualTo(name);
 
      }

--- a/server/container/util/src/main/java/org/apache/james/util/OptionalUtils.java
+++ b/server/container/util/src/main/java/org/apache/james/util/OptionalUtils.java
@@ -23,6 +23,9 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
 public class OptionalUtils {
 
     @FunctionalInterface
@@ -40,6 +43,16 @@ public class OptionalUtils {
     public static <T> Stream<T> toStream(Optional<T> optional) {
         return optional.map(Stream::of)
             .orElse(Stream.of());
+    }
+
+    public static <T> ImmutableList<T> toList(Optional<T> optional) {
+        return optional.map(ImmutableList::of)
+            .orElse(ImmutableList.of());
+    }
+
+    public static <T> ImmutableSet<T> toSet(Optional<T> optional) {
+        return optional.map(ImmutableSet::of)
+            .orElse(ImmutableSet.of());
     }
 
     @SafeVarargs

--- a/server/data/data-jcr/src/main/java/org/apache/james/mailrepository/jcr/JCRMailRepository.java
+++ b/server/data/data-jcr/src/main/java/org/apache/james/mailrepository/jcr/JCRMailRepository.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.Properties;
 
 import javax.annotation.PostConstruct;
@@ -210,7 +211,7 @@ public class JCRMailRepository extends AbstractMailRepository implements MailRep
         setError(node, mail.getErrorMessage());
         setRemoteHost(node, mail.getRemoteHost());
         setRemoteAddr(node, mail.getRemoteAddr());
-        setSender(node, mail.getSender());
+        setSender(node, mail.getSenderAsOptional());
         setRecipients(node, mail.getRecipients());
         setMessage(node, mail.getMessage());
         setAttributes(node, mail);
@@ -417,8 +418,8 @@ public class JCRMailRepository extends AbstractMailRepository implements MailRep
      * @throws RepositoryException
      *             if a repository error occurs
      */
-    private void setSender(Node node, MailAddress sender) throws RepositoryException {
-        node.setProperty("james:sender", sender.toString());
+    private void setSender(Node node, Optional<MailAddress> sender) throws RepositoryException {
+        node.setProperty("james:sender", sender.map(MailAddress::asString).orElse(MailAddress.NULL_SENDER_AS_STRING));
     }
 
     /**

--- a/server/data/data-jdbc/src/main/java/org/apache/james/mailrepository/jdbc/JDBCMailRepository.java
+++ b/server/data/data-jdbc/src/main/java/org/apache/james/mailrepository/jdbc/JDBCMailRepository.java
@@ -435,10 +435,10 @@ public class JDBCMailRepository extends AbstractMailRepository {
                     updateMessage = conn.prepareStatement(sqlQueries.getSqlString("updateMessageSQL", true));
                     updateMessage.setString(1, mc.getState());
                     updateMessage.setString(2, mc.getErrorMessage());
-                    if (mc.getSender() == null) {
+                    if (!mc.getSenderAsOptional().isPresent()) {
                         updateMessage.setNull(3, java.sql.Types.VARCHAR);
                     } else {
-                        updateMessage.setString(3, mc.getSender().toString());
+                        updateMessage.setString(3, mc.getSenderAsOptional().get().toString());
                     }
                     StringBuilder recipients = new StringBuilder();
                     for (Iterator<MailAddress> i = mc.getRecipients().iterator(); i.hasNext();) {
@@ -529,10 +529,10 @@ public class JDBCMailRepository extends AbstractMailRepository {
                     insertMessage.setString(2, repositoryName);
                     insertMessage.setString(3, mc.getState());
                     insertMessage.setString(4, mc.getErrorMessage());
-                    if (mc.getSender() == null) {
+                    if (!mc.getSenderAsOptional().isPresent()) {
                         insertMessage.setNull(5, Types.VARCHAR);
                     } else {
-                        insertMessage.setString(5, mc.getSender().toString());
+                        insertMessage.setString(5, mc.getSenderAsOptional().get().toString());
                     }
                     StringBuilder recipients = new StringBuilder();
                     for (Iterator<MailAddress> i = mc.getRecipients().iterator(); i.hasNext();) {

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailetContext.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailetContext.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
@@ -396,7 +397,7 @@ public class JamesMailetContext implements MailetContext, Configurable {
 
     @Override
     public void sendMail(Mail mail) throws MessagingException {
-        sendMail(mail, Mail.DEFAULT);
+        sendMail(mail, Optional.ofNullable(mail.getState()).orElse(Mail.DEFAULT));
     }
 
     @Override

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/CamelProcessor.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/CamelProcessor.java
@@ -75,7 +75,7 @@ public class CamelProcessor {
                      .addContext("mailet", mailet.getClass().getSimpleName())
                      .addContext("mail", mail.getName())
                      .addContext("recipients", ImmutableList.copyOf(mail.getRecipients()))
-                     .addContext("sender", mail.getSender())
+                     .addContext("sender", mail.getSenderAsOptional())
                      .build()) {
             MailetPipelineLogging.logBeginOfMailetProcess(mailet, mail);
             mailet.service(mail);

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/MatcherSplitter.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/MatcherSplitter.java
@@ -103,7 +103,7 @@ public class MatcherSplitter {
                          .addContext("state", mail.getState())
                          .addContext("mail", mail.getName())
                          .addContext("recipients", ImmutableList.copyOf(mail.getRecipients()))
-                         .addContext("sender", mail.getSender())
+                         .addContext("sender", mail.getSenderAsOptional())
                          .build()) {
                 // call the matcher
                 matchedRcpts = matcher.match(mail);

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/BayesianAnalysis.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/BayesianAnalysis.java
@@ -294,7 +294,7 @@ public class BayesianAnalysis extends GenericMailet {
 
             if (ignoreLocalSender) {
                 // ignore the message if the sender is local
-                if (mail.getSender() != null && getMailetContext().isLocalServer(mail.getSender().getDomain())) {
+                if (mail.hasSender() && getMailetContext().isLocalServer(mail.getSenderAsOptional().get().getDomain())) {
                     return;
                 }
             }
@@ -323,12 +323,10 @@ public class BayesianAnalysis extends GenericMailet {
             probabilityForm.applyPattern("##0.##%");
             String probabilityString = probabilityForm.format(probability);
 
-            String senderString;
-            if (mail.getSender() == null) {
-                senderString = "null";
-            } else {
-                senderString = mail.getSender().toString();
-            }
+            String senderString = mail.getSenderAsOptional()
+                .map(MailAddress::asString)
+                .orElse("null");
+
             if (probability > 0.1) {
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug(headerName + ": " + probabilityString + "; From: " + senderString + "; Recipient(s): " + getAddressesString(mail.getRecipients()));

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/Bounce.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/Bounce.java
@@ -237,11 +237,11 @@ public class Bounce extends GenericMailet implements RedirectNotify {
 
     @Override
     public void service(Mail originalMail) throws MessagingException {
-        if (originalMail.getSender() == null) {
+        if (!originalMail.hasSender()) {
             passThrough(originalMail);
         } else {
             if (getInitParameters().isDebug()) {
-                LOGGER.debug("Processing a bounce request for a message with a reverse path.  The bounce will be sent to {}", originalMail.getSender());
+                LOGGER.debug("Processing a bounce request for a message with a reverse path.  The bounce will be sent to {}", originalMail.getSenderAsOptional());
             }
             ProcessRedirectNotify.from(this).process(originalMail);
         }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessor.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessor.java
@@ -35,6 +35,7 @@ import org.apache.james.rrt.api.RecipientRewriteTable.ErrorMappingException;
 import org.apache.james.rrt.api.RecipientRewriteTableException;
 import org.apache.james.rrt.lib.Mapping;
 import org.apache.james.rrt.lib.Mappings;
+import org.apache.james.server.core.MailImpl;
 import org.apache.james.util.MemoizedSupplier;
 import org.apache.james.util.OptionalUtils;
 import org.apache.mailet.Mail;
@@ -127,7 +128,14 @@ public class RecipientRewriteTableProcessor {
         RrtExecutionResult executionResults = executeRrtFor(mail);
 
         if (!executionResults.recipientWithError.isEmpty()) {
-            mailetContext.sendMail(mail.getSender(), executionResults.recipientWithError, mail.getMessage(), errorProcessor);
+            MailImpl newMail = MailImpl.builder()
+                .name(mail.getName())
+                .sender(mail.getSenderAsOptional())
+                .recipients(executionResults.recipientWithError)
+                .mimeMessage(mail.getMessage())
+                .state(errorProcessor)
+                .build();
+            mailetContext.sendMail(newMail);
         }
 
         if (executionResults.newRecipients.isEmpty()) {
@@ -155,7 +163,7 @@ public class RecipientRewriteTableProcessor {
             Mappings mappings = virtualTableStore.getMappings(recipient.getLocalPart(), recipient.getDomain());
 
             if (mappings != null && !mappings.isEmpty()) {
-                List<MailAddress> newMailAddresses = handleMappings(mappings, mail.getSender(), recipient, mail.getMessage());
+                List<MailAddress> newMailAddresses = handleMappings(mappings, mail, recipient, mail.getMessage());
                 return RrtExecutionResult.success(newMailAddresses);
             }
             return RrtExecutionResult.success(recipient);
@@ -166,14 +174,14 @@ public class RecipientRewriteTableProcessor {
     }
 
     @VisibleForTesting
-    List<MailAddress> handleMappings(Mappings mappings, MailAddress sender, MailAddress recipient, MimeMessage message) throws MessagingException {
+    List<MailAddress> handleMappings(Mappings mappings, Mail mail, MailAddress recipient, MimeMessage message) throws MessagingException {
         ImmutableList<MailAddress> mailAddresses = mappings.asStream()
             .map(mapping -> mapping.appendDomainIfNone(defaultDomainSupplier))
             .map(Mapping::asMailAddress)
             .flatMap(OptionalUtils::toStream)
             .collect(Guavate.toImmutableList());
 
-        forwardToRemoteAddress(sender, recipient, message, mailAddresses);
+        forwardToRemoteAddress(mail, recipient, message, mailAddresses);
 
         return getLocalAddresses(mailAddresses);
     }
@@ -184,14 +192,20 @@ public class RecipientRewriteTableProcessor {
             .collect(Guavate.toImmutableList());
     }
 
-    private void forwardToRemoteAddress(MailAddress sender, MailAddress recipient, MimeMessage message, ImmutableList<MailAddress> mailAddresses) {
+    private void forwardToRemoteAddress(Mail mail, MailAddress recipient, MimeMessage message, ImmutableList<MailAddress> mailAddresses) {
         ImmutableList<MailAddress> remoteAddresses = mailAddresses.stream()
             .filter(mailAddress -> !mailetContext.isLocalServer(mailAddress.getDomain()))
             .collect(Guavate.toImmutableList());
 
         if (!remoteAddresses.isEmpty()) {
             try {
-                mailetContext.sendMail(sender, remoteAddresses, message);
+                mailetContext.sendMail(
+                    MailImpl.builder()
+                        .name(mail.getName())
+                        .sender(mail.getSenderAsOptional())
+                        .recipients(remoteAddresses)
+                        .mimeMessage(message)
+                        .build());
                 LOGGER.info("Mail for {} forwarded to {}", recipient, remoteAddresses);
             } catch (MessagingException ex) {
                 LOGGER.warn("Error forwarding mail to {}", remoteAddresses);

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RemoteDelivery.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RemoteDelivery.java
@@ -204,7 +204,7 @@ public class RemoteDelivery extends GenericMailet {
                 serviceWithGateway(mail);
             }
         } else {
-            LOGGER.debug("Mail {} from {} has no recipients and can not be remotely delivered", mail.getName(), mail.getSender());
+            LOGGER.debug("Mail {} from {} has no recipients and can not be remotely delivered", mail.getName(), mail.getSenderAsOptional());
         }
         mail.setState(Mail.GHOST);
     }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/SPF.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/SPF.java
@@ -71,17 +71,13 @@ public class SPF extends GenericMailet {
 
     @Override
     public void service(Mail mail) throws MessagingException {
-        String sender;
-        MailAddress senderAddr = mail.getSender();
         String remoteAddr = mail.getRemoteAddr();
         String helo = mail.getRemoteHost();
 
         if (!remoteAddr.equals("127.0.0.1")) {
-            if (senderAddr != null) {
-                sender = senderAddr.toString();
-            } else {
-                sender = "";
-            }
+            String sender = mail.getSenderAsOptional()
+                .map(MailAddress::asString)
+                .orElse("");
             SPFResult result = spf.checkSPF(remoteAddr, sender, helo);
             mail.setAttribute(EXPLANATION_ATTRIBUTE, result.getExplanation());
             mail.setAttribute(RESULT_ATTRIBUTE, result.getResult());

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/ToSenderDomainRepository.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/ToSenderDomainRepository.java
@@ -24,6 +24,8 @@ import java.util.Optional;
 import javax.inject.Inject;
 import javax.mail.MessagingException;
 
+import org.apache.james.core.Domain;
+import org.apache.james.core.MailAddress;
 import org.apache.james.mailrepository.api.MailRepository;
 import org.apache.james.mailrepository.api.MailRepositoryStore;
 import org.apache.james.mailrepository.api.MailRepositoryUrl;
@@ -89,7 +91,12 @@ public class ToSenderDomainRepository extends GenericMailet {
 
     @Override
     public void service(Mail mail) throws MessagingException {
-        MailRepositoryUrl repositoryUrl = MailRepositoryUrl.from(urlPrefix + mail.getSender().getDomain().asString());
+        String domain = mail.getSenderAsOptional()
+            .map(MailAddress::getDomain)
+            .map(Domain::asString)
+            .orElse("");
+
+        MailRepositoryUrl repositoryUrl = MailRepositoryUrl.from(urlPrefix + domain);
         store(mail, repositoryUrl);
         if (!passThrough) {
             mail.setState(Mail.GHOST);

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/ToSenderFolder.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/ToSenderFolder.java
@@ -79,12 +79,14 @@ public class ToSenderFolder extends GenericMailet {
     }
 
     private void doService(Mail mail) throws MessagingException {
-        MailAddress sender = mail.getSender();
-        String username = retrieveUser(sender);
+        if (mail.hasSender()) {
+            MailAddress sender = mail.getSenderAsOptional().get();
+            String username = retrieveUser(sender);
 
-        mailboxAppender.append(mail.getMessage(), username, folder);
+            mailboxAppender.append(mail.getMessage(), username, folder);
 
-        LOGGER.error("Local delivery with ToSenderFolder mailet for mail {} with sender {} in folder {}", mail.getName(), sender, folder);
+            LOGGER.error("Local delivery with ToSenderFolder mailet for mail {} with sender {} in folder {}", mail.getName(), sender, folder);
+        }
     }
 
     private String retrieveUser(MailAddress sender) throws MessagingException {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/WhiteListManager.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/WhiteListManager.java
@@ -244,10 +244,10 @@ public class WhiteListManager extends GenericMailet {
     public void service(Mail mail) throws MessagingException {
 
         // check if it's a local sender
-        MailAddress senderMailAddress = mail.getSender();
-        if (senderMailAddress == null) {
+        if (mail.hasSender()) {
             return;
         }
+        MailAddress senderMailAddress = mail.getSenderAsOptional().get();
         if (!getMailetContext().isLocalEmail(senderMailAddress)) {
             // not a local sender, so return
             return;
@@ -375,7 +375,7 @@ public class WhiteListManager extends GenericMailet {
      * Manages a display request.
      */
     private void manageDisplayRequest(Mail mail) throws MessagingException {
-        MailAddress senderMailAddress = mail.getSender();
+        MailAddress senderMailAddress = mail.getSenderAsOptional().get();
         String senderUser = senderMailAddress.getLocalPart().toLowerCase(Locale.US);
         Domain senderHost = senderMailAddress.getDomain();
 
@@ -423,7 +423,7 @@ public class WhiteListManager extends GenericMailet {
      * Manages an insert request.
      */
     private void manageInsertRequest(Mail mail) throws MessagingException {
-        MailAddress senderMailAddress = mail.getSender();
+        MailAddress senderMailAddress = mail.getSenderAsOptional().get();
         String senderUser = senderMailAddress.getLocalPart().toLowerCase(Locale.US);
         Domain senderHost = senderMailAddress.getDomain();
 
@@ -544,7 +544,7 @@ public class WhiteListManager extends GenericMailet {
      * Manages a remove request.
      */
     private void manageRemoveRequest(Mail mail) throws MessagingException {
-        MailAddress senderMailAddress = mail.getSender();
+        MailAddress senderMailAddress = mail.getSenderAsOptional().get();
         String senderUser = senderMailAddress.getLocalPart().toLowerCase(Locale.US);
         Domain senderHost = senderMailAddress.getDomain();
 
@@ -665,7 +665,7 @@ public class WhiteListManager extends GenericMailet {
         try {
             MailAddress notifier = getMailetContext().getPostmaster();
 
-            MailAddress senderMailAddress = mail.getSender();
+            MailAddress senderMailAddress = mail.getSenderAsOptional().get();
 
             MimeMessage message = mail.getMessage();
             // Create the reply message

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/DeliveryUtils.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/DeliveryUtils.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import org.apache.james.core.MailAddress;
 
 public class DeliveryUtils {
-
+    @SuppressWarnings("deprecated")
     public static String prettyPrint(MailAddress mailAddress) {
         return prettyPrint(Optional.ofNullable(mailAddress)
             .filter(address -> ! address.isNullSender()));

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/DeliveryUtils.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/DeliveryUtils.java
@@ -19,16 +19,20 @@
 
 package org.apache.james.transport.mailets.delivery;
 
+import java.util.Optional;
+
 import org.apache.james.core.MailAddress;
 
 public class DeliveryUtils {
 
     public static String prettyPrint(MailAddress mailAddress) {
-        if (mailAddress != null) {
-            return mailAddress.asPrettyString();
-        } else {
-            return "<>";
-        }
+        return prettyPrint(Optional.ofNullable(mailAddress)
+            .filter(address -> ! address.isNullSender()));
+    }
+
+    public static String prettyPrint(Optional<MailAddress> mailAddress) {
+        return mailAddress.map(MailAddress::asPrettyString)
+            .orElse(MailAddress.NULL_SENDER_AS_STRING);
     }
 
 }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/MailDispatcher.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/MailDispatcher.java
@@ -28,6 +28,7 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.server.core.MailImpl;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailetContext;
 import org.apache.mailet.PerRecipientHeaders.Header;
@@ -68,7 +69,7 @@ public class MailDispatcher {
             return this;
         }
 
-        public MailDispatcher build() throws MessagingException {
+        public MailDispatcher build() {
             Preconditions.checkNotNull(mailStore);
             Preconditions.checkNotNull(mailetContext);
             return new MailDispatcher(mailStore, consume.orElse(CONSUME), mailetContext);
@@ -87,7 +88,7 @@ public class MailDispatcher {
     }
 
     public void dispatch(Mail mail) throws MessagingException {
-        Collection<MailAddress> errors =  customizeHeadersAndDeliver(mail);
+        List<MailAddress> errors =  customizeHeadersAndDeliver(mail);
         if (!errors.isEmpty()) {
             // If there were errors, we redirect the email to the ERROR
             // processor.
@@ -96,7 +97,13 @@ public class MailDispatcher {
             // the sender. Note that this email doesn't include any details
             // regarding the details of the failure(s).
             // In the future we may wish to address this.
-            mailetContext.sendMail(mail.getSender(), errors, mail.getMessage(), Mail.ERROR);
+            Mail newMail = MailImpl.builder()
+                .sender(mail.getSenderAsOptional())
+                .recipients(errors)
+                .mimeMessage(mail.getMessage())
+                .state(Mail.ERROR)
+                .build();
+            mailetContext.sendMail(newMail);
         }
         if (consume) {
             // Consume this message
@@ -104,19 +111,19 @@ public class MailDispatcher {
         }
     }
 
-    private Collection<MailAddress> customizeHeadersAndDeliver(Mail mail) throws MessagingException {
+    private List<MailAddress> customizeHeadersAndDeliver(Mail mail) throws MessagingException {
         MimeMessage message = mail.getMessage();
         // Set Return-Path and remove all other Return-Path headers from the message
         // This only works because there is a placeholder inserted by MimeMessageWrapper
-        message.setHeader(RFC2822Headers.RETURN_PATH, DeliveryUtils.prettyPrint(mail.getSender()));
+        message.setHeader(RFC2822Headers.RETURN_PATH, DeliveryUtils.prettyPrint(mail.getSenderAsOptional()));
 
-        Collection<MailAddress> errors = deliver(mail, message);
+        List<MailAddress> errors = deliver(mail, message);
 
         return errors;
     }
 
-    private Collection<MailAddress> deliver(Mail mail, MimeMessage message) {
-        Collection<MailAddress> errors = new ArrayList<>();
+    private List<MailAddress> deliver(Mail mail, MimeMessage message) {
+        List<MailAddress> errors = new ArrayList<>();
         for (MailAddress recipient : mail.getRecipients()) {
             try {
                 Map<String, List<String>> savedHeaders = saveHeaders(mail, recipient);

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/SimpleMailStore.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/SimpleMailStore.java
@@ -66,7 +66,7 @@ public class SimpleMailStore implements MailStore {
             return this;
         }
 
-        public SimpleMailStore build() throws MessagingException {
+        public SimpleMailStore build() {
             Preconditions.checkNotNull(usersRepos);
             Preconditions.checkNotNull(folder);
             Preconditions.checkNotNull(mailboxAppender);
@@ -96,7 +96,7 @@ public class SimpleMailStore implements MailStore {
 
         metric.increment();
         LOGGER.info("Local delivered mail {} successfully from {} to {} in folder {} with composedMessageId {}", mail.getName(),
-            DeliveryUtils.prettyPrint(mail.getSender()), DeliveryUtils.prettyPrint(recipient), locatedFolder, composedMessageId);
+            DeliveryUtils.prettyPrint(mail.getSenderAsOptional()), DeliveryUtils.prettyPrint(recipient), locatedFolder, composedMessageId);
     }
 
     private String locateFolder(String username, Mail mail) {
@@ -106,7 +106,7 @@ public class SimpleMailStore implements MailStore {
         return folder;
     }
 
-    private String computeUsername(MailAddress recipient) throws MessagingException {
+    private String computeUsername(MailAddress recipient) {
         try {
             return usersRepository.getUser(recipient);
         } catch (UsersRepositoryException e) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/ActionContext.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/ActionContext.java
@@ -19,10 +19,8 @@
 package org.apache.james.transport.mailets.jsieve;
 
 import java.time.ZonedDateTime;
-import java.util.Collection;
 
 import javax.mail.MessagingException;
-import javax.mail.internet.MimeMessage;
 
 import org.apache.james.core.MailAddress;
 import org.apache.mailet.Mail;
@@ -60,12 +58,10 @@ public interface ActionContext {
 
     /**
      * Posts the given mail.
-     * @param sender possibly null
-     * @param recipients not null
      * @param mail not null
      * @throws MessagingException when mail cannot be posted
      */
-    public void post(MailAddress sender, Collection<MailAddress> recipients, MimeMessage mail) throws MessagingException;
+    public void post(Mail mail) throws MessagingException;
 
     /**
      * Gets name (including version) of this server.

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/RedirectAction.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/RedirectAction.java
@@ -18,13 +18,10 @@
  ****************************************************************/
 package org.apache.james.transport.mailets.jsieve;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
 import javax.mail.MessagingException;
-import javax.mail.internet.InternetAddress;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.server.core.MailImpl;
 import org.apache.jsieve.mail.Action;
 import org.apache.jsieve.mail.ActionRedirect;
 import org.apache.mailet.Mail;
@@ -59,10 +56,13 @@ public class RedirectAction implements MailAction {
      */
     public void execute(ActionRedirect anAction, Mail aMail, ActionContext context) throws MessagingException {
         ActionUtils.detectAndHandleLocalLooping(aMail, context, "redirect");
-        Collection<MailAddress> recipients = new ArrayList<>(1);
-        recipients.add(new MailAddress(new InternetAddress(anAction.getAddress())));
-        MailAddress sender = aMail.getSender();
-        context.post(sender, recipients, aMail.getMessage());
+
+        context.post(MailImpl.builder()
+            .sender(aMail.getSenderAsOptional())
+            .recipient(new MailAddress(anAction.getAddress()))
+            .mimeMessage(aMail.getMessage())
+            .build());
+
         LOGGER.debug("Redirected Message ID: {} to \"{}\"", aMail.getMessage().getMessageID(), anAction.getAddress());
         DiscardAction.removeRecipient(aMail, context);
     }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/RejectAction.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/RejectAction.java
@@ -20,9 +20,7 @@ package org.apache.james.transport.mailets.jsieve;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 
 import javax.mail.Address;
 import javax.mail.MessagingException;

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/RejectAction.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/RejectAction.java
@@ -21,6 +21,7 @@ package org.apache.james.transport.mailets.jsieve;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 
 import javax.mail.Address;
@@ -38,11 +39,15 @@ import org.apache.james.mdn.fields.ReportingUserAgent;
 import org.apache.james.mdn.modifier.DispositionModifier;
 import org.apache.james.mdn.sending.mode.DispositionSendingMode;
 import org.apache.james.mdn.type.DispositionType;
+import org.apache.james.server.core.MailImpl;
 import org.apache.jsieve.mail.Action;
 import org.apache.jsieve.mail.ActionReject;
 import org.apache.mailet.Mail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.github.fge.lambdas.Throwing;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Performs the rejection of a mail, with a reply to the sender. 
@@ -133,13 +138,14 @@ public class RejectAction implements MailAction {
         reply.setContent(multipart);
         reply.saveChanges();
         Address[] recipientAddresses = reply.getAllRecipients();
-        if (null != recipientAddresses) {
-            Collection<MailAddress> recipients = new ArrayList<>(recipientAddresses.length);
-            for (Address recipientAddress : recipientAddresses) {
-                recipients.add(new MailAddress(
-                        (InternetAddress) recipientAddress));
-            }
-            context.post(null, recipients, reply);
+        if (recipientAddresses != null) {
+            context.post(MailImpl.builder()
+                .recipients(Arrays.stream(recipientAddresses)
+                    .map(address -> (InternetAddress) address)
+                    .map(Throwing.function(MailAddress::new))
+                    .collect(ImmutableList.toImmutableList()))
+                .mimeMessage(reply)
+                .build());
         } else {
             LOGGER.info("Unable to send reject MDN. Could not determine the recipient.");
         }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/SieveMailAdapter.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/SieveMailAdapter.java
@@ -375,8 +375,8 @@ public class SieveMailAdapter implements MailAdapter, EnvelopeAccessors, ActionC
     }
     
     @Override
-    public void post(MailAddress sender, Collection<MailAddress> recipients, MimeMessage mail) throws MessagingException {
-        getMailetContext().sendMail(sender, recipients, mail);
+    public void post(Mail mail) throws MessagingException {
+        getMailetContext().sendMail(mail);
     }
 
     @Override

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/SieveMailAdapter.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/SieveMailAdapter.java
@@ -260,8 +260,9 @@ public class SieveMailAdapter implements MailAdapter, EnvelopeAccessors, ActionC
      * @return String
      */
     public String getEnvelopeFrom() {
-        MailAddress sender = getMail().getSender(); 
-        return (null == sender ? "" : sender.toString());
+        return getMail().getSenderAsOptional()
+            .map(MailAddress::asString)
+            .orElse("");
     }
     
     /**

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/SieveMailAdapter.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/SieveMailAdapter.java
@@ -21,7 +21,6 @@ package org.apache.james.transport.mailets.jsieve;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/VacationAction.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/VacationAction.java
@@ -27,6 +27,7 @@ import javax.mail.MessagingException;
 import javax.mail.internet.AddressException;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.server.core.MailImpl;
 import org.apache.jsieve.mail.Action;
 import org.apache.jsieve.mail.optional.ActionVacation;
 import org.apache.mailet.Mail;
@@ -64,7 +65,12 @@ public class VacationAction implements MailAction {
             .reason(actionVacation.getReason())
             .subject(actionVacation.getSubject())
             .build();
-        context.post(vacationReply.getSender(), vacationReply.getRecipients(), vacationReply.getMimeMessage());
+
+        context.post(MailImpl.builder()
+            .sender(vacationReply.getSender())
+            .recipients(vacationReply.getRecipients())
+            .mimeMessage(vacationReply.getMimeMessage())
+            .build());
     }
 
     private boolean isStillInVacation(ActionVacation actionVacation, int dayDifference) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/VacationReply.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/jsieve/VacationReply.java
@@ -38,7 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 
 public class VacationReply {
     private static final Logger LOGGER = LoggerFactory.getLogger(VacationReply.class);
@@ -53,6 +53,8 @@ public class VacationReply {
         private String subject;
 
         public Builder(Mail originalMail, ActionContext context) {
+            Preconditions.checkArgument(originalMail.hasSender());
+
             this.originalMail = originalMail;
             this.context = context;
         }
@@ -85,7 +87,7 @@ public class VacationReply {
             reply.setSubject(generateNotificationSubject());
             reply.setContent(generateNotificationContent());
 
-            return new VacationReply(retrieveOriginalSender(), Lists.newArrayList(originalMail.getSender()), reply);
+            return new VacationReply(retrieveOriginalSender(), ImmutableList.of(originalMail.getSenderAsOptional().get()), reply);
         }
 
         private boolean eitherReasonOrMime() {
@@ -126,13 +128,13 @@ public class VacationReply {
             return multipart;
         }
 
-        private MailAddress retrieveOriginalSender() throws AddressException {
+        private MailAddress retrieveOriginalSender() {
             return Optional.ofNullable(from)
-                .map(address -> retrieveAddressFromString(address, context))
+                .map(this::retrieveAddressFromString)
                 .orElse(context.getRecipient());
         }
 
-        private MailAddress retrieveAddressFromString(String address, ActionContext context) {
+        private MailAddress retrieveAddressFromString(String address) {
             try {
                 return new MailAddress(address);
             } catch (AddressException e) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/redirect/NotifyMailetsMessage.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/redirect/NotifyMailetsMessage.java
@@ -69,7 +69,7 @@ public class NotifyMailetsMessage {
             builder.append("  Sent date: " + message.getSentDate())
                 .append(LINE_BREAK);
         }
-        builder.append("  MAIL FROM: " + originalMail.getSender())
+        builder.append("  MAIL FROM: " + originalMail.getSenderAsOptional().map(MailAddress::asString).orElse(MailAddress.NULL_SENDER_AS_STRING))
             .append(LINE_BREAK);
 
         boolean firstRecipient = true;

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/redirect/ProcessRedirectNotify.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/redirect/ProcessRedirectNotify.java
@@ -58,7 +58,7 @@ public class ProcessRedirectNotify {
 
             if (mailet.getInitParameters().isDebug()) {
                 LOGGER.debug("New mail - sender: {}, recipients: {}, name: {}, remoteHost: {}, remoteAddr: {}, state: {}, lastUpdated: {}, errorMessage: {}",
-                        newMail.getSender(), newMail.getRecipients(), newMail.getName(), newMail.getRemoteHost(), newMail.getRemoteAddr(), newMail.getState(), newMail.getLastUpdated(), newMail.getErrorMessage());
+                        newMail.getSenderAsOptional(), newMail.getRecipients(), newMail.getName(), newMail.getRemoteHost(), newMail.getRemoteAddr(), newMail.getState(), newMail.getLastUpdated(), newMail.getErrorMessage());
             }
 
             // Create the message
@@ -92,7 +92,7 @@ public class ProcessRedirectNotify {
                 }
             } else {
                 throw new MessagingException(mailet.getMailetName() + " mailet cannot forward " + originalMail.getName() + ". " +
-                        "Invalid sender domain for " + newMail.getSender() + ". " +
+                        "Invalid sender domain for " + newMail.getSenderAsOptional() + ". " +
                         "Consider using the Resend mailet " + "using a different sender.");
             }
 
@@ -177,9 +177,9 @@ public class ProcessRedirectNotify {
     @SuppressWarnings("deprecation")
     private boolean senderDomainIsValid(Mail mail) throws MessagingException {
         return !mailet.getInitParameters().getFakeDomainCheck()
-                || mail.getSender() == null
+                || !mail.hasSender()
                 || !mailet.getMailetContext()
-            .getMailServers(mail.getSender()
+            .getMailServers(mail.getSenderAsOptional().get()
                 .getDomain())
             .isEmpty();
     }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/Bouncer.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/Bouncer.java
@@ -47,7 +47,7 @@ public class Bouncer {
     }
 
     public void bounce(Mail mail, Exception ex) {
-        if (mail.getSender() == null) {
+        if (!mail.hasSender()) {
             LOGGER.debug("Null Sender: no bounce will be generated for {}", mail.getName());
         } else {
             if (configuration.getBounceProcessor() != null) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/MailDelivrer.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/MailDelivrer.java
@@ -91,7 +91,7 @@ public class MailDelivrer {
     private ExecutionResult tryDeliver(Mail mail) throws MessagingException {
         if (mail.getRecipients().isEmpty()) {
             LOGGER.info("No recipients specified... not sure how this could have happened.");
-            return ExecutionResult.permanentFailure(new Exception("No recipients specified for " + mail.getName() + " sent by " + mail.getSender()));
+            return ExecutionResult.permanentFailure(new Exception("No recipients specified for " + mail.getName() + " sent by " + mail.getSenderAsOptional()));
         }
         if (configuration.isDebug()) {
             LOGGER.debug("Attempting to deliver {}", mail.getName());

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/MailDelivrerToHost.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/MailDelivrerToHost.java
@@ -27,6 +27,7 @@ import javax.mail.Session;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 
+import org.apache.james.core.MailAddress;
 import org.apache.mailet.HostAddress;
 import org.apache.mailet.Mail;
 import org.apache.mailet.MailetContext;
@@ -77,12 +78,9 @@ public class MailDelivrerToHost {
 
     private Properties getPropertiesForMail(Mail mail) {
         Properties props = session.getProperties();
-        if (mail.getSender() == null) {
-            props.put("mail.smtp.from", "<>");
-        } else {
-            String sender = mail.getSender().toString();
-            props.put("mail.smtp.from", sender);
-        }
+        props.put("mail.smtp.from", mail.getSenderAsOptional()
+            .map(MailAddress::asString)
+            .orElse(MailAddress.NULL_SENDER_AS_STRING));
         return props;
     }
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/AbstractSQLWhitelistMatcher.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/AbstractSQLWhitelistMatcher.java
@@ -135,10 +135,10 @@ public abstract class AbstractSQLWhitelistMatcher extends GenericMatcher {
     @Override
     public Collection<MailAddress> match(Mail mail) throws MessagingException {
         // check if it's a local sender
-        MailAddress senderMailAddress = mail.getSender();
-        if (senderMailAddress == null) {
+        if (!mail.hasSender()) {
             return null;
         }
+        MailAddress senderMailAddress = mail.getSenderAsOptional().get();
         if (getMailetContext().isLocalEmail(senderMailAddress)) {
             // is a local sender, so return
             return null;

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/IsInWhiteList.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/IsInWhiteList.java
@@ -79,7 +79,10 @@ public class IsInWhiteList extends AbstractSQLWhitelistMatcher {
 
     @Override
     protected boolean matchedWhitelist(MailAddress recipientMailAddress, Mail mail) throws MessagingException {
-        MailAddress senderMailAddress = mail.getSender();
+        if (!mail.hasSender()) {
+            return true;
+        }
+        MailAddress senderMailAddress = mail.getSenderAsOptional().get();
         String senderUser = senderMailAddress.getLocalPart().toLowerCase(Locale.US);
         Domain senderHost = senderMailAddress.getDomain();
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/IsSenderInRRTLoop.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/IsSenderInRRTLoop.java
@@ -56,7 +56,9 @@ public class IsSenderInRRTLoop extends GenericMatcher {
     @Override
     public Collection<MailAddress> match(Mail mail) {
         try {
-            recipientRewriteTable.getMappings(mail.getSender().getLocalPart(), mail.getSender().getDomain());
+            if (mail.hasSender()) {
+                recipientRewriteTable.getMappings(mail.getSenderAsOptional().get().getLocalPart(), mail.getSenderAsOptional().get().getDomain());
+            }
         } catch (RecipientRewriteTable.TooManyMappingException e) {
             return mail.getRecipients();
         } catch (Exception e) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/SenderInFakeDomain.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/SenderInFakeDomain.java
@@ -38,10 +38,10 @@ public class SenderInFakeDomain extends AbstractNetworkMatcher {
 
     @Override
     public Collection<MailAddress> match(Mail mail) {
-        if (mail.getSender() == null) {
+        if (mail.hasSender()) {
             return null;
         }
-        Domain domain = mail.getSender().getDomain();
+        Domain domain = mail.getSenderAsOptional().get().getDomain();
         // DNS Lookup for this domain
         @SuppressWarnings("deprecation")
         Collection<String> servers = getMailetContext().getMailServers(domain);

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/dlp/Dlp.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/dlp/Dlp.java
@@ -66,9 +66,7 @@ public class Dlp extends GenericMatcher {
     }
 
     private Optional<DLPConfigurationItem.Id> findFirstMatchingRule(Mail mail) {
-        return Optional
-                .ofNullable(mail.getSender())
-                .filter(sender -> !sender.isNullSender())
+        return mail.getSenderAsOptional()
                 .flatMap(sender -> matchingRule(sender, mail));
     }
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/dlp/DlpDomainRules.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/dlp/DlpDomainRules.java
@@ -39,7 +39,6 @@ import org.apache.james.dlp.api.DLPConfigurationItem.Targets;
 import org.apache.james.javax.AddressHelper;
 import org.apache.james.javax.MultipartUtil;
 import org.apache.james.util.OptionalUtils;
-import org.apache.james.util.StreamUtils;
 import org.apache.mailet.Mail;
 
 import com.github.fge.lambdas.Throwing;
@@ -169,8 +168,7 @@ public class DlpDomainRules {
             }
 
             private Stream<String> listEnvelopSender(Mail mail) {
-                return StreamUtils.ofNullables(mail.getSender())
-                    .filter(sender -> !sender.isNullSender())
+                return OptionalUtils.toStream(mail.getSenderAsOptional())
                     .map(MailAddress::asString);
             }
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/util/ReplyToUtils.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/util/ReplyToUtils.java
@@ -20,8 +20,6 @@ package org.apache.james.transport.util;
 
 import java.util.Optional;
 
-import javax.mail.MessagingException;
-
 import org.apache.james.core.MailAddress;
 import org.apache.james.transport.mailets.redirect.SpecialAddress;
 import org.apache.mailet.Mail;
@@ -42,12 +40,12 @@ public class ReplyToUtils {
         this.replyTo = replyTo;
     }
 
-    public Optional<MailAddress> getReplyTo(Mail originalMail) throws MessagingException {
+    public Optional<MailAddress> getReplyTo(Mail originalMail) {
         if (replyTo.isPresent()) {
             if (replyTo.get().equals(SpecialAddress.UNALTERED)) {
                 return Optional.empty();
             }
-            return Optional.ofNullable(originalMail.getSender());
+            return originalMail.getSenderAsOptional();
         }
         return Optional.empty();
     }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/util/SpecialAddressesUtils.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/util/SpecialAddressesUtils.java
@@ -33,6 +33,7 @@ import org.apache.james.transport.mailets.redirect.AddressExtractor;
 import org.apache.james.transport.mailets.redirect.RedirectNotify;
 import org.apache.james.transport.mailets.redirect.SpecialAddress;
 import org.apache.james.transport.mailets.redirect.SpecialAddressKind;
+import org.apache.james.util.OptionalUtils;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.RFC2822Headers;
 import org.slf4j.Logger;
@@ -98,7 +99,7 @@ public class SpecialAddressesUtils {
             case SENDER:
             case FROM:
             case REVERSE_PATH:
-                return Optional.ofNullable(mail.getSender())
+                return mail.getSenderAsOptional()
                     .map(ImmutableSet::of)
                     .orElse(ImmutableSet.of());
             case REPLY_TO:
@@ -129,11 +130,7 @@ public class SpecialAddressesUtils {
     }
 
     private Set<MailAddress> getSender(Mail mail) {
-        MailAddress sender = mail.getSender();
-        if (sender != null) {
-            return ImmutableSet.of(sender);
-        }
-        return ImmutableSet.of();
+        return OptionalUtils.toSet(mail.getSenderAsOptional());
     }
 
     private Set<MailAddress> getReplyTos(InternetAddress[] replyToArray) {
@@ -189,10 +186,7 @@ public class SpecialAddressesUtils {
         switch (specialAddressKind) {
             case SENDER:
             case REVERSE_PATH:
-                return Optional.ofNullable(mail.getSender())
-                    .filter(address -> !address.isNullSender())
-                    .map(ImmutableSet::of)
-                    .orElse(ImmutableSet.of());
+                return OptionalUtils.toSet(mail.getSenderAsOptional());
             case FROM:
                 try {
                     InternetAddress[] fromArray = (InternetAddress[]) mail.getMessage().getFrom();
@@ -225,12 +219,8 @@ public class SpecialAddressesUtils {
         if (addresses != null) {
             return MailAddressUtils.from(addresses);
         } else {
-            MailAddress reversePath = mail.getSender();
-            if (reversePath != null) {
-                return ImmutableList.of(reversePath);
-            }
+            return OptionalUtils.toList(mail.getSenderAsOptional());
         }
-        return ImmutableList.of();
     }
 
     private List<MailAddress> toHeaders(Mail mail) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/util/SpecialAddressesUtils.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/util/SpecialAddressesUtils.java
@@ -87,10 +87,6 @@ public class SpecialAddressesUtils {
             return ImmutableSet.of(mailAddress);
         }
 
-        if (mailAddress.isNullSender()) {
-            return ImmutableList.of();
-        }
-
         SpecialAddressKind specialAddressKind = SpecialAddressKind.forValue(mailAddress.getLocalPart());
         if (specialAddressKind == null) {
             return ImmutableSet.of(mailAddress);

--- a/server/mailet/mailets/src/test/java/org/apache/james/samples/mailets/HelloWorldMailet.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/samples/mailets/HelloWorldMailet.java
@@ -18,8 +18,7 @@
  ****************************************************************/
 package org.apache.james.samples.mailets;
 
-import javax.mail.MessagingException;
-
+import org.apache.james.core.MailAddress;
 import org.apache.mailet.Mail;
 import org.apache.mailet.Mailet;
 import org.apache.mailet.MailetConfig;
@@ -49,13 +48,13 @@ public class HelloWorldMailet implements Mailet {
     }
 
     @Override
-    public void init(MailetConfig config) throws MessagingException {
+    public void init(MailetConfig config) {
         this.config = config;
     }
 
     @Override
-    public void service(Mail mail) throws MessagingException {
+    public void service(Mail mail) {
         LOGGER.info("Hello, World!");
-        LOGGER.info("You have mail from {}", mail.getSender().getLocalPart());
+        LOGGER.info("You have mail from {}", mail.getSenderAsOptional().map(MailAddress::getLocalPart));
     }
 }

--- a/server/mailet/mailets/src/test/java/org/apache/james/samples/mailets/InstrumentationMailet.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/samples/mailets/InstrumentationMailet.java
@@ -88,8 +88,8 @@ public class InstrumentationMailet implements Mailet {
             LOGGER.info("Remote Address: " + mail.getRemoteAddr());
             LOGGER.info("Remote Host: " + mail.getRemoteHost());
             LOGGER.info("State: " + mail.getState());
-            LOGGER.info("Sender host: " + mail.getSender().getDomain().name());
-            LOGGER.info("Sender user: " + mail.getSender().getLocalPart());
+            LOGGER.info("Sender host: " + mail.getSenderAsOptional().map(mailAddress -> mailAddress.getDomain().name()));
+            LOGGER.info("Sender user: " + mail.getSenderAsOptional().map(MailAddress::getLocalPart));
             Collection<MailAddress> recipients = mail.getRecipients();
             for (MailAddress address : recipients) {
                 LOGGER.info("Recipient: " + address.getLocalPart() + "@" + address.getDomain().name());

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessorTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessorTest.java
@@ -68,7 +68,7 @@ public class RecipientRewriteTableProcessorTest {
         MockitoAnnotations.initMocks(this);
         mailetContext = FakeMailContext.defaultContext();
         processor = new RecipientRewriteTableProcessor(virtualTableStore, domainList, mailetContext);
-        mail = FakeMail.builder().build();
+        mail = FakeMail.builder().sender(MailAddressFixture.ANY_AT_JAMES).build();
         mappings = MappingsImpl.builder()
                 .add(MailAddressFixture.ANY_AT_JAMES.toString())
                 .build();
@@ -86,7 +86,7 @@ public class RecipientRewriteTableProcessorTest {
                 .add(MailAddressFixture.OTHER_AT_JAMES.toString())
                 .build();
 
-        processor.handleMappings(mappings, MailAddressFixture.ANY_AT_JAMES, MailAddressFixture.OTHER_AT_JAMES, message);
+        processor.handleMappings(mappings, FakeMail.builder().sender(MailAddressFixture.ANY_AT_JAMES).build(), MailAddressFixture.OTHER_AT_JAMES, message);
     }
 
     @Test
@@ -97,7 +97,7 @@ public class RecipientRewriteTableProcessorTest {
                 .add(MailAddressFixture.OTHER_AT_JAMES.toString())
                 .build();
 
-        processor.handleMappings(mappings, MailAddressFixture.ANY_AT_JAMES, MailAddressFixture.OTHER_AT_JAMES, message);
+        processor.handleMappings(mappings, mail, MailAddressFixture.OTHER_AT_JAMES, message);
     }
 
     @Test
@@ -109,7 +109,7 @@ public class RecipientRewriteTableProcessorTest {
                 .add(MailAddressFixture.OTHER_AT_JAMES.toString())
                 .build();
 
-        Collection<MailAddress> result = processor.handleMappings(mappings, MailAddressFixture.ANY_AT_JAMES, MailAddressFixture.OTHER_AT_JAMES, message);
+        Collection<MailAddress> result = processor.handleMappings(mappings, mail, MailAddressFixture.OTHER_AT_JAMES, message);
 
         assertThat(result).containsOnly(nonDomainWithDefaultLocal);
     }
@@ -125,7 +125,7 @@ public class RecipientRewriteTableProcessorTest {
                 .add(MailAddressFixture.OTHER_AT_JAMES.toString())
                 .build();
 
-        Collection<MailAddress> result = processor.handleMappings(mappings, MailAddressFixture.ANY_AT_JAMES, MailAddressFixture.OTHER_AT_JAMES, message);
+        Collection<MailAddress> result = processor.handleMappings(mappings, mail, MailAddressFixture.OTHER_AT_JAMES, message);
 
         assertThat(result).containsOnly(MailAddressFixture.ANY_AT_LOCAL);
     }
@@ -140,7 +140,7 @@ public class RecipientRewriteTableProcessorTest {
                 .add(MailAddressFixture.OTHER_AT_JAMES.toString())
                 .build();
 
-        Collection<MailAddress> result = processor.handleMappings(mappings, MailAddressFixture.ANY_AT_JAMES, MailAddressFixture.OTHER_AT_JAMES, message);
+        Collection<MailAddress> result = processor.handleMappings(mappings, mail, MailAddressFixture.OTHER_AT_JAMES, message);
 
         assertThat(result).containsOnly(nonDomainWithDefaultLocal);
     }
@@ -156,7 +156,7 @@ public class RecipientRewriteTableProcessorTest {
                 .add(MailAddressFixture.OTHER_AT_JAMES.toString())
                 .build();
 
-        processor.handleMappings(mappings, MailAddressFixture.ANY_AT_JAMES, MailAddressFixture.OTHER_AT_JAMES, message);
+        processor.handleMappings(mappings, mail, MailAddressFixture.OTHER_AT_JAMES, message);
 
         FakeMailContext.SentMail expected = FakeMailContext.sentMailBuilder()
                 .sender(MailAddressFixture.ANY_AT_JAMES)
@@ -177,7 +177,7 @@ public class RecipientRewriteTableProcessorTest {
                 .add(INVALID_MAIL_ADDRESS)
                 .build();
 
-        processor.handleMappings(mappings, MailAddressFixture.ANY_AT_JAMES, MailAddressFixture.OTHER_AT_JAMES, message);
+        processor.handleMappings(mappings, mail, MailAddressFixture.OTHER_AT_JAMES, message);
 
         assertThat(mailetContext.getSentMails()).isEmpty();
     }
@@ -192,7 +192,7 @@ public class RecipientRewriteTableProcessorTest {
                 .add(MailAddressFixture.ANY_AT_LOCAL.toString())
                 .build();
 
-        Collection<MailAddress> result = processor.handleMappings(mappings, MailAddressFixture.ANY_AT_JAMES, MailAddressFixture.OTHER_AT_JAMES, message);
+        Collection<MailAddress> result = processor.handleMappings(mappings, mail, MailAddressFixture.OTHER_AT_JAMES, message);
 
         assertThat(result).containsOnly(nonDomainWithDefaultLocal, MailAddressFixture.ANY_AT_LOCAL);
     }
@@ -206,7 +206,7 @@ public class RecipientRewriteTableProcessorTest {
                 .add(MailAddressFixture.OTHER_AT_JAMES.toString())
                 .build();
 
-        Collection<MailAddress> result = processor.handleMappings(mappings, MailAddressFixture.ANY_AT_JAMES, MailAddressFixture.OTHER_AT_JAMES, message);
+        Collection<MailAddress> result = processor.handleMappings(mappings, mail, MailAddressFixture.OTHER_AT_JAMES, message);
 
         FakeMailContext.SentMail expected = FakeMailContext.sentMailBuilder()
                 .sender(MailAddressFixture.ANY_AT_JAMES)

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/DeliveryUtilsTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/DeliveryUtilsTest.java
@@ -21,14 +21,28 @@ package org.apache.james.transport.mailets.delivery;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Optional;
+
+import org.apache.james.core.MailAddress;
 import org.apache.mailet.base.MailAddressFixture;
 import org.junit.Test;
 
 public class DeliveryUtilsTest {
 
     @Test
+    public void prettyPrintShouldDisplayNullAddressesOptional() {
+        assertThat(DeliveryUtils.prettyPrint(Optional.empty())).isEqualTo("<>");
+    }
+
+    @Test
     public void prettyPrintShouldDisplayNullAddresses() {
-        assertThat(DeliveryUtils.prettyPrint(null)).isEqualTo("<>");
+        MailAddress mailAddress = null;
+        assertThat(DeliveryUtils.prettyPrint(mailAddress)).isEqualTo("<>");
+    }
+
+    @Test
+    public void prettyPrintShouldDisplayNullSender() {
+        assertThat(DeliveryUtils.prettyPrint(MailAddress.nullSender())).isEqualTo("<>");
     }
 
     @Test

--- a/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
+++ b/server/mailrepository/mailrepository-api/src/test/java/org/apache/james/mailrepository/MailRepositoryContract.java
@@ -150,7 +150,7 @@ public interface MailRepositoryContract {
 
         testee.store(mail);
 
-        assertThat(testee.retrieve(MAIL_1).getSender()).isEqualTo(MailAddress.nullSender());
+        assertThat(testee.retrieve(MAIL_1).getSenderAsOptional()).isEmpty();
     }
 
     @Test

--- a/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryMailDAO.java
+++ b/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryMailDAO.java
@@ -174,7 +174,7 @@ public class CassandraMailRepositoryMailDAO {
 
     private MailDTO toMail(Row row) {
         MailAddress sender = Optional.ofNullable(row.getString(SENDER))
-            .map(MailAddress::getMailSender)
+            .flatMap(MailAddress::getMailSenderAsOptional)
             .orElse(null);
         List<MailAddress> recipients = row.getList(RECIPIENTS, String.class)
             .stream()

--- a/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryMailDAO.java
+++ b/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryMailDAO.java
@@ -145,7 +145,7 @@ public class CassandraMailRepositoryMailDAO {
             .setString(HEADER_BLOB_ID, headerId.asString())
             .setString(BODY_BLOB_ID, bodyId.asString())
             .setString(STATE, mail.getState())
-            .setString(SENDER, Optional.ofNullable(mail.getSender())
+            .setString(SENDER, mail.getSenderAsOptional()
                 .map(MailAddress::asString)
                 .orElse(null))
             .setList(RECIPIENTS, asStringList(mail.getRecipients()))

--- a/server/mailrepository/mailrepository-cassandra/src/test/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryMailDAOTest.java
+++ b/server/mailrepository/mailrepository-cassandra/src/test/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryMailDAOTest.java
@@ -104,7 +104,7 @@ class CassandraMailRepositoryMailDAOTest {
                     .containsOnly(MailAddressFixture.RECIPIENT1);
             softly.assertThat(partialMail.getPerRecipientSpecificHeaders().getHeadersForRecipient(MailAddressFixture.RECIPIENT1))
                     .containsOnly(header);
-            softly.assertThat(partialMail.getSender()).isEqualTo(MailAddressFixture.SENDER);
+            softly.assertThat(partialMail.getSenderAsOptional()).contains(MailAddressFixture.SENDER);
             softly.assertThat(partialMail.getRecipients()).containsOnly(MailAddressFixture.RECIPIENT1, MailAddressFixture.RECIPIENT2);
         });
     }

--- a/server/protocols/fetchmail/src/main/java/org/apache/james/fetchmail/MessageProcessor.java
+++ b/server/protocols/fetchmail/src/main/java/org/apache/james/fetchmail/MessageProcessor.java
@@ -628,7 +628,7 @@ public class MessageProcessor extends ProcessorAbstract {
             StringBuilder messageBuffer = new StringBuilder("Created mail with name: ");
             messageBuffer.append(mail.getName());
             messageBuffer.append(", sender: ");
-            messageBuffer.append(mail.getSender());
+            messageBuffer.append(mail.getSenderAsOptional());
             messageBuffer.append(", recipients: ");
             for (Object o : mail.getRecipients()) {
                 messageBuffer.append(o);

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationMailet.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationMailet.java
@@ -65,6 +65,9 @@ public class VacationMailet extends GenericMailet {
     @Override
     public void service(Mail mail) {
         try {
+            if (!mail.hasSender()) {
+                return;
+            }
             if (! automaticallySentMailDetector.isAutomaticallySent(mail)) {
                 ZonedDateTime processingDate = zonedDateTimeProvider.get();
                 mail.getRecipients()
@@ -84,7 +87,7 @@ public class VacationMailet extends GenericMailet {
                 vacationRepository.retrieveVacation(accountId),
                 notificationRegistry.isRegistered(
                     AccountId.fromString(recipient.toString()),
-                    RecipientId.fromMailAddress(processedMail.getSender())),
+                    RecipientId.fromMailAddress(processedMail.getSenderAsOptional().get())),
                 (vacation, alreadySent) ->
                     sendNotificationIfRequired(recipient, processedMail, processingDate, vacation, alreadySent))
             .thenCompose(Function.identity());
@@ -110,10 +113,10 @@ public class VacationMailet extends GenericMailet {
                 .build(mimeMessageBodyGenerator);
             sendNotification(vacationReply);
             return notificationRegistry.register(AccountId.fromString(recipient.toString()),
-                RecipientId.fromMailAddress(processedMail.getSender()),
+                RecipientId.fromMailAddress(processedMail.getSenderAsOptional().get()),
                 vacation.getToDate());
         } catch (MessagingException e) {
-            LOGGER.warn("Failed to send JMAP vacation notification from {} to {}", recipient, processedMail.getSender(), e);
+            LOGGER.warn("Failed to send JMAP vacation notification from {} to {}", recipient, processedMail.getSenderAsOptional(), e);
             return CompletableFuture.completedFuture(null);
         }
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationReply.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationReply.java
@@ -33,7 +33,6 @@ import org.apache.mailet.base.AutomaticallySentMailDetector;
 
 import com.github.fge.lambdas.Throwing;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 
 public class VacationReply {
 

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationReply.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/VacationReply.java
@@ -27,6 +27,7 @@ import javax.mail.internet.MimeMessage;
 import org.apache.james.core.MailAddress;
 import org.apache.james.jmap.api.vacation.Vacation;
 import org.apache.james.jmap.utils.MimeMessageBodyGenerator;
+import org.apache.james.util.OptionalUtils;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.AutomaticallySentMailDetector;
 
@@ -68,16 +69,16 @@ public class VacationReply {
 
         public VacationReply build(MimeMessageBodyGenerator mimeMessageBodyGenerator) throws MessagingException {
             Preconditions.checkState(mailRecipient != null, "Original recipient address should not be null");
-            Preconditions.checkState(originalMail.getSender() != null, "Original sender address should not be null");
+            Preconditions.checkState(originalMail.hasSender(), "Original sender address should not be null");
 
-            return new VacationReply(mailRecipient, ImmutableList.of(originalMail.getSender()), generateMimeMessage(mimeMessageBodyGenerator));
+            return new VacationReply(mailRecipient, OptionalUtils.toList(originalMail.getSenderAsOptional()), generateMimeMessage(mimeMessageBodyGenerator));
         }
 
         private MimeMessage generateMimeMessage(MimeMessageBodyGenerator mimeMessageBodyGenerator) throws MessagingException {
             MimeMessage reply = (MimeMessage) originalMail.getMessage().reply(NOT_REPLY_TO_ALL);
             vacation.getSubject().ifPresent(Throwing.consumer(subjectString -> reply.setHeader("subject", subjectString)));
             reply.setHeader(FROM_HEADER, mailRecipient.toString());
-            reply.setHeader(TO_HEADER, originalMail.getSender().toString());
+            reply.setHeader(TO_HEADER, originalMail.getSenderAsOptional().get().toString());
             reply.setHeader(AutomaticallySentMailDetector.AUTO_SUBMITTED_HEADER, AutomaticallySentMailDetector.AUTO_REPLIED_VALUE);
 
             return mimeMessageBodyGenerator.from(reply, vacation.getTextBody(), vacation.getHtmlBody());

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMessagesUpdateProcessor.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/methods/SetMessagesUpdateProcessor.java
@@ -180,7 +180,7 @@ public class SetMessagesUpdateProcessor implements SetMessagesProcessor {
             if (maybeMessageToSend.isPresent()) {
                 MessageResult messageToSend = maybeMessageToSend.get();
                 MailImpl mail = buildMailFromMessage(messageToSend);
-                assertUserIsSender(mailboxSession, mail.getSender());
+                assertUserIsSender(mailboxSession, mail.getSenderAsOptional());
                 messageSender.sendMessage(messageId, mail, mailboxSession);
                 referenceUpdater.updateReferences(messageToSend.getHeaders(), mailboxSession);
             } else {
@@ -189,8 +189,11 @@ public class SetMessagesUpdateProcessor implements SetMessagesProcessor {
         }
     }
 
-    private void assertUserIsSender(MailboxSession session, MailAddress sender) throws MailboxSendingNotAllowedException {
-        if (!session.getUser().isSameUser(sender.asString())) {
+    private void assertUserIsSender(MailboxSession session, Optional<MailAddress> sender) throws MailboxSendingNotAllowedException {
+        boolean userIsSender = sender.map(address -> session.getUser().isSameUser(address.asString()))
+            .orElse(false);
+
+        if (!userIsSender) {
             String allowedSender = session.getUser().getUserName();
             throw new MailboxSendingNotAllowedException(allowedSender);
         }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/send/MailFactoryTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/send/MailFactoryTest.java
@@ -116,7 +116,7 @@ public class MailFactoryTest {
         Mail actual = testee.build(message, envelope);
         
         assertThat(actual.getName()).isEqualTo(expectedName);
-        assertThat(actual.getSender()).isEqualTo(expectedSender);
+        assertThat(actual.getSenderAsOptional()).contains(expectedSender);
         assertThat(actual.getRecipients()).containsAll(expectedRecipients);
     }
 }

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/DataLineJamesMessageHookHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/DataLineJamesMessageHookHandler.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 import javax.mail.MessagingException;
 
@@ -260,8 +261,14 @@ public class DataLineJamesMessageHookHandler implements DataLineFilter, Extensib
         }
 
         @Override
+        @Deprecated
         public MailAddress getSender() {
             return mail.getSender();
+        }
+
+        @Override
+        public Optional<MailAddress> getSenderAsOptional() {
+            return mail.getSenderAsOptional();
         }
 
         @Override

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/DataLineJamesMessageHookHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/DataLineJamesMessageHookHandler.java
@@ -99,9 +99,9 @@ public class DataLineJamesMessageHookHandler implements DataLineFilter, Extensib
 
                 @SuppressWarnings("unchecked")
                 List<MailAddress> recipientCollection = (List<MailAddress>) session.getAttachment(SMTPSession.RCPT_LIST, State.Transaction);
-                MailAddress mailAddress = (MailAddress) session.getAttachment(SMTPSession.SENDER, State.Transaction);
+                Optional<MailAddress> sender = (Optional<MailAddress>) session.getAttachment(SMTPSession.SENDER, State.Transaction);
 
-                MailImpl mail = new MailImpl(MailImpl.getId(), mailAddress, recipientCollection);
+                MailImpl mail = new MailImpl(MailImpl.getId(), sender, recipientCollection);
 
                 // store mail in the session so we can be sure it get disposed later
                 session.setAttachment(SMTPConstants.MAIL, mail, State.Transaction);

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SendMailHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SendMailHandler.java
@@ -68,7 +68,7 @@ public class SendMailHandler implements JamesMessageHook {
 
         try {
             queue.enQueue(mail);
-            LOGGER.info("Successfully spooled mail {} from {} on {} for {}", mail.getName(), mail.getSender(), session.getRemoteAddress().getAddress(), mail.getRecipients());
+            LOGGER.info("Successfully spooled mail {} from {} on {} for {}", mail.getName(), mail.getSenderAsOptional(), session.getRemoteAddress().getAddress(), mail.getRecipients());
         } catch (MessagingException me) {
             LOGGER.error("Unknown error occurred while processing DATA.", me);
             return HookResult.builder()

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SenderAuthIdentifyVerificationRcptHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SenderAuthIdentifyVerificationRcptHook.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.smtpserver;
 
+import java.util.Optional;
+
 import javax.inject.Inject;
 
 import org.apache.commons.configuration.Configuration;
@@ -61,7 +63,7 @@ public class SenderAuthIdentifyVerificationRcptHook extends AbstractSenderAuthId
     }
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender, MailAddress rcpt) {
         ExtendedSMTPSession nSession = (ExtendedSMTPSession) session;
         if (nSession.verifyIdentity()) {
             return super.doRcpt(session, sender, rcpt);

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/JDBCGreylistHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/JDBCGreylistHandler.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.sql.DataSource;
@@ -353,7 +354,7 @@ public class JDBCGreylistHandler extends AbstractGreylistHandler implements Prot
     }
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender, MailAddress rcpt) {
         if ((wNetworks == null) || (!wNetworks.matchInetNetwork(session.getRemoteAddress().getAddress().getHostAddress()))) {
             return super.doRcpt(session, sender, rcpt);
         } else {

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SPFHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SPFHandler.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.smtpserver.fastfail;
 
+import java.util.Optional;
+
 import javax.inject.Inject;
 
 import org.apache.commons.configuration.Configuration;
@@ -148,7 +150,7 @@ public class SPFHandler implements JamesMessageHook, MailHook, RcptHook, Protoco
     }
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender, MailAddress rcpt) {
         if (!session.isRelayingAllowed()) {
             // Check if session is blocklisted
             if (session.getAttachment(SPF_BLOCKLISTED, State.Transaction) != null) {

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptMX.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptMX.java
@@ -22,6 +22,7 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -87,7 +88,7 @@ public class ValidRcptMX implements RcptHook, ProtocolHandler {
     }
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, Optional<MailAddress> sender, MailAddress rcpt) {
 
         Domain domain = rcpt.getDomain();
 

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
@@ -344,7 +344,7 @@ public class SMTPServerTest {
         }
 
         if (sender != null) {
-            assertThat(mailData.getSender().toString())
+            assertThat(mailData.getSenderAsOptional().map(MailAddress::asString).orElse(MailAddress.NULL_SENDER_AS_STRING))
                 .as("sender verfication")
                 .isEqualTo(sender);
         }

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SPFHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SPFHandlerTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.jspf.core.DNSRequest;
@@ -177,7 +178,7 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
+        assertThat(spf.doRcpt(mockedSMTPSession, Optional.of(sender), rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
     }
 
     @Test
@@ -190,7 +191,7 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("fail").isEqualTo(HookReturnCode.deny());
+        assertThat(spf.doRcpt(mockedSMTPSession, Optional.of(sender), rcpt).getResult()).describedAs("fail").isEqualTo(HookReturnCode.deny());
     }
 
     @Test
@@ -203,7 +204,7 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("softfail declined").isEqualTo(HookReturnCode.declined());
+        assertThat(spf.doRcpt(mockedSMTPSession, Optional.of(sender), rcpt).getResult()).describedAs("softfail declined").isEqualTo(HookReturnCode.declined());
     }
 
     @Test
@@ -219,7 +220,7 @@ public class SPFHandlerTest {
         spf.setBlockSoftFail(true);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("softfail reject").isEqualTo(HookReturnCode.deny());
+        assertThat(spf.doRcpt(mockedSMTPSession, Optional.of(sender), rcpt).getResult()).describedAs("softfail reject").isEqualTo(HookReturnCode.deny());
     }
 
     @Test
@@ -235,7 +236,7 @@ public class SPFHandlerTest {
         spf.setBlockSoftFail(true);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("permerror reject").isEqualTo(HookReturnCode.deny());
+        assertThat(spf.doRcpt(mockedSMTPSession, Optional.of(sender), rcpt).getResult()).describedAs("permerror reject").isEqualTo(HookReturnCode.deny());
     }
 
     @Test
@@ -250,7 +251,7 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("temperror denysoft").isEqualTo(HookReturnCode.denySoft());
+        assertThat(spf.doRcpt(mockedSMTPSession, Optional.of(sender), rcpt).getResult()).describedAs("temperror denysoft").isEqualTo(HookReturnCode.denySoft());
     }
 
     @Test
@@ -264,7 +265,7 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
+        assertThat(spf.doRcpt(mockedSMTPSession, Optional.of(sender), rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
     }
 
     @Test
@@ -279,6 +280,6 @@ public class SPFHandlerTest {
         spf.setBlockPermError(false);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
+        assertThat(spf.doRcpt(mockedSMTPSession, Optional.of(sender), rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
     }
 }

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SPFHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SPFHandlerTest.java
@@ -170,7 +170,7 @@ public class SPFHandlerTest {
 
     @Test
     public void testSPFpass() throws Exception {
-        MailAddress sender = new MailAddress("test@spf1.james.apache.org");
+        Optional<MailAddress> sender = Optional.of(new MailAddress("test@spf1.james.apache.org"));
         MailAddress rcpt = new MailAddress("test@localhost");
         setupMockedSMTPSession("192.168.100.1", "spf1.james.apache.org");
         SPFHandler spf = new SPFHandler();
@@ -178,12 +178,12 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, Optional.of(sender), rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
     }
 
     @Test
     public void testSPFfail() throws Exception {
-        MailAddress sender = new MailAddress("test@spf2.james.apache.org");
+        Optional<MailAddress> sender = Optional.of(new MailAddress("test@spf2.james.apache.org"));
         MailAddress rcpt = new MailAddress("test@localhost");
         setupMockedSMTPSession("192.168.100.1", "spf2.james.apache.org");
         SPFHandler spf = new SPFHandler();
@@ -191,12 +191,12 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, Optional.of(sender), rcpt).getResult()).describedAs("fail").isEqualTo(HookReturnCode.deny());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("fail").isEqualTo(HookReturnCode.deny());
     }
 
     @Test
     public void testSPFsoftFail() throws Exception {
-        MailAddress sender = new MailAddress("test@spf3.james.apache.org");
+        Optional<MailAddress> sender = Optional.of(new MailAddress("test@spf3.james.apache.org"));
         MailAddress rcpt = new MailAddress("test@localhost");
         setupMockedSMTPSession("192.168.100.1", "spf3.james.apache.org");
         SPFHandler spf = new SPFHandler();
@@ -204,12 +204,12 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, Optional.of(sender), rcpt).getResult()).describedAs("softfail declined").isEqualTo(HookReturnCode.declined());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("softfail declined").isEqualTo(HookReturnCode.declined());
     }
 
     @Test
     public void testSPFsoftFailRejectEnabled() throws Exception {
-        MailAddress sender = new MailAddress("test@spf3.james.apache.org");
+        Optional<MailAddress> sender = Optional.of(new MailAddress("test@spf3.james.apache.org"));
         MailAddress rcpt = new MailAddress("test@localhost");
 
         setupMockedSMTPSession("192.168.100.1", "spf3.james.apache.org");
@@ -220,12 +220,12 @@ public class SPFHandlerTest {
         spf.setBlockSoftFail(true);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, Optional.of(sender), rcpt).getResult()).describedAs("softfail reject").isEqualTo(HookReturnCode.deny());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("softfail reject").isEqualTo(HookReturnCode.deny());
     }
 
     @Test
     public void testSPFpermError() throws Exception {
-        MailAddress sender = new MailAddress("test@spf4.james.apache.org");
+        Optional<MailAddress> sender = Optional.of(new MailAddress("test@spf4.james.apache.org"));
         MailAddress rcpt = new MailAddress("test@localhost");
 
         setupMockedSMTPSession("192.168.100.1", "spf4.james.apache.org");
@@ -236,12 +236,12 @@ public class SPFHandlerTest {
         spf.setBlockSoftFail(true);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, Optional.of(sender), rcpt).getResult()).describedAs("permerror reject").isEqualTo(HookReturnCode.deny());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("permerror reject").isEqualTo(HookReturnCode.deny());
     }
 
     @Test
     public void testSPFtempError() throws Exception {
-        MailAddress sender = new MailAddress("test@spf5.james.apache.org");
+        Optional<MailAddress> sender = Optional.of(new MailAddress("test@spf5.james.apache.org"));
         MailAddress rcpt = new MailAddress("test@localhost");
 
         setupMockedSMTPSession("192.168.100.1", "spf5.james.apache.org");
@@ -251,12 +251,12 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, Optional.of(sender), rcpt).getResult()).describedAs("temperror denysoft").isEqualTo(HookReturnCode.denySoft());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("temperror denysoft").isEqualTo(HookReturnCode.denySoft());
     }
 
     @Test
     public void testSPFNoRecord() throws Exception {
-        MailAddress sender = new MailAddress("test@spf6.james.apache.org");
+        Optional<MailAddress> sender = Optional.of(new MailAddress("test@spf6.james.apache.org"));
         MailAddress rcpt = new MailAddress("test@localhost");
 
         setupMockedSMTPSession("192.168.100.1", "spf6.james.apache.org");
@@ -265,12 +265,12 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, Optional.of(sender), rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
     }
 
     @Test
     public void testSPFpermErrorRejectDisabled() throws Exception {
-        MailAddress sender = new MailAddress("test@spf4.james.apache.org");
+        Optional<MailAddress> sender = Optional.of(new MailAddress("test@spf4.james.apache.org"));
         MailAddress rcpt = new MailAddress("test@localhost");
         setupMockedSMTPSession("192.168.100.1", "spf4.james.apache.org");
         SPFHandler spf = new SPFHandler();
@@ -280,6 +280,6 @@ public class SPFHandlerTest {
         spf.setBlockPermError(false);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, Optional.of(sender), rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
     }
 }

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SpamAssassinHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SpamAssassinHandlerTest.java
@@ -22,10 +22,13 @@ import static org.apache.james.spamassassin.SpamAssassinResult.STATUS_MAIL_ATTRI
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
+import java.util.Optional;
 
 import javax.mail.MessagingException;
+import javax.mail.internet.AddressException;
 import javax.mail.internet.MimeMessage;
 
+import org.apache.james.core.MailAddress;
 import org.apache.james.core.builder.MimeMessageBuilder;
 import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.james.protocols.smtp.SMTPSession;
@@ -72,7 +75,11 @@ public class SpamAssassinHandlerTest {
 
             @Override
             public Object getAttachment(String key, State state) {
-                sstate.put(SMTPSession.SENDER, "sender@james.apache.org");
+                try {
+                    sstate.put(SMTPSession.SENDER, Optional.of(new MailAddress("sender@james.apache.org")));
+                } catch (AddressException e) {
+                    throw new RuntimeException(e);
+                }
                 if (state == State.Connection) {
                     return connectionState.get(key);
                 } else {

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/URIRBLHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/URIRBLHandlerTest.java
@@ -27,10 +27,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 
 import javax.mail.MessagingException;
+import javax.mail.internet.AddressException;
 import javax.mail.internet.MimeMessage;
 
+import org.apache.james.core.MailAddress;
 import org.apache.james.core.builder.MimeMessageBuilder;
 import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.dnsservice.api.mock.MockDNSService;
@@ -78,7 +81,11 @@ public class URIRBLHandlerTest {
 
             @Override
             public Object getAttachment(String key, State state) {
-                sstate.put(SMTPSession.SENDER, "sender@james.apache.org");
+                try {
+                    sstate.put(SMTPSession.SENDER, Optional.of(new MailAddress("sender@james.apache.org")));
+                } catch (AddressException e) {
+                    throw new RuntimeException(e);
+                }
 
                 if (state == State.Connection) {
                     return connectionState.get(key);

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.util.HashMap;
+import java.util.Optional;
 
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
@@ -115,7 +116,7 @@ public class ValidRcptHandlerTest {
     public void doRcptShouldRejectNotExistingLocalUsersWhenNoRelay() {
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, SENDER, invalidUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, Optional.of(SENDER), invalidUserEmail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.deny());
     }
@@ -124,7 +125,7 @@ public class ValidRcptHandlerTest {
     public void doRcptShouldDenyNotExistingLocalUsersWhenRelay() {
         SMTPSession session = setupMockedSMTPSession(RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, SENDER, invalidUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, Optional.of(SENDER), invalidUserEmail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.deny());
     }
@@ -134,7 +135,7 @@ public class ValidRcptHandlerTest {
         MailAddress mailAddress = new MailAddress(INVALID_USER + "@otherdomain");
         SMTPSession session = setupMockedSMTPSession(RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, SENDER, mailAddress).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, Optional.of(SENDER), mailAddress).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
@@ -144,7 +145,7 @@ public class ValidRcptHandlerTest {
         MailAddress mailAddress = new MailAddress(INVALID_USER + "@otherdomain");
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, SENDER, mailAddress).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, Optional.of(SENDER), mailAddress).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
@@ -153,7 +154,7 @@ public class ValidRcptHandlerTest {
     public void doRcptShouldDeclineValidUsersWhenNoRelay() throws Exception {
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, SENDER, validUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, Optional.of(SENDER), validUserEmail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
@@ -162,7 +163,7 @@ public class ValidRcptHandlerTest {
     public void doRcptShouldDeclineValidUsersWhenRelay() throws Exception {
         SMTPSession session = setupMockedSMTPSession(RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, SENDER, validUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, Optional.of(SENDER), validUserEmail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
@@ -173,7 +174,7 @@ public class ValidRcptHandlerTest {
 
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, SENDER, validUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, Optional.of(SENDER), validUserEmail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
@@ -185,7 +186,7 @@ public class ValidRcptHandlerTest {
 
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, SENDER, user1mail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, Optional.of(SENDER), user1mail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
@@ -196,7 +197,7 @@ public class ValidRcptHandlerTest {
 
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, SENDER, user1mail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, Optional.of(SENDER), user1mail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptMXTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptMXTest.java
@@ -21,6 +21,7 @@ package org.apache.james.smtpserver;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
+import java.util.Optional;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.dnsservice.api.DNSService;
@@ -83,7 +84,7 @@ public class ValidRcptMXTest {
         ValidRcptMX handler = new ValidRcptMX();
         handler.setDNSService(dns);
         handler.setBannedNetworks(ImmutableList.of(bannedAddress), dns);
-        HookReturnCode rCode = handler.doRcpt(session, null, mailAddress).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, Optional.empty(), mailAddress).getResult();
 
         assertThat(HookReturnCode.deny()).describedAs("Reject").isEqualTo(rCode);
     }

--- a/server/protocols/webadmin/webadmin-mailqueue/src/main/java/org/apache/james/webadmin/dto/MailQueueItemDTO.java
+++ b/server/protocols/webadmin/webadmin-mailqueue/src/main/java/org/apache/james/webadmin/dto/MailQueueItemDTO.java
@@ -38,10 +38,10 @@ public class MailQueueItemDTO {
         return new Builder();
     }
 
-    public static MailQueueItemDTO from(ManageableMailQueue.MailQueueItemView mailQueueItemView) throws MailQueueException {
+    public static MailQueueItemDTO from(ManageableMailQueue.MailQueueItemView mailQueueItemView) {
         return builder()
                 .name(mailQueueItemView.getMail().getName())
-                .sender(mailQueueItemView.getMail().getSender())
+                .sender(mailQueueItemView.getMail().getSenderAsOptional())
                 .recipients(mailQueueItemView.getMail().getRecipients())
                 .nextDelivery(mailQueueItemView.getNextDelivery())
                 .build();
@@ -64,6 +64,11 @@ public class MailQueueItemDTO {
 
         public Builder sender(MailAddress sender) {
             this.sender = sender.asString();
+            return this;
+        }
+
+        public Builder sender(Optional<MailAddress> sender) {
+            sender.ifPresent(this::sender);
             return this;
         }
 

--- a/server/protocols/webadmin/webadmin-mailqueue/src/main/java/org/apache/james/webadmin/dto/MailQueueItemDTO.java
+++ b/server/protocols/webadmin/webadmin-mailqueue/src/main/java/org/apache/james/webadmin/dto/MailQueueItemDTO.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.james.core.MailAddress;
-import org.apache.james.queue.api.MailQueue.MailQueueException;
 import org.apache.james.queue.api.ManageableMailQueue;
 
 import com.github.steveash.guavate.Guavate;

--- a/server/protocols/webadmin/webadmin-mailqueue/src/test/java/org/apache/james/webadmin/dto/MailQueueItemDTOTest.java
+++ b/server/protocols/webadmin/webadmin-mailqueue/src/test/java/org/apache/james/webadmin/dto/MailQueueItemDTOTest.java
@@ -61,7 +61,7 @@ public class MailQueueItemDTOTest {
                 .collect(Guavate.toImmutableList());
 
         softly.assertThat(mailQueueItemDTO.getName()).isEqualTo(mail.getName());
-        softly.assertThat(mailQueueItemDTO.getSender()).isEqualTo(mail.getSender().asString());
+        softly.assertThat(mailQueueItemDTO.getSender()).isEqualTo(mail.getSenderAsOptional().get().asString());
         softly.assertThat(mailQueueItemDTO.getRecipients()).isEqualTo(expectedRecipients);
         softly.assertThat(mailQueueItemDTO.getNextDelivery()).contains(date);
     }

--- a/server/protocols/webadmin/webadmin-mailqueue/src/test/java/org/apache/james/webadmin/routes/MailQueueRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailqueue/src/test/java/org/apache/james/webadmin/routes/MailQueueRoutesTest.java
@@ -263,7 +263,7 @@ public class MailQueueRoutesTest {
                     .contentType(ContentType.JSON)
                     .body(".", hasSize(1))
                     .body(firstMail + ".name", equalTo(mail.getName()))
-                    .body(firstMail + ".sender", equalTo(SENDER))
+                    .body(firstMail + ".sender", equalTo(SENDER.asString()))
                     .body(firstMail + ".recipients", equalTo(expectedRecipients));
             }
 

--- a/server/protocols/webadmin/webadmin-mailqueue/src/test/java/org/apache/james/webadmin/routes/MailQueueRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailqueue/src/test/java/org/apache/james/webadmin/routes/MailQueueRoutesTest.java
@@ -25,6 +25,7 @@ import static io.restassured.RestAssured.with;
 import static io.restassured.config.EncoderConfig.encoderConfig;
 import static io.restassured.config.RestAssuredConfig.newConfig;
 import static org.apache.james.webadmin.WebAdminServer.NO_CONFIGURATION;
+import static org.apache.mailet.base.MailAddressFixture.SENDER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -262,7 +263,7 @@ public class MailQueueRoutesTest {
                     .contentType(ContentType.JSON)
                     .body(".", hasSize(1))
                     .body(firstMail + ".name", equalTo(mail.getName()))
-                    .body(firstMail + ".sender", equalTo(mail.getSender().asString()))
+                    .body(firstMail + ".sender", equalTo(SENDER))
                     .body(firstMail + ".recipients", equalTo(expectedRecipients));
             }
 

--- a/server/protocols/webadmin/webadmin-mailrepository/src/main/java/org/apache/james/webadmin/dto/MailDto.java
+++ b/server/protocols/webadmin/webadmin-mailrepository/src/main/java/org/apache/james/webadmin/dto/MailDto.java
@@ -54,7 +54,7 @@ public class MailDto {
     public static MailDto fromMail(Mail mail, Set<AdditionalField> additionalFields) throws MessagingException, InaccessibleFieldException {
         Optional<MessageContent> messageContent = fetchMessage(additionalFields, mail);
         return new MailDto(mail.getName(),
-            Optional.ofNullable(mail.getSender()).map(MailAddress::asString),
+            mail.getSenderAsOptional().map(MailAddress::asString),
             mail.getRecipients().stream().map(MailAddress::asString).collect(Guavate.toImmutableList()),
             Optional.ofNullable(mail.getErrorMessage()),
             Optional.ofNullable(mail.getState()),

--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/MailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/MailQueueContract.java
@@ -92,7 +92,7 @@ public interface MailQueueContract {
     }
 
     @Test
-    default void queueShouldPreserveNullSender() throws Exception {
+    default void queueShouldPreserveHandleSender() throws Exception {
         enQueue(FakeMail.builder()
             .name("name")
             .mimeMessage(createMimeMessage())
@@ -102,8 +102,8 @@ public interface MailQueueContract {
             .build());
 
         MailQueue.MailQueueItem mailQueueItem = getMailQueue().deQueue();
-        assertThat(mailQueueItem.getMail().getSender())
-            .isEqualTo(MailAddress.nullSender());
+        assertThat(mailQueueItem.getMail().getSenderAsOptional())
+            .isEmpty();
     }
 
     @Test
@@ -113,8 +113,8 @@ public interface MailQueueContract {
             .build());
 
         MailQueue.MailQueueItem mailQueueItem = getMailQueue().deQueue();
-        assertThat(mailQueueItem.getMail().getSender())
-            .isEqualTo(SENDER);
+        assertThat(mailQueueItem.getMail().getSenderAsOptional())
+            .contains(SENDER);
     }
 
     @Test

--- a/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
+++ b/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
@@ -419,7 +419,7 @@ public class JMSMailQueue implements ManageableMailQueue, JMSSupport, MailPriori
         splitter.split(attributeNames)
                 .forEach(name -> setMailAttribute(message, mail, name));
 
-        mail.setSender(MailAddress.getMailSender(message.getStringProperty(JAMES_MAIL_SENDER)));
+        MailAddress.getMailSenderAsOptional(message.getStringProperty(JAMES_MAIL_SENDER)).ifPresent(mail::setSender);
         mail.setState(message.getStringProperty(JAMES_MAIL_STATE));
     }
 

--- a/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
+++ b/server/queue/queue-jms/src/main/java/org/apache/james/queue/jms/JMSMailQueue.java
@@ -333,7 +333,7 @@ public class JMSMailQueue implements ManageableMailQueue, JMSSupport, MailPriori
         props.put(JAMES_MAIL_REMOTEADDR, mail.getRemoteAddr());
         props.put(JAMES_MAIL_REMOTEHOST, mail.getRemoteHost());
 
-        String sender = Optional.ofNullable(mail.getSender()).map(MailAddress::asString).orElse("");
+        String sender = mail.getSenderAsOptional().map(MailAddress::asString).orElse("");
 
         org.apache.james.util.streams.Iterators.toStream(mail.getAttributeNames())
                 .forEach(attrName -> props.put(attrName, SerializationUtil.serialize(mail.getAttribute(attrName))));

--- a/server/queue/queue-jms/src/main/java/org/apache/james/queue/library/MailQueueManagement.java
+++ b/server/queue/queue-jms/src/main/java/org/apache/james/queue/library/MailQueueManagement.java
@@ -127,11 +127,7 @@ public class MailQueueManagement extends StandardMBean implements MailQueueManag
             Optional<ZonedDateTime> nextDelivery = mView.getNextDelivery();
             Map<String, Object> map = new HashMap<>();
             map.put(names[0], m.getName());
-            String sender = null;
-            MailAddress senderAddress = m.getSender();
-            if (senderAddress != null) {
-                sender = senderAddress.toString();
-            }
+            String sender = m.getSenderAsOptional().map(MailAddress::asString).orElse(null);
             map.put(names[1], sender);
             map.put(names[2], m.getState());
 

--- a/server/queue/queue-memory/src/main/java/org/apache/james/queue/memory/MemoryMailQueueFactory.java
+++ b/server/queue/queue-memory/src/main/java/org/apache/james/queue/memory/MemoryMailQueueFactory.java
@@ -192,8 +192,9 @@ public class MemoryMailQueueFactory implements MailQueueFactory<ManageableMailQu
                         .map(MailAddress::asString)
                         .anyMatch(value::equals);
                 case Sender:
-                    return item.getMail().getSender()
-                        .asString()
+                    return item.getMail().getSenderAsOptional()
+                        .map(MailAddress::asString)
+                        .orElse(MailAddress.NULL_SENDER_AS_STRING)
                         .equals(value);
                 default:
                     throw new NotImplementedException("Unknown type " + type);

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReferenceDTO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReferenceDTO.java
@@ -56,7 +56,7 @@ class MailReferenceDTO {
                 .map(MailAddress::asString)
                 .collect(Guavate.toImmutableList()),
             mail.getName(),
-            Optional.ofNullable(mail.getSender()).map(MailAddress::asString),
+            mail.getSenderAsOptional().map(MailAddress::asString),
             mail.getState(),
             mail.getErrorMessage(),
             Optional.ofNullable(mail.getLastUpdated()).map(Date::toInstant),

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReferenceDTO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReferenceDTO.java
@@ -187,7 +187,7 @@ class MailReferenceDTO {
 
     MailImpl toMailWithMimeMessage(MimeMessage mimeMessage) throws MessagingException {
         MailImpl mail = new MailImpl(name,
-            sender.map(MailAddress::getMailSender).orElse(null),
+            sender.flatMap(MailAddress::getMailSenderAsOptional).orElse(null),
             recipients.stream()
                 .map(Throwing.<String, MailAddress>function(MailAddress::new).sneakyThrow())
                 .collect(Guavate.toImmutableList()),

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/DeleteCondition.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/DeleteCondition.java
@@ -22,6 +22,7 @@ package org.apache.james.queue.rabbitmq.view.api;
 import java.util.Objects;
 
 import org.apache.commons.lang3.NotImplementedException;
+import org.apache.james.core.MailAddress;
 import org.apache.james.queue.api.ManageableMailQueue;
 import org.apache.mailet.Mail;
 
@@ -58,7 +59,10 @@ public interface DeleteCondition {
         @Override
         public boolean shouldBeDeleted(Mail mail) {
             Preconditions.checkNotNull(mail);
-            return mail.getSender().asString().equals(senderAsString);
+            return mail.getSenderAsOptional()
+                .map(MailAddress::asString)
+                .orElse(MailAddress.NULL_SENDER_AS_STRING)
+                .equals(senderAsString);
         }
 
         @Override

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDAO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDAO.java
@@ -47,7 +47,6 @@ import static org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlice
 import static org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices.Slice;
 
 import java.util.Date;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
@@ -131,7 +130,7 @@ class EnqueuedMailsDAO {
             .setString(HEADER_BLOB_ID, mimeMessagePartsId.getHeaderBlobId().asString())
             .setString(BODY_BLOB_ID, mimeMessagePartsId.getBodyBlobId().asString())
             .setString(STATE, mail.getState())
-            .setString(SENDER, Optional.ofNullable(mail.getSender())
+            .setString(SENDER, mail.getSenderAsOptional()
                 .map(MailAddress::asString)
                 .orElse(null))
             .setList(RECIPIENTS, asStringList(mail.getRecipients()))

--- a/server/testing/src/main/java/org/apache/james/utils/SMTPMessageSender.java
+++ b/server/testing/src/main/java/org/apache/james/utils/SMTPMessageSender.java
@@ -113,7 +113,7 @@ public class SMTPMessageSender extends ExternalResource implements Closeable {
     }
 
     public SMTPMessageSender sendMessage(Mail mail) throws MessagingException, IOException {
-        String from = mail.getSender().asString();
+        String from = mail.getSenderAsOptional().map(MailAddress::asString).orElse(MailAddress.NULL_SENDER_AS_STRING);
         doHelo();
         doSetSender(from);
         mail.getRecipients().stream()


### PR DESCRIPTION
## Why

 - 1. The usage of null values requires implicit knowledge on the caller side. The unaware caller then fails to handle special values.
 - 2. In some context the meaning of 'null' can refer to diffent things:
    - A not yet specified sender
    - A specified null sender

## Proposed solution

Using an optional to represent a sender allows the 'null case' to be **explicit**. The caller has to handle it in order to access the underlying mail address.

## API impact

Here are the impacted models:

 - Mail (mailet-api): getSender deprecation + new getSenderAsOptional method + Mail::duplicate (see below)
 - MailEnvelope (protocols-smtp): getSender deprecation + new getSenderAsOptional method
 - MailAddress (core): nullSender deprecation + getMailSender deprecation + new getMailSenderAsOptional method

Here are the impacted APIs:
 - SMTP MailHook (Called upon `MAIL FROM` command) 
 - SMTP RcptHook  (Called upon `RCPT TO` command)

The APIs are retro-compatible for caller and implementers using the double default method cross call:
 - The caller can call any of both method
 - The implementer only needs to implement one of the methods, the over one will be inferred from the interface.
 - The main drawback of this technique is that an implemented will not get compile-time checks forcing him to implement at least one of these methods, and if he forgets to do so, he creates an infinite recursive call loop...

The type of one SMTPSession attachment had been changed. The users explicitly relying on this rather than on the explicit APIs parameters will get failure upon the upgrade.

## Implementation difficulties

 - Need to call MailetContext::sendMail with a null sender. Rather than adding yet-another-set of send* methods there, I prefered slightly correcting sendMail(Mail mail), and implementing a Mail::duplicate method.