### PR TITLE
[Cucumber tests] delete unused test life cycle callbacks

### DIFF
--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandra.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandra.java
@@ -54,11 +54,15 @@ public class DockerCassandra {
     }
 
     public void start() {
-        cassandraContainer.start();
+        if (!cassandraContainer.isRunning()) {
+            cassandraContainer.start();
+        }
     }
 
     public void stop() {
-        cassandraContainer.stop();
+        if (cassandraContainer.isRunning()) {
+            cassandraContainer.stop();
+        }
     }
 
     public Host getHost() {

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandraRule.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandraRule.java
@@ -34,7 +34,7 @@ public class DockerCassandraRule implements TestRule {
     }
 
     public void start() {
-
+        DockerCassandraSingleton.singleton.start();
     }
 
     public void stop() {

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraDownloadCucumberTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraDownloadCucumberTest.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.jmap.cassandra.cucumber;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -32,14 +30,4 @@ import cucumber.api.junit.Cucumber;
                 tags = {"not @Ignore"},
                 strict = true)
 public class CassandraDownloadCucumberTest {
-
-    @BeforeClass
-    public static void init() {
-        CucumberCassandraSingleton.cassandraServer.start();
-    }
-
-    @AfterClass
-    public static void after() {
-        CucumberCassandraSingleton.cassandraServer.stop();
-    }
 }

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraGetMessagesMethodTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraGetMessagesMethodTest.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.jmap.cassandra.cucumber;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -31,15 +29,4 @@ import cucumber.api.junit.Cucumber;
                 glue = {"org.apache.james.jmap.methods.integration", "org.apache.james.jmap.cassandra.cucumber"},
                 strict = true)
 public class CassandraGetMessagesMethodTest {
-
-    @BeforeClass
-    public static void init() {
-        CucumberCassandraSingleton.cassandraServer.start();
-    }
-
-    @AfterClass
-    public static void after() {
-        CucumberCassandraSingleton.cassandraServer.stop();
-    }
-
 }

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraIMAPKeywordsInconsistenciesTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraIMAPKeywordsInconsistenciesTest.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.jmap.cassandra.cucumber;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -31,14 +29,4 @@ import cucumber.api.junit.Cucumber;
     glue = {"org.apache.james.jmap.methods.integration", "org.apache.james.jmap.cassandra.cucumber"},
     strict = true)
 public class CassandraIMAPKeywordsInconsistenciesTest {
-
-    @BeforeClass
-    public static void init() {
-        CucumberCassandraSingleton.cassandraServer.start();
-    }
-
-    @AfterClass
-    public static void after() {
-        CucumberCassandraSingleton.cassandraServer.stop();
-    }
 }

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraIMAPSetMessagesCompatibilityTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraIMAPSetMessagesCompatibilityTest.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.jmap.cassandra.cucumber;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -31,15 +29,4 @@ import cucumber.api.junit.Cucumber;
     glue = {"org.apache.james.jmap.methods.integration", "org.apache.james.jmap.cassandra.cucumber"},
     strict = true)
 public class CassandraIMAPSetMessagesCompatibilityTest {
-
-    @BeforeClass
-    public static void init() {
-        CucumberCassandraSingleton.cassandraServer.start();
-    }
-
-    @AfterClass
-    public static void after() {
-        CucumberCassandraSingleton.cassandraServer.stop();
-    }
-
 }

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraMailboxSharingTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraMailboxSharingTest.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.jmap.cassandra.cucumber;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -39,15 +37,4 @@ import cucumber.api.junit.Cucumber;
     tags = {"not @Ignore"},
     strict = true)
 public class CassandraMailboxSharingTest {
-
-    @BeforeClass
-    public static void init() {
-        CucumberCassandraSingleton.cassandraServer.start();
-    }
-
-    @AfterClass
-    public static void after() {
-        CucumberCassandraSingleton.cassandraServer.stop();
-    }
-
 }

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraMessageSharingTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraMessageSharingTest.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.jmap.cassandra.cucumber;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -40,15 +38,4 @@ import cucumber.api.junit.Cucumber;
     tags = {"not @Ignore"},
     strict = true)
 public class CassandraMessageSharingTest {
-
-    @BeforeClass
-    public static void init() {
-        CucumberCassandraSingleton.cassandraServer.start();
-    }
-
-    @AfterClass
-    public static void after() {
-        CucumberCassandraSingleton.cassandraServer.stop();
-    }
-
 }

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraSetMailboxesMethodCucumberTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraSetMailboxesMethodCucumberTest.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.jmap.cassandra.cucumber;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -31,15 +29,4 @@ import cucumber.api.junit.Cucumber;
                 glue = { "org.apache.james.jmap.methods.integration", "org.apache.james.jmap.cassandra.cucumber" },
                 strict = true)
 public class CassandraSetMailboxesMethodCucumberTest {
-
-    @BeforeClass
-    public static void init() {
-        CucumberCassandraSingleton.cassandraServer.start();
-    }
-
-    @AfterClass
-    public static void after() {
-        CucumberCassandraSingleton.cassandraServer.stop();
-    }
-
 }

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraSetMessagesMethodCucumberTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraSetMessagesMethodCucumberTest.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.jmap.cassandra.cucumber;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -31,14 +29,4 @@ import cucumber.api.junit.Cucumber;
                 glue = {"org.apache.james.jmap.methods.integration", "org.apache.james.jmap.cassandra.cucumber"},
                 strict = true)
 public class CassandraSetMessagesMethodCucumberTest {
-
-    @BeforeClass
-    public static void init() {
-        CucumberCassandraSingleton.cassandraServer.start();
-    }
-
-    @AfterClass
-    public static void after() {
-        CucumberCassandraSingleton.cassandraServer.stop();
-    }
 }

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraStepdefs.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraStepdefs.java
@@ -67,6 +67,7 @@ public class CassandraStepdefs {
 
     @Before
     public void init() throws Exception {
+        cassandraServer.start();
         temporaryFolder.create();
         embeddedElasticSearch.before();
         mainStepdefs.messageIdFactory = new CassandraMessageId.Factory();

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraUploadCucumberTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraUploadCucumberTest.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.jmap.cassandra.cucumber;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -32,15 +30,4 @@ import cucumber.api.junit.Cucumber;
                 tags = {"not @Ignore"},
                 strict = true)
 public class CassandraUploadCucumberTest {
-
-    @BeforeClass
-    public static void init() {
-        CucumberCassandraSingleton.cassandraServer.start();
-    }
-
-    @AfterClass
-    public static void after() {
-        CucumberCassandraSingleton.cassandraServer.stop();
-    }
-    
 }


### PR DESCRIPTION
I checked, the beforeAll and afterAll callback don't affect any at all to setup cassandra containers startup or shutdown. Cassandra container starting is triggered by another tricky method call. It's `DockerCassandraRule.getHost()`, it will automatically starting cassandra container  by trigger static code block of `DockerCassandraSingleton` . `start()` & `stop()` methods from `DockerCassandraRule` don't reach to `DockerCassandraSingleton` but `getHost()` does. Here is the code of `DockerCassandraRule`:
```java
public class DockerCassandraRule implements TestRule {
    ...
    public void start() {}     // doesn't reach to DockerCassandraSingleton.singleton to trigger static method
    public void stop() {}     // doesn't reach to DockerCassandraSingleton.singleton to trigger static method
    public Host getHost() {
        return DockerCassandraSingleton.singleton.getHost(); // triger static block execution
    } 
   ....
}
```

Here is the code of `DockerCassandraSingleton`: 
```java
public class DockerCassandraSingleton {
    public static final DockerCassandra singleton = new DockerCassandra();
    static {
        singleton.start();   // when some statements reach to DockerCassandraSingleton, then static block will be triggered
    }
    ....
}
```

If I was right. This PR will be green