### PR TITLE
MAILBOX-357 Only use Mailbox APIs for MailboxEvents

### DIFF
--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/ElasticSearchIndexerTest.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/ElasticSearchIndexerTest.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 
 import org.apache.james.backends.es.utils.TestingClientProvider;
 import org.apache.james.util.concurrent.NamedThreadFactory;

--- a/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndex.java
+++ b/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndex.java
@@ -46,7 +46,7 @@ import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.SearchQuery;
 import org.apache.james.mailbox.model.UpdatedFlags;
-import org.apache.james.mailbox.store.mail.MessageMapperFactory;
+import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
@@ -68,7 +68,7 @@ public class ElasticSearchListeningMessageSearchIndex extends ListeningMessageSe
     private final MessageToElasticSearchJson messageToElasticSearchJson;
 
     @Inject
-    public ElasticSearchListeningMessageSearchIndex(MessageMapperFactory factory,
+    public ElasticSearchListeningMessageSearchIndex(MailboxSessionMapperFactory factory,
                                                     @Named(MailboxElasticSearchConstants.InjectionNames.MAILBOX) ElasticSearchIndexer indexer,
                                                     ElasticSearchSearcher searcher, MessageToElasticSearchJson messageToElasticSearchJson,
                                                     MailboxManager mailboxManager) {

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndexTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndexTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
@@ -60,14 +59,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 public class ElasticSearchListeningMessageSearchIndexTest {
-    
-
-    public static final long MODSEQ = 18L;
-    public static final MessageUid MESSAGE_UID = MessageUid.of(1);
-    public static final TestId MAILBOX_ID = TestId.of(12);
-    public static final String ELASTIC_SEARCH_ID = "12:1";
-    public static final String EXPECTED_JSON_CONTENT = "json content";
-    public static final String USERNAME = "username";
+    private static final long MODSEQ = 18L;
+    private static final MessageUid MESSAGE_UID = MessageUid.of(1);
+    private static final TestId MAILBOX_ID = TestId.of(12);
+    private static final String ELASTIC_SEARCH_ID = "12:1";
+    private static final String EXPECTED_JSON_CONTENT = "json content";
+    private static final String USERNAME = "username";
 
     private ElasticSearchIndexer elasticSearchIndexer;
     private MessageToElasticSearchJson messageToElasticSearchJson;
@@ -76,8 +73,7 @@ public class ElasticSearchListeningMessageSearchIndexTest {
     private List<User> users;
     
     @Before
-    public void setup() throws JsonProcessingException {
-
+    public void setup() {
         MessageMapperFactory mapperFactory = mock(MessageMapperFactory.class);
         messageToElasticSearchJson = mock(MessageToElasticSearchJson.class);
         ElasticSearchSearcher elasticSearchSearcher = mock(ElasticSearchSearcher.class);
@@ -131,7 +127,7 @@ public class ElasticSearchListeningMessageSearchIndexTest {
         verify(elasticSearchIndexer).index(eq(ELASTIC_SEARCH_ID), eq(EXPECTED_JSON_CONTENT));
     }
 
-    private MailboxMessage mockedMessage(MessageUid messageId) throws IOException {
+    private MailboxMessage mockedMessage(MessageUid messageId) {
         MailboxMessage message = mock(MailboxMessage.class);
         when(message.getUid())
             .thenReturn(messageId);

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndexTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndexTest.java
@@ -42,7 +42,7 @@ import org.apache.james.mailbox.elasticsearch.search.ElasticSearchSearcher;
 import org.apache.james.mailbox.mock.MockMailboxSession;
 import org.apache.james.mailbox.model.TestId;
 import org.apache.james.mailbox.model.UpdatedFlags;
-import org.apache.james.mailbox.store.mail.MessageMapperFactory;
+import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.elasticsearch.ElasticsearchException;
@@ -74,7 +74,7 @@ public class ElasticSearchListeningMessageSearchIndexTest {
     
     @Before
     public void setup() {
-        MessageMapperFactory mapperFactory = mock(MessageMapperFactory.class);
+        MailboxSessionMapperFactory mapperFactory = mock(MailboxSessionMapperFactory.class);
         messageToElasticSearchJson = mock(MessageToElasticSearchJson.class);
         ElasticSearchSearcher elasticSearchSearcher = mock(ElasticSearchSearcher.class);
         MailboxManager mockMailboxManager = mock(MailboxManager.class);

--- a/mailbox/lucene/src/main/java/org/apache/james/mailbox/lucene/search/LuceneMessageSearchIndex.java
+++ b/mailbox/lucene/src/main/java/org/apache/james/mailbox/lucene/search/LuceneMessageSearchIndex.java
@@ -66,7 +66,7 @@ import org.apache.james.mailbox.model.SearchQuery.NumericOperator;
 import org.apache.james.mailbox.model.SearchQuery.UidCriterion;
 import org.apache.james.mailbox.model.SearchQuery.UidRange;
 import org.apache.james.mailbox.model.UpdatedFlags;
-import org.apache.james.mailbox.store.mail.MessageMapperFactory;
+import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
@@ -363,24 +363,22 @@ public class LuceneMessageSearchIndex extends ListeningMessageSearchIndex {
 
     @Inject
     public LuceneMessageSearchIndex(
-        MessageMapperFactory factory,
+        MailboxSessionMapperFactory factory,
         MailboxId.Factory mailboxIdFactory,
         Directory directory,
         MessageId.Factory messageIdFactory,
-        MailboxManager mailboxManager
-    ) throws IOException {
+        MailboxManager mailboxManager) throws IOException {
         this(factory, mailboxIdFactory, directory, false, true, messageIdFactory, mailboxManager);
     }
 
     public LuceneMessageSearchIndex(
-            MessageMapperFactory factory,
+            MailboxSessionMapperFactory factory,
             MailboxId.Factory mailboxIdFactory,
             Directory directory,
             boolean dropIndexOnStart,
             boolean lenient,
             MessageId.Factory messageIdFactory,
-            MailboxManager mailboxManager
-    ) throws IOException {
+            MailboxManager mailboxManager) throws IOException {
         super(factory, mailboxManager);
         this.mailboxIdFactory = mailboxIdFactory;
         this.messageIdFactory = messageIdFactory;

--- a/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
+++ b/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
@@ -98,7 +98,7 @@ public class SpamAssassinListenerTest {
         spamCapitalMailboxId = mailboxMapper.save(new SimpleMailbox(MailboxPath.forUser(USER, "SPAM"), UID_VALIDITY));
         trashMailboxId = mailboxMapper.save(new SimpleMailbox(MailboxPath.forUser(USER, "Trash"), UID_VALIDITY));
 
-        listener = new SpamAssassinListener(spamAssassin, systemMailboxesProvider, MailboxListener.ExecutionMode.SYNCHRONOUS);
+        listener = new SpamAssassinListener(spamAssassin, systemMailboxesProvider, mailboxManager, mapperFactory, MailboxListener.ExecutionMode.SYNCHRONOUS);
     }
 
     @After

--- a/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
+++ b/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
@@ -48,7 +48,6 @@ import org.apache.james.mailbox.store.SimpleMessageMetaData;
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.apache.james.mailbox.store.SystemMailboxesProviderImpl;
 import org.apache.james.mailbox.store.event.EventFactory;
-import org.apache.james.mailbox.store.event.EventFactory.AddedImpl;
 import org.apache.james.mailbox.store.event.MessageMoveEvent;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
@@ -249,13 +248,11 @@ public class SpamAssassinListenerTest {
     @Test
     public void eventShouldCallSpamAssassinHamLearningWhenTheMessageIsAddedInInbox() {
         SimpleMailboxMessage message = createMessage(inboxId);
-        EventFactory eventFactory = new EventFactory();
-        AddedImpl addedEvent = eventFactory.new AddedImpl(
-                MAILBOX_SESSION.getSessionId(),
-                MAILBOX_SESSION.getUser().getCoreUser(),
-                inbox,
+
+        MailboxListener.Added addedEvent = new EventFactory().added(
+                MAILBOX_SESSION,
                 ImmutableSortedMap.of(MessageUid.of(45), new SimpleMessageMetaData(message)),
-                ImmutableMap.of(MessageUid.of(45), message));
+                inbox);
 
         listener.event(addedEvent);
 
@@ -265,13 +262,11 @@ public class SpamAssassinListenerTest {
     @Test
     public void eventShouldNotCallSpamAssassinHamLearningWhenTheMessageIsAddedInAMailboxOtherThanInbox() {
         SimpleMailboxMessage message = createMessage(mailboxId1);
-        EventFactory eventFactory = new EventFactory();
-        AddedImpl addedEvent = eventFactory.new AddedImpl(
-                MAILBOX_SESSION.getSessionId(),
-                MAILBOX_SESSION.getUser().getCoreUser(),
-                mailbox1,
-                ImmutableSortedMap.of(MessageUid.of(45), new SimpleMessageMetaData(message)),
-                ImmutableMap.of(MessageUid.of(45), message));
+
+        MailboxListener.Added addedEvent = new EventFactory().added(
+            MAILBOX_SESSION,
+            ImmutableSortedMap.of(MessageUid.of(45), new SimpleMessageMetaData(message)),
+            inbox);
 
         listener.event(addedEvent);
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -739,7 +739,7 @@ public class StoreMessageManager implements org.apache.james.mailbox.MessageMana
         for (MailboxMessage message : originalRows.getEntriesSeen()) {
             messagesMap.put(message.getUid(), immutableMailboxMessageFactory.from(to.getMailboxEntity().getMailboxId(), message));
         }
-        dispatcher.added(session, copiedUids, to.getMailboxEntity(), messagesMap.build());
+        dispatcher.added(session, copiedUids, to.getMailboxEntity());
         dispatcher.moved(session,
             MessageMoves.builder()
                 .previousMailboxIds(getMailboxEntity().getMailboxId())
@@ -759,7 +759,7 @@ public class StoreMessageManager implements org.apache.james.mailbox.MessageMana
         for (MailboxMessage message : originalRows.getEntriesSeen()) {
             messagesMap.put(message.getUid(), immutableMailboxMessageFactory.from(to.getMailboxEntity().getMailboxId(), message));
         }
-        dispatcher.added(session, moveUids, to.getMailboxEntity(), messagesMap.build());
+        dispatcher.added(session, moveUids, to.getMailboxEntity());
         dispatcher.expunged(session, collectMetadata(moveResult.getOriginalMessages()), getMailboxEntity());
         dispatcher.moved(session,
             MessageMoves.builder()

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/EventFactory.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/EventFactory.java
@@ -51,14 +51,12 @@ public class EventFactory {
 
     public final class AddedImpl extends MailboxListener.Added implements MailboxAware {
         private final Map<MessageUid, MessageMetaData> added;
-        private final Map<MessageUid, MailboxMessage> availableMessages;
         private final Mailbox mailbox;
 
-        public AddedImpl(MailboxSession.SessionId sessionId, User user, Mailbox mailbox, SortedMap<MessageUid, MessageMetaData> uids, Map<MessageUid, MailboxMessage> availableMessages) {
+        public AddedImpl(MailboxSession.SessionId sessionId, User user, Mailbox mailbox, SortedMap<MessageUid, MessageMetaData> uids) {
             super(sessionId, user, new StoreMailboxPath(mailbox), mailbox.getMailboxId());
             this.added = ImmutableMap.copyOf(uids);
             this.mailbox = mailbox;
-            this.availableMessages = ImmutableMap.copyOf(availableMessages);
         }
 
         @Override
@@ -74,10 +72,6 @@ public class EventFactory {
         @Override
         public Mailbox getMailbox() {
             return mailbox;
-        }
-
-        public Map<MessageUid, MailboxMessage> getAvailableMessages() {
-            return availableMessages;
         }
     }
 
@@ -193,12 +187,12 @@ public class EventFactory {
         }
     }
 
-    public MailboxListener.Added added(MailboxSession session, SortedMap<MessageUid, MessageMetaData> uids, Mailbox mailbox, Map<MessageUid, MailboxMessage> cachedMessages) {
-        return added(session.getSessionId(), session.getUser().getCoreUser(), uids, mailbox, cachedMessages);
+    public MailboxListener.Added added(MailboxSession session, SortedMap<MessageUid, MessageMetaData> uids, Mailbox mailbox) {
+        return added(session.getSessionId(), session.getUser().getCoreUser(), uids, mailbox);
     }
 
-    public MailboxListener.Added added(MailboxSession.SessionId sessionId, User user, SortedMap<MessageUid, MessageMetaData> uids, Mailbox mailbox, Map<MessageUid, MailboxMessage> cachedMessages) {
-        return new AddedImpl(sessionId, user, mailbox, uids, cachedMessages);
+    public MailboxListener.Added added(MailboxSession.SessionId sessionId, User user, SortedMap<MessageUid, MessageMetaData> uids, Mailbox mailbox) {
+        return new AddedImpl(sessionId, user, mailbox, uids);
     }
 
     public MailboxListener.Expunged expunged(MailboxSession session,  Map<MessageUid, MessageMetaData> uids, Mailbox mailbox) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/EventFactory.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/EventFactory.java
@@ -45,10 +45,10 @@ import com.google.common.collect.ImmutableMap;
 
 public class EventFactory {
 
-    public final class AddedImpl extends MailboxListener.Added {
+    private final class AddedImpl extends MailboxListener.Added {
         private final Map<MessageUid, MessageMetaData> added;
 
-        public AddedImpl(MailboxSession.SessionId sessionId, User user, Mailbox mailbox, SortedMap<MessageUid, MessageMetaData> uids) {
+        AddedImpl(MailboxSession.SessionId sessionId, User user, Mailbox mailbox, SortedMap<MessageUid, MessageMetaData> uids) {
             super(sessionId, user, new StoreMailboxPath(mailbox), mailbox.getMailboxId());
             this.added = ImmutableMap.copyOf(uids);
         }
@@ -64,10 +64,10 @@ public class EventFactory {
         }
     }
 
-    public final class ExpungedImpl extends MailboxListener.Expunged {
+    private final class ExpungedImpl extends MailboxListener.Expunged {
         private final Map<MessageUid, MessageMetaData> uids;
 
-        public ExpungedImpl(MailboxSession.SessionId sessionId, User user, Mailbox mailbox,  Map<MessageUid, MessageMetaData> uids) {
+        ExpungedImpl(MailboxSession.SessionId sessionId, User user, Mailbox mailbox, Map<MessageUid, MessageMetaData> uids) {
             super(sessionId, user,  new StoreMailboxPath(mailbox), mailbox.getMailboxId());
             this.uids = ImmutableMap.copyOf(uids);
         }
@@ -83,11 +83,11 @@ public class EventFactory {
         }
     }
 
-    public final class FlagsUpdatedImpl extends MailboxListener.FlagsUpdated {
+    private final class FlagsUpdatedImpl extends MailboxListener.FlagsUpdated {
         private final List<MessageUid> uids;
         private final List<UpdatedFlags> uFlags;
 
-        public FlagsUpdatedImpl(MailboxSession.SessionId sessionId, User user, Mailbox mailbox, List<MessageUid> uids, List<UpdatedFlags> uFlags) {
+        FlagsUpdatedImpl(MailboxSession.SessionId sessionId, User user, Mailbox mailbox, List<MessageUid> uids, List<UpdatedFlags> uFlags) {
             super(sessionId, user, new StoreMailboxPath(mailbox), mailbox.getMailboxId());
             this.uids = ImmutableList.copyOf(uids);
             this.uFlags = ImmutableList.copyOf(uFlags);
@@ -104,22 +104,22 @@ public class EventFactory {
         }
     }
 
-    public final class MailboxDeletionImpl extends MailboxListener.MailboxDeletion {
-        public MailboxDeletionImpl(MailboxSession.SessionId sessionId, User user, Mailbox mailbox, QuotaRoot quotaRoot, QuotaCount deletedMessageCount, QuotaSize totalDeletedSize) {
+    private final class MailboxDeletionImpl extends MailboxListener.MailboxDeletion {
+        MailboxDeletionImpl(MailboxSession.SessionId sessionId, User user, Mailbox mailbox, QuotaRoot quotaRoot, QuotaCount deletedMessageCount, QuotaSize totalDeletedSize) {
             super(sessionId, user, new StoreMailboxPath(mailbox), quotaRoot, deletedMessageCount, totalDeletedSize, mailbox.getMailboxId());
         }
     }
 
-    public final class MailboxAddedImpl extends MailboxListener.MailboxAdded {
-        public MailboxAddedImpl(MailboxSession.SessionId sessionId, User user, Mailbox mailbox) {
+    private final class MailboxAddedImpl extends MailboxListener.MailboxAdded {
+        MailboxAddedImpl(MailboxSession.SessionId sessionId, User user, Mailbox mailbox) {
             super(sessionId, user,  new StoreMailboxPath(mailbox), mailbox.getMailboxId());
         }
     }
 
-    public final class MailboxRenamedEventImpl extends MailboxListener.MailboxRenamed {
+    private final class MailboxRenamedEventImpl extends MailboxListener.MailboxRenamed {
         private final MailboxPath newPath;
 
-        public MailboxRenamedEventImpl(MailboxSession.SessionId sessionId, User user, MailboxPath oldPath, Mailbox newMailbox) {
+        MailboxRenamedEventImpl(MailboxSession.SessionId sessionId, User user, MailboxPath oldPath, Mailbox newMailbox) {
             super(sessionId, user, oldPath, newMailbox.getMailboxId());
             this.newPath = new StoreMailboxPath(newMailbox);
         }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/EventFactory.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/EventFactory.java
@@ -45,18 +45,12 @@ import com.google.common.collect.ImmutableMap;
 
 public class EventFactory {
 
-    public interface MailboxAware {
-        Mailbox getMailbox();
-    }
-
-    public final class AddedImpl extends MailboxListener.Added implements MailboxAware {
+    public final class AddedImpl extends MailboxListener.Added {
         private final Map<MessageUid, MessageMetaData> added;
-        private final Mailbox mailbox;
 
         public AddedImpl(MailboxSession.SessionId sessionId, User user, Mailbox mailbox, SortedMap<MessageUid, MessageMetaData> uids) {
             super(sessionId, user, new StoreMailboxPath(mailbox), mailbox.getMailboxId());
             this.added = ImmutableMap.copyOf(uids);
-            this.mailbox = mailbox;
         }
 
         @Override
@@ -68,21 +62,14 @@ public class EventFactory {
         public MessageMetaData getMetaData(MessageUid uid) {
             return added.get(uid);
         }
-
-        @Override
-        public Mailbox getMailbox() {
-            return mailbox;
-        }
     }
 
-    public final class ExpungedImpl extends MailboxListener.Expunged implements MailboxAware {
+    public final class ExpungedImpl extends MailboxListener.Expunged {
         private final Map<MessageUid, MessageMetaData> uids;
-        private final Mailbox mailbox;
 
         public ExpungedImpl(MailboxSession.SessionId sessionId, User user, Mailbox mailbox,  Map<MessageUid, MessageMetaData> uids) {
             super(sessionId, user,  new StoreMailboxPath(mailbox), mailbox.getMailboxId());
             this.uids = ImmutableMap.copyOf(uids);
-            this.mailbox = mailbox;
         }
 
         @Override
@@ -94,25 +81,16 @@ public class EventFactory {
         public MessageMetaData getMetaData(MessageUid uid) {
             return uids.get(uid);
         }
-
-        @Override
-        public Mailbox getMailbox() {
-            return mailbox;
-        }
     }
 
-    public final class FlagsUpdatedImpl extends MailboxListener.FlagsUpdated implements MailboxAware {
+    public final class FlagsUpdatedImpl extends MailboxListener.FlagsUpdated {
         private final List<MessageUid> uids;
-
-        private final Mailbox mailbox;
-
         private final List<UpdatedFlags> uFlags;
 
         public FlagsUpdatedImpl(MailboxSession.SessionId sessionId, User user, Mailbox mailbox, List<MessageUid> uids, List<UpdatedFlags> uFlags) {
             super(sessionId, user, new StoreMailboxPath(mailbox), mailbox.getMailboxId());
             this.uids = ImmutableList.copyOf(uids);
             this.uFlags = ImmutableList.copyOf(uFlags);
-            this.mailbox = mailbox;
         }
 
         @Override
@@ -124,66 +102,31 @@ public class EventFactory {
         public List<UpdatedFlags> getUpdatedFlags() {
             return uFlags;
         }
-
-        @Override
-        public Mailbox getMailbox() {
-            return mailbox;
-        }
-
     }
 
-    public final class MailboxDeletionImpl extends MailboxListener.MailboxDeletion implements MailboxAware {
-        private final Mailbox mailbox;
-
+    public final class MailboxDeletionImpl extends MailboxListener.MailboxDeletion {
         public MailboxDeletionImpl(MailboxSession.SessionId sessionId, User user, Mailbox mailbox, QuotaRoot quotaRoot, QuotaCount deletedMessageCount, QuotaSize totalDeletedSize) {
             super(sessionId, user, new StoreMailboxPath(mailbox), quotaRoot, deletedMessageCount, totalDeletedSize, mailbox.getMailboxId());
-            this.mailbox = mailbox;
         }
-
-
-        @Override
-        public Mailbox getMailbox() {
-            return mailbox;
-        }
-
     }
 
-    public final class MailboxAddedImpl extends MailboxListener.MailboxAdded implements MailboxAware {
-
-        private final Mailbox mailbox;
-
+    public final class MailboxAddedImpl extends MailboxListener.MailboxAdded {
         public MailboxAddedImpl(MailboxSession.SessionId sessionId, User user, Mailbox mailbox) {
             super(sessionId, user,  new StoreMailboxPath(mailbox), mailbox.getMailboxId());
-            this.mailbox = mailbox;
         }
-
-
-        @Override
-        public Mailbox getMailbox() {
-            return mailbox;
-        }
-
     }
 
-    public final class MailboxRenamedEventImpl extends MailboxListener.MailboxRenamed implements MailboxAware {
-
+    public final class MailboxRenamedEventImpl extends MailboxListener.MailboxRenamed {
         private final MailboxPath newPath;
-        private final Mailbox newMailbox;
 
         public MailboxRenamedEventImpl(MailboxSession.SessionId sessionId, User user, MailboxPath oldPath, Mailbox newMailbox) {
             super(sessionId, user, oldPath, newMailbox.getMailboxId());
             this.newPath = new StoreMailboxPath(newMailbox);
-            this.newMailbox = newMailbox;
         }
 
         @Override
         public MailboxPath getNewPath() {
             return newPath;
-        }
-
-        @Override
-        public Mailbox getMailbox() {
-            return newMailbox;
         }
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxAnnotationListener.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxAnnotationListener.java
@@ -52,11 +52,11 @@ public class MailboxAnnotationListener implements MailboxListener {
 
     @Override
     public void event(Event event) {
-        if (event instanceof EventFactory.MailboxDeletionImpl) {
+        if (event instanceof MailboxDeletion) {
             try {
                 MailboxSession mailboxSession = mailboxManager.createSystemSession(event.getUser().asString());
                 AnnotationMapper annotationMapper = mailboxSessionMapperFactory.getAnnotationMapper(mailboxSession);
-                MailboxId mailboxId = ((EventFactory.MailboxDeletionImpl) event).getMailbox().getMailboxId();
+                MailboxId mailboxId = ((MailboxDeletion) event).getMailboxId();
 
                 deleteRelatedAnnotations(mailboxId, annotationMapper);
             } catch (MailboxException e) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
@@ -81,8 +81,8 @@ public class MailboxEventDispatcher {
      * @param uids Sorted map with uids and message meta data
      * @param mailbox The mailbox
      */
-    public void added(MailboxSession session, SortedMap<MessageUid, MessageMetaData> uids, Mailbox mailbox, Map<MessageUid, MailboxMessage> cachedMessages) {
-        listener.event(eventFactory.added(session, uids, mailbox, cachedMessages));
+    public void added(MailboxSession session, SortedMap<MessageUid, MessageMetaData> uids, Mailbox mailbox) {
+        listener.event(eventFactory.added(session, uids, mailbox));
     }
 
     public void added(MailboxSession session, Mailbox mailbox, MailboxMessage mailboxMessage) {
@@ -90,14 +90,14 @@ public class MailboxEventDispatcher {
         SortedMap<MessageUid, MessageMetaData> metaDataMap = ImmutableSortedMap.<MessageUid, MessageMetaData>naturalOrder()
                 .put(messageMetaData.getUid(), messageMetaData)
                 .build();
-        added(session, metaDataMap, mailbox, ImmutableMap.of(mailboxMessage.getUid(), mailboxMessage));
+        added(session, metaDataMap, mailbox);
     }
 
     public void added(MailboxSession session, MessageMetaData messageMetaData, Mailbox mailbox) {
         SortedMap<MessageUid, MessageMetaData> metaDataMap = ImmutableSortedMap.<MessageUid, MessageMetaData>naturalOrder()
             .put(messageMetaData.getUid(), messageMetaData)
             .build();
-        added(session, metaDataMap, mailbox, ImmutableMap.<MessageUid, MailboxMessage>of());
+        added(session, metaDataMap, mailbox);
     }
 
     /**

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/LazyMessageSearchIndex.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/LazyMessageSearchIndex.java
@@ -35,8 +35,8 @@ import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.SearchQuery;
 import org.apache.james.mailbox.model.UpdatedFlags;
+import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
 import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
-import org.apache.james.mailbox.store.mail.MessageMapperFactory;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.slf4j.Logger;
@@ -59,10 +59,10 @@ public class LazyMessageSearchIndex extends ListeningMessageSearchIndex {
 
     private final ListeningMessageSearchIndex index;
     private final ConcurrentHashMap<MailboxId, Object> indexed = new ConcurrentHashMap<>();
-    private final MessageMapperFactory factory;
+    private final MailboxSessionMapperFactory factory;
     
     
-    public LazyMessageSearchIndex(ListeningMessageSearchIndex index, MessageMapperFactory factory, MailboxManager mailboxManager) {
+    public LazyMessageSearchIndex(ListeningMessageSearchIndex index, MailboxSessionMapperFactory factory, MailboxManager mailboxManager) {
         super(factory, mailboxManager);
         this.index = index;
         this.factory = factory;

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/ListeningMessageSearchIndex.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/ListeningMessageSearchIndex.java
@@ -102,19 +102,19 @@ public abstract class ListeningMessageSearchIndex implements MessageSearchIndex,
     }
 
     private void handleAdded(MailboxSession session, Mailbox mailbox, Added added) {
-        added.getUids()
+        MessageRange.toRanges(added.getUids())
             .stream()
-            .flatMap(uid -> retrieveMailboxMessage(session, mailbox, uid))
+            .flatMap(range -> retrieveMailboxMessages(session, mailbox, range))
             .forEach(mailboxMessage -> addMessage(session, mailbox, mailboxMessage));
     }
 
-    private Stream<MailboxMessage> retrieveMailboxMessage(MailboxSession session, Mailbox mailbox, MessageUid uid) {
+    private Stream<MailboxMessage> retrieveMailboxMessages(MailboxSession session, Mailbox mailbox, MessageRange range) {
         try {
             return Stream.of(factory.getMessageMapper(session)
-                .findInMailbox(mailbox, MessageRange.one(uid), FetchType.Full, UNLIMITED)
+                .findInMailbox(mailbox, range, FetchType.Full, UNLIMITED)
                 .next());
         } catch (Exception e) {
-            LOGGER.error("Could not retrieve message {} in mailbox {}", uid.asLong(), mailbox.getMailboxId().serialize(), e);
+            LOGGER.error("Could not retrieve message {} in mailbox {}", range.toString(), mailbox.getMailboxId().serialize(), e);
             return Stream.empty();
         }
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/ListeningMessageSearchIndex.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/ListeningMessageSearchIndex.java
@@ -29,9 +29,9 @@ import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.UpdatedFlags;
+import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
 import org.apache.james.mailbox.store.event.EventFactory;
 import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
-import org.apache.james.mailbox.store.mail.MessageMapperFactory;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.slf4j.Logger;
@@ -47,10 +47,10 @@ public abstract class ListeningMessageSearchIndex implements MessageSearchIndex,
     private static final Logger LOGGER = LoggerFactory.getLogger(ListeningMessageSearchIndex.class);
 
     private static final int UNLIMITED = -1;
-    private final MessageMapperFactory factory;
+    private final MailboxSessionMapperFactory factory;
     private final MailboxManager mailboxManager;
 
-    public ListeningMessageSearchIndex(MessageMapperFactory factory, MailboxManager mailboxManager) {
+    public ListeningMessageSearchIndex(MailboxSessionMapperFactory factory, MailboxManager mailboxManager) {
         this.factory = factory;
         this.mailboxManager = mailboxManager;
     }

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/SelectedMailboxImplTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/SelectedMailboxImplTest.java
@@ -63,7 +63,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 
 public class SelectedMailboxImplTest {
@@ -171,6 +170,6 @@ public class SelectedMailboxImplTest {
         TreeMap<MessageUid, MessageMetaData> result = new TreeMap<>();
         result.put(EMITTED_EVENT_UID, new SimpleMessageMetaData(EMITTED_EVENT_UID, MOD_SEQ, new Flags(), SIZE, new Date(), new DefaultMessageId()));
         mailboxListener.event(new EventFactory().added(MailboxSession.SessionId.of(random.nextLong()),
-            mock(User.class), result, mailbox, ImmutableMap.of()));
+            mock(User.class), result, mailbox));
     }
 }

--- a/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-integration-testing/jmap-integration-testing-common/src/test/java/org/apache/james/jmap/methods/integration/SetMessagesMethodTest.java
@@ -96,7 +96,6 @@ import org.apache.james.mailbox.model.SerializableQuotaValue;
 import org.apache.james.mailbox.probe.ACLProbe;
 import org.apache.james.mailbox.probe.MailboxProbe;
 import org.apache.james.mailbox.probe.QuotaProbe;
-import org.apache.james.mailbox.store.event.EventFactory;
 import org.apache.james.modules.ACLProbeImpl;
 import org.apache.james.modules.MailboxProbeImpl;
 import org.apache.james.modules.QuotaProbesImpl;
@@ -2338,10 +2337,10 @@ public abstract class SetMessagesMethodTest {
     }
 
     private boolean isAddedToOutboxEvent(String messageId, Event event, String outboxId) {
-        if (!(event instanceof EventFactory.AddedImpl)) {
+        if (!(event instanceof MailboxListener.Added)) {
             return false;
         }
-        EventFactory.AddedImpl added = (EventFactory.AddedImpl) event;
+        MailboxListener.Added added = (MailboxListener.Added) event;
         return added.getMailboxId().serialize().equals(outboxId)
             && added.getUids().size() == 1
             && added.getMetaData(added.getUids().get(0)).getMessageId().serialize().equals(messageId);


### PR DESCRIPTION
Store events where used for two features:
 - Avoiding reading the mailbox from the store
 - Caching messages to save some reads

We need to rely on Mailbox API and read mailbox/messages from the MailboxFactory.