### PR TITLE
[WIP] Package swift product

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -44,7 +44,7 @@ There is many other ways one can help us: packaging, communication, etc ...
  * https://github.com/apache/james-project/#how-to-release-via-maven-release-plugin[How to release via maven release plugin]
  * https://github.com/apache/james-project/#how-to-check-the-compilation[How to check the compilation]
  * https://github.com/apache/james-project/#how-to-run-james-in-docker[How to run James in Docker]
- ** https://github.com/apache/james-project/#run-james-with-java-8--guice--cassandra-rabbitmq-elasticsearch[Run James with Java 8 + Guice + Cassandra + RabbitMQ + ElasticSearch]
+ ** https://github.com/apache/james-project/#run-james-with-java-8--guice--cassandra-rabbitmq-swift-elasticsearch[Run James with Java 8 + Guice + Cassandra + RabbitMQ + Swift + ElasticSearch]
  ** https://github.com/apache/james-project/#run-james-with-java-8--guice--cassandra--elasticsearch[Run James with Java 8 + Guice + Cassandra + ElasticSearch]
  ** https://github.com/apache/james-project/#run-james-with-java-8--guice--jpa--lucene[Run James with Java 8 + Guice + JPA + Lucene]
  ** https://github.com/apache/james-project/#run-james-with-java-8--spring--jpa[Run James with Java 8 + Spring + JPA]
@@ -195,13 +195,13 @@ If you are using a a fresh installation of Docker, your DOCKER_HOST should be un
 
 This feature is available for three configurations :
 
- * Java 8 + Guice + Cassandra + RabbitMQ + ElasticSearch
+ * Java 8 + Guice + Cassandra + RabbitMQ + Swift + ElasticSearch
  * Java 8 + Guice + Cassandra + ElasticSearch
  * Java 8 + Guice + JPA + Lucene
  * Java 8 + Spring + JPA
 
 
-=== Run James with Java 8 + Guice + Cassandra + RabbitMQ + ElasticSearch
+=== Run James with Java 8 + Guice + Cassandra + RabbitMQ + Swift + ElasticSearch
 
 
 ==== Requirements
@@ -222,6 +222,10 @@ You need a running *cassandra* in docker. To achieve this run:
 You need a running *rabbitmq* in docker. To achieve this run:
 
     $ docker run -d --name=rabbitmq rabbitmq:3.7.7-management
+
+You need a running *swift* objectstorage in docker. To achieve this run:
+
+    $ docker run -d --name=swift jeantil/openstack-keystone-swift:pike
 
 You need a running *ElasticSearch* in docker. To achieve this run:
 
@@ -246,7 +250,7 @@ Then we need to build james container :
 To run this container :
 
     $ docker run --hostname HOSTNAME -p "25:25" -p 80:80 -p "110:110" -p "143:143" -p "465:465" -p "587:587" -p "993:993" --link cassandra:cassandra --link rabbitmq:rabbitmq
-   --link elasticsearch:elasticsearch --link tika:tika --name james_run -t james_run
+   --link elasticsearch:elasticsearch --link tika:tika --link swift:swift --name james_run -t james_run
 
 Where :
 

--- a/README.adoc
+++ b/README.adoc
@@ -522,7 +522,8 @@ Where:
 - ITERATION is the release number used after the last hyphen (e.g. 3.0.1, 3.1.0, 3.2.0...)
 - BASE is the image jar and executable are copied from. Defaults to linagora/james-project
 - BASE_LDAP is the image jar and executable are copied from for a deployment with an LDAP user repository. Defaults to linagora/james-ldap-project
-- BASE_RABBITMQ is the image jar and executable are copied from for a deployment of linagora/james-project + RabbitMQ. Defaults to linagora/james-rabbitmq-project
+- BASE_RABBITMQ is the image jar and executable are copied from for a deployment of linagora/james-project + RabbitMQ + Swift BlobStore.
+Defaults to linagora/james-rabbitmq-project
 - TAG is the tag of these docker images. Defaults to latest.
 
 Then, you have to run the container:

--- a/dockerfiles/packaging/guice/cassandra/package.sh
+++ b/dockerfiles/packaging/guice/cassandra/package.sh
@@ -37,7 +37,7 @@ docker run \
    --volume $PWD/dockerfiles/run/guice/cassandra-ldap/destination:/cassandra/destination \
    -t james/project -s $SHA1
 
-# Compile James with Cassandra + RabbitMQ
+# Compile James with Cassandra + RabbitMQ + Swift BlobStore
 docker run \
    --rm \
    --volume $PWD/.m2:/root/.m2 \

--- a/dockerfiles/packaging/guice/cassandra/package/etc/james/templates/objectstorage.properties
+++ b/dockerfiles/packaging/guice/cassandra/package/etc/james/templates/objectstorage.properties
@@ -1,0 +1,11 @@
+# Configuration for swift BlobStore
+objectstorage.payload.codec=DEFAULT
+objectstorage.provider=swift
+objectstorage.namespace=james
+objectstorage.swift.authapi=tmpauth
+objectstorage.swift.endpoint=http://swift:8080/auth/v1.0
+objectstorage.swift.credentials=testing
+objectstorage.swift.tempauth.username=tester
+objectstorage.swift.tempauth.tenantname=test
+objectstorage.swift.tempauth.passheadername=X-Storage-Pass
+objectstorage.swift.tempauth.userheadername=X-Storage-User

--- a/dockerfiles/run/docker-compose.yml
+++ b/dockerfiles/run/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - cassandra
       - tika
       - rabbitmq
+      - swift
     entrypoint: bash -c "java -Dworking.directory=/root/ -jar james-server.jar"
     image: linagora/james-project:latest
     container_name: james
@@ -35,3 +36,9 @@ services:
     ports:
       - "5672:5672"
       - "15672:15672"
+  swift:
+    image: jeantil/openstack-keystone-swift:pike
+    ports:
+      - "5000:5000"
+      - "8080:8080"
+      - "35357:35357"

--- a/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/objectstorage.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/objectstorage.properties
@@ -1,0 +1,11 @@
+# Configuration for swift BlobStore
+objectstorage.payload.codec=DEFAULT
+objectstorage.provider=swift
+objectstorage.namespace=james
+objectstorage.swift.authapi=tmpauth
+objectstorage.swift.endpoint=http://swift:8080/auth/v1.0
+objectstorage.swift.credentials=testing
+objectstorage.swift.tempauth.username=tester
+objectstorage.swift.tempauth.tenantname=test
+objectstorage.swift.tempauth.passheadername=X-Storage-Pass
+objectstorage.swift.tempauth.userheadername=X-Storage-User

--- a/src/site/markdown/server/install/guice-cassandra-rabbitmq-swift.md
+++ b/src/site/markdown/server/install/guice-cassandra-rabbitmq-swift.md
@@ -1,11 +1,11 @@
-# Guice-Cassandra-Rabbitmq installation guide
+# Guice-Cassandra-Rabbitmq-Swift installation guide
 
 ## Building
 
 ### Requirements
 
  - Java 8 SDK
- - Docker ∕ ElasticSearch 2.4.6 and Cassandra 3.11.3
+ - Docker ∕ ElasticSearch 2.4.6, RabbitMQ Management 3.3.7, Swift ObjectStorage and Cassandra 3.11.3
  - Maven 3
 
 ### Building the artifacts
@@ -28,6 +28,7 @@ mvn clean install
  * Cassandra 3.11.3
  * ElasticSearch 2.4.6
  * RabbitMQ-Management 3.7.7
+ * Swift ObjectStorage
 ### James Launch
 
 To run james, you have to create a directory containing required configuration files.
@@ -48,6 +49,7 @@ You need to have a Cassandra, ElasticSearch and RabbitMQ instance running. You c
 $ docker run -d --port 9042:9042 --name=cassandra cassandra:3.11.3
 $ docker run -d --port 9200:9200 --port 9300:9300 --name=elasticsearch elasticsearch:2.4.6
 $ docker run -d --port 5672:5672 --port 15672:15672 --name=rabbitmq rabbitmq:3.7.7-management
+$ docker run -d --port 5000:5000 --port 8080:8080 --port 35357:35357 --name=swift jeantil/openstack-keystone-swift:pike
 ```
 
 Once everything is set up, you just have to run the jar with:

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -107,7 +107,7 @@
                     </item>
                     <item name="2. Packaging" href="/server/packaging.html" />
                     <item name="3. Install James" href="/server/install.html" collapse="true">
-                        <item name="Cassandra-RabbitMQ-guice" href="/server/install/guice-cassandra-rabbitmq.html" />
+                        <item name="Cassandra-RabbitMQ-Swift-guice" href="/server/install/guice-cassandra-rabbitmq.html" />
                         <item name="Cassandra-guice" href="/server/install/guice-cassandra.html" />
                         <item name="JPA-guice" href="/server/install/guice-jpa.html" />
                         <item name="JPA-SMTP-guice" href="/server/install/guice-jpa-smtp.html" />


### PR DESCRIPTION
- By merging `cassadra-rabbitmq` product to `cassandra-rabbitmq-swift` product
- Bind `BlobStoreChoosingModule` to CassandraRabbitMQServerMain instead of `CassandraObjectStoreModule`
- `objectstore.properties` with swift implementation and configurations. Currently using tempauth api, will move to other apis because tempauth is for testing purpose