### PR TITLE
MAILBOX-367 Disable using Nio in RabbitMQ ConnectionFactory

### DIFF
--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backend/rabbitmq/RabbitMQConnectionFactory.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backend/rabbitmq/RabbitMQConnectionFactory.java
@@ -48,7 +48,6 @@ public class RabbitMQConnectionFactory {
         try {
             ConnectionFactory connectionFactory = new ConnectionFactory();
             connectionFactory.setUri(rabbitMQConfiguration.getUri());
-            connectionFactory.useNio();
             return connectionFactory;
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
- While using Nio, RabbitMQEventBusTest #2084 running is not stable. Tests are passed when run separately but not when run at the same time.
- Some tests sometimes be hang for a long times (ie: 9 minutes)
```
[e6486ce48b0304a5cb57df1a11ba3dc5e5ba926f] [INFO] Apache James :: Mailbox :: Event :: RabbitMQ implementation FAILURE [12:23 min]
```
I can not find any better solutions for this except disabling Nio. 