### PR TITLE
[WIP] MAILBOX-356 Rename Key column in JPAMailboxAnnotation

### DIFF
--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/JPAMailboxAnnotation.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/JPAMailboxAnnotation.java
@@ -41,7 +41,7 @@ import com.google.common.base.Objects;
 public class JPAMailboxAnnotation {
 
     public static final String MAILBOX_ID = "MAILBOX_ID";
-    public static final String KEY = "KEY";
+    public static final String ANNOTATION_KEY = "ANNOTATION_KEY";
     public static final String VALUE = "VALUE";
 
     @Id
@@ -49,7 +49,7 @@ public class JPAMailboxAnnotation {
     private long mailboxId;
 
     @Id
-    @Column(name = KEY, length = 200)
+    @Column(name = ANNOTATION_KEY, length = 200)
     private String key;
 
     @Basic()


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/MAILBOX-356

The JPAMailboxAnnotation class has a field named 'key' which is mapped to a field named 'KEY' that is supposed to be created in the database table JAMES_MAILBOX_ANNOTATION