### PR TITLE
Use NIO for RabbitMQ connections

### DIFF
--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backend/rabbitmq/RabbitMQConnectionFactory.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backend/rabbitmq/RabbitMQConnectionFactory.java
@@ -48,6 +48,7 @@ public class RabbitMQConnectionFactory {
         try {
             ConnectionFactory connectionFactory = new ConnectionFactory();
             connectionFactory.setUri(rabbitMQConfiguration.getUri());
+            connectionFactory.useNio();
             return connectionFactory;
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Tests run on top of DeQueue as Flux use the simple SMTP scenario, CassandraBlobStore.

Before:

![capture d ecran de 2018-12-25 14-52-24](https://user-images.githubusercontent.com/6928740/50416758-dd9f7200-0854-11e9-987b-49f1d1aac00a.png)

After:

![capture d ecran de 2018-12-25 14-52-21](https://user-images.githubusercontent.com/6928740/50416761-e55f1680-0854-11e9-9f5e-96796fa5f6e9.png)

Conclusions:

 - 5% thoughput reduction
 - 5% average latencies reductions, 44% p99 reduction

Note: The NIO setup is recommended by RabbitMQ Reactor lib