### PR TITLE
JAMES-2314 Use awaitStop to await error handlers cleanup

### DIFF
--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/WebAdminServer.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/WebAdminServer.java
@@ -160,6 +160,7 @@ public class WebAdminServer implements Configurable {
     public void destroy() {
         if (configuration.isEnabled()) {
             service.stop();
+            service.awaitStop();
             LOGGER.info("Web admin server stopped");
         }
     }

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/routes/ErrorRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/routes/ErrorRoutesTest.java
@@ -35,8 +35,8 @@ import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.james.webadmin.WebAdminServer;
 import org.apache.james.webadmin.WebAdminUtils;
 import org.apache.james.webadmin.utils.ErrorResponder;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import io.restassured.RestAssured;
@@ -44,10 +44,10 @@ import io.restassured.RestAssured;
 public class ErrorRoutesTest {
     private static final String NOT_FOUND = "notFound";
 
-    private static WebAdminServer webAdminServer;
+    private WebAdminServer webAdminServer;
 
-    @BeforeClass
-    public static void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         webAdminServer = WebAdminUtils.createWebAdminServer(
                 new NoopMetricFactory(),
                 new ErrorRoutes());
@@ -60,8 +60,8 @@ public class ErrorRoutesTest {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @After
+    public void tearDown() {
         webAdminServer.destroy();
     }
 


### PR DESCRIPTION
This strategy is better than using a static setUp/tearDown. It is enabled thanks to latest Spark upgrade.