### PR TITLE
JAMES-2582 Swift blobstore factory should not be instanciated if not …

### DIFF
--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/objectstore/BlobStoreChoosingModule.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/objectstore/BlobStoreChoosingModule.java
@@ -23,6 +23,7 @@ import java.io.FileNotFoundException;
 import java.util.function.Supplier;
 
 import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.apache.commons.configuration.Configuration;
@@ -49,7 +50,7 @@ import com.google.inject.multibindings.Multibinder;
 
 public class BlobStoreChoosingModule extends AbstractModule {
 
-    interface BlobStoreFactory extends Supplier<BlobStore> {}
+    interface BlobStoreFactory extends Provider<BlobStore> {}
 
     static class CassandraBlobStoreFactory implements BlobStoreFactory {
         private final Session session;
@@ -98,36 +99,31 @@ public class BlobStoreChoosingModule extends AbstractModule {
         bind(CassandraBlobStoreFactory.class).in(Scopes.SINGLETON);
         Multibinder<CassandraModule> cassandraDataDefinitions = Multibinder.newSetBinder(binder(), CassandraModule.class);
         cassandraDataDefinitions.addBinding().toInstance(CassandraBlobModule.MODULE);
+
+        bind(BlobStore.class).toProvider(BlobStoreFactory.class).in(Scopes.SINGLETON);
     }
 
     @VisibleForTesting
     @Provides
     @Singleton
     BlobStoreFactory provideBlobStoreFactory(PropertiesProvider propertiesProvider,
-                                             CassandraBlobStoreFactory cassandraBlobStoreFactory,
-                                             SwiftBlobStoreFactory swiftBlobStoreFactory) throws ConfigurationException {
+                                             Provider<CassandraBlobStoreFactory> cassandraBlobStoreFactoryProvider,
+                                             Provider<SwiftBlobStoreFactory> swiftBlobStoreFactoryProvider) throws ConfigurationException {
         try {
             Configuration configuration = propertiesProvider.getConfiguration(BLOBSTORE_CONFIGURATION_NAME);
             BlobStoreChoosingConfiguration choosingConfiguration = BlobStoreChoosingConfiguration.from(configuration);
             switch (choosingConfiguration.getImplementation()) {
                 case SWIFT:
-                    return swiftBlobStoreFactory;
+                    return swiftBlobStoreFactoryProvider.get();
                 case CASSANDRA:
-                    return cassandraBlobStoreFactory;
+                    return cassandraBlobStoreFactoryProvider.get();
                 default:
                     throw new RuntimeException(String.format("can not get the right blobstore provider with configuration %s",
                         choosingConfiguration.toString()));
             }
         } catch (FileNotFoundException e) {
             LOGGER.warn("Could not find " + BLOBSTORE_CONFIGURATION_NAME + " configuration file, using cassandra blobstore as the default");
-            return cassandraBlobStoreFactory;
+            return cassandraBlobStoreFactoryProvider.get();
         }
     }
-
-    @Provides
-    @Singleton
-    private BlobStore provideBlobStore(BlobStoreFactory blobStoreFactory) {
-        return blobStoreFactory.get();
-    }
-
 }

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/objectstore/BlobStoreChoosingModule.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/objectstore/BlobStoreChoosingModule.java
@@ -20,7 +20,6 @@
 package org.apache.james.modules.objectstore;
 
 import java.io.FileNotFoundException;
-import java.util.function.Supplier;
 
 import javax.inject.Inject;
 import javax.inject.Provider;

--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/modules/objectstore/BlobStoreChoosingModuleTest.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/modules/objectstore/BlobStoreChoosingModuleTest.java
@@ -45,7 +45,7 @@ class BlobStoreChoosingModuleTest {
             .register(BLOBSTORE_CONFIGURATION_NAME, configuration)
             .build();
 
-        assertThatThrownBy(() -> module.provideBlobStoreFactory(propertyProvider, CASSANDRA_BLOBSTORE_FACTORY, SWIFT_BLOBSTORE_FACTORY))
+        assertThatThrownBy(() -> module.provideBlobStoreFactory(propertyProvider, () -> CASSANDRA_BLOBSTORE_FACTORY, () -> SWIFT_BLOBSTORE_FACTORY))
             .isInstanceOf(IllegalStateException.class);
     }
 
@@ -58,7 +58,7 @@ class BlobStoreChoosingModuleTest {
             .register(BLOBSTORE_CONFIGURATION_NAME, configuration)
             .build();
 
-        assertThatThrownBy(() -> module.provideBlobStoreFactory(propertyProvider, CASSANDRA_BLOBSTORE_FACTORY, SWIFT_BLOBSTORE_FACTORY))
+        assertThatThrownBy(() -> module.provideBlobStoreFactory(propertyProvider, () -> CASSANDRA_BLOBSTORE_FACTORY, () -> SWIFT_BLOBSTORE_FACTORY))
             .isInstanceOf(IllegalStateException.class);
     }
 
@@ -71,7 +71,7 @@ class BlobStoreChoosingModuleTest {
             .register(BLOBSTORE_CONFIGURATION_NAME, configuration)
             .build();
 
-        assertThatThrownBy(() -> module.provideBlobStoreFactory(propertyProvider, CASSANDRA_BLOBSTORE_FACTORY, SWIFT_BLOBSTORE_FACTORY))
+        assertThatThrownBy(() -> module.provideBlobStoreFactory(propertyProvider, () -> CASSANDRA_BLOBSTORE_FACTORY, () -> SWIFT_BLOBSTORE_FACTORY))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -82,7 +82,7 @@ class BlobStoreChoosingModuleTest {
             .register("other_configuration_file", new PropertiesConfiguration())
             .build();
 
-        assertThat(module.provideBlobStoreFactory(propertyProvider, CASSANDRA_BLOBSTORE_FACTORY, SWIFT_BLOBSTORE_FACTORY))
+        assertThat(module.provideBlobStoreFactory(propertyProvider, () -> CASSANDRA_BLOBSTORE_FACTORY, () -> SWIFT_BLOBSTORE_FACTORY))
             .isEqualTo(CASSANDRA_BLOBSTORE_FACTORY);
     }
 
@@ -95,7 +95,7 @@ class BlobStoreChoosingModuleTest {
             .register(BLOBSTORE_CONFIGURATION_NAME, configuration)
             .build();
 
-        assertThat(module.provideBlobStoreFactory(propertyProvider, CASSANDRA_BLOBSTORE_FACTORY, SWIFT_BLOBSTORE_FACTORY))
+        assertThat(module.provideBlobStoreFactory(propertyProvider, () -> CASSANDRA_BLOBSTORE_FACTORY, () -> SWIFT_BLOBSTORE_FACTORY))
             .isEqualTo(SWIFT_BLOBSTORE_FACTORY);
     }
 
@@ -108,7 +108,7 @@ class BlobStoreChoosingModuleTest {
             .register(BLOBSTORE_CONFIGURATION_NAME, configuration)
             .build();
 
-        assertThat(module.provideBlobStoreFactory(propertyProvider, CASSANDRA_BLOBSTORE_FACTORY, SWIFT_BLOBSTORE_FACTORY))
+        assertThat(module.provideBlobStoreFactory(propertyProvider, () -> CASSANDRA_BLOBSTORE_FACTORY, () -> SWIFT_BLOBSTORE_FACTORY))
             .isEqualTo(CASSANDRA_BLOBSTORE_FACTORY);
     }
 }


### PR DESCRIPTION
…required

            If we don't enable Swift we should not fail when configuration is absent.
            The factory eagerly load the configuration right now, so I solved the
            issue with "another level of indirection" (tm).