### PR TITLE
prototype for using jib to build our docker images

### DIFF
--- a/server/container/guice/jpa-smtp/pom.xml
+++ b/server/container/guice/jpa-smtp/pom.xml
@@ -111,6 +111,43 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <version>0.10.1</version>
+                <executions>
+                    <execution>
+                        <id>docker packaging</id>
+                        <goals>
+                            <goal>buildTar</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <to>
+                                <image>james-jpa-jib</image>
+                            </to>
+                            <container>
+                                <mainClass>org.apache.james.JPAJamesServerMain</mainClass>
+                                <volumes>
+                                    <volume>/root/</volume>
+                                    <volume>/logs</volume>
+                                </volumes>
+                                <jvmFlags>
+                                    <jvmFlag>-javaagent:openjpa-3.0.0.jar</jvmFlag>
+                                    <jvmFlag>-Dworking.directory=/root</jvmFlag>
+                                    <jvmFlag>-Dlogback.configurationFile=/root/conf/logback.xml</jvmFlag>
+                                </jvmFlags>
+                                <ports>
+                                    <port>25</port>
+                                    <port>465</port>
+                                    <port>587</port>
+                                    <port>8000</port>
+                                </ports>
+                            </container>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/server/container/guice/jpa-smtp/pom.xml
+++ b/server/container/guice/jpa-smtp/pom.xml
@@ -132,7 +132,7 @@
                                     <volume>/logs</volume>
                                 </volumes>
                                 <jvmFlags>
-                                    <jvmFlag>-javaagent:openjpa-3.0.0.jar</jvmFlag>
+                                    <jvmFlag>-javaagent:/app/libs/openjpa-3.0.0.jar</jvmFlag>
                                     <jvmFlag>-Dworking.directory=/root</jvmFlag>
                                     <jvmFlag>-Dlogback.configurationFile=/root/conf/logback.xml</jvmFlag>
                                 </jvmFlags>


### PR DESCRIPTION
image layers before : 

```
$ docker image history linagora/james-jpa-guice
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
57e1e442d543        41 minutes ago      /bin/sh -c #(nop)  ENTRYPOINT ["/bin/sh" "-c…   0B                  
2fa03ef898aa        41 minutes ago      /bin/sh -c #(nop)  VOLUME [/logs]               0B                  
0a20914523e8        41 minutes ago      /bin/sh -c #(nop) ADD dir:0dd8ad87149fe159e9…   37.2kB              
1f2432126591        41 minutes ago      /bin/sh -c #(nop) ADD dir:cee6de9e063b84a11d…   22.2MB              
ea3890607dc0        41 minutes ago      /bin/sh -c #(nop) ADD file:a6d86cf008b96222b…   37.4kB              
06e2a13374b8        41 minutes ago      /bin/sh -c #(nop) ADD dir:1ee7b33d65cf6d204d…   80.5MB              
302fbabaa1fd        41 minutes ago      /bin/sh -c #(nop) ADD file:37144c6b017eca45f…   28.8kB              
b1e965e7764b        4 days ago          /bin/sh -c #(nop) WORKDIR /root                 0B                  
786822ced7da        4 days ago          /bin/sh -c #(nop)  EXPOSE 110 143 25 465 587…   0B                  
dd20fb277e3c        4 weeks ago         /bin/sh -c /var/lib/dpkg/info/ca-certificate…   355kB               
<missing>           4 weeks ago         /bin/sh -c set -ex;   if [ ! -d /usr/share/m…   309MB               
<missing>           4 weeks ago         /bin/sh -c #(nop)  ENV CA_CERTIFICATES_JAVA_…   0B                  
<missing>           4 weeks ago         /bin/sh -c #(nop)  ENV JAVA_DEBIAN_VERSION=8…   0B                  
<missing>           4 weeks ago         /bin/sh -c #(nop)  ENV JAVA_VERSION=8u181       0B                  
<missing>           4 weeks ago         /bin/sh -c #(nop)  ENV JAVA_HOME=/docker-jav…   0B                  
<missing>           4 weeks ago         /bin/sh -c ln -svT "/usr/lib/jvm/java-8-open…   33B                 
<missing>           4 weeks ago         /bin/sh -c {   echo '#!/bin/sh';   echo 'set…   87B                 
<missing>           4 weeks ago         /bin/sh -c #(nop)  ENV LANG=C.UTF-8             0B                  
<missing>           4 weeks ago         /bin/sh -c apt-get update && apt-get install…   2.05MB              
<missing>           4 weeks ago         /bin/sh -c set -ex;  if ! command -v gpg > /…   7.81MB              
<missing>           4 weeks ago         /bin/sh -c apt-get update && apt-get install…   23.2MB              
<missing>           4 weeks ago         /bin/sh -c #(nop)  CMD ["bash"]                 0B                  
<missing>           4 weeks ago         /bin/sh -c #(nop) ADD file:a61c14b18252183a4…   101MB               
```

and after : 

```
$ docker image history james-jpa-jib
IMAGE               CREATED             CREATED BY                SIZE                COMMENT
5fa48bbd2395        48 years ago        jib-maven-plugin:0.10.1   0B                  classes
<missing>           48 years ago        jib-maven-plugin:0.10.1   60.1kB              resources
<missing>           48 years ago        jib-maven-plugin:0.10.1   2.94MB              snapshot dependencies
<missing>           48 years ago        jib-maven-plugin:0.10.1   65.4MB              dependencies
<missing>           48 years ago        bazel build ...           99.8MB              
<missing>           48 years ago        bazel build ...           1.93MB              
<missing>           48 years ago        bazel build ...           16.8MB            
```
I can present you the pros/cons of jib tomorrow if you want (this first one being that you don't need a docker daemon to build the docker image)