### PR TITLE
EXPERIMENT to fix unstable RabbitMQMailQueue concurrentEnqueueDequeue…

### DIFF
--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/MailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/MailQueueContract.java
@@ -48,6 +48,7 @@ import org.apache.james.util.concurrency.ConcurrentTestRunner;
 import org.apache.mailet.Mail;
 import org.apache.mailet.PerRecipientHeaders;
 import org.apache.mailet.base.test.FakeMail;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -361,7 +362,7 @@ public interface MailQueueContract {
         assertThat(tryDequeue.get().getMail().getName()).isEqualTo("name");
     }
 
-    @Test
+    @RepeatedTest(100)
     default void concurrentEnqueueDequeueShouldNotFail() throws Exception {
         MailQueue testee = getMailQueue();
 

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
@@ -128,7 +128,7 @@ class Dequeuer {
         return new AsyncRetryExecutor(Executors.newSingleThreadScheduledExecutor())
             .withFixedRate()
             .withMinDelay(TEN_MS)
-            .retryOn(NoMailYetException.class)
+            .retryOn(NoMailYetException.class, IOException.class)
             .getWithRetry(this::singleChannelRead);
     }
 

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
@@ -133,6 +133,8 @@ public class RabbitMQMailQueueTest implements ManageableMailQueueContract, MailQ
     @AfterEach
     void tearDown() {
         mqManagementApi.deleteAllQueues();
+
+        assertThat(mqManagementApi.listCreatedMailQueueNames()).isEmpty();
     }
 
     @Override


### PR DESCRIPTION
…ShouldNotFail

Hypothesis: Deleting the queues adds some delays, next test client attempt
to create the queue (that still exist), then that queue is deleted and the new
test fails to use the queue...