### PR TITLE
JAMES-2636 Little RRT API refactorings

### DIFF
--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
@@ -35,8 +35,6 @@ import com.google.common.base.Preconditions;
  */
 public interface RecipientRewriteTable {
     class ErrorMappingException extends Exception {
-        private static final long serialVersionUID = 2348752938798L;
-
         public ErrorMappingException(String string) {
             super(string);
         }

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
@@ -35,27 +35,6 @@ import com.google.common.base.Preconditions;
  */
 public interface RecipientRewriteTable {
 
-    interface Domains {
-
-        Domain WILDCARD = new Domain(RecipientRewriteTable.WILDCARD) {
-
-            @Override
-            public String name() {
-                throw new IllegalStateException();
-            }
-
-            @Override
-            public String toString() {
-                return "Domain : * (Wildcard)";
-            }
-        };
-    }
-
-    /**
-     * The wildcard used for alias domain mappings
-     */
-    String WILDCARD = "*";
-
     void addMapping(MappingSource source, Mapping mapping) throws RecipientRewriteTableException;
 
     void removeMapping(MappingSource source, Mapping mapping) throws RecipientRewriteTableException;

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
@@ -88,7 +88,7 @@ public interface RecipientRewriteTable {
      * @throws ErrorMappingException
      *             get thrown if an error mapping was found
      */
-    Mappings getMappings(String user, Domain domain) throws ErrorMappingException, RecipientRewriteTableException;
+    Mappings getResolvedMappings(String user, Domain domain) throws ErrorMappingException, RecipientRewriteTableException;
 
     /**
      * Return the explicit mapping stored for the given user and domain. Return
@@ -97,7 +97,7 @@ public interface RecipientRewriteTable {
      * @return the collection which holds the mappings.
      * @throws RecipientRewriteTableException
      */
-    Mappings getUserDomainMappings(MappingSource source) throws RecipientRewriteTableException;
+    Mappings getStoredMappings(MappingSource source) throws RecipientRewriteTableException;
 
     /**
      * Return a Map which holds all mappings. The key is the user@domain and the

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
@@ -34,6 +34,24 @@ import com.google.common.base.Preconditions;
  * Interface which should be implemented of classes which map recipients.
  */
 public interface RecipientRewriteTable {
+    class ErrorMappingException extends Exception {
+        private static final long serialVersionUID = 2348752938798L;
+
+        public ErrorMappingException(String string) {
+            super(string);
+        }
+    }
+
+    class TooManyMappingException extends ErrorMappingException {
+        public TooManyMappingException(String string) {
+            super(string);
+        }
+    }
+
+    EnumSet<Mapping.Type> listSourcesSupportedType = EnumSet.of(
+        Mapping.Type.Group,
+        Mapping.Type.Forward,
+        Mapping.Type.Address);
 
     void addMapping(MappingSource source, Mapping mapping) throws RecipientRewriteTableException;
 
@@ -91,40 +109,12 @@ public interface RecipientRewriteTable {
     Map<MappingSource, Mappings> getAllMappings() throws RecipientRewriteTableException;
 
     default List<MappingSource> listSources(Mapping mapping) throws RecipientRewriteTableException {
-        Preconditions.checkArgument(supportsSourceListing(mapping),
+        Preconditions.checkArgument(listSourcesSupportedType.contains(mapping.getType()),
             String.format("Not supported mapping of type %s", mapping.getType()));
 
         return getAllMappings().entrySet().stream()
             .filter(entry -> entry.getValue().contains(mapping))
             .map(Map.Entry::getKey)
             .collect(Guavate.toImmutableList());
-    }
-
-    EnumSet<Mapping.Type> listSourcesSupportedType = EnumSet.of(
-        Mapping.Type.Group,
-        Mapping.Type.Forward,
-        Mapping.Type.Address);
-
-    default boolean supportsSourceListing(Mapping mapping) {
-        return listSourcesSupportedType.contains(
-            mapping.getType());
-    }
-
-    class ErrorMappingException extends Exception {
-
-        private static final long serialVersionUID = 2348752938798L;
-
-        public ErrorMappingException(String string) {
-            super(string);
-        }
-
-    }
-
-    class TooManyMappingException extends ErrorMappingException {
-        
-        public TooManyMappingException(String string) {
-            super(string);
-        }
-
     }
 }

--- a/server/data/data-cassandra/src/main/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTable.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTable.java
@@ -113,7 +113,7 @@ public class CassandraRecipientRewriteTable extends AbstractRecipientRewriteTabl
     }
 
     @Override
-    public Mappings getUserDomainMappings(MappingSource source) {
+    public Mappings getStoredMappings(MappingSource source) {
         return retrieveMappings(source)
             .orElse(null);
     }

--- a/server/data/data-file/src/main/java/org/apache/james/rrt/file/XMLRecipientRewriteTable.java
+++ b/server/data/data-file/src/main/java/org/apache/james/rrt/file/XMLRecipientRewriteTable.java
@@ -68,7 +68,7 @@ public class XMLRecipientRewriteTable extends AbstractRecipientRewriteTable {
     }
 
     @Override
-    public Mappings getUserDomainMappings(MappingSource source) {
+    public Mappings getStoredMappings(MappingSource source) {
         if (mappings == null) {
             return null;
         } else {

--- a/server/data/data-file/src/test/java/org/apache/james/rrt/file/XMLRecipientRewriteTableTest.java
+++ b/server/data/data-file/src/test/java/org/apache/james/rrt/file/XMLRecipientRewriteTableTest.java
@@ -80,7 +80,7 @@ public class XMLRecipientRewriteTableTest extends AbstractRecipientRewriteTableT
     }
 
     protected void addMappingToConfiguration(MappingSource source, String mapping, Type type) throws RecipientRewriteTableException {
-        Mappings mappings = Optional.ofNullable(virtualUserTable.getUserDomainMappings(source))
+        Mappings mappings = Optional.ofNullable(virtualUserTable.getStoredMappings(source))
             .orElse(MappingsImpl.empty());
 
         Mappings updatedMappings = MappingsImpl.from(mappings)
@@ -91,7 +91,7 @@ public class XMLRecipientRewriteTableTest extends AbstractRecipientRewriteTableT
     }
 
     protected void removeMappingFromConfiguration(MappingSource source, String mapping, Type type) throws RecipientRewriteTableException {
-        Mappings oldMappings = Optional.ofNullable(virtualUserTable.getUserDomainMappings(source))
+        Mappings oldMappings = Optional.ofNullable(virtualUserTable.getStoredMappings(source))
             .orElseThrow(() -> new RecipientRewriteTableException("Cannot remove from null mappings"));
 
         Mappings updatedMappings = oldMappings.remove(Mapping.of(type, mapping));

--- a/server/data/data-jdbc/src/main/java/org/apache/james/rrt/jdbc/JDBCRecipientRewriteTable.java
+++ b/server/data/data-jdbc/src/main/java/org/apache/james/rrt/jdbc/JDBCRecipientRewriteTable.java
@@ -189,7 +189,7 @@ public class JDBCRecipientRewriteTable extends AbstractRecipientRewriteTable {
 
     @Override
     public void addMapping(MappingSource source, Mapping mapping) throws RecipientRewriteTableException {
-        Mappings map = getUserDomainMappings(source);
+        Mappings map = getStoredMappings(source);
         if (map != null && map.size() != 0) {
             Mappings updatedMappings = MappingsImpl.from(map).add(mapping).build();
             doUpdateMapping(source, updatedMappings.serialize());
@@ -228,7 +228,7 @@ public class JDBCRecipientRewriteTable extends AbstractRecipientRewriteTable {
     }
 
     @Override
-    public Mappings getUserDomainMappings(MappingSource source) throws RecipientRewriteTableException {
+    public Mappings getStoredMappings(MappingSource source) throws RecipientRewriteTableException {
         Connection conn = null;
         PreparedStatement mappingStmt = null;
         try {
@@ -291,7 +291,7 @@ public class JDBCRecipientRewriteTable extends AbstractRecipientRewriteTable {
 
     @Override
     public void removeMapping(MappingSource source, Mapping mapping) throws RecipientRewriteTableException {
-        Mappings map = getUserDomainMappings(source);
+        Mappings map = getStoredMappings(source);
         if (map != null && map.size() > 1) {
             Mappings updatedMappings = map.remove(mapping);
             doUpdateMapping(source, updatedMappings.serialize());

--- a/server/data/data-jpa/src/main/java/org/apache/james/rrt/jpa/JPARecipientRewriteTable.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/rrt/jpa/JPARecipientRewriteTable.java
@@ -65,7 +65,7 @@ public class JPARecipientRewriteTable extends AbstractRecipientRewriteTable {
 
     @Override
     public void addMapping(MappingSource source, Mapping mapping) throws RecipientRewriteTableException {
-        Mappings map = getUserDomainMappings(source);
+        Mappings map = getStoredMappings(source);
         if (!map.isEmpty()) {
             Mappings updatedMappings = MappingsImpl.from(map).add(mapping).build();
             doUpdateMapping(source, updatedMappings.serialize());
@@ -111,7 +111,7 @@ public class JPARecipientRewriteTable extends AbstractRecipientRewriteTable {
     }
 
     @Override
-    public Mappings getUserDomainMappings(MappingSource source) throws RecipientRewriteTableException {
+    public Mappings getStoredMappings(MappingSource source) throws RecipientRewriteTableException {
         EntityManager entityManager = entityManagerFactory.createEntityManager();
         final EntityTransaction transaction = entityManager.getTransaction();
         try {
@@ -164,7 +164,7 @@ public class JPARecipientRewriteTable extends AbstractRecipientRewriteTable {
 
     @Override
     public void removeMapping(MappingSource source, Mapping mapping) throws RecipientRewriteTableException {
-        Mappings map = getUserDomainMappings(source);
+        Mappings map = getStoredMappings(source);
         if (map.size() > 1) {
             Mappings updatedMappings = map.remove(mapping);
             doUpdateMapping(source, updatedMappings.serialize());

--- a/server/data/data-library/src/main/java/org/apache/james/rrt/lib/AbstractRecipientRewriteTable.java
+++ b/server/data/data-library/src/main/java/org/apache/james/rrt/lib/AbstractRecipientRewriteTable.java
@@ -95,7 +95,7 @@ public abstract class AbstractRecipientRewriteTable implements RecipientRewriteT
     }
 
     @Override
-    public Mappings getMappings(String user, Domain domain) throws ErrorMappingException, RecipientRewriteTableException {
+    public Mappings getResolvedMappings(String user, Domain domain) throws ErrorMappingException, RecipientRewriteTableException {
         return getMappings(User.fromLocalPartWithDomain(user, domain), mappingLimit);
     }
 
@@ -312,7 +312,7 @@ public abstract class AbstractRecipientRewriteTable implements RecipientRewriteT
     protected abstract Mappings mapAddress(String user, Domain domain) throws RecipientRewriteTableException;
 
     private void checkDuplicateMapping(MappingSource source, Mapping mapping) throws RecipientRewriteTableException {
-        Mappings mappings = getUserDomainMappings(source);
+        Mappings mappings = getStoredMappings(source);
         if (mappings != null && mappings.contains(mapping)) {
             throw new MappingAlreadyExistsException("Mapping " + mapping + " for " + source.asString() + " already exist!");
         }

--- a/server/data/data-library/src/main/java/org/apache/james/rrt/lib/RecipientRewriteTableManagement.java
+++ b/server/data/data-library/src/main/java/org/apache/james/rrt/lib/RecipientRewriteTableManagement.java
@@ -95,7 +95,7 @@ public class RecipientRewriteTableManagement extends StandardMBean implements Re
     @Override
     public Mappings getUserDomainMappings(String user, String domain) throws RecipientRewriteTableException {
         MappingSource source = MappingSource.fromUser(user, domain);
-        return rrt.getUserDomainMappings(source);
+        return rrt.getStoredMappings(source);
     }
 
     @Override

--- a/server/data/data-library/src/main/java/org/apache/james/user/lib/AbstractJamesUsersRepository.java
+++ b/server/data/data-library/src/main/java/org/apache/james/user/lib/AbstractJamesUsersRepository.java
@@ -121,7 +121,7 @@ public abstract class AbstractJamesUsersRepository extends AbstractUsersReposito
     }
 
     @Override
-    public Mappings getMappings(String username, Domain domain) throws ErrorMappingException, RecipientRewriteTableException {
+    public Mappings getResolvedMappings(String username, Domain domain) throws ErrorMappingException, RecipientRewriteTableException {
         Builder mappingsBuilder = MappingsImpl.builder();
         try {
             User user = getUserByName(username);
@@ -192,7 +192,7 @@ public abstract class AbstractJamesUsersRepository extends AbstractUsersReposito
                     }
                     try {
                         MappingSource source = MappingSource.fromUser(org.apache.james.core.User.fromUsername(user));
-                        mappings.put(source, getMappings(username, domain));
+                        mappings.put(source, getResolvedMappings(username, domain));
                     } catch (ErrorMappingException e) {
                         // shold never happen here
                     }
@@ -206,7 +206,7 @@ public abstract class AbstractJamesUsersRepository extends AbstractUsersReposito
     }
 
     @Override
-    public Mappings getUserDomainMappings(MappingSource source) throws RecipientRewriteTableException {
+    public Mappings getStoredMappings(MappingSource source) throws RecipientRewriteTableException {
         return MappingsImpl.empty();
     }
 

--- a/server/data/data-library/src/test/java/org/apache/james/rrt/lib/AbstractRecipientRewriteTableTest.java
+++ b/server/data/data-library/src/test/java/org/apache/james/rrt/lib/AbstractRecipientRewriteTableTest.java
@@ -74,7 +74,7 @@ public abstract class AbstractRecipientRewriteTableTest {
     public void testStoreAndGetMappings() throws Exception {
         Domain domain = Domain.of("test");
         virtualUserTable.addMapping(MappingSource.fromDomain(domain), Mapping.regex("prefix_.*:admin@test"));
-        assertThat(virtualUserTable.getMappings("prefix_abc", domain)).isNotEmpty();
+        assertThat(virtualUserTable.getResolvedMappings("prefix_abc", domain)).isNotEmpty();
     }
 
     @Test
@@ -87,12 +87,12 @@ public abstract class AbstractRecipientRewriteTableTest {
         String regex2 = "(.+)@test";
         String invalidRegex = ".*):";
 
-        assertThat(virtualUserTable.getMappings(USER, domain)).describedAs("No mapping")
+        assertThat(virtualUserTable.getResolvedMappings(USER, domain)).describedAs("No mapping")
             .isEqualTo(MappingsImpl.empty());
 
         virtualUserTable.addMapping(source, Mapping.regex(regex));
         virtualUserTable.addMapping(source, Mapping.regex(regex2));
-        assertThat(virtualUserTable.getMappings(USER, domain)).describedAs("Two mappings").hasSize(2);
+        assertThat(virtualUserTable.getResolvedMappings(USER, domain)).describedAs("Two mappings").hasSize(2);
         assertThat(virtualUserTable.getAllMappings()).describedAs("One mappingline").hasSize(1);
         virtualUserTable.removeMapping(source, Mapping.regex(regex));
 
@@ -104,7 +104,7 @@ public abstract class AbstractRecipientRewriteTableTest {
         virtualUserTable.removeMapping(source, Mapping.regex(regex2));
 
 
-        assertThat(virtualUserTable.getMappings(USER, domain)).describedAs("No mapping")
+        assertThat(virtualUserTable.getResolvedMappings(USER, domain)).describedAs("No mapping")
             .isEqualTo(MappingsImpl.empty());
         assertThat(virtualUserTable.getAllMappings()).describedAs("No mapping").isEmpty();
     }
@@ -140,19 +140,19 @@ public abstract class AbstractRecipientRewriteTableTest {
         MappingSource source = MappingSource.fromUser(USER, domain);
         String address2 = "test@james";
 
-        assertThat(virtualUserTable.getMappings(USER, domain)).describedAs("No mapping")
+        assertThat(virtualUserTable.getResolvedMappings(USER, domain)).describedAs("No mapping")
             .isEqualTo(MappingsImpl.empty());
 
         virtualUserTable.addMapping(source, Mapping.address(ADDRESS));
         virtualUserTable.addMapping(source, Mapping.address(address2));
 
-        assertThat(virtualUserTable.getMappings(USER, domain)).describedAs("Two mappings").hasSize(2);
+        assertThat(virtualUserTable.getResolvedMappings(USER, domain)).describedAs("Two mappings").hasSize(2);
         assertThat(virtualUserTable.getAllMappings()).describedAs("One mappingline").hasSize(1);
 
         virtualUserTable.removeMapping(source, Mapping.address(ADDRESS));
         virtualUserTable.removeMapping(source, Mapping.address(address2));
 
-        assertThat(virtualUserTable.getMappings(USER, domain)).describedAs("No mapping")
+        assertThat(virtualUserTable.getResolvedMappings(USER, domain)).describedAs("No mapping")
             .isEqualTo(MappingsImpl.empty());
         assertThat(virtualUserTable.getAllMappings()).describedAs("No mapping").isEmpty();
     }
@@ -163,20 +163,20 @@ public abstract class AbstractRecipientRewriteTableTest {
         MappingSource source = MappingSource.fromUser(USER, domain);
         String error = "bounce!";
 
-        assertThat(virtualUserTable.getMappings(USER, domain)).describedAs("No mapping")
+        assertThat(virtualUserTable.getResolvedMappings(USER, domain)).describedAs("No mapping")
             .isEqualTo(MappingsImpl.empty());
 
         virtualUserTable.addMapping(source, Mapping.error(error));
         assertThat(virtualUserTable.getAllMappings()).describedAs("One mappingline").hasSize(1);
 
         assertThatThrownBy(() ->
-            virtualUserTable.getMappings(USER, domain))
+            virtualUserTable.getResolvedMappings(USER, domain))
             .describedAs("Exception thrown on to many mappings")
             .isInstanceOf(ErrorMappingException.class);
 
         virtualUserTable.removeMapping(source, Mapping.error(error));
 
-        assertThat(virtualUserTable.getMappings(USER, domain)).describedAs("No mapping")
+        assertThat(virtualUserTable.getResolvedMappings(USER, domain)).describedAs("No mapping")
             .isEqualTo(MappingsImpl.empty());
         assertThat(virtualUserTable.getAllMappings()).describedAs("No mapping").isEmpty();
     }
@@ -188,21 +188,21 @@ public abstract class AbstractRecipientRewriteTableTest {
         String address2 = "test@james";
         MappingSource source = MappingSource.fromUser(USER, domain);
 
-        assertThat(virtualUserTable.getMappings(USER, domain)).describedAs("No mapping")
+        assertThat(virtualUserTable.getResolvedMappings(USER, domain)).describedAs("No mapping")
             .isEqualTo(MappingsImpl.empty());
 
         virtualUserTable.addMapping(MappingSource.fromDomain(domain), Mapping.address(ADDRESS));
         virtualUserTable.addMapping(source, Mapping.address(address2));
 
-        assertThat(virtualUserTable.getMappings(USER, domain)).describedAs("One mappings").hasSize(1);
-        assertThat(virtualUserTable.getMappings(user2, domain)).describedAs("One mappings").hasSize(1);
+        assertThat(virtualUserTable.getResolvedMappings(USER, domain)).describedAs("One mappings").hasSize(1);
+        assertThat(virtualUserTable.getResolvedMappings(user2, domain)).describedAs("One mappings").hasSize(1);
 
         virtualUserTable.removeMapping(source, Mapping.address(address2));
         virtualUserTable.removeMapping(MappingSource.fromDomain(domain), Mapping.address(ADDRESS));
 
-        assertThat(virtualUserTable.getMappings(USER, domain)).describedAs("No mapping")
+        assertThat(virtualUserTable.getResolvedMappings(USER, domain)).describedAs("No mapping")
             .isEqualTo(MappingsImpl.empty());
-        assertThat(virtualUserTable.getMappings(user2, domain)).describedAs("No mapping")
+        assertThat(virtualUserTable.getResolvedMappings(user2, domain)).describedAs("No mapping")
             .isEqualTo(MappingsImpl.empty());
     }
 
@@ -224,17 +224,17 @@ public abstract class AbstractRecipientRewriteTableTest {
 
         virtualUserTable.addMapping(source1, Mapping.address(user2 + "@" + domain2.asString()));
         virtualUserTable.addMapping(source2, Mapping.address(user3 + "@" + domain3.asString()));
-        assertThat(virtualUserTable.getMappings(user1, domain1)).containsOnly(Mapping.address(user3 + "@" + domain3.asString()));
+        assertThat(virtualUserTable.getResolvedMappings(user1, domain1)).containsOnly(Mapping.address(user3 + "@" + domain3.asString()));
         virtualUserTable.addMapping(source3, Mapping.address(user1 + "@" + domain1.asString()));
 
         assertThatThrownBy(() ->
-            virtualUserTable.getMappings(user1, domain1))
+            virtualUserTable.getResolvedMappings(user1, domain1))
             .describedAs("Exception thrown on to many mappings")
             .isInstanceOf(ErrorMappingException.class);
 
         // disable recursive mapping
         virtualUserTable.setRecursiveMapping(false);
-        assertThat(virtualUserTable.getMappings(user1, domain1)).describedAs("Not recursive mapped").containsExactly(Mapping.address(user2 + "@" + domain2.asString()));
+        assertThat(virtualUserTable.getResolvedMappings(user1, domain1)).describedAs("Not recursive mapped").containsExactly(Mapping.address(user2 + "@" + domain2.asString()));
     }
 
     @Test
@@ -249,7 +249,7 @@ public abstract class AbstractRecipientRewriteTableTest {
         virtualUserTable.addMapping(MappingSource.fromDomain(aliasDomain), Mapping.address(user2 + "@" + domain));
         virtualUserTable.addMapping(MappingSource.fromDomain(aliasDomain), Mapping.domain(Domain.of(domain)));
 
-        assertThat(virtualUserTable.getMappings(user, aliasDomain))
+        assertThat(virtualUserTable.getResolvedMappings(user, aliasDomain))
             .describedAs("Domain mapped as first, Address mapped as second")
             .isEqualTo(MappingsImpl.builder()
                 .add(Mapping.address(user + "@" + domain))
@@ -279,7 +279,7 @@ public abstract class AbstractRecipientRewriteTableTest {
         virtualUserTable.addMapping(source, Mapping.address(ADDRESS));
         virtualUserTable.addMapping(source, Mapping.regex(ADDRESS));
 
-        assertThat(virtualUserTable.getMappings(USER, domain)).hasSize(2);
+        assertThat(virtualUserTable.getResolvedMappings(USER, domain)).hasSize(2);
     }
 
     @Test
@@ -291,7 +291,7 @@ public abstract class AbstractRecipientRewriteTableTest {
         virtualUserTable.addMapping(source, Mapping.forward(ADDRESS));
         virtualUserTable.addMapping(source, Mapping.forward(address2));
 
-        assertThat(virtualUserTable.getMappings(USER, domain)).hasSize(2);
+        assertThat(virtualUserTable.getResolvedMappings(USER, domain)).hasSize(2);
     }
 
     @Test
@@ -306,7 +306,7 @@ public abstract class AbstractRecipientRewriteTableTest {
         virtualUserTable.removeMapping(source, Mapping.forward(ADDRESS));
         virtualUserTable.removeMapping(source, Mapping.forward(address2));
 
-        assertThat(virtualUserTable.getMappings(USER, domain))
+        assertThat(virtualUserTable.getResolvedMappings(USER, domain))
             .isEqualTo(MappingsImpl.empty());
     }
 
@@ -319,7 +319,7 @@ public abstract class AbstractRecipientRewriteTableTest {
         virtualUserTable.addMapping(source, Mapping.group(ADDRESS));
         virtualUserTable.addMapping(source, Mapping.group(address2));
 
-        assertThat(virtualUserTable.getMappings(USER, domain)).hasSize(2);
+        assertThat(virtualUserTable.getResolvedMappings(USER, domain)).hasSize(2);
     }
 
     @Test
@@ -334,7 +334,7 @@ public abstract class AbstractRecipientRewriteTableTest {
         virtualUserTable.removeMapping(source, Mapping.group(ADDRESS));
         virtualUserTable.removeMapping(source, Mapping.group(address2));
 
-        assertThat(virtualUserTable.getMappings(USER, domain))
+        assertThat(virtualUserTable.getResolvedMappings(USER, domain))
             .isEqualTo(MappingsImpl.empty());
     }
 

--- a/server/data/data-library/src/test/java/org/apache/james/rrt/lib/RewriteTablesStepdefs.java
+++ b/server/data/data-library/src/test/java/org/apache/james/rrt/lib/RewriteTablesStepdefs.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 
 import org.apache.james.core.Domain;
-import org.apache.james.rrt.api.RecipientRewriteTable;
 import org.apache.james.rrt.api.RecipientRewriteTable.ErrorMappingException;
 import org.apache.james.rrt.api.RecipientRewriteTableException;
 
@@ -56,6 +55,10 @@ public class RewriteTablesStepdefs {
     @Given("store \"([^\"]*)\" address mapping for user \"([^\"]*)\" at domain \"([^\"]*)\"")
     public void storeAddressMappingForUserAtDomain(String address, String user, String domain) throws Throwable {
         MappingSource source = MappingSource.fromUser(user, domain);
+        storeAddressMappingForUserAtDomain(address, source);
+    }
+
+    private void storeAddressMappingForUserAtDomain(String address, MappingSource source) throws RecipientRewriteTableException {
         rewriteTable.addAddressMapping(source, address);
     }
 
@@ -67,7 +70,7 @@ public class RewriteTablesStepdefs {
 
     @Given("store \"([^\"]*)\" address mapping as wildcard for domain \"([^\"]*)\"")
     public void storeAddressMappingAsWildcardAtDomain(String address, String domain) throws Throwable {
-        storeAddressMappingForUserAtDomain(address, RecipientRewriteTable.WILDCARD, domain);
+        storeAddressMappingForUserAtDomain(address, MappingSource.fromDomain(Domain.of(domain)));
     }
 
     @Given("store \"([^\"]*)\" alias domain mapping for domain \"([^\"]*)\"")
@@ -106,6 +109,10 @@ public class RewriteTablesStepdefs {
     @When("user \"([^\"]*)\" at domain \"([^\"]*)\" removes a address mapping \"([^\"]*)\"")
     public void userAtDomainRemovesAddressMapping(String user, String domain, String address) throws Throwable {
         MappingSource source = MappingSource.fromUser(user, domain);
+        userAtDomainRemovesAddressMapping(address, source);
+    }
+
+    private void userAtDomainRemovesAddressMapping(String address, MappingSource source) throws RecipientRewriteTableException {
         rewriteTable.removeAddressMapping(source, address);
     }
 
@@ -129,7 +136,7 @@ public class RewriteTablesStepdefs {
 
     @When("wildcard address mapping \"([^\"]*)\" at domain \"([^\"]*)\" is removed")
     public void removeWildcardAddressMappingAtDomain(String address, String domain) throws Throwable {
-        userAtDomainRemovesAddressMapping(RecipientRewriteTable.WILDCARD, domain, address);
+        userAtDomainRemovesAddressMapping(address, MappingSource.fromDomain(Domain.of(domain)));
     }
 
     @When("alias domain mapping \"([^\"]*)\" for \"([^\"]*)\" domain is removed")

--- a/server/data/data-library/src/test/java/org/apache/james/rrt/lib/RewriteTablesStepdefs.java
+++ b/server/data/data-library/src/test/java/org/apache/james/rrt/lib/RewriteTablesStepdefs.java
@@ -151,12 +151,12 @@ public class RewriteTablesStepdefs {
 
     @Then("mappings for user \"([^\"]*)\" at domain \"([^\"]*)\" should be empty")
     public void assertMappingsIsEmpty(String user, String domain) throws Throwable {
-        assertThat(rewriteTable.getMappings(user, Domain.of(domain))).isNullOrEmpty();
+        assertThat(rewriteTable.getResolvedMappings(user, Domain.of(domain))).isNullOrEmpty();
     }
 
     @Then("mappings for user \"([^\"]*)\" at domain \"([^\"]*)\" should contain only \"([^\"]*)\"")
     public void assertMappingsForUser(String user, String domain, List<String> mappings) throws Throwable {
-        assertThat(rewriteTable.getMappings(user, Domain.of(domain)).asStrings()).containsOnlyElementsOf(mappings);
+        assertThat(rewriteTable.getResolvedMappings(user, Domain.of(domain)).asStrings()).containsOnlyElementsOf(mappings);
     }
 
     @Then("a \"([^\"]*)\" exception should have been thrown")
@@ -166,7 +166,7 @@ public class RewriteTablesStepdefs {
 
     @Then("retrieving mappings for user \"([^\"]*)\" at domain \"([^\"]*)\" should raise an ErrorMappingException with message \"([^\"]*)\"")
     public void retrievingMappingsForUserAtDomainShouldRaiseAnException(String user, String domain, String message) throws Exception {
-        assertThatThrownBy(() -> rewriteTable.getMappings(user, Domain.of(domain)))
+        assertThatThrownBy(() -> rewriteTable.getResolvedMappings(user, Domain.of(domain)))
             .isInstanceOf(ErrorMappingException.class)
             .hasMessage(message);
     }

--- a/server/data/data-memory/src/main/java/org/apache/james/rrt/memory/MemoryRecipientRewriteTable.java
+++ b/server/data/data-memory/src/main/java/org/apache/james/rrt/memory/MemoryRecipientRewriteTable.java
@@ -94,7 +94,7 @@ public class MemoryRecipientRewriteTable extends AbstractRecipientRewriteTable {
     }
 
     @Override
-    public Mappings getUserDomainMappings(MappingSource mappingSource) {
+    public Mappings getStoredMappings(MappingSource mappingSource) {
         return retrieveMappings(mappingSource)
             .orElse(null);
     }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessor.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessor.java
@@ -161,7 +161,7 @@ public class RecipientRewriteTableProcessor {
 
     private RrtExecutionResult executeRrtForRecipient(Mail mail, MailAddress recipient) {
         try {
-            Mappings mappings = virtualTableStore.getMappings(recipient.getLocalPart(), recipient.getDomain());
+            Mappings mappings = virtualTableStore.getResolvedMappings(recipient.getLocalPart(), recipient.getDomain());
 
             if (mappings != null && !mappings.isEmpty()) {
                 List<MailAddress> newMailAddresses = handleMappings(mappings, mail, recipient);

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/IsSenderInRRTLoop.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/IsSenderInRRTLoop.java
@@ -57,7 +57,7 @@ public class IsSenderInRRTLoop extends GenericMatcher {
     public Collection<MailAddress> match(Mail mail) {
         try {
             if (mail.hasSender()) {
-                recipientRewriteTable.getMappings(mail.getMaybeSender().get().getLocalPart(), mail.getMaybeSender().get().getDomain());
+                recipientRewriteTable.getResolvedMappings(mail.getMaybeSender().get().getLocalPart(), mail.getMaybeSender().get().getDomain());
             }
         } catch (RecipientRewriteTable.TooManyMappingException e) {
             return mail.getRecipients();

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessorTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/RecipientRewriteTableProcessorTest.java
@@ -221,7 +221,7 @@ public class RecipientRewriteTableProcessorTest {
     
     @Test
     public void processShouldNotRewriteRecipientWhenVirtualTableStoreReturnNullMappings() throws Exception {
-        when(virtualTableStore.getMappings(any(String.class), any(Domain.class))).thenReturn(null);
+        when(virtualTableStore.getResolvedMappings(any(String.class), any(Domain.class))).thenReturn(null);
 
         mail = FakeMail.builder()
             .mimeMessage(message)
@@ -235,7 +235,7 @@ public class RecipientRewriteTableProcessorTest {
     
     @Test
     public void processShouldSendMailToAllErrorRecipientsWhenErrorMappingException() throws Exception {
-        when(virtualTableStore.getMappings(eq("other"), eq(Domain.of(MailAddressFixture.JAMES_LOCAL)))).thenThrow(ErrorMappingException.class);
+        when(virtualTableStore.getResolvedMappings(eq("other"), eq(Domain.of(MailAddressFixture.JAMES_LOCAL)))).thenThrow(ErrorMappingException.class);
 
         mail = FakeMail.builder()
             .sender(MailAddressFixture.ANY_AT_JAMES)
@@ -259,7 +259,7 @@ public class RecipientRewriteTableProcessorTest {
     
     @Test
     public void processShouldSendMailToAllErrorRecipientsWhenRecipientRewriteTableException() throws Exception {
-        when(virtualTableStore.getMappings(eq("other"), eq(Domain.of(MailAddressFixture.JAMES_LOCAL)))).thenThrow(RecipientRewriteTableException.class);
+        when(virtualTableStore.getResolvedMappings(eq("other"), eq(Domain.of(MailAddressFixture.JAMES_LOCAL)))).thenThrow(RecipientRewriteTableException.class);
 
         mail = FakeMail.builder()
             .sender(MailAddressFixture.ANY_AT_JAMES)
@@ -283,7 +283,7 @@ public class RecipientRewriteTableProcessorTest {
     
     @Test
     public void processShouldNotSendMailWhenNoErrorRecipients() throws Exception {
-        when(virtualTableStore.getMappings(any(String.class), any(Domain.class))).thenReturn(null);
+        when(virtualTableStore.getResolvedMappings(any(String.class), any(Domain.class))).thenReturn(null);
 
         mail = FakeMail.builder()
             .mimeMessage(message)
@@ -297,7 +297,7 @@ public class RecipientRewriteTableProcessorTest {
     
     @Test
     public void processShouldResetMailStateToGhostWhenCanNotBuildNewRecipient() throws Exception {
-        when(virtualTableStore.getMappings(any(String.class), any(Domain.class))).thenReturn(mappings);
+        when(virtualTableStore.getResolvedMappings(any(String.class), any(Domain.class))).thenReturn(mappings);
         when(domainList.getDefaultDomain()).thenReturn(Domain.of(MailAddressFixture.JAMES_LOCAL));
 
         mail = FakeMail.builder()

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptHandler.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptHandler.java
@@ -81,7 +81,7 @@ public class ValidRcptHandler extends AbstractValidRcptHandler implements Protoc
         LOGGER.debug("Unknown user {} check if it's an alias", username);
 
         try {
-            Mappings targetString = recipientRewriteTable.getMappings(recipient.getLocalPart(), recipient.getDomain());
+            Mappings targetString = recipientRewriteTable.getResolvedMappings(recipient.getLocalPart(), recipient.getDomain());
 
             if (!targetString.isEmpty()) {
                 return true;

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/DomainMappingsRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/DomainMappingsRoutes.java
@@ -160,7 +160,7 @@ public class DomainMappingsRoutes implements Routes {
     public List<String> getMapping(Request request, Response response) throws RecipientRewriteTableException {
         MappingSource mappingSource = mappingSourceFrom(request);
 
-        return Optional.ofNullable(recipientRewriteTable.getUserDomainMappings(mappingSource).select(Mapping.Type.Domain))
+        return Optional.ofNullable(recipientRewriteTable.getStoredMappings(mappingSource).select(Mapping.Type.Domain))
                 .filter(mappings -> !mappings.isEmpty())
                 .filter(mappings -> mappings.contains(Mapping.Type.Domain))
                 .map(this::toDomainList)

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/ForwardRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/ForwardRoutes.java
@@ -234,7 +234,7 @@ public class ForwardRoutes implements Routes {
     })
     public ImmutableSet<ForwardDestinationResponse> listForwardDestinations(Request request, Response response) throws RecipientRewriteTableException {
         MailAddress baseAddress = parseMailAddress(request.params(FORWARD_BASE_ADDRESS));
-        Mappings mappings = Optional.ofNullable(recipientRewriteTable.getUserDomainMappings(MappingSource.fromMailAddress(baseAddress)))
+        Mappings mappings = Optional.ofNullable(recipientRewriteTable.getStoredMappings(MappingSource.fromMailAddress(baseAddress)))
             .orElse(MappingsImpl.empty())
             .select(Mapping.Type.Forward);
 

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/GroupsRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/GroupsRoutes.java
@@ -242,7 +242,7 @@ public class GroupsRoutes implements Routes {
     })
     public ImmutableSortedSet<String> listGroupMembers(Request request, Response response) throws RecipientRewriteTableException {
         MailAddress groupAddress = parseMailAddress(request.params(GROUP_ADDRESS));
-        Mappings mappings = Optional.ofNullable(recipientRewriteTable.getUserDomainMappings(MappingSource.fromMailAddress(groupAddress)))
+        Mappings mappings = Optional.ofNullable(recipientRewriteTable.getStoredMappings(MappingSource.fromMailAddress(groupAddress)))
             .orElse(MappingsImpl.empty())
             .select(Mapping.Type.Group);
 

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/DomainMappingsRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/DomainMappingsRoutesTest.java
@@ -231,7 +231,7 @@ class DomainMappingsRoutesTest {
 
             recipientRewriteTable.addAliasDomainMapping(mappingSource, Domain.of(alias));
 
-            Assumptions.assumeTrue(recipientRewriteTable.getUserDomainMappings(mappingSource) != null);
+            Assumptions.assumeTrue(recipientRewriteTable.getStoredMappings(mappingSource) != null);
 
             given()
                 .body("to.com")
@@ -247,7 +247,7 @@ class DomainMappingsRoutesTest {
         void getSpecificDomainMappingShouldRespondWithNotFoundWhenHasNoAliases() throws RecipientRewriteTableException {
             String domain = "from.com";
 
-            when(recipientRewriteTable.getUserDomainMappings(any())).thenReturn(MappingsImpl.empty());
+            when(recipientRewriteTable.getStoredMappings(any())).thenReturn(MappingsImpl.empty());
 
             when()
                 .get(domain)
@@ -263,7 +263,7 @@ class DomainMappingsRoutesTest {
         void getSpecificDomainMappingShouldRespondWithNotFoundWhenHasEmptyAliases() throws RecipientRewriteTableException {
             String domain = "from.com";
 
-            when(recipientRewriteTable.getUserDomainMappings(any())).thenReturn(MappingsImpl.empty());
+            when(recipientRewriteTable.getStoredMappings(any())).thenReturn(MappingsImpl.empty());
 
             when()
                 .get(domain)
@@ -306,7 +306,7 @@ class DomainMappingsRoutesTest {
             String aliasDomain = "a.com";
             Mappings mappings = MappingsImpl.fromMappings(Mapping.domain(Domain.of(aliasDomain)));
 
-            when(recipientRewriteTable.getUserDomainMappings(any())).thenReturn(mappings);
+            when(recipientRewriteTable.getStoredMappings(any())).thenReturn(mappings);
 
             List<String> body =
             when()

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/ForwardRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/ForwardRoutesTest.java
@@ -665,7 +665,7 @@ class ForwardRoutesTest {
         void getShouldReturnErrorWhenRecipientRewriteTableExceptionIsThrown() throws Exception {
             doThrow(RecipientRewriteTableException.class)
                 .when(memoryRecipientRewriteTable)
-                .getUserDomainMappings(any());
+                .getStoredMappings(any());
 
             when()
                 .get(ALICE)
@@ -677,7 +677,7 @@ class ForwardRoutesTest {
         void getShouldReturnErrorWhenRuntimeExceptionIsThrown() throws Exception {
             doThrow(RuntimeException.class)
                 .when(memoryRecipientRewriteTable)
-                .getUserDomainMappings(any());
+                .getStoredMappings(any());
 
             when()
                 .get(ALICE)

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/GroupsRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/GroupsRoutesTest.java
@@ -670,7 +670,7 @@ class GroupsRoutesTest {
         void getShouldReturnErrorWhenRecipientRewriteTableExceptionIsThrown() throws Exception {
             doThrow(RecipientRewriteTableException.class)
                 .when(memoryRecipientRewriteTable)
-                .getUserDomainMappings(any());
+                .getStoredMappings(any());
 
             when()
                 .get(GROUP1)
@@ -682,7 +682,7 @@ class GroupsRoutesTest {
         void getShouldReturnErrorWhenRuntimeExceptionIsThrown() throws Exception {
             doThrow(RuntimeException.class)
                 .when(memoryRecipientRewriteTable)
-                .getUserDomainMappings(any());
+                .getStoredMappings(any());
 
             when()
                 .get(GROUP1)


### PR DESCRIPTION
The methods names (**getMappings** vs **getUserDomainMappings**) were not explicit at all and failed to correctly explain the difference between both methods.

The attempted to give them a more appropriate name. **getResolvedMappings** vs **getStoredMappings**

Being there, we also did some minor RRT refactorings...