### PR TITLE
JAMES-2622 Use an optimized JRE based image in dockerfiles

### DIFF
--- a/dockerfiles/run/guice/cassandra-ldap/Dockerfile
+++ b/dockerfiles/run/guice/cassandra-ldap/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION	1.0
 
-FROM openjdk:8u171-jdk
+FROM openjdk:8u181-jre-alpine
 
 # Ports that are used
 #

--- a/dockerfiles/run/guice/cassandra-ldap/Dockerfile
+++ b/dockerfiles/run/guice/cassandra-ldap/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION	1.0
 
-FROM openjdk:8u181-jre-alpine
+FROM openjdk:8u181-jre
 
 # Ports that are used
 #

--- a/dockerfiles/run/guice/cassandra-rabbitmq-ldap/Dockerfile
+++ b/dockerfiles/run/guice/cassandra-rabbitmq-ldap/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION	1.0
 
-FROM openjdk:8u171-jdk
+FROM openjdk:8u181-jre-alpine
 
 # Ports that are used
 #

--- a/dockerfiles/run/guice/cassandra-rabbitmq-ldap/Dockerfile
+++ b/dockerfiles/run/guice/cassandra-rabbitmq-ldap/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION	1.0
 
-FROM openjdk:8u181-jre-alpine
+FROM openjdk:8u181-jre
 
 # Ports that are used
 #

--- a/dockerfiles/run/guice/cassandra-rabbitmq/Dockerfile
+++ b/dockerfiles/run/guice/cassandra-rabbitmq/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION	1.0
 
-FROM openjdk:8u171-jdk
+FROM openjdk:8u181-jre-alpine
 
 # Ports that are used
 #

--- a/dockerfiles/run/guice/cassandra-rabbitmq/Dockerfile
+++ b/dockerfiles/run/guice/cassandra-rabbitmq/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION	1.0
 
-FROM openjdk:8u181-jre-alpine
+FROM openjdk:8u181-jre
 
 # Ports that are used
 #

--- a/dockerfiles/run/guice/cassandra/Dockerfile
+++ b/dockerfiles/run/guice/cassandra/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION	1.0
 
-FROM openjdk:8u171-jdk
+FROM openjdk:8u181-jre-alpine
 
 # Ports that are used
 #

--- a/dockerfiles/run/guice/cassandra/Dockerfile
+++ b/dockerfiles/run/guice/cassandra/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION	1.0
 
-FROM openjdk:8u181-jre-alpine
+FROM openjdk:8u181-jre
 
 # Ports that are used
 #

--- a/dockerfiles/run/guice/jpa-smtp/Dockerfile
+++ b/dockerfiles/run/guice/jpa-smtp/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION	1.0
 
-FROM openjdk:8u171-jdk
+FROM openjdk:8u181-jre-alpine
 
 # Ports that are used
 #

--- a/dockerfiles/run/guice/jpa-smtp/Dockerfile
+++ b/dockerfiles/run/guice/jpa-smtp/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION	1.0
 
-FROM openjdk:8u181-jre-alpine
+FROM openjdk:8u181-jre
 
 # Ports that are used
 #

--- a/dockerfiles/run/guice/jpa/Dockerfile
+++ b/dockerfiles/run/guice/jpa/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION	1.0
 
-FROM openjdk:8u171-jdk
+FROM openjdk:8u181-jre-alpine
 
 # Ports that are used
 #

--- a/dockerfiles/run/guice/jpa/Dockerfile
+++ b/dockerfiles/run/guice/jpa/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION	1.0
 
-FROM openjdk:8u181-jre-alpine
+FROM openjdk:8u181-jre
 
 # Ports that are used
 #

--- a/dockerfiles/run/spring/Dockerfile
+++ b/dockerfiles/run/spring/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION	1.0
 
-FROM openjdk:8u171-jdk
+FROM openjdk:8u181-jre-alpine
 
 # Ports that are used
 #

--- a/dockerfiles/run/spring/Dockerfile
+++ b/dockerfiles/run/spring/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION	1.0
 
-FROM openjdk:8u181-jre-alpine
+FROM openjdk:8u181-jre
 
 # Ports that are used
 #


### PR DESCRIPTION
**Original with JDK**
✗ docker image inspect linagora/james-project:latest | gron | grep -i size
json[0].Size = 741657808;
json[0].VirtualSize = 741657808;

Compressed Size in DockerHub: 351 MB


**With JRE**
✗ docker image inspect james_run | gron | grep -i size                    
json[0].Size = 566924448;
json[0].VirtualSize = 566924448;

Compressed Size in DockerHub: 294 MB


**With JRE-alpine**
✗ docker image inspect james_run | gron | grep -i size
json[0].Size = 207138815;
json[0].VirtualSize = 207138815;

Compressed Size in DockerHub: 168 MB