### PR TITLE
CassandraMailQueueView - Delete multiple mails should update browse once

### DIFF
--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailDelete.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailDelete.java
@@ -58,8 +58,7 @@ public class CassandraMailQueueMailDelete {
 
     Mono<Void> considerDeleted(MailKey mailKey, MailQueueName mailQueueName) {
         return deletedMailsDao
-            .markAsDeleted(mailQueueName, mailKey)
-            .doOnTerminate(() -> maybeUpdateBrowseStart(mailQueueName));
+            .markAsDeleted(mailQueueName, mailKey);
     }
 
     Mono<Boolean> isDeleted(Mail mail, MailQueueName mailQueueName) {
@@ -71,7 +70,7 @@ public class CassandraMailQueueMailDelete {
         updateNewBrowseStart(mailQueueName, newBrowseStart);
     }
 
-    private void maybeUpdateBrowseStart(MailQueueName mailQueueName) {
+    public void maybeUpdateBrowseStart(MailQueueName mailQueueName) {
         if (shouldUpdateBrowseStart()) {
             updateBrowseStart(mailQueueName);
         }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
@@ -122,7 +122,8 @@ public class CassandraMailQueueView implements MailQueueView {
     }
 
     private Mono<Void> delete(MailKey mailKey) {
-        return cassandraMailQueueMailDelete.considerDeleted(mailKey, mailQueueName);
+        return cassandraMailQueueMailDelete.considerDeleted(mailKey, mailQueueName)
+            .doOnTerminate(() -> cassandraMailQueueMailDelete.maybeUpdateBrowseStart(mailQueueName));
     }
 
     @Override


### PR DESCRIPTION
Here is the case: In `CassandraMailQueueView`, delete multiple mails is executed in `browseThenDelete()`
```java
    private long browseThenDelete(DeleteCondition deleteCondition) {
        return cassandraMailQueueBrowser.browseReferences(mailQueueName)
            .map(EnqueuedItemWithSlicingContext::getEnqueuedItem)
            .filter(mailReference -> deleteCondition.shouldBeDeleted(mailReference.getMail()))
            .map(mailReference -> cassandraMailQueueMailDelete.considerDeleted(mailReference.getMail(), mailQueueName))
            .count()
            .doOnTerminate(() -> cassandraMailQueueMailDelete.updateBrowseStart(mailQueueName)) // (1)
            .block();
    }
```
which invokes `cassandraMailQueueMailDelete.considerDeleted(mailReference.getMail(), mailQueueName)`  => then invokes `maybeUpdateBrowseStart()` everytime (Delete a condition that matches 10 mails will invokes `maybeUpdateBrowseStart()` 10 times + 1 at (1) = 11 times )