### PR TITLE
JAMES-2529 JMAP filtering: Better resilience upon  address parsing

### DIFF
--- a/server/container/util/src/main/java/org/apache/james/util/OptionalUtils.java
+++ b/server/container/util/src/main/java/org/apache/james/util/OptionalUtils.java
@@ -20,6 +20,7 @@ package org.apache.james.util;
 
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.function.BiPredicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -64,5 +65,13 @@ public class OptionalUtils {
         return requestValue
             .filter(value -> !value.equals(storeValue))
             .isPresent();
+    }
+
+    public static <T, U> boolean matches(Optional<T> optional1, Optional<U> optional2, BiPredicate<T, U> biPredicate) {
+        return optional1.map(value1 ->
+            optional2
+                .map(value2 -> biPredicate.test(value1, value2))
+                .orElse(false))
+            .orElse(false);
     }
 }

--- a/server/container/util/src/test/java/org/apache/james/util/OptionalUtilsTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/OptionalUtilsTest.java
@@ -234,4 +234,54 @@ public class OptionalUtilsTest {
         assertThat(OptionalUtils.containsDifferent(Optional.of("any"), "other")).isTrue();
     }
 
+    @Test
+    public void matchesShouldReturnFalseWhenFirstOptionalIsEmpty() {
+        assertThat(
+            OptionalUtils.matches(
+                Optional.empty(),
+                Optional.of(42),
+                Integer::equals))
+            .isFalse();
+    }
+
+    @Test
+    public void matchesShouldReturnFalseWhenSecondOptionalIsEmpty() {
+        assertThat(
+            OptionalUtils.matches(
+                Optional.of(42),
+                Optional.empty(),
+                Integer::equals))
+            .isFalse();
+    }
+
+    @Test
+    public void matchesShouldReturnFalseWhenBothOptionalsAreEmpty() {
+        assertThat(
+            OptionalUtils.matches(
+                Optional.empty(),
+                Optional.empty(),
+                Integer::equals))
+            .isFalse();
+    }
+
+    @Test
+    public void matchesShouldReturnFalseWhenConditionIsNotMatching() {
+        assertThat(
+            OptionalUtils.matches(
+                Optional.of(42),
+                Optional.of(43),
+                Integer::equals))
+            .isFalse();
+    }
+
+    @Test
+    public void matchesShouldReturnTrueWhenConditionIsMatching() {
+        assertThat(
+            OptionalUtils.matches(
+                Optional.of(42),
+                Optional.of(42),
+                Integer::equals))
+            .isTrue();
+    }
+
 }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/filter/ContentMatcher.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/filter/ContentMatcher.java
@@ -62,10 +62,18 @@ public interface ContentMatcher {
             }
         }
 
-        boolean exactMatch(AddressHeader other) {
+        boolean matchesIgnoreCase(AddressHeader other) {
+            boolean sameAddress = OptionalUtils.matches(address, other.address, String::equalsIgnoreCase);
+            boolean samePersonal = OptionalUtils.matches(personal, other.personal, String::equalsIgnoreCase);
+            boolean personalMatchesAddress = OptionalUtils.matches(personal, other.address, String::equalsIgnoreCase);
+            boolean addressMatchesPersonal = OptionalUtils.matches(address, other.personal, String::equalsIgnoreCase);
+
             return fullAddress.equalsIgnoreCase(other.fullAddress)
-                || OptionalUtils.matches(address, other.address, String::equalsIgnoreCase)
-                || OptionalUtils.matches(personal, other.personal, String::equalsIgnoreCase);
+                || (sameAddress && samePersonal)
+                || (sameAddress && !personal.isPresent())
+                || (samePersonal && !address.isPresent())
+                || (personalMatchesAddress && sameAddress)
+                || (addressMatchesPersonal && samePersonal);
         }
     }
 
@@ -78,7 +86,7 @@ public interface ContentMatcher {
                 .orElse(new AddressHeader(valueToMatch));
 
             return contents.map(ContentMatcher::asAddressHeader)
-                .anyMatch(addressHeaderToMatch::exactMatch);
+                .anyMatch(addressHeaderToMatch::matchesIgnoreCase);
         }
 
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/filter/ContentMatcher.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/filter/ContentMatcher.java
@@ -28,6 +28,7 @@ import javax.mail.internet.InternetAddress;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.james.jmap.api.filtering.Rule;
+import org.apache.james.util.OptionalUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,8 +46,11 @@ public interface ContentMatcher {
         private AddressHeader(String fullAddress) {
             this.fullAddress = fullAddress;
             Optional<InternetAddress> internetAddress = parseFullAddress();
-            this.personal = internetAddress.map(InternetAddress::getPersonal);
             this.address = internetAddress.map(InternetAddress::getAddress);
+            this.personal = OptionalUtils.or(
+                internetAddress.map(InternetAddress::getPersonal),
+                address,
+                Optional.of(fullAddress));
         }
 
         private Optional<InternetAddress> parseFullAddress() {
@@ -57,6 +61,26 @@ public interface ContentMatcher {
                 return Optional.empty();
             }
         }
+
+        boolean exactMatch(AddressHeader other) {
+            return fullAddress.equalsIgnoreCase(other.fullAddress)
+                || OptionalUtils.matches(address, other.address, String::equalsIgnoreCase)
+                || OptionalUtils.matches(personal, other.personal, String::equalsIgnoreCase);
+        }
+    }
+
+    class ExactAddressContentMatcher implements ContentMatcher {
+        @Override
+        public boolean match(Stream<String> contents, String valueToMatch) {
+            AddressHeader addressHeaderToMatch =  HeaderExtractor.toAddressContents(new String[] {valueToMatch})
+                .map(AddressHeader::new)
+                .findAny()
+                .orElse(new AddressHeader(valueToMatch));
+
+            return contents.map(ContentMatcher::asAddressHeader)
+                .anyMatch(addressHeaderToMatch::exactMatch);
+        }
+
     }
 
     ContentMatcher STRING_CONTAINS_MATCHER = (contents, valueToMatch) -> contents.anyMatch(content -> StringUtils.contains(content, valueToMatch));
@@ -68,18 +92,12 @@ public interface ContentMatcher {
         .map(ContentMatcher::asAddressHeader)
         .anyMatch(addressHeader -> StringUtils.containsIgnoreCase(addressHeader.fullAddress, valueToMatch));
     ContentMatcher ADDRESS_NOT_CONTAINS_MATCHER = negate(ADDRESS_CONTAINS_MATCHER);
-    ContentMatcher ADDRESS_EXACTLY_EQUALS_MATCHER = (contents, valueToMatch) -> contents
-        .map(ContentMatcher::asAddressHeader)
-        .anyMatch(addressHeader ->
-            valueToMatch.equalsIgnoreCase(addressHeader.fullAddress)
-                || addressHeader.address.map(valueToMatch::equalsIgnoreCase).orElse(false)
-                || addressHeader.personal.map(valueToMatch::equalsIgnoreCase).orElse(false));
-    ContentMatcher ADDRESS_NOT_EXACTLY_EQUALS_MATCHER = negate(ADDRESS_EXACTLY_EQUALS_MATCHER);
+    ContentMatcher ADDRESS_NOT_EXACTLY_EQUALS_MATCHER = negate(new ExactAddressContentMatcher());
 
     Map<Rule.Condition.Comparator, ContentMatcher> HEADER_ADDRESS_MATCHER_REGISTRY = ImmutableMap.<Rule.Condition.Comparator, ContentMatcher>builder()
         .put(Rule.Condition.Comparator.CONTAINS, ADDRESS_CONTAINS_MATCHER)
         .put(Rule.Condition.Comparator.NOT_CONTAINS, ADDRESS_NOT_CONTAINS_MATCHER)
-        .put(Rule.Condition.Comparator.EXACTLY_EQUALS, ADDRESS_EXACTLY_EQUALS_MATCHER)
+        .put(Rule.Condition.Comparator.EXACTLY_EQUALS, new ExactAddressContentMatcher())
         .put(Rule.Condition.Comparator.NOT_EXACTLY_EQUALS, ADDRESS_NOT_EXACTLY_EQUALS_MATCHER)
         .build();
 

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/filter/ContentMatcher.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/filter/ContentMatcher.java
@@ -53,7 +53,7 @@ public interface ContentMatcher {
             try {
                 return Optional.of(new InternetAddress(fullAddress));
             } catch (AddressException e) {
-                LOGGER.error("error while parsing full address {}", fullAddress, e);
+                LOGGER.info("error while parsing full address {}", fullAddress, e);
                 return Optional.empty();
             }
         }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/filter/HeaderExtractor.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/filter/HeaderExtractor.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.functions.ThrowingFunction;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 
 public interface HeaderExtractor extends ThrowingFunction<Mail, Stream<String>> {
@@ -75,7 +76,8 @@ public interface HeaderExtractor extends ThrowingFunction<Mail, Stream<String>> 
             } catch (Exception e) {
                 LOGGER.info("Failed parsing header. Falling back to unparsed header value matching", e);
                 return Stream.of(mail.getMessage().getHeader(fallbackHeaderName))
-                    .map(MimeUtil::unscrambleHeaderValue);
+                    .map(MimeUtil::unscrambleHeaderValue)
+                    .flatMap(s -> Splitter.on(',').trimResults().splitToList(s).stream());
             }
         };
     }

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/filter/HeaderExtractor.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/filter/HeaderExtractor.java
@@ -84,11 +84,9 @@ public interface HeaderExtractor extends ThrowingFunction<Mail, Stream<String>> 
     }
 
     static Stream<String> toAddressContents(String[] headers) {
-        return Stream.concat(
-            StreamUtils.ofNullable(headers),
-            StreamUtils.ofNullable(headers)
+        return StreamUtils.ofNullable(headers)
                 .map(Throwing.function(string -> InternetAddress.parseHeader(string, !STRICT_PARSING)))
-                .flatMap(AddressHelper::asStringStream));
+                .flatMap(AddressHelper::asStringStream);
     }
 
     static Optional<HeaderExtractor> asHeaderExtractor(Rule.Condition.Field field) {

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/filter/HeaderExtractor.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/mailet/filter/HeaderExtractor.java
@@ -25,8 +25,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import javax.mail.Address;
 import javax.mail.Message;
+import javax.mail.internet.InternetAddress;
 
 import org.apache.james.javax.AddressHelper;
 import org.apache.james.jmap.api.filtering.Rule;
@@ -36,8 +36,8 @@ import org.apache.mailet.Mail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.fge.lambdas.Throwing;
 import com.github.fge.lambdas.functions.ThrowingFunction;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 
 public interface HeaderExtractor extends ThrowingFunction<Mail, Stream<String>> {
@@ -48,7 +48,7 @@ public interface HeaderExtractor extends ThrowingFunction<Mail, Stream<String>> 
     HeaderExtractor CC_EXTRACTOR = recipientExtractor(Message.RecipientType.CC);
     HeaderExtractor TO_EXTRACTOR = recipientExtractor(Message.RecipientType.TO);
     HeaderExtractor RECIPIENT_EXTRACTOR = and(TO_EXTRACTOR, CC_EXTRACTOR);
-    HeaderExtractor FROM_EXTRACTOR = addressExtractor(mail -> mail.getMessage().getFrom(), FROM);
+    HeaderExtractor FROM_EXTRACTOR = addressExtractor(mail -> mail.getMessage().getHeader(FROM), FROM);
 
     Map<Rule.Condition.Field, HeaderExtractor> HEADER_EXTRACTOR_REGISTRY = ImmutableMap.<Rule.Condition.Field, HeaderExtractor>builder()
         .put(Rule.Condition.Field.SUBJECT, SUBJECT_EXTRACTOR)
@@ -58,34 +58,37 @@ public interface HeaderExtractor extends ThrowingFunction<Mail, Stream<String>> 
         .put(Rule.Condition.Field.TO, TO_EXTRACTOR)
         .build();
 
+    boolean STRICT_PARSING = true;
+
     static HeaderExtractor and(HeaderExtractor headerExtractor1, HeaderExtractor headerExtractor2) {
         return (Mail mail) -> StreamUtils.flatten(headerExtractor1.apply(mail), headerExtractor2.apply(mail));
     }
 
     static HeaderExtractor recipientExtractor(Message.RecipientType type) {
-        ThrowingFunction<Mail, Address[]> addressGetter = mail -> mail.getMessage().getRecipients(type);
-        String fallbackHeaderName = type.toString();
+        String headerName = type.toString();
+        ThrowingFunction<Mail, String[]> addressGetter = mail -> mail.getMessage().getHeader(headerName);
 
-        return addressExtractor(addressGetter, fallbackHeaderName);
+        return addressExtractor(addressGetter, headerName);
     }
 
-    static HeaderExtractor addressExtractor(ThrowingFunction<Mail, Address[]> addressGetter, String fallbackHeaderName) {
+    static HeaderExtractor addressExtractor(ThrowingFunction<Mail, String[]> addressGetter, String fallbackHeaderName) {
         return mail -> {
             try {
-                return toContent(addressGetter.apply(mail));
+                return toAddressContents(addressGetter.apply(mail));
             } catch (Exception e) {
                 LOGGER.info("Failed parsing header. Falling back to unparsed header value matching", e);
                 return Stream.of(mail.getMessage().getHeader(fallbackHeaderName))
-                    .map(MimeUtil::unscrambleHeaderValue)
-                    .flatMap(s -> Splitter.on(',').trimResults().splitToList(s).stream());
+                    .map(MimeUtil::unscrambleHeaderValue);
             }
         };
     }
 
-    static Stream<String> toContent(Address[] addresses) {
-        return Optional.ofNullable(addresses)
-            .map(AddressHelper::asStringStream)
-            .orElse(Stream.empty());
+    static Stream<String> toAddressContents(String[] headers) {
+        return Stream.concat(
+            StreamUtils.ofNullable(headers),
+            StreamUtils.ofNullable(headers)
+                .map(Throwing.function(string -> InternetAddress.parseHeader(string, !STRICT_PARSING)))
+                .flatMap(AddressHelper::asStringStream));
     }
 
     static Optional<HeaderExtractor> asHeaderExtractor(Rule.Condition.Field field) {

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/filter/JMAPFilteringTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/filter/JMAPFilteringTest.java
@@ -237,6 +237,26 @@ class JMAPFilteringTest {
                         .valueToMatch(USER_1_ADDRESS),
 
                     argumentBuilder(fieldAndHeader.field)
+                        .description("Address exact match in a failing " + fieldAndHeader.headerName + " header")
+                        .header(fieldAndHeader.headerName, "invalid@ white.space.in.domain.tld")
+                        .valueToMatch("invalid@ white.space.in.domain.tld"),
+
+                    argumentBuilder(fieldAndHeader.field)
+                        .description("Address exact match in a failing " + fieldAndHeader.headerName + " header with multiple values")
+                        .header(fieldAndHeader.headerName, USER_1_FULL_ADDRESS + ", invalid@ white.space.in.domain.tld")
+                        .valueToMatch(USER_1_FULL_ADDRESS),
+
+                    argumentBuilder(fieldAndHeader.field)
+                        .description("Address exact match in a failing " + fieldAndHeader.headerName + " header with multiple values")
+                        .header(fieldAndHeader.headerName, USER_1_FULL_ADDRESS + ", invalid@ white.space.in.domain.tld")
+                        .valueToMatch(USER_1_ADDRESS),
+
+                    argumentBuilder(fieldAndHeader.field)
+                        .description("Address exact match in a failing " + fieldAndHeader.headerName + " header with multiple values")
+                        .header(fieldAndHeader.headerName, USER_1_FULL_ADDRESS + ", invalid@ white.space.in.domain.tld")
+                        .valueToMatch(USER_1_USERNAME),
+
+                    argumentBuilder(fieldAndHeader.field)
                         .description("Full header exact match in a full " + fieldAndHeader.headerName + " header")
                         .header(fieldAndHeader.headerName, USER_1_FULL_ADDRESS)
                         .valueToMatch(USER_1_FULL_ADDRESS),
@@ -315,6 +335,11 @@ class JMAPFilteringTest {
                         .description("Full header partial match in a full " + fieldAndHeader.headerName + " header")
                         .header(fieldAndHeader.headerName, USER_1_FULL_ADDRESS)
                         .valueToMatch("ser1 <"),
+
+                    argumentBuilder(fieldAndHeader.field)
+                        .description("Address exact match in a full " + fieldAndHeader.headerName + " header with multiple addresses")
+                        .header(fieldAndHeader.headerName, USER_1_FULL_ADDRESS + ", Invalid <invalid@ white.space.in.domain.tld>")
+                        .valueToMatch("invalid@ white.space.in.domain.tld"),
 
                     argumentBuilder(fieldAndHeader.field)
                         .description("Address partial match in a full " + fieldAndHeader.headerName + " header")

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/filter/JMAPFilteringTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/filter/JMAPFilteringTest.java
@@ -242,6 +242,36 @@ class JMAPFilteringTest {
                         .valueToMatch("invalid@ white.space.in.domain.tld"),
 
                     argumentBuilder(fieldAndHeader.field)
+                        .description("Address exact match in a coma quoted " + fieldAndHeader.headerName + " header")
+                        .header(fieldAndHeader.headerName, "Toto <\"a, b\"@quoted.com>")
+                        .valueToMatch("\"a, b\"@quoted.com"),
+
+                    argumentBuilder(fieldAndHeader.field)
+                        .description("Username exact match in a coma quoted " + fieldAndHeader.headerName + " header")
+                        .header(fieldAndHeader.headerName, "Toto <\"a, b\"@quoted.com>")
+                        .valueToMatch("Toto"),
+
+                    argumentBuilder(fieldAndHeader.field)
+                        .description("Full exact match in a coma quoted " + fieldAndHeader.headerName + " header")
+                        .header(fieldAndHeader.headerName, "Toto <\"a, b\"@quoted.com>")
+                        .valueToMatch("Toto <\"a, b\"@quoted.com>"),
+
+                    argumentBuilder(fieldAndHeader.field)
+                        .description("Address exact match in a failing + coma quoted" + fieldAndHeader.headerName + " header")
+                        .header(fieldAndHeader.headerName, "invalid@ space.org, Toto <\"a, b\"@quoted.com>")
+                        .valueToMatch("\"a, b\"@quoted.com"),
+
+                    argumentBuilder(fieldAndHeader.field)
+                        .description("Username exact match in a failing + coma quoted " + fieldAndHeader.headerName + " header")
+                        .header(fieldAndHeader.headerName, "invalid@ space.org, Toto <\"a, b\"@quoted.com>")
+                        .valueToMatch("Toto"),
+
+                    argumentBuilder(fieldAndHeader.field)
+                        .description("Full exact match in a failing + coma quoted " + fieldAndHeader.headerName + " header")
+                        .header(fieldAndHeader.headerName, "invalid@ space.org, Toto <\"a, b\"@quoted.com>")
+                        .valueToMatch("Toto <\"a, b\"@quoted.com>"),
+
+                    argumentBuilder(fieldAndHeader.field)
                         .description("Address exact match in a failing " + fieldAndHeader.headerName + " header with multiple values")
                         .header(fieldAndHeader.headerName, USER_1_FULL_ADDRESS + ", invalid@ white.space.in.domain.tld")
                         .valueToMatch(USER_1_FULL_ADDRESS),

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/filter/JMAPFilteringTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/filter/JMAPFilteringTest.java
@@ -292,6 +292,11 @@ class JMAPFilteringTest {
                         .valueToMatch(USER_1_FULL_ADDRESS),
 
                     argumentBuilder(fieldAndHeader.field)
+                        .description("Exact match in a full " + fieldAndHeader.headerName + " header with a symetric emailer")
+                        .header(fieldAndHeader.headerName, "\"toto@domain.tld\" <toto@domain.tld>")
+                        .valueToMatch("toto@domain.tld"),
+
+                    argumentBuilder(fieldAndHeader.field)
                         .description("Username exact match in a username only " + fieldAndHeader.headerName + " header")
                         .header(fieldAndHeader.headerName, USER_1_USERNAME)
                         .valueToMatch(USER_1_USERNAME),
@@ -489,6 +494,26 @@ class JMAPFilteringTest {
                         .description("Nomatch in a " + fieldAndHeader.headerName + " empty header")
                         .header(fieldAndHeader.headerName, EMPTY)
                         .valueToMatch(SHOULD_NOT_MATCH),
+
+                    argumentBuilder(fieldAndHeader.field)
+                        .description("Nomatch when different address in a fully specified emailer for " + fieldAndHeader.headerName + " field")
+                        .header(fieldAndHeader.headerName, "\"me\" <notme@example.com>")
+                        .valueToMatch("\"me\" <me@example.com>"),
+
+                    argumentBuilder(fieldAndHeader.field)
+                        .description("Nomatch when different username in a fully specified emailer for " + fieldAndHeader.headerName + " field")
+                        .header(fieldAndHeader.headerName, "\"notme\" <me@example.com>")
+                        .valueToMatch("\"definitlyme\" <me@example.com>"),
+
+                    argumentBuilder(fieldAndHeader.field)
+                        .description("No match in a full " + fieldAndHeader.headerName + " header with a symetric emailer - different personal")
+                        .header(fieldAndHeader.headerName, "\"toto@domain.tld\" <toto@domain.tld>")
+                        .valueToMatch("\"tata@domain.tld\" <toto@domain.tld>"),
+
+                    argumentBuilder(fieldAndHeader.field)
+                        .description("No match in a full " + fieldAndHeader.headerName + " header with a symetric emailer - different address")
+                        .header(fieldAndHeader.headerName, "\"toto@domain.tld\" <toto@domain.tld>")
+                        .valueToMatch("\"toto@domain.tld\" <tata@domain.tld>"),
 
                     argumentBuilder(fieldAndHeader.field)
                         .description("Nomatch in a missing " + fieldAndHeader.headerName + " header")

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/filter/JMAPFilteringTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/filter/JMAPFilteringTest.java
@@ -232,6 +232,11 @@ class JMAPFilteringTest {
                         .valueToMatch(USER_1_ADDRESS),
 
                     argumentBuilder(fieldAndHeader.field)
+                        .description("Address exact match in a full " + fieldAndHeader.headerName + " header with multiple addresses")
+                        .header(fieldAndHeader.headerName, USER_1_FULL_ADDRESS + ", " + USER_2_FULL_ADDRESS)
+                        .valueToMatch(USER_1_ADDRESS),
+
+                    argumentBuilder(fieldAndHeader.field)
                         .description("Full header exact match in a full " + fieldAndHeader.headerName + " header")
                         .header(fieldAndHeader.headerName, USER_1_FULL_ADDRESS)
                         .valueToMatch(USER_1_FULL_ADDRESS),

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/filter/JMAPFilteringTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/mailet/filter/JMAPFilteringTest.java
@@ -335,6 +335,11 @@ class JMAPFilteringTest {
                     argumentBuilder(fieldAndHeader.field)
                         .description("Full header exact match in a full " + fieldAndHeader.headerName + " with an invalid structure")
                         .header(fieldAndHeader.headerName, "Benoit <invalid")
+                        .valueToMatch("Benoit <invalid"),
+
+                    argumentBuilder(fieldAndHeader.field)
+                        .description("Full header exact match in a full " + fieldAndHeader.headerName + " with an invalid structure - multi address")
+                        .header(fieldAndHeader.headerName, "Valid <toto@domain.tld>, Benoit <invalid")
                         .valueToMatch("Benoit <invalid"))
                     .flatMap(JMAPFilteringTest::forBothCase)),
 


### PR DESCRIPTION
Looking at some ci logs:

```
error while parsing full address  XXXX <XXXX@XXXX>, YYYY <YYY@ YYYY>
  javax.mail.internet.AddressException: Domain contains control or whitespace
 at   javax.mail.internet.InternetAddress.checkAddress(InternetAddress.java:1402)
 at javax.mail.internet.InternetAddress.parse(InternetAddress.java:1087)
 at javax.mail.internet.InternetAddress.parse(InternetAddress.java:752)
 at javax.mail.internet.InternetAddress.<init>(InternetAddress.java:119)
 at org.apache.james.jmap.mailet.filter.ContentMatcher$AddressHeader.parseFullAddress(ContentMatcher.java:54)
 at org.apache.james.jmap.mailet.filter.ContentMatcher$AddressHeader.<init>(ContentMatcher.java:47) 
at org.apache.james.jmap.mailet.filter.ContentMatcher$AddressHeader.<init>(ContentMatcher.java:38) 
at org.apache.james.jmap.mailet.filter.ContentMatcher.asAddressHeader(ContentMatcher.java:113)
```

(Notice the space in YYY@ YYYY, that address is invalid)

We see that if there is a failed address, the content extractor fails to split per address.

This makes the following  story fail:

```
As a user I match adress A with a JMAP Filtering rule (exact match)
When I receive a mail with address A and an invalid address in the same header
Then I want my JMAP filtering rule to match
```

This pull request solves this and add tests for multi-addresses headers