### PR TITLE
JAMES-2632 Reduce query count upon GetMailboxes

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
@@ -35,6 +35,7 @@ import javax.mail.Flags;
 import org.apache.james.mailbox.MailboxManager.MessageCapabilities;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.UnsupportedCriteriaException;
+import org.apache.james.mailbox.exception.UnsupportedRightException;
 import org.apache.james.mailbox.model.ComposedMessageId;
 import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxCounters;
@@ -440,4 +441,11 @@ public interface MessageManager {
         MailboxACL getACL();
 
     }
+
+    /**
+     * Get resolved ACL on this Mailbox for the given Session
+     *
+     * The result will be the same as calling {MessageManager#getMetaDtata().getAcl()} but will load fewer data
+     */
+    MailboxACL getResolvedAcl(MailboxSession mailboxSession) throws UnsupportedRightException;
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/quota/MaxQuotaManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/quota/MaxQuotaManager.java
@@ -116,6 +116,13 @@ public interface MaxQuotaManager {
      */
     Optional<QuotaSize> getMaxStorage(QuotaRoot quotaRoot) throws MailboxException;
 
+    default Optional<QuotaSize> getMaxStorage(Map<Quota.Scope, QuotaSize> maxStorageDetails) {
+        return OptionalUtils.or(
+            Optional.ofNullable(maxStorageDetails.get(Quota.Scope.User)),
+            Optional.ofNullable(maxStorageDetails.get(Quota.Scope.Domain)),
+            Optional.ofNullable(maxStorageDetails.get(Quota.Scope.Global)));
+    }
+
     /**
      * Return the maximum message count which is allowed for the given {@link QuotaRoot} (in fact the user which the session is bound to)
      *
@@ -123,6 +130,13 @@ public interface MaxQuotaManager {
      * @return maximum of allowed message count
      */
     Optional<QuotaCount> getMaxMessage(QuotaRoot quotaRoot) throws MailboxException;
+
+    default Optional<QuotaCount> getMaxMessage(Map<Quota.Scope, QuotaCount> maxMessagesDetails) {
+        return OptionalUtils.or(
+            Optional.ofNullable(maxMessagesDetails.get(Quota.Scope.User)),
+            Optional.ofNullable(maxMessagesDetails.get(Quota.Scope.Domain)),
+            Optional.ofNullable(maxMessagesDetails.get(Quota.Scope.Global)));
+    }
 
     Map<Quota.Scope, QuotaCount> listMaxMessagesDetails(QuotaRoot quotaRoot);
 

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/quota/MaxQuotaManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/quota/MaxQuotaManager.java
@@ -27,6 +27,7 @@ import org.apache.james.core.quota.QuotaCount;
 import org.apache.james.core.quota.QuotaSize;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Quota;
+import org.apache.james.mailbox.model.Quota.Scope;
 import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.util.OptionalUtils;
 
@@ -114,7 +115,10 @@ public interface MaxQuotaManager {
      * @param quotaRoot Quota root argument from RFC 2087 ( correspond to the user owning this mailbox )
      * @return The maximum storage in bytes if any
      */
-    Optional<QuotaSize> getMaxStorage(QuotaRoot quotaRoot) throws MailboxException;
+    default Optional<QuotaSize> getMaxStorage(QuotaRoot quotaRoot) throws MailboxException {
+        Map<Scope, QuotaSize> maxStorageDetails = listMaxStorageDetails(quotaRoot);
+        return getMaxStorage(maxStorageDetails);
+    }
 
     default Optional<QuotaSize> getMaxStorage(Map<Quota.Scope, QuotaSize> maxStorageDetails) {
         return OptionalUtils.or(
@@ -129,7 +133,10 @@ public interface MaxQuotaManager {
      * @param quotaRoot Quota root argument from RFC 2087 ( correspond to the user owning this mailbox )
      * @return maximum of allowed message count
      */
-    Optional<QuotaCount> getMaxMessage(QuotaRoot quotaRoot) throws MailboxException;
+    default Optional<QuotaCount> getMaxMessage(QuotaRoot quotaRoot) throws MailboxException {
+        Map<Scope, QuotaCount> maxMessagesDetails = listMaxMessagesDetails(quotaRoot);
+        return getMaxMessage(maxMessagesDetails);
+    }
 
     default Optional<QuotaCount> getMaxMessage(Map<Quota.Scope, QuotaCount> maxMessagesDetails) {
         return OptionalUtils.or(

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/quota/CassandraPerUserMaxQuotaManager.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/quota/CassandraPerUserMaxQuotaManager.java
@@ -22,7 +22,6 @@ package org.apache.james.mailbox.cassandra.quota;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -34,7 +33,6 @@ import org.apache.james.core.quota.QuotaSize;
 import org.apache.james.mailbox.model.Quota;
 import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
-import org.apache.james.util.OptionalUtils;
 
 import com.github.fge.lambdas.Throwing;
 import com.github.steveash.guavate.Guavate;
@@ -132,34 +130,6 @@ public class CassandraPerUserMaxQuotaManager implements MaxQuotaManager {
     @Override
     public Optional<QuotaCount> getGlobalMaxMessage() {
         return globalQuota.getGlobalMaxMessage();
-    }
-
-    @Override
-    public Optional<QuotaSize> getMaxStorage(QuotaRoot quotaRoot) {
-        Supplier<Optional<QuotaSize>> domainQuotaSupplier = Throwing.supplier(() -> quotaRoot.getDomain()
-            .flatMap(this::getDomainMaxStorage)).sneakyThrow();
-        Supplier<Optional<QuotaSize>> globalDomainSupplier = Throwing.supplier(this::getGlobalMaxStorage).sneakyThrow();
-
-        return Stream
-            .of(() -> perUserQuota.getMaxStorage(quotaRoot),
-                domainQuotaSupplier,
-                globalDomainSupplier)
-            .flatMap(supplier -> OptionalUtils.toStream(supplier.get()))
-            .findFirst();
-    }
-
-    @Override
-    public Optional<QuotaCount> getMaxMessage(QuotaRoot quotaRoot) {
-        Supplier<Optional<QuotaCount>> domainQuotaSupplier = Throwing.supplier(() -> quotaRoot.getDomain()
-            .flatMap(this::getDomainMaxMessage)).sneakyThrow();
-        Supplier<Optional<QuotaCount>> globalDomainSupplier = Throwing.supplier(this::getGlobalMaxMessage).sneakyThrow();
-
-        return Stream
-            .of(() -> perUserQuota.getMaxMessage(quotaRoot),
-                domainQuotaSupplier,
-                globalDomainSupplier)
-            .flatMap(supplier -> OptionalUtils.toStream(supplier.get()))
-            .findFirst();
     }
 
     @Override

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/JPAPerUserMaxQuotaManager.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/quota/JPAPerUserMaxQuotaManager.java
@@ -22,7 +22,6 @@ package org.apache.james.mailbox.jpa.quota;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -34,7 +33,6 @@ import org.apache.james.core.quota.QuotaSize;
 import org.apache.james.mailbox.model.Quota;
 import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
-import org.apache.james.util.OptionalUtils;
 
 import com.github.fge.lambdas.Throwing;
 import com.github.steveash.guavate.Guavate;
@@ -116,26 +114,6 @@ public class JPAPerUserMaxQuotaManager implements MaxQuotaManager {
     @Override
     public Optional<QuotaCount> getGlobalMaxMessage() {
         return dao.getGlobalMaxMessage();
-    }
-
-    @Override
-    public Optional<QuotaSize> getMaxStorage(QuotaRoot quotaRoot) {
-        return Stream
-            .of((Supplier<Optional<QuotaSize>>) () -> dao.getMaxStorage(quotaRoot),
-                () -> quotaRoot.getDomain().flatMap(this::getDomainMaxStorage),
-                this::getGlobalMaxStorage)
-            .flatMap(supplier -> OptionalUtils.toStream(supplier.get()))
-            .findFirst();
-    }
-
-    @Override
-    public Optional<QuotaCount> getMaxMessage(QuotaRoot quotaRoot) {
-        return Stream
-            .of((Supplier<Optional<QuotaCount>>) () -> dao.getMaxMessage(quotaRoot),
-                () -> quotaRoot.getDomain().flatMap(this::getDomainMaxMessage),
-                this::getGlobalMaxMessage)
-            .flatMap(supplier -> OptionalUtils.toStream(supplier.get()))
-            .findFirst();
     }
 
     @Override

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/quota/InMemoryPerUserMaxQuotaManager.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/quota/InMemoryPerUserMaxQuotaManager.java
@@ -31,7 +31,6 @@ import org.apache.james.core.quota.QuotaSize;
 import org.apache.james.mailbox.model.Quota;
 import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
-import org.apache.james.util.OptionalUtils;
 
 import com.github.fge.lambdas.Throwing;
 import com.github.steveash.guavate.Guavate;
@@ -70,22 +69,6 @@ public class InMemoryPerUserMaxQuotaManager implements MaxQuotaManager {
     @Override
     public void removeDomainMaxStorage(Domain domain) {
         domainMaxStorage.remove(domain);
-    }
-
-    @Override
-    public Optional<QuotaSize> getMaxStorage(QuotaRoot quotaRoot) {
-        return OptionalUtils.or(
-            Optional.ofNullable(userMaxStorage.get(quotaRoot.getValue())),
-            quotaRoot.getDomain().flatMap(this::getDomainMaxStorage),
-            maxStorage);
-    }
-
-    @Override
-    public Optional<QuotaCount> getMaxMessage(QuotaRoot quotaRoot) {
-        return OptionalUtils.or(
-            Optional.ofNullable(userMaxMessage.get(quotaRoot.getValue())),
-            quotaRoot.getDomain().flatMap(this::getDomainMaxMessage),
-            maxMessage);
     }
 
     @Override

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -50,6 +50,7 @@ import org.apache.james.mailbox.events.MailboxIdRegistrationKey;
 import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.ReadOnlyException;
+import org.apache.james.mailbox.exception.UnsupportedRightException;
 import org.apache.james.mailbox.model.ComposedMessageId;
 import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxCounters;
@@ -473,7 +474,7 @@ public class StoreMessageManager implements org.apache.james.mailbox.MessageMana
 
     @Override
     public MetaData getMetaData(boolean resetRecent, MailboxSession mailboxSession, MetaData.FetchGroup fetchGroup) throws MailboxException {
-        MailboxACL resolvedAcl = storeRightManager.getResolvedMailboxACL(mailbox, mailboxSession);
+        MailboxACL resolvedAcl = getResolvedAcl(mailboxSession);
         boolean hasReadRight = storeRightManager.hasRight(mailbox, MailboxACL.Right.Read, mailboxSession);
         if (!hasReadRight) {
             return MailboxMetaData.sensibleInformationFree(resolvedAcl, getMailboxEntity().getUidValidity(), isWriteable(mailboxSession), isModSeqPermanent(mailboxSession));
@@ -522,6 +523,11 @@ public class StoreMessageManager implements org.apache.james.mailbox.MessageMana
             break;
         }
         return new MailboxMetaData(recent, permanentFlags, uidValidity, uidNext, highestModSeq, messageCount, unseenCount, firstUnseen, isWriteable(mailboxSession), isModSeqPermanent(mailboxSession), resolvedAcl);
+    }
+
+    @Override
+    public MailboxACL getResolvedAcl(MailboxSession mailboxSession) throws UnsupportedRightException {
+        return storeRightManager.getResolvedMailboxACL(mailbox, mailboxSession);
     }
 
     /**

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/StoreQuotaManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/StoreQuotaManager.java
@@ -19,12 +19,15 @@
 
 package org.apache.james.mailbox.store.quota;
 
+import java.util.Map;
+
 import javax.inject.Inject;
 
 import org.apache.james.core.quota.QuotaCount;
 import org.apache.james.core.quota.QuotaSize;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Quota;
+import org.apache.james.mailbox.model.Quota.Scope;
 import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.mailbox.quota.CurrentQuotaManager;
 import org.apache.james.mailbox.quota.MaxQuotaManager;
@@ -47,20 +50,22 @@ public class StoreQuotaManager implements QuotaManager {
 
     @Override
     public Quota<QuotaCount> getMessageQuota(QuotaRoot quotaRoot) throws MailboxException {
+        Map<Scope, QuotaCount> maxMessageDetails = maxQuotaManager.listMaxMessagesDetails(quotaRoot);
         return Quota.<QuotaCount>builder()
             .used(currentQuotaManager.getCurrentMessageCount(quotaRoot))
-            .computedLimit(maxQuotaManager.getMaxMessage(quotaRoot).orElse(QuotaCount.unlimited()))
-            .limitsByScope(maxQuotaManager.listMaxMessagesDetails(quotaRoot))
+            .computedLimit(maxQuotaManager.getMaxMessage(maxMessageDetails).orElse(QuotaCount.unlimited()))
+            .limitsByScope(maxMessageDetails)
             .build();
     }
 
 
     @Override
     public Quota<QuotaSize> getStorageQuota(QuotaRoot quotaRoot) throws MailboxException {
+        Map<Scope, QuotaSize> maxStorageDetails = maxQuotaManager.listMaxStorageDetails(quotaRoot);
         return Quota.<QuotaSize>builder()
             .used(currentQuotaManager.getCurrentStorage(quotaRoot))
-            .computedLimit(maxQuotaManager.getMaxStorage(quotaRoot).orElse(QuotaSize.unlimited()))
-            .limitsByScope(maxQuotaManager.listMaxStorageDetails(quotaRoot))
+            .computedLimit(maxQuotaManager.getMaxStorage(maxStorageDetails).orElse(QuotaSize.unlimited()))
+            .limitsByScope(maxStorageDetails)
             .build();
     }
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/quota/StoreQuotaManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/quota/StoreQuotaManagerTest.java
@@ -20,9 +20,11 @@
 package org.apache.james.mailbox.store.quota;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.james.core.quota.QuotaCount;
@@ -49,34 +51,38 @@ public class StoreQuotaManagerTest {
         quotaRoot = QuotaRoot.quotaRoot("benwa", Optional.empty());
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void getMessageQuotaShouldWorkWithNumericValues() throws Exception {
-        when(mockedMaxQuotaManager.getMaxMessage(quotaRoot)).thenReturn(Optional.of(QuotaCount.count(360L)));
+        when(mockedMaxQuotaManager.getMaxMessage(any(Map.class))).thenReturn(Optional.of(QuotaCount.count(360L)));
         when(mockedCurrentQuotaManager.getCurrentMessageCount(quotaRoot)).thenReturn(QuotaCount.count(36L));
         assertThat(testee.getMessageQuota(quotaRoot)).isEqualTo(
             Quota.<QuotaCount>builder().used(QuotaCount.count(36)).computedLimit(QuotaCount.count(360)).build());
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void getStorageQuotaShouldWorkWithNumericValues() throws Exception {
-        when(mockedMaxQuotaManager.getMaxStorage(quotaRoot)).thenReturn(Optional.of(QuotaSize.size(360L)));
+        when(mockedMaxQuotaManager.getMaxStorage(any(Map.class))).thenReturn(Optional.of(QuotaSize.size(360L)));
         when(mockedCurrentQuotaManager.getCurrentStorage(quotaRoot)).thenReturn(QuotaSize.size(36L));
         assertThat(testee.getStorageQuota(quotaRoot)).isEqualTo(
             Quota.<QuotaSize>builder().used(QuotaSize.size(36)).computedLimit(QuotaSize.size(360)).build());
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void getStorageQuotaShouldCalculateCurrentQuotaWhenUnlimited() throws Exception {
-        when(mockedMaxQuotaManager.getMaxStorage(quotaRoot)).thenReturn(Optional.of(QuotaSize.unlimited()));
+        when(mockedMaxQuotaManager.getMaxStorage(any(Map.class))).thenReturn(Optional.of(QuotaSize.unlimited()));
         when(mockedCurrentQuotaManager.getCurrentStorage(quotaRoot)).thenReturn(QuotaSize.size(36L));
 
         assertThat(testee.getStorageQuota(quotaRoot)).isEqualTo(
             Quota.<QuotaSize>builder().used(QuotaSize.size(36)).computedLimit(QuotaSize.unlimited()).build());
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void getMessageQuotaShouldCalculateCurrentQuotaWhenUnlimited() throws Exception {
-        when(mockedMaxQuotaManager.getMaxMessage(quotaRoot)).thenReturn(Optional.of(QuotaCount.unlimited()));
+        when(mockedMaxQuotaManager.getMaxMessage(any(Map.class))).thenReturn(Optional.of(QuotaCount.unlimited()));
         when(mockedCurrentQuotaManager.getCurrentMessageCount(quotaRoot)).thenReturn(QuotaCount.count(36L));
 
         assertThat(testee.getMessageQuota(quotaRoot)).isEqualTo(

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/MailboxFactory.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/model/MailboxFactory.java
@@ -51,7 +51,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 
 public class MailboxFactory {
-    public static final boolean NO_RESET_RECENT = false;
     private final MailboxManager mailboxManager;
     private final QuotaManager quotaManager;
     private final QuotaRootResolver quotaRootResolver;
@@ -113,9 +112,8 @@ public class MailboxFactory {
         boolean isOwner = mailboxPath.belongsTo(mailboxSession);
         Optional<Role> role = Role.from(mailboxPath.getName());
         MailboxCounters mailboxCounters = messageManager.getMailboxCounters(mailboxSession);
-        MessageManager.MetaData metaData = messageManager.getMetaData(NO_RESET_RECENT, mailboxSession, MessageManager.MetaData.FetchGroup.NO_COUNT);
 
-        Rights rights = Rights.fromACL(metaData.getACL())
+        Rights rights = Rights.fromACL(messageManager.getResolvedAcl(mailboxSession))
             .removeEntriesFor(Username.forMailboxPath(mailboxPath));
         Username username = Username.fromSession(mailboxSession);
         Quotas quotas = getQuotas(mailboxPath);


### PR DESCRIPTION
Non-controversial part of https://github.com/linagora/james-project/pull/2147

Before:

master: 

![capture d ecran de 2019-02-01 15-54-22](https://user-images.githubusercontent.com/6928740/52112704-ec3e2d80-2639-11e9-82fd-3de21e598a17.png)

This branch:

![capture d ecran de 2019-02-11 14-24-46](https://user-images.githubusercontent.com/6928740/52550041-ea7a2400-2e08-11e9-93c2-3db69371ac12.png)

Conclusions:

 - p99 divided by 3
 - meantime divided by 2.5
 - throughput increase is minimal due to long sleep delays between calls (1 to 2 s)
