### PR TITLE
Starting 2 Cassandra james server concurrently fails

### DIFF
--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/init/CassandraTableManagerConcurrentTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/init/CassandraTableManagerConcurrentTest.java
@@ -1,0 +1,63 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.cassandra.init;
+
+import java.time.Duration;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.DockerCassandraExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.util.Host;
+import org.apache.james.util.concurrency.ConcurrentTestRunner;
+import org.apache.james.util.concurrency.ConcurrentTestRunner.ConcurrentOperation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.datastax.driver.core.DataType;
+
+class CassandraTableManagerConcurrentTest {
+    private static final String TABLE_NAME = "tablename";
+
+    public static final CassandraModule MODULE = CassandraModule.aggregateModules(
+            CassandraSchemaVersionModule.MODULE,
+            CassandraModule.table(TABLE_NAME)
+                .comment("Testing table")
+                .statement(statement -> statement
+                        .addPartitionKey("id", DataType.timeuuid())
+                        .addClusteringColumn("clustering", DataType.bigint()))
+                .build());
+
+    @RegisterExtension
+    static DockerCassandraExtension cassandraExtension = new DockerCassandraExtension();
+
+    @Test
+    void initializeTableShouldCreateAllTheTables() throws Exception{
+        Host cassandraHost = cassandraExtension.getDockerCassandra().getHost();
+        ConcurrentOperation concurrentOperation = (a, b) -> CassandraCluster.create(MODULE, cassandraHost);
+
+
+        ConcurrentTestRunner.builder()
+            .operation(concurrentOperation)
+            .threadCount(2)
+            .operationCount(10)
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
+    }
+}


### PR DESCRIPTION
This test will fail....

```
java.util.concurrent.ExecutionException: java.lang.RuntimeException: java.lang.RuntimeException: com.datastax.driver.core.exceptions.ServerError: An unexpected error occurred server side on localhost/127.0.0.1:32818: java.lang.RuntimeException: java.util.concurrent.ExecutionException: org.apache.cassandra.exceptions.ConfigurationException: Column family ID mismatch (found b0736470-22b8-11e9-b4fb-f58bd8d3766a; expected b07168a0-22b8-11e9-b4fb-f58bd8d3766a)

	at java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.util.concurrent.FutureTask.get(FutureTask.java:192)
	at org.apache.james.util.concurrency.ConcurrentTestRunner.assertNoException(ConcurrentTestRunner.java:160)
	at org.apache.james.util.concurrency.ConcurrentTestRunner.runSuccessfullyWithin(ConcurrentTestRunner.java:177)
	at org.apache.james.util.concurrency.ConcurrentTestRunner$Builder.runSuccessfullyWithin(ConcurrentTestRunner.java:83)
	at org.apache.james.backends.cassandra.init.CassandraTableManagerConcurrentTest.initializeTableShouldCreateAllTheTables(CassandraTableManagerConcurrentTest.java:61)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:513)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:115)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:170)
	at org.junit.jupiter.engine.execution.ThrowableCollector.execute(ThrowableCollector.java:40)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:166)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:113)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:58)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor$NodeExecutor.lambda$executeRecursively$3(HierarchicalTestExecutor.java:113)
	at org.junit.platform.engine.support.hierarchical.SingleTestExecutor.executeSafely(SingleTestExecutor.java:66)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor$NodeExecutor.executeRecursively(HierarchicalTestExecutor.java:108)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor$NodeExecutor.execute(HierarchicalTestExecutor.java:79)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor$NodeExecutor.lambda$executeRecursively$2(HierarchicalTestExecutor.java:121)
```