### PR TITLE
Avoid failing on missing license for EML files in Mailet sub-project

### DIFF
--- a/mailet/pom.xml
+++ b/mailet/pom.xml
@@ -106,6 +106,7 @@
                                 <exclude>**/*.iml</exclude>
                                 <exclude>**/*.ics</exclude>
                                 <exclude>**/*.mime</exclude>
+                                <exclude>**/*.eml</exclude>
                                 <exclude>src/site/**</exclude>
                             </excludes>
                         </configuration>


### PR DESCRIPTION
Running `mvn` directly by the command line generated a failed Apache Rat report.