### PR TITLE
MAILBOX-374 Use a single channel for Event dispatching 

### DIFF
--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/EventDispatcher.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/EventDispatcher.java
@@ -57,7 +57,7 @@ public class EventDispatcher {
     private final AMQP.BasicProperties basicProperties;
     private final Object lock = new Object();
     private EmitterProcessor<OutboundMessage> emitterProcessor;
-    private Disposable consumerSubscripotion;
+    private Disposable consumerSubscription;
 
     EventDispatcher(EventBusId eventBusId, EventSerializer eventSerializer, Sender sender, MailboxListenerRegistry mailboxListenerRegistry) {
         this.eventSerializer = eventSerializer;
@@ -75,12 +75,12 @@ public class EventDispatcher {
             .block();
 
         emitterProcessor = EmitterProcessor.create();
-        consumerSubscripotion = sender.send(emitterProcessor.publish().autoConnect()).subscribe();
+        consumerSubscription = sender.send(emitterProcessor.publish().autoConnect()).subscribe();
     }
 
     void stop() {
         emitterProcessor.dispose();
-        consumerSubscripotion.dispose();
+        consumerSubscription.dispose();
     }
 
     Mono<Void> dispatch(Event event, Set<RegistrationKey> keys) {

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/EventDispatcher.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/EventDispatcher.java
@@ -109,8 +109,12 @@ public class EventDispatcher {
             Stream.of(RoutingKeyConverter.RoutingKey.empty()),
             keys.stream().map(RoutingKeyConverter.RoutingKey::of));
 
+        return doDispatch(serializedEvent, MAILBOX_EVENT_EXCHANGE_NAME, routingKeyStream, basicProperties);
+    }
+
+    Mono<Void> doDispatch(Mono<byte[]> serializedEvent, String exchangeName, Stream<RoutingKeyConverter.RoutingKey> routingKeyStream, AMQP.BasicProperties properties) {
         Stream<OutboundMessage> outboundMessages = routingKeyStream
-            .map(routingKey -> new OutboundMessage(MAILBOX_EVENT_EXCHANGE_NAME, routingKey.asString(), basicProperties, serializedEvent.block()));
+            .map(routingKey -> new OutboundMessage(exchangeName, routingKey.asString(), properties, serializedEvent.block()));
 
         return Mono.fromRunnable(() -> {
             synchronized (lock) {

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupConsumerRetry.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupConsumerRetry.java
@@ -25,6 +25,8 @@ import static org.apache.james.backend.rabbitmq.Constants.EMPTY_ROUTING_KEY;
 import static org.apache.james.mailbox.events.GroupRegistration.RETRY_COUNT;
 import static org.apache.james.mailbox.events.RabbitMQEventBus.MAILBOX_EVENT;
 
+import java.util.stream.Stream;
+
 import org.apache.james.mailbox.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,13 +40,10 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.rabbitmq.BindingSpecification;
 import reactor.rabbitmq.ExchangeSpecification;
-import reactor.rabbitmq.OutboundMessage;
 import reactor.rabbitmq.Sender;
 
 class GroupConsumerRetry {
-
     static class RetryExchangeName {
-
         static RetryExchangeName of(Group group) {
             return new RetryExchangeName(GroupRegistration.groupName(group.getClass()));
         }
@@ -63,65 +62,24 @@ class GroupConsumerRetry {
         }
     }
 
-    static class RetryPublisher {
-
-        private final Sender sender;
-        private final RetryExchangeName retryExchangeName;
-        private final RetryBackoffConfiguration retryBackoff;
-        private final EventDeadLetters eventDeadLetters;
-        private final GroupRegistration.WorkQueueName queueName;
-
-        RetryPublisher(Sender sender, RetryExchangeName retryExchangeName, RetryBackoffConfiguration retryBackoff,
-                       EventDeadLetters eventDeadLetters, GroupRegistration.WorkQueueName queueName) {
-            this.sender = sender;
-            this.retryExchangeName = retryExchangeName;
-            this.retryBackoff = retryBackoff;
-            this.eventDeadLetters = eventDeadLetters;
-            this.queueName = queueName;
-        }
-
-        Mono<Void> publish(Event event, byte[] eventAsByte, int currentRetryCount) {
-            return Mono.just(currentRetryCount)
-                .flatMap(retryCount -> retryOrStoreToDeadLetter(event, eventAsByte, retryCount));
-        }
-
-        private Mono<Void> retryOrStoreToDeadLetter(Event event, byte[] eventAsByte, int currentRetryCount) {
-            if (currentRetryCount >= retryBackoff.getMaxRetries()) {
-                return eventDeadLetters.store(queueName.getGroup(), event);
-            }
-
-            return sendRetryMessage(event, eventAsByte, currentRetryCount);
-        }
-
-        private Mono<Void> sendRetryMessage(Event event, byte[] eventAsByte, int currentRetryCount) {
-            Mono<OutboundMessage> retryMessage = Mono.just(new OutboundMessage(
-                retryExchangeName.asString(),
-                EMPTY_ROUTING_KEY,
-                new AMQP.BasicProperties.Builder()
-                    .headers(ImmutableMap.of(RETRY_COUNT, currentRetryCount + 1))
-                    .build(),
-                eventAsByte));
-
-            return sender.send(retryMessage)
-                .doOnError(throwable -> LOGGER.error("Exception happens when publishing event of user {} to retry exchange," +
-                    "this event will be lost forever",
-                    event.getUser().asString(), throwable));
-        }
-    }
-
     private static final Logger LOGGER = LoggerFactory.getLogger(GroupConsumerRetry.class);
 
     private final Sender sender;
     private final GroupRegistration.WorkQueueName queueName;
     private final RetryExchangeName retryExchangeName;
-    private final RetryPublisher retryPublisher;
+    private final RetryBackoffConfiguration retryBackoff;
+    private final EventDeadLetters eventDeadLetters;
+    private final EventDispatcher eventDispatcher;
 
     GroupConsumerRetry(Sender sender, GroupRegistration.WorkQueueName queueName, Group group,
-                       RetryBackoffConfiguration retryBackoff, EventDeadLetters eventDeadLetters) {
+                       RetryBackoffConfiguration retryBackoff, EventDeadLetters eventDeadLetters,
+                       EventDispatcher eventDispatcher) {
         this.sender = sender;
         this.queueName = queueName;
         this.retryExchangeName = RetryExchangeName.of(group);
-        this.retryPublisher = new RetryPublisher(sender, retryExchangeName, retryBackoff, eventDeadLetters, queueName);
+        this.retryBackoff = retryBackoff;
+        this.eventDeadLetters = eventDeadLetters;
+        this.eventDispatcher = eventDispatcher;
     }
 
     Mono<Void> createRetryExchange() {
@@ -140,6 +98,27 @@ class GroupConsumerRetry {
         LOGGER.error("Exception happens when handling event {} of user {}",
             event.getEventId().getId().toString(), event.getUser().asString(), throwable);
 
-        return retryPublisher.publish(event, eventAsBytes, currentRetryCount);
+        if (currentRetryCount >= retryBackoff.getMaxRetries()) {
+            return eventDeadLetters.store(queueName.getGroup(), event);
+        } else {
+            return sendRetryMessage(event, eventAsBytes, currentRetryCount);
+        }
+    }
+
+    private Mono<Void> sendRetryMessage(Event event, byte[] eventAsByte, int currentRetryCount) {
+        return eventDispatcher
+            .doDispatch(Mono.just(eventAsByte),
+                retryExchangeName.asString(),
+                Stream.of(RoutingKeyConverter.RoutingKey.empty()),
+                createProperties(currentRetryCount))
+            .doOnError(throwable -> LOGGER.error("Exception happens when publishing event of user {} to retry exchange," +
+                    "this event will be lost forever",
+                event.getUser().asString(), throwable));
+    }
+
+    private AMQP.BasicProperties createProperties(int currentRetryCount) {
+        return new AMQP.BasicProperties.Builder()
+            .headers(ImmutableMap.of(RETRY_COUNT, currentRetryCount + 1))
+            .build();
     }
 }

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupRegistration.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupRegistration.java
@@ -102,7 +102,7 @@ class GroupRegistration implements Registration {
     GroupRegistration(Mono<Connection> connectionSupplier, Sender sender, EventSerializer eventSerializer,
                       MailboxListener mailboxListener, Group group, RetryBackoffConfiguration retryBackoff,
                       EventDeadLetters eventDeadLetters,
-                      Runnable unregisterGroup) {
+                      Runnable unregisterGroup, EventDispatcher eventDispatcher) {
         this.eventSerializer = eventSerializer;
         this.mailboxListener = mailboxListener;
         this.queueName = WorkQueueName.of(group);
@@ -110,7 +110,7 @@ class GroupRegistration implements Registration {
         this.receiver = RabbitFlux.createReceiver(new ReceiverOptions().connectionMono(connectionSupplier));
         this.receiverSubscriber = Optional.empty();
         this.unregisterGroup = unregisterGroup;
-        this.retryHandler = new GroupConsumerRetry(sender, queueName, group, retryBackoff, eventDeadLetters);
+        this.retryHandler = new GroupConsumerRetry(sender, queueName, group, retryBackoff, eventDeadLetters, eventDispatcher);
         this.delayGenerator = WaitDelayGenerator.of(retryBackoff);
     }
 

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupRegistrationHandler.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupRegistrationHandler.java
@@ -37,15 +37,18 @@ class GroupRegistrationHandler {
     private final Mono<Connection> connectionMono;
     private final RetryBackoffConfiguration retryBackoff;
     private final EventDeadLetters eventDeadLetters;
+    private final EventDispatcher eventDispatcher;
 
     GroupRegistrationHandler(EventSerializer eventSerializer, Sender sender, Mono<Connection> connectionMono,
                              RetryBackoffConfiguration retryBackoff,
-                             EventDeadLetters eventDeadLetters) {
+                             EventDeadLetters eventDeadLetters,
+                             EventDispatcher eventDispatcher) {
         this.eventSerializer = eventSerializer;
         this.sender = sender;
         this.connectionMono = connectionMono;
         this.retryBackoff = retryBackoff;
         this.eventDeadLetters = eventDeadLetters;
+        this.eventDispatcher = eventDispatcher;
         this.groupRegistrations = new ConcurrentHashMap<>();
     }
 
@@ -73,6 +76,7 @@ class GroupRegistrationHandler {
             group,
             retryBackoff,
             eventDeadLetters,
-            () -> groupRegistrations.remove(group));
+            () -> groupRegistrations.remove(group),
+            eventDispatcher);
     }
 }

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/RabbitMQEventBus.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/RabbitMQEventBus.java
@@ -73,10 +73,10 @@ public class RabbitMQEventBus implements EventBus {
             sender = RabbitFlux.createSender(new SenderOptions().connectionMono(connectionMono));
             mailboxListenerRegistry = new MailboxListenerRegistry();
             keyRegistrationHandler = new KeyRegistrationHandler(eventBusId, eventSerializer, sender, connectionMono, routingKeyConverter, mailboxListenerRegistry);
-            groupRegistrationHandler = new GroupRegistrationHandler(eventSerializer, sender, connectionMono, retryBackoff, eventDeadLetters);
             eventDispatcher = new EventDispatcher(eventBusId, eventSerializer, sender, mailboxListenerRegistry);
-
             eventDispatcher.start();
+            groupRegistrationHandler = new GroupRegistrationHandler(eventSerializer, sender, connectionMono, retryBackoff, eventDeadLetters, eventDispatcher);
+
             keyRegistrationHandler.start();
             isRunning.set(true);
         }

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/RabbitMQEventBus.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/RabbitMQEventBus.java
@@ -36,7 +36,7 @@ import reactor.rabbitmq.RabbitFlux;
 import reactor.rabbitmq.Sender;
 import reactor.rabbitmq.SenderOptions;
 
-class RabbitMQEventBus implements EventBus {
+public class RabbitMQEventBus implements EventBus {
     static final String MAILBOX_EVENT = "mailboxEvent";
     static final String MAILBOX_EVENT_EXCHANGE_NAME = MAILBOX_EVENT + "-exchange";
     static final String EVENT_BUS_ID = "eventBusId";
@@ -55,7 +55,7 @@ class RabbitMQEventBus implements EventBus {
     private EventDispatcher eventDispatcher;
     private Sender sender;
 
-    RabbitMQEventBus(RabbitMQConnectionFactory rabbitMQConnectionFactory, EventSerializer eventSerializer,
+    public RabbitMQEventBus(RabbitMQConnectionFactory rabbitMQConnectionFactory, EventSerializer eventSerializer,
                      RetryBackoffConfiguration retryBackoff,
                      RoutingKeyConverter routingKeyConverter,
                      EventDeadLetters eventDeadLetters) {
@@ -85,6 +85,7 @@ class RabbitMQEventBus implements EventBus {
     @PreDestroy
     public void stop() {
         if (isRunning.get()) {
+            eventDispatcher.stop();
             groupRegistrationHandler.stop();
             keyRegistrationHandler.stop();
             sender.close();

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/RoutingKeyConverter.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/RoutingKeyConverter.java
@@ -34,7 +34,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
-class RoutingKeyConverter {
+public class RoutingKeyConverter {
     private static final String SEPARATOR = ":";
 
     static class RoutingKey {
@@ -67,7 +67,7 @@ class RoutingKeyConverter {
     private final Set<RegistrationKey.Factory> factories;
 
     @Inject
-    RoutingKeyConverter(Set<RegistrationKey.Factory> factories) {
+    public RoutingKeyConverter(Set<RegistrationKey.Factory> factories) {
         this.factories = factories;
     }
 


### PR DESCRIPTION
Before, a channel was used for every call to `Sender::send`.

We now use an infinite flux on which we publish the events to use a single channel for this.

This is a temporary workaround, waiting for cleaner channel-pool management in next release of rabbitmq-reactor.