### PR TITLE
James 2617 es6 metrics 2

### DIFF
--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -175,18 +175,18 @@ public abstract class MailboxManagerTest {
 
     @Nested
     class AnnotationTests {
-        private final MailboxAnnotationKey PRIVATE_KEY = new MailboxAnnotationKey("/private/comment");
-        private final MailboxAnnotationKey PRIVATE_CHILD_KEY = new MailboxAnnotationKey("/private/comment/user");
-        private final MailboxAnnotationKey PRIVATE_GRANDCHILD_KEY = new MailboxAnnotationKey("/private/comment/user/name");
-        private final MailboxAnnotationKey SHARED_KEY = new MailboxAnnotationKey("/shared/comment");
+        private final MailboxAnnotationKey privateKey = new MailboxAnnotationKey("/private/comment");
+        private final MailboxAnnotationKey privateChildKey = new MailboxAnnotationKey("/private/comment/user");
+        private final MailboxAnnotationKey privateGrandchildKey = new MailboxAnnotationKey("/private/comment/user/name");
+        private final MailboxAnnotationKey sharedKey = new MailboxAnnotationKey("/shared/comment");
 
-        private final MailboxAnnotation PRIVATE_ANNOTATION = MailboxAnnotation.newInstance(PRIVATE_KEY, "My private comment");
-        private final MailboxAnnotation PRIVATE_CHILD_ANNOTATION = MailboxAnnotation.newInstance(PRIVATE_CHILD_KEY, "My private comment");
-        private final MailboxAnnotation PRIVATE_GRANDCHILD_ANNOTATION = MailboxAnnotation.newInstance(PRIVATE_GRANDCHILD_KEY, "My private comment");
-        private final MailboxAnnotation PRIVATE_ANNOTATION_UPDATE = MailboxAnnotation.newInstance(PRIVATE_KEY, "My updated private comment");
-        private final MailboxAnnotation SHARED_ANNOTATION =  MailboxAnnotation.newInstance(SHARED_KEY, "My shared comment");
+        private final MailboxAnnotation privateAnnotation = MailboxAnnotation.newInstance(privateKey, "My private comment");
+        private final MailboxAnnotation privateChildAnnotation = MailboxAnnotation.newInstance(privateChildKey, "My private comment");
+        private final MailboxAnnotation privateGrandchildAnnotation = MailboxAnnotation.newInstance(privateGrandchildKey, "My private comment");
+        private final MailboxAnnotation privateAnnotationUpdate = MailboxAnnotation.newInstance(privateKey, "My updated private comment");
+        private final MailboxAnnotation sharedAnnotation =  MailboxAnnotation.newInstance(sharedKey, "My shared comment");
 
-        private final List<MailboxAnnotation> ANNOTATIONS = ImmutableList.of(PRIVATE_ANNOTATION, SHARED_ANNOTATION);
+        private final List<MailboxAnnotation> annotations = ImmutableList.of(privateAnnotation, sharedAnnotation);
 
         @Test
         void updateAnnotationsShouldUpdateStoredAnnotation() throws Exception {
@@ -195,10 +195,10 @@ public abstract class MailboxManagerTest {
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
 
-            mailboxManager.updateAnnotations(inbox, session, ImmutableList.of(PRIVATE_ANNOTATION));
+            mailboxManager.updateAnnotations(inbox, session, ImmutableList.of(privateAnnotation));
 
-            mailboxManager.updateAnnotations(inbox, session, ImmutableList.of(PRIVATE_ANNOTATION_UPDATE));
-            assertThat(mailboxManager.getAllAnnotations(inbox, session)).containsOnly(PRIVATE_ANNOTATION_UPDATE);
+            mailboxManager.updateAnnotations(inbox, session, ImmutableList.of(privateAnnotationUpdate));
+            assertThat(mailboxManager.getAllAnnotations(inbox, session)).containsOnly(privateAnnotationUpdate);
         }
 
         @Test
@@ -208,9 +208,9 @@ public abstract class MailboxManagerTest {
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
 
-            mailboxManager.updateAnnotations(inbox, session, ImmutableList.of(PRIVATE_ANNOTATION));
+            mailboxManager.updateAnnotations(inbox, session, ImmutableList.of(privateAnnotation));
 
-            mailboxManager.updateAnnotations(inbox, session, ImmutableList.of(MailboxAnnotation.nil(PRIVATE_KEY)));
+            mailboxManager.updateAnnotations(inbox, session, ImmutableList.of(MailboxAnnotation.nil(privateKey)));
             assertThat(mailboxManager.getAllAnnotations(inbox, session)).isEmpty();
         }
 
@@ -220,7 +220,7 @@ public abstract class MailboxManagerTest {
             session = mailboxManager.createSystemSession(USER_2);
             MailboxPath inbox = MailboxPath.inbox(session);
 
-            assertThatThrownBy(() -> mailboxManager.updateAnnotations(inbox, session, ImmutableList.of(PRIVATE_ANNOTATION)))
+            assertThatThrownBy(() -> mailboxManager.updateAnnotations(inbox, session, ImmutableList.of(privateAnnotation)))
                 .isInstanceOf(MailboxException.class);
         }
 
@@ -241,9 +241,9 @@ public abstract class MailboxManagerTest {
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
 
-            mailboxManager.updateAnnotations(inbox, session, ANNOTATIONS);
+            mailboxManager.updateAnnotations(inbox, session, annotations);
 
-            assertThat(mailboxManager.getAllAnnotations(inbox, session)).isEqualTo(ANNOTATIONS);
+            assertThat(mailboxManager.getAllAnnotations(inbox, session)).isEqualTo(annotations);
         }
 
         @Test
@@ -263,10 +263,10 @@ public abstract class MailboxManagerTest {
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
 
-            mailboxManager.updateAnnotations(inbox, session, ANNOTATIONS);
+            mailboxManager.updateAnnotations(inbox, session, annotations);
 
-            assertThat(mailboxManager.getAnnotationsByKeys(inbox, session, ImmutableSet.of(PRIVATE_KEY)))
-                .containsOnly(PRIVATE_ANNOTATION);
+            assertThat(mailboxManager.getAnnotationsByKeys(inbox, session, ImmutableSet.of(privateKey)))
+                .containsOnly(privateAnnotation);
         }
 
         @Test
@@ -275,7 +275,7 @@ public abstract class MailboxManagerTest {
             session = mailboxManager.createSystemSession(USER_2);
             MailboxPath inbox = MailboxPath.inbox(session);
 
-            assertThatThrownBy(() -> mailboxManager.getAnnotationsByKeys(inbox, session, ImmutableSet.of(PRIVATE_KEY)))
+            assertThatThrownBy(() -> mailboxManager.getAnnotationsByKeys(inbox, session, ImmutableSet.of(privateKey)))
                 .isInstanceOf(MailboxException.class);
         }
 
@@ -286,10 +286,10 @@ public abstract class MailboxManagerTest {
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
 
-            mailboxManager.updateAnnotations(inbox, session, ImmutableList.of(PRIVATE_ANNOTATION, PRIVATE_CHILD_ANNOTATION, PRIVATE_GRANDCHILD_ANNOTATION));
+            mailboxManager.updateAnnotations(inbox, session, ImmutableList.of(privateAnnotation, privateChildAnnotation, privateGrandchildAnnotation));
 
-            assertThat(mailboxManager.getAnnotationsByKeysWithOneDepth(inbox, session, ImmutableSet.of(PRIVATE_KEY)))
-                .contains(PRIVATE_ANNOTATION, PRIVATE_CHILD_ANNOTATION);
+            assertThat(mailboxManager.getAnnotationsByKeysWithOneDepth(inbox, session, ImmutableSet.of(privateKey)))
+                .contains(privateAnnotation, privateChildAnnotation);
         }
 
         @Test
@@ -298,7 +298,7 @@ public abstract class MailboxManagerTest {
             session = mailboxManager.createSystemSession(USER_2);
             MailboxPath inbox = MailboxPath.inbox(session);
 
-            assertThatThrownBy(() -> mailboxManager.getAnnotationsByKeysWithAllDepth(inbox, session, ImmutableSet.of(PRIVATE_KEY)))
+            assertThatThrownBy(() -> mailboxManager.getAnnotationsByKeysWithAllDepth(inbox, session, ImmutableSet.of(privateKey)))
                 .isInstanceOf(MailboxException.class);
         }
 
@@ -309,10 +309,10 @@ public abstract class MailboxManagerTest {
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
 
-            mailboxManager.updateAnnotations(inbox, session, ImmutableList.of(PRIVATE_ANNOTATION, PRIVATE_CHILD_ANNOTATION, PRIVATE_GRANDCHILD_ANNOTATION));
+            mailboxManager.updateAnnotations(inbox, session, ImmutableList.of(privateAnnotation, privateChildAnnotation, privateGrandchildAnnotation));
 
-            assertThat(mailboxManager.getAnnotationsByKeysWithAllDepth(inbox, session, ImmutableSet.of(PRIVATE_KEY)))
-                .contains(PRIVATE_ANNOTATION, PRIVATE_CHILD_ANNOTATION, PRIVATE_GRANDCHILD_ANNOTATION);
+            assertThat(mailboxManager.getAnnotationsByKeysWithAllDepth(inbox, session, ImmutableSet.of(privateKey)))
+                .contains(privateAnnotation, privateChildAnnotation, privateGrandchildAnnotation);
         }
 
         @Test
@@ -322,7 +322,7 @@ public abstract class MailboxManagerTest {
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
 
-            assertThatThrownBy(() -> mailboxManager.updateAnnotations(inbox, session, ImmutableList.of(MailboxAnnotation.newInstance(PRIVATE_KEY, "The limitation of data is less than 30"))))
+            assertThatThrownBy(() -> mailboxManager.updateAnnotations(inbox, session, ImmutableList.of(MailboxAnnotation.newInstance(privateKey, "The limitation of data is less than 30"))))
                 .isInstanceOf(AnnotationException.class);
         }
 

--- a/mailet/base/src/test/java/org/apache/mailet/base/MailetPipelineLoggingTest.java
+++ b/mailet/base/src/test/java/org/apache/mailet/base/MailetPipelineLoggingTest.java
@@ -22,21 +22,13 @@ package org.apache.mailet.base;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.mailet.Mail;
-import org.junit.Before;
 import org.junit.Test;
 
 public class MailetPipelineLoggingTest {
 
-    MailetPipelineLogging testee;
-
-    @Before
-    public void setup() {
-        testee = new MailetPipelineLogging();
-    }
-
     @Test
     public void getMailetInfoShouldReturnMailetInfoWhenGiven() {
-        assertThat(testee.getMailetInfo(new MailetWithMailetInfo()))
+        assertThat(MailetPipelineLogging.getMailetInfo(new MailetWithMailetInfo()))
             .isEqualTo("this is my info");
     }
 
@@ -54,7 +46,7 @@ public class MailetPipelineLoggingTest {
 
     @Test
     public void getMailetInfoShouldReturnSimpleClassNameWhenMailetInfoIsEmpty() {
-        assertThat(testee.getMailetInfo(new MailetWithoutMailetInfo()))
+        assertThat(MailetPipelineLogging.getMailetInfo(new MailetWithoutMailetInfo()))
             .isEqualTo("MailetWithoutMailetInfo");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1812,6 +1812,11 @@
                 <version>2.4.0</version>
             </dependency>
             <dependency>
+                <groupId>com.linagora</groupId>
+                <artifactId>metrics-elasticsearch-reporter</artifactId>
+                <version>${es-reporter.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.rest-assured</groupId>
                 <artifactId>rest-assured</artifactId>
                 <version>3.1.0</version>
@@ -2374,11 +2379,6 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlet</artifactId>
                 <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.linagora</groupId>
-                <artifactId>metrics-elasticsearch-reporter</artifactId>
-                <version>${es-reporter.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -634,7 +634,7 @@
         <testcontainers.version>1.9.0</testcontainers.version>
         <assertj.version>3.3.0</assertj.version>
         <es.version>2.2.1</es.version>
-        <es-reporter.version>6.0.0-SNAPSHOT</es-reporter.version>
+        <es-reporter.version>6.0.0-RC</es-reporter.version>
         <guava.version>25.1-jre</guava.version>
 
         <jutf7.version>1.0.0</jutf7.version>

--- a/pom.xml
+++ b/pom.xml
@@ -634,7 +634,7 @@
         <testcontainers.version>1.9.0</testcontainers.version>
         <assertj.version>3.3.0</assertj.version>
         <es.version>2.2.1</es.version>
-        <es-reporter.version>2.2.0</es-reporter.version>
+        <es-reporter.version>6.0.0-SNAPSHOT</es-reporter.version>
         <guava.version>25.1-jre</guava.version>
 
         <jutf7.version>1.0.0</jutf7.version>
@@ -2376,9 +2376,9 @@
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.elasticsearch</groupId>
+                <groupId>com.linagora</groupId>
                 <artifactId>metrics-elasticsearch-reporter</artifactId>
-                <version>2.2.0</version>
+                <version>${es-reporter.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/JamesServerWithRetryConnectionTest.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/JamesServerWithRetryConnectionTest.java
@@ -84,7 +84,7 @@ class JamesServerWithRetryConnectionTest {
     private static final int ELASTIC_SEARCH_PORT = 9300;
     private static final int ELASTIC_SEARCH_HTTP_PORT = 9200;
 
-    private static SwarmGenericContainer elasticSearchContainer = new SwarmGenericContainer(Images.ELASTICSEARCH)
+    private static SwarmGenericContainer elasticSearchContainer = new SwarmGenericContainer(Images.ELASTICSEARCH_2)
         .withExposedPorts(ELASTIC_SEARCH_HTTP_PORT, ELASTIC_SEARCH_PORT);
     private static final DockerCassandraRule cassandraRule = new DockerCassandraRule();
 

--- a/server/container/metrics/metrics-es-reporter/pom.xml
+++ b/server/container/metrics/metrics-es-reporter/pom.xml
@@ -53,6 +53,10 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
         </dependency>
@@ -66,11 +70,6 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
@@ -78,6 +77,16 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>metrics-elasticsearch-reporter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/server/container/metrics/metrics-es-reporter/pom.xml
+++ b/server/container/metrics/metrics-es-reporter/pom.xml
@@ -53,10 +53,6 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
         </dependency>
@@ -86,6 +82,11 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/server/container/metrics/metrics-es-reporter/pom.xml
+++ b/server/container/metrics/metrics-es-reporter/pom.xml
@@ -53,6 +53,10 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.linagora</groupId>
+            <artifactId>metrics-elasticsearch-reporter</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
         </dependency>
@@ -69,10 +73,6 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.linagora</groupId>
-            <artifactId>metrics-elasticsearch-reporter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/server/container/metrics/metrics-es-reporter/pom.xml
+++ b/server/container/metrics/metrics-es-reporter/pom.xml
@@ -71,7 +71,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.elasticsearch</groupId>
+            <groupId>com.linagora</groupId>
             <artifactId>metrics-elasticsearch-reporter</artifactId>
         </dependency>
         <dependency>

--- a/server/container/metrics/metrics-es-reporter/pom.xml
+++ b/server/container/metrics/metrics-es-reporter/pom.xml
@@ -57,6 +57,11 @@
             <artifactId>metrics-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/server/container/metrics/metrics-es-reporter/src/main/java/org/apache/james/metrics/es/ESMetricReporter.java
+++ b/server/container/metrics/metrics-es-reporter/src/main/java/org/apache/james/metrics/es/ESMetricReporter.java
@@ -26,10 +26,9 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
-import org.elasticsearch.metrics.ElasticsearchReporter;
-
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
+import com.linagora.elasticsearch.metrics.ElasticsearchReporter;
 
 public class ESMetricReporter {
 

--- a/server/container/metrics/metrics-es-reporter/src/test/java/org/apache/james/metric/es/DockerElasticSearch2Extension.java
+++ b/server/container/metrics/metrics-es-reporter/src/test/java/org/apache/james/metric/es/DockerElasticSearch2Extension.java
@@ -35,7 +35,7 @@ public class DockerElasticSearch2Extension implements ParameterResolver, BeforeE
     private DockerElasticSearch2Extension() {
         this.elasticSearchContainer = new SwarmGenericContainer(Images.ELASTICSEARCH)
             .withAffinityToContainer()
-            .withExposedPorts(ESReporterTest.ES_HTTP_PORT)
+            .withExposedPorts(ESReporterContract.ES_HTTP_PORT)
             .waitingFor(new HostPortWaitStrategy().withRateLimiter(RateLimiters.TWENTIES_PER_SECOND));
     }
 

--- a/server/container/metrics/metrics-es-reporter/src/test/java/org/apache/james/metric/es/DockerElasticSearch2Extension.java
+++ b/server/container/metrics/metrics-es-reporter/src/test/java/org/apache/james/metric/es/DockerElasticSearch2Extension.java
@@ -1,0 +1,61 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.metric.es;
+
+import org.apache.james.util.docker.Images;
+import org.apache.james.util.docker.RateLimiters;
+import org.apache.james.util.docker.SwarmGenericContainer;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
+
+public class DockerElasticSearch2Extension implements ParameterResolver, BeforeEachCallback, AfterEachCallback {
+    private final SwarmGenericContainer elasticSearchContainer;
+
+    private DockerElasticSearch2Extension() {
+        this.elasticSearchContainer = new SwarmGenericContainer(Images.ELASTICSEARCH)
+            .withAffinityToContainer()
+            .withExposedPorts(ESReporterTest.ES_HTTP_PORT)
+            .waitingFor(new HostPortWaitStrategy().withRateLimiter(RateLimiters.TWENTIES_PER_SECOND));
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) {
+        elasticSearchContainer.start();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) {
+        elasticSearchContainer.stop();
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return (parameterContext.getParameter().getType() == SwarmGenericContainer.class);
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return elasticSearchContainer;
+    }
+}

--- a/server/container/metrics/metrics-es-reporter/src/test/java/org/apache/james/metric/es/DockerElasticSearch6Extension.java
+++ b/server/container/metrics/metrics-es-reporter/src/test/java/org/apache/james/metric/es/DockerElasticSearch6Extension.java
@@ -29,11 +29,12 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 
-public class DockerElasticSearch2Extension implements ParameterResolver, BeforeEachCallback, AfterEachCallback {
+public class DockerElasticSearch6Extension implements ParameterResolver, BeforeEachCallback, AfterEachCallback {
     private final SwarmGenericContainer elasticSearchContainer;
 
-    private DockerElasticSearch2Extension() {
-        this.elasticSearchContainer = new SwarmGenericContainer(Images.ELASTICSEARCH_2)
+    private DockerElasticSearch6Extension() {
+        this.elasticSearchContainer = new SwarmGenericContainer(Images.ELASTICSEARCH_6)
+            .withEnv("discovery.type", "single-node")
             .withAffinityToContainer()
             .withExposedPorts(ESReporterContract.ES_HTTP_PORT)
             .waitingFor(new HostPortWaitStrategy().withRateLimiter(RateLimiters.TWENTIES_PER_SECOND));

--- a/server/container/metrics/metrics-es-reporter/src/test/java/org/apache/james/metric/es/ES2ReporterTest.java
+++ b/server/container/metrics/metrics-es-reporter/src/test/java/org/apache/james/metric/es/ES2ReporterTest.java
@@ -1,0 +1,26 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.metric.es;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(DockerElasticSearch2Extension.class)
+class ES2ReporterTest extends ESReporterContract {
+}

--- a/server/container/metrics/metrics-es-reporter/src/test/java/org/apache/james/metric/es/ES6ReporterTest.java
+++ b/server/container/metrics/metrics-es-reporter/src/test/java/org/apache/james/metric/es/ES6ReporterTest.java
@@ -17,14 +17,10 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.util.docker;
+package org.apache.james.metric.es;
 
-public interface Images {
-    String FAKE_SMTP = "weave/rest-smtp-sink:latest";
-    String RABBITMQ = "rabbitmq:3.7.7-management";
-    String ELASTICSEARCH_2 = "elasticsearch:2.4.6";
-    String ELASTICSEARCH_6 = "elasticsearch:6.5.1";
-    String NGINX = "nginx:1.15.1";
-    String TIKA = "logicalspark/docker-tikaserver:1.19.1";
-    String SPAMASSASSIN = "dinkel/spamassassin:3.4.0";
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(DockerElasticSearch6Extension.class)
+class ES6ReporterTest extends ESReporterContract {
 }

--- a/server/container/metrics/metrics-es-reporter/src/test/java/org/apache/james/metric/es/ESReportedConfigurationTest.java
+++ b/server/container/metrics/metrics-es-reporter/src/test/java/org/apache/james/metric/es/ESReportedConfigurationTest.java
@@ -20,43 +20,36 @@
 package org.apache.james.metric.es;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.james.metrics.es.ESReporterConfiguration;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class ESReportedConfigurationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+class ESReportedConfigurationTest {
 
     @Test
-    public void builderShouldThrowWhenNotToldIfEnabled() {
-        expectedException.expect(IllegalStateException.class);
-
-        ESReporterConfiguration.builder().build();
+    void builderShouldThrowWhenNotToldIfEnabled() {
+        assertThatThrownBy(() -> ESReporterConfiguration.builder().build())
+            .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void builderShouldThrowIfEnabledWithoutHostAndPort() {
-        expectedException.expect(IllegalStateException.class);
-
-        ESReporterConfiguration.builder()
-            .enabled()
-            .build();
+    void builderShouldThrowIfEnabledWithoutHostAndPort() {
+        assertThatThrownBy(() -> ESReporterConfiguration.builder()
+                .enabled()
+                .build())
+            .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void builderShouldThrowOnNullHost() {
-        expectedException.expect(NullPointerException.class);
-
-        ESReporterConfiguration.builder()
-            .onHost(null, 18);
+    void builderShouldThrowOnNullHost() {
+        assertThatThrownBy(() -> ESReporterConfiguration.builder()
+                .onHost(null, 18))
+            .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void builderShouldWorkWhenDisabled() {
+    void builderShouldWorkWhenDisabled() {
         ESReporterConfiguration configuration = ESReporterConfiguration.builder()
             .disabled()
             .build();
@@ -67,18 +60,17 @@ public class ESReportedConfigurationTest {
     }
 
     @Test
-    public void getHostWithPortShouldThrowWhenDisabled() {
+    void getHostWithPortShouldThrowWhenDisabled() {
         ESReporterConfiguration configuration = ESReporterConfiguration.builder()
             .disabled()
             .build();
 
-        expectedException.expect(IllegalStateException.class);
-
-        configuration.getHostWithPort();
+        assertThatThrownBy(() -> configuration.getHostWithPort())
+            .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void builderShouldWorkWhenEnabled() {
+    void builderShouldWorkWhenEnabled() {
         int port = 14;
         String host = "host";
         ESReporterConfiguration configuration = ESReporterConfiguration.builder()

--- a/server/container/metrics/metrics-es-reporter/src/test/java/org/apache/james/metric/es/ESReporterContract.java
+++ b/server/container/metrics/metrics-es-reporter/src/test/java/org/apache/james/metric/es/ESReporterContract.java
@@ -37,14 +37,12 @@ import org.awaitility.Duration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.codahale.metrics.MetricRegistry;
 
 import io.restassured.RestAssured;
 
-@ExtendWith(DockerElasticSearch2Extension.class)
-class ESReporterTest {
+abstract class ESReporterContract {
     public static final String INDEX = "index_name";
     public static final long PERIOD_IN_SECOND = 1L;
     public static final int DELAY_IN_MS = 100;

--- a/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/ReadOnlyUsersLDAPRepositoryTest.java
+++ b/server/data/data-ldap/src/test/java/org/apache/james/user/ldap/ReadOnlyUsersLDAPRepositoryTest.java
@@ -92,7 +92,7 @@ public class ReadOnlyUsersLDAPRepositoryTest {
 
             ReadOnlyUsersLDAPRepository usersLDAPRepository = new ReadOnlyUsersLDAPRepository(domainList);
 
-            assertThatThrownBy(()-> usersLDAPRepository.configure(configuration))
+            assertThatThrownBy(() -> usersLDAPRepository.configure(configuration))
                 .isInstanceOf(ConversionException.class);
         }
     }

--- a/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/KeywordsTest.java
+++ b/server/protocols/jmap/src/test/java/org/apache/james/jmap/model/KeywordsTest.java
@@ -199,6 +199,7 @@ public class KeywordsTest {
             .fromMap(ImmutableMap.of("in&valid", true)))
             .isEqualTo(Keywords.DEFAULT_VALUE);
     }
+
     @Test
     public void fromFlagsShouldNotThrowOnInvalidKeywordForLenientFactory() {
         assertThat(Keywords.lenientFactory()

--- a/third-party/spamassassin/src/test/java/org/apache/james/spamassassin/SpamAssassinExtension.java
+++ b/third-party/spamassassin/src/test/java/org/apache/james/spamassassin/SpamAssassinExtension.java
@@ -55,10 +55,11 @@ public class SpamAssassinExtension implements BeforeAllCallback, AfterEachCallba
                 .withFileFromClasspath("run.sh", "docker/spamassassin/run.sh")
                 .withFileFromClasspath("spamd.sh", "docker/spamassassin/spamd.sh")
                 .withFileFromClasspath("rule-update.sh", "docker/spamassassin/rule-update.sh")
-                .withFileFromClasspath("bayes_pg.sql", "docker/spamassassin/bayes_pg.sql"))
-            .withCreateContainerCmdModifier(cmd -> cmd.withName(containerName()));
-        spamAssassinContainer.withStartupTimeout(STARTUP_TIMEOUT);
-        spamAssassinContainer.waitingFor(new SpamAssassinWaitStrategy(spamAssassinContainer, STARTUP_TIMEOUT));
+                .withFileFromClasspath("bayes_pg.sql", "docker/spamassassin/bayes_pg.sql"));
+        spamAssassinContainer
+            .withCreateContainerCmdModifier(cmd -> cmd.withName(containerName()))
+            .withStartupTimeout(STARTUP_TIMEOUT)
+            .waitingFor(new SpamAssassinWaitStrategy(spamAssassinContainer, STARTUP_TIMEOUT));
     }
 
     @Override


### PR DESCRIPTION
Here is a new PR to make James metrics compatible with Elastic Search 6.

This time I handled integration tests, and also externalized the needed library. This library needs to be released and the version needs to be updated so that we can merge this PR.

Replaces #1981 