### PR TITLE
Event should carry a isNoop method

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/Event.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/Event.java
@@ -23,4 +23,6 @@ import org.apache.james.core.User;
 public interface Event {
 
     User getUser();
+
+    boolean isNoop();
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxListener.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxListener.java
@@ -92,6 +92,11 @@ public interface MailboxListener {
         }
 
         @Override
+        public boolean isNoop() {
+            return false;
+        }
+
+        @Override
         public User getUser() {
             return user;
         }
@@ -206,6 +211,11 @@ public interface MailboxListener {
             this.totalDeletedSize = totalDeletedSize;
         }
 
+        @Override
+        public boolean isNoop() {
+            return false;
+        }
+
         public QuotaRoot getQuotaRoot() {
             return quotaRoot;
         }
@@ -250,6 +260,11 @@ public interface MailboxListener {
         }
 
         @Override
+        public boolean isNoop() {
+            return false;
+        }
+
+        @Override
         public final boolean equals(Object o) {
             if (o instanceof MailboxAdded) {
                 MailboxAdded that = (MailboxAdded) o;
@@ -277,6 +292,11 @@ public interface MailboxListener {
         public MailboxRenamed(MailboxSession.SessionId sessionId, User user, MailboxPath path, MailboxId mailboxId, MailboxPath newPath) {
             super(sessionId, user, path, mailboxId);
             this.newPath = newPath;
+        }
+
+        @Override
+        public boolean isNoop() {
+            return newPath.equals(path);
         }
 
         /**
@@ -322,6 +342,11 @@ public interface MailboxListener {
 
         public ACLDiff getAclDiff() {
             return aclDiff;
+        }
+
+        @Override
+        public boolean isNoop() {
+            return aclDiff.getNewACL().equals(aclDiff.getOldACL());
         }
 
         @Override
@@ -405,6 +430,11 @@ public interface MailboxListener {
         }
 
         @Override
+        public boolean isNoop() {
+            return expunged.isEmpty();
+        }
+
+        @Override
         public final boolean equals(Object o) {
             if (o instanceof Expunged) {
                 Expunged that = (Expunged) o;
@@ -446,6 +476,11 @@ public interface MailboxListener {
 
         public List<UpdatedFlags> getUpdatedFlags() {
             return updatedFlags;
+        }
+
+        @Override
+        public boolean isNoop() {
+            return updatedFlags.isEmpty();
         }
 
         @Override
@@ -496,6 +531,11 @@ public interface MailboxListener {
 
         public Map<MessageUid, MessageMetaData> getAdded() {
             return added;
+        }
+
+        @Override
+        public boolean isNoop() {
+            return added.isEmpty();
         }
 
         @Override

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MessageMoveEvent.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MessageMoveEvent.java
@@ -89,6 +89,7 @@ public class MessageMoveEvent implements Event {
         this.messageIds = messageIds;
     }
 
+    @Override
     public boolean isNoop() {
         return messageIds.isEmpty();
     }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxListenerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxListenerTest.java
@@ -19,11 +19,50 @@
 
 package org.apache.james.mailbox;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+
+import javax.mail.Flags;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.james.core.User;
+import org.apache.james.core.quota.QuotaCount;
+import org.apache.james.core.quota.QuotaSize;
+import org.apache.james.mailbox.acl.ACLDiff;
+import org.apache.james.mailbox.model.MailboxACL;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.MessageMetaData;
+import org.apache.james.mailbox.model.Quota;
+import org.apache.james.mailbox.model.QuotaRoot;
+import org.apache.james.mailbox.model.TestId;
+import org.apache.james.mailbox.model.TestMessageId;
+import org.apache.james.mailbox.model.UpdatedFlags;
 import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedMap;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 class MailboxListenerTest {
+    private static final MailboxPath PATH = MailboxPath.forUser("bob", "mailbox");
+    private static final MailboxPath OTHER_PATH = MailboxPath.forUser("bob", "mailbox.other");
+    private static final User BOB = User.fromUsername("bob");
+    private static final MailboxSession.SessionId SESSION_ID = MailboxSession.SessionId.of(42);
+    private static final TestId MAILBOX_ID = TestId.of(18);
+    private static final QuotaRoot QUOTA_ROOT = QuotaRoot.quotaRoot("bob", Optional.empty());
+    private static final QuotaCount QUOTA_COUNT = QuotaCount.count(34);
+    private static final QuotaSize QUOTA_SIZE = QuotaSize.size(48);
+    private static final MailboxACL ACL_1 = new MailboxACL(
+        Pair.of(MailboxACL.EntryKey.createUserEntryKey("Bob"), new MailboxACL.Rfc4314Rights(MailboxACL.Right.Administer)));
+    private static final MailboxACL ACL_2 = new MailboxACL(
+        Pair.of(MailboxACL.EntryKey.createUserEntryKey("Bob"), new MailboxACL.Rfc4314Rights(MailboxACL.Right.Read)));
+    private static final MessageUid UID = MessageUid.of(85);
+    private static final MessageMetaData META_DATA = new MessageMetaData(UID, 45, new Flags(), 45, new Date(), TestMessageId.of(75));
+
     @Test
     void mailboxAddedShouldMatchBeanContract() {
         EqualsVerifier.forClass(MailboxListener.MailboxAdded.class).verify();
@@ -57,5 +96,111 @@ class MailboxListenerTest {
     @Test
     void flagUpdatedShouldMatchBeanContract() {
         EqualsVerifier.forClass(MailboxListener.FlagsUpdated.class).verify();
+    }
+
+    @Test
+    void renameWithSameNameShouldBeNoop() {
+        MailboxListener.MailboxRenamed mailboxRenamed = new MailboxListener.MailboxRenamed(SESSION_ID, BOB, PATH, MAILBOX_ID, PATH);
+
+        assertThat(mailboxRenamed.isNoop()).isTrue();
+    }
+
+    @Test
+    void renameWithDifferentNameShouldNotBeNoop() {
+        MailboxListener.MailboxRenamed mailboxRenamed = new MailboxListener.MailboxRenamed(SESSION_ID, BOB, PATH, MAILBOX_ID, OTHER_PATH);
+
+        assertThat(mailboxRenamed.isNoop()).isFalse();
+    }
+
+    @Test
+    void addedShouldNotBeNoop() {
+        MailboxListener.MailboxAdded added = new MailboxListener.MailboxAdded(SESSION_ID, BOB, PATH, MAILBOX_ID);
+
+        assertThat(added.isNoop()).isFalse();
+    }
+
+    @Test
+    void removedShouldNotBeNoop() {
+        MailboxListener.MailboxDeletion deletion = new MailboxListener.MailboxDeletion(SESSION_ID, BOB, PATH, QUOTA_ROOT,
+            QUOTA_COUNT, QUOTA_SIZE, MAILBOX_ID);
+
+        assertThat(deletion.isNoop()).isFalse();
+    }
+
+    @Test
+    void aclDiffWithSameAclShouldBeNoop() {
+        MailboxListener.MailboxACLUpdated aclUpdated = new MailboxListener.MailboxACLUpdated(SESSION_ID, BOB, PATH, ACLDiff.computeDiff(ACL_1, ACL_1), MAILBOX_ID);
+
+        assertThat(aclUpdated.isNoop()).isTrue();
+    }
+
+    @Test
+    void aclDiffWithDifferentAclShouldNotBeNoop() {
+        MailboxListener.MailboxACLUpdated aclUpdated = new MailboxListener.MailboxACLUpdated(SESSION_ID, BOB, PATH, ACLDiff.computeDiff(ACL_1, ACL_2), MAILBOX_ID);
+
+        assertThat(aclUpdated.isNoop()).isFalse();
+    }
+
+    @Test
+    void addedShouldBeNoopWhenEmpty() {
+        MailboxListener.Added added = new MailboxListener.Added(SESSION_ID, BOB, PATH, MAILBOX_ID, ImmutableSortedMap.of());
+
+        assertThat(added.isNoop()).isTrue();
+    }
+
+    @Test
+    void addedShouldNotBeNoopWhenNotEmpty() {
+        MailboxListener.Added added = new MailboxListener.Added(SESSION_ID, BOB, PATH, MAILBOX_ID, ImmutableSortedMap.of(UID, META_DATA));
+
+        assertThat(added.isNoop()).isFalse();
+    }
+
+    @Test
+    void expungedShouldBeNoopWhenEmpty() {
+        MailboxListener.Expunged expunged = new MailboxListener.Expunged(SESSION_ID, BOB, PATH, MAILBOX_ID, ImmutableSortedMap.of());
+
+        assertThat(expunged.isNoop()).isTrue();
+    }
+
+    @Test
+    void expungedShouldNotBeNoopWhenNotEmpty() {
+        MailboxListener.Expunged expunged = new MailboxListener.Expunged(SESSION_ID, BOB, PATH, MAILBOX_ID, ImmutableSortedMap.of(UID, META_DATA));
+
+        assertThat(expunged.isNoop()).isFalse();
+    }
+
+    @Test
+    void flagsUpdatedShouldBeNoopWhenEmpty() {
+        MailboxListener.FlagsUpdated flagsUpdated = new MailboxListener.FlagsUpdated(SESSION_ID, BOB, PATH, MAILBOX_ID, ImmutableList.of());
+
+        assertThat(flagsUpdated.isNoop()).isTrue();
+    }
+
+    @Test
+    void flagsUpdatedShouldNotBeNoopWhenNotEmpty() {
+        MailboxListener.FlagsUpdated flagsUpdated = new MailboxListener.FlagsUpdated(SESSION_ID, BOB, PATH, MAILBOX_ID,
+            ImmutableList.of(UpdatedFlags.builder()
+                .uid(UID)
+                .modSeq(45)
+                .newFlags(new Flags())
+                .oldFlags(new Flags(Flags.Flag.ANSWERED))
+                .build()));
+
+        assertThat(flagsUpdated.isNoop()).isFalse();
+    }
+
+    @Test
+    void quotaUsageUpdatedEventShouldNotBeNoop() {
+        MailboxListener.QuotaUsageUpdatedEvent event = new MailboxListener.QuotaUsageUpdatedEvent(BOB, QUOTA_ROOT,
+            Quota.<QuotaCount>builder()
+                .used(QUOTA_COUNT)
+                .computedLimit(QuotaCount.unlimited())
+                .build(),
+            Quota.<QuotaSize>builder()
+                .used(QUOTA_SIZE)
+                .computedLimit(QuotaSize.unlimited())
+                .build(), Instant.now());
+
+        assertThat(event.isNoop()).isFalse();
     }
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/EventBusContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/EventBusContract.java
@@ -28,18 +28,23 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 
+import org.apache.james.core.User;
 import org.apache.james.mailbox.MailboxListener;
+import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.TestId;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 
 public interface EventBusContract {
     MailboxListener.MailboxEvent event = mock(MailboxListener.MailboxEvent.class);
@@ -70,6 +75,30 @@ public interface EventBusContract {
         eventBus().dispatch(event, NO_KEYS).block();
 
         verify(listener, times(1)).event(any());
+    }
+
+    @Test
+    default void groupListenersShouldNotReceiveNoopEvents() {
+        MailboxListener listener = newListener();
+
+        eventBus().register(listener, new GroupA());
+
+        MailboxListener.Added noopEvent = new MailboxListener.Added(MailboxSession.SessionId.of(18), User.fromUsername("bob"), MailboxPath.forUser("bob", "mailbox"), TestId.of(58), ImmutableSortedMap.of());
+        eventBus().dispatch(noopEvent, NO_KEYS).block();
+
+        verifyNoMoreInteractions(listener);
+    }
+
+    @Test
+    default void registeredListenersShouldNotReceiveNoopEvents() {
+        MailboxListener listener = newListener();
+
+        eventBus().register(listener, KEY_1);
+
+        MailboxListener.Added noopEvent = new MailboxListener.Added(MailboxSession.SessionId.of(18), User.fromUsername("bob"), MailboxPath.forUser("bob", "mailbox"), TestId.of(58), ImmutableSortedMap.of());
+        eventBus().dispatch(noopEvent, KEY_1).block();
+
+        verifyNoMoreInteractions(listener);
     }
 
     @Test

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/util/EventCollector.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/util/EventCollector.java
@@ -53,14 +53,4 @@ public class EventCollector implements MailboxListener {
         events.add(event);
     }
 
-    public void mailboxDeleted() {
-    }
-
-    public void mailboxRenamed(String origName, String newName) {
-    }
-
-    public boolean isClosed() {
-        return false;
-    }
-
 }

--- a/mailbox/event/event-memory/src/main/java/org/apache/james/mailbox/events/InVMEventBus.java
+++ b/mailbox/event/event-memory/src/main/java/org/apache/james/mailbox/events/InVMEventBus.java
@@ -62,7 +62,10 @@ public class InVMEventBus implements EventBus {
 
     @Override
     public Mono<Void> dispatch(Event event, Set<RegistrationKey> keys) {
-        return eventDelivery.deliver(registeredListeners(keys), event).synchronousListenerFuture();
+        if (!event.isNoop()) {
+            return eventDelivery.deliver(registeredListeners(keys), event).synchronousListenerFuture();
+        }
+        return Mono.empty();
     }
 
     private Set<MailboxListener> registeredListeners(Set<RegistrationKey> keys) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/DefaultDelegatingMailboxListener.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/DefaultDelegatingMailboxListener.java
@@ -91,18 +91,20 @@ public class DefaultDelegatingMailboxListener implements DelegatingMailboxListen
 
     @Override
     public void event(Event event) {
-        ImmutableList<MailboxListener> listeners = ImmutableList.<MailboxListener>builder()
-            .addAll(registry.getGlobalListeners())
-            .addAll(registeredMailboxListeners(event))
-            .build();
+        if (!event.isNoop()) {
+            ImmutableList<MailboxListener> listeners = ImmutableList.<MailboxListener>builder()
+                .addAll(registry.getGlobalListeners())
+                .addAll(registeredMailboxListeners(event))
+                .build();
 
-        eventDelivery.deliver(listeners, event)
-            .synchronousListenerFuture()
-            .block();
+            eventDelivery.deliver(listeners, event)
+                .synchronousListenerFuture()
+                .block();
 
-        if (event instanceof MailboxDeletion) {
-            MailboxDeletion deletion = (MailboxDeletion) event;
-            registry.deleteRegistryFor(deletion.getMailboxId());
+            if (event instanceof MailboxDeletion) {
+                MailboxDeletion deletion = (MailboxDeletion) event;
+                registry.deleteRegistryFor(deletion.getMailboxId());
+            }
         }
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
@@ -169,8 +169,6 @@ public class MailboxEventDispatcher {
     }
 
     public void event(Event event) {
-        if (!event.isNoop()) {
-            listener.event(event);
-        }
+        listener.event(event);
     }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/event/MailboxEventDispatcher.java
@@ -33,7 +33,6 @@ import org.apache.james.core.quota.QuotaSize;
 import org.apache.james.mailbox.Event;
 import org.apache.james.mailbox.MailboxListener;
 import org.apache.james.mailbox.MailboxSession;
-import org.apache.james.mailbox.MessageMoveEvent;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.acl.ACLDiff;
 import org.apache.james.mailbox.model.MailboxId;
@@ -84,7 +83,7 @@ public class MailboxEventDispatcher {
      * @param mailbox The mailbox
      */
     public void added(MailboxSession session, SortedMap<MessageUid, MessageMetaData> uids, Mailbox mailbox) {
-        listener.event(eventFactory.added(session, uids, mailbox));
+        event(eventFactory.added(session, uids, mailbox));
     }
 
     public void added(MailboxSession session, Mailbox mailbox, MailboxMessage mailboxMessage) {
@@ -111,9 +110,7 @@ public class MailboxEventDispatcher {
      * @param mailbox The mailbox
      */
     public void expunged(MailboxSession session,  Map<MessageUid, MessageMetaData> uids, Mailbox mailbox) {
-        if (!uids.isEmpty()) {
-            listener.event(eventFactory.expunged(session, uids, mailbox));
-        }
+        event(eventFactory.expunged(session, uids, mailbox));
     }
 
     public void expunged(MailboxSession session,  MessageMetaData messageMetaData, Mailbox mailbox) {
@@ -128,9 +125,7 @@ public class MailboxEventDispatcher {
      * registered MailboxListener will get triggered then
      */
     public void flagsUpdated(MailboxSession session, Mailbox mailbox, List<UpdatedFlags> uflags) {
-        if (!uflags.isEmpty()) {
-            listener.event(eventFactory.flagsUpdated(session, mailbox, uflags));
-        }
+        event(eventFactory.flagsUpdated(session, mailbox, uflags));
     }
 
     public void flagsUpdated(MailboxSession session, Mailbox mailbox, UpdatedFlags uflags) {
@@ -142,7 +137,7 @@ public class MailboxEventDispatcher {
      * MailboxListener will get triggered then
      */
     public void mailboxRenamed(MailboxSession session, MailboxPath from, Mailbox to) {
-        listener.event(eventFactory.mailboxRenamed(session, from, to));
+        event(eventFactory.mailboxRenamed(session, from, to));
     }
 
     /**
@@ -150,7 +145,7 @@ public class MailboxEventDispatcher {
      * MailboxListener will get triggered then
      */
     public void mailboxDeleted(MailboxSession session, Mailbox mailbox, QuotaRoot quotaRoot, QuotaCount deletedMessageCount, QuotaSize totalDeletedSize) {
-        listener.event(eventFactory.mailboxDeleted(session, mailbox, quotaRoot, deletedMessageCount, totalDeletedSize));
+        event(eventFactory.mailboxDeleted(session, mailbox, quotaRoot, deletedMessageCount, totalDeletedSize));
     }
 
     /**
@@ -158,26 +153,24 @@ public class MailboxEventDispatcher {
      * MailboxListener will get triggered then
      */
     public void mailboxAdded(MailboxSession session, Mailbox mailbox) {
-        listener.event(eventFactory.mailboxAdded(session, mailbox));
+        event(eventFactory.mailboxAdded(session, mailbox));
     }
 
     public void aclUpdated(MailboxSession session, MailboxPath mailboxPath, ACLDiff aclDiff, MailboxId mailboxId) {
-        listener.event(eventFactory.aclUpdated(session, mailboxPath, aclDiff, mailboxId));
+        event(eventFactory.aclUpdated(session, mailboxPath, aclDiff, mailboxId));
     }
 
     public void moved(MailboxSession session, MessageMoves messageMoves, Collection<MessageId> messageIds) {
-        MessageMoveEvent moveEvent = eventFactory.moved(session, messageMoves, messageIds);
-
-        if (!moveEvent.isNoop()) {
-            listener.event(moveEvent);
-        }
+        event(eventFactory.moved(session, messageMoves, messageIds));
     }
 
     public void quota(User user, QuotaRoot quotaRoot, Quota<QuotaCount> countQuota, Quota<QuotaSize> sizeQuota) {
-        listener.event(new MailboxListener.QuotaUsageUpdatedEvent(user, quotaRoot, countQuota, sizeQuota, Instant.now()));
+        event(new MailboxListener.QuotaUsageUpdatedEvent(user, quotaRoot, countQuota, sizeQuota, Instant.now()));
     }
 
     public void event(Event event) {
-        listener.event(event);
+        if (!event.isNoop()) {
+            listener.event(event);
+        }
     }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/MailboxEventDispatcherTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/MailboxEventDispatcherTest.java
@@ -44,7 +44,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 public class MailboxEventDispatcherTest {
     private static final MailboxSession.SessionId SESSION_ID = MailboxSession.SessionId.of(10);
@@ -91,7 +90,7 @@ public class MailboxEventDispatcherTest {
         assertThat(collector.getEvents()).hasSize(1)
             .are(INSTANCE_OF_EVENT_FLAGS_UPDATED);
         MailboxListener.FlagsUpdated event = (MailboxListener.FlagsUpdated) collector.getEvents()
-                .get(0);
+            .get(0);
         assertThat(event.getUpdatedFlags().get(0).systemFlagIterator()).isEmpty();
     }
 
@@ -110,7 +109,7 @@ public class MailboxEventDispatcherTest {
         assertThat(collector.getEvents()).hasSize(1)
             .are(INSTANCE_OF_EVENT_FLAGS_UPDATED);
         MailboxListener.FlagsUpdated event = (MailboxListener.FlagsUpdated) collector.getEvents()
-                .get(0);
+            .get(0);
         assertThat(event.getUpdatedFlags().get(0).systemFlagIterator())
             .containsOnly(Flags.Flag.ANSWERED);
     }
@@ -130,7 +129,7 @@ public class MailboxEventDispatcherTest {
         assertThat(collector.getEvents()).hasSize(1)
             .are(INSTANCE_OF_EVENT_FLAGS_UPDATED);
         MailboxListener.FlagsUpdated event = (MailboxListener.FlagsUpdated) collector.getEvents()
-                .get(0);
+            .get(0);
         assertThat(event.getUpdatedFlags().get(0).systemFlagIterator())
             .containsOnly(Flags.Flag.ANSWERED);
     }
@@ -149,7 +148,7 @@ public class MailboxEventDispatcherTest {
         assertThat(collector.getEvents()).hasSize(1)
             .are(INSTANCE_OF_EVENT_FLAGS_UPDATED);
         MailboxListener.FlagsUpdated event = (MailboxListener.FlagsUpdated) collector.getEvents()
-                .get(0);
+            .get(0);
         assertThat(event.getUpdatedFlags().get(0).systemFlagIterator())
             .containsOnly(Flags.Flag.DELETED);
     }
@@ -168,7 +167,7 @@ public class MailboxEventDispatcherTest {
         assertThat(collector.getEvents()).hasSize(1)
             .are(INSTANCE_OF_EVENT_FLAGS_UPDATED);
         MailboxListener.FlagsUpdated event = (MailboxListener.FlagsUpdated) collector.getEvents()
-                .get(0);
+            .get(0);
         assertThat(event.getUpdatedFlags().get(0).systemFlagIterator())
             .containsOnly(Flags.Flag.DELETED);
     }
@@ -187,7 +186,7 @@ public class MailboxEventDispatcherTest {
         assertThat(collector.getEvents()).hasSize(1)
             .are(INSTANCE_OF_EVENT_FLAGS_UPDATED);
         MailboxListener.FlagsUpdated event = (MailboxListener.FlagsUpdated) collector.getEvents()
-                .get(0);
+            .get(0);
         assertThat(event.getUpdatedFlags().get(0).systemFlagIterator())
             .containsOnly(Flags.Flag.DRAFT);
     }
@@ -206,7 +205,7 @@ public class MailboxEventDispatcherTest {
         assertThat(collector.getEvents()).hasSize(1)
             .are(INSTANCE_OF_EVENT_FLAGS_UPDATED);
         MailboxListener.FlagsUpdated event = (MailboxListener.FlagsUpdated) collector.getEvents()
-                .get(0);
+            .get(0);
         assertThat(event.getUpdatedFlags().get(0).systemFlagIterator())
             .containsOnly(Flags.Flag.DRAFT);
     }
@@ -225,7 +224,7 @@ public class MailboxEventDispatcherTest {
         assertThat(collector.getEvents()).hasSize(1)
             .are(INSTANCE_OF_EVENT_FLAGS_UPDATED);
         MailboxListener.FlagsUpdated event = (MailboxListener.FlagsUpdated) collector.getEvents()
-                .get(0);
+            .get(0);
         assertThat(event.getUpdatedFlags().get(0).systemFlagIterator())
             .containsOnly(Flags.Flag.FLAGGED);
     }
@@ -244,7 +243,7 @@ public class MailboxEventDispatcherTest {
         assertThat(collector.getEvents()).hasSize(1)
             .are(INSTANCE_OF_EVENT_FLAGS_UPDATED);
         MailboxListener.FlagsUpdated event = (MailboxListener.FlagsUpdated) collector.getEvents()
-                .get(0);
+            .get(0);
         assertThat(event.getUpdatedFlags().get(0).systemFlagIterator())
             .containsOnly(Flags.Flag.FLAGGED);
     }
@@ -263,7 +262,7 @@ public class MailboxEventDispatcherTest {
         assertThat(collector.getEvents()).hasSize(1)
             .are(INSTANCE_OF_EVENT_FLAGS_UPDATED);
         MailboxListener.FlagsUpdated event = (MailboxListener.FlagsUpdated) collector.getEvents()
-                .get(0);
+            .get(0);
         assertThat(event.getUpdatedFlags().get(0).systemFlagIterator())
             .containsOnly(Flags.Flag.RECENT);
     }
@@ -282,7 +281,7 @@ public class MailboxEventDispatcherTest {
         assertThat(collector.getEvents()).hasSize(1)
             .are(INSTANCE_OF_EVENT_FLAGS_UPDATED);
         MailboxListener.FlagsUpdated event = (MailboxListener.FlagsUpdated) collector.getEvents()
-                .get(0);
+            .get(0);
         assertThat(event.getUpdatedFlags().get(0).systemFlagIterator())
             .containsOnly(Flags.Flag.RECENT);
     }
@@ -301,7 +300,7 @@ public class MailboxEventDispatcherTest {
         assertThat(collector.getEvents()).hasSize(1)
             .are(INSTANCE_OF_EVENT_FLAGS_UPDATED);
         MailboxListener.FlagsUpdated event = (MailboxListener.FlagsUpdated) collector.getEvents()
-                .get(0);
+            .get(0);
         assertThat(event.getUpdatedFlags().get(0).systemFlagIterator())
             .containsOnly(Flags.Flag.SEEN);
     }
@@ -346,17 +345,5 @@ public class MailboxEventDispatcherTest {
                 .get(0);
         assertThat(event.getUpdatedFlags().get(0).systemFlagIterator())
             .containsOnly(Flags.Flag.SEEN, Flags.Flag.RECENT, Flags.Flag.ANSWERED);
-    }
-
-    @Test
-    public void expungedShouldNotFireEventWhenEmptyMap() {
-        dispatcher.expunged(session, ImmutableMap.of(), mailbox);
-        assertThat(collector.getEvents()).isEmpty();
-    }
-
-    @Test
-    public void flagsUpdatedShouldNotFireEventWhenEmptyIdList() {
-        dispatcher.flagsUpdated(session, mailbox, ImmutableList.of());
-        assertThat(collector.getEvents()).isEmpty();
     }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/event/DefaultDelegatingMailboxListenerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/event/DefaultDelegatingMailboxListenerTest.java
@@ -81,7 +81,7 @@ public class DefaultDelegatingMailboxListenerTest {
 
     @Test
     public void eventShouldWork() {
-        MailboxListener.MailboxEvent event = new MailboxListener.MailboxEvent(null, null, MAILBOX_PATH, MAILBOX_ID) {};
+        MailboxListener.MailboxEvent event = new MailboxListener.MailboxAdded(null, null, MAILBOX_PATH, MAILBOX_ID);
         defaultDelegatingMailboxListener.event(event);
         assertThat(mailboxEventCollector.getEvents()).containsExactly(event);
         assertThat(eachNodeEventCollector.getEvents()).containsExactly(event);
@@ -90,7 +90,7 @@ public class DefaultDelegatingMailboxListenerTest {
 
     @Test
     public void eventShouldOnlyTriggerMAILBOXListenerRelatedToTheEvent() {
-        MailboxListener.MailboxEvent event = new MailboxListener.MailboxEvent(null, null, OTHER_MAILBOX_PATH, OTHER_MAILBOX_ID) {};
+        MailboxListener.MailboxEvent event = new MailboxListener.MailboxAdded(null, null, OTHER_MAILBOX_PATH, OTHER_MAILBOX_ID);
         defaultDelegatingMailboxListener.event(event);
         assertThat(mailboxEventCollector.getEvents()).isEmpty();
         assertThat(eachNodeEventCollector.getEvents()).containsExactly(event);
@@ -102,9 +102,9 @@ public class DefaultDelegatingMailboxListenerTest {
         QuotaRoot quotaRoot = QuotaRoot.quotaRoot("root", null);
         QuotaCount deletedMessageCount = QuotaCount.count(123);
         QuotaSize totalDeletedSize = QuotaSize.size(456);
-        MailboxListener.MailboxDeletion event = new MailboxListener.MailboxDeletion(null, null, MAILBOX_PATH, quotaRoot, deletedMessageCount, totalDeletedSize, MAILBOX_ID) {};
+        MailboxListener.MailboxDeletion event = new MailboxListener.MailboxDeletion(null, null, MAILBOX_PATH, quotaRoot, deletedMessageCount, totalDeletedSize, MAILBOX_ID);
         defaultDelegatingMailboxListener.event(event);
-        MailboxListener.MailboxEvent secondEvent = new MailboxListener.MailboxEvent(null, null, MAILBOX_PATH, MAILBOX_ID) {};
+        MailboxListener.MailboxEvent secondEvent = new MailboxListener.MailboxAdded(null, null, MAILBOX_PATH, MAILBOX_ID);
         defaultDelegatingMailboxListener.event(secondEvent);
         assertThat(mailboxEventCollector.getEvents()).containsExactly(event);
         assertThat(eachNodeEventCollector.getEvents()).containsOnly(event, secondEvent);
@@ -116,9 +116,9 @@ public class DefaultDelegatingMailboxListenerTest {
         QuotaRoot quotaRoot = QuotaRoot.quotaRoot("root", null);
         QuotaCount quotaCount = QuotaCount.count(123);
         QuotaSize quotaSize = QuotaSize.size(456);
-        MailboxListener.MailboxDeletion event = new MailboxListener.MailboxDeletion(null, null, MAILBOX_PATH, quotaRoot, quotaCount, quotaSize, MAILBOX_ID) {};
+        MailboxListener.MailboxDeletion event = new MailboxListener.MailboxDeletion(null, null, MAILBOX_PATH, quotaRoot, quotaCount, quotaSize, MAILBOX_ID);
         defaultDelegatingMailboxListener.event(event);
-        MailboxListener.MailboxEvent secondEvent = new MailboxListener.MailboxEvent(null, null, OTHER_MAILBOX_PATH, MAILBOX_ID) {};
+        MailboxListener.MailboxEvent secondEvent = new MailboxListener.MailboxAdded(null, null, OTHER_MAILBOX_PATH, MAILBOX_ID);
         defaultDelegatingMailboxListener.event(secondEvent);
         assertThat(mailboxEventCollector.getEvents()).containsExactly(event);
         assertThat(eachNodeEventCollector.getEvents()).containsOnly(event, secondEvent);
@@ -128,7 +128,7 @@ public class DefaultDelegatingMailboxListenerTest {
     @Test
     public void removeListenerShouldWork() {
         defaultDelegatingMailboxListener.removeListener(MAILBOX_ID, mailboxEventCollector, null);
-        MailboxListener.MailboxEvent event = new MailboxListener.MailboxEvent(null, null, MAILBOX_PATH, MAILBOX_ID) {};
+        MailboxListener.MailboxEvent event = new MailboxListener.MailboxAdded(null, null, MAILBOX_PATH, MAILBOX_ID);
         defaultDelegatingMailboxListener.event(event);
         assertThat(mailboxEventCollector.getEvents()).isEmpty();
         assertThat(eachNodeEventCollector.getEvents()).containsExactly(event);
@@ -138,7 +138,7 @@ public class DefaultDelegatingMailboxListenerTest {
     @Test
     public void removeListenerShouldNotRemoveAListenerFromADifferentPath() {
         defaultDelegatingMailboxListener.removeListener(OTHER_MAILBOX_ID, mailboxEventCollector, null);
-        MailboxListener.MailboxEvent event = new MailboxListener.MailboxEvent(null, null, MAILBOX_PATH, MAILBOX_ID) {};
+        MailboxListener.MailboxEvent event = new MailboxListener.MailboxAdded(null, null, MAILBOX_PATH, MAILBOX_ID);
         defaultDelegatingMailboxListener.event(event);
         assertThat(mailboxEventCollector.getEvents()).containsExactly(event);
         assertThat(eachNodeEventCollector.getEvents()).containsExactly(event);
@@ -148,7 +148,7 @@ public class DefaultDelegatingMailboxListenerTest {
     @Test
     public void removeGlobalListenerShouldWorkForONCE() {
         defaultDelegatingMailboxListener.removeGlobalListener(eachNodeEventCollector, null);
-        MailboxListener.MailboxEvent event = new MailboxListener.MailboxEvent(null, null, MAILBOX_PATH, MAILBOX_ID) {};
+        MailboxListener.MailboxEvent event = new MailboxListener.MailboxAdded(null, null, MAILBOX_PATH, MAILBOX_ID);
         defaultDelegatingMailboxListener.event(event);
         assertThat(mailboxEventCollector.getEvents()).containsExactly(event);
         assertThat(eachNodeEventCollector.getEvents()).isEmpty();
@@ -158,7 +158,7 @@ public class DefaultDelegatingMailboxListenerTest {
     @Test
     public void removeGlobalListenerShouldWorkForEACH_NODE() throws Exception {
         defaultDelegatingMailboxListener.removeGlobalListener(onceEventCollector, null);
-        MailboxListener.MailboxEvent event = new MailboxListener.MailboxEvent(null, null, MAILBOX_PATH, MAILBOX_ID) {};
+        MailboxListener.MailboxEvent event = new MailboxListener.MailboxAdded(null, null, MAILBOX_PATH, MAILBOX_ID);
         defaultDelegatingMailboxListener.event(event);
         assertThat(mailboxEventCollector.getEvents()).containsExactly(event);
         assertThat(eachNodeEventCollector.getEvents()).containsExactly(event);
@@ -168,8 +168,8 @@ public class DefaultDelegatingMailboxListenerTest {
     @Test
     public void listenersErrorsShouldNotBePropageted() throws Exception {
         MailboxSession session = MailboxSessionUtil.create("benwa");
-        MailboxListener.MailboxEvent event = new MailboxListener.MailboxEvent(session.getSessionId(),
-            session.getUser(), MAILBOX_PATH, MAILBOX_ID) {};
+        MailboxListener.MailboxEvent event = new MailboxListener.MailboxAdded(session.getSessionId(),
+            session.getUser(), MAILBOX_PATH, MAILBOX_ID);
         MailboxListener mockedListener = mock(MailboxListener.class);
         when(mockedListener.getType()).thenReturn(MailboxListener.ListenerType.ONCE);
         doThrow(new RuntimeException()).when(mockedListener).event(event);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/event/DefaultDelegatingMailboxListenerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/event/DefaultDelegatingMailboxListenerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.apache.james.core.User;
 import org.apache.james.core.quota.QuotaCount;
 import org.apache.james.core.quota.QuotaSize;
 import org.apache.james.mailbox.MailboxListener;
@@ -37,6 +38,8 @@ import org.apache.james.mailbox.model.TestId;
 import org.apache.james.mailbox.util.EventCollector;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableSortedMap;
 
 public class DefaultDelegatingMailboxListenerTest {
 
@@ -177,6 +180,16 @@ public class DefaultDelegatingMailboxListenerTest {
         defaultDelegatingMailboxListener.addGlobalListener(mockedListener, null);
 
         defaultDelegatingMailboxListener.event(event);
+    }
+
+
+    @Test
+    public void listenersShouldReceiveEvents() {
+        MailboxListener.Added noopEvent = new MailboxListener.Added(MailboxSession.SessionId.of(18), User.fromUsername("bob"), MailboxPath.forUser("bob", "mailbox"), TestId.of(58), ImmutableSortedMap.of());
+
+        defaultDelegatingMailboxListener.event(noopEvent);
+
+        assertThat(onceEventCollector.getEvents()).isEmpty();
     }
 
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/event/MailboxAnnotationListenerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/event/MailboxAnnotationListenerTest.java
@@ -95,7 +95,7 @@ public class MailboxAnnotationListenerTest {
 
     @Test
     public void eventShouldDoNothingIfDoNotHaveMailboxDeletionEvent() {
-        MailboxListener.MailboxEvent event = new MailboxListener.MailboxEvent(null, null, MAILBOX_PATH, MAILBOX_ID) {};
+        MailboxListener.MailboxEvent event = new MailboxListener.MailboxAdded(null, null, MAILBOX_PATH, MAILBOX_ID);
         listener.event(event);
 
         verifyNoMoreInteractions(mailboxSessionMapperFactory);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
@@ -135,8 +135,8 @@ public class MailboxEventAnalyserTest {
 
     @Test
     public void testShouldBeNoSizeChangeOnOtherEvent() {
-        MailboxListener.MailboxEvent event = new MailboxListener.MailboxEvent(MAILBOX_SESSION.getSessionId(),
-            MAILBOX_SESSION.getUser(), MAILBOX_PATH, MAILBOX_ID) {};
+        MailboxListener.MailboxEvent event = new MailboxListener.MailboxAdded(MAILBOX_SESSION.getSessionId(),
+            MAILBOX_SESSION.getUser(), MAILBOX_PATH, MAILBOX_ID);
       
         testee.event(event);
 


### PR DESCRIPTION
MailboxEventDispatcher currently has two responsibilities:

 - Offer convenience methods for building events. This responsibility is removed by https://github.com/linagora/james-project/pull/2058

 - And filtering out noop events, which this PR addresses.

Making events reponsible of telling if they are noop is a first move to eventBus adoption.