### PR TITLE
JAMES-2557 Part 2: MaybeSender in RCPT hooks & MailEnvelope

### DIFF
--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/MailEnvelope.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/MailEnvelope.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.util.List;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 
 /**
  * The MailEnvelope of a SMTP-Transaction
@@ -51,10 +52,32 @@ public interface MailEnvelope {
     /**
      * Return the sender of the mail which was supplied int the MAIL FROM:
      * command. If its a "null" sender, null will get returned
-     * 
+     *
+     * @deprecated @see {@link #getMaybeSender()}
+     *
+     * Note that SMTP null sender ( "&lt;&gt;" ) needs to be implicitly handled by the caller under the form of 'null' or
+     * {@link MailAddress#nullSender()}. Replacement method adds type safety on this operation.
+     *
      * @return sender
      */
-    MailAddress getSender();
+    @Deprecated
+    default MailAddress getSender() {
+        return getMaybeSender().asOptional().orElse(MailAddress.nullSender());
+    }
+
+    /**
+     * Returns the sender of the message, as specified by the SMTP "MAIL FROM" command,
+     * or internally defined.
+     *
+     * 'null' or {@link MailAddress#nullSender()} are handled with {@link MaybeSender}.
+     *
+     * @since Mailet API v3.2.0
+     * @return the sender of this message wrapped in an optional
+     */
+    @SuppressWarnings("deprecated")
+    default MaybeSender getMaybeSender() {
+        return MaybeSender.of(getSender());
+    }
 
     /**
      * Return the OutputStream of the message

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/MailEnvelopeImpl.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/MailEnvelopeImpl.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.util.List;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 
 /**
  * MailEnvelope implementation which stores everything in memory
@@ -37,7 +38,7 @@ public class MailEnvelopeImpl implements MailEnvelope {
 
     private List<MailAddress> recipients;
 
-    private MailAddress sender;
+    private MaybeSender sender;
 
     private ByteArrayOutputStream outputStream;
 
@@ -55,7 +56,7 @@ public class MailEnvelopeImpl implements MailEnvelope {
     }
 
     @Override
-    public MailAddress getSender() {
+    public MaybeSender getMaybeSender() {
         return sender;
     }
 
@@ -73,7 +74,7 @@ public class MailEnvelopeImpl implements MailEnvelope {
      * 
      * @param sender
      */
-    public void setSender(MailAddress sender) {
+    public void setSender(MaybeSender sender) {
         this.sender = sender;
     }
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractAuthRequiredToRelayRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractAuthRequiredToRelayRcptHook.java
@@ -20,6 +20,7 @@ package org.apache.james.protocols.smtp.core;
 
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.smtp.SMTPRetCode;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.dsn.DSNStatus;
@@ -48,8 +49,7 @@ public abstract class AbstractAuthRequiredToRelayRcptHook implements RcptHook {
         .build();
     
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender,
-                             MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
         if (!session.isRelayingAllowed()) {
             Domain toDomain = rcpt.getDomain();
             if (!isLocalDomain(toDomain)) {

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AbstractSenderAuthIdentifyVerificationRcptHook.java
@@ -22,6 +22,7 @@ import java.util.Locale;
 
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.api.ProtocolSession;
 import org.apache.james.protocols.smtp.SMTPRetCode;
 import org.apache.james.protocols.smtp.SMTPSession;
@@ -42,8 +43,7 @@ public abstract class AbstractSenderAuthIdentifyVerificationRcptHook implements 
         .build();
     
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender,
-                             MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
         if (session.getUser() != null) {
             String authUser = (session.getUser()).toLowerCase(Locale.US);
             MailAddress senderAddress = (MailAddress) session.getAttachment(
@@ -62,7 +62,7 @@ public abstract class AbstractSenderAuthIdentifyVerificationRcptHook implements 
         return HookResult.DECLINED;
     }
 
-    public String retrieveSender(MailAddress sender, MailAddress senderAddress) {
+    public String retrieveSender(MaybeSender sender, MailAddress senderAddress) {
         if (senderAddress != null && !sender.isNullSender()) {
             return getUser(senderAddress);
         }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AcceptRecipientIfRelayingIsAllowed.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/AcceptRecipientIfRelayingIsAllowed.java
@@ -21,6 +21,7 @@ package org.apache.james.protocols.smtp.core;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.hook.HookResult;
 import org.apache.james.protocols.smtp.hook.RcptHook;
@@ -31,8 +32,7 @@ import org.apache.james.protocols.smtp.hook.RcptHook;
 public class AcceptRecipientIfRelayingIsAllowed implements RcptHook {
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender,
-                             MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
         if (session.isRelayingAllowed()) {
             return HookResult.OK;
         }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/DataCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/DataCmdHandler.java
@@ -31,6 +31,7 @@ import javax.inject.Inject;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.metrics.api.TimeMetric;
 import org.apache.james.protocols.api.ProtocolSession;
@@ -171,14 +172,15 @@ public class DataCmdHandler implements CommandHandler<SMTPSession>, ExtensibleHa
      */
     @SuppressWarnings("unchecked")
     protected Response doDATA(SMTPSession session, String argument) {
-        MailEnvelope env = createEnvelope(session, (MailAddress) session.getAttachment(SMTPSession.SENDER,ProtocolSession.State.Transaction), new ArrayList<>((Collection<MailAddress>) session.getAttachment(SMTPSession.RCPT_LIST, ProtocolSession.State.Transaction)));
+        MailAddress sender = (MailAddress) session.getAttachment(SMTPSession.SENDER, ProtocolSession.State.Transaction);
+        MailEnvelope env = createEnvelope(session, MaybeSender.of(sender), new ArrayList<>((Collection<MailAddress>) session.getAttachment(SMTPSession.RCPT_LIST, ProtocolSession.State.Transaction)));
         session.setAttachment(MAILENV, env,ProtocolSession.State.Transaction);
         session.pushLineHandler(lineHandler);
         
         return DATA_READY;
     }
     
-    protected MailEnvelope createEnvelope(SMTPSession session, MailAddress sender, List<MailAddress> recipients) {
+    protected MailEnvelope createEnvelope(SMTPSession session, MaybeSender sender, List<MailAddress> recipients) {
         MailEnvelopeImpl env = new MailEnvelopeImpl();
         env.setRecipients(recipients);
         env.setSender(sender);

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/MailCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/MailCmdHandler.java
@@ -31,6 +31,7 @@ import javax.inject.Inject;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.protocols.api.ProtocolSession.State;
 import org.apache.james.protocols.api.Request;
@@ -257,10 +258,7 @@ public class MailCmdHandler extends AbstractHookableCmdHandler<MailHook> {
     @Override
     protected HookResult callHook(MailHook rawHook, SMTPSession session, String parameters) {
         MailAddress sender = (MailAddress) session.getAttachment(SMTPSession.SENDER, State.Transaction);
-        if (sender.isNullSender()) {
-            sender = null;
-        }
-        return rawHook.doMail(session, sender);
+        return rawHook.doMail(session, MaybeSender.of(sender));
     }
 
     

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/PostmasterAbuseRcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/PostmasterAbuseRcptHook.java
@@ -21,6 +21,7 @@ package org.apache.james.protocols.smtp.core;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.hook.HookResult;
 import org.apache.james.protocols.smtp.hook.RcptHook;
@@ -34,7 +35,7 @@ public class PostmasterAbuseRcptHook implements RcptHook {
     private static final Logger LOGGER = LoggerFactory.getLogger(PostmasterAbuseRcptHook.class);
     
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
         if (rcpt.getLocalPart().equalsIgnoreCase("postmaster") || rcpt.getLocalPart().equalsIgnoreCase("abuse")) {
             LOGGER.debug("Sender allowed");
             return HookResult.OK;

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/RcptCmdHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/RcptCmdHandler.java
@@ -29,6 +29,7 @@ import javax.inject.Inject;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.protocols.api.ProtocolSession.State;
 import org.apache.james.protocols.api.Response;
@@ -228,10 +229,10 @@ public class RcptCmdHandler extends AbstractHookableCmdHandler<RcptHook> impleme
     }
 
     @Override
-    protected HookResult callHook(RcptHook rawHook, SMTPSession session,
-                                  String parameters) {
+    protected HookResult callHook(RcptHook rawHook, SMTPSession session, String parameters) {
+        MailAddress sender = (MailAddress) session.getAttachment(SMTPSession.SENDER, State.Transaction);
         return rawHook.doRcpt(session,
-                (MailAddress) session.getAttachment(SMTPSession.SENDER, State.Transaction),
+                MaybeSender.of(sender),
                 (MailAddress) session.getAttachment(CURRENT_RECIPIENT, State.Transaction));
     }
 

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractGreylistHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractGreylistHandler.java
@@ -22,6 +22,7 @@ package org.apache.james.protocols.smtp.core.fastfail;
 import java.util.Iterator;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.smtp.SMTPRetCode;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.dsn.DSNStatus;
@@ -76,15 +77,12 @@ public abstract class AbstractGreylistHandler implements RcptHook {
     }
 
 
-    private HookResult doGreyListCheck(SMTPSession session, MailAddress senderAddress, MailAddress recipAddress) {
+    private HookResult doGreyListCheck(SMTPSession session, MaybeSender senderAddress, MailAddress recipAddress) {
         String recip = "";
-        String sender = "";
+        String sender = senderAddress.asString("");
 
         if (recipAddress != null) {
             recip = recipAddress.toString();
-        }
-        if (senderAddress != null) {
-            sender = senderAddress.toString();
         }
     
         long time = System.currentTimeMillis();
@@ -219,7 +217,7 @@ public abstract class AbstractGreylistHandler implements RcptHook {
   
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
         if (!session.isRelayingAllowed()) {
             return doGreyListCheck(session, sender,rcpt);
         } else {

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractValidRcptHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/AbstractValidRcptHandler.java
@@ -21,6 +21,7 @@ package org.apache.james.protocols.smtp.core.fastfail;
 
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.smtp.SMTPRetCode;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.dsn.DSNStatus;
@@ -37,7 +38,7 @@ public abstract class AbstractValidRcptHandler implements RcptHook {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractValidRcptHandler.class);
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
         if (!isLocalDomain(session, rcpt.getDomain())) {
             return HookResult.DECLINED;
         }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandler.java
@@ -27,6 +27,7 @@ import java.util.StringTokenizer;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.api.ProtocolSession.State;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.dsn.DSNStatus;
@@ -178,7 +179,7 @@ public class DNSRBLHandler implements RcptHook {
     }
     
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
         checkDNSRBL(session, session.getRemoteAddress().getAddress().getHostAddress());
     
         if (!session.isRelayingAllowed()) {

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/MaxRcptHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/MaxRcptHandler.java
@@ -24,6 +24,7 @@ package org.apache.james.protocols.smtp.core.fastfail;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.smtp.SMTPRetCode;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.dsn.DSNStatus;
@@ -56,7 +57,7 @@ public class MaxRcptHandler implements RcptHook {
     }
    
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
         if ((session.getRcptCount() + 1) > maxRcpt) {
             LOGGER.info("Maximum recipients of {} reached", maxRcpt);
             

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandler.java
@@ -25,6 +25,7 @@ import java.net.UnknownHostException;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.api.ProtocolSession.State;
 import org.apache.james.protocols.smtp.SMTPRetCode;
 import org.apache.james.protocols.smtp.SMTPSession;
@@ -93,7 +94,7 @@ public class ResolvableEhloHeloHandler implements RcptHook, HeloHook {
     }
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
         if (check(session,rcpt)) {
             return HookResult.builder()
                 .hookReturnCode(HookReturnCode.deny())

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/SpamTrapHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/SpamTrapHandler.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.hook.HookResult;
 import org.apache.james.protocols.smtp.hook.RcptHook;
@@ -69,7 +70,7 @@ public class SpamTrapHandler implements RcptHook {
     }
     
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
         String address = session.getRemoteAddress().getAddress().getHostAddress();
         if (isBlocked(address, session)) {
             return HookResult.DENY;

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/SupressDuplicateRcptHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/SupressDuplicateRcptHandler.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.api.ProtocolSession.State;
 import org.apache.james.protocols.smtp.SMTPRetCode;
 import org.apache.james.protocols.smtp.SMTPSession;
@@ -52,7 +53,7 @@ public class SupressDuplicateRcptHandler implements RcptHook {
 
     @Override
     @SuppressWarnings("unchecked")
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
         Collection<MailAddress> rcptList = (Collection<MailAddress>) session.getAttachment(SMTPSession.RCPT_LIST, State.Transaction);
     
         // Check if the recipient is already in the rcpt list

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandler.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandler.java
@@ -18,7 +18,7 @@
  ****************************************************************/
 package org.apache.james.protocols.smtp.core.fastfail;
 
-import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.smtp.SMTPRetCode;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.dsn.DSNStatus;
@@ -34,8 +34,8 @@ public abstract class ValidSenderDomainHandler implements MailHook {
 
 
     @Override
-    public HookResult doMail(SMTPSession session, MailAddress sender) {
-        if (sender != null  && !hasMXRecord(session,sender.getDomain().name())) {
+    public HookResult doMail(SMTPSession session, MaybeSender sender) {
+        if (!sender.isNullSender()  && !hasMXRecord(session,sender.get().getDomain().name())) {
             return HookResult.builder()
                 .hookReturnCode(HookReturnCode.deny())
                 .smtpReturnCode(SMTPRetCode.SYNTAX_ERROR_ARGUMENTS)

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/MailHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/MailHook.java
@@ -20,6 +20,7 @@
 package org.apache.james.protocols.smtp.hook;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.smtp.SMTPSession;
 
 /**
@@ -30,10 +31,27 @@ public interface MailHook extends Hook {
 
     /**
      * Return the HookResult after run the hook
+     *
+     * @Deprecated use {@link #doMail(SMTPSession, MaybeSender)} instead
      * 
      * @param session the SMTPSession
      * @param sender the sender MailAddress
      * @return HockResult
      */
-    HookResult doMail(SMTPSession session, MailAddress sender);
+    @Deprecated
+    default HookResult doMail(SMTPSession session, MailAddress sender) {
+        return doMail(session, MaybeSender.of(sender));
+    }
+
+    /**
+     * Return the HookResult after run the hook
+     *
+     * This strongly typed version of do mail is safer to use.
+     *
+     * @since James 3.2.0
+     */
+    @SuppressWarnings("deprecated")
+    default HookResult doMail(SMTPSession session, MaybeSender sender) {
+        return doMail(session, sender.asOptional().orElse(MailAddress.nullSender()));
+    }
 }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/RcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/RcptHook.java
@@ -45,7 +45,7 @@ public interface RcptHook extends Hook {
     /**
      * Return the HookResult after run the hook
      *
-     * this strongly typed version smoothly handled null sender and should be prefered.
+     * this strongly typed version smoothly handle null sender and should be prefered.
      */
     @SuppressWarnings("deprecated")
     default HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/RcptHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/RcptHook.java
@@ -19,6 +19,7 @@
 package org.apache.james.protocols.smtp.hook;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.smtp.SMTPSession;
 
 /**
@@ -28,12 +29,27 @@ public interface RcptHook extends Hook {
     
     /**
      * Return the HookResult after run the hook
+     *
+     * @deprecated Use {@link #doRcpt(SMTPSession, MaybeSender, MailAddress)} instead
      * 
      * @param session the SMTPSession
      * @param sender the sender MailAddress
      * @param rcpt the recipient MailAddress
      * @return HookResult
      */
-    HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt);
+    @Deprecated
+    default HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+        return doRcpt(session, MaybeSender.of(sender), rcpt);
+    }
+
+    /**
+     * Return the HookResult after run the hook
+     *
+     * this strongly typed version smoothly handled null sender and should be prefered.
+     */
+    @SuppressWarnings("deprecated")
+    default HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
+        return doRcpt(session, sender.asOptional().orElse(null), rcpt);
+    }
 
 }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/SimpleHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/SimpleHook.java
@@ -57,7 +57,7 @@ public class SimpleHook implements HeloHook, MailHook, RcptHook, MessageHook {
      * Return {@link HookResult} with {@link HookReturnCode#DECLINED}
      */
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
         return HookResult.DECLINED;
 
     }

--- a/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/SimpleHook.java
+++ b/protocols/smtp/src/main/java/org/apache/james/protocols/smtp/hook/SimpleHook.java
@@ -22,6 +22,7 @@ package org.apache.james.protocols.smtp.hook;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.smtp.MailEnvelope;
 import org.apache.james.protocols.smtp.SMTPSession;
 
@@ -65,7 +66,7 @@ public class SimpleHook implements HeloHook, MailHook, RcptHook, MessageHook {
      * Return {@link HookResult} with {@link HookReturnCode#DECLINED}
      */
     @Override
-    public HookResult doMail(SMTPSession session, MailAddress sender) {
+    public HookResult doMail(SMTPSession session, MaybeSender sender) {
         return HookResult.DECLINED;
 
     }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
@@ -695,7 +695,7 @@ public abstract class AbstractSMTPServerTest {
             }
 
             @Override
-            public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+            public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
                 if (RCPT1.equals(rcpt.toString())) {
                     return HookResult.DENY;
                 } else {
@@ -759,7 +759,7 @@ public abstract class AbstractSMTPServerTest {
             }
 
             @Override
-            public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+            public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
                 if (RCPT1.equals(rcpt.toString())) {
                     return HookResult.DENYSOFT;
                 } else {

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
@@ -1115,7 +1115,7 @@ public abstract class AbstractSMTPServerTest {
     }
     
     protected static void checkEnvelope(MailEnvelope env, String sender, List<String> recipients, String msg) throws IOException {
-        assertThat(env.getSender().toString()).isEqualTo(sender);
+        assertThat(env.getMaybeSender().asString()).isEqualTo(sender);
 
         List<MailAddress> envRecipients = env.getRecipients();
         assertThat(envRecipients.size()).isEqualTo(recipients.size());

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/AbstractSMTPServerTest.java
@@ -37,6 +37,7 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.net.smtp.SMTPClient;
 import org.apache.commons.net.smtp.SMTPReply;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.james.protocols.api.Protocol;
 import org.apache.james.protocols.api.ProtocolServer;
@@ -593,7 +594,7 @@ public abstract class AbstractSMTPServerTest {
             }
 
             @Override
-            public HookResult doMail(SMTPSession session, MailAddress sender) {
+            public HookResult doMail(SMTPSession session, MaybeSender sender) {
                 return HookResult.DENY;
             }
         };
@@ -643,7 +644,7 @@ public abstract class AbstractSMTPServerTest {
             }
 
             @Override
-            public HookResult doMail(SMTPSession session, MailAddress sender) {
+            public HookResult doMail(SMTPSession session, MaybeSender sender) {
                 return HookResult.DENYSOFT;
             }
         };

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/DNSRBLHandlerTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.api.ProtocolSession.State;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.utils.BaseFakeSMTPSession;
@@ -183,7 +184,7 @@ public class DNSRBLHandlerTest {
 
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
-        rbl.doRcpt(mockedSMTPSession, null, new MailAddress("test@localhost"));
+        rbl.doRcpt(mockedSMTPSession, MaybeSender.nullSender(), new MailAddress("test@localhost"));
         assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, State.Connection)).describedAs("Details").isEqualTo("Blocked - see http://www.spamcop.net/bl.shtml?127.0.0.2");
         assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Blocked").isNotNull();
     }
@@ -196,7 +197,7 @@ public class DNSRBLHandlerTest {
 
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(false);
-        rbl.doRcpt(mockedSMTPSession, null, new MailAddress("test@localhost"));
+        rbl.doRcpt(mockedSMTPSession, MaybeSender.nullSender(), new MailAddress("test@localhost"));
         assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("No details").isNull();
         assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Blocked").isNotNull();
     }
@@ -210,7 +211,7 @@ public class DNSRBLHandlerTest {
 
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
-        rbl.doRcpt(mockedSMTPSession, null, new MailAddress("test@localhost"));
+        rbl.doRcpt(mockedSMTPSession, MaybeSender.nullSender(), new MailAddress("test@localhost"));
         assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("No details").isNull();
         assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Not blocked").isNull();
     }
@@ -225,7 +226,7 @@ public class DNSRBLHandlerTest {
 
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
-        rbl.doRcpt(mockedSMTPSession, null, new MailAddress("test@localhost"));
+        rbl.doRcpt(mockedSMTPSession, MaybeSender.nullSender(), new MailAddress("test@localhost"));
         assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("No details").isNull();
         assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Not blocked").isNull();
     }
@@ -240,7 +241,7 @@ public class DNSRBLHandlerTest {
 
         rbl.setBlacklist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
-        rbl.doRcpt(mockedSMTPSession, null, new MailAddress("test@localhost"));
+        rbl.doRcpt(mockedSMTPSession, MaybeSender.nullSender(), new MailAddress("test@localhost"));
         assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).isNull();
         assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Blocked").isNotNull();
     }
@@ -255,7 +256,7 @@ public class DNSRBLHandlerTest {
 
         rbl.setWhitelist(new String[] { "bl.spamcop.net." });
         rbl.setGetDetail(true);
-        rbl.doRcpt(mockedSMTPSession, null, new MailAddress("test@localhost"));
+        rbl.doRcpt(mockedSMTPSession, MaybeSender.nullSender(), new MailAddress("test@localhost"));
         assertThat(mockedSMTPSession.getAttachment(RBL_DETAIL_MAIL_ATTRIBUTE_NAME, Connection)).isNull();
         assertThat(mockedSMTPSession.getAttachment(RBL_BLOCKLISTED_MAIL_ATTRIBUTE_NAME, Connection)).withFailMessage("Not blocked").isNull();
     }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/MaxRcptHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/MaxRcptHandlerTest.java
@@ -60,7 +60,7 @@ public class MaxRcptHandlerTest {
         MaxRcptHandler handler = new MaxRcptHandler();
         
         handler.setMaxRcpt(2);
-        HookReturnCode resp = handler.doRcpt(session,null,new MailAddress("test@test")).getResult();
+        HookReturnCode resp = handler.doRcpt(session, MailAddress.nullSender(), new MailAddress("test@test")).getResult();
     
         assertThat(HookReturnCode.deny()).describedAs("Rejected.. To many recipients").isEqualTo(resp);
     }
@@ -72,7 +72,7 @@ public class MaxRcptHandlerTest {
         MaxRcptHandler handler = new MaxRcptHandler();    
 
         handler.setMaxRcpt(4);
-        HookReturnCode resp = handler.doRcpt(session,null,new MailAddress("test@test")).getResult();
+        HookReturnCode resp = handler.doRcpt(session, MailAddress.nullSender(), new MailAddress("test@test")).getResult();
         
         assertThat(HookReturnCode.declined()).describedAs("Not Rejected..").isEqualTo(resp);
     }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ResolvableEhloHeloHandlerTest.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.hook.HookReturnCode;
 import org.apache.james.protocols.smtp.utils.BaseFakeSMTPSession;
@@ -126,7 +127,7 @@ public class ResolvableEhloHeloHandlerTest {
         handler.doHelo(session, INVALID_HOST);
         assertThat(session.getAttachment(BAD_EHLO_HELO, Transaction)).withFailMessage("Invalid HELO").isNotNull();
 
-        HookReturnCode result = handler.doRcpt(session,null, mailAddress).getResult();
+        HookReturnCode result = handler.doRcpt(session, MaybeSender.nullSender(), mailAddress).getResult();
         assertThat(HookReturnCode.deny()).describedAs("Reject").isEqualTo(result);
     }
     
@@ -140,7 +141,7 @@ public class ResolvableEhloHeloHandlerTest {
         handler.doHelo(session, VALID_HOST);
         assertThat(session.getAttachment(BAD_EHLO_HELO, Transaction)).withFailMessage("Valid HELO").isNull();
 
-        HookReturnCode result = handler.doRcpt(session,null, mailAddress).getResult();
+        HookReturnCode result = handler.doRcpt(session, MaybeSender.nullSender(), mailAddress).getResult();
         assertThat(HookReturnCode.declined()).describedAs("Not reject").isEqualTo(result);
     }
    
@@ -155,7 +156,7 @@ public class ResolvableEhloHeloHandlerTest {
         assertThat(session.getAttachment(BAD_EHLO_HELO, Transaction)).withFailMessage("Value stored").isNotNull();
 
 
-        HookReturnCode result = handler.doRcpt(session,null, mailAddress).getResult();
+        HookReturnCode result = handler.doRcpt(session, MaybeSender.nullSender(), mailAddress).getResult();
         assertThat(HookReturnCode.deny()).describedAs("Reject").isEqualTo(result);
     }
     
@@ -171,7 +172,7 @@ public class ResolvableEhloHeloHandlerTest {
         assertThat(session.getAttachment(BAD_EHLO_HELO, Transaction)).withFailMessage("Value stored").isNotNull();
 
 
-        HookReturnCode result = handler.doRcpt(session,null, mailAddress).getResult();
+        HookReturnCode result = handler.doRcpt(session, MaybeSender.nullSender(), mailAddress).getResult();
         assertThat(HookReturnCode.deny()).describedAs("Reject").isEqualTo(result);
     }
 }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/SpamTrapHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/SpamTrapHandlerTest.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.hook.HookReturnCode;
 import org.apache.james.protocols.smtp.utils.BaseFakeSMTPSession;
@@ -63,17 +64,17 @@ public class SpamTrapHandlerTest {
         handler.setBlockTime(blockTime);
         handler.setSpamTrapRecipients(rcpts);
 
-        HookReturnCode result = handler.doRcpt(setUpSMTPSession(ip),null,new MailAddress(SPAM_TRAP_RECIP1)).getResult();
+        HookReturnCode result = handler.doRcpt(setUpSMTPSession(ip), MaybeSender.nullSender(), new MailAddress(SPAM_TRAP_RECIP1)).getResult();
     
         assertThat(result).describedAs("Blocked on first connect").isEqualTo(HookReturnCode.deny());
     
 
-        result = handler.doRcpt(setUpSMTPSession(ip),null,new MailAddress(RECIP1)).getResult();
+        result = handler.doRcpt(setUpSMTPSession(ip), MaybeSender.nullSender(), new MailAddress(RECIP1)).getResult();
     
         assertThat(result).describedAs("Blocked on second connect").isEqualTo(HookReturnCode.deny());
     
         
-        result = handler.doRcpt(setUpSMTPSession(ip2),null,new MailAddress(RECIP1)).getResult();
+        result = handler.doRcpt(setUpSMTPSession(ip2), MaybeSender.nullSender(), new MailAddress(RECIP1)).getResult();
     
         assertThat(result).describedAs("Not Blocked").isEqualTo(HookReturnCode.declined());
     
@@ -84,7 +85,7 @@ public class SpamTrapHandlerTest {
             fail("Failed to sleep for " + blockTime + " ms");
         }
     
-        result = handler.doRcpt(setUpSMTPSession(ip),null,new MailAddress(RECIP1)).getResult();
+        result = handler.doRcpt(setUpSMTPSession(ip), MaybeSender.nullSender(), new MailAddress(RECIP1)).getResult();
     
         assertThat(result).describedAs("Not blocked. BlockTime exceeded").isEqualTo(HookReturnCode.declined());
     }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandlerTest.java
@@ -107,7 +107,7 @@ public class ValidSenderDomainHandlerTest {
     @Test
     public void testNullSenderNotReject() {
         ValidSenderDomainHandler handler = createHandler();
-        HookReturnCode response = handler.doMail(setupMockedSession(null), MailAddress.nullSender()).getResult();
+        HookReturnCode response = handler.doMail(setupMockedSession(null), MaybeSender.nullSender()).getResult();
         
         assertThat(HookReturnCode.declined()).describedAs("Not blocked cause its a nullsender").isEqualTo(response);
     }

--- a/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandlerTest.java
+++ b/protocols/smtp/src/test/java/org/apache/james/protocols/smtp/core/fastfail/ValidSenderDomainHandlerTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.protocols.api.ProtocolSession.State;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.hook.HookReturnCode;
@@ -106,7 +107,7 @@ public class ValidSenderDomainHandlerTest {
     @Test
     public void testNullSenderNotReject() {
         ValidSenderDomainHandler handler = createHandler();
-        HookReturnCode response = handler.doMail(setupMockedSession(null),null).getResult();
+        HookReturnCode response = handler.doMail(setupMockedSession(null), MailAddress.nullSender()).getResult();
         
         assertThat(HookReturnCode.declined()).describedAs("Not blocked cause its a nullsender").isEqualTo(response);
     }
@@ -115,7 +116,8 @@ public class ValidSenderDomainHandlerTest {
     public void testInvalidSenderDomainReject() throws Exception {
         ValidSenderDomainHandler handler = createHandler();
         SMTPSession session = setupMockedSession(new MailAddress("invalid@invalid"));
-        HookReturnCode response = handler.doMail(session,(MailAddress) session.getAttachment(SMTPSession.SENDER, State.Transaction)).getResult();
+        MailAddress sender = (MailAddress) session.getAttachment(SMTPSession.SENDER, State.Transaction);
+        HookReturnCode response = handler.doMail(session, MaybeSender.of(sender)).getResult();
         
         assertThat(HookReturnCode.deny()).describedAs("Blocked cause we use reject action").isEqualTo(response);
     }

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/DataLineJamesMessageHookHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/DataLineJamesMessageHookHandler.java
@@ -31,6 +31,7 @@ import javax.mail.MessagingException;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.lifecycle.api.LifecycleUtil;
 import org.apache.james.protocols.api.ProtocolSession.State;
 import org.apache.james.protocols.api.Response;
@@ -259,10 +260,9 @@ public class DataLineJamesMessageHookHandler implements DataLineFilter, Extensib
             return ImmutableList.copyOf(mail.getRecipients());
         }
 
-        @SuppressWarnings("deprecated") // This will be handled in a followup pull request See JAMES-2557
         @Override
-        public MailAddress getSender() {
-            return mail.getSender();
+        public MaybeSender getMaybeSender() {
+            return mail.getMaybeSender();
         }
 
         @Override

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SenderAuthIdentifyVerificationRcptHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SenderAuthIdentifyVerificationRcptHook.java
@@ -24,6 +24,7 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.domainlist.api.DomainList;
 import org.apache.james.domainlist.api.DomainListException;
 import org.apache.james.protocols.smtp.SMTPSession;
@@ -61,7 +62,7 @@ public class SenderAuthIdentifyVerificationRcptHook extends AbstractSenderAuthId
     }
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
         ExtendedSMTPSession nSession = (ExtendedSMTPSession) session;
         if (nSession.verifyIdentity()) {
             return super.doRcpt(session, sender, rcpt);

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/JDBCGreylistHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/JDBCGreylistHandler.java
@@ -38,6 +38,7 @@ import javax.sql.DataSource;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.dnsservice.library.netmatcher.NetMatcher;
 import org.apache.james.filesystem.api.FileSystem;
@@ -353,7 +354,7 @@ public class JDBCGreylistHandler extends AbstractGreylistHandler implements Prot
     }
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
         if ((wNetworks == null) || (!wNetworks.matchInetNetwork(session.getRemoteAddress().getAddress().getHostAddress()))) {
             return super.doRcpt(session, sender, rcpt);
         } else {

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SPFHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/SPFHandler.java
@@ -149,7 +149,7 @@ public class SPFHandler implements JamesMessageHook, MailHook, RcptHook, Protoco
     }
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
         if (!session.isRelayingAllowed()) {
             // Check if session is blocklisted
             if (session.getAttachment(SPF_BLOCKLISTED, State.Transaction) != null) {

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptMX.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptMX.java
@@ -29,6 +29,7 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.dnsservice.api.TemporaryResolutionException;
 import org.apache.james.dnsservice.library.netmatcher.NetMatcher;
@@ -87,7 +88,7 @@ public class ValidRcptMX implements RcptHook, ProtocolHandler {
     }
 
     @Override
-    public HookResult doRcpt(SMTPSession session, MailAddress sender, MailAddress rcpt) {
+    public HookResult doRcpt(SMTPSession session, MaybeSender sender, MailAddress rcpt) {
 
         Domain domain = rcpt.getDomain();
 

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SPFHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SPFHandlerTest.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.jspf.core.DNSRequest;
 import org.apache.james.jspf.core.DNSService;
 import org.apache.james.jspf.core.exceptions.TimeoutException;
@@ -169,7 +170,7 @@ public class SPFHandlerTest {
 
     @Test
     public void testSPFpass() throws Exception {
-        MailAddress sender = new MailAddress("test@spf1.james.apache.org");
+        MaybeSender sender = MaybeSender.of(new MailAddress("test@spf1.james.apache.org"));
         MailAddress rcpt = new MailAddress("test@localhost");
         setupMockedSMTPSession("192.168.100.1", "spf1.james.apache.org");
         SPFHandler spf = new SPFHandler();
@@ -177,12 +178,12 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender.get(), rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
     }
 
     @Test
     public void testSPFfail() throws Exception {
-        MailAddress sender = new MailAddress("test@spf2.james.apache.org");
+        MaybeSender sender = MaybeSender.of(new MailAddress("test@spf2.james.apache.org"));
         MailAddress rcpt = new MailAddress("test@localhost");
         setupMockedSMTPSession("192.168.100.1", "spf2.james.apache.org");
         SPFHandler spf = new SPFHandler();
@@ -190,12 +191,12 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("fail").isEqualTo(HookReturnCode.deny());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender.get(), rcpt).getResult()).describedAs("fail").isEqualTo(HookReturnCode.deny());
     }
 
     @Test
     public void testSPFsoftFail() throws Exception {
-        MailAddress sender = new MailAddress("test@spf3.james.apache.org");
+        MaybeSender sender = MaybeSender.of(new MailAddress("test@spf3.james.apache.org"));
         MailAddress rcpt = new MailAddress("test@localhost");
         setupMockedSMTPSession("192.168.100.1", "spf3.james.apache.org");
         SPFHandler spf = new SPFHandler();
@@ -203,12 +204,12 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("softfail declined").isEqualTo(HookReturnCode.declined());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender.get(), rcpt).getResult()).describedAs("softfail declined").isEqualTo(HookReturnCode.declined());
     }
 
     @Test
     public void testSPFsoftFailRejectEnabled() throws Exception {
-        MailAddress sender = new MailAddress("test@spf3.james.apache.org");
+        MaybeSender sender = MaybeSender.of(new MailAddress("test@spf3.james.apache.org"));
         MailAddress rcpt = new MailAddress("test@localhost");
 
         setupMockedSMTPSession("192.168.100.1", "spf3.james.apache.org");
@@ -219,12 +220,12 @@ public class SPFHandlerTest {
         spf.setBlockSoftFail(true);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("softfail reject").isEqualTo(HookReturnCode.deny());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender.get(), rcpt).getResult()).describedAs("softfail reject").isEqualTo(HookReturnCode.deny());
     }
 
     @Test
     public void testSPFpermError() throws Exception {
-        MailAddress sender = new MailAddress("test@spf4.james.apache.org");
+        MaybeSender sender = MaybeSender.of(new MailAddress("test@spf4.james.apache.org"));
         MailAddress rcpt = new MailAddress("test@localhost");
 
         setupMockedSMTPSession("192.168.100.1", "spf4.james.apache.org");
@@ -235,12 +236,12 @@ public class SPFHandlerTest {
         spf.setBlockSoftFail(true);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("permerror reject").isEqualTo(HookReturnCode.deny());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender.get(), rcpt).getResult()).describedAs("permerror reject").isEqualTo(HookReturnCode.deny());
     }
 
     @Test
     public void testSPFtempError() throws Exception {
-        MailAddress sender = new MailAddress("test@spf5.james.apache.org");
+        MaybeSender sender = MaybeSender.of(new MailAddress("test@spf5.james.apache.org"));
         MailAddress rcpt = new MailAddress("test@localhost");
 
         setupMockedSMTPSession("192.168.100.1", "spf5.james.apache.org");
@@ -250,12 +251,12 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("temperror denysoft").isEqualTo(HookReturnCode.denySoft());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender.get(), rcpt).getResult()).describedAs("temperror denysoft").isEqualTo(HookReturnCode.denySoft());
     }
 
     @Test
     public void testSPFNoRecord() throws Exception {
-        MailAddress sender = new MailAddress("test@spf6.james.apache.org");
+        MaybeSender sender = MaybeSender.of(new MailAddress("test@spf6.james.apache.org"));
         MailAddress rcpt = new MailAddress("test@localhost");
 
         setupMockedSMTPSession("192.168.100.1", "spf6.james.apache.org");
@@ -264,12 +265,12 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender.get(), rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
     }
 
     @Test
     public void testSPFpermErrorRejectDisabled() throws Exception {
-        MailAddress sender = new MailAddress("test@spf4.james.apache.org");
+        MaybeSender sender = MaybeSender.of(new MailAddress("test@spf4.james.apache.org"));
         MailAddress rcpt = new MailAddress("test@localhost");
         setupMockedSMTPSession("192.168.100.1", "spf4.james.apache.org");
         SPFHandler spf = new SPFHandler();
@@ -279,6 +280,6 @@ public class SPFHandlerTest {
         spf.setBlockPermError(false);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender.get(), rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
     }
 }

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SPFHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SPFHandlerTest.java
@@ -178,7 +178,7 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender.get(), rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
     }
 
     @Test
@@ -191,7 +191,7 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender.get(), rcpt).getResult()).describedAs("fail").isEqualTo(HookReturnCode.deny());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("fail").isEqualTo(HookReturnCode.deny());
     }
 
     @Test
@@ -204,7 +204,7 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender.get(), rcpt).getResult()).describedAs("softfail declined").isEqualTo(HookReturnCode.declined());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("softfail declined").isEqualTo(HookReturnCode.declined());
     }
 
     @Test
@@ -220,7 +220,7 @@ public class SPFHandlerTest {
         spf.setBlockSoftFail(true);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender.get(), rcpt).getResult()).describedAs("softfail reject").isEqualTo(HookReturnCode.deny());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("softfail reject").isEqualTo(HookReturnCode.deny());
     }
 
     @Test
@@ -236,7 +236,7 @@ public class SPFHandlerTest {
         spf.setBlockSoftFail(true);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender.get(), rcpt).getResult()).describedAs("permerror reject").isEqualTo(HookReturnCode.deny());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("permerror reject").isEqualTo(HookReturnCode.deny());
     }
 
     @Test
@@ -251,7 +251,7 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender.get(), rcpt).getResult()).describedAs("temperror denysoft").isEqualTo(HookReturnCode.denySoft());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("temperror denysoft").isEqualTo(HookReturnCode.denySoft());
     }
 
     @Test
@@ -265,7 +265,7 @@ public class SPFHandlerTest {
         spf.setDNSService(mockedDnsService);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender.get(), rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
     }
 
     @Test
@@ -280,6 +280,6 @@ public class SPFHandlerTest {
         spf.setBlockPermError(false);
 
         assertThat(spf.doMail(mockedSMTPSession, sender).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
-        assertThat(spf.doRcpt(mockedSMTPSession, sender.get(), rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
+        assertThat(spf.doRcpt(mockedSMTPSession, sender, rcpt).getResult()).describedAs("declined").isEqualTo(HookReturnCode.declined());
     }
 }

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
@@ -48,6 +48,7 @@ public class ValidRcptHandlerTest {
     private static final String USER2 = "user2";
     private static final String PASSWORD = "xxx";
     private static final boolean RELAYING_ALLOWED = true;
+    private static final MaybeSender MAYBE_SENDER = MaybeSender.of(SENDER);
 
     private ValidRcptHandler handler;
     private MemoryRecipientRewriteTable memoryRecipientRewriteTable;
@@ -116,7 +117,7 @@ public class ValidRcptHandlerTest {
     public void doRcptShouldRejectNotExistingLocalUsersWhenNoRelay() {
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.of(SENDER), invalidUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MAYBE_SENDER, invalidUserEmail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.deny());
     }
@@ -125,7 +126,7 @@ public class ValidRcptHandlerTest {
     public void doRcptShouldDenyNotExistingLocalUsersWhenRelay() {
         SMTPSession session = setupMockedSMTPSession(RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.of(SENDER), invalidUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MAYBE_SENDER, invalidUserEmail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.deny());
     }
@@ -135,7 +136,7 @@ public class ValidRcptHandlerTest {
         MailAddress mailAddress = new MailAddress(INVALID_USER + "@otherdomain");
         SMTPSession session = setupMockedSMTPSession(RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.of(SENDER), mailAddress).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MAYBE_SENDER, mailAddress).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
@@ -145,7 +146,7 @@ public class ValidRcptHandlerTest {
         MailAddress mailAddress = new MailAddress(INVALID_USER + "@otherdomain");
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.of(SENDER), mailAddress).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MAYBE_SENDER, mailAddress).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
@@ -154,7 +155,7 @@ public class ValidRcptHandlerTest {
     public void doRcptShouldDeclineValidUsersWhenNoRelay() throws Exception {
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.of(SENDER), validUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MAYBE_SENDER, validUserEmail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
@@ -163,7 +164,7 @@ public class ValidRcptHandlerTest {
     public void doRcptShouldDeclineValidUsersWhenRelay() throws Exception {
         SMTPSession session = setupMockedSMTPSession(RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.of(SENDER), validUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MAYBE_SENDER, validUserEmail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
@@ -174,7 +175,7 @@ public class ValidRcptHandlerTest {
 
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.of(SENDER), validUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MAYBE_SENDER, validUserEmail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
@@ -186,7 +187,7 @@ public class ValidRcptHandlerTest {
 
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.of(SENDER), user1mail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MAYBE_SENDER, user1mail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
@@ -197,7 +198,7 @@ public class ValidRcptHandlerTest {
 
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.of(SENDER), user1mail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MAYBE_SENDER, user1mail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptHandlerTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.domainlist.lib.DomainListConfiguration;
 import org.apache.james.domainlist.memory.MemoryDomainList;
@@ -115,7 +116,7 @@ public class ValidRcptHandlerTest {
     public void doRcptShouldRejectNotExistingLocalUsersWhenNoRelay() {
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, SENDER, invalidUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.of(SENDER), invalidUserEmail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.deny());
     }
@@ -124,7 +125,7 @@ public class ValidRcptHandlerTest {
     public void doRcptShouldDenyNotExistingLocalUsersWhenRelay() {
         SMTPSession session = setupMockedSMTPSession(RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, SENDER, invalidUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.of(SENDER), invalidUserEmail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.deny());
     }
@@ -134,7 +135,7 @@ public class ValidRcptHandlerTest {
         MailAddress mailAddress = new MailAddress(INVALID_USER + "@otherdomain");
         SMTPSession session = setupMockedSMTPSession(RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, SENDER, mailAddress).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.of(SENDER), mailAddress).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
@@ -144,7 +145,7 @@ public class ValidRcptHandlerTest {
         MailAddress mailAddress = new MailAddress(INVALID_USER + "@otherdomain");
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, SENDER, mailAddress).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.of(SENDER), mailAddress).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
@@ -153,7 +154,7 @@ public class ValidRcptHandlerTest {
     public void doRcptShouldDeclineValidUsersWhenNoRelay() throws Exception {
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, SENDER, validUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.of(SENDER), validUserEmail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
@@ -162,7 +163,7 @@ public class ValidRcptHandlerTest {
     public void doRcptShouldDeclineValidUsersWhenRelay() throws Exception {
         SMTPSession session = setupMockedSMTPSession(RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, SENDER, validUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.of(SENDER), validUserEmail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
@@ -173,7 +174,7 @@ public class ValidRcptHandlerTest {
 
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, SENDER, validUserEmail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.of(SENDER), validUserEmail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
@@ -185,7 +186,7 @@ public class ValidRcptHandlerTest {
 
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, SENDER, user1mail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.of(SENDER), user1mail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }
@@ -196,7 +197,7 @@ public class ValidRcptHandlerTest {
 
         SMTPSession session = setupMockedSMTPSession(!RELAYING_ALLOWED);
 
-        HookReturnCode rCode = handler.doRcpt(session, SENDER, user1mail).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.of(SENDER), user1mail).getResult();
 
         assertThat(rCode).isEqualTo(HookReturnCode.declined());
     }

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptMXTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/ValidRcptMXTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.HashMap;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.dnsservice.api.InMemoryDNSService;
 import org.apache.james.protocols.smtp.SMTPSession;
@@ -83,7 +84,7 @@ public class ValidRcptMXTest {
         ValidRcptMX handler = new ValidRcptMX();
         handler.setDNSService(dns);
         handler.setBannedNetworks(ImmutableList.of(bannedAddress), dns);
-        HookReturnCode rCode = handler.doRcpt(session, null, mailAddress).getResult();
+        HookReturnCode rCode = handler.doRcpt(session, MaybeSender.nullSender(), mailAddress).getResult();
 
         assertThat(HookReturnCode.deny()).describedAs("Reject").isEqualTo(rCode);
     }


### PR DESCRIPTION
Second part of https://github.com/linagora/james-project/pull/1831

Remains:
 - Use `MaybeSender` in the SMTP session sender attachment
 - Deprecate `MailAddress.nullSender()`