### PR TITLE
MAILBOX-367 extracting RabbitMQ mailqueue common parts to RabbitMQ backend module

### DIFF
--- a/backends-common/rabbitmq/pom.xml
+++ b/backends-common/rabbitmq/pom.xml
@@ -30,6 +30,10 @@
     <artifactId>apache-james-backends-rabbitmq</artifactId>
     <name>Apache James RabbitMQ backend</name>
 
+    <properties>
+        <feign.version>10.0.1</feign.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${james.groupId}</groupId>
@@ -60,6 +64,21 @@
         <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-core</artifactId>
+            <version>${feign.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-jackson</artifactId>
+            <version>${feign.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-slf4j</artifactId>
+            <version>${feign.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backend/rabbitmq/RabbitMQManagementApi.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backend/rabbitmq/RabbitMQManagementApi.java
@@ -17,7 +17,7 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.queue.rabbitmq;
+package org.apache.james.backend.rabbitmq;
 
 import java.util.Date;
 import java.util.List;
@@ -25,7 +25,6 @@ import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
-import org.apache.james.backend.rabbitmq.RabbitMQConfiguration;
 import org.apache.james.util.OptionalUtils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -71,7 +70,7 @@ public class RabbitMQManagementApi {
     private final Api api;
 
     @Inject
-    RabbitMQManagementApi(RabbitMQConfiguration configuration) {
+    public RabbitMQManagementApi(RabbitMQConfiguration configuration) {
         RabbitMQConfiguration.ManagementCredentials credentials = configuration.getManagementCredentials();
         api = Feign.builder()
             .requestInterceptor(new BasicAuthRequestInterceptor(credentials.getUser(), new String(credentials.getPassword())))
@@ -84,11 +83,11 @@ public class RabbitMQManagementApi {
             .target(Api.class, configuration.getManagementUri().toString());
     }
 
-    Stream<MailQueueName> listCreatedMailQueueNames() {
+    public Stream<RabbitMQQueueName> listCreatedMailQueueNames() {
         return api.listQueues()
             .stream()
             .map(x -> x.name)
-            .map(MailQueueName::fromRabbitWorkQueueName)
+            .map(RabbitMQQueueName::fromRabbitWorkQueueName)
             .flatMap(OptionalUtils::toStream)
             .distinct();
     }

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backend/rabbitmq/RabbitMQQueueName.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backend/rabbitmq/RabbitMQQueueName.java
@@ -17,7 +17,7 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.queue.rabbitmq;
+package org.apache.james.backend.rabbitmq;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -26,7 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
-public final class MailQueueName {
+public final class RabbitMQQueueName {
 
     static class WorkQueueName {
         static Optional<WorkQueueName> fromString(String name) {
@@ -51,8 +51,8 @@ public final class MailQueueName {
             return WORKQUEUE_PREFIX + name;
         }
 
-        MailQueueName toMailQueueName() {
-            return MailQueueName.fromString(name);
+        RabbitMQQueueName toRabbitMQQueueName() {
+            return RabbitMQQueueName.fromString(name);
         }
 
         @Override
@@ -114,19 +114,19 @@ public final class MailQueueName {
     private static final String EXCHANGE_PREFIX = PREFIX + "-exchange-";
     @VisibleForTesting static final String WORKQUEUE_PREFIX = PREFIX + "-workqueue-";
 
-    public static MailQueueName fromString(String name) {
+    public static RabbitMQQueueName fromString(String name) {
         Preconditions.checkNotNull(name);
-        return new MailQueueName(name);
+        return new RabbitMQQueueName(name);
     }
 
-    static Optional<MailQueueName> fromRabbitWorkQueueName(String workQueueName) {
+    static Optional<RabbitMQQueueName> fromRabbitWorkQueueName(String workQueueName) {
         return WorkQueueName.fromString(workQueueName)
-            .map(WorkQueueName::toMailQueueName);
+            .map(WorkQueueName::toRabbitMQQueueName);
     }
 
     private final String name;
 
-    private MailQueueName(String name) {
+    private RabbitMQQueueName(String name) {
         this.name = name;
     }
 
@@ -144,8 +144,8 @@ public final class MailQueueName {
 
     @Override
     public final boolean equals(Object o) {
-        if (o instanceof MailQueueName) {
-            MailQueueName that = (MailQueueName) o;
+        if (o instanceof RabbitMQQueueName) {
+            RabbitMQQueueName that = (RabbitMQQueueName) o;
             return Objects.equals(name, that.name);
         }
         return false;

--- a/backends-common/rabbitmq/src/test/java/org/apache/james/backend/rabbitmq/RabbitMQQueueNameTest.java
+++ b/backends-common/rabbitmq/src/test/java/org/apache/james/backend/rabbitmq/RabbitMQQueueNameTest.java
@@ -17,7 +17,7 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.queue.rabbitmq;
+package org.apache.james.backend.rabbitmq;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -26,67 +26,67 @@ import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-class MailQueueNameTest {
+class RabbitMQQueueNameTest {
 
     @Test
     void fromStringShouldThrowWhenNull() {
-        assertThatThrownBy(() -> MailQueueName.fromString(null))
+        assertThatThrownBy(() -> RabbitMQQueueName.fromString(null))
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void fromStringShouldReturnInstanceWhenEmptyString() {
-        assertThat(MailQueueName.fromString("")).isNotNull();
+        assertThat(RabbitMQQueueName.fromString("")).isNotNull();
     }
 
     @Test
     void fromStringShouldReturnInstanceWhenArbitraryString() {
-        assertThat(MailQueueName.fromString("whatever")).isNotNull();
+        assertThat(RabbitMQQueueName.fromString("whatever")).isNotNull();
     }
 
     @Test
     void fromRabbitWorkQueueNameShouldThrowWhenNull() {
-        assertThatThrownBy(() -> MailQueueName.fromRabbitWorkQueueName(null))
+        assertThatThrownBy(() -> RabbitMQQueueName.fromRabbitWorkQueueName(null))
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void fromRabbitWorkQueueNameShouldReturnEmptyWhenArbitraryString() {
-        assertThat(MailQueueName.fromRabbitWorkQueueName("whatever"))
+        assertThat(RabbitMQQueueName.fromRabbitWorkQueueName("whatever"))
             .isEmpty();
     }
 
     @Test
     void fromRabbitWorkQueueNameShouldReturnInstanceWhenPrefixOnlyString() {
-        assertThat(MailQueueName.fromRabbitWorkQueueName(MailQueueName.WORKQUEUE_PREFIX))
-            .contains(MailQueueName.fromString(""));
+        assertThat(RabbitMQQueueName.fromRabbitWorkQueueName(RabbitMQQueueName.WORKQUEUE_PREFIX))
+            .contains(RabbitMQQueueName.fromString(""));
     }
 
     @Test
     void fromRabbitWorkQueueNameShouldReturnInstanceWhenValidQueueName() {
-        assertThat(MailQueueName.fromRabbitWorkQueueName(MailQueueName.WORKQUEUE_PREFIX + "myQueue"))
-            .contains(MailQueueName.fromString("myQueue"));
+        assertThat(RabbitMQQueueName.fromRabbitWorkQueueName(RabbitMQQueueName.WORKQUEUE_PREFIX + "myQueue"))
+            .contains(RabbitMQQueueName.fromString("myQueue"));
     }
 
     @Test
     void shouldConformToBeanContract() {
-        EqualsVerifier.forClass(MailQueueName.class).verify();
+        EqualsVerifier.forClass(RabbitMQQueueName.class).verify();
     }
 
     @Test
     void exchangeNameShouldConformToBeanContract() {
-        EqualsVerifier.forClass(MailQueueName.ExchangeName.class).verify();
+        EqualsVerifier.forClass(RabbitMQQueueName.ExchangeName.class).verify();
     }
 
     @Test
     void workQueueNameShouldConformToBeanContract() {
-        EqualsVerifier.forClass(MailQueueName.WorkQueueName.class).verify();
+        EqualsVerifier.forClass(RabbitMQQueueName.WorkQueueName.class).verify();
     }
 
     @Test
     void fromRabbitWorkQueueNameShouldReturnIdentityWhenToRabbitWorkQueueName() {
-        MailQueueName myQueue = MailQueueName.fromString("myQueue");
-        assertThat(MailQueueName.fromRabbitWorkQueueName(myQueue.toWorkQueueName().asString()))
+        RabbitMQQueueName myQueue = RabbitMQQueueName.fromString("myQueue");
+        assertThat(RabbitMQQueueName.fromRabbitWorkQueueName(myQueue.toWorkQueueName().asString()))
             .contains(myQueue);
     }
 

--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/modules/TestRabbitMQModule.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/modules/TestRabbitMQModule.java
@@ -30,7 +30,7 @@ import javax.inject.Singleton;
 import org.apache.james.CleanupTasksPerformer;
 import org.apache.james.backend.rabbitmq.DockerRabbitMQ;
 import org.apache.james.backend.rabbitmq.RabbitMQConfiguration;
-import org.apache.james.queue.rabbitmq.RabbitMQManagementApi;
+import org.apache.james.backend.rabbitmq.RabbitMQManagementApi;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.CassandraMailQueueViewConfiguration;
 
 import com.google.inject.AbstractModule;

--- a/server/queue/queue-rabbitmq/pom.xml
+++ b/server/queue/queue-rabbitmq/pom.xml
@@ -32,10 +32,6 @@
 
     <name>Apache James :: Server :: Mail Queue :: RabbitMQ</name>
 
-    <properties>
-        <feign.version>10.0.1</feign.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>${james.groupId}</groupId>
@@ -154,21 +150,6 @@
         <dependency>
             <groupId>com.rabbitmq</groupId>
             <artifactId>amqp-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.github.openfeign</groupId>
-            <artifactId>feign-core</artifactId>
-            <version>${feign.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.github.openfeign</groupId>
-            <artifactId>feign-jackson</artifactId>
-            <version>${feign.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.github.openfeign</groupId>
-            <artifactId>feign-slf4j</artifactId>
-            <version>${feign.version}</version>
         </dependency>
         <dependency>
             <groupId>io.projectreactor</groupId>

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
@@ -28,6 +28,8 @@ import java.util.concurrent.ThreadFactory;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.apache.james.backend.rabbitmq.RabbitMQClient;
+import org.apache.james.backend.rabbitmq.RabbitMQQueueName;
 import org.apache.james.metrics.api.Metric;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.queue.api.MailQueue;
@@ -67,14 +69,14 @@ class Dequeuer {
 
     private static final int TEN_MS = 10;
 
-    private final MailQueueName name;
-    private final RabbitClient rabbitClient;
+    private final RabbitMQQueueName name;
+    private final RabbitMQClient rabbitClient;
     private final Function<MailReferenceDTO, Mail> mailLoader;
     private final Metric dequeueMetric;
     private final MailReferenceSerializer mailReferenceSerializer;
     private final MailQueueView mailQueueView;
 
-    Dequeuer(MailQueueName name, RabbitClient rabbitClient, Function<MailReferenceDTO, Mail> mailLoader,
+    Dequeuer(RabbitMQQueueName name, RabbitMQClient rabbitClient, Function<MailReferenceDTO, Mail> mailLoader,
              MailReferenceSerializer serializer, MetricFactory metricFactory,
              MailQueueView mailQueueView) {
         this.name = name;

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/EnqueuedItem.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/EnqueuedItem.java
@@ -22,6 +22,7 @@ package org.apache.james.queue.rabbitmq;
 import java.time.Instant;
 import java.util.Objects;
 
+import org.apache.james.backend.rabbitmq.RabbitMQQueueName;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.MailKey;
 import org.apache.mailet.Mail;
@@ -34,7 +35,7 @@ public class EnqueuedItem {
 
         @FunctionalInterface
         interface RequireMailQueueName {
-            RequireMail mailQueueName(MailQueueName mailQueueName);
+            RequireMail mailQueueName(RabbitMQQueueName mailQueueName);
         }
 
         @FunctionalInterface
@@ -53,12 +54,12 @@ public class EnqueuedItem {
         }
 
         class ReadyToBuild {
-            private final MailQueueName mailQueueName;
+            private final RabbitMQQueueName mailQueueName;
             private final Mail mail;
             private final Instant enqueuedTime;
             private final MimeMessagePartsId partsId;
 
-            ReadyToBuild(MailQueueName mailQueueName, Mail mail, Instant enqueuedTime, MimeMessagePartsId partsId) {
+            ReadyToBuild(RabbitMQQueueName mailQueueName, Mail mail, Instant enqueuedTime, MimeMessagePartsId partsId) {
                 Preconditions.checkNotNull(mailQueueName, "'mailQueueName' is mandatory");
                 Preconditions.checkNotNull(mail, "'mail' is mandatory");
                 Preconditions.checkNotNull(enqueuedTime, "'enqueuedTime' is mandatory");
@@ -79,13 +80,13 @@ public class EnqueuedItem {
         return queueName -> mail -> enqueuedTime -> partsId -> new Builder.ReadyToBuild(queueName, mail, enqueuedTime, partsId);
     }
 
-    private final MailQueueName mailQueueName;
+    private final RabbitMQQueueName mailQueueName;
     private final Mail mail;
     private final MailKey mailKey;
     private final Instant enqueuedTime;
     private final MimeMessagePartsId partsId;
 
-    EnqueuedItem(MailQueueName mailQueueName, Mail mail, Instant enqueuedTime, MimeMessagePartsId partsId) {
+    EnqueuedItem(RabbitMQQueueName mailQueueName, Mail mail, Instant enqueuedTime, MimeMessagePartsId partsId) {
         this.mailQueueName = mailQueueName;
         this.mail = mail;
         this.enqueuedTime = enqueuedTime;
@@ -94,7 +95,7 @@ public class EnqueuedItem {
         this.mailKey = MailKey.of(mail.getName());
     }
 
-    public MailQueueName getMailQueueName() {
+    public RabbitMQQueueName getMailQueueName() {
         return mailQueueName;
     }
 

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Enqueuer.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Enqueuer.java
@@ -27,6 +27,8 @@ import java.util.concurrent.CompletableFuture;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
+import org.apache.james.backend.rabbitmq.RabbitMQClient;
+import org.apache.james.backend.rabbitmq.RabbitMQQueueName;
 import org.apache.james.blob.api.Store;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.james.metrics.api.Metric;
@@ -39,15 +41,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.fge.lambdas.Throwing;
 
 class Enqueuer {
-    private final MailQueueName name;
-    private final RabbitClient rabbitClient;
+    private final RabbitMQQueueName name;
+    private final RabbitMQClient rabbitClient;
     private final Store<MimeMessage, MimeMessagePartsId> mimeMessageStore;
     private final MailReferenceSerializer mailReferenceSerializer;
     private final Metric enqueueMetric;
     private final MailQueueView mailQueueView;
     private final Clock clock;
 
-    Enqueuer(MailQueueName name, RabbitClient rabbitClient, Store<MimeMessage, MimeMessagePartsId> mimeMessageStore,
+    Enqueuer(RabbitMQQueueName name, RabbitMQClient rabbitClient, Store<MimeMessage, MimeMessagePartsId> mimeMessageStore,
              MailReferenceSerializer serializer, MetricFactory metricFactory,
              MailQueueView mailQueueView, Clock clock) {
         this.name = name;

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueue.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueue.java
@@ -21,6 +21,7 @@ package org.apache.james.queue.rabbitmq;
 
 import java.util.concurrent.TimeUnit;
 
+import org.apache.james.backend.rabbitmq.RabbitMQQueueName;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.queue.api.MailQueueItemDecoratorFactory;
 import org.apache.james.queue.api.ManageableMailQueue;
@@ -37,14 +38,14 @@ public class RabbitMQMailQueue implements ManageableMailQueue {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RabbitMQMailQueue.class);
 
-    private final MailQueueName name;
+    private final RabbitMQQueueName name;
     private final MetricFactory metricFactory;
     private final Enqueuer enqueuer;
     private final Dequeuer dequeuer;
     private final MailQueueView mailQueueView;
     private final MailQueueItemDecoratorFactory decoratorFactory;
 
-    RabbitMQMailQueue(MetricFactory metricFactory, MailQueueName name,
+    RabbitMQMailQueue(MetricFactory metricFactory, RabbitMQQueueName name,
                       Enqueuer enqueuer, Dequeuer dequeuer,
                       MailQueueView mailQueueView, MailQueueItemDecoratorFactory decoratorFactory) {
         this.metricFactory = metricFactory;

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/MailQueueView.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/MailQueueView.java
@@ -21,18 +21,18 @@ package org.apache.james.queue.rabbitmq.view.api;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.james.backend.rabbitmq.RabbitMQQueueName;
 import org.apache.james.queue.api.ManageableMailQueue;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
-import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.mailet.Mail;
 
 public interface MailQueueView {
 
     interface Factory {
-        MailQueueView create(MailQueueName mailQueueName);
+        MailQueueView create(RabbitMQQueueName mailQueueName);
     }
 
-    void initialize(MailQueueName mailQueueName);
+    void initialize(RabbitMQQueueName mailQueueName);
 
     CompletableFuture<Void> storeMail(EnqueuedItem enqueuedItem);
 

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/BrowseStartDAO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/BrowseStartDAO.java
@@ -34,13 +34,14 @@ import java.util.Date;
 
 import javax.inject.Inject;
 
+import org.apache.james.backend.rabbitmq.RabbitMQQueueName;
 import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
-import org.apache.james.queue.rabbitmq.MailQueueName;
 
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.google.common.annotations.VisibleForTesting;
+
 import reactor.core.publisher.Mono;
 
 public class BrowseStartDAO {
@@ -78,25 +79,25 @@ public class BrowseStartDAO {
             .value(QUEUE_NAME, bindMarker(QUEUE_NAME)));
     }
 
-    Mono<Instant> findBrowseStart(MailQueueName queueName) {
+    Mono<Instant> findBrowseStart(RabbitMQQueueName queueName) {
         return selectOne(queueName)
             .map(this::getBrowseStart);
     }
 
-    Mono<Void> updateBrowseStart(MailQueueName mailQueueName, Instant sliceStart) {
+    Mono<Void> updateBrowseStart(RabbitMQQueueName mailQueueName, Instant sliceStart) {
         return Mono.fromCompletionStage(executor.executeVoid(updateOne.bind()
             .setTimestamp(BROWSE_START, Date.from(sliceStart))
             .setString(QUEUE_NAME, mailQueueName.asString())));
     }
 
-    Mono<Void> insertInitialBrowseStart(MailQueueName mailQueueName, Instant sliceStart) {
+    Mono<Void> insertInitialBrowseStart(RabbitMQQueueName mailQueueName, Instant sliceStart) {
         return Mono.fromCompletionStage(executor.executeVoid(insertOne.bind()
             .setTimestamp(BROWSE_START, Date.from(sliceStart))
             .setString(QUEUE_NAME, mailQueueName.asString())));
     }
 
     @VisibleForTesting
-    Mono<Row> selectOne(MailQueueName queueName) {
+    Mono<Row> selectOne(RabbitMQQueueName queueName) {
         return Mono.fromCompletionStage(executor.executeSingleRow(
             selectOne.bind()
                 .setString(QUEUE_NAME, queueName.asString())))

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailStore.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailStore.java
@@ -24,8 +24,8 @@ import java.time.Instant;
 
 import javax.inject.Inject;
 
+import org.apache.james.backend.rabbitmq.RabbitMQQueueName;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
-import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.CassandraMailQueueViewConfiguration;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices.BucketId;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.EnqueuedItemWithSlicingContext;
@@ -57,7 +57,7 @@ public class CassandraMailQueueMailStore {
         return enqueuedMailsDao.insert(enqueuedItemAndSlicing);
     }
 
-    Mono<Void> initializeBrowseStart(MailQueueName mailQueueName) {
+    Mono<Void> initializeBrowseStart(RabbitMQQueueName mailQueueName) {
         return browseStartDao
             .insertInitialBrowseStart(mailQueueName, currentSliceStartInstant());
     }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
@@ -23,9 +23,9 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.inject.Inject;
 
+import org.apache.james.backend.rabbitmq.RabbitMQQueueName;
 import org.apache.james.queue.api.ManageableMailQueue;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
-import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.api.DeleteCondition;
 import org.apache.james.queue.rabbitmq.view.api.MailQueueView;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.CassandraMailQueueViewConfiguration;
@@ -57,7 +57,7 @@ public class CassandraMailQueueView implements MailQueueView {
         }
 
         @Override
-        public MailQueueView create(MailQueueName mailQueueName) {
+        public MailQueueView create(RabbitMQQueueName mailQueueName) {
             return new CassandraMailQueueView(storeHelper, mailQueueName, cassandraMailQueueBrowser, cassandraMailQueueMailDelete);
         }
     }
@@ -66,10 +66,10 @@ public class CassandraMailQueueView implements MailQueueView {
     private final CassandraMailQueueBrowser cassandraMailQueueBrowser;
     private final CassandraMailQueueMailDelete cassandraMailQueueMailDelete;
 
-    private final MailQueueName mailQueueName;
+    private final RabbitMQQueueName mailQueueName;
 
     CassandraMailQueueView(CassandraMailQueueMailStore storeHelper,
-                           MailQueueName mailQueueName,
+                           RabbitMQQueueName mailQueueName,
                            CassandraMailQueueBrowser cassandraMailQueueBrowser,
                            CassandraMailQueueMailDelete cassandraMailQueueMailDelete) {
         this.mailQueueName = mailQueueName;
@@ -79,7 +79,7 @@ public class CassandraMailQueueView implements MailQueueView {
     }
 
     @Override
-    public void initialize(MailQueueName mailQueueName) {
+    public void initialize(RabbitMQQueueName mailQueueName) {
         storeHelper.initializeBrowseStart(mailQueueName).block();
     }
 

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAO.java
@@ -29,12 +29,13 @@ import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueV
 
 import javax.inject.Inject;
 
+import org.apache.james.backend.rabbitmq.RabbitMQQueueName;
 import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
-import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.MailKey;
 
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Session;
+
 import reactor.core.publisher.Mono;
 
 public class DeletedMailsDAO {
@@ -63,20 +64,20 @@ public class DeletedMailsDAO {
             .and(eq(MAIL_KEY, bindMarker(MAIL_KEY))));
     }
 
-    Mono<Void> markAsDeleted(MailQueueName mailQueueName, MailKey mailKey) {
+    Mono<Void> markAsDeleted(RabbitMQQueueName mailQueueName, MailKey mailKey) {
         return Mono.fromCompletionStage(executor.executeVoid(insertOne.bind()
             .setString(QUEUE_NAME, mailQueueName.asString())
             .setString(MAIL_KEY, mailKey.getMailKey())));
     }
 
-    Mono<Boolean> isDeleted(MailQueueName mailQueueName, MailKey mailKey) {
+    Mono<Boolean> isDeleted(RabbitMQQueueName mailQueueName, MailKey mailKey) {
         return Mono.fromCompletionStage(executor.executeReturnExists(
             selectOne.bind()
                 .setString(QUEUE_NAME, mailQueueName.asString())
                 .setString(MAIL_KEY, mailKey.getMailKey())));
     }
 
-    Mono<Boolean> isStillEnqueued(MailQueueName mailQueueName, MailKey mailKey) {
+    Mono<Boolean> isStillEnqueued(RabbitMQQueueName mailQueueName, MailKey mailKey) {
         return isDeleted(mailQueueName, mailKey)
             .map(b -> !b);
     }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDAO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDAO.java
@@ -50,18 +50,19 @@ import java.util.Date;
 
 import javax.inject.Inject;
 
+import org.apache.james.backend.rabbitmq.RabbitMQQueueName;
 import org.apache.james.backends.cassandra.init.CassandraTypesProvider;
 import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
 import org.apache.james.backends.cassandra.utils.CassandraUtils;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
-import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.EnqueuedItemWithSlicingContext;
 import org.apache.mailet.Mail;
 
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Session;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -140,7 +141,7 @@ public class EnqueuedMailsDAO {
     }
 
     Flux<EnqueuedItemWithSlicingContext> selectEnqueuedMails(
-        MailQueueName queueName, Slice slice, BucketId bucketId) {
+        RabbitMQQueueName queueName, Slice slice, BucketId bucketId) {
 
         return Mono.fromCompletionStage(executor.execute(
             selectFrom.bind()

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoUtil.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoUtil.java
@@ -53,12 +53,12 @@ import java.util.Optional;
 import javax.mail.internet.AddressException;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.james.backend.rabbitmq.RabbitMQQueueName;
 import org.apache.james.backends.cassandra.init.CassandraTypesProvider;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.james.core.MailAddress;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
-import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.EnqueuedItemWithSlicingContext;
 import org.apache.james.server.core.MailImpl;
@@ -78,7 +78,7 @@ import com.google.common.collect.ImmutableMap;
 public class EnqueuedMailsDaoUtil {
 
     static EnqueuedItemWithSlicingContext toEnqueuedMail(Row row, BlobId.Factory blobFactory) {
-        MailQueueName queueName = MailQueueName.fromString(row.getString(QUEUE_NAME));
+        RabbitMQQueueName queueName = RabbitMQQueueName.fromString(row.getString(QUEUE_NAME));
         Instant timeRangeStart = row.getTimestamp(TIME_RANGE_START).toInstant();
         BucketedSlices.BucketId bucketId = BucketedSlices.BucketId.of(row.getInt(BUCKET_ID));
         Instant enqueuedTime = row.getTimestamp(ENQUEUED_TIME).toInstant();

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/EnqueuedItemTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/EnqueuedItemTest.java
@@ -21,6 +21,11 @@ package org.apache.james.queue.rabbitmq;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Instant;
+
+import javax.mail.MessagingException;
+
+import org.apache.james.backend.rabbitmq.RabbitMQQueueName;
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.mailet.Mail;
@@ -29,18 +34,15 @@ import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-import javax.mail.MessagingException;
-import java.time.Instant;
-
 class EnqueuedItemTest {
 
-    private MailQueueName mailQueueName;
+    private RabbitMQQueueName mailQueueName;
     private Mail mail;
     private Instant enqueuedTime;
     private MimeMessagePartsId partsId;
 
     EnqueuedItemTest() throws MessagingException {
-        mailQueueName = MailQueueName.fromString("mailQueueName");
+        mailQueueName = RabbitMQQueueName.fromString("mailQueueName");
         mail = FakeMail.defaultFakeMail();
         enqueuedTime = Instant.now();
         partsId = MimeMessagePartsId.builder()

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueConfigurationChangeTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueConfigurationChangeTest.java
@@ -33,8 +33,10 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.apache.james.backend.rabbitmq.RabbitMQClient;
 import org.apache.james.backend.rabbitmq.RabbitMQConfiguration;
 import org.apache.james.backend.rabbitmq.RabbitMQExtension;
+import org.apache.james.backend.rabbitmq.RabbitMQManagementApi;
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
@@ -90,7 +92,7 @@ class RabbitMQMailQueueConfigurationChangeTest {
 
     private UpdatableTickingClock clock;
     private RabbitMQManagementApi mqManagementApi;
-    private RabbitClient rabbitClient;
+    private RabbitMQClient rabbitClient;
     private ThreadLocalRandom random;
     private MimeMessageStore.Factory mimeMessageStoreFactory;
 
@@ -106,7 +108,7 @@ class RabbitMQMailQueueConfigurationChangeTest {
             .managementUri(rabbitMQExtension.getRabbitMQ().managementUri())
             .managementCredentials(DEFAULT_MANAGEMENT_CREDENTIAL)
             .build();
-        rabbitClient = new RabbitClient(rabbitMQExtension.getRabbitChannelPool());
+        rabbitClient = new RabbitMQClient(rabbitMQExtension.getRabbitChannelPool());
         mqManagementApi = new RabbitMQManagementApi(rabbitMQConfiguration);
     }
 

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
@@ -33,8 +33,11 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.apache.james.backend.rabbitmq.DockerRabbitMQ;
+import org.apache.james.backend.rabbitmq.RabbitMQClient;
 import org.apache.james.backend.rabbitmq.RabbitMQConfiguration;
 import org.apache.james.backend.rabbitmq.RabbitMQExtension;
+import org.apache.james.backend.rabbitmq.RabbitMQManagementApi;
+import org.apache.james.backend.rabbitmq.RabbitMQQueueName;
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
@@ -117,7 +120,7 @@ public class RabbitMQMailQueueTest implements ManageableMailQueueContract, MailQ
             .managementCredentials(DEFAULT_MANAGEMENT_CREDENTIAL)
             .build();
 
-        RabbitClient rabbitClient = new RabbitClient(rabbitMQExtension.getRabbitChannelPool());
+        RabbitMQClient rabbitClient = new RabbitMQClient(rabbitMQExtension.getRabbitChannelPool());
         RabbitMQMailQueueFactory.PrivateFactory factory = new RabbitMQMailQueueFactory.PrivateFactory(
             metricTestSystem.getSpyMetricFactory(),
             metricTestSystem.getSpyGaugeRegistry(),
@@ -215,7 +218,7 @@ public class RabbitMQMailQueueTest implements ManageableMailQueueContract, MailQ
         String name = "myQueue";
         mailQueueFactory.createQueue(name);
 
-        boolean initialized = CassandraMailQueueViewTestFactory.isInitialized(cassandra.getConf(), MailQueueName.fromString(name));
+        boolean initialized = CassandraMailQueueViewTestFactory.isInitialized(cassandra.getConf(), RabbitMQQueueName.fromString(name));
         assertThat(initialized).isTrue();
     }
 

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMqMailQueueFactoryTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMqMailQueueFactoryTest.java
@@ -31,8 +31,10 @@ import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.james.backend.rabbitmq.RabbitMQClient;
 import org.apache.james.backend.rabbitmq.RabbitMQConfiguration;
 import org.apache.james.backend.rabbitmq.RabbitMQExtension;
+import org.apache.james.backend.rabbitmq.RabbitMQManagementApi;
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.mail.MimeMessageStore;
 import org.apache.james.metrics.api.NoopGaugeRegistry;
@@ -70,7 +72,7 @@ class RabbitMqMailQueueFactoryTest implements MailQueueFactoryContract<RabbitMQM
             .managementCredentials(DEFAULT_MANAGEMENT_CREDENTIAL)
             .build();
 
-        RabbitClient rabbitClient = new RabbitClient(rabbitMQExtension.getRabbitChannelPool());
+        RabbitMQClient rabbitClient = new RabbitMQClient(rabbitMQExtension.getRabbitChannelPool());
         RabbitMQMailQueueFactory.PrivateFactory factory = new RabbitMQMailQueueFactory.PrivateFactory(
             new NoopMetricFactory(),
             new NoopGaugeRegistry(),

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/BrowseStartDAOTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/BrowseStartDAOTest.java
@@ -23,9 +23,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
 
+import org.apache.james.backend.rabbitmq.RabbitMQQueueName;
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
-import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -34,8 +34,8 @@ import reactor.core.publisher.Mono;
 
 class BrowseStartDAOTest {
 
-    private static final MailQueueName OUT_GOING_1 = MailQueueName.fromString("OUT_GOING_1");
-    private static final MailQueueName OUT_GOING_2 = MailQueueName.fromString("OUT_GOING_2");
+    private static final RabbitMQQueueName OUT_GOING_1 = RabbitMQQueueName.fromString("OUT_GOING_1");
+    private static final RabbitMQQueueName OUT_GOING_2 = RabbitMQQueueName.fromString("OUT_GOING_2");
     private static final Instant NOW = Instant.now();
     private static final Instant NOW_PLUS_TEN_SECONDS = NOW.plusSeconds(10);
 

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewTestFactory.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewTestFactory.java
@@ -23,6 +23,7 @@ import java.time.Clock;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
+import org.apache.james.backend.rabbitmq.RabbitMQQueueName;
 import org.apache.james.backends.cassandra.init.CassandraTypesProvider;
 import org.apache.james.backends.cassandra.utils.CassandraUtils;
 import org.apache.james.blob.api.HashBlobId;
@@ -30,7 +31,6 @@ import org.apache.james.blob.mail.MimeMessageStore;
 import org.apache.james.eventsourcing.eventstore.cassandra.CassandraEventStore;
 import org.apache.james.eventsourcing.eventstore.cassandra.EventStoreDao;
 import org.apache.james.eventsourcing.eventstore.cassandra.JsonEventSerializer;
-import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.CassandraMailQueueViewConfiguration;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.CassandraMailQueueViewConfigurationModule;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.EventsourcingConfigurationManagement;
@@ -68,7 +68,7 @@ public class CassandraMailQueueViewTestFactory {
             configuration);
     }
 
-    public static boolean isInitialized(Session session, MailQueueName mailQueueName) {
+    public static boolean isInitialized(Session session, RabbitMQQueueName mailQueueName) {
         BrowseStartDAO browseStartDao = new BrowseStartDAO(session);
         return browseStartDao.findBrowseStart(mailQueueName)
             .map(Optional::ofNullable)

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAOTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAOTest.java
@@ -21,9 +21,9 @@ package org.apache.james.queue.rabbitmq.view.cassandra;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.james.backend.rabbitmq.RabbitMQQueueName;
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
-import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.MailKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,8 +31,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 class DeletedMailsDAOTest {
 
-    private static final MailQueueName OUT_GOING_1 = MailQueueName.fromString("OUT_GOING_1");
-    private static final MailQueueName OUT_GOING_2 = MailQueueName.fromString("OUT_GOING_2");
+    private static final RabbitMQQueueName OUT_GOING_1 = RabbitMQQueueName.fromString("OUT_GOING_1");
+    private static final RabbitMQQueueName OUT_GOING_2 = RabbitMQQueueName.fromString("OUT_GOING_2");
     private static final MailKey MAIL_KEY_1 = MailKey.of("mailkey1");
     private static final MailKey MAIL_KEY_2 = MailKey.of("mailkey2");
 

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import java.time.Instant;
 import java.util.List;
 
+import org.apache.james.backend.rabbitmq.RabbitMQQueueName;
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.utils.CassandraUtils;
@@ -34,7 +35,6 @@ import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
-import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.EnqueuedItemWithSlicingContext;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.MailKey;
 import org.apache.mailet.base.test.FakeMail;
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 class EnqueuedMailsDaoTest {
 
-    private static final MailQueueName OUT_GOING_1 = MailQueueName.fromString("OUT_GOING_1");
+    private static final RabbitMQQueueName OUT_GOING_1 = RabbitMQQueueName.fromString("OUT_GOING_1");
     private static final MailKey MAIL_KEY_1 = MailKey.of("mailkey1");
     private static int BUCKET_ID_VALUE = 10;
     private static final BucketId BUCKET_ID = BucketId.of(BUCKET_ID_VALUE);

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/model/EnqueuedItemWithSlicingContextTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/model/EnqueuedItemWithSlicingContextTest.java
@@ -21,17 +21,18 @@ package org.apache.james.queue.rabbitmq.view.cassandra.model;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Instant;
+
+import javax.mail.MessagingException;
+
+import org.apache.james.backend.rabbitmq.RabbitMQQueueName;
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
-import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.mailet.base.test.FakeMail;
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-
-import javax.mail.MessagingException;
-import java.time.Instant;
 
 class EnqueuedItemWithSlicingContextTest {
 
@@ -40,7 +41,7 @@ class EnqueuedItemWithSlicingContextTest {
 
     private EnqueuedItemWithSlicingContextTest() throws MessagingException {
         enqueuedItem = EnqueuedItem.builder()
-                .mailQueueName(MailQueueName.fromString("mailQueueName"))
+                .mailQueueName(RabbitMQQueueName.fromString("mailQueueName"))
                 .mail(FakeMail.builder()
                         .name("name")
                         .build())


### PR DESCRIPTION
First step in order to implement RabbitMQEventBus. Because I see some very-common parts in RabbitQM mailqueue module could be reused inside

RabbitMQ eventbus like: creating exchanges, polling, publishing, interacting
with rabbitmq management

Basically, there is only moving & renaming classes, nothing else