### PR TITLE
Fix "unconfigured table schemaversion" while run RabbitMQMailQueueTest

### DIFF
--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
@@ -39,6 +39,7 @@ import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.init.configuration.CassandraConfiguration;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.cassandra.CassandraBlobModule;
 import org.apache.james.blob.cassandra.CassandraBlobsDAO;
@@ -80,7 +81,8 @@ public class RabbitMQMailQueueTest implements ManageableMailQueueContract, MailQ
     static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(CassandraModule.aggregateModules(
         CassandraBlobModule.MODULE,
         CassandraMailQueueViewModule.MODULE,
-        CassandraEventStoreModule.MODULE));
+        CassandraEventStoreModule.MODULE,
+        CassandraSchemaVersionModule.MODULE));
 
     @RegisterExtension
     static RabbitMQExtension rabbitMQExtension = new RabbitMQExtension();


### PR DESCRIPTION
```
java.lang.RuntimeException: com.datastax.driver.core.exceptions.InvalidQueryException: unconfigured table schemaversion

    at org.apache.james.backends.cassandra.CassandraCluster.<init>(CassandraCluster.java:67)
    at org.apache.james.backends.cassandra.CassandraCluster.create(CassandraCluster.java:42)
    at org.apache.james.backends.cassandra.CassandraClusterExtension.beforeAll(CassandraClusterExtension.java:44)
```