### PR TITLE
[POC] Evaluation of Dedicated Executor Pool for Swift BlobStore

### DIFF
--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAOBuilder.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAOBuilder.java
@@ -30,6 +30,8 @@ import com.google.common.base.Preconditions;
 
 public class ObjectStorageBlobsDAOBuilder {
 
+    private static final int DEFAULT_POOL_SIZE = 10;
+
     public static RequireContainerName forBlobStore(Supplier<BlobStore> supplier) {
         return containerName -> blobIdFactory -> new ReadyToBuild(supplier, blobIdFactory, containerName);
     }
@@ -50,12 +52,14 @@ public class ObjectStorageBlobsDAOBuilder {
         private final ContainerName containerName;
         private final BlobId.Factory blobIdFactory;
         private Optional<PayloadCodec> payloadCodec;
+        private Optional<Integer> executorPoolSize;
 
         public ReadyToBuild(Supplier<BlobStore> supplier, BlobId.Factory blobIdFactory, ContainerName containerName) {
             this.blobIdFactory = blobIdFactory;
             this.containerName = containerName;
             this.payloadCodec = Optional.empty();
             this.supplier = supplier;
+            this.executorPoolSize = Optional.empty();
         }
 
         public ReadyToBuild payloadCodec(PayloadCodec payloadCodec) {
@@ -68,11 +72,16 @@ public class ObjectStorageBlobsDAOBuilder {
             return this;
         }
 
+        public ReadyToBuild executorPoolSize(Optional<Integer> executorPoolSize) {
+            this.executorPoolSize = executorPoolSize;
+            return this;
+        }
+
         public ObjectStorageBlobsDAO build() {
             Preconditions.checkState(containerName != null);
             Preconditions.checkState(blobIdFactory != null);
 
-            return new ObjectStorageBlobsDAO(containerName, blobIdFactory, supplier.get(), payloadCodec.orElse(PayloadCodec.DEFAULT_CODEC));
+            return new ObjectStorageBlobsDAO(containerName, blobIdFactory, supplier.get(), payloadCodec.orElse(PayloadCodec.DEFAULT_CODEC), executorPoolSize.orElse(DEFAULT_POOL_SIZE));
         }
 
         @VisibleForTesting

--- a/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/ObjectStorageDependenciesModule.java
+++ b/server/container/guice/blob-objectstorage-guice/src/main/java/org/apache/james/modules/objectstorage/ObjectStorageDependenciesModule.java
@@ -75,6 +75,7 @@ public class ObjectStorageDependenciesModule extends AbstractModule {
         ObjectStorageBlobsDAO dao = selectDaoBuilder(configuration)
             .container(configuration.getNamespace())
             .blobIdFactory(blobIdFactory)
+            .executorPoolSize(configuration.getExecutorPoolSize())
             .build();
         dao.createContainer(configuration.getNamespace()).get(1, TimeUnit.MINUTES);
         return dao;


### PR DESCRIPTION
I tweaked Swift BlobStore a bit to allow execute blobStore operations in an separated Executor, and not use the default one of CompletableFuture.

Here is the result:
1. Current James Implementation on master:
**Mean**: 7210ms
**Mean of sendMessage**: 25149ms
**Error rate**: 5%
**Throughput/s**: 10req/s
![ovh current-james](https://user-images.githubusercontent.com/39297818/49359333-818b7700-f708-11e8-9ee5-a0a714974ec8.png)

2. James with dedicated executor with pool size **10**
**Mean**: 5389ms
**Mean of sendMessage**: 18768ms
**Error rate**: 5%
**Throughput/s**: 13req/s
**Note**: Errors is centralized almost into `sendMessage` operations, where blobStore does it works.
![ovh james-with-swift-dedicated-executor-pool-10](https://user-images.githubusercontent.com/39297818/49359541-1a21f700-f709-11e8-8ced-92ff9a87890e.png)

2. James with dedicated executor with pool size **20**
**Mean**: 1736ms
**Mean of sendMessage**: 6375ms
**Error rate**: 5%
**Throughput/s**: 24req/s
**Note**: Error rates are little bit higher, but latency is really improved.
![ovh james-with-swift-dedicated-executor-pool-20](https://user-images.githubusercontent.com/39297818/49359770-b3e9a400-f709-11e8-9440-2eaae908b8f7.png)

My thinking about this experiment: Using BlobStore with default executor from CompletableFuture makes james "thread starving" and impacts to other operations where we use default executor from CompletableFuture. Tweaked james version with 20 of pool size really drags down the latency of most operations. There is higher error rate of this version may because of "JVM thread management busy" which is matter of a not really powerful server with huge number of java threads. I believe I would bring better result with a more cpu server. 
Conclusion: Dedicated executor for swift blobstore can gain some improvements.