### PR TITLE
MAILBOX-359 EventFactory should expose builders for events

### DIFF
--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraCombinationManagerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraCombinationManagerTest.java
@@ -19,14 +19,12 @@
 
 package org.apache.james.mailbox.cassandra;
 
-import static org.mockito.Mockito.mock;
-
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.DockerCassandraRule;
-import org.apache.james.mailbox.MailboxListener;
 import org.apache.james.mailbox.cassandra.mail.MailboxAggregateModule;
 import org.apache.james.mailbox.store.AbstractCombinationManagerTest;
 import org.apache.james.mailbox.store.CombinationManagerTestSystem;
+import org.apache.james.mailbox.store.event.DefaultDelegatingMailboxListener;
 import org.apache.james.mailbox.store.event.MailboxEventDispatcher;
 import org.apache.james.mailbox.store.quota.NoQuotaManager;
 import org.junit.After;
@@ -64,7 +62,9 @@ public class CassandraCombinationManagerTest extends AbstractCombinationManagerT
     
     @Override
     public CombinationManagerTestSystem createTestingData() throws Exception {
-        return CassandraCombinationManagerTestSystem.createTestingData(cassandra, new NoQuotaManager(), MailboxEventDispatcher.ofListener(mock(MailboxListener.class)));
+        DefaultDelegatingMailboxListener mailboxListener = new DefaultDelegatingMailboxListener();
+        MailboxEventDispatcher mailboxEventDispatcher = new MailboxEventDispatcher(mailboxListener);
+        return CassandraCombinationManagerTestSystem.createTestingData(cassandra, new NoQuotaManager(), mailboxEventDispatcher);
     }
     
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerStorageTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerStorageTest.java
@@ -19,14 +19,12 @@
 
 package org.apache.james.mailbox.cassandra;
 
-import static org.mockito.Mockito.mock;
-
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.DockerCassandraRule;
-import org.apache.james.mailbox.MailboxListener;
 import org.apache.james.mailbox.cassandra.mail.MailboxAggregateModule;
 import org.apache.james.mailbox.store.AbstractMessageIdManagerStorageTest;
 import org.apache.james.mailbox.store.MessageIdManagerTestSystem;
+import org.apache.james.mailbox.store.event.DefaultDelegatingMailboxListener;
 import org.apache.james.mailbox.store.event.MailboxEventDispatcher;
 import org.apache.james.mailbox.store.quota.NoQuotaManager;
 import org.junit.After;
@@ -64,6 +62,8 @@ public class CassandraMessageIdManagerStorageTest extends AbstractMessageIdManag
     
     @Override
     protected MessageIdManagerTestSystem createTestingData() throws Exception {
-        return CassandraMessageIdManagerTestSystem.createTestingData(cassandra, new NoQuotaManager(), MailboxEventDispatcher.ofListener(mock(MailboxListener.class)));
+        DefaultDelegatingMailboxListener mailboxListener = new DefaultDelegatingMailboxListener();
+        MailboxEventDispatcher mailboxEventDispatcher = new MailboxEventDispatcher(mailboxListener);
+        return CassandraMessageIdManagerTestSystem.createTestingData(cassandra, new NoQuotaManager(), mailboxEventDispatcher);
     }
 }

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMailboxMapper.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMailboxMapper.java
@@ -231,6 +231,7 @@ public class MaildirMailboxMapper extends NonTransactionalMapper implements Mail
             try {
                 folder.setUidValidity(mailbox.getUidValidity());
                 folder.setMailboxId(maildirId);
+                mailbox.setMailboxId(maildirId);
             } catch (IOException ioe) {
                 throw new MailboxException("Failed to save Mailbox " + mailbox, ioe);
 

--- a/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdConfigurationChangesTest.java
+++ b/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdConfigurationChangesTest.java
@@ -29,10 +29,10 @@ import static org.apache.james.mailbox.quota.model.QuotaThresholdFixture.mailetC
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.james.eventsourcing.eventstore.EventStore;
-import org.apache.james.mailbox.MailboxListener.QuotaUsageUpdatedEvent;
 import org.apache.james.mailbox.quota.QuotaFixture.Counts;
 import org.apache.james.mailbox.quota.QuotaFixture.Sizes;
 import org.apache.james.mailbox.quota.mailing.QuotaMailingListenerConfiguration;
+import org.apache.james.mailbox.store.event.EventFactory;
 import org.apache.mailet.base.test.FakeMailContext;
 import org.junit.jupiter.api.Test;
 
@@ -56,13 +56,25 @@ public interface QuotaThresholdConfigurationChangesTest {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, CONFIGURATION_50);
 
-
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._55_PERCENT)
+            .instant(NOW)
+            .build());
 
         testee = new QuotaThresholdListenersTestSystem(mailetContext, store, CONFIGURATION_75);
 
         mailetContext.resetSentMails();
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, NOW));
+
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._55_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).isEmpty();
     }
@@ -72,12 +84,25 @@ public interface QuotaThresholdConfigurationChangesTest {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, CONFIGURATION_75);
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._92_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._92_PERCENT)
+            .instant(NOW)
+            .build());
 
         testee = new QuotaThresholdListenersTestSystem(mailetContext, store, CONFIGURATION_50);
 
         mailetContext.resetSentMails();
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._92_PERCENT, NOW));
+
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._92_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).isEmpty();
     }
@@ -87,12 +112,25 @@ public interface QuotaThresholdConfigurationChangesTest {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, CONFIGURATION_50);
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._92_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._92_PERCENT)
+            .instant(NOW)
+            .build());
 
         testee = new QuotaThresholdListenersTestSystem(mailetContext, store, CONFIGURATION_75);
 
         mailetContext.resetSentMails();
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._92_PERCENT, NOW));
+
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._92_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).hasSize(1);
     }
@@ -102,12 +140,25 @@ public interface QuotaThresholdConfigurationChangesTest {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, CONFIGURATION_50);
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._30_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._30_PERCENT)
+            .instant(NOW)
+            .build());
 
         testee = new QuotaThresholdListenersTestSystem(mailetContext, store, CONFIGURATION_75);
 
         mailetContext.resetSentMails();
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._30_PERCENT, NOW));
+
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._30_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).isEmpty();
     }
@@ -117,12 +168,24 @@ public interface QuotaThresholdConfigurationChangesTest {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, CONFIGURATION_75);
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._30_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._30_PERCENT)
+            .instant(NOW)
+            .build());
 
         testee = new QuotaThresholdListenersTestSystem(mailetContext, store, CONFIGURATION_50);
 
         mailetContext.resetSentMails();
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._30_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._30_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).isEmpty();
     }
@@ -132,12 +195,25 @@ public interface QuotaThresholdConfigurationChangesTest {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, CONFIGURATION_75);
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._60_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._60_PERCENT)
+            .instant(NOW)
+            .build());
 
         testee = new QuotaThresholdListenersTestSystem(mailetContext, store, CONFIGURATION_50);
 
         mailetContext.resetSentMails();
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._60_PERCENT, NOW));
+
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._60_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).hasSize(1);
     }
@@ -147,13 +223,26 @@ public interface QuotaThresholdConfigurationChangesTest {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, CONFIGURATION_50);
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._92_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._92_PERCENT)
+            .instant(NOW)
+            .build());
 
         testee = new QuotaThresholdListenersTestSystem(mailetContext, store,
             CONFIGURATION_50_75);
 
         mailetContext.resetSentMails();
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._92_PERCENT, NOW));
+
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._92_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).hasSize(1);
     }
@@ -163,13 +252,26 @@ public interface QuotaThresholdConfigurationChangesTest {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, CONFIGURATION_50);
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._60_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._60_PERCENT)
+            .instant(NOW)
+            .build());
 
         testee = new QuotaThresholdListenersTestSystem(mailetContext, store,
             CONFIGURATION_50_75);
 
         mailetContext.resetSentMails();
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._60_PERCENT, NOW));
+
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._60_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).isEmpty();
     }
@@ -179,13 +281,26 @@ public interface QuotaThresholdConfigurationChangesTest {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, CONFIGURATION_75);
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._92_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._92_PERCENT)
+            .instant(NOW)
+            .build());
 
         testee = new QuotaThresholdListenersTestSystem(mailetContext, store,
             CONFIGURATION_50_75);
 
         mailetContext.resetSentMails();
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._92_PERCENT, NOW));
+
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._92_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).isEmpty();
     }
@@ -196,12 +311,25 @@ public interface QuotaThresholdConfigurationChangesTest {
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store,
             CONFIGURATION_50_75);
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._92_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._92_PERCENT)
+            .instant(NOW)
+            .build());
 
         testee = new QuotaThresholdListenersTestSystem(mailetContext, store, CONFIGURATION_75);
 
         mailetContext.resetSentMails();
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._92_PERCENT, NOW));
+
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._92_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).isEmpty();
     }
@@ -212,12 +340,25 @@ public interface QuotaThresholdConfigurationChangesTest {
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store,
             CONFIGURATION_50_75);
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._92_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._92_PERCENT)
+            .instant(NOW)
+            .build());
 
         testee = new QuotaThresholdListenersTestSystem(mailetContext, store, CONFIGURATION_50);
 
         mailetContext.resetSentMails();
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._92_PERCENT, NOW));
+
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._92_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).isEmpty();
     }
@@ -228,12 +369,25 @@ public interface QuotaThresholdConfigurationChangesTest {
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store,
             CONFIGURATION_50_75);
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._60_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._60_PERCENT)
+            .instant(NOW)
+            .build());
 
         testee = new QuotaThresholdListenersTestSystem(mailetContext, store, CONFIGURATION_50);
 
         mailetContext.resetSentMails();
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._60_PERCENT, NOW));
+
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._60_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).isEmpty();
     }

--- a/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdMailingIntegrationTest.java
+++ b/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdMailingIntegrationTest.java
@@ -38,10 +38,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Duration;
 
 import org.apache.james.eventsourcing.eventstore.EventStore;
-import org.apache.james.mailbox.MailboxListener.QuotaUsageUpdatedEvent;
 import org.apache.james.mailbox.quota.QuotaFixture.Counts;
 import org.apache.james.mailbox.quota.QuotaFixture.Sizes;
 import org.apache.james.mailbox.quota.mailing.QuotaMailingListenerConfiguration;
+import org.apache.james.mailbox.store.event.EventFactory;
 import org.apache.james.util.concurrency.ConcurrentTestRunner;
 import org.apache.mailet.base.test.FakeMailContext;
 import org.junit.jupiter.api.Test;
@@ -53,7 +53,13 @@ public interface QuotaThresholdMailingIntegrationTest {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, DEFAULT_CONFIGURATION);
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._30_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._30_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).isEmpty();
     }
@@ -62,10 +68,23 @@ public interface QuotaThresholdMailingIntegrationTest {
     default void shouldNotSendMailWhenNoThresholdUpdate(EventStore store) throws Exception {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, DEFAULT_CONFIGURATION);
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, ONE_HOUR_AGO));
+
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._55_PERCENT)
+            .instant(ONE_HOUR_AGO)
+            .build());
         mailetContext.resetSentMails();
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._55_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).isEmpty();
     }
@@ -74,11 +93,29 @@ public interface QuotaThresholdMailingIntegrationTest {
     default void shouldNotSendMailWhenThresholdOverPassedRecently(EventStore store) throws Exception {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, DEFAULT_CONFIGURATION);
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, TWELVE_HOURS_AGO));
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._30_PERCENT, SIX_HOURS_AGO));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._55_PERCENT)
+            .instant(TWELVE_HOURS_AGO)
+            .build());
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._30_PERCENT)
+            .instant(SIX_HOURS_AGO)
+            .build());
         mailetContext.resetSentMails();
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._55_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).isEmpty();
     }
@@ -88,7 +125,13 @@ public interface QuotaThresholdMailingIntegrationTest {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, DEFAULT_CONFIGURATION);
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._55_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).hasSize(1);
     }
@@ -97,9 +140,21 @@ public interface QuotaThresholdMailingIntegrationTest {
     default void shouldNotSendDuplicates(EventStore store) throws Exception {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, DEFAULT_CONFIGURATION);
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, ONE_HOUR_AGO));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._55_PERCENT)
+            .instant(ONE_HOUR_AGO)
+            .build());
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._55_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).hasSize(1);
     }
@@ -108,9 +163,21 @@ public interface QuotaThresholdMailingIntegrationTest {
     default void shouldNotifySeparatelyCountAndSize(EventStore store) throws Exception {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, DEFAULT_CONFIGURATION);
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, ONE_HOUR_AGO));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._55_PERCENT)
+            .instant(ONE_HOUR_AGO)
+            .build());
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._52_PERCENT, Sizes._60_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._52_PERCENT)
+            .quotaSize(Sizes._60_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).hasSize(2);
     }
@@ -120,7 +187,13 @@ public interface QuotaThresholdMailingIntegrationTest {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, DEFAULT_CONFIGURATION);
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._52_PERCENT, Sizes._55_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._52_PERCENT)
+            .quotaSize(Sizes._55_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).hasSize(1);
     }
@@ -129,11 +202,29 @@ public interface QuotaThresholdMailingIntegrationTest {
     default void shouldSendMailWhenThresholdOverPassedOverGracePeriod(EventStore store) throws Exception {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, DEFAULT_CONFIGURATION);
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, TWELVE_DAYS_AGO));
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._30_PERCENT, SIX_DAYS_AGO));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._55_PERCENT)
+            .instant(TWELVE_DAYS_AGO)
+            .build());
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._30_PERCENT)
+            .instant(SIX_DAYS_AGO)
+            .build());
         mailetContext.resetSentMails();
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._55_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).hasSize(1);
     }
@@ -142,10 +233,22 @@ public interface QuotaThresholdMailingIntegrationTest {
     default void shouldNotSendMailWhenNoThresholdUpdateForCount(EventStore store) throws Exception {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, DEFAULT_CONFIGURATION);
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._32_PERCENT, Sizes._55_PERCENT, TWO_DAYS_AGO));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._32_PERCENT)
+            .quotaSize(Sizes._55_PERCENT)
+            .instant(TWO_DAYS_AGO)
+            .build());
         mailetContext.resetSentMails();
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._60_PERCENT, TWO_DAYS_AGO));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._60_PERCENT)
+            .instant(TWO_DAYS_AGO)
+            .build());
 
         assertThat(mailetContext.getSentMails()).isEmpty();
     }
@@ -154,11 +257,29 @@ public interface QuotaThresholdMailingIntegrationTest {
     default void shouldNotSendMailWhenThresholdOverPassedRecentlyForCount(EventStore store) throws Exception {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, DEFAULT_CONFIGURATION);
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._52_PERCENT, Sizes._30_PERCENT, TWELVE_HOURS_AGO));
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._30_PERCENT, SIX_HOURS_AGO));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._52_PERCENT)
+            .quotaSize(Sizes._30_PERCENT)
+            .instant(TWELVE_HOURS_AGO)
+            .build());
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._30_PERCENT)
+            .instant(SIX_HOURS_AGO)
+            .build());
         mailetContext.resetSentMails();
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._52_PERCENT, Sizes._30_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._52_PERCENT)
+            .quotaSize(Sizes._30_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).isEmpty();
     }
@@ -168,7 +289,13 @@ public interface QuotaThresholdMailingIntegrationTest {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, DEFAULT_CONFIGURATION);
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._52_PERCENT, Sizes._30_PERCENT, TWELVE_HOURS_AGO));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._52_PERCENT)
+            .quotaSize(Sizes._30_PERCENT)
+            .instant(TWELVE_HOURS_AGO)
+            .build());
 
         assertThat(mailetContext.getSentMails()).hasSize(1);
     }
@@ -177,11 +304,29 @@ public interface QuotaThresholdMailingIntegrationTest {
     default void shouldSendMailWhenThresholdOverPassedOverGracePeriodForCount(EventStore store) throws Exception {
         FakeMailContext mailetContext = mailetContext();
         QuotaThresholdListenersTestSystem testee = new QuotaThresholdListenersTestSystem(mailetContext, store, DEFAULT_CONFIGURATION);
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._52_PERCENT, Sizes._30_PERCENT, TWELVE_DAYS_AGO));
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._30_PERCENT, SIX_DAYS_AGO));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._52_PERCENT)
+            .quotaSize(Sizes._30_PERCENT)
+            .instant(TWELVE_DAYS_AGO)
+            .build());
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._40_PERCENT)
+            .quotaSize(Sizes._30_PERCENT)
+            .instant(SIX_DAYS_AGO)
+            .build());
         mailetContext.resetSentMails();
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._52_PERCENT, Sizes._30_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._52_PERCENT)
+            .quotaSize(Sizes._30_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails()).hasSize(1);
     }
@@ -195,8 +340,20 @@ public interface QuotaThresholdMailingIntegrationTest {
                 .gracePeriod(GRACE_PERIOD)
                 .build());
 
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._52_PERCENT, Sizes._30_PERCENT, NOW));
-        testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._85_PERCENT, Sizes._42_PERCENT, NOW));
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._52_PERCENT)
+            .quotaSize(Sizes._30_PERCENT)
+            .instant(NOW)
+            .build());
+        testee.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._85_PERCENT)
+            .quotaSize(Sizes._42_PERCENT)
+            .instant(NOW)
+            .build());
 
         assertThat(mailetContext.getSentMails())
             .hasSize(2);
@@ -212,7 +369,13 @@ public interface QuotaThresholdMailingIntegrationTest {
                 .build());
 
         ConcurrentTestRunner.builder()
-            .operation((threadNb, step) -> testee.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._40_PERCENT, Sizes._55_PERCENT, NOW)))
+            .operation((threadNb, step) -> testee.event(EventFactory.quotaUpdated()
+                    .user(BOB_USER)
+                    .quotaRoot(QUOTAROOT)
+                    .quotaCount(Counts._40_PERCENT)
+                    .quotaSize(Sizes._55_PERCENT)
+                    .instant(NOW)
+                    .build()))
             .threadCount(10)
             .runSuccessfullyWithin(Duration.ofMinutes(1));
 

--- a/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/events/ElasticSearchQuotaMailboxListenerTest.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/events/ElasticSearchQuotaMailboxListenerTest.java
@@ -34,9 +34,9 @@ import org.apache.james.backends.es.ElasticSearchIndexer;
 import org.apache.james.backends.es.EmbeddedElasticSearch;
 import org.apache.james.backends.es.utils.TestingClientProvider;
 import org.apache.james.mailbox.Event;
-import org.apache.james.mailbox.MailboxListener.QuotaUsageUpdatedEvent;
 import org.apache.james.mailbox.quota.QuotaFixture.Counts;
 import org.apache.james.mailbox.quota.QuotaFixture.Sizes;
+import org.apache.james.mailbox.store.event.EventFactory;
 import org.apache.james.quota.search.elasticsearch.QuotaRatioElasticSearchConstants;
 import org.apache.james.quota.search.elasticsearch.QuotaSearchIndexCreationUtil;
 import org.apache.james.quota.search.elasticsearch.json.QuotaRatioToElasticSearchJson;
@@ -93,7 +93,13 @@ public class ElasticSearchQuotaMailboxListenerTest {
 
     @Test
     public void eventShouldIndexEventWhenQuotaEvent() throws Exception {
-        quotaMailboxListener.event(new QuotaUsageUpdatedEvent(BOB_USER, QUOTAROOT, Counts._52_PERCENT, Sizes._55_PERCENT, NOW));
+        quotaMailboxListener.event(EventFactory.quotaUpdated()
+            .user(BOB_USER)
+            .quotaRoot(QUOTAROOT)
+            .quotaCount(Counts._52_PERCENT)
+            .quotaSize(Sizes._55_PERCENT)
+            .instant(NOW)
+            .build());
 
         embeddedElasticSearch.awaitForElasticSearch();
 

--- a/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/json/QuotaRatioToElasticSearchJsonTest.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/json/QuotaRatioToElasticSearchJsonTest.java
@@ -25,26 +25,28 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Optional;
 
-import org.apache.james.core.Domain;
 import org.apache.james.core.User;
 import org.apache.james.mailbox.MailboxListener.QuotaUsageUpdatedEvent;
 import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.mailbox.quota.QuotaFixture;
+import org.apache.james.mailbox.store.event.EventFactory;
 import org.apache.james.util.ClassLoaderUtils;
 import org.junit.jupiter.api.Test;
 
-public class QuotaRatioToElasticSearchJsonTest {
+class QuotaRatioToElasticSearchJsonTest {
+
+    private static final QuotaRoot QUOTA_ROOT = QuotaRoot.quotaRoot("any", Optional.empty());
 
     @Test
-    public void quotaRatioShouldBeWellConvertedToJson() throws IOException {
+    void quotaRatioShouldBeWellConvertedToJson() throws IOException {
         String user = "user@domain.org";
-        QuotaUsageUpdatedEvent event = new QuotaUsageUpdatedEvent(
-                User.fromUsername(user),
-                QuotaRoot.quotaRoot("any", Optional.of(Domain.of("domain.org"))),
-                QuotaFixture.Counts._52_PERCENT,
-                QuotaFixture.Sizes._55_PERCENT,
-                Instant.now());
-        
+        QuotaUsageUpdatedEvent event = EventFactory.quotaUpdated()
+            .user(User.fromUsername(user))
+            .quotaRoot(QUOTA_ROOT)
+            .quotaCount(QuotaFixture.Counts._52_PERCENT)
+            .quotaSize(QuotaFixture.Sizes._55_PERCENT)
+            .instant(Instant.now())
+            .build();
 
         QuotaRatioToElasticSearchJson quotaRatioToElasticSearchJson = new QuotaRatioToElasticSearchJson();
         String convertToJson = quotaRatioToElasticSearchJson.convertToJson(user, event);
@@ -55,14 +57,15 @@ public class QuotaRatioToElasticSearchJsonTest {
     }
 
     @Test
-    public void quotaRatioShouldBeWellConvertedToJsonWhenNoDomain() throws IOException {
+    void quotaRatioShouldBeWellConvertedToJsonWhenNoDomain() throws IOException {
         String user = "user";
-        QuotaUsageUpdatedEvent event = new QuotaUsageUpdatedEvent(
-                User.fromUsername(user),
-                QuotaRoot.quotaRoot("any", Optional.empty()),
-                QuotaFixture.Counts._52_PERCENT,
-                QuotaFixture.Sizes._55_PERCENT,
-                Instant.now());
+        QuotaUsageUpdatedEvent event = EventFactory.quotaUpdated()
+            .user(User.fromUsername(user))
+            .quotaRoot(QUOTA_ROOT)
+            .quotaCount(QuotaFixture.Counts._52_PERCENT)
+            .quotaSize(QuotaFixture.Sizes._55_PERCENT)
+            .instant(Instant.now())
+            .build();
 
 
         QuotaRatioToElasticSearchJson quotaRatioToElasticSearchJson = new QuotaRatioToElasticSearchJson();

--- a/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/json/QuotaRatioToElasticSearchJsonTest.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/json/QuotaRatioToElasticSearchJsonTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Optional;
 
+import org.apache.james.core.Domain;
 import org.apache.james.core.User;
 import org.apache.james.mailbox.MailboxListener.QuotaUsageUpdatedEvent;
 import org.apache.james.mailbox.model.QuotaRoot;
@@ -35,14 +36,12 @@ import org.junit.jupiter.api.Test;
 
 class QuotaRatioToElasticSearchJsonTest {
 
-    private static final QuotaRoot QUOTA_ROOT = QuotaRoot.quotaRoot("any", Optional.empty());
-
     @Test
     void quotaRatioShouldBeWellConvertedToJson() throws IOException {
         String user = "user@domain.org";
         QuotaUsageUpdatedEvent event = EventFactory.quotaUpdated()
             .user(User.fromUsername(user))
-            .quotaRoot(QUOTA_ROOT)
+            .quotaRoot(QuotaRoot.quotaRoot(user, Optional.of(Domain.of("domain.org"))))
             .quotaCount(QuotaFixture.Counts._52_PERCENT)
             .quotaSize(QuotaFixture.Sizes._55_PERCENT)
             .instant(Instant.now())
@@ -61,7 +60,7 @@ class QuotaRatioToElasticSearchJsonTest {
         String user = "user";
         QuotaUsageUpdatedEvent event = EventFactory.quotaUpdated()
             .user(User.fromUsername(user))
-            .quotaRoot(QUOTA_ROOT)
+            .quotaRoot(QuotaRoot.quotaRoot(user, Optional.empty()))
             .quotaCount(QuotaFixture.Counts._52_PERCENT)
             .quotaSize(QuotaFixture.Sizes._55_PERCENT)
             .instant(Instant.now())

--- a/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
+++ b/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
@@ -232,7 +232,7 @@ public class SpamAssassinListenerTest {
     public void eventShouldCallSpamAssassinHamLearningWhenTheMessageIsAddedInInbox() throws Exception {
         SimpleMailboxMessage message = createMessage(inbox);
 
-        MailboxListener.Added addedEvent = new EventFactory().added()
+        MailboxListener.Added addedEvent = EventFactory.added()
             .mailboxSession(MAILBOX_SESSION)
             .mailbox(inbox)
             .addMessage(message)
@@ -247,7 +247,7 @@ public class SpamAssassinListenerTest {
     public void eventShouldNotCallSpamAssassinHamLearningWhenTheMessageIsAddedInAMailboxOtherThanInbox() throws Exception {
         SimpleMailboxMessage message = createMessage(mailbox1);
 
-        MailboxListener.Added addedEvent = new EventFactory().added()
+        MailboxListener.Added addedEvent = EventFactory.added()
             .mailboxSession(MAILBOX_SESSION)
             .mailbox(mailbox1)
             .addMessage(message)

--- a/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
+++ b/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
@@ -37,7 +37,6 @@ import org.apache.james.mailbox.MailboxListener;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MailboxSessionUtil;
 import org.apache.james.mailbox.MessageMoveEvent;
-import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.acl.SimpleGroupMembershipResolver;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
@@ -58,14 +57,10 @@ import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableSortedMap;
-
 public class SpamAssassinListenerTest {
-
     public static final String USER = "user";
     private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(USER);
     private static final int UID_VALIDITY = 43;
-    private static final MessageUid UID = MessageUid.of(45);
     private static final TestMessageId MESSAGE_ID = TestMessageId.of(45);
 
     private SpamAssassin spamAssassin;
@@ -237,9 +232,11 @@ public class SpamAssassinListenerTest {
     public void eventShouldCallSpamAssassinHamLearningWhenTheMessageIsAddedInInbox() throws Exception {
         SimpleMailboxMessage message = createMessage(inbox);
 
-        ImmutableSortedMap<MessageUid, MessageMetaData> sortedMap = ImmutableSortedMap.of(UID, message.metaData());
-        MailboxListener.Added addedEvent = new EventFactory().added(
-                MAILBOX_SESSION, sortedMap, inbox);
+        MailboxListener.Added addedEvent = new EventFactory().added()
+            .mailboxSession(MAILBOX_SESSION)
+            .mailbox(inbox)
+            .addMessage(message)
+            .build();
 
         listener.event(addedEvent);
 
@@ -250,10 +247,11 @@ public class SpamAssassinListenerTest {
     public void eventShouldNotCallSpamAssassinHamLearningWhenTheMessageIsAddedInAMailboxOtherThanInbox() throws Exception {
         SimpleMailboxMessage message = createMessage(mailbox1);
 
-        MailboxListener.Added addedEvent = new EventFactory().added(
-            MAILBOX_SESSION,
-            ImmutableSortedMap.of(UID, message.metaData()),
-            mailbox1);
+        MailboxListener.Added addedEvent = new EventFactory().added()
+            .mailboxSession(MAILBOX_SESSION)
+            .mailbox(mailbox1)
+            .addMessage(message)
+            .build();
 
         listener.event(addedEvent);
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/EventFactory.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/EventFactory.java
@@ -242,6 +242,37 @@ public class EventFactory {
         }
     }
 
+    public static class MailboxRenamedBuilder extends MailboxEventBuilder<MailboxRenamedBuilder> {
+        private MailboxPath newPath;
+
+        @Override
+        protected MailboxRenamedBuilder backReference() {
+            return this;
+        }
+
+        public MailboxRenamedBuilder newPath(MailboxPath newPath) {
+            this.newPath = newPath;
+            return this;
+        }
+
+        public MailboxRenamedBuilder oldPath(MailboxPath oldPath) {
+            this.path = oldPath;
+            return this;
+        }
+
+        public MailboxListener.MailboxRenamed build() {
+            mailboxEventChecks();
+            Preconditions.checkState(path != null, "Field `newPath` is compulsory");
+
+            return new MailboxListener.MailboxRenamed(
+                sessionId,
+                user,
+                path,
+                mailboxId,
+                newPath);
+        }
+    }
+
     public static class FlagsUpdatedBuilder extends MailboxEventBuilder<FlagsUpdatedBuilder> {
         private final ImmutableList.Builder<UpdatedFlags> updatedFlags;
 
@@ -285,12 +316,8 @@ public class EventFactory {
         return new FlagsUpdatedBuilder();
     }
 
-    public MailboxListener.MailboxRenamed mailboxRenamed(MailboxSession session, MailboxPath from, Mailbox to) {
-        return mailboxRenamed(session.getSessionId(), session.getUser(), from, to);
-    }
-
-    public MailboxListener.MailboxRenamed mailboxRenamed(MailboxSession.SessionId sessionId, User user, MailboxPath from, Mailbox to) {
-        return new MailboxListener.MailboxRenamed(sessionId, user, from, to.getMailboxId(), to.generateAssociatedPath());
+    public MailboxRenamedBuilder mailboxRenamed() {
+        return new MailboxRenamedBuilder();
     }
 
     public MailboxDeletionBuilder mailboxDeleted() {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/EventFactory.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/EventFactory.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.mailbox.store.event;
 
-import java.util.Collection;
-
 import org.apache.james.core.User;
 import org.apache.james.core.quota.QuotaCount;
 import org.apache.james.core.quota.QuotaSize;
@@ -31,9 +29,7 @@ import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.acl.ACLDiff;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
-import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.MessageMetaData;
-import org.apache.james.mailbox.model.MessageMoves;
 import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
@@ -332,11 +328,7 @@ public class EventFactory {
         return new MailboxAclUpdatedBuilder();
     }
 
-    public MessageMoveEvent moved(MailboxSession session, MessageMoves messageMoves, Collection<MessageId> messageIds) {
-        return MessageMoveEvent.builder()
-                .user(session.getUser())
-                .messageMoves(messageMoves)
-                .messageId(messageIds)
-                .build();
+    public MessageMoveEvent.Builder moved() {
+        return MessageMoveEvent.builder();
     }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/EventFactory.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/EventFactory.java
@@ -300,35 +300,35 @@ public class EventFactory {
         }
     }
 
-    public AddedBuilder added() {
+    public static AddedBuilder added() {
         return new AddedBuilder();
     }
 
-    public ExpungedBuilder expunged() {
+    public static ExpungedBuilder expunged() {
         return new ExpungedBuilder();
     }
 
-    public FlagsUpdatedBuilder flagsUpdated() {
+    public static FlagsUpdatedBuilder flagsUpdated() {
         return new FlagsUpdatedBuilder();
     }
 
-    public MailboxRenamedBuilder mailboxRenamed() {
+    public static MailboxRenamedBuilder mailboxRenamed() {
         return new MailboxRenamedBuilder();
     }
 
-    public MailboxDeletionBuilder mailboxDeleted() {
+    public static MailboxDeletionBuilder mailboxDeleted() {
         return new MailboxDeletionBuilder();
     }
 
-    public MailboxAddedBuilder mailboxAdded() {
+    public static MailboxAddedBuilder mailboxAdded() {
         return new MailboxAddedBuilder();
     }
 
-    public MailboxAclUpdatedBuilder aclUpdated() {
+    public static MailboxAclUpdatedBuilder aclUpdated() {
         return new MailboxAclUpdatedBuilder();
     }
 
-    public MessageMoveEvent.Builder moved() {
+    public static MessageMoveEvent.Builder moved() {
         return MessageMoveEvent.builder();
     }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/EventFactory.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/EventFactory.java
@@ -41,7 +41,56 @@ import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
 
+import com.google.common.base.Preconditions;
+
 public class EventFactory {
+    public static class MailboxAddedBuilder {
+        private MailboxPath path;
+        private MailboxId mailboxId;
+        private User user;
+        private MailboxSession.SessionId sessionId;
+
+        public MailboxAddedBuilder mailbox(Mailbox mailbox) {
+            path(mailbox.generateAssociatedPath());
+            mailboxId(mailbox.getMailboxId());
+            return this;
+        }
+
+        public MailboxAddedBuilder mailboxSession(MailboxSession mailboxSession) {
+            user(mailboxSession.getUser());
+            sessionId(mailboxSession.getSessionId());
+            return this;
+        }
+
+        public MailboxAddedBuilder mailboxId(MailboxId mailboxId) {
+            this.mailboxId = mailboxId;
+            return this;
+        }
+
+        public MailboxAddedBuilder path(MailboxPath path) {
+            this.path = path;
+            return this;
+        }
+
+        public MailboxAddedBuilder user(User user) {
+            this.user = user;
+            return this;
+        }
+
+        public MailboxAddedBuilder sessionId(MailboxSession.SessionId sessionId) {
+            this.sessionId = sessionId;
+            return this;
+        }
+
+        public MailboxListener.MailboxAdded build() {
+            Preconditions.checkState(user != null, "Field `user` is compulsory");
+            Preconditions.checkState(mailboxId != null, "Field `mailboxId` is compulsory");
+            Preconditions.checkState(path != null, "Field `path` is compulsory");
+            Preconditions.checkState(sessionId != null, "Field `sessionId` is compulsory");
+
+            return new MailboxListener.MailboxAdded(sessionId, user, path, mailboxId);
+        }
+    }
 
     public MailboxListener.Added added(MailboxSession session, SortedMap<MessageUid, MessageMetaData> uids, Mailbox mailbox) {
         return added(session.getSessionId(), session.getUser(), uids, mailbox);
@@ -81,12 +130,8 @@ public class EventFactory {
         return new MailboxListener.MailboxDeletion(sessionId, user, mailbox.generateAssociatedPath(), quotaRoot, deletedMessageCount, totalDeletedSize, mailbox.getMailboxId());
     }
 
-    public MailboxListener.MailboxAdded mailboxAdded(MailboxSession session, Mailbox mailbox) {
-        return mailboxAdded(session.getSessionId(), session.getUser(), mailbox);
-    }
-
-    public MailboxListener.MailboxAdded mailboxAdded(MailboxSession.SessionId sessionId, User user, Mailbox mailbox) {
-        return new MailboxListener.MailboxAdded(sessionId, user, mailbox.generateAssociatedPath(), mailbox.getMailboxId());
+    public MailboxAddedBuilder mailboxAdded() {
+        return new MailboxAddedBuilder();
     }
 
     public MailboxListener.MailboxACLUpdated aclUpdated(MailboxSession session, MailboxPath mailboxPath, ACLDiff aclDiff, MailboxId mailboxId) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/EventFactory.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/EventFactory.java
@@ -168,6 +168,32 @@ public class EventFactory {
         }
     }
 
+    public static class MailboxAclUpdatedBuilder extends MailboxEventBuilder<MailboxAclUpdatedBuilder> {
+        private ACLDiff aclDiff;
+
+        public MailboxAclUpdatedBuilder aclDiff(ACLDiff aclDiff) {
+            this.aclDiff = aclDiff;
+            return this;
+        }
+
+        @Override
+        protected MailboxAclUpdatedBuilder backReference() {
+            return this;
+        }
+
+        public MailboxListener.MailboxACLUpdated build() {
+            Preconditions.checkState(aclDiff != null, "Field `aclDiff` is compulsory");
+            mailboxEventChecks();
+
+            return new MailboxListener.MailboxACLUpdated(
+                sessionId,
+                user,
+                path,
+                aclDiff,
+                mailboxId);
+        }
+    }
+
     public static class MailboxAddedBuilder extends MailboxEventBuilder<MailboxAddedBuilder> {
         @Override
         protected MailboxAddedBuilder backReference() {
@@ -275,12 +301,8 @@ public class EventFactory {
         return new MailboxAddedBuilder();
     }
 
-    public MailboxListener.MailboxACLUpdated aclUpdated(MailboxSession session, MailboxPath mailboxPath, ACLDiff aclDiff, MailboxId mailboxId) {
-        return aclUpdated(session.getSessionId(), session.getUser(), mailboxPath, aclDiff, mailboxId);
-    }
-
-    public MailboxListener.MailboxACLUpdated aclUpdated(MailboxSession.SessionId sessionId, User user, MailboxPath mailboxPath, ACLDiff aclDiff, MailboxId mailboxId) {
-        return new MailboxListener.MailboxACLUpdated(sessionId, user, mailboxPath, aclDiff, mailboxId);
+    public MailboxAclUpdatedBuilder aclUpdated() {
+        return new MailboxAclUpdatedBuilder();
     }
 
     public MessageMoveEvent moved(MailboxSession session, MessageMoves messageMoves, Collection<MessageId> messageIds) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
@@ -149,7 +149,13 @@ public class MailboxEventDispatcher {
      * MailboxListener will get triggered then
      */
     public void mailboxDeleted(MailboxSession session, Mailbox mailbox, QuotaRoot quotaRoot, QuotaCount deletedMessageCount, QuotaSize totalDeletedSize) {
-        event(eventFactory.mailboxDeleted(session, mailbox, quotaRoot, deletedMessageCount, totalDeletedSize));
+        event(eventFactory.mailboxDeleted()
+            .mailboxSession(session)
+            .mailbox(mailbox)
+            .quotaRoot(quotaRoot)
+            .deletedMessageCount(deletedMessageCount)
+            .totalDeletedSize(totalDeletedSize)
+            .build());
     }
 
     /**

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
@@ -178,7 +178,12 @@ public class MailboxEventDispatcher {
     }
 
     public void aclUpdated(MailboxSession session, MailboxPath mailboxPath, ACLDiff aclDiff, MailboxId mailboxId) {
-        event(eventFactory.aclUpdated(session, mailboxPath, aclDiff, mailboxId));
+        event(eventFactory.aclUpdated()
+            .mailboxSession(session)
+            .path(mailboxPath)
+            .mailboxId(mailboxId)
+            .aclDiff(aclDiff)
+            .build());
     }
 
     public void moved(MailboxSession session, MessageMoves messageMoves, Collection<MessageId> messageIds) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
@@ -192,7 +192,11 @@ public class MailboxEventDispatcher {
     }
 
     public void moved(MailboxSession session, MessageMoves messageMoves, Collection<MessageId> messageIds) {
-        event(eventFactory.moved(session, messageMoves, messageIds));
+        event(eventFactory.moved()
+            .session(session)
+            .messageMoves(messageMoves)
+            .messageId(messageIds)
+            .build());
     }
 
     public void quota(User user, QuotaRoot quotaRoot, Quota<QuotaCount> countQuota, Quota<QuotaSize> sizeQuota) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
@@ -149,7 +149,12 @@ public class MailboxEventDispatcher {
      * MailboxListener will get triggered then
      */
     public void mailboxRenamed(MailboxSession session, MailboxPath from, Mailbox to) {
-        event(eventFactory.mailboxRenamed(session, from, to));
+        event(eventFactory.mailboxRenamed()
+            .mailboxSession(session)
+            .mailboxId(to.getMailboxId())
+            .oldPath(from)
+            .newPath(to.generateAssociatedPath())
+            .build());
     }
 
     /**

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
@@ -46,7 +46,6 @@ import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
@@ -55,20 +54,11 @@ import com.google.common.collect.ImmutableSortedMap;
  * Helper class to dispatch {@link org.apache.james.mailbox.Event}'s to registerend MailboxListener
  */
 public class MailboxEventDispatcher {
-    @VisibleForTesting
-    public static MailboxEventDispatcher ofListener(MailboxListener mailboxListener) {
-        return new MailboxEventDispatcher(mailboxListener);
-    }
-
     private final MailboxListener listener;
 
     @Inject
     public MailboxEventDispatcher(DelegatingMailboxListener delegatingMailboxListener) {
-        this((MailboxListener) delegatingMailboxListener);
-    }
-
-    private MailboxEventDispatcher(MailboxListener listener) {
-        this.listener = listener;
+        this.listener = delegatingMailboxListener;
     }
 
     /**

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
@@ -83,7 +83,11 @@ public class MailboxEventDispatcher {
      * @param mailbox The mailbox
      */
     public void added(MailboxSession session, SortedMap<MessageUid, MessageMetaData> uids, Mailbox mailbox) {
-        event(eventFactory.added(session, uids, mailbox));
+        event(eventFactory.added()
+            .mailbox(mailbox)
+            .mailboxSession(session)
+            .addMetaData(uids.values())
+            .build());
     }
 
     public void added(MailboxSession session, Mailbox mailbox, MailboxMessage mailboxMessage) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
@@ -114,7 +114,11 @@ public class MailboxEventDispatcher {
      * @param mailbox The mailbox
      */
     public void expunged(MailboxSession session,  Map<MessageUid, MessageMetaData> uids, Mailbox mailbox) {
-        event(eventFactory.expunged(session, uids, mailbox));
+        event(eventFactory.expunged()
+            .mailbox(mailbox)
+            .mailboxSession(session)
+            .addMetaData(uids.values())
+            .build());
     }
 
     public void expunged(MailboxSession session,  MessageMetaData messageMetaData, Mailbox mailbox) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
@@ -153,7 +153,10 @@ public class MailboxEventDispatcher {
      * MailboxListener will get triggered then
      */
     public void mailboxAdded(MailboxSession session, Mailbox mailbox) {
-        event(eventFactory.mailboxAdded(session, mailbox));
+        listener.event(eventFactory.mailboxAdded()
+            .mailbox(mailbox)
+            .mailboxSession(session)
+            .build());
     }
 
     public void aclUpdated(MailboxSession session, MailboxPath mailboxPath, ACLDiff aclDiff, MailboxId mailboxId) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
@@ -125,7 +125,11 @@ public class MailboxEventDispatcher {
      * registered MailboxListener will get triggered then
      */
     public void flagsUpdated(MailboxSession session, Mailbox mailbox, List<UpdatedFlags> uflags) {
-        event(eventFactory.flagsUpdated(session, mailbox, uflags));
+        event(eventFactory.flagsUpdated()
+            .mailbox(mailbox)
+            .mailboxSession(session)
+            .updatedFags(uflags)
+            .build());
     }
 
     public void flagsUpdated(MailboxSession session, Mailbox mailbox, UpdatedFlags uflags) {
@@ -153,7 +157,7 @@ public class MailboxEventDispatcher {
      * MailboxListener will get triggered then
      */
     public void mailboxAdded(MailboxSession session, Mailbox mailbox) {
-        listener.event(eventFactory.mailboxAdded()
+        event(eventFactory.mailboxAdded()
             .mailbox(mailbox)
             .mailboxSession(session)
             .build());

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
@@ -71,8 +71,8 @@ public class MailboxEventDispatcher {
      */
     public void added(MailboxSession session, SortedMap<MessageUid, MessageMetaData> uids, Mailbox mailbox) {
         event(EventFactory.added()
-            .mailbox(mailbox)
             .mailboxSession(session)
+            .mailbox(mailbox)
             .addMetaData(uids.values())
             .build());
     }
@@ -102,8 +102,8 @@ public class MailboxEventDispatcher {
      */
     public void expunged(MailboxSession session,  Map<MessageUid, MessageMetaData> uids, Mailbox mailbox) {
         event(EventFactory.expunged()
-            .mailbox(mailbox)
             .mailboxSession(session)
+            .mailbox(mailbox)
             .addMetaData(uids.values())
             .build());
     }
@@ -121,9 +121,9 @@ public class MailboxEventDispatcher {
      */
     public void flagsUpdated(MailboxSession session, Mailbox mailbox, List<UpdatedFlags> uflags) {
         event(EventFactory.flagsUpdated()
-            .mailbox(mailbox)
             .mailboxSession(session)
-            .updatedFags(uflags)
+            .mailbox(mailbox)
+            .updatedFlags(uflags)
             .build());
     }
 
@@ -153,8 +153,8 @@ public class MailboxEventDispatcher {
             .mailboxSession(session)
             .mailbox(mailbox)
             .quotaRoot(quotaRoot)
-            .deletedMessageCount(deletedMessageCount)
-            .totalDeletedSize(totalDeletedSize)
+            .quotaCount(deletedMessageCount)
+            .quotaSize(totalDeletedSize)
             .build());
     }
 
@@ -164,16 +164,16 @@ public class MailboxEventDispatcher {
      */
     public void mailboxAdded(MailboxSession session, Mailbox mailbox) {
         event(EventFactory.mailboxAdded()
-            .mailbox(mailbox)
             .mailboxSession(session)
+            .mailbox(mailbox)
             .build());
     }
 
     public void aclUpdated(MailboxSession session, MailboxPath mailboxPath, ACLDiff aclDiff, MailboxId mailboxId) {
         event(EventFactory.aclUpdated()
             .mailboxSession(session)
-            .path(mailboxPath)
             .mailboxId(mailboxId)
+            .mailboxPath(mailboxPath)
             .aclDiff(aclDiff)
             .build());
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
@@ -55,23 +55,20 @@ import com.google.common.collect.ImmutableSortedMap;
  * Helper class to dispatch {@link org.apache.james.mailbox.Event}'s to registerend MailboxListener
  */
 public class MailboxEventDispatcher {
-
     @VisibleForTesting
     public static MailboxEventDispatcher ofListener(MailboxListener mailboxListener) {
-        return new MailboxEventDispatcher(mailboxListener, new EventFactory());
+        return new MailboxEventDispatcher(mailboxListener);
     }
 
     private final MailboxListener listener;
-    private final EventFactory eventFactory;
 
     @Inject
     public MailboxEventDispatcher(DelegatingMailboxListener delegatingMailboxListener) {
-        this(delegatingMailboxListener, new EventFactory());
+        this((MailboxListener) delegatingMailboxListener);
     }
 
-    private MailboxEventDispatcher(MailboxListener listener, EventFactory eventFactory) {
+    private MailboxEventDispatcher(MailboxListener listener) {
         this.listener = listener;
-        this.eventFactory = eventFactory;
     }
 
     /**
@@ -83,7 +80,7 @@ public class MailboxEventDispatcher {
      * @param mailbox The mailbox
      */
     public void added(MailboxSession session, SortedMap<MessageUid, MessageMetaData> uids, Mailbox mailbox) {
-        event(eventFactory.added()
+        event(EventFactory.added()
             .mailbox(mailbox)
             .mailboxSession(session)
             .addMetaData(uids.values())
@@ -114,7 +111,7 @@ public class MailboxEventDispatcher {
      * @param mailbox The mailbox
      */
     public void expunged(MailboxSession session,  Map<MessageUid, MessageMetaData> uids, Mailbox mailbox) {
-        event(eventFactory.expunged()
+        event(EventFactory.expunged()
             .mailbox(mailbox)
             .mailboxSession(session)
             .addMetaData(uids.values())
@@ -133,7 +130,7 @@ public class MailboxEventDispatcher {
      * registered MailboxListener will get triggered then
      */
     public void flagsUpdated(MailboxSession session, Mailbox mailbox, List<UpdatedFlags> uflags) {
-        event(eventFactory.flagsUpdated()
+        event(EventFactory.flagsUpdated()
             .mailbox(mailbox)
             .mailboxSession(session)
             .updatedFags(uflags)
@@ -149,7 +146,7 @@ public class MailboxEventDispatcher {
      * MailboxListener will get triggered then
      */
     public void mailboxRenamed(MailboxSession session, MailboxPath from, Mailbox to) {
-        event(eventFactory.mailboxRenamed()
+        event(EventFactory.mailboxRenamed()
             .mailboxSession(session)
             .mailboxId(to.getMailboxId())
             .oldPath(from)
@@ -162,7 +159,7 @@ public class MailboxEventDispatcher {
      * MailboxListener will get triggered then
      */
     public void mailboxDeleted(MailboxSession session, Mailbox mailbox, QuotaRoot quotaRoot, QuotaCount deletedMessageCount, QuotaSize totalDeletedSize) {
-        event(eventFactory.mailboxDeleted()
+        event(EventFactory.mailboxDeleted()
             .mailboxSession(session)
             .mailbox(mailbox)
             .quotaRoot(quotaRoot)
@@ -176,14 +173,14 @@ public class MailboxEventDispatcher {
      * MailboxListener will get triggered then
      */
     public void mailboxAdded(MailboxSession session, Mailbox mailbox) {
-        event(eventFactory.mailboxAdded()
+        event(EventFactory.mailboxAdded()
             .mailbox(mailbox)
             .mailboxSession(session)
             .build());
     }
 
     public void aclUpdated(MailboxSession session, MailboxPath mailboxPath, ACLDiff aclDiff, MailboxId mailboxId) {
-        event(eventFactory.aclUpdated()
+        event(EventFactory.aclUpdated()
             .mailboxSession(session)
             .path(mailboxPath)
             .mailboxId(mailboxId)
@@ -192,7 +189,7 @@ public class MailboxEventDispatcher {
     }
 
     public void moved(MailboxSession session, MessageMoves messageMoves, Collection<MessageId> messageIds) {
-        event(eventFactory.moved()
+        event(EventFactory.moved()
             .session(session)
             .messageMoves(messageMoves)
             .messageId(messageIds)

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/MailboxEventDispatcherTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/MailboxEventDispatcherTest.java
@@ -35,6 +35,7 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageResult;
 import org.apache.james.mailbox.model.TestId;
 import org.apache.james.mailbox.model.UpdatedFlags;
+import org.apache.james.mailbox.store.event.DefaultDelegatingMailboxListener;
 import org.apache.james.mailbox.store.event.MailboxEventDispatcher;
 import org.apache.james.mailbox.store.mail.model.Mailbox;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailbox;
@@ -68,7 +69,9 @@ public class MailboxEventDispatcherTest {
     public void setUp() throws Exception {
         collector = new EventCollector();
 
-        dispatcher = MailboxEventDispatcher.ofListener(collector);
+        DefaultDelegatingMailboxListener mailboxListener = new DefaultDelegatingMailboxListener();
+        mailboxListener.addGlobalListener(collector, session);
+        dispatcher = new MailboxEventDispatcher(mailboxListener);
         result = mock(MessageResult.class);
         mailbox = new SimpleMailbox(MailboxPath.forUser("user", "name"), UID_VALIDITY, MAILBOX_ID);
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/event/MailboxAnnotationListenerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/event/MailboxAnnotationListenerTest.java
@@ -80,10 +80,10 @@ public class MailboxAnnotationListenerTest {
         deleteEvent = EventFactory.mailboxDeleted()
             .mailboxSession(mailboxSession)
             .mailboxId(mailboxId)
-            .path(MailboxPath.forUser("user", "name"))
+            .mailboxPath(MailboxPath.forUser("user", "name"))
             .quotaRoot(QuotaRoot.quotaRoot("root", Optional.empty()))
-            .deletedMessageCount(QuotaCount.count(123))
-            .totalDeletedSize(QuotaSize.size(456))
+            .quotaCount(QuotaCount.count(123))
+            .quotaSize(QuotaSize.size(456))
             .build();
 
         when(mailboxManager.createSystemSession(deleteEvent.getUser().asString()))

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/event/MailboxAnnotationListenerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/event/MailboxAnnotationListenerTest.java
@@ -42,8 +42,6 @@ import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.mailbox.model.TestId;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
 import org.apache.james.mailbox.store.mail.AnnotationMapper;
-import org.apache.james.mailbox.store.mail.model.Mailbox;
-import org.apache.james.mailbox.store.mail.model.impl.SimpleMailbox;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -69,8 +67,6 @@ public class MailboxAnnotationListenerTest {
     @Mock private AnnotationMapper annotationMapper;
     @Mock private MailboxId mailboxId;
 
-    private Mailbox mailbox;
-    private EventFactory eventFactory;
     private MailboxAnnotationListener listener;
     private MailboxListener.MailboxEvent deleteEvent;
     private MailboxSession mailboxSession;
@@ -80,13 +76,15 @@ public class MailboxAnnotationListenerTest {
         MockitoAnnotations.initMocks(this);
         mailboxSession = MailboxSessionUtil.create("test");
         listener = new MailboxAnnotationListener(mailboxSessionMapperFactory, mailboxManager);
-        eventFactory = new EventFactory();
-        mailbox = new SimpleMailbox(MailboxPath.forUser("user", "name"), UID_VALIDITY, mailboxId);
 
-        QuotaRoot quotaRoot = QuotaRoot.quotaRoot("root", Optional.empty());
-        QuotaCount quotaCount = QuotaCount.count(123);
-        QuotaSize quotaSize = QuotaSize.size(456);
-        deleteEvent = eventFactory.mailboxDeleted(mailboxSession, mailbox, quotaRoot, quotaCount, quotaSize);
+        deleteEvent = new EventFactory().mailboxDeleted()
+            .mailboxSession(mailboxSession)
+            .mailboxId(mailboxId)
+            .path(MailboxPath.forUser("user", "name"))
+            .quotaRoot(QuotaRoot.quotaRoot("root", Optional.empty()))
+            .deletedMessageCount(QuotaCount.count(123))
+            .totalDeletedSize(QuotaSize.size(456))
+            .build();
 
         when(mailboxManager.createSystemSession(deleteEvent.getUser().asString()))
             .thenReturn(mailboxSession);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/event/MailboxAnnotationListenerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/event/MailboxAnnotationListenerTest.java
@@ -77,7 +77,7 @@ public class MailboxAnnotationListenerTest {
         mailboxSession = MailboxSessionUtil.create("test");
         listener = new MailboxAnnotationListener(mailboxSessionMapperFactory, mailboxManager);
 
-        deleteEvent = new EventFactory().mailboxDeleted()
+        deleteEvent = EventFactory.mailboxDeleted()
             .mailboxSession(mailboxSession)
             .mailboxId(mailboxId)
             .path(MailboxPath.forUser("user", "name"))

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
@@ -53,7 +53,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSortedMap;
 
 public class MailboxEventAnalyserTest {
     private static final MessageUid UID = MessageUid.of(900);
@@ -107,7 +106,6 @@ public class MailboxEventAnalyserTest {
         }
     }
 
-
     private static final MessageUid MESSAGE_UID = MessageUid.of(1);
     private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create("user");
     private static final MailboxSession OTHER_MAILBOX_SESSION = MailboxSessionUtil.create("user");
@@ -116,6 +114,11 @@ public class MailboxEventAnalyserTest {
     private static final TestId MAILBOX_ID = TestId.of(36);
     private static final int UID_VALIDITY = 1024;
     private static final SimpleMailbox DEFAULT_MAILBOX = new SimpleMailbox(MAILBOX_PATH, UID_VALIDITY, MAILBOX_ID);
+    private static final MailboxListener.Added ADDED = new EventFactory().added()
+        .mailboxSession(MAILBOX_SESSION)
+        .mailbox(DEFAULT_MAILBOX)
+        .addMetaData(new MessageMetaData(MessageUid.of(11), 0, new Flags(), 45, new Date(), new DefaultMessageId()))
+        .build();
 
     private SelectedMailboxImpl testee;
     private EventFactory eventFactory;
@@ -164,23 +167,14 @@ public class MailboxEventAnalyserTest {
 
     @Test
     public void testShouldBeNoSizeChangeOnAdded() {
-        MailboxListener.Added mailboxAdded = eventFactory.added(
-            MAILBOX_SESSION,
-            ImmutableSortedMap.of(MessageUid.of(11),
-                new MessageMetaData(MessageUid.of(11), 0, new Flags(), 45, new Date(), new DefaultMessageId())),
-            DEFAULT_MAILBOX);
-        testee.event(mailboxAdded);
+        testee.event(ADDED);
+
         assertThat(testee.isSizeChanged()).isTrue();
     }
 
     @Test
     public void testShouldNoSizeChangeAfterReset() {
-        MailboxListener.Added mailboxAdded = eventFactory.added(
-            MAILBOX_SESSION,
-            ImmutableSortedMap.of(MessageUid.of(11),
-                new MessageMetaData(MessageUid.of(11), 0, new Flags(), 45, new Date(), new DefaultMessageId())),
-            DEFAULT_MAILBOX);
-        testee.event(mailboxAdded);
+        testee.event(ADDED);
         testee.resetEvents();
 
         assertThat(testee.isSizeChanged()).isFalse();

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
@@ -183,7 +183,7 @@ public class MailboxEventAnalyserTest {
         MailboxListener.FlagsUpdated update = EventFactory.flagsUpdated()
             .mailboxSession(MAILBOX_SESSION)
             .mailbox(DEFAULT_MAILBOX)
-            .updatedFags(NOOP_UPDATED_FLAGS)
+            .updatedFlag(NOOP_UPDATED_FLAGS)
             .build();
 
         testee.event(update);
@@ -196,7 +196,7 @@ public class MailboxEventAnalyserTest {
         MailboxListener.FlagsUpdated update = EventFactory.flagsUpdated()
             .mailboxSession(OTHER_MAILBOX_SESSION)
             .mailbox(DEFAULT_MAILBOX)
-            .updatedFags(ADD_ANSWERED_UPDATED_FLAGS)
+            .updatedFlag(ADD_ANSWERED_UPDATED_FLAGS)
             .build();
 
         testee.event(update);
@@ -211,7 +211,7 @@ public class MailboxEventAnalyserTest {
         MailboxListener.FlagsUpdated update = EventFactory.flagsUpdated()
             .mailboxSession(MAILBOX_SESSION)
             .mailbox(DEFAULT_MAILBOX)
-            .updatedFags(ADD_ANSWERED_UPDATED_FLAGS)
+            .updatedFlag(ADD_ANSWERED_UPDATED_FLAGS)
             .build();
 
         analyser.event(update);
@@ -226,7 +226,7 @@ public class MailboxEventAnalyserTest {
         MailboxListener.FlagsUpdated update = EventFactory.flagsUpdated()
             .mailboxSession(OTHER_MAILBOX_SESSION)
             .mailbox(DEFAULT_MAILBOX)
-            .updatedFags(ADD_ANSWERED_UPDATED_FLAGS)
+            .updatedFlag(ADD_ANSWERED_UPDATED_FLAGS)
             .build();
 
         testee.event(update);
@@ -241,7 +241,7 @@ public class MailboxEventAnalyserTest {
         MailboxListener.FlagsUpdated update = EventFactory.flagsUpdated()
             .mailboxSession(MAILBOX_SESSION)
             .mailbox(DEFAULT_MAILBOX)
-            .updatedFags(NOOP_UPDATED_FLAGS)
+            .updatedFlag(NOOP_UPDATED_FLAGS)
             .build();
 
         testee.event(update);
@@ -256,7 +256,7 @@ public class MailboxEventAnalyserTest {
         MailboxListener.FlagsUpdated update = EventFactory.flagsUpdated()
             .mailboxSession(MAILBOX_SESSION)
             .mailbox(DEFAULT_MAILBOX)
-            .updatedFags(ADD_RECENT_UPDATED_FLAGS)
+            .updatedFlag(ADD_RECENT_UPDATED_FLAGS)
             .build();
 
         testee.event(update);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
@@ -114,14 +114,13 @@ public class MailboxEventAnalyserTest {
     private static final TestId MAILBOX_ID = TestId.of(36);
     private static final int UID_VALIDITY = 1024;
     private static final SimpleMailbox DEFAULT_MAILBOX = new SimpleMailbox(MAILBOX_PATH, UID_VALIDITY, MAILBOX_ID);
-    private static final MailboxListener.Added ADDED = new EventFactory().added()
+    private static final MailboxListener.Added ADDED = EventFactory.added()
         .mailboxSession(MAILBOX_SESSION)
         .mailbox(DEFAULT_MAILBOX)
         .addMetaData(new MessageMetaData(MessageUid.of(11), 0, new Flags(), 45, new Date(), new DefaultMessageId()))
         .build();
 
     private SelectedMailboxImpl testee;
-    private EventFactory eventFactory;
 
     @Before
     public void setUp() throws MailboxException {
@@ -152,7 +151,6 @@ public class MailboxEventAnalyserTest {
             .thenReturn(new SingleMessageResultIterator(messageResult));
 
         testee = new SelectedMailboxImpl(mailboxManager, imapSession, MAILBOX_PATH);
-        eventFactory = new EventFactory();
     }
 
     @Test
@@ -182,7 +180,7 @@ public class MailboxEventAnalyserTest {
 
     @Test
     public void testShouldNotSetUidWhenNoSystemFlagChange() {
-        MailboxListener.FlagsUpdated update = new EventFactory().flagsUpdated()
+        MailboxListener.FlagsUpdated update = EventFactory.flagsUpdated()
             .mailboxSession(MAILBOX_SESSION)
             .mailbox(DEFAULT_MAILBOX)
             .updatedFags(NOOP_UPDATED_FLAGS)
@@ -195,7 +193,7 @@ public class MailboxEventAnalyserTest {
 
     @Test
     public void testShouldSetUidWhenSystemFlagChange() {
-        MailboxListener.FlagsUpdated update = new EventFactory().flagsUpdated()
+        MailboxListener.FlagsUpdated update = EventFactory.flagsUpdated()
             .mailboxSession(OTHER_MAILBOX_SESSION)
             .mailbox(DEFAULT_MAILBOX)
             .updatedFags(ADD_ANSWERED_UPDATED_FLAGS)
@@ -210,7 +208,7 @@ public class MailboxEventAnalyserTest {
     public void testShouldClearFlagUidsUponReset() {
         SelectedMailboxImpl analyser = this.testee;
 
-        MailboxListener.FlagsUpdated update = new EventFactory().flagsUpdated()
+        MailboxListener.FlagsUpdated update = EventFactory.flagsUpdated()
             .mailboxSession(MAILBOX_SESSION)
             .mailbox(DEFAULT_MAILBOX)
             .updatedFags(ADD_ANSWERED_UPDATED_FLAGS)
@@ -225,7 +223,7 @@ public class MailboxEventAnalyserTest {
 
     @Test
     public void testShouldSetUidWhenSystemFlagChangeDifferentSessionInSilentMode() {
-        MailboxListener.FlagsUpdated update = new EventFactory().flagsUpdated()
+        MailboxListener.FlagsUpdated update = EventFactory.flagsUpdated()
             .mailboxSession(OTHER_MAILBOX_SESSION)
             .mailbox(DEFAULT_MAILBOX)
             .updatedFags(ADD_ANSWERED_UPDATED_FLAGS)
@@ -240,7 +238,7 @@ public class MailboxEventAnalyserTest {
 
     @Test
     public void testShouldNotSetUidWhenSystemFlagChangeSameSessionInSilentMode() {
-        MailboxListener.FlagsUpdated update = new EventFactory().flagsUpdated()
+        MailboxListener.FlagsUpdated update = EventFactory.flagsUpdated()
             .mailboxSession(MAILBOX_SESSION)
             .mailbox(DEFAULT_MAILBOX)
             .updatedFags(NOOP_UPDATED_FLAGS)
@@ -255,7 +253,7 @@ public class MailboxEventAnalyserTest {
 
     @Test
     public void testShouldNotSetUidWhenOnlyRecentFlagUpdated() {
-        MailboxListener.FlagsUpdated update = new EventFactory().flagsUpdated()
+        MailboxListener.FlagsUpdated update = EventFactory.flagsUpdated()
             .mailboxSession(MAILBOX_SESSION)
             .mailbox(DEFAULT_MAILBOX)
             .updatedFags(ADD_RECENT_UPDATED_FLAGS)

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/SelectedMailboxImplTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/SelectedMailboxImplTest.java
@@ -164,9 +164,9 @@ public class SelectedMailboxImplTest {
 
     private void emitEvent(MailboxListener mailboxListener) {
         mailboxListener.event(EventFactory.added()
+            .mailboxSession(MailboxSessionUtil.create("user"))
             .mailbox(mailbox)
             .addMetaData(new MessageMetaData(EMITTED_EVENT_UID, MOD_SEQ, new Flags(), SIZE, new Date(), new DefaultMessageId()))
-            .mailboxSession(MailboxSessionUtil.create("user"))
             .build());
     }
 }

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/SelectedMailboxImplTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/SelectedMailboxImplTest.java
@@ -163,7 +163,7 @@ public class SelectedMailboxImplTest {
     }
 
     private void emitEvent(MailboxListener mailboxListener) {
-        mailboxListener.event(new EventFactory().added()
+        mailboxListener.event(EventFactory.added()
             .mailbox(mailbox)
             .addMetaData(new MessageMetaData(EMITTED_EVENT_UID, MOD_SEQ, new Flags(), SIZE, new Date(), new DefaultMessageId()))
             .mailboxSession(MailboxSessionUtil.create("user"))

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/SelectedMailboxImplTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/SelectedMailboxImplTest.java
@@ -26,10 +26,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.security.SecureRandom;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.TreeMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -37,12 +35,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.mail.Flags;
 
-import org.apache.james.core.User;
 import org.apache.james.imap.api.ImapSessionUtils;
 import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.mailbox.MailboxListener;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MailboxSessionUtil;
 import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.model.MailboxConstants;
@@ -165,10 +163,10 @@ public class SelectedMailboxImplTest {
     }
 
     private void emitEvent(MailboxListener mailboxListener) {
-        SecureRandom random = new SecureRandom();
-        TreeMap<MessageUid, MessageMetaData> result = new TreeMap<>();
-        result.put(EMITTED_EVENT_UID, new MessageMetaData(EMITTED_EVENT_UID, MOD_SEQ, new Flags(), SIZE, new Date(), new DefaultMessageId()));
-        mailboxListener.event(new EventFactory().added(MailboxSession.SessionId.of(random.nextLong()),
-            mock(User.class), result, mailbox));
+        mailboxListener.event(new EventFactory().added()
+            .mailbox(mailbox)
+            .addMetaData(new MessageMetaData(EMITTED_EVENT_UID, MOD_SEQ, new Flags(), SIZE, new Date(), new DefaultMessageId()))
+            .mailboxSession(MailboxSessionUtil.create("user"))
+            .build());
     }
 }


### PR DESCRIPTION
Following https://github.com/linagora/james-project/pull/2045#discussion_r242102511 here are builders in EventFactory for Mailbox Events.

This is part of a larger refactoring whose step 2 gonna feature **Dispatcher** removal: Event emitters will directly emit their events using these builders on the DelegatingListener, which will later be the EventBus...