### PR TITLE
JAMES-2544 Avoid negative bucketIds in RabbitMQMailQueue

### DIFF
--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailStore.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailStore.java
@@ -79,7 +79,7 @@ public class CassandraMailQueueMailStore {
 
     private BucketId computedBucketId(Mail mail) {
         int mailKeyHashCode = mail.getName().hashCode();
-        int bucketIdValue = mailKeyHashCode % configuration.getBucketCount();
+        int bucketIdValue = Math.abs(mailKeyHashCode) % configuration.getBucketCount();
         return BucketId.of(bucketIdValue);
     }
 }

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
@@ -23,6 +23,7 @@ import static java.time.temporal.ChronoUnit.HOURS;
 import static org.apache.james.backend.rabbitmq.RabbitMQFixture.DEFAULT_MANAGEMENT_CREDENTIAL;
 import static org.apache.james.queue.api.Mails.defaultMail;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -216,6 +217,14 @@ public class RabbitMQMailQueueTest implements ManageableMailQueueContract, MailQ
 
         boolean initialized = CassandraMailQueueViewTestFactory.isInitialized(cassandra.getConf(), MailQueueName.fromString(name));
         assertThat(initialized).isTrue();
+    }
+
+    @Test
+    void enQueueShouldNotThrowOnMailNameWithNegativeHash() {
+        String negativehashedString = "this sting will have a negative hash"; //hash value: -1256871313
+        
+        assertThatCode(() -> getMailQueue().enQueue(defaultMail().name(negativehashedString).build()))
+            .doesNotThrowAnyException();
     }
 
     @Disabled("JAMES-2614 RabbitMQMailQueueTest::concurrentEnqueueDequeueShouldNotFail is unstable." +


### PR DESCRIPTION
This improves build stability (Integration tests uses random mail names that can lead to random failures linked to that bug hence timeouts)

This improves Gatling figures (errors then are linked to Rabbit::getSize stuff)