### PR TITLE
JAMES-2456 Add content type to Tika logs

### DIFF
--- a/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/TikaHttpClientImpl.java
+++ b/mailbox/tika/src/main/java/org/apache/james/mailbox/tika/TikaHttpClientImpl.java
@@ -62,7 +62,7 @@ public class TikaHttpClientImpl implements TikaHttpClient {
                         .returnContent()
                         .asStream());
         } catch (IOException e) {
-            LOGGER.warn("Failing to call Tika", e);
+            LOGGER.warn("Failing to call Tika for content type {}", contentType, e);
             return Optional.empty();
         }
     }


### PR DESCRIPTION
We have many non-contextualized logs from Tika client failing to execute some requests.

Having the content type included in the lgos should help to diagnose what is happening.