### PR TITLE
JAMES-2578 Additional API to ease Attribute* uses

### DIFF
--- a/mailet/api/src/main/java/org/apache/mailet/Attribute.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Attribute.java
@@ -32,8 +32,12 @@ import com.google.common.base.Preconditions;
  * @since Mailet API v3.2
  */
 public class Attribute {
-    public static Attribute convertToAttribute(String name, Object value) {
+    public static Attribute of(String name, Object value) {
         AttributeName attributeName = AttributeName.of(name);
+        return of(attributeName, value);
+    }
+
+    public static Attribute of(AttributeName attributeName, Object value) {
         AttributeValue<?> attributeValue = AttributeValue.ofAny(value);
 
         return new Attribute(attributeName, attributeValue);

--- a/mailet/api/src/main/java/org/apache/mailet/Mail.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Mail.java
@@ -248,7 +248,7 @@ public interface Mail extends Serializable, Cloneable {
      *
      * A cast will be attempted to match the type expected by the user.
      *
-     * Returns empty optionals upon missing attribute or type mismatch.
+     * Returns an empty optional upon missing attribute or type mismatch.
      *
      * @since Mailet API v3.2
      */
@@ -260,7 +260,7 @@ public interface Mail extends Serializable, Cloneable {
     /**
      * Returns the raw attribute value corresponding to an attribute name.
      *
-     * Returns empty optionals upon missing attribute
+     * Returns an empty optional upon missing attribute
      *
      * @since Mailet API v3.2
      */

--- a/mailet/api/src/main/java/org/apache/mailet/Mail.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Mail.java
@@ -244,6 +244,41 @@ public interface Mail extends Serializable, Cloneable {
     Optional<Attribute> getAttribute(AttributeName name);
 
     /**
+     * Returns the raw attribute value corresponding to an attribute name.
+     *
+     * A cast will be attempted to match the type expected by the user.
+     *
+     * Returns empty optionals upon missing attribute or type mismatch.
+     *
+     * @since Mailet API v3.2
+     */
+    default <T> Optional<T> getRawAttributeValue(AttributeName name, Class<T> type) {
+        return getRawAttributeValue(name)
+            .flatMap(value -> tryToCast(type, value));
+    }
+
+    /**
+     * Returns the raw attribute value corresponding to an attribute name.
+     *
+     * Returns empty optionals upon missing attribute
+     *
+     * @since Mailet API v3.2
+     */
+    default Optional<?> getRawAttributeValue(AttributeName name) {
+        return getAttribute(name)
+            .map(Attribute::getValue)
+            .map(AttributeValue::getValue);
+    }
+
+    static <T> Optional<T> tryToCast(Class<T> type, Object value) {
+        if (type.isInstance(value)) {
+            return Optional.of(type.cast(value));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
      * Returns an Iterator over the names of all attributes which are set
      * in this Mail instance.
      * <p>

--- a/mailet/api/src/test/java/org/apache/mailet/AttributeTest.java
+++ b/mailet/api/src/test/java/org/apache/mailet/AttributeTest.java
@@ -46,7 +46,7 @@ class AttributeTest {
 
     @Test
     void convertToAttributeShouldReturnCorrespondingAttribute() {
-        assertThat(Attribute.convertToAttribute("name", "value"))
+        assertThat(Attribute.of("name", "value"))
             .isEqualTo(new Attribute(
                 AttributeName.of("name"),
                 AttributeValue.of("value")));

--- a/mailet/api/src/test/java/org/apache/mailet/ContractMailTest.java
+++ b/mailet/api/src/test/java/org/apache/mailet/ContractMailTest.java
@@ -23,6 +23,7 @@ package org.apache.mailet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,7 +57,17 @@ public abstract class ContractMailTest {
         void newMailShouldHaveNoAttribute() {
             assertThat(mail.attributes()).isEmpty();
         }
-        
+
+        @Test
+        void getRawAttributeValueShouldReturnEmptyWhenNone() {
+            assertThat(mail.getRawAttributeValue(ATTRIBUTE_NAME_1)).isEmpty();
+        }
+
+        @Test
+        void getRawAttributeValueWithCastShouldReturnEmptyWhenNone() {
+            assertThat(mail.getRawAttributeValue(ATTRIBUTE_NAME_1, String.class)).isEmpty();
+        }
+
         @Test
         void newMailShouldHaveNoAttributeName() {
             assertThat(mail.attributeNames()).isEmpty();
@@ -101,6 +112,21 @@ public abstract class ContractMailTest {
         @Test
         void shouldBeRetrievable() {
             assertThat(mail.getAttribute(ATTRIBUTE_NAME_1)).contains(ATTRIBUTE_1);
+        }
+
+        @Test
+        void getRawAttributeValueShouldReturnContainedValue() {
+            assertThat(mail.getRawAttributeValue(ATTRIBUTE_NAME_1)).isEqualTo(Optional.of(true));
+        }
+
+        @Test
+        void getRawAttributeValueWithCastShouldReturnContainedValue() {
+            assertThat(mail.getRawAttributeValue(ATTRIBUTE_NAME_1, Boolean.class)).contains(true);
+        }
+
+        @Test
+        void getRawAttributeValueWithCastShouldReturnEmptyWhenWrongType() {
+            assertThat(mail.getRawAttributeValue(ATTRIBUTE_NAME_1, String.class)).isEmpty();
         }
         
         @Test

--- a/mailet/test/src/main/java/org/apache/mailet/base/test/FakeMail.java
+++ b/mailet/test/src/main/java/org/apache/mailet/base/test/FakeMail.java
@@ -245,7 +245,7 @@ public class FakeMail implements Mail {
 
         @Deprecated
         public Builder attribute(String name, Serializable object) {
-            Attribute attribute = Attribute.convertToAttribute(name, object);
+            Attribute attribute = Attribute.of(name, object);
             this.attributes.put(attribute.getName(), attribute);
             return this;
         }
@@ -254,7 +254,7 @@ public class FakeMail implements Mail {
         public Builder attributes(Map<String, Serializable> attributes) {
             this.attributes.putAll(attributes.entrySet()
                 .stream()
-                .map(entry -> Attribute.convertToAttribute(entry.getKey(), entry.getValue()))
+                .map(entry -> Attribute.of(entry.getKey(), entry.getValue()))
                 .collect(ImmutableMap.toImmutableMap(
                     Attribute::getName,
                     Function.identity())));
@@ -305,7 +305,7 @@ public class FakeMail implements Mail {
     private static ImmutableMap<AttributeName, Attribute> toAttributeMap(Map<String, ?> attributes) {
         return attributes.entrySet()
             .stream()
-            .map(entry -> Attribute.convertToAttribute(entry.getKey(), entry.getValue()))
+            .map(entry -> Attribute.of(entry.getKey(), entry.getValue()))
             .collect(ImmutableMap.toImmutableMap(
                 Attribute::getName,
                 Function.identity()));
@@ -479,7 +479,7 @@ public class FakeMail implements Mail {
 
     @Override
     public Serializable setAttribute(String name, Serializable object) {
-        Attribute attribute = Attribute.convertToAttribute(name, object);
+        Attribute attribute = Attribute.of(name, object);
         Attribute previous = attributes.put(attribute.getName(), attribute);
 
         return toSerializable(previous);

--- a/server/container/core/src/main/java/org/apache/james/server/core/MailImpl.java
+++ b/server/container/core/src/main/java/org/apache/james/server/core/MailImpl.java
@@ -217,7 +217,7 @@ public class MailImpl implements Disposable, Mail {
 
         @Deprecated
         public Builder attribute(String name, Serializable object) {
-            attribute(Attribute.convertToAttribute(name, object));
+            attribute(Attribute.of(name, object));
             return this;
         }
 
@@ -280,7 +280,7 @@ public class MailImpl implements Disposable, Mail {
     private static Map<AttributeName, Attribute> toAttributeMap(Map<String, ?> attributes) {
         return attributes.entrySet()
             .stream()
-            .map(entry -> Attribute.convertToAttribute(entry.getKey(), entry.getValue()))
+            .map(entry -> Attribute.of(entry.getKey(), entry.getValue()))
             .collect(Collectors.toMap(
                 Attribute::getName,
                 Function.identity()));
@@ -778,7 +778,7 @@ public class MailImpl implements Disposable, Mail {
     @Override
     public Serializable setAttribute(String key, Serializable object) {
         Preconditions.checkNotNull(key, "Key of an attribute should not be null");
-        Attribute attribute = Attribute.convertToAttribute(key, object);
+        Attribute attribute = Attribute.of(key, object);
         Attribute previous = attributes.put(attribute.getName(), attribute);
 
         return toSerializable(previous);


### PR DESCRIPTION
In https://github.com/linagora/james-project/pull/1883 many comments suggest that the API we designed previously is too verbose.

Hence as such, here is my humble proposal to make this work easier.

Most notably, setting a mail attribute should be as easy as:

```
mail.setAttribute(Attribute.of(rawName, rawValue); // rawName being a String
mail.setAttribute(Attribute.of(name, rawValue); // name being an AttributeName
```

This should limit a bit the boiler plate...