### PR TITLE
MAILBOX-359 First refactorings for handling MailboxEvents serialization

### DIFF
--- a/mailbox/event/json/pom.xml
+++ b/mailbox/event/json/pom.xml
@@ -39,6 +39,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apache-james-mailbox-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apache-james-mailbox-api</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.beachape</groupId>
             <artifactId>enumeratum_${scala.base}</artifactId>
             <version>1.5.13</version>
@@ -52,10 +62,6 @@
             <groupId>net.javacrumbs.json-unit</groupId>
             <artifactId>json-unit-assertj</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.james</groupId>
-            <artifactId>apache-james-mailbox-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>

--- a/mailbox/event/json/src/main/scala/org/apache/james/event/json/EventSerializer.scala
+++ b/mailbox/event/json/src/main/scala/org/apache/james/event/json/EventSerializer.scala
@@ -25,15 +25,15 @@ import java.util.Optional
 import julienrf.json.derived
 import org.apache.james.core.quota.{QuotaCount, QuotaSize, QuotaValue}
 import org.apache.james.core.{Domain, User}
-import org.apache.james.mailbox.MailboxListener.{QuotaEvent => JavaQuotaEvent, QuotaUsageUpdatedEvent => JavaQuotaUsageUpdatedEvent}
+import org.apache.james.mailbox.MailboxListener.{QuotaUsageUpdatedEvent => JavaQuotaUsageUpdatedEvent}
 import org.apache.james.mailbox.model.{MailboxId, QuotaRoot, Quota => JavaQuota}
 import org.apache.james.mailbox.{Event => JavaEvent}
-import play.api.libs.json._
+import play.api.libs.json.{JsError, JsNull, JsNumber, JsObject, JsResult, JsString, JsSuccess, Json, OFormat, Reads, Writes}
 
 import scala.collection.JavaConverters._
 
 private sealed trait Event {
-  def toJava: JavaQuotaEvent
+  def toJava: JavaEvent
 }
 
 private object DTO {
@@ -51,7 +51,7 @@ private object DTO {
                                     sizeQuota: Quota[QuotaSize], time: Instant) extends Event {
     def getQuotaRoot: QuotaRoot = quotaRoot
 
-    override def toJava: JavaQuotaEvent =
+    override def toJava: JavaEvent =
       new JavaQuotaUsageUpdatedEvent(user, getQuotaRoot, countQuota.toJava, sizeQuota.toJava, time)
   }
 }

--- a/mailbox/event/json/src/main/scala/org/apache/james/event/json/EventSerializer.scala
+++ b/mailbox/event/json/src/main/scala/org/apache/james/event/json/EventSerializer.scala
@@ -100,7 +100,7 @@ private class JsonSerialize(mailboxIdFactory: MailboxId.Factory) {
   implicit val quotaCReads: Reads[DTO.Quota[QuotaCount]] = Json.reads[DTO.Quota[QuotaCount]]
   implicit val quotaSReads: Reads[DTO.Quota[QuotaSize]] = Json.reads[DTO.Quota[QuotaSize]]
 
-  implicit val quotaEventOFormat: OFormat[Event] = derived.oformat()
+  implicit val eventOFormat: OFormat[Event] = derived.oformat()
 
   def toJson(event: Event): String = Json.toJson(event).toString()
 

--- a/mailbox/event/json/src/test/java/org/apache/james/event/json/QuotaUsageUpdatedEventSerializationTest.java
+++ b/mailbox/event/json/src/test/java/org/apache/james/event/json/QuotaUsageUpdatedEventSerializationTest.java
@@ -36,7 +36,7 @@ import org.apache.james.mailbox.model.QuotaRoot;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-class QuotaEventTest {
+class QuotaUsageUpdatedEventSerializationTest {
 
     private static final User USER = User.fromUsername("user");
     private static final QuotaRoot QUOTA_ROOT = QuotaRoot.quotaRoot("foo", Optional.empty());
@@ -63,7 +63,7 @@ class QuotaEventTest {
             "}" +
         "}";
 
-    private static final QuotaEvent$ QUOTA_EVENT_MODULE = QuotaEvent$.MODULE$;
+    private static final EventSerializer$ QUOTA_EVENT_MODULE = EventSerializer$.MODULE$;
 
     @Nested
     class WithUser {

--- a/mailbox/event/json/src/test/java/org/apache/james/event/json/QuotaUsageUpdatedEventSerializationTest.java
+++ b/mailbox/event/json/src/test/java/org/apache/james/event/json/QuotaUsageUpdatedEventSerializationTest.java
@@ -33,6 +33,7 @@ import org.apache.james.core.quota.QuotaSize;
 import org.apache.james.mailbox.MailboxListener;
 import org.apache.james.mailbox.model.Quota;
 import org.apache.james.mailbox.model.QuotaRoot;
+import org.apache.james.mailbox.model.TestId;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -63,7 +64,7 @@ class QuotaUsageUpdatedEventSerializationTest {
             "}" +
         "}";
 
-    private static final EventSerializer$ QUOTA_EVENT_MODULE = EventSerializer$.MODULE$;
+    private static final EventSerializer EVENT_SERIALIZER = new EventSerializer(new TestId.Factory());
 
     @Nested
     class WithUser {
@@ -93,13 +94,13 @@ class QuotaUsageUpdatedEventSerializationTest {
 
                 @Test
                 void fromJsonShouldReturnQuotaEvent() {
-                    assertThat(QUOTA_EVENT_MODULE.fromJson(quotaUsageUpdatedEvent).get())
+                    assertThat(EVENT_SERIALIZER.fromJson(quotaUsageUpdatedEvent).get())
                         .isEqualTo(eventWithUserContainsUsername);
                 }
 
                 @Test
                 void toJsonShouldReturnQuotaEventJson() {
-                    assertThatJson(QUOTA_EVENT_MODULE.toJson(eventWithUserContainsUsername))
+                    assertThatJson(EVENT_SERIALIZER.toJson(eventWithUserContainsUsername))
                         .isEqualTo(quotaUsageUpdatedEvent);
                 }
             }
@@ -126,13 +127,13 @@ class QuotaUsageUpdatedEventSerializationTest {
 
                 @Test
                 void fromJsonShouldReturnQuotaEvent() {
-                    assertThat(QUOTA_EVENT_MODULE.fromJson(quotaUsageUpdatedEvent).get())
+                    assertThat(EVENT_SERIALIZER.fromJson(quotaUsageUpdatedEvent).get())
                         .isEqualTo(eventWithUserContainsUsernameAndDomain);
                 }
 
                 @Test
                 void toJsonShouldReturnQuotaEventJson() {
-                    assertThatJson(QUOTA_EVENT_MODULE.toJson(eventWithUserContainsUsernameAndDomain))
+                    assertThatJson(EVENT_SERIALIZER.toJson(eventWithUserContainsUsernameAndDomain))
                         .isEqualTo(quotaUsageUpdatedEvent);
                 }
             }
@@ -153,7 +154,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                         "\"user\":\"\"" +
                         "}" +
                     "}";
-                assertThatThrownBy(() -> QUOTA_EVENT_MODULE.fromJson(quotaUsageUpdatedEvent))
+                assertThatThrownBy(() -> EVENT_SERIALIZER.fromJson(quotaUsageUpdatedEvent))
                     .isInstanceOf(IllegalArgumentException.class);
             }
 
@@ -170,7 +171,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                         "}" +
                     "}";
 
-                assertThatThrownBy(() ->QUOTA_EVENT_MODULE.fromJson(quotaUsageUpdatedEvent).get())
+                assertThatThrownBy(() -> EVENT_SERIALIZER.fromJson(quotaUsageUpdatedEvent).get())
                     .isInstanceOf(NoSuchElementException.class);
             }
 
@@ -186,7 +187,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                         "\"user\":\"@domain\"" +
                         "}" +
                     "}";
-                assertThatThrownBy(() -> QUOTA_EVENT_MODULE.fromJson(quotaUsageUpdatedEvent))
+                assertThatThrownBy(() -> EVENT_SERIALIZER.fromJson(quotaUsageUpdatedEvent))
                     .isInstanceOf(IllegalArgumentException.class);
             }
         }
@@ -201,13 +202,13 @@ class QuotaUsageUpdatedEventSerializationTest {
 
             @Test
             void toJsonShouldReturnSerializedJsonQuotaRoot() {
-                assertThatJson(QUOTA_EVENT_MODULE.toJson(DEFAULT_QUOTA_EVENT))
+                assertThatJson(EVENT_SERIALIZER.toJson(DEFAULT_QUOTA_EVENT))
                     .isEqualTo(DEFAULT_QUOTA_EVENT_JSON);
             }
 
             @Test
             void fromJsonShouldDeserializeQuotaRootJson() {
-                assertThat(QUOTA_EVENT_MODULE.fromJson(DEFAULT_QUOTA_EVENT_JSON).get())
+                assertThat(EVENT_SERIALIZER.fromJson(DEFAULT_QUOTA_EVENT_JSON).get())
                     .isEqualTo(DEFAULT_QUOTA_EVENT);
             }
         }
@@ -235,13 +236,13 @@ class QuotaUsageUpdatedEventSerializationTest {
 
             @Test
             void toJsonShouldSerializeWithEmptyQuotaRoot() {
-                assertThatJson(QUOTA_EVENT_MODULE.toJson(eventWithEmptyQuotaRoot))
+                assertThatJson(EVENT_SERIALIZER.toJson(eventWithEmptyQuotaRoot))
                     .isEqualTo(quotaUsageUpdatedEvent);
             }
 
             @Test
             void fromJsonShouldDeserializeWithEmptyQuotaRoot() {
-                assertThat(QUOTA_EVENT_MODULE.fromJson(quotaUsageUpdatedEvent).get())
+                assertThat(EVENT_SERIALIZER.fromJson(quotaUsageUpdatedEvent).get())
                     .isEqualTo(eventWithEmptyQuotaRoot);
             }
         }
@@ -268,13 +269,13 @@ class QuotaUsageUpdatedEventSerializationTest {
 
             @Test
             void toJsonShouldThrowWithNullQuotaRoot() {
-                assertThatThrownBy(() -> QUOTA_EVENT_MODULE.toJson(eventWithNullQuotaRoot))
+                assertThatThrownBy(() -> EVENT_SERIALIZER.toJson(eventWithNullQuotaRoot))
                     .isInstanceOf(NullPointerException.class);
             }
 
             @Test
             void fromJsonShouldThrowWithNullQuotaRoot() {
-                assertThatThrownBy(() -> QUOTA_EVENT_MODULE.fromJson(quotaUsageUpdatedEvent).get())
+                assertThatThrownBy(() -> EVENT_SERIALIZER.fromJson(quotaUsageUpdatedEvent).get())
                     .isInstanceOf(NoSuchElementException.class);
             }
         }
@@ -317,7 +318,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void toJsonShouldSerializeQuotaCount() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaCount(limitedQuotaCountByScopes(Quota.Scope.Global));
 
-                    assertThatJson(QUOTA_EVENT_MODULE.toJson(quotaEvent))
+                    assertThatJson(EVENT_SERIALIZER.toJson(quotaEvent))
                         .isEqualTo(limitedQuotaCountEventJsonGlobalScope);
                 }
 
@@ -325,7 +326,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void fromJsonShouldDeserializeQuotaCount() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaCount(limitedQuotaCountByScopes(Quota.Scope.Global));
 
-                    assertThat(QUOTA_EVENT_MODULE.fromJson(limitedQuotaCountEventJsonGlobalScope).get())
+                    assertThat(EVENT_SERIALIZER.fromJson(limitedQuotaCountEventJsonGlobalScope).get())
                         .isEqualTo(quotaEvent);
                 }
             }
@@ -347,7 +348,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void toJsonShouldSerializeQuotaCount() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaCount(limitedQuotaCountByScopes(Quota.Scope.Domain));
 
-                    assertThatJson(QUOTA_EVENT_MODULE.toJson(quotaEvent))
+                    assertThatJson(EVENT_SERIALIZER.toJson(quotaEvent))
                         .isEqualTo(limitedQuotaCountEventJsonDomainScope);
                 }
 
@@ -355,7 +356,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void fromJsonShouldDeserializeQuotaCount() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaCount(limitedQuotaCountByScopes(Quota.Scope.Domain));
 
-                    assertThat(QUOTA_EVENT_MODULE.fromJson(limitedQuotaCountEventJsonDomainScope).get())
+                    assertThat(EVENT_SERIALIZER.fromJson(limitedQuotaCountEventJsonDomainScope).get())
                         .isEqualTo(quotaEvent);
                 }
             }
@@ -377,7 +378,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void toJsonShouldSerializeQuotaCount() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaCount(limitedQuotaCountByScopes(Quota.Scope.User));
 
-                    assertThatJson(QUOTA_EVENT_MODULE.toJson(quotaEvent))
+                    assertThatJson(EVENT_SERIALIZER.toJson(quotaEvent))
                         .isEqualTo(limitedQuotaCountEventJsonUserScope);
                 }
 
@@ -385,7 +386,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void fromJsonShouldDeserializeQuotaCount() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaCount(limitedQuotaCountByScopes(Quota.Scope.User));
 
-                    assertThat(QUOTA_EVENT_MODULE.fromJson(limitedQuotaCountEventJsonUserScope).get())
+                    assertThat(EVENT_SERIALIZER.fromJson(limitedQuotaCountEventJsonUserScope).get())
                         .isEqualTo(quotaEvent);
                 }
             }
@@ -419,7 +420,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void toJsonShouldSerializeQuotaCount() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaCount(unLimitedQuotaCountByScopes(Quota.Scope.Global));
 
-                    assertThatJson(QUOTA_EVENT_MODULE.toJson(quotaEvent))
+                    assertThatJson(EVENT_SERIALIZER.toJson(quotaEvent))
                         .isEqualTo(unLimitedQuotaCountEventJsonGlobalScope);
                 }
 
@@ -427,7 +428,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void fromJsonShouldDeserializeQuotaCount() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaCount(unLimitedQuotaCountByScopes(Quota.Scope.Global));
 
-                    assertThat(QUOTA_EVENT_MODULE.fromJson(unLimitedQuotaCountEventJsonGlobalScope).get())
+                    assertThat(EVENT_SERIALIZER.fromJson(unLimitedQuotaCountEventJsonGlobalScope).get())
                         .isEqualTo(quotaEvent);
                 }
             }
@@ -449,7 +450,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void toJsonShouldSerializeQuotaCount() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaCount(unLimitedQuotaCountByScopes(Quota.Scope.Domain));
 
-                    assertThatJson(QUOTA_EVENT_MODULE.toJson(quotaEvent))
+                    assertThatJson(EVENT_SERIALIZER.toJson(quotaEvent))
                         .isEqualTo(unLimitedQuotaCountEventJsonDomainScope);
                 }
 
@@ -457,7 +458,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void fromJsonShouldDeserializeQuotaCount() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaCount(unLimitedQuotaCountByScopes(Quota.Scope.Domain));
 
-                    assertThat(QUOTA_EVENT_MODULE.fromJson(unLimitedQuotaCountEventJsonDomainScope).get())
+                    assertThat(EVENT_SERIALIZER.fromJson(unLimitedQuotaCountEventJsonDomainScope).get())
                         .isEqualTo(quotaEvent);
                 }
             }
@@ -479,7 +480,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void toJsonShouldSerializeQuotaCount() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaCount(unLimitedQuotaCountByScopes(Quota.Scope.User));
 
-                    assertThatJson(QUOTA_EVENT_MODULE.toJson(quotaEvent))
+                    assertThatJson(EVENT_SERIALIZER.toJson(quotaEvent))
                         .isEqualTo(unLimitedQuotaCountEventJsonUserScope);
                 }
 
@@ -487,7 +488,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void fromJsonShouldDeserializeQuotaCount() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaCount(unLimitedQuotaCountByScopes(Quota.Scope.User));
 
-                    assertThat(QUOTA_EVENT_MODULE.fromJson(unLimitedQuotaCountEventJsonUserScope).get())
+                    assertThat(EVENT_SERIALIZER.fromJson(unLimitedQuotaCountEventJsonUserScope).get())
                         .isEqualTo(quotaEvent);
                 }
             }
@@ -531,7 +532,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void toJsonShouldSerializeQuotaSize() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaSize(limitedQuotaSizeByScopes(Quota.Scope.Global));
 
-                    assertThatJson(QUOTA_EVENT_MODULE.toJson(quotaEvent))
+                    assertThatJson(EVENT_SERIALIZER.toJson(quotaEvent))
                         .isEqualTo(limitedQuotaSizeEventJsonGlobalScope);
                 }
 
@@ -539,7 +540,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void fromJsonShouldDeserializeQuotaSize() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaSize(limitedQuotaSizeByScopes(Quota.Scope.Global));
 
-                    assertThat(QUOTA_EVENT_MODULE.fromJson(limitedQuotaSizeEventJsonGlobalScope).get())
+                    assertThat(EVENT_SERIALIZER.fromJson(limitedQuotaSizeEventJsonGlobalScope).get())
                         .isEqualTo(quotaEvent);
                 }
             }
@@ -561,7 +562,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void toJsonShouldSerializeQuotaSize() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaSize(limitedQuotaSizeByScopes(Quota.Scope.Domain));
 
-                    assertThatJson(QUOTA_EVENT_MODULE.toJson(quotaEvent))
+                    assertThatJson(EVENT_SERIALIZER.toJson(quotaEvent))
                         .isEqualTo(limitedQuotaSizeEventJsonDomainScope);
                 }
 
@@ -569,7 +570,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void fromJsonShouldDeserializeQuotaSize() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaSize(limitedQuotaSizeByScopes(Quota.Scope.Domain));
 
-                    assertThat(QUOTA_EVENT_MODULE.fromJson(limitedQuotaSizeEventJsonDomainScope).get())
+                    assertThat(EVENT_SERIALIZER.fromJson(limitedQuotaSizeEventJsonDomainScope).get())
                         .isEqualTo(quotaEvent);
                 }
             }
@@ -591,7 +592,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void toJsonShouldSerializeQuotaSize() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaSize(limitedQuotaSizeByScopes(Quota.Scope.User));
 
-                    assertThatJson(QUOTA_EVENT_MODULE.toJson(quotaEvent))
+                    assertThatJson(EVENT_SERIALIZER.toJson(quotaEvent))
                         .isEqualTo(limitedQuotaSizeEventJsonUserScope);
                 }
 
@@ -599,7 +600,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void fromJsonShouldDeserializeQuotaSize() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaSize(limitedQuotaSizeByScopes(Quota.Scope.User));
 
-                    assertThat(QUOTA_EVENT_MODULE.fromJson(limitedQuotaSizeEventJsonUserScope).get())
+                    assertThat(EVENT_SERIALIZER.fromJson(limitedQuotaSizeEventJsonUserScope).get())
                         .isEqualTo(quotaEvent);
                 }
             }
@@ -634,7 +635,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void toJsonShouldSerializeQuotaSize() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaSize(unLimitedQuotaSizeByScopes(Quota.Scope.Global));
 
-                    assertThatJson(QUOTA_EVENT_MODULE.toJson(quotaEvent))
+                    assertThatJson(EVENT_SERIALIZER.toJson(quotaEvent))
                         .isEqualTo(unLimitedQuotaSizeEventJsonGlobalScope);
                 }
 
@@ -642,7 +643,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void fromJsonShouldDeserializeQuotaSize() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaSize(unLimitedQuotaSizeByScopes(Quota.Scope.Global));
 
-                    assertThat(QUOTA_EVENT_MODULE.fromJson(unLimitedQuotaSizeEventJsonGlobalScope).get())
+                    assertThat(EVENT_SERIALIZER.fromJson(unLimitedQuotaSizeEventJsonGlobalScope).get())
                         .isEqualTo(quotaEvent);
                 }
             }
@@ -664,7 +665,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void toJsonShouldSerializeQuotaSize() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaSize(unLimitedQuotaSizeByScopes(Quota.Scope.Domain));
 
-                    assertThatJson(QUOTA_EVENT_MODULE.toJson(quotaEvent))
+                    assertThatJson(EVENT_SERIALIZER.toJson(quotaEvent))
                         .isEqualTo(unLimitedQuotaSizeEventJsonDomainScope);
                 }
 
@@ -672,7 +673,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void fromJsonShouldDeserializeQuotaSize() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaSize(unLimitedQuotaSizeByScopes(Quota.Scope.Domain));
 
-                    assertThat(QUOTA_EVENT_MODULE.fromJson(unLimitedQuotaSizeEventJsonDomainScope).get())
+                    assertThat(EVENT_SERIALIZER.fromJson(unLimitedQuotaSizeEventJsonDomainScope).get())
                         .isEqualTo(quotaEvent);
                 }
             }
@@ -694,7 +695,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void toJsonShouldSerializeQuotaSize() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaSize(unLimitedQuotaSizeByScopes(Quota.Scope.User));
 
-                    assertThatJson(QUOTA_EVENT_MODULE.toJson(quotaEvent))
+                    assertThatJson(EVENT_SERIALIZER.toJson(quotaEvent))
                         .isEqualTo(unLimitedQuotaSizeEventJsonUserScope);
                 }
 
@@ -702,7 +703,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                 void fromJsonShouldDeserializeQuotaSize() {
                     MailboxListener.QuotaUsageUpdatedEvent quotaEvent = quotaEventByQuotaSize(unLimitedQuotaSizeByScopes(Quota.Scope.User));
 
-                    assertThat(QUOTA_EVENT_MODULE.fromJson(unLimitedQuotaSizeEventJsonUserScope).get())
+                    assertThat(EVENT_SERIALIZER.fromJson(unLimitedQuotaSizeEventJsonUserScope).get())
                         .isEqualTo(quotaEvent);
                 }
             }
@@ -714,13 +715,13 @@ class QuotaUsageUpdatedEventSerializationTest {
 
         @Test
         void toJsonShouldReturnSerializedJsonEventWhenTimeIsValid() {
-            assertThatJson(QUOTA_EVENT_MODULE.toJson(DEFAULT_QUOTA_EVENT))
+            assertThatJson(EVENT_SERIALIZER.toJson(DEFAULT_QUOTA_EVENT))
                 .isEqualTo(DEFAULT_QUOTA_EVENT_JSON);
         }
 
         @Test
         void fromJsonShouldReturnDeSerializedEventWhenTimeIsValid() {
-            assertThat(QUOTA_EVENT_MODULE.fromJson(DEFAULT_QUOTA_EVENT_JSON).get())
+            assertThat(EVENT_SERIALIZER.fromJson(DEFAULT_QUOTA_EVENT_JSON).get())
                 .isEqualTo(DEFAULT_QUOTA_EVENT);
         }
 
@@ -736,7 +737,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                     "}" +
                 "}";
 
-            assertThatThrownBy(() -> QUOTA_EVENT_MODULE.fromJson(quotaUsageUpdatedEvent).get())
+            assertThatThrownBy(() -> EVENT_SERIALIZER.fromJson(quotaUsageUpdatedEvent).get())
                 .isInstanceOf(NoSuchElementException.class);
         }
 
@@ -753,7 +754,7 @@ class QuotaUsageUpdatedEventSerializationTest {
                     "}" +
                 "}";
 
-            assertThatThrownBy(() -> QUOTA_EVENT_MODULE.fromJson(quotaUsageUpdatedEvent).get())
+            assertThatThrownBy(() -> EVENT_SERIALIZER.fromJson(quotaUsageUpdatedEvent).get())
                 .isInstanceOf(NoSuchElementException.class);
         }
     }


### PR DESCRIPTION
 - Generify EventSerializer to not just handle QuotaEvents
 - Wire the MailboxId.Factory - required to serialize - deserialize mailboxIds
 - The pom file was not matching our standards