### PR TITLE
MPT-43 Add AWAIT command

### DIFF
--- a/mailbox/lucene/src/main/java/org/apache/james/mailbox/lucene/search/LuceneMessageSearchIndex.java
+++ b/mailbox/lucene/src/main/java/org/apache/james/mailbox/lucene/search/LuceneMessageSearchIndex.java
@@ -1353,4 +1353,8 @@ public class LuceneMessageSearchIndex extends ListeningMessageSearchIndex {
             throw new MailboxException("Unable to delete message from index", e);
         }
     }
+
+    public void commit() throws IOException {
+        writer.commit();
+    }
 }

--- a/mpt/core/src/main/java/org/apache/james/mpt/api/Session.java
+++ b/mpt/core/src/main/java/org/apache/james/mpt/api/Session.java
@@ -59,4 +59,6 @@ public interface Session {
      * @throws Exception
      */
     void stop() throws Exception;
+
+    void await() throws Exception;
 }

--- a/mpt/core/src/main/java/org/apache/james/mpt/protocol/FileProtocolSessionBuilder.java
+++ b/mpt/core/src/main/java/org/apache/james/mpt/protocol/FileProtocolSessionBuilder.java
@@ -134,6 +134,8 @@ public class FileProtocolSessionBuilder extends ProtocolSessionBuilder {
                     }
                 } else if (next.startsWith(REINIT)) {
                     session.reinit(sessionNumber);
+                }  else if (next.startsWith(AWAIT)) {
+                    session.await(sessionNumber);
                 } else if (next.startsWith(OPEN_UNORDERED_BLOCK_TAG)) {
                     List<String> unorderedLines = new ArrayList<>(5);
                     next = reader.readLine();

--- a/mpt/core/src/main/java/org/apache/james/mpt/protocol/ProtocolSession.java
+++ b/mpt/core/src/main/java/org/apache/james/mpt/protocol/ProtocolSession.java
@@ -219,6 +219,11 @@ public class ProtocolSession implements ProtocolInteractor {
         testElements.add(new ReinitElement(sessionNumber));
     }
 
+    public void await(int sessionNumber) {
+        this.maxSessionNumber = Math.max(this.maxSessionNumber, sessionNumber);
+        testElements.add(new AwaitElement(sessionNumber));
+    }
+
     public void timer(TimerCommand timerCommand, String timerName) {
         testElements.add(new TimerElement(timerCommand, timerName));
     }
@@ -622,6 +627,24 @@ public class ProtocolSession implements ProtocolInteractor {
         @Override
         public void testProtocol(Session[] sessions, boolean continueAfterFailure) throws Exception {
             Thread.sleep(timeToWaitInMs);
+        }
+
+        @Override
+        public boolean isClient() {
+            return false;
+        }
+    }
+
+    private class AwaitElement implements ProtocolElement {
+        private final int sessionNumber;
+
+        private AwaitElement(int sessionNumber) {
+            this.sessionNumber = Math.max(0, sessionNumber);
+        }
+
+        @Override
+        public void testProtocol(Session[] sessions, boolean continueAfterFailure) throws Exception {
+            sessions[sessionNumber].await();
         }
 
         @Override

--- a/mpt/core/src/main/java/org/apache/james/mpt/protocol/ProtocolSessionBuilder.java
+++ b/mpt/core/src/main/java/org/apache/james/mpt/protocol/ProtocolSessionBuilder.java
@@ -41,6 +41,8 @@ public class ProtocolSessionBuilder {
 
     public static final String LOG = "LOG";
 
+    public static final String AWAIT = "AWAIT";
+
     public static final String WAIT = "WAIT";
 
     public static final String SERVER_CONTINUATION_TAG = "S: \\+";

--- a/mpt/core/src/main/java/org/apache/james/mpt/session/ExternalSession.java
+++ b/mpt/core/src/main/java/org/apache/james/mpt/session/ExternalSession.java
@@ -35,6 +35,7 @@ import org.awaitility.Duration;
 public final class ExternalSession implements Session {
 
     private static final byte[] CRLF = { '\r', '\n' };
+    public static final int FIVE_SECONDS = 5000;
 
     private final SocketChannel socket;
 
@@ -170,6 +171,11 @@ public final class ExternalSession implements Session {
             socket.write(lineEndBuffer);
         }
         monitor.debug("[Done]");
+    }
+
+    @Override
+    public void await() throws Exception {
+        Thread.sleep(FIVE_SECONDS);
     }
 
     /**

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
@@ -38,7 +38,6 @@ import org.apache.james.mailbox.cassandra.quota.CassandraGlobalMaxQuotaDao;
 import org.apache.james.mailbox.cassandra.quota.CassandraPerDomainMaxQuotaDao;
 import org.apache.james.mailbox.cassandra.quota.CassandraPerUserMaxQuotaDao;
 import org.apache.james.mailbox.cassandra.quota.CassandraPerUserMaxQuotaManager;
-import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.quota.QuotaRootResolver;
 import org.apache.james.mailbox.store.JVMMailboxPathLocker;
 import org.apache.james.mailbox.store.StoreMailboxAnnotationManager;
@@ -131,7 +130,7 @@ public class CassandraHostSystem extends JamesImapHostSystem {
     }
 
     @Override
-    public void setQuotaLimits(QuotaCount maxMessageQuota, QuotaSize maxStorageQuota) throws MailboxException {
+    public void setQuotaLimits(QuotaCount maxMessageQuota, QuotaSize maxStorageQuota) {
         perUserMaxQuotaManager.setGlobalMaxMessage(maxMessageQuota);
         perUserMaxQuotaManager.setGlobalMaxStorage(maxStorageQuota);
     }
@@ -139,5 +138,10 @@ public class CassandraHostSystem extends JamesImapHostSystem {
     @Override
     public MailboxManager getMailboxManager() {
         return mailboxManager;
+    }
+
+    @Override
+    protected void await() {
+
     }
 }

--- a/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/host/JamesImapHostSystem.java
+++ b/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/host/JamesImapHostSystem.java
@@ -91,6 +91,8 @@ public abstract class JamesImapHostSystem implements ImapHostSystem, GrantRights
     }
 
     protected abstract MailboxManager getMailboxManager();
+
+    protected abstract void await() throws Exception;
     
     @Override
     public void createMailbox(MailboxPath mailboxPath) throws Exception {
@@ -166,6 +168,10 @@ public abstract class JamesImapHostSystem implements ImapHostSystem, GrantRights
             in.nextLine(line);
         }
 
+        @Override
+        public void await() throws Exception {
+            JamesImapHostSystem.this.await();
+        }
     }
 
     private HierarchicalConfiguration userRepositoryConfiguration() {

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/UidSearchAtomsIndexer.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/UidSearchAtomsIndexer.test
@@ -2113,7 +2113,7 @@ S: A99 OK STORE completed\.
 
 LOG INFO Waiting for Indexer to index data
 
-WAIT 5000
+AWAIT
 
 LOG INFO Performing tests about search
 
@@ -2316,7 +2316,7 @@ S: A202 OK (\[.+\] )?APPEND completed\.
 
 LOG INFO Waiting for Indexer to index data
 
-WAIT 1000
+AWAIT
 
 LOG INFO Performing tests about search
 

--- a/mpt/impl/imap-mailbox/elasticsearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/host/ElasticSearchHostSystem.java
+++ b/mpt/impl/imap-mailbox/elasticsearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/host/ElasticSearchHostSystem.java
@@ -138,7 +138,12 @@ public class ElasticSearchHostSystem extends JamesImapHostSystem {
     }
 
     @Override
-    public void setQuotaLimits(QuotaCount maxMessageQuota, QuotaSize maxStorageQuota) throws Exception {
+    public void setQuotaLimits(QuotaCount maxMessageQuota, QuotaSize maxStorageQuota) {
         throw new NotImplementedException();
+    }
+
+    @Override
+    protected void await() {
+        embeddedElasticSearch.awaitForElasticSearch();
     }
 }

--- a/mpt/impl/imap-mailbox/elasticsearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/host/ElasticSearchHostSystem.java
+++ b/mpt/impl/imap-mailbox/elasticsearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/host/ElasticSearchHostSystem.java
@@ -114,7 +114,7 @@ public class ElasticSearchHostSystem extends JamesImapHostSystem {
         this.mailboxManager.setMessageSearchIndex(searchIndex);
         this.mailboxManager.addGlobalListener(searchIndex, new MockMailboxSession("admin"));
 
-        final ImapProcessor defaultImapProcessorFactory =
+        ImapProcessor defaultImapProcessorFactory =
             DefaultImapProcessorFactory.createDefaultProcessor(this.mailboxManager,
                 new StoreSubscriptionManager(factory),
                 new NoQuotaManager(),
@@ -123,8 +123,6 @@ public class ElasticSearchHostSystem extends JamesImapHostSystem {
         configure(new DefaultImapDecoderFactory().buildImapDecoder(),
             new DefaultImapEncoderFactory().buildImapEncoder(),
             defaultImapProcessorFactory);
-
-        embeddedElasticSearch.awaitForElasticSearch();
     }
 
     @Override

--- a/mpt/impl/imap-mailbox/external-james/src/test/resources/org/apache/james/imap/scripts/ValidateDeployment.test
+++ b/mpt/impl/imap-mailbox/external-james/src/test/resources/org/apache/james/imap/scripts/ValidateDeployment.test
@@ -497,7 +497,7 @@ S: b OK STORE completed.
 
 # Indexation may be asynchronous
 LOG INFO Waiting for indexation
-WAIT 1000
+WAIT 5000
 
 C: c SEARCH FLAGGED
 S: \* SEARCH 1 2 3 4

--- a/mpt/impl/imap-mailbox/hbase/src/test/java/org/apache/james/mpt/imapmailbox/hbase/host/HBaseHostSystem.java
+++ b/mpt/impl/imap-mailbox/hbase/src/test/java/org/apache/james/mpt/imapmailbox/hbase/host/HBaseHostSystem.java
@@ -179,7 +179,12 @@ public class HBaseHostSystem extends JamesImapHostSystem {
     }
 
     @Override
-    public void setQuotaLimits(QuotaCount maxMessageQuota, QuotaSize maxStorageQuota) throws Exception {
+    public void setQuotaLimits(QuotaCount maxMessageQuota, QuotaSize maxStorageQuota) {
         throw new NotImplementedException();
+    }
+
+    @Override
+    protected void await() {
+
     }
 }

--- a/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/host/InMemoryHostSystem.java
+++ b/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/host/InMemoryHostSystem.java
@@ -103,4 +103,9 @@ public class InMemoryHostSystem extends JamesImapHostSystem {
         perUserMaxQuotaManager.setGlobalMaxMessage(maxMessageQuota);
         perUserMaxQuotaManager.setGlobalMaxStorage(maxStorageQuota);
     }
+
+    @Override
+    protected void await() {
+
+    }
 }

--- a/mpt/impl/imap-mailbox/jcr/src/test/java/org/apache/james/mpt/imapmailbox/jcr/host/JCRHostSystem.java
+++ b/mpt/impl/imap-mailbox/jcr/src/test/java/org/apache/james/mpt/imapmailbox/jcr/host/JCRHostSystem.java
@@ -180,8 +180,12 @@ public class JCRHostSystem extends JamesImapHostSystem {
     }
 
     @Override
-    public void setQuotaLimits(QuotaCount maxMessageQuota, QuotaSize maxStorageQuota) throws Exception {
+    public void setQuotaLimits(QuotaCount maxMessageQuota, QuotaSize maxStorageQuota) {
         throw new NotImplementedException();
     }
 
+    @Override
+    protected void await() {
+
+    }
 }

--- a/mpt/impl/imap-mailbox/jpa/src/test/java/org/apache/james/mpt/imapmailbox/jpa/host/JPAHostSystem.java
+++ b/mpt/impl/imap-mailbox/jpa/src/test/java/org/apache/james/mpt/imapmailbox/jpa/host/JPAHostSystem.java
@@ -170,4 +170,8 @@ public class JPAHostSystem extends JamesImapHostSystem {
         maxQuotaManager.setGlobalMaxStorage(maxStorageQuota);
     }
 
+    @Override
+    protected void await() throws Exception {
+
+    }
 }

--- a/mpt/impl/imap-mailbox/lucenesearch/src/test/java/org/apache/james/mpt/imapmailbox/lucenesearch/host/LuceneSearchHostSystem.java
+++ b/mpt/impl/imap-mailbox/lucenesearch/src/test/java/org/apache/james/mpt/imapmailbox/lucenesearch/host/LuceneSearchHostSystem.java
@@ -66,6 +66,7 @@ public class LuceneSearchHostSystem extends JamesImapHostSystem {
 
     private File tempFile;
     private InMemoryMailboxManager mailboxManager;
+    private LuceneMessageSearchIndex searchIndex;
 
     @Override
     public void beforeTest() throws Exception {
@@ -115,7 +116,7 @@ public class LuceneSearchHostSystem extends JamesImapHostSystem {
                 rightManager);
 
             FSDirectory fsDirectory = FSDirectory.open(tempFile);
-            LuceneMessageSearchIndex searchIndex = new LuceneMessageSearchIndex(mapperFactory, new InMemoryId.Factory(), fsDirectory, messageIdFactory);
+            searchIndex = new LuceneMessageSearchIndex(mapperFactory, new InMemoryId.Factory(), fsDirectory, messageIdFactory);
             searchIndex.setEnableSuffixMatch(true);
             mailboxManager.setMessageSearchIndex(searchIndex);
 
@@ -155,4 +156,8 @@ public class LuceneSearchHostSystem extends JamesImapHostSystem {
         throw new NotImplementedException();
     }
 
+    @Override
+    protected void await() throws Exception {
+        searchIndex.commit();
+    }
 }

--- a/mpt/impl/imap-mailbox/maildir/src/test/java/org/apache/james/mpt/imapmailbox/maildir/host/MaildirHostSystem.java
+++ b/mpt/impl/imap-mailbox/maildir/src/test/java/org/apache/james/mpt/imapmailbox/maildir/host/MaildirHostSystem.java
@@ -127,8 +127,12 @@ public class MaildirHostSystem extends JamesImapHostSystem {
     }
 
     @Override
-    public void setQuotaLimits(QuotaCount maxMessageQuota, QuotaSize maxStorageQuota) throws Exception {
+    public void setQuotaLimits(QuotaCount maxMessageQuota, QuotaSize maxStorageQuota) {
         throw new NotImplementedException();
     }
 
+    @Override
+    protected void await() {
+
+    }
 }

--- a/mpt/impl/managesieve/core/src/main/java/org/apache/james/mpt/host/ManageSieveSession.java
+++ b/mpt/impl/managesieve/core/src/main/java/org/apache/james/mpt/host/ManageSieveSession.java
@@ -74,19 +74,24 @@ public class ManageSieveSession implements Session {
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
     }
 
     @Override
-    public void restart() throws Exception {
+    public void restart() {
     }
 
     @Override
-    public void writeLine(String line) throws Exception {
+    public void await() {
+
+    }
+
+    @Override
+    public void writeLine(String line) {
         isReadLast = false;
         in.nextLine(line);
     }


### PR DESCRIPTION
Some Host systems might need to wait a bit to make changes available for search.

Currently, we use a fixed wait strategy that leads to either:
 - Lost time waiting for too long
 - Or build instability if we did not wait for too long

This strategy a flawed and we should allow using more clever MPT command

I propose an AWAIT command allowing host systems to implement the most suitable await logic to their needs.