### PR TITLE
MAILBOX-374 Use sendOptions to make channel infinite in RabbitMQEventBus

### DIFF
--- a/mailbox/event/event-rabbitmq/pom.xml
+++ b/mailbox/event/event-rabbitmq/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>io.projectreactor.rabbitmq</groupId>
             <artifactId>reactor-rabbitmq</artifactId>
-            <version>1.0.0.RELEASE</version>
+            <version>1.1.0.RC2</version>
         </dependency>
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
@@ -116,5 +116,14 @@
         </dependency>
     </dependencies>
 
-
+    <repositories>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/EventDispatcher.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/EventDispatcher.java
@@ -47,6 +47,7 @@ import reactor.core.publisher.MonoProcessor;
 import reactor.core.scheduler.Schedulers;
 import reactor.rabbitmq.ExchangeSpecification;
 import reactor.rabbitmq.OutboundMessage;
+import reactor.rabbitmq.SendOptions;
 import reactor.rabbitmq.Sender;
 
 class EventDispatcher {
@@ -57,10 +58,12 @@ class EventDispatcher {
     private final MailboxListenerRegistry mailboxListenerRegistry;
     private final AMQP.BasicProperties basicProperties;
     private final MailboxListenerExecutor mailboxListenerExecutor;
+    private final SendOptions sendOptions;
 
-    EventDispatcher(EventBusId eventBusId, EventSerializer eventSerializer, Sender sender, MailboxListenerRegistry mailboxListenerRegistry, MailboxListenerExecutor mailboxListenerExecutor) {
+    EventDispatcher(EventBusId eventBusId, EventSerializer eventSerializer, Sender sender, SendOptions sendOptions, MailboxListenerRegistry mailboxListenerRegistry, MailboxListenerExecutor mailboxListenerExecutor) {
         this.eventSerializer = eventSerializer;
         this.sender = sender;
+        this.sendOptions = sendOptions;
         this.mailboxListenerRegistry = mailboxListenerRegistry;
         this.basicProperties = new AMQP.BasicProperties.Builder()
             .headers(ImmutableMap.of(EVENT_BUS_ID, eventBusId.asString()))
@@ -126,7 +129,7 @@ class EventDispatcher {
             .flatMap(routingKey -> serializedEvent
                 .map(payload -> new OutboundMessage(MAILBOX_EVENT_EXCHANGE_NAME, routingKey.asString(), basicProperties, payload)));
 
-        return sender.send(outboundMessages);
+        return sender.send(outboundMessages, sendOptions);
     }
 
     private byte[] serializeEvent(Event event) {

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupConsumerRetry.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupConsumerRetry.java
@@ -41,6 +41,7 @@ import reactor.core.publisher.Mono;
 import reactor.rabbitmq.BindingSpecification;
 import reactor.rabbitmq.ExchangeSpecification;
 import reactor.rabbitmq.OutboundMessage;
+import reactor.rabbitmq.SendOptions;
 import reactor.rabbitmq.Sender;
 
 class GroupConsumerRetry {
@@ -71,9 +72,11 @@ class GroupConsumerRetry {
     private final RetryBackoffConfiguration retryBackoff;
     private final EventDeadLetters eventDeadLetters;
     private final Group group;
+    private final SendOptions sendOptions;
 
-    GroupConsumerRetry(Sender sender, Group group, RetryBackoffConfiguration retryBackoff, EventDeadLetters eventDeadLetters) {
+    GroupConsumerRetry(Sender sender, SendOptions sendOptions, Group group, RetryBackoffConfiguration retryBackoff, EventDeadLetters eventDeadLetters) {
         this.sender = sender;
+        this.sendOptions = sendOptions;
         this.retryExchangeName = RetryExchangeName.of(group);
         this.retryBackoff = retryBackoff;
         this.eventDeadLetters = eventDeadLetters;
@@ -114,7 +117,7 @@ class GroupConsumerRetry {
                 .build(),
             eventAsByte));
 
-        return sender.send(retryMessage)
+        return sender.send(retryMessage, sendOptions)
             .doOnError(throwable -> createStructuredLogger(event)
                 .log(logger -> logger.error("Exception happens when publishing event to retry exchange, this event will be stored in deadLetter", throwable)))
             .onErrorResume(e -> eventDeadLetters.store(group, event));

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupRegistration.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupRegistration.java
@@ -51,6 +51,7 @@ import reactor.rabbitmq.QueueSpecification;
 import reactor.rabbitmq.RabbitFlux;
 import reactor.rabbitmq.Receiver;
 import reactor.rabbitmq.ReceiverOptions;
+import reactor.rabbitmq.SendOptions;
 import reactor.rabbitmq.Sender;
 
 class GroupRegistration implements Registration {
@@ -88,8 +89,9 @@ class GroupRegistration implements Registration {
     private final MailboxListenerExecutor mailboxListenerExecutor;
     private Optional<Disposable> receiverSubscriber;
 
-    GroupRegistration(Mono<Connection> connectionSupplier, Sender sender, EventSerializer eventSerializer,
-                      MailboxListener mailboxListener, Group group, RetryBackoffConfiguration retryBackoff,
+    GroupRegistration(Mono<Connection> connectionSupplier, Sender sender, SendOptions sendOptions,
+                      EventSerializer eventSerializer, MailboxListener mailboxListener,
+                      Group group, RetryBackoffConfiguration retryBackoff,
                       EventDeadLetters eventDeadLetters,
                       Runnable unregisterGroup, MailboxListenerExecutor mailboxListenerExecutor) {
         this.eventSerializer = eventSerializer;
@@ -100,7 +102,7 @@ class GroupRegistration implements Registration {
         this.mailboxListenerExecutor = mailboxListenerExecutor;
         this.receiverSubscriber = Optional.empty();
         this.unregisterGroup = unregisterGroup;
-        this.retryHandler = new GroupConsumerRetry(sender, group, retryBackoff, eventDeadLetters);
+        this.retryHandler = new GroupConsumerRetry(sender, sendOptions, group, retryBackoff, eventDeadLetters);
         this.delayGenerator = WaitDelayGenerator.of(retryBackoff);
         this.group = group;
     }

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupRegistrationHandler.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupRegistrationHandler.java
@@ -28,6 +28,7 @@ import org.apache.james.mailbox.MailboxListener;
 import com.rabbitmq.client.Connection;
 
 import reactor.core.publisher.Mono;
+import reactor.rabbitmq.SendOptions;
 import reactor.rabbitmq.Sender;
 
 class GroupRegistrationHandler {
@@ -38,12 +39,14 @@ class GroupRegistrationHandler {
     private final RetryBackoffConfiguration retryBackoff;
     private final EventDeadLetters eventDeadLetters;
     private final MailboxListenerExecutor mailboxListenerExecutor;
+    private final SendOptions sendOptions;
 
-    GroupRegistrationHandler(EventSerializer eventSerializer, Sender sender, Mono<Connection> connectionMono,
-                             RetryBackoffConfiguration retryBackoff,
+    GroupRegistrationHandler(EventSerializer eventSerializer, Sender sender, SendOptions sendOptions,
+                             Mono<Connection> connectionMono, RetryBackoffConfiguration retryBackoff,
                              EventDeadLetters eventDeadLetters, MailboxListenerExecutor mailboxListenerExecutor) {
         this.eventSerializer = eventSerializer;
         this.sender = sender;
+        this.sendOptions = sendOptions;
         this.connectionMono = connectionMono;
         this.retryBackoff = retryBackoff;
         this.eventDeadLetters = eventDeadLetters;
@@ -70,6 +73,7 @@ class GroupRegistrationHandler {
         return new GroupRegistration(
             connectionMono,
             sender,
+            sendOptions,
             eventSerializer,
             listener,
             group,

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/KeyRegistrationHandler.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/KeyRegistrationHandler.java
@@ -54,6 +54,8 @@ import reactor.rabbitmq.Sender;
 class KeyRegistrationHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(KeyRegistrationHandler.class);
 
+    private static final String QUEUE_NAME_FOR_SERVER_GENERATE_NAME = "";
+
     private final EventBusId eventBusId;
     private final MailboxListenerRegistry mailboxListenerRegistry;
     private final EventSerializer eventSerializer;
@@ -78,7 +80,7 @@ class KeyRegistrationHandler {
     }
 
     void start() {
-        sender.declareQueue(QueueSpecification.queue()
+        sender.declareQueue(QueueSpecification.queue(QUEUE_NAME_FOR_SERVER_GENERATE_NAME)
             .durable(DURABLE)
             .exclusive(EXCLUSIVE)
             .autoDelete(AUTO_DELETE)

--- a/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusTest.java
+++ b/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusTest.java
@@ -163,6 +163,15 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
             .anyMatch(exchange -> exchange.getName().equals(retryExchangeName.asString()));
     }
 
+    @Test
+    void channelIsNotClosedAfterEventDispatched() {
+        eventBus.dispatch(EVENT, KEY_1).block();
+
+        assertThat(eventBus.getSendOptions().getChannelMono()
+            .map(channel -> channel.isOpen() && channel.getConnection().isOpen()).block())
+                .isEqualTo(true);
+    }
+
     @Nested
     class ConcurrentTest implements EventBusConcurrentTestContract.MultiEventBusConcurrentContract,
         EventBusConcurrentTestContract.SingleEventBusConcurrentContract {


### PR DESCRIPTION
Based on RC of reactor-rabbitmq (1.1.0.RC2), introduce sender with send option to make infinite channel when repeat send event multiple times.