### PR TITLE
JAMES-2580 Categorize test set for Cassandra Jmap Integration tests

### DIFF
--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/pom.xml
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/pom.xml
@@ -224,11 +224,10 @@
                 <version>2.22.0</version>
                 <configuration>
                     <argLine>-Xms512m -Xmx1024m</argLine>
-                    <reuseForks>false</reuseForks>
+                    <reuseForks>true</reuseForks>
                     <!-- Fail tests longer than 2 hours, prevent form random locking tests -->
                     <forkedProcessTimeoutInSeconds>7200</forkedProcessTimeoutInSeconds>
-                    <!-- Run only Cassandra Jmap Integration tests-->
-                    <groups>org.apache.james.jmap.categories.BasicFeature</groups>
+                    <groups combine.self="override">org.apache.james.jmap.categories.BasicFeature,org.apache.james.jmap.categories.EnableCucumber</groups>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/pom.xml
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/pom.xml
@@ -215,5 +215,35 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
+                <configuration>
+                    <argLine>-Xms512m -Xmx1024m</argLine>
+                    <reuseForks>false</reuseForks>
+                    <!-- Fail tests longer than 2 hours, prevent form random locking tests -->
+                    <forkedProcessTimeoutInSeconds>7200</forkedProcessTimeoutInSeconds>
+                    <!-- Run only Cassandra Jmap Integration tests-->
+                    <groups>org.apache.james.jmap.categories.BasicFeature</groups>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>${junit.jupiter.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.vintage</groupId>
+                        <artifactId>junit-vintage-engine</artifactId>
+                        <version>${junit.vintage.version}</version>
+                     </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
     
 </project>

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraDownloadCucumberTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraDownloadCucumberTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.jmap.cassandra.cucumber;
 
+import org.apache.james.jmap.categories.EnableCucumber;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -27,7 +29,8 @@ import cucumber.api.junit.Cucumber;
 @RunWith(Cucumber.class)
 @CucumberOptions(features = {"classpath:cucumber/DownloadEndpoint.feature", "classpath:cucumber/DownloadGet.feature", "classpath:cucumber/DownloadPost.feature"},
                 glue = {"org.apache.james.jmap.methods.integration", "org.apache.james.jmap.cassandra.cucumber"},
-                tags = {"not @Ignore"},
+                tags = {"not @Ignore", "@BasicFeature"},
                 strict = true)
+@Category(EnableCucumber.class)
 public class CassandraDownloadCucumberTest {
 }

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraGetMessagesMethodTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraGetMessagesMethodTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.jmap.cassandra.cucumber;
 
+import org.apache.james.jmap.categories.EnableCucumber;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -27,6 +29,8 @@ import cucumber.api.junit.Cucumber;
 @RunWith(Cucumber.class)
 @CucumberOptions(features = "classpath:cucumber/GetMessages.feature",
                 glue = {"org.apache.james.jmap.methods.integration", "org.apache.james.jmap.cassandra.cucumber"},
+                tags = {"not @Ignore", "@BasicFeature"},
                 strict = true)
+@Category(EnableCucumber.class)
 public class CassandraGetMessagesMethodTest {
 }

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraIMAPKeywordsInconsistenciesTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraIMAPKeywordsInconsistenciesTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.jmap.cassandra.cucumber;
 
+import org.apache.james.jmap.categories.EnableCucumber;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -27,6 +29,8 @@ import cucumber.api.junit.Cucumber;
 @RunWith(Cucumber.class)
 @CucumberOptions(features = "classpath:cucumber/ImapKeywordsConsistency.feature",
     glue = {"org.apache.james.jmap.methods.integration", "org.apache.james.jmap.cassandra.cucumber"},
+    tags = {"not @Ignore", "@BasicFeature"},
     strict = true)
+@Category(EnableCucumber.class)
 public class CassandraIMAPKeywordsInconsistenciesTest {
 }

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraIMAPSetMessagesCompatibilityTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraIMAPSetMessagesCompatibilityTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.jmap.cassandra.cucumber;
 
+import org.apache.james.jmap.categories.EnableCucumber;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -27,6 +29,8 @@ import cucumber.api.junit.Cucumber;
 @RunWith(Cucumber.class)
 @CucumberOptions(features = "classpath:cucumber/ImapSetMessagesMailboxesUpdatesCompatibility.feature",
     glue = {"org.apache.james.jmap.methods.integration", "org.apache.james.jmap.cassandra.cucumber"},
+    tags = {"not @Ignore", "@BasicFeature"},
     strict = true)
+@Category(EnableCucumber.class)
 public class CassandraIMAPSetMessagesCompatibilityTest {
 }

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraMailboxSharingTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraMailboxSharingTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.jmap.cassandra.cucumber;
 
+import org.apache.james.jmap.categories.EnableCucumber;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -34,7 +36,8 @@ import cucumber.api.junit.Cucumber;
     "classpath:cucumber/sharing/MoveMailboxAndSharing.feature",
     "classpath:cucumber/sharing/RenamingMailboxAndSharing.feature" },
     glue = { "org.apache.james.jmap.methods.integration", "org.apache.james.jmap.cassandra.cucumber" },
-    tags = {"not @Ignore"},
+    tags = {"not @Ignore", "@BasicFeature"},
     strict = true)
+@Category(EnableCucumber.class)
 public class CassandraMailboxSharingTest {
 }

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraMessageSharingTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraMessageSharingTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.jmap.cassandra.cucumber;
 
+import org.apache.james.jmap.categories.EnableCucumber;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -35,7 +37,8 @@ import cucumber.api.junit.Cucumber;
     "classpath:cucumber/sharing/SetFlagAndSharing.feature",
     "classpath:cucumber/sharing/CopyAndSharing.feature" },
     glue = { "org.apache.james.jmap.methods.integration", "org.apache.james.jmap.cassandra.cucumber" },
-    tags = {"not @Ignore"},
+    tags = {"not @Ignore", "@BasicFeature"},
     strict = true)
+@Category(EnableCucumber.class)
 public class CassandraMessageSharingTest {
 }

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraSetMailboxesMethodCucumberTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraSetMailboxesMethodCucumberTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.jmap.cassandra.cucumber;
 
+import org.apache.james.jmap.categories.EnableCucumber;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -27,6 +29,8 @@ import cucumber.api.junit.Cucumber;
 @RunWith(Cucumber.class)
 @CucumberOptions(features = { "classpath:cucumber/MailboxModification.feature", "classpath:cucumber/SetMailboxes.feature" },
                 glue = { "org.apache.james.jmap.methods.integration", "org.apache.james.jmap.cassandra.cucumber" },
+                tags = {"not @Ignore", "@BasicFeature"},
                 strict = true)
+@Category(EnableCucumber.class)
 public class CassandraSetMailboxesMethodCucumberTest {
 }

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraSetMessagesMethodCucumberTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraSetMessagesMethodCucumberTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.jmap.cassandra.cucumber;
 
+import org.apache.james.jmap.categories.EnableCucumber;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -27,6 +29,8 @@ import cucumber.api.junit.Cucumber;
 @RunWith(Cucumber.class)
 @CucumberOptions(features = "classpath:cucumber/SetMessages.feature",
                 glue = {"org.apache.james.jmap.methods.integration", "org.apache.james.jmap.cassandra.cucumber"},
+                tags = {"not @Ignore", "@BasicFeature"},
                 strict = true)
+@Category(EnableCucumber.class)
 public class CassandraSetMessagesMethodCucumberTest {
 }

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraUploadCucumberTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraUploadCucumberTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.jmap.cassandra.cucumber;
 
+import org.apache.james.jmap.categories.EnableCucumber;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -27,7 +29,8 @@ import cucumber.api.junit.Cucumber;
 @RunWith(Cucumber.class)
 @CucumberOptions(features = {"classpath:cucumber/UploadEndpoint.feature"},
                 glue = {"org.apache.james.jmap.methods.integration", "org.apache.james.jmap.cassandra.cucumber"},
-                tags = {"not @Ignore"},
+                tags = {"not @Ignore", "@BasicFeature"},
                 strict = true)
+@Category(EnableCucumber.class)
 public class CassandraUploadCucumberTest {
 }

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/JMAPAuthenticationTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/JMAPAuthenticationTest.java
@@ -33,12 +33,14 @@ import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 import org.apache.james.GuiceJamesServer;
+import org.apache.james.jmap.categories.BasicFeature;
 import org.apache.james.jmap.model.ContinuationToken;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.JmapGuiceProbe;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -186,6 +188,7 @@ public abstract class JMAPAuthenticationTest {
             .body("methods", hasItem(userCredentials.getPassword()));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void mustReturnContinuationTokenWhenValidResquest() throws Exception {
         given()
@@ -199,6 +202,7 @@ public abstract class JMAPAuthenticationTest {
             .body("continuationToken", isA(String.class));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void mustReturnAuthenticationFailedWhenBadPassword() throws Exception {
         String continuationToken = fromGoodContinuationTokenRequest();
@@ -271,6 +275,7 @@ public abstract class JMAPAuthenticationTest {
             .statusCode(201);
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void mustSendJsonContainingAccessTokenAndEndpointsWhenGoodPassword() throws Exception {
         String continuationToken = fromGoodContinuationTokenRequest();
@@ -291,7 +296,7 @@ public abstract class JMAPAuthenticationTest {
     }
     
     @Test
-    public void getMustReturnUnauthorizedWithoutAuthroizationHeader() throws Exception {
+    public void getMustReturnUnauthorizedWithoutAuthorizationHeader() throws Exception {
         given()
         .when()
             .get("/authentication")
@@ -300,7 +305,7 @@ public abstract class JMAPAuthenticationTest {
     }
 
     @Test
-    public void getMustReturnUnauthorizedWithoutAValidAuthroizationHeader() throws Exception {
+    public void getMustReturnUnauthorizedWithoutAValidAuthorizationHeader() throws Exception {
         given()
             .header("Authorization", UUID.randomUUID())
         .when()
@@ -309,6 +314,7 @@ public abstract class JMAPAuthenticationTest {
             .statusCode(401);
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMustReturnEndpointsWhenValidAuthorizationHeader() throws Exception {
         String continuationToken = fromGoodContinuationTokenRequest();
@@ -326,6 +332,7 @@ public abstract class JMAPAuthenticationTest {
             .body("download", equalTo("/download"));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMustReturnEndpointsWhenValidJwtAuthorizationHeader() throws Exception {
         String token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0.T04BTk" +
@@ -357,7 +364,7 @@ public abstract class JMAPAuthenticationTest {
         .then()
             .statusCode(200);
     }
-    
+
     @Test
     public void getMustReturnBadCredentialsWhenInvalidJwtAuthorizationHeader() throws Exception {
         String token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0.T04BTk" +
@@ -417,7 +424,7 @@ public abstract class JMAPAuthenticationTest {
         .then()
             .statusCode(401);
     }
-    
+
     @Test
     public void deleteMustReturnOKNoContentOnValidAuthorizationToken() throws Exception {
         String continuationToken = fromGoodContinuationTokenRequest();
@@ -430,6 +437,7 @@ public abstract class JMAPAuthenticationTest {
             .statusCode(204);
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void deleteMustInvalidAuthorizationOnCorrectAuthorization() throws Exception {
         String continuationToken = fromGoodContinuationTokenRequest();

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/ProvisioningTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/ProvisioningTest.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.time.Duration;
 
 import org.apache.james.GuiceJamesServer;
+import org.apache.james.jmap.categories.BasicFeature;
 import org.apache.james.mailbox.DefaultMailboxes;
 import org.apache.james.modules.MailboxProbeImpl;
 import org.apache.james.util.concurrency.ConcurrentTestRunner;
@@ -41,6 +42,7 @@ import org.apache.james.utils.JmapGuiceProbe;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import io.restassured.RestAssured;
 
@@ -98,6 +100,7 @@ public abstract class ProvisioningTest {
             .body(ARGUMENTS + ".list.name", hasItems(DefaultMailboxes.DEFAULT_MAILBOXES.toArray()));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void provisionMailboxesShouldSubscribeToThem() throws Exception {
         String token = authenticateJamesUser(baseUri(jmapServer), USER, PASSWORD).serialize();

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/VacationIntegrationTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/VacationIntegrationTest.java
@@ -42,6 +42,7 @@ import org.apache.james.GuiceJamesServer;
 import org.apache.james.jmap.api.access.AccessToken;
 import org.apache.james.jmap.api.vacation.AccountId;
 import org.apache.james.jmap.api.vacation.VacationPatch;
+import org.apache.james.jmap.categories.BasicFeature;
 import org.apache.james.mailbox.DefaultMailboxes;
 import org.apache.james.mailbox.model.MailboxConstants;
 import org.apache.james.mailbox.probe.MailboxProbe;
@@ -52,6 +53,7 @@ import org.apache.james.utils.JmapGuiceProbe;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import io.restassured.RestAssured;
 
@@ -99,6 +101,7 @@ public abstract class VacationIntegrationTest {
         guiceJamesServer.stop();
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void jmapVacationShouldGenerateAReplyWhenActive() throws Exception {
         /* Test scenario :

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/VacationRelayIntegrationTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/VacationRelayIntegrationTest.java
@@ -33,6 +33,7 @@ import org.apache.james.GuiceJamesServer;
 import org.apache.james.dnsservice.api.InMemoryDNSService;
 import org.apache.james.jmap.api.vacation.AccountId;
 import org.apache.james.jmap.api.vacation.VacationPatch;
+import org.apache.james.jmap.categories.BasicFeature;
 import org.apache.james.mailbox.DefaultMailboxes;
 import org.apache.james.mailbox.model.MailboxConstants;
 import org.apache.james.mailbox.probe.MailboxProbe;
@@ -47,6 +48,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public abstract class VacationRelayIntegrationTest {
 
@@ -97,6 +99,7 @@ public abstract class VacationRelayIntegrationTest {
         guiceJamesServer.stop();
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void forwardingAnEmailShouldWork() throws Exception {
         jmapGuiceProbe.modifyVacation(AccountId.fromString(USER_WITH_DOMAIN), VacationPatch

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/categories/BasicFeature.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/categories/BasicFeature.java
@@ -1,0 +1,27 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.categories;
+
+/**
+ * Category marker for Junit 4 conditional execution
+ * Marks tests that should be run on every product
+ */
+public interface BasicFeature {
+}

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/categories/EnableCucumber.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/categories/EnableCucumber.java
@@ -1,0 +1,27 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.categories;
+
+/**
+ * Category marker for Junit 4 conditional execution
+ * Enables cucumber test by default as cucumber tags are being used for conditional execution
+ */
+public interface EnableCucumber {
+}

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/FilterTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/FilterTest.java
@@ -46,6 +46,7 @@ import java.util.Locale;
 import org.apache.james.GuiceJamesServer;
 import org.apache.james.jmap.JmapCommonRequests;
 import org.apache.james.jmap.api.access.AccessToken;
+import org.apache.james.jmap.categories.BasicFeature;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.modules.MailboxProbeImpl;
@@ -55,6 +56,7 @@ import org.apache.james.utils.JmapGuiceProbe;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import io.restassured.RestAssured;
 
@@ -155,6 +157,7 @@ public abstract class FilterTest {
             .body(ARGUMENTS + ".description", equalTo("The field 'accountId' of 'GetFilterRequest' is not supported"));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setFilterShouldOverwritePreviouslyStoredRules() {
         MailboxId mailbox1 = randomMailboxId();
@@ -436,6 +439,7 @@ public abstract class FilterTest {
             .body(ARGUMENTS + ".updated", hasSize(1));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getFilterShouldRetrievePreviouslyStoredRules() {
         MailboxId mailbox1 = randomMailboxId();
@@ -510,6 +514,7 @@ public abstract class FilterTest {
             .body(ARGUMENTS + ".singleton[1].action.appendIn.mailboxIds", containsInAnyOrder(mailbox2.serialize()));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setFilterShouldClearPreviouslyStoredRulesWhenEmptyBody() {
         MailboxId mailbox = randomMailboxId();
@@ -689,6 +694,7 @@ public abstract class FilterTest {
             .body(ARGUMENTS + ".singleton[4].condition.comparator", equalTo("contains"));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void messageShouldBeAppendedInSpecificMailboxWhenFromRuleMatches() {
         given()
@@ -1020,6 +1026,7 @@ public abstract class FilterTest {
             () -> JmapCommonRequests.isAnyMessageFoundInRecipientsMailbox(accessToken, matchedMailbox));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void messageShouldBeAppendedInInboxWhenFromDoesNotMatchRule() {
         given()
@@ -1299,7 +1306,7 @@ public abstract class FilterTest {
 
 
     @Test
-    public void messageShouldBeAppendedInInboxWhenSubjectRuleDoesNotMatchRuleBecaseOfCase() {
+    public void messageShouldBeAppendedInInboxWhenSubjectRuleDoesNotMatchRuleBecauseOfCase() {
         given()
             .header("Authorization", accessToken.serialize())
             .body("[[" +

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/ForwardIntegrationTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/ForwardIntegrationTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.james.GuiceJamesServer;
 import org.apache.james.jmap.api.access.AccessToken;
+import org.apache.james.jmap.categories.BasicFeature;
 import org.apache.james.probe.DataProbe;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.JmapGuiceProbe;
@@ -55,6 +56,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import io.restassured.RestAssured;
 import io.restassured.specification.RequestSpecification;
@@ -95,6 +97,7 @@ public abstract class ForwardIntegrationTest {
         jmapServer.stop();
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void messageShouldBeForwardedWhenDefinedInRESTAPI() {
         webAdminApi.put(String.format("/address/forwards/%s/targets/%s", ALICE, BOB));

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/GetMailboxesMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/GetMailboxesMethodTest.java
@@ -58,6 +58,7 @@ import org.apache.james.GuiceJamesServer;
 import org.apache.james.core.quota.QuotaCount;
 import org.apache.james.core.quota.QuotaSize;
 import org.apache.james.jmap.api.access.AccessToken;
+import org.apache.james.jmap.categories.BasicFeature;
 import org.apache.james.jmap.model.mailbox.MailboxNamespace;
 import org.apache.james.mailbox.DefaultMailboxes;
 import org.apache.james.mailbox.MessageManager.AppendCommand;
@@ -80,6 +81,7 @@ import org.apache.james.utils.JmapGuiceProbe;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -175,6 +177,7 @@ public abstract class GetMailboxesMethodTest {
             .body(ARGUMENTS + ".type", equalTo("invalidArguments"));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMailboxesShouldReturnMailboxesWhenIdsMatch() {
         String mailboxId = mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, ALICE, DefaultMailboxes.INBOX).serialize();
@@ -225,6 +228,7 @@ public abstract class GetMailboxesMethodTest {
             .body(ARGUMENTS + ".list", empty());
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMailboxesShouldReturnAllMailboxesWhenIdsIsNull() {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, ALICE, "myMailbox");
@@ -344,6 +348,7 @@ public abstract class GetMailboxesMethodTest {
             .body(ARGUMENTS + ".description", containsString("{\"ids\":true}"));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMailboxesShouldReturnDefaultMailboxesWhenAuthenticatedUserDoesntHaveAnAccountYet() {
         String token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMzM3QGRvbWFpbi50bGQiLCJuYW1lIjoiTmV3IFVzZXIif"
@@ -526,6 +531,7 @@ public abstract class GetMailboxesMethodTest {
             .body(FIRST_MAILBOX + ".role", equalTo(DefaultMailboxes.OUTBOX.toLowerCase(Locale.US)));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMailboxesShouldReturnMailboxesWithFilteredSharedWithWhenShared() throws Exception {
         String mailboxName = "name";
@@ -574,6 +580,7 @@ public abstract class GetMailboxesMethodTest {
         assertThat(sharedWith).containsOnlyKeys(ALICE, CEDRIC);
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMailboxesShouldReturnAllAccessibleMailboxesWhenEmptyIds() throws Exception {
         String sharedMailboxName = "BobShared";
@@ -778,6 +785,7 @@ public abstract class GetMailboxesMethodTest {
             .body(FIRST_MAILBOX + ".quotas['#private&alice@domain.tld']['MESSAGE'].max", nullValue());
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMailboxesShouldReturnMaxStorageQuotasForInboxWhenSet() throws Exception {
         quotaProbe.setGlobalMaxStorage(SerializableQuotaValue.valueOf(Optional.of(QuotaSize.size(42))));
@@ -867,6 +875,7 @@ public abstract class GetMailboxesMethodTest {
             .body(FIRST_MAILBOX + ".quotas['#private&alice@domain.tld']['MESSAGE'].used", equalTo(0));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMailboxesShouldReturnUpdatedQuotasForInboxWhenMailReceived() throws Exception {
         String mailboxId = mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, ALICE, DefaultMailboxes.INBOX).serialize();

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/GetMessageListMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/GetMessageListMethodTest.java
@@ -50,6 +50,7 @@ import javax.mail.Flags;
 
 import org.apache.james.GuiceJamesServer;
 import org.apache.james.jmap.api.access.AccessToken;
+import org.apache.james.jmap.categories.BasicFeature;
 import org.apache.james.jmap.model.Number;
 import org.apache.james.mailbox.FlagsBuilder;
 import org.apache.james.mailbox.MessageManager;
@@ -75,6 +76,7 @@ import org.apache.james.utils.JmapGuiceProbe;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import io.restassured.RestAssured;
 
@@ -142,8 +144,9 @@ public abstract class GetMessageListMethodTest {
             .body(ARGUMENTS + ".messageIds", empty());
     }
 
+    @Category(BasicFeature.class)
     @Test
-    public void getMessageListShouldListMessageWhenTheUserHasOnlyReadRight() throws Exception {
+    public void getMessagesListShouldListMessageWhenTheUserHasOnlyReadRight() throws Exception {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, BOB, "delegated");
         MailboxPath delegatedMailboxPath = MailboxPath.forUser(BOB, "delegated");
         ComposedMessageId message = mailboxProbe.appendMessage(BOB, delegatedMailboxPath,
@@ -235,6 +238,7 @@ public abstract class GetMessageListMethodTest {
             .body(ARGUMENTS + ".messageIds", contains(message.getMessageId().serialize()));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMessageListShouldNotDuplicateMessagesInSeveralMailboxes() throws Exception {
         MailboxId mailboxId = mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, ALICE, "mailbox");
@@ -498,6 +502,7 @@ public abstract class GetMessageListMethodTest {
                 not(containsInAnyOrder(messageForwarded.getMessageId().serialize()))));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMessageListANDOperatorShouldReturnMessagesWhichMatchAllConditions() throws Exception {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, ALICE, "mailbox");
@@ -748,6 +753,7 @@ public abstract class GetMessageListMethodTest {
             .body(ARGUMENTS + ".messageIds", containsInAnyOrder(message1.getMessageId().serialize(), message2.getMessageId().serialize()));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMessageListShouldReturnAllMessagesOfCurrentUserOnlyWhenMultipleMailboxesAndNoParameters() throws Exception {
         String otherUser = "other@" + DOMAIN;
@@ -779,6 +785,7 @@ public abstract class GetMessageListMethodTest {
             .body(ARGUMENTS + ".messageIds", containsInAnyOrder(message1.getMessageId().serialize(), message2.getMessageId().serialize()));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMessageListShouldExcludeMessagesWhenInMailboxesFilterMatches() throws Exception {
         MailboxId mailboxId = mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, ALICE, "mailbox");
@@ -859,7 +866,7 @@ public abstract class GetMessageListMethodTest {
     }
 
     @Test
-    public void getMessageListShouldExcludeMessagesWhenIdenticalNotInMailboxesAndInmailboxesFilterMatch() throws Exception {
+    public void getMessageListShouldExcludeMessagesWhenIdenticalNotInMailboxesAndInMailboxesFilterMatch() throws Exception {
         MailboxId mailboxId = mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, ALICE, "mailbox");
         mailboxProbe.appendMessage(ALICE, MailboxPath.forUser(ALICE, "mailbox"),
                 new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes()), new Date(), false, new Flags());
@@ -952,6 +959,7 @@ public abstract class GetMessageListMethodTest {
             .body(ARGUMENTS + ".messageIds", empty());
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMessageListShouldIncludeMessagesWhenTextFilterMatchesBody() throws Exception {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, ALICE, "mailbox");
@@ -1178,6 +1186,7 @@ public abstract class GetMessageListMethodTest {
             .body(ARGUMENTS + ".messageIds", contains(composedMessageId.getMessageId().serialize()));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMessageListShouldSortMessagesWhenSortedByDateDefault() throws Exception {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, ALICE, "mailbox");
@@ -1472,6 +1481,7 @@ public abstract class GetMessageListMethodTest {
             .body(ARGUMENTS + ".messageIds", contains(message3.getMessageId().serialize(), message2.getMessageId().serialize(), message1.getMessageId().serialize()));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMessageListShouldSupportIdSorting() throws Exception {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, ALICE, "mailbox");
@@ -1584,6 +1594,7 @@ public abstract class GetMessageListMethodTest {
             .body(ARGUMENTS + ".messageIds", contains(message2.getMessageId().serialize()));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMessageListShouldReturnSkipMessagesWhenPositionAndLimitGiven() throws Exception {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, ALICE, "mailbox");
@@ -1678,6 +1689,7 @@ public abstract class GetMessageListMethodTest {
             .body(ARGUMENTS + ".messageIds", containsInAnyOrder(message1.getMessageId().serialize(), message2.getMessageId().serialize(), message3.getMessageId().serialize()));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMessageListShouldChainFetchingMessagesWhenAskedFor() throws Exception {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, ALICE, "mailbox");
@@ -1702,6 +1714,7 @@ public abstract class GetMessageListMethodTest {
             .body("[1][1].list[0].id", equalTo(message.getMessageId().serialize()));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getMessageListShouldComputeTextBodyWhenNoTextBodyButHtmlBody() throws Exception {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, ALICE, "mailbox");

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/GetVacationResponseTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/GetVacationResponseTest.java
@@ -40,6 +40,7 @@ import org.apache.james.jmap.FixedDateZonedDateTimeProvider;
 import org.apache.james.jmap.api.access.AccessToken;
 import org.apache.james.jmap.api.vacation.AccountId;
 import org.apache.james.jmap.api.vacation.VacationPatch;
+import org.apache.james.jmap.categories.BasicFeature;
 import org.apache.james.probe.DataProbe;
 import org.apache.james.util.date.ZonedDateTimeProvider;
 import org.apache.james.utils.DataProbeImpl;
@@ -47,6 +48,7 @@ import org.apache.james.utils.JmapGuiceProbe;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -90,6 +92,7 @@ public abstract class GetVacationResponseTest {
         jmapServer.stop();
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getVacationResponseShouldReturnDefaultValue() {
         given()
@@ -115,6 +118,7 @@ public abstract class GetVacationResponseTest {
             .body(ARGUMENTS + ".list[0].htmlBody", nullValue());
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void getVacationResponseShouldReturnStoredValue() {
         jmapGuiceProbe.modifyVacation(AccountId.fromString(ALICE),

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/QuotaMailingTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/QuotaMailingTest.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 import org.apache.james.GuiceJamesServer;
 import org.apache.james.core.quota.QuotaSize;
 import org.apache.james.jmap.api.access.AccessToken;
+import org.apache.james.jmap.categories.BasicFeature;
 import org.apache.james.mailbox.DefaultMailboxes;
 import org.apache.james.mailbox.model.MailboxConstants;
 import org.apache.james.mailbox.model.SerializableQuotaValue;
@@ -52,6 +53,7 @@ import org.apache.james.utils.JmapGuiceProbe;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.google.common.base.Strings;
 
@@ -95,6 +97,7 @@ public abstract class QuotaMailingTest {
         jmapServer.stop();
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void shouldSendANoticeWhenThresholdExceeded() throws Exception {
         jmapServer.getProbe(QuotaProbesImpl.class)

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SendMDNMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SendMDNMethodTest.java
@@ -48,6 +48,7 @@ import org.apache.james.GuiceJamesServer;
 import org.apache.james.core.quota.QuotaSize;
 import org.apache.james.jmap.MessageAppender;
 import org.apache.james.jmap.api.access.AccessToken;
+import org.apache.james.jmap.categories.BasicFeature;
 import org.apache.james.mailbox.DefaultMailboxes;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.MailboxConstants;
@@ -63,6 +64,7 @@ import org.apache.james.utils.JmapGuiceProbe;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.google.common.collect.Iterables;
 
@@ -278,6 +280,7 @@ public abstract class SendMDNMethodTest {
                     "Explanation: Disposition-Notification-To header is missing")));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void sendMDNShouldSendAMDNBackToTheOriginalMessageAuthor() {
         String bartSentJmapMessageId = bartSendMessageToHomer();

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMailboxesMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMailboxesMethodTest.java
@@ -48,6 +48,7 @@ import java.io.IOException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.james.GuiceJamesServer;
 import org.apache.james.jmap.api.access.AccessToken;
+import org.apache.james.jmap.categories.BasicFeature;
 import org.apache.james.mailbox.DefaultMailboxes;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.model.MailboxACL;
@@ -65,6 +66,7 @@ import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -240,6 +242,7 @@ public abstract class SetMailboxesMethodTest {
         assertThat(mailboxProbe.listSubscriptions(username)).doesNotContain(overLimitName);
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void userShouldBeSubscribedOnCreatedMailboxWhenCreateMailbox() throws Exception {
         String requestBody =
@@ -410,6 +413,7 @@ public abstract class SetMailboxesMethodTest {
             DefaultMailboxes.DRAFTS);
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void subscriptionUserShouldBeDeletedWhenCreateThenDestroyMailboxWithJMAP() throws Exception {
         String requestBody =
@@ -521,6 +525,7 @@ public abstract class SetMailboxesMethodTest {
             .body(ARGUMENTS + ".description", equalTo("The field 'sortOrder' of 'MailboxCreateRequest' is not supported"));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setMailboxesShouldReturnCreatedMailbox() {
         String requestBody =
@@ -866,6 +871,7 @@ public abstract class SetMailboxesMethodTest {
                         ));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setMailboxesShouldReturnDestroyedMailbox() {
         MailboxId mailboxId = mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, username, "myBox");
@@ -1117,6 +1123,7 @@ public abstract class SetMailboxesMethodTest {
             .body(ARGUMENTS + ".updated", contains(mailboxId.serialize()));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setMailboxesShouldReturnUpdatedWhenNameUpdateAskedOnExistingMailbox() {
         MailboxId mailboxId = mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, username, "myBox");
@@ -1324,6 +1331,7 @@ public abstract class SetMailboxesMethodTest {
             .body(FIRST_MAILBOX + ".sharedWith", hasEntry(user, ImmutableList.of(ADMINISTER, WRITE)));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void updateShouldModifyStoredDataWhenUpdatingACL() {
         String myBox = "myBox";
@@ -1539,6 +1547,7 @@ public abstract class SetMailboxesMethodTest {
             .body(ARGUMENTS + ".list[0].name", equalTo("myRenamedBox"));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setMailboxesShouldReturnMailboxIdWhenMovingToAnotherParentMailbox() {
         MailboxId mailboxId = mailboxProbe

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
@@ -77,6 +77,7 @@ import org.apache.james.core.quota.QuotaSize;
 import org.apache.james.jmap.HttpJmapAuthentication;
 import org.apache.james.jmap.MessageAppender;
 import org.apache.james.jmap.api.access.AccessToken;
+import org.apache.james.jmap.categories.BasicFeature;
 import org.apache.james.mailbox.DefaultMailboxes;
 import org.apache.james.mailbox.Event;
 import org.apache.james.mailbox.FlagsBuilder;
@@ -119,6 +120,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -282,6 +284,7 @@ public abstract class SetMessagesMethodTest {
             .body(ARGUMENTS + ".destroyed", contains(message.getMessageId().serialize()));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setMessagesShouldDeleteMessageWhenMatchingMessage() throws Exception {
         // Given
@@ -436,6 +439,7 @@ public abstract class SetMessagesMethodTest {
             .body(ARGUMENTS + ".updated", hasSize(0));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setMessagesShouldUpdateKeywordsWhenKeywordsArePassed() throws MailboxException {
         mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME, "mailbox");
@@ -984,6 +988,7 @@ public abstract class SetMessagesMethodTest {
             .body(ARGUMENTS + ".updated", hasSize(0));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setMessagesShouldReturnCreatedMessageWhenSendingMessage() {
         String messageCreationId = "creationId1337";
@@ -1281,6 +1286,7 @@ public abstract class SetMessagesMethodTest {
             .body(ARGUMENTS + ".created[\"" + messageCreationId + "\"].keywords.$Flagged", equalTo(true));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setMessagesShouldAllowDraftCreation() {
         String messageCreationId = "creationId1337";
@@ -1315,6 +1321,7 @@ public abstract class SetMessagesMethodTest {
             .body(ARGUMENTS + ".created", hasKey(messageCreationId));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setMessagesShouldNotAllowDraftCreationWhenOverQuota() throws MailboxException {
         QuotaProbe quotaProbe = jmapServer.getProbe(QuotaProbesImpl.class);
@@ -1355,6 +1362,7 @@ public abstract class SetMessagesMethodTest {
             .body(ARGUMENTS + ".notCreated[\"" + messageCreationId + "\"].type", equalTo("maxQuotaReached"));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setMessagesWithABigBodyShouldReturnCreatedMessageWhenSendingMessage() {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails(LogDetail.HEADERS);
@@ -1430,6 +1438,7 @@ public abstract class SetMessagesMethodTest {
         }
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setMessagesShouldNotAllowCopyWhenOverQuota() throws MailboxException {
         QuotaProbe quotaProbe = jmapServer.getProbe(QuotaProbesImpl.class);
@@ -2096,6 +2105,7 @@ public abstract class SetMessagesMethodTest {
             .body(ARGUMENTS + ".notCreated[\"" + messageCreationId + "\"].description", endsWith("MailboxId invalid"));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setMessagesShouldSendMessageByMovingDraftToOutbox() {
         String draftCreationId = "creationId1337";
@@ -2337,6 +2347,7 @@ public abstract class SetMessagesMethodTest {
             && added.getMetaData(added.getUids().get(0)).getMessageId().serialize().equals(messageId);
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setMessagesShouldMoveMessageInSentWhenMessageIsSent() {
         // Given
@@ -2724,6 +2735,7 @@ public abstract class SetMessagesMethodTest {
             .body(ARGUMENTS + ".created", aMapWithSize(0));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setMessagesShouldDeliverMessageToRecipient() throws Exception {
         // Sender
@@ -2766,6 +2778,7 @@ public abstract class SetMessagesMethodTest {
         calmlyAwait.atMost(30, TimeUnit.SECONDS).until(() -> isAnyMessageFoundInRecipientsMailboxes(recipientToken));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setMessagesShouldTriggerMaxQuotaReachedWhenTryingToSendMessageAndQuotaReached() throws Exception {
         QuotaProbe quotaProbe = jmapServer.getProbe(QuotaProbesImpl.class);
@@ -3238,6 +3251,7 @@ public abstract class SetMessagesMethodTest {
             .spec(getSetMessagesUpdateOKResponseAssertions(messageToMoveId));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void mailboxIdsShouldBeInDestinationWhenUsingForMove() throws Exception {
         String newMailboxName = "heartFolder";
@@ -3280,6 +3294,7 @@ public abstract class SetMessagesMethodTest {
             .body(firstMessage + ".mailboxIds", contains(heartFolderId));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void mailboxIdsShouldNotBeAnymoreInSourceWhenUsingForMove() throws Exception {
         String newMailboxName = "heartFolder";
@@ -3323,6 +3338,7 @@ public abstract class SetMessagesMethodTest {
             .body(firstMessage + ".mailboxIds", not(contains(inboxId)));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void mailboxIdsShouldBeInBothMailboxWhenUsingForCopy() throws Exception {
         String newMailboxName = "heartFolder";
@@ -4044,6 +4060,7 @@ public abstract class SetMessagesMethodTest {
         checkBlobContent(blobId, rawBytes);
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void attachmentsShouldBeRetrievedWhenChainingSetMessagesAndGetMessagesTextAttachment() throws Exception {
         byte[] rawBytes = ByteStreams.toByteArray(new ZeroedInputStream(_1MB));
@@ -4599,6 +4616,7 @@ public abstract class SetMessagesMethodTest {
                 hasEntry("X-Forwarded-Message-Id", "forward value")));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setMessagesShouldUpdateIsAnsweredWhenInReplyToHeaderSentViaOutbox() throws Exception {
         OriginalMessage firstMessage = receiveFirstMessage();
@@ -4645,6 +4663,7 @@ public abstract class SetMessagesMethodTest {
             .body(message + ".isAnswered", equalTo(true));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setMessagesShouldUpdateIsForwardedWhenXForwardedHeaderSentViaOutbox() throws Exception {
         OriginalMessage firstMessage = receiveFirstMessage();

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetVacationResponseTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetVacationResponseTest.java
@@ -38,12 +38,14 @@ import org.apache.james.jmap.api.access.AccessToken;
 import org.apache.james.jmap.api.vacation.AccountId;
 import org.apache.james.jmap.api.vacation.Vacation;
 import org.apache.james.jmap.api.vacation.VacationPatch;
+import org.apache.james.jmap.categories.BasicFeature;
 import org.apache.james.util.ValuePatch;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.JmapGuiceProbe;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -169,6 +171,7 @@ public abstract class SetVacationResponseTest {
             .body(ARGUMENTS + ".notUpdated.singleton.description", equalTo("There is one VacationResponse object per account, with id set to \\\"singleton\\\" and not to " + id));
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setVacationResponseShouldReturnCorrectAnswerUponValidVacationResponse() {
         String bodyRequest = "[[" +
@@ -208,6 +211,7 @@ public abstract class SetVacationResponseTest {
         assertThat(vacation.getSubject()).contains(SUBJECT);
     }
 
+    @Category(BasicFeature.class)
     @Test
     public void setVacationResponseShouldAllowResets() {
         jmapGuiceProbe.modifyVacation(AccountId.fromString(USER),

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/DownloadEndpoint.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/DownloadEndpoint.feature
@@ -70,6 +70,7 @@ Feature: Download endpoint
     When "usera@domain.tld" downloads "a1" with wrong blobId
     Then the user should not be authorized
 
+  @BasicFeature
   Scenario: A user should have access to the download endpoint when an authentication token is valid
     Given "usera@domain.tld" is trusted for attachment "a1"
     When "usera@domain.tld" downloads "a1"

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/DownloadGet.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/DownloadGet.feature
@@ -26,6 +26,7 @@ Feature: Download GET
     And a user "bob@domain.tld"
     And "alice@domain.tld" has a mailbox "INBOX"
 
+  @BasicFeature
   Scenario: Getting an attachment previously stored
     Given "alice@domain.tld" mailbox "INBOX" contains a message "1" with an attachment "2"
     When "alice@domain.tld" downloads "2"
@@ -49,6 +50,7 @@ Feature: Download GET
     Then she can read that blob
     And the attachment is named "ديناصور.odt"
 
+  @BasicFeature
   Scenario: Getting a message blob previously stored
     Given "alice@domain.tld" mailbox "INBOX" contains a message "1"
     When "alice@domain.tld" downloads "1"

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/DownloadPost.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/DownloadPost.feature
@@ -30,6 +30,7 @@ Feature: Alternative authentication mechanism for getting attachment via a POST 
     When "username@domain.tld" asks for a token for attachment "123"
     Then the user should receive a not found response
 
+  @BasicFeature
   Scenario: Asking for an attachment access token with a previously stored blobId
     Given "username@domain.tld" mailbox "INBOX" contains a message "1" with an attachment "2"
     When "username@domain.tld" asks for a token for attachment "2"

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/GetMessages.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/GetMessages.feature
@@ -58,6 +58,7 @@ Feature: GetMessages method
     Then no error is returned
     And the notFound list should contain the requested message id
 
+  @BasicFeature
   Scenario: Retrieving message should return messages when exists
     Given "alice@domain.tld" has a message "m1" in "INBOX" mailbox with subject "my test subject", content "testmail"
     When "alice@domain.tld" ask for messages "m1"
@@ -154,6 +155,7 @@ Feature: GetMessages method
     And the id of the message is "m1"
     And the subject of the message is "my test subject"
 
+  @BasicFeature
   Scenario: Retrieving message should return attachments when some
     Given "alice@domain.tld" has a message "m1" in "INBOX" mailbox with two attachments
     When "alice@domain.tld" ask for messages "m1"
@@ -334,6 +336,7 @@ Feature: GetMessages method
             |content-type                                       |tranfer-encoding   |content                                                                                                     |preview                                                                                      |
             |"text/html; charset=iso-8859-1"                    |quoted-printable   |"Dans le cadre du stage effectu=E9 Mlle 2017, =E0 sign=E9e d=E8s que possible, =E0, tr=E8s, journ=E9e.."    |effectué, à, signée dès, très, journée                                                                        |
 
+  @BasicFeature
   Scenario Outline: Retrieving message should display keywords as jmap flag
     Given "alice@domain.tld" has a message "m1" in the "INBOX" mailbox with flags <flags>
     When "alice@domain.tld" ask for messages "m1"
@@ -434,7 +437,6 @@ Feature: GetMessages method
     |name     |"IMG_6112.JPG"                |
     |isInline |false                         |
 
-  @Only
   Scenario: Header only text calendar should be read as normal calendar attachment by JMAP
     Given "alice@domain.tld" receives a SMTP message specified in file "eml/ics_in_header.eml" as message "m1"
     When "alice@domain.tld" ask for messages "m1"
@@ -446,5 +448,5 @@ Feature: GetMessages method
     |key      | value                        |
     |type     |"text/calendar"               |
     |size     |1056                          |
-    |name     |"event.ics"                |
+    |name     |"event.ics"                   |
     |isInline |false                         |

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/MailboxModification.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/MailboxModification.feature
@@ -26,11 +26,13 @@ Feature: Mailbox modification
     Given a domain named "domain.tld"
     And a connected user "username@domain.tld"
 
+  @BasicFeature
   Scenario: Renaming a mailbox should keep messages
     Given mailbox "A" with 2 messages
     When renaming mailbox "A" to "B"
     Then mailbox "B" contains 2 messages
 
+  @BasicFeature
   Scenario: Moving a mailbox should keep messages
     Given mailbox "A" with 2 messages
     And mailbox "A.B" with 3 messages

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/SetMessages.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/SetMessages.feature
@@ -27,6 +27,7 @@ Feature: SetMessages method
 
 # Flags update
 
+  @BasicFeature
   Scenario: A user can update the flags on a message
     Given "bob@domain.tld" sets flags "$Flagged,$Seen" on message "mBob"
     When "bob@domain.tld" sets flags "$Flagged,$Forwarded" on message "mBob"
@@ -53,6 +54,7 @@ Feature: SetMessages method
     When "bob@domain.tld" marks the message "mDraft" as flagged
     Then "bob@domain.tld" should see message "mDraft" with keywords "$Draft,$Flagged"
 
+  @BasicFeature
   Scenario: A user can destroy a draft
     Given "bob@domain.tld" has a mailbox "Drafts"
     And "bob@domain.tld" tries to create a draft message "mDraft" in mailbox "Drafts"

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/UploadEndpoint.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/UploadEndpoint.feature
@@ -55,6 +55,7 @@ Feature: An upload endpoint should be available to upload contents
     When "username@domain.tld" upload a content without content type
     Then the user should receive bad request response
 
+  @BasicFeature
   Scenario: Uploading a content, the content should be retrievable
     When "username@domain.tld" upload a content
     Then "username@domain.tld" should be able to retrieve the content

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/sharing/CopyAndSharing.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/sharing/CopyAndSharing.feature
@@ -35,6 +35,7 @@ Feature: Copy message and sharing
     Then the mailbox "shared" has 1 message
     And the mailbox "shared" has 1 unseen message
 
+  @BasicFeature
   Scenario: Copy message should update the total and the unread counts when asked by sharer / sharee view
     Given "alice@domain.tld" copies "m1" from mailbox "INBOX" to mailbox "shared"
     When "bob@domain.tld" lists mailboxes

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/sharing/DownloadAndSharing.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/sharing/DownloadAndSharing.feature
@@ -32,6 +32,7 @@ Feature: Download endpoint and shared mailbox
     When "bob@domain.tld" downloads "a1"
     Then the user should be authorized
 
+  @BasicFeature
   Scenario: Bob can download attachment of another user when shared mailbox
     When "bob@domain.tld" downloads "a1"
     Then he can read that blob

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/sharing/GetMessageAndSharing.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/sharing/GetMessageAndSharing.feature
@@ -28,6 +28,7 @@ Feature: GetMessages method on shared mailbox
     And "alice@domain.tld" shares her mailbox "shared" with "bob@domain.tld" with "lr" rights
     And "alice@domain.tld" has a message "m1" in "shared" mailbox with subject "my test subject", content "testmail"
 
+  @BasicFeature
   Scenario: Retrieving a message in a mailbox delegated to me
     When "bob@domain.tld" ask for messages "m1"
     Then no error is returned

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/sharing/GetMessageListAndSharing.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/sharing/GetMessageListAndSharing.feature
@@ -35,6 +35,7 @@ Feature: Listing message from shared mailbox
     Then the mailbox "shared" has 2 messages
     And the mailbox "shared" has 2 unseen messages
 
+  @BasicFeature
   Scenario: Sharee can read the total and unread counts on a shared folder
     Given "alice@domain.tld" has a message "m1" in "shared" mailbox
     And "alice@domain.tld" has a message "m2" in "shared" mailbox with subject "my test subject 2", content "testmail 2"

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/sharing/MoveMailboxAndSharing.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/sharing/MoveMailboxAndSharing.feature
@@ -68,6 +68,7 @@ Feature: Moving mailbox and sharing
     Then "bob@domain.tld" lists mailboxes
     And the mailboxes should contain "sharedChild" in "Delegated" namespace, with no parent mailbox
 
+  @BasicFeature
   Scenario: A sharee should be able to retrieve a mailbox after sharer moved it into another mailbox
     Given "alice@domain.tld" has a mailbox "notShared"
     When "alice@domain.tld" moves the mailbox "shared.sharedChild" owned by "alice@domain.tld", into mailbox "notShared" owned by "alice@domain.tld"

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/sharing/MoveMessageAndSharing.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/sharing/MoveMessageAndSharing.feature
@@ -73,6 +73,7 @@ Feature: Move message and sharing
     Then the mailbox "sharedBis" has 0 messages
     And the mailbox "sharedBis" has 0 unseen messages
 
+  @BasicFeature
   Scenario: Move message should update the total and the unread counts when asked by sharee / sharee view
     Given "bob@domain.tld" has a message "m1" in "bobMailbox" mailbox
     And "bob@domain.tld" moves "m1" to mailbox "shared" of user "alice@domain.tld"

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/sharing/RenamingMailboxAndSharing.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/sharing/RenamingMailboxAndSharing.feature
@@ -26,6 +26,7 @@ Feature: Renaming mailbox and sharing
     And "alice@domain.tld" has a mailbox "shared"
     And "alice@domain.tld" shares her mailbox "shared" with "bob@domain.tld" with "aeilrwt" rights
 
+  @BasicFeature
   Scenario: A sharee should be able to access a shared mailbox after it has been renamed by the owner
     Given "alice@domain.tld" renames her mailbox "shared" to "mySharedMailbox"
     When "bob@domain.tld" lists mailboxes

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/sharing/SetFlagAndSharing.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/sharing/SetFlagAndSharing.feature
@@ -33,6 +33,7 @@ Feature: Set flag and sharing
     Then the mailbox "shared" has 1 message
     And the mailbox "shared" has 0 unseen messages
 
+  @BasicFeature
   Scenario: Set flags by sharer should update unseen count when read by sharee
     When "alice@domain.tld" sets flags "$Seen" on message "m1"
     And "bob@domain.tld" lists mailboxes

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/sharing/SetMessagesOnSharedMailbox.feature
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/resources/cucumber/sharing/SetMessagesOnSharedMailbox.feature
@@ -28,6 +28,7 @@ Feature: SetMessages method on shared folders
     And "bob@domain.tld" has a message "mBob" in "shared" mailbox with two attachments in text
     And "alice@domain.tld" has a message "mAlice" in "INBOX" mailbox with two attachments in text
 
+  @BasicFeature
   Scenario: A delegated user can copy messages from shared mailbox when having "read" right
     Given "bob@domain.tld" shares his mailbox "shared" with "alice@domain.tld" with "lr" rights
     And "alice@domain.tld" copies "mBob" from mailbox "shared" of user "bob@domain.tld" to mailbox "INBOX" of user "alice@domain.tld"
@@ -35,12 +36,14 @@ Feature: SetMessages method on shared folders
         |alice@domain.tld |INBOX  |
         |bob@domain.tld   |shared |
 
+  @BasicFeature
   Scenario: A delegated user can move messages out of shared mailbox when having "read" and "delete" rights
     Given "bob@domain.tld" shares his mailbox "shared" with "alice@domain.tld" with "lrte" rights
     And "alice@domain.tld" moves "mBob" to mailbox "INBOX" of user "alice@domain.tld"
     Then "alice@domain.tld" should see message "mBob" in mailboxes:
         |alice@domain.tld |INBOX  |
 
+  @BasicFeature
   Scenario: A delegated user can add messages to a shared mailbox when having "insert" rights
     Given "bob@domain.tld" shares his mailbox "shared" with "alice@domain.tld" with "lri" rights
     And "alice@domain.tld" copies "mAlice" from mailbox "INBOX" of user "alice@domain.tld" to mailbox "shared" of user "bob@domain.tld"
@@ -75,7 +78,7 @@ Feature: SetMessages method on shared folders
     When "alice@domain.tld" moves "mBob" to mailbox "INBOX" of user "alice@domain.tld"
     Then message "mBob" is not updated
 
-
+  @BasicFeature
   Scenario: A delegated user add keywords on a delegated message when having "write" right
     Given "bob@domain.tld" shares his mailbox "shared" with "alice@domain.tld" with "lrw" rights
     When "alice@domain.tld" sets flags "$Flagged" on message "mBob"
@@ -86,6 +89,7 @@ Feature: SetMessages method on shared folders
     When "alice@domain.tld" sets flags "$Flagged" on message "mBob"
     Then message "mBob" is not updated
 
+  @BasicFeature
   Scenario: A delegated user remove keywords on a delegated message when having "write" right
     Given "bob@domain.tld" shares his mailbox "shared" with "alice@domain.tld" with "lrw" rights
     And "bob@domain.tld" sets flags "$Flagged" on message "mBob"


### PR DESCRIPTION
Result:
- BasicFeature: tagged 63/457 tests
- Cucumber: tagged 25/209 tests
- Totally: 88/660

=> Time to run cassandra jmap integration tests on local machine: 4m30s (not a joke)