### PR TITLE
MAILBOX-372 Test dispatching from the listeners

### DIFF
--- a/mailbox/event/event-memory/src/main/java/org/apache/james/mailbox/events/delivery/InVmEventDelivery.java
+++ b/mailbox/event/event-memory/src/main/java/org/apache/james/mailbox/events/delivery/InVmEventDelivery.java
@@ -82,6 +82,7 @@ public class InVmEventDelivery implements EventDelivery {
                 listenerName(mailboxListener),
                 eventName(event),
                 throwable))
+            .subscribeOn(Schedulers.elastic())
             .retryBackoff(MAX_RETRIES, FIRST_BACKOFF, MAX_BACKOFF, DEFAULT_JITTER_FACTOR)
             .doOnError(throwable -> LOGGER.error("listener {} exceeded maximum retry({}) to handle event {}",
                 listenerName(mailboxListener),

--- a/mailbox/event/event-memory/src/test/java/org/apache/james/mailbox/events/InVMEventBusTest.java
+++ b/mailbox/event/event-memory/src/test/java/org/apache/james/mailbox/events/InVMEventBusTest.java
@@ -22,7 +22,6 @@ package org.apache.james.mailbox.events;
 import org.apache.james.mailbox.events.delivery.InVmEventDelivery;
 import org.apache.james.metrics.api.NoopMetricFactory;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 
 public class InVMEventBusTest implements KeyContract.SingleEventBusKeyContract, GroupContract.SingleEventBusGroupContract,
     ErrorHandlingContract{
@@ -39,11 +38,5 @@ public class InVMEventBusTest implements KeyContract.SingleEventBusKeyContract, 
     @Override
     public EventBus eventBus() {
         return eventBus;
-    }
-
-    @Disabled("MAILBOX-372 Reactor fails telling us calling .block is not allowed in the retrying thread")
-    @Override
-    public void retryingListenerCallingDispatchShouldNotFail() {
-
     }
 }

--- a/mailbox/event/event-memory/src/test/java/org/apache/james/mailbox/events/InVMEventBusTest.java
+++ b/mailbox/event/event-memory/src/test/java/org/apache/james/mailbox/events/InVMEventBusTest.java
@@ -22,6 +22,7 @@ package org.apache.james.mailbox.events;
 import org.apache.james.mailbox.events.delivery.InVmEventDelivery;
 import org.apache.james.metrics.api.NoopMetricFactory;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 
 public class InVMEventBusTest implements KeyContract.SingleEventBusKeyContract, GroupContract.SingleEventBusGroupContract,
     ErrorHandlingContract{
@@ -38,5 +39,11 @@ public class InVMEventBusTest implements KeyContract.SingleEventBusKeyContract, 
     @Override
     public EventBus eventBus() {
         return eventBus;
+    }
+
+    @Disabled("MAILBOX-372 Reactor fails telling us calling .block is not allowed in the retrying thread")
+    @Override
+    public void retryingListenerCallingDispatchShouldNotFail() {
+
     }
 }


### PR DESCRIPTION
This behaviour corresponds to ListeningCurrentQuotaUpdater

We demonstrate here that InVMEventDelivery do not support dispatch while retrying.

The failing test needs to be solved in a later pull request...

The exact cause is : 

```
java.lang.IllegalStateException: block()/blockFirst()/blockLast() are blocking, which is not supported in thread parallel-3
	at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:77)
	at reactor.core.publisher.Mono.block(Mono.java:1493)
	at org.apache.james.mailbox.store.quota.ListeningCurrentQuotaUpdater.handleExpungedEvent(ListeningCurrentQuotaUpdater.java:102)
	at org.apache.james.mailbox.store.quota.ListeningCurrentQuotaUpdater.event(ListeningCurrentQuotaUpdater.java:73)
	at org.apache.james.mailbox.events.delivery.InVmEventDelivery.doDeliverToListener(InVmEventDelivery.java:97)
	... 17 common frames omitted
```

Found while executing gatling...