### PR TITLE
JAMES-2655 Simplify JPA RRT query logic

### DIFF
--- a/server/data/data-jpa/src/main/java/org/apache/james/rrt/jpa/JPARecipientRewriteTable.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/rrt/jpa/JPARecipientRewriteTable.java
@@ -54,8 +54,6 @@ public class JPARecipientRewriteTable extends AbstractRecipientRewriteTable {
 
     /**
      * Set the entity manager to use.
-     * 
-     * @param entityManagerFactory
      */
     @Inject
     @PersistenceUnit(unitName = "James")
@@ -153,11 +151,7 @@ public class JPARecipientRewriteTable extends AbstractRecipientRewriteTable {
     /**
      * Update the mapping for the given user and domain
      *
-     * @param user the user
-     * @param domain the domain
-     * @param mapping the mapping
      * @return true if update was successfully
-     * @throws RecipientRewriteTableException
      */
     private boolean doUpdateMapping(MappingSource source, String mapping) throws RecipientRewriteTableException {
         EntityManager entityManager = entityManagerFactory.createEntityManager();
@@ -188,11 +182,6 @@ public class JPARecipientRewriteTable extends AbstractRecipientRewriteTable {
 
     /**
      * Remove a mapping for the given user and domain
-     * 
-     * @param user the user
-     * @param domain the domain
-     * @param mapping the mapping
-     * @throws RecipientRewriteTableException
      */
     private void doRemoveMapping(MappingSource source, String mapping) throws RecipientRewriteTableException {
         EntityManager entityManager = entityManagerFactory.createEntityManager();
@@ -220,11 +209,6 @@ public class JPARecipientRewriteTable extends AbstractRecipientRewriteTable {
 
     /**
      * Add mapping for given user and domain
-     * 
-     * @param user the user
-     * @param domain the domain
-     * @param mapping the mapping
-     * @throws RecipientRewriteTableException
      */
     private void doAddMapping(MappingSource source, String mapping) throws RecipientRewriteTableException {
         EntityManager entityManager = entityManagerFactory.createEntityManager();

--- a/server/data/data-jpa/src/main/java/org/apache/james/rrt/jpa/JPARecipientRewriteTable.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/rrt/jpa/JPARecipientRewriteTable.java
@@ -80,8 +80,8 @@ public class JPARecipientRewriteTable extends AbstractRecipientRewriteTable {
         if (userDomainMapping != null && !userDomainMapping.isEmpty()) {
             return userDomainMapping;
         }
-        MappingSource domainDource = MappingSource.fromDomain(domain);
-        Mappings domainMapping = getMapping(domainDource.getFixedUser(), domain, "selectUserDomainMapping");
+        MappingSource domainSource = MappingSource.fromDomain(domain);
+        Mappings domainMapping = getMapping(domainSource.getFixedUser(), domain, "selectUserDomainMapping");
         if (domainMapping != null && !domainMapping.isEmpty()) {
             return domainMapping;
         }

--- a/server/data/data-jpa/src/main/java/org/apache/james/rrt/jpa/JPARecipientRewriteTable.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/rrt/jpa/JPARecipientRewriteTable.java
@@ -76,11 +76,16 @@ public class JPARecipientRewriteTable extends AbstractRecipientRewriteTable {
 
     @Override
     protected Mappings mapAddress(String user, Domain domain) throws RecipientRewriteTableException {
-        Mappings mapping = getMapping(user, domain, "selectExactMappings");
-        if (!mapping.isEmpty()) {
-            return mapping;
+        Mappings userDomainMapping = getMapping(user, domain, "selectUserDomainMapping");
+        if (userDomainMapping != null && !userDomainMapping.isEmpty()) {
+            return userDomainMapping;
         }
-        return getMapping(user, domain, "selectMappings");
+        MappingSource domainDource = MappingSource.fromDomain(domain);
+        Mappings domainMapping = getMapping(domainDource.getFixedUser(), domain, "selectUserDomainMapping");
+        if (domainMapping != null && !domainMapping.isEmpty()) {
+            return domainMapping;
+        }
+        return MappingsImpl.empty();
     }
 
     private Mappings getMapping(String user, Domain domain, String queryName) throws RecipientRewriteTableException {
@@ -175,7 +180,7 @@ public class JPARecipientRewriteTable extends AbstractRecipientRewriteTable {
 
     /**
      * Update the mapping for the given user and domain
-     * 
+     *
      * @param user the user
      * @param domain the domain
      * @param mapping the mapping

--- a/server/data/data-jpa/src/main/java/org/apache/james/rrt/jpa/model/JPARecipientRewrite.java
+++ b/server/data/data-jpa/src/main/java/org/apache/james/rrt/jpa/model/JPARecipientRewrite.java
@@ -39,12 +39,10 @@ import com.google.common.base.Objects;
 @Entity(name = "JamesRecipientRewrite")
 @Table(name = JPARecipientRewrite.JAMES_RECIPIENT_REWRITE)
 @NamedQueries({ 
-    @NamedQuery(name = "selectMappings", query = "SELECT rrt FROM JamesRecipientRewrite rrt WHERE (rrt.user LIKE :user OR rrt.user='*') and (rrt.domain like :domain or rrt.domain='*') ORDER BY rrt.domain DESC"),
-    @NamedQuery(name = "selectExactMappings", query = "SELECT rrt FROM JamesRecipientRewrite rrt WHERE (rrt.user LIKE :user) and (rrt.domain like :domain) ORDER BY rrt.domain DESC"),
-        @NamedQuery(name = "selectUserDomainMapping", query = "SELECT rrt FROM JamesRecipientRewrite rrt WHERE rrt.user=:user AND rrt.domain=:domain"), 
-        @NamedQuery(name = "selectAllMappings", query = "SELECT rrt FROM JamesRecipientRewrite rrt"),
-        @NamedQuery(name = "deleteMapping", query = "DELETE FROM JamesRecipientRewrite rrt WHERE rrt.user=:user AND rrt.domain=:domain AND rrt.targetAddress=:targetAddress"),
-        @NamedQuery(name = "updateMapping", query = "UPDATE JamesRecipientRewrite rrt SET rrt.targetAddress=:targetAddress WHERE rrt.user=:user AND rrt.domain=:domain") })
+    @NamedQuery(name = "selectUserDomainMapping", query = "SELECT rrt FROM JamesRecipientRewrite rrt WHERE rrt.user=:user AND rrt.domain=:domain"),
+    @NamedQuery(name = "selectAllMappings", query = "SELECT rrt FROM JamesRecipientRewrite rrt"),
+    @NamedQuery(name = "deleteMapping", query = "DELETE FROM JamesRecipientRewrite rrt WHERE rrt.user=:user AND rrt.domain=:domain AND rrt.targetAddress=:targetAddress"),
+    @NamedQuery(name = "updateMapping", query = "UPDATE JamesRecipientRewrite rrt SET rrt.targetAddress=:targetAddress WHERE rrt.user=:user AND rrt.domain=:domain") })
 @IdClass(JPARecipientRewrite.RecipientRewriteTableId.class)
 public class JPARecipientRewrite {
 


### PR DESCRIPTION
Previous queries were complex and were syntactically incorrect when run against
MariaDB as reported by Marc Chamberlin.

This lead to portability issue.

Note that simplifying queries is an attempt to solve this.