### PR TITLE
JAMES-2598 Fix packaging Cassandra + ElasticSearch + Swift + RabbitMQ + Ldap Error

### DIFF
--- a/dockerfiles/packaging/guice/cassandra/Dockerfile
+++ b/dockerfiles/packaging/guice/cassandra/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE=linagora/james-project
 ARG BASE_LDAP=linagora/james-ldap-project
 ARG BASE_RABBITMQ=linagora/james-rabbitmq-project
-ARG BASE_RABBITMQ_LDAP=linagora/james-rabbitmq-ldap-project
+ARG BASE_RABBITMQ_LDAP=linagora/james-cassandra-rabbitmq-ldap-project
 ARG TAG=latest
 FROM ${BASE}:${TAG} as source
 FROM ${BASE_LDAP}:${TAG} as sourceLdap


### PR DESCRIPTION
james-build-packages have error in pipeline
```
Step 9/34 : FROM ${BASE_RABBITMQ_LDAP}:${TAG} as sourceRabbitMQLdap
pull access denied for linagora/james-rabbitmq-ldap-project, repository does not exist or may require 'docker login'
ERROR: Job failed: exit code 1
```
Because the image name are different.