### PR TITLE
JAMES-2550 Significantly improve RabbitMQMailQueue::getSize performance

### DIFF
--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/DeleteCondition.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/DeleteCondition.java
@@ -86,6 +86,10 @@ public interface DeleteCondition {
             this.name = name;
         }
 
+        public String getName() {
+            return name;
+        }
+
         @Override
         public boolean shouldBeDeleted(Mail mail) {
             Preconditions.checkNotNull(mail);

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailDelete.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailDelete.java
@@ -54,8 +54,12 @@ public class CassandraMailQueueMailDelete {
     }
 
     CompletableFuture<Void> considerDeleted(Mail mail, MailQueueName mailQueueName) {
+        return considerDeleted(MailKey.fromMail(mail), mailQueueName);
+    }
+
+    CompletableFuture<Void> considerDeleted(MailKey mailKey, MailQueueName mailQueueName) {
         return deletedMailsDao
-            .markAsDeleted(mailQueueName, MailKey.fromMail(mail))
+            .markAsDeleted(mailQueueName, mailKey)
             .thenRunAsync(() -> maybeUpdateBrowseStart(mailQueueName));
     }
 

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
@@ -32,6 +32,7 @@ import org.apache.james.queue.rabbitmq.view.api.MailQueueView;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.CassandraMailQueueViewConfiguration;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.EventsourcingConfigurationManagement;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.EnqueuedItemWithSlicingContext;
+import org.apache.james.queue.rabbitmq.view.cassandra.model.MailKey;
 import org.apache.james.util.FluentFutureStream;
 import org.apache.mailet.Mail;
 
@@ -105,6 +106,16 @@ public class CassandraMailQueueView implements MailQueueView {
 
     @Override
     public CompletableFuture<Long> delete(DeleteCondition deleteCondition) {
+        if (deleteCondition instanceof DeleteCondition.WithName) {
+            DeleteCondition.WithName nameDeleteCondition = (DeleteCondition.WithName) deleteCondition;
+
+            return delete(MailKey.of(nameDeleteCondition.getName())).thenApply(any -> 1L);
+        }
+
+        return browseThenDelete(deleteCondition);
+    }
+
+    private CompletableFuture<Long> browseThenDelete(DeleteCondition deleteCondition) {
         CompletableFuture<Long> result = cassandraMailQueueBrowser.browseReferences(mailQueueName)
             .map(EnqueuedItemWithSlicingContext::getEnqueuedItem)
             .filter(mailReference -> deleteCondition.shouldBeDeleted(mailReference.getMail()))
@@ -116,6 +127,10 @@ public class CassandraMailQueueView implements MailQueueView {
         result.thenRunAsync(() -> cassandraMailQueueMailDelete.updateBrowseStart(mailQueueName));
 
         return result;
+    }
+
+    private CompletableFuture<Void> delete(MailKey mailKey) {
+        return cassandraMailQueueMailDelete.considerDeleted(mailKey, mailQueueName);
     }
 
     @Override

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
@@ -21,6 +21,7 @@ package org.apache.james.queue.rabbitmq.view.cassandra;
 
 import static com.datastax.driver.core.DataType.blob;
 import static com.datastax.driver.core.DataType.cint;
+import static com.datastax.driver.core.DataType.counter;
 import static com.datastax.driver.core.DataType.list;
 import static com.datastax.driver.core.DataType.map;
 import static com.datastax.driver.core.DataType.text;
@@ -71,6 +72,13 @@ public interface CassandraMailQueueViewModule {
         String MAIL_KEY = "mailKey";
     }
 
+    interface SizeTable {
+        String TABLE_NAME = "mailQueueSize";
+
+        String QUEUE_NAME = "queueName";
+        String SIZE = "size";
+    }
+
     CassandraModule MODULE = CassandraModule
         .type(EnqueuedMailsTable.HEADER_TYPE)
             .statement(statement -> statement
@@ -99,6 +107,13 @@ public interface CassandraMailQueueViewModule {
             .addColumn(EnqueuedMailsTable.REMOTE_ADDR, text())
             .addColumn(EnqueuedMailsTable.LAST_UPDATED, timestamp())
             .addUDTMapColumn(EnqueuedMailsTable.PER_RECIPIENT_SPECIFIC_HEADERS, text(), frozen(EnqueuedMailsTable.HEADER_TYPE)))
+
+        .table(SizeTable.TABLE_NAME)
+        .comment("Stores the size for each Mail Queue")
+        .options(options -> options)
+        .statement(statement -> statement
+            .addPartitionKey(SizeTable.QUEUE_NAME, text())
+            .addColumn(SizeTable.SIZE, counter()))
 
         .table(BrowseStartTable.TABLE_NAME)
         .comment("this table allows to find the starting point of iteration from the table: "

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAO.java
@@ -53,6 +53,7 @@ public class DeletedMailsDAO {
 
     private PreparedStatement prepareInsert(Session session) {
         return session.prepare(insertInto(TABLE_NAME)
+            .ifNotExists()
             .value(QUEUE_NAME, bindMarker(QUEUE_NAME))
             .value(MAIL_KEY, bindMarker(MAIL_KEY)));
     }
@@ -64,8 +65,8 @@ public class DeletedMailsDAO {
             .and(eq(MAIL_KEY, bindMarker(MAIL_KEY))));
     }
 
-    CompletableFuture<Void> markAsDeleted(MailQueueName mailQueueName, MailKey mailKey) {
-        return executor.executeVoid(insertOne.bind()
+    CompletableFuture<Boolean> markAsDeleted(MailQueueName mailQueueName, MailKey mailKey) {
+        return executor.executeReturnApplied(insertOne.bind()
             .setString(QUEUE_NAME, mailQueueName.asString())
             .setString(MAIL_KEY, mailKey.getMailKey()));
     }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/SizeDao.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/SizeDao.java
@@ -1,0 +1,84 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.queue.rabbitmq.view.cassandra;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.decr;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.incr;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.update;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import javax.inject.Inject;
+
+import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
+import org.apache.james.queue.rabbitmq.MailQueueName;
+import org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.SizeTable;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.Assignment;
+
+class SizeDao {
+
+    private final CassandraAsyncExecutor executor;
+    private final PreparedStatement select;
+    private final PreparedStatement increment;
+    private final PreparedStatement decrement;
+
+    @Inject
+    SizeDao(Session session) {
+        executor = new CassandraAsyncExecutor(session);
+        select = prepareSelect(session);
+        increment = prepareIncrement(session, incr(SizeTable.SIZE));
+        decrement = prepareIncrement(session, decr(SizeTable.SIZE));
+    }
+
+    private PreparedStatement prepareSelect(Session session) {
+        return session.prepare(select()
+            .from(SizeTable.TABLE_NAME)
+            .where(eq(SizeTable.QUEUE_NAME, bindMarker(SizeTable.QUEUE_NAME))));
+    }
+
+    private PreparedStatement prepareIncrement(Session session, Assignment assignment) {
+        return session.prepare(update(SizeTable.TABLE_NAME)
+            .where(eq(SizeTable.QUEUE_NAME, bindMarker(SizeTable.QUEUE_NAME)))
+            .with(assignment));
+    }
+
+    CompletableFuture<Void> increment(MailQueueName mailQueueName) {
+        return executor.executeVoid(increment.bind()
+            .setString(SizeTable.QUEUE_NAME, mailQueueName.asString()));
+    }
+
+    CompletableFuture<Void> decrement(MailQueueName mailQueueName) {
+        return executor.executeVoid(decrement.bind()
+            .setString(SizeTable.QUEUE_NAME, mailQueueName.asString()));
+    }
+
+    CompletableFuture<Optional<Long>> getSize(MailQueueName mailQueueName) {
+        return executor.executeSingleRow(select.bind()
+            .setString(SizeTable.QUEUE_NAME, mailQueueName.asString()))
+            .thenApply(maybeRow -> maybeRow.map(row -> row.getLong(SizeTable.SIZE)));
+    }
+}

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewTestFactory.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewTestFactory.java
@@ -25,11 +25,11 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import org.apache.james.backends.cassandra.init.CassandraTypesProvider;
 import org.apache.james.backends.cassandra.utils.CassandraUtils;
+import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.mail.MimeMessageStore;
 import org.apache.james.eventsourcing.eventstore.cassandra.CassandraEventStore;
 import org.apache.james.eventsourcing.eventstore.cassandra.EventStoreDao;
 import org.apache.james.eventsourcing.eventstore.cassandra.JsonEventSerializer;
-import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.CassandraMailQueueViewConfiguration;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.CassandraMailQueueViewConfigurationModule;
@@ -49,10 +49,11 @@ public class CassandraMailQueueViewTestFactory {
         EnqueuedMailsDAO enqueuedMailsDao = new EnqueuedMailsDAO(session, CassandraUtils.WITH_DEFAULT_CONFIGURATION, typesProvider, blobIdFactory);
         BrowseStartDAO browseStartDao = new BrowseStartDAO(session);
         DeletedMailsDAO deletedMailsDao = new DeletedMailsDAO(session);
+        SizeDao sizeDao = new SizeDao(session);
 
         CassandraMailQueueBrowser cassandraMailQueueBrowser = new CassandraMailQueueBrowser(browseStartDao, deletedMailsDao, enqueuedMailsDao, mimeMessageStoreFactory, configuration, clock);
-        CassandraMailQueueMailStore cassandraMailQueueMailStore = new CassandraMailQueueMailStore(enqueuedMailsDao, browseStartDao, configuration, clock);
-        CassandraMailQueueMailDelete cassandraMailQueueMailDelete = new CassandraMailQueueMailDelete(deletedMailsDao, browseStartDao, cassandraMailQueueBrowser, configuration, random);
+        CassandraMailQueueMailStore cassandraMailQueueMailStore = new CassandraMailQueueMailStore(enqueuedMailsDao, browseStartDao, sizeDao, configuration, clock);
+        CassandraMailQueueMailDelete cassandraMailQueueMailDelete = new CassandraMailQueueMailDelete(deletedMailsDao, browseStartDao, sizeDao, cassandraMailQueueBrowser, configuration, random);
 
 
         EventsourcingConfigurationManagement eventsourcingConfigurationManagement = new EventsourcingConfigurationManagement(new CassandraEventStore(new EventStoreDao(session, CassandraUtils.WITH_DEFAULT_CONFIGURATION,
@@ -62,6 +63,7 @@ public class CassandraMailQueueViewTestFactory {
             cassandraMailQueueMailStore,
             cassandraMailQueueBrowser,
             cassandraMailQueueMailDelete,
+            sizeDao,
             eventsourcingConfigurationManagement,
             configuration);
     }

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/SizeDaoTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/SizeDaoTest.java
@@ -1,0 +1,73 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.queue.rabbitmq.view.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.queue.rabbitmq.MailQueueName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class SizeDaoTest {
+    private static final MailQueueName OUT_GOING = MailQueueName.fromString("OUT_GOING_1");
+
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(CassandraMailQueueViewModule.MODULE);
+
+    private SizeDao testee;
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandra) {
+        testee = new SizeDao(cassandra.getConf());
+    }
+
+    @Test
+    void getSizeShouldReturnEmptyByDefault() {
+        assertThat(testee.getSize(OUT_GOING).join()).isEmpty();
+    }
+
+    @Test
+    void getSizeShouldBeIncrementedAfterIncrementCall() {
+        testee.increment(OUT_GOING).join();
+
+        assertThat(testee.getSize(OUT_GOING).join()).contains(1L);
+    }
+
+    @Test
+    void getSizeShouldBeIncrementedMultipleTimesAfterSeveralIncrementCall() {
+        testee.increment(OUT_GOING).join();
+        testee.increment(OUT_GOING).join();
+
+        assertThat(testee.getSize(OUT_GOING).join()).contains(2L);
+    }
+
+    @Test
+    void getSizeShouldBeDecrementedAfterDecrementCall() {
+        testee.increment(OUT_GOING).join();
+        testee.increment(OUT_GOING).join();
+
+        testee.decrement(OUT_GOING).join();
+
+        assertThat(testee.getSize(OUT_GOING).join()).contains(1L);
+    }
+}


### PR DESCRIPTION
Observation: Gatling test shows error periodically every 30 seconds.

We could see these logs : 

```
[97529c0332fd83d2e29bcfd2517009e53f7b0d44] [INFO] Running org.apache.james.jmap.rabbitmq.RabbitMQForwardIntegrationTest
[97529c0332fd83d2e29bcfd2517009e53f7b0d44] 2018-11-27 08:14:38,500 ERROR [metrics-elasticsearch-reporter-17-thread-1] - [com.codahale.metrics.ScheduledReporter]- Exception thrown from ElasticsearchReporter#report. Exception was suppressed.
[97529c0332fd83d2e29bcfd2517009e53f7b0d44] java.util.concurrent.CompletionException: com.datastax.driver.core.exceptions.NoHostAvailableException: All host(s) tried for query failed (no host was tried)
[97529c0332fd83d2e29bcfd2517009e53f7b0d44] 	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:292)
[97529c0332fd83d2e29bcfd2517009e53f7b0d44] 	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:308)
[97529c0332fd83d2e29bcfd2517009e53f7b0d44] 	at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:593)
[97529c0332fd83d2e29bcfd2517009e53f7b0d44] 	at java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:614)
[97529c0332fd83d2e29bcfd2517009e53f7b0d44] 	at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:1983)
[97529c0332fd83d2e29bcfd2517009e53f7b0d44] 	at org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor.executeSingleRow(CassandraAsyncExecutor.java:61)
[97529c0332fd83d2e29bcfd2517009e53f7b0d44] 	at org.apache.james.queue.rabbitmq.view.cassandra.BrowseStartDAO.selectOne(BrowseStartDAO.java:101)
[97529c0332fd83d2e29bcfd2517009e53f7b0d44] 	at org.apache.james.queue.rabbitmq.view.cassandra.BrowseStartDAO.findBrowseStart(BrowseStartDAO.java:83)
[97529c0332fd83d2e29bcfd2517009e53f7b0d44] 	at org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueBrowser.browseReferences(CassandraMailQueueBrowser.java:112)
[97529c0332fd83d2e29bcfd2517009e53f7b0d44] 	at org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueView.getSize(CassandraMailQueueView.java:101)
```

We can notice that the metric reporter generates an exception while getting mail queue size...

The idea of this PR is to denormalise the size.

This is a follow up of https://github.com/linagora/james-project/pull/1960. Please refer to it for performance comparison...

Here are the perf results:

![capture d ecran de 2018-11-28 10-07-29](https://user-images.githubusercontent.com/6928740/49126266-83fb6480-f2f5-11e8-999e-0c154632545d.png)

So:

- No more errors
-  31% throughtput improvment (465280 instead of 352697)
-  50% improvment of p99 (305ms instead of 610ms)

This PR at the very least proves the impact of size metric collection on correctness, which might deserve additional work.

BTW I want to mention size projection correction is easy to implement:
 - trigger it anytime the queue has a negative size or that a RabbitMQ poll action did not get emails & size is positivie
 - Then browseReference, & count them
 - I wonder how 'exact' size need to be. Can we tolerate errors a bit here?