### PR TITLE
JAMES-2661 WebAdmin API for EventDeadLetters

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/events/GenericGroup.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/events/GenericGroup.java
@@ -22,6 +22,7 @@ package org.apache.james.mailbox.events;
 import java.util.Objects;
 
 public class GenericGroup extends Group {
+    static final String DELIMITER = "-";
     private final String groupName;
 
     public GenericGroup(String groupName) {
@@ -30,7 +31,7 @@ public class GenericGroup extends Group {
 
     @Override
     public String asString() {
-        return super.asString() + "-" + groupName;
+        return super.asString() + DELIMITER + groupName;
     }
 
     @Override

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/events/Group.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/events/Group.java
@@ -25,16 +25,26 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
 public class Group {
-    public static Group deserialize(String serializedGroup) throws InstantiationException, IllegalAccessException, ClassNotFoundException {
-        Preconditions.checkNotNull(serializedGroup, "A serialized group can not be null");
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(serializedGroup), "A serialized group can not be empty");
-
-        if (serializedGroup.startsWith(GenericGroup.class.getName() + GenericGroup.DELIMITER)) {
-            return new GenericGroup(serializedGroup.substring(GenericGroup.class.getName().length() + 1));
+    public static class GroupDeserializationException extends Exception {
+        GroupDeserializationException(Throwable cause) {
+            super(cause);
         }
+    }
 
-        Class<?> groupClass = Class.forName(serializedGroup);
-        return instanciateGroup(groupClass);
+    public static Group deserialize(String serializedGroup) throws GroupDeserializationException {
+        try {
+            Preconditions.checkNotNull(serializedGroup, "A serialized group can not be null");
+            Preconditions.checkArgument(!Strings.isNullOrEmpty(serializedGroup), "A serialized group can not be empty");
+
+            if (serializedGroup.startsWith(GenericGroup.class.getName() + GenericGroup.DELIMITER)) {
+                return new GenericGroup(serializedGroup.substring(GenericGroup.class.getName().length() + 1));
+            }
+
+            Class<?> groupClass = Class.forName(serializedGroup);
+            return instanciateGroup(groupClass);
+        } catch (Exception e) {
+            throw new GroupDeserializationException(e);
+        }
     }
 
     private static Group instanciateGroup(Class<?> aClass) throws InstantiationException, IllegalAccessException {

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/events/Group.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/events/Group.java
@@ -22,19 +22,19 @@ package org.apache.james.mailbox.events;
 import java.util.Objects;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 
 public class Group {
     public static Group deserialize(String serializedGroup) throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        Preconditions.checkNotNull(serializedGroup, "A serialized group can not be null");
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(serializedGroup), "A serialized group can not be empty");
+
         if (serializedGroup.startsWith(GenericGroup.class.getName() + GenericGroup.DELIMITER)) {
             return new GenericGroup(serializedGroup.substring(GenericGroup.class.getName().length() + 1));
         }
-        return loadGroup(serializedGroup);
-    }
 
-    private static Group loadGroup(String serializedGroup) throws ClassNotFoundException, InstantiationException, IllegalAccessException {
-        ClassLoader classLoader = Group.class.getClassLoader();
-        Class<?> aClass = classLoader.loadClass(serializedGroup);
-        return instanciateGroup(aClass);
+        Class<?> groupClass = Class.forName(serializedGroup);
+        return instanciateGroup(groupClass);
     }
 
     private static Group instanciateGroup(Class<?> aClass) throws InstantiationException, IllegalAccessException {

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/events/Group.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/events/Group.java
@@ -21,7 +21,27 @@ package org.apache.james.mailbox.events;
 
 import java.util.Objects;
 
+import com.google.common.base.Preconditions;
+
 public class Group {
+    public static Group deserialize(String serializedGroup) throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        if (serializedGroup.startsWith(GenericGroup.class.getName() + GenericGroup.DELIMITER)) {
+            return new GenericGroup(serializedGroup.substring(GenericGroup.class.getName().length() + 1));
+        }
+        return loadGroup(serializedGroup);
+    }
+
+    private static Group loadGroup(String serializedGroup) throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+        ClassLoader classLoader = Group.class.getClassLoader();
+        Class<?> aClass = classLoader.loadClass(serializedGroup);
+        return instanciateGroup(aClass);
+    }
+
+    private static Group instanciateGroup(Class<?> aClass) throws InstantiationException, IllegalAccessException {
+        Preconditions.checkArgument(Group.class.isAssignableFrom(aClass), "The supplied class is not a group: " + aClass.getName());
+        return (Group) aClass.newInstance();
+    }
+
     public String asString() {
         return getClass().getName();
     }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/GroupTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/GroupTest.java
@@ -98,30 +98,30 @@ class GroupTest {
     @Test
     void deserializeShouldThrowWhenClassNotFound() {
         assertThatThrownBy(() -> Group.deserialize("org.apache.james.mailbox.events.Noone"))
-            .isInstanceOf(ClassNotFoundException.class);
+            .isInstanceOf(Group.GroupDeserializationException.class);
     }
 
     @Test
     void deserializeShouldThrowWhenNotAGroup() {
         assertThatThrownBy(() -> Group.deserialize("java.lang.String"))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(Group.GroupDeserializationException.class);
     }
 
     @Test
     void deserializeShouldThrowWhenConstructorArgumentsRequired() {
         assertThatThrownBy(() -> Group.deserialize("org.apache.james.mailbox.events.GenericGroup"))
-            .isInstanceOf(InstantiationException.class);
+            .isInstanceOf(Group.GroupDeserializationException.class);
     }
 
     @Test
     void deserializeShouldThrowWhenNull() {
         assertThatThrownBy(() -> Group.deserialize(null))
-            .isInstanceOf(NullPointerException.class);
+            .isInstanceOf(Group.GroupDeserializationException.class);
     }
 
     @Test
     void deserializeShouldThrowWhenEmpty() {
         assertThatThrownBy(() -> Group.deserialize(""))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(Group.GroupDeserializationException.class);
     }
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/GroupTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/GroupTest.java
@@ -113,4 +113,15 @@ class GroupTest {
             .isInstanceOf(InstantiationException.class);
     }
 
+    @Test
+    void deserializeShouldThrowWhenNull() {
+        assertThatThrownBy(() -> Group.deserialize(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void deserializeShouldThrowWhenEmpty() {
+        assertThatThrownBy(() -> Group.deserialize(""))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/GroupTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/GroupTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.mailbox.events;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
@@ -75,4 +76,41 @@ class GroupTest {
     void asStringShouldReturnNameWhenGenericGroup() {
         assertThat(new GenericGroup("abc").asString()).isEqualTo("org.apache.james.mailbox.events.GenericGroup-abc");
     }
+
+    @Test
+    void deserializeShouldReturnGroupWhenGenericGroup() throws Exception {
+        assertThat(Group.deserialize("org.apache.james.mailbox.events.GenericGroup-abc"))
+            .isEqualTo(new GenericGroup("abc"));
+    }
+
+    @Test
+    void deserializeShouldReturnGroupWhenEmptyGenericGroup() throws Exception {
+        assertThat(Group.deserialize("org.apache.james.mailbox.events.GenericGroup-"))
+            .isEqualTo(new GenericGroup(""));
+    }
+
+    @Test
+    void deserializeShouldReturnGroupWhenExtendsGroup() throws Exception {
+        assertThat(Group.deserialize("org.apache.james.mailbox.events.EventBusTestFixture$GroupA"))
+            .isEqualTo(new EventBusTestFixture.GroupA());
+    }
+
+    @Test
+    void deserializeShouldThrowWhenClassNotFound() {
+        assertThatThrownBy(() -> Group.deserialize("org.apache.james.mailbox.events.Noone"))
+            .isInstanceOf(ClassNotFoundException.class);
+    }
+
+    @Test
+    void deserializeShouldThrowWhenNotAGroup() {
+        assertThatThrownBy(() -> Group.deserialize("java.lang.String"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void deserializeShouldThrowWhenConstructorArgumentsRequired() {
+        assertThatThrownBy(() -> Group.deserialize("org.apache.james.mailbox.events.GenericGroup"))
+            .isInstanceOf(InstantiationException.class);
+    }
+
 }

--- a/server/protocols/webadmin/webadmin-mailbox/pom.xml
+++ b/server/protocols/webadmin/webadmin-mailbox/pom.xml
@@ -50,6 +50,10 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-mailbox-event-json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>apache-james-mailbox-event-memory</artifactId>
             <scope>test</scope>
         </dependency>

--- a/server/protocols/webadmin/webadmin-mailbox/pom.xml
+++ b/server/protocols/webadmin/webadmin-mailbox/pom.xml
@@ -50,6 +50,11 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-mailbox-event-memory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>apache-james-mailbox-memory</artifactId>
             <scope>test</scope>
         </dependency>

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/EventDeadLettersRoutes.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/EventDeadLettersRoutes.java
@@ -1,0 +1,63 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.routes;
+
+import javax.inject.Inject;
+
+import org.apache.james.mailbox.events.EventDeadLetters;
+import org.apache.james.mailbox.events.Group;
+import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.utils.JsonTransformer;
+
+import com.github.steveash.guavate.Guavate;
+
+import spark.Request;
+import spark.Response;
+import spark.Service;
+
+public class EventDeadLettersRoutes implements Routes {
+    private static final String BASE_PATH = "/events/deadLetter";
+
+    private final EventDeadLetters deadLetters;
+    private final JsonTransformer jsonTransformer;
+
+    @Inject
+    EventDeadLettersRoutes(EventDeadLetters deadLetters, JsonTransformer jsonTransformer) {
+        this.deadLetters = deadLetters;
+        this.jsonTransformer = jsonTransformer;
+    }
+
+    @Override
+    public String getBasePath() {
+        return BASE_PATH;
+    }
+
+    @Override
+    public void define(Service service) {
+        service.get(BASE_PATH + "/groups", this::listGroups, jsonTransformer);
+    }
+
+    private Iterable<String> listGroups(Request request, Response response) {
+        return deadLetters.groupsWithFailedEvents()
+            .map(Group::asString)
+            .collect(Guavate.toImmutableList())
+            .block();
+    }
+}

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/EventDeadLettersRoutes.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/EventDeadLettersRoutes.java
@@ -64,6 +64,7 @@ public class EventDeadLettersRoutes implements Routes {
         service.get(BASE_PATH + "/groups", this::listGroups, jsonTransformer);
         service.get(BASE_PATH + "/groups/" + GROUP_PARAM + "/events", this::listFailedEvents, jsonTransformer);
         service.get(BASE_PATH + "/groups/" + GROUP_PARAM + "/events/" + EVENT_ID_PARAM, this::getEventDetails);
+        service.delete(BASE_PATH + "/groups/" + GROUP_PARAM + "/events/" + EVENT_ID_PARAM, this::deleteEvent);
     }
 
     private Iterable<String> listGroups(Request request, Response response) {
@@ -89,6 +90,15 @@ public class EventDeadLettersRoutes implements Routes {
         return deadLetters.failedEvent(group, eventId)
             .map(eventSerializer::toJson)
             .block();
+    }
+
+    private Response deleteEvent(Request request, Response response) {
+        Group group = parseGroup(request);
+        Event.EventId eventId = parseEventId(request);
+
+        deadLetters.remove(group, eventId).block();
+        response.status(HttpStatus.NO_CONTENT_204);
+        return response;
     }
 
     private Group parseGroup(Request request) {

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/EventDeadLettersRoutes.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/EventDeadLettersRoutes.java
@@ -143,7 +143,7 @@ public class EventDeadLettersRoutes implements Routes {
     @ApiResponses(value = {
         @ApiResponse(code = HttpStatus.OK_200, message = "OK - returns an event detail", response = Event.class),
         @ApiResponse(code = HttpStatus.BAD_REQUEST_400, message = "Invalid group name or event id"),
-        @ApiResponse(code = HttpStatus.NOT_FOUND_404, message = "No message with this eventId"),
+        @ApiResponse(code = HttpStatus.NOT_FOUND_404, message = "No event with this eventId"),
         @ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = "Internal server error - Something went bad on the server side.")
     })
     private String getEventDetails(Request request, Response response) {

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/EventDeadLettersRoutes.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/EventDeadLettersRoutes.java
@@ -143,6 +143,7 @@ public class EventDeadLettersRoutes implements Routes {
     @ApiResponses(value = {
         @ApiResponse(code = HttpStatus.OK_200, message = "OK - returns an event detail", response = Event.class),
         @ApiResponse(code = HttpStatus.BAD_REQUEST_400, message = "Invalid group name or event id"),
+        @ApiResponse(code = HttpStatus.NOT_FOUND_404, message = "No message with this eventId"),
         @ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = "Internal server error - Something went bad on the server side.")
     })
     private String getEventDetails(Request request, Response response) {

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/EventDeadLettersRoutes.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/EventDeadLettersRoutes.java
@@ -191,7 +191,7 @@ public class EventDeadLettersRoutes implements Routes {
         String groupAsString = request.params(GROUP_PARAM);
         try {
             return Group.deserialize(groupAsString);
-        } catch (Exception e) {
+        } catch (Group.GroupDeserializationException e) {
             throw ErrorResponder.builder()
                 .statusCode(HttpStatus.BAD_REQUEST_400)
                 .message("Can not deserialize the supplied group: " + groupAsString)

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/EventDeadLettersRoutes.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/EventDeadLettersRoutes.java
@@ -19,9 +19,14 @@
 
 package org.apache.james.webadmin.routes;
 
+import java.util.List;
 import java.util.UUID;
 
 import javax.inject.Inject;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 
 import org.apache.james.event.json.EventSerializer;
 import org.apache.james.mailbox.events.Event;
@@ -34,10 +39,19 @@ import org.eclipse.jetty.http.HttpStatus;
 
 import com.github.steveash.guavate.Guavate;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import spark.Request;
 import spark.Response;
 import spark.Service;
 
+@Api(tags = "EventDeadLetter")
+@Path("/events/deadLetter")
+@Produces("application/json")
 public class EventDeadLettersRoutes implements Routes {
     private static final String BASE_PATH = "/events/deadLetter";
     private static final String GROUP_PARAM = ":group";
@@ -67,6 +81,13 @@ public class EventDeadLettersRoutes implements Routes {
         service.delete(BASE_PATH + "/groups/" + GROUP_PARAM + "/events/" + EVENT_ID_PARAM, this::deleteEvent);
     }
 
+    @GET
+    @Path("/groups")
+    @ApiOperation(value = "List groups")
+    @ApiResponses(value = {
+        @ApiResponse(code = HttpStatus.OK_200, message = "OK - list group names", response = List.class),
+        @ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = "Internal server error - Something went bad on the server side.")
+    })
     private Iterable<String> listGroups(Request request, Response response) {
         return deadLetters.groupsWithFailedEvents()
             .map(Group::asString)
@@ -74,6 +95,23 @@ public class EventDeadLettersRoutes implements Routes {
             .block();
     }
 
+    @GET
+    @Path("/groups/" + GROUP_PARAM + "/events")
+    @ApiOperation(value = "List failed events for a given group")
+    @ApiImplicitParams({
+        @ApiImplicitParam(
+            required = true,
+            name = "group",
+            paramType = "path parameter",
+            dataType = "String",
+            defaultValue = "none",
+            value = "Compulsory. Needs to be a valid group name")
+    })
+    @ApiResponses(value = {
+        @ApiResponse(code = HttpStatus.OK_200, message = "OK - list of failed eventIds for a given group", response = List.class),
+        @ApiResponse(code = HttpStatus.BAD_REQUEST_400, message = "Invalid group name"),
+        @ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = "Internal server error - Something went bad on the server side.")
+    })
     private Iterable<String> listFailedEvents(Request request, Response response) {
         Group group = parseGroup(request);
         return deadLetters.failedEventIds(group)
@@ -83,6 +121,30 @@ public class EventDeadLettersRoutes implements Routes {
             .block();
     }
 
+    @GET
+    @Path("/groups/" + GROUP_PARAM + "/events/" + EVENT_ID_PARAM)
+    @ApiOperation(value = "Returns an event detail")
+    @ApiImplicitParams({
+        @ApiImplicitParam(
+            required = true,
+            name = "group",
+            paramType = "path parameter",
+            dataType = "String",
+            defaultValue = "none",
+            value = "Compulsory. Needs to be a valid group name"),
+        @ApiImplicitParam(
+            required = true,
+            name = "eventId",
+            paramType = "path parameter",
+            dataType = "String",
+            defaultValue = "none",
+            value = "Compulsory. Needs to be a valid eventId")
+    })
+    @ApiResponses(value = {
+        @ApiResponse(code = HttpStatus.OK_200, message = "OK - returns an event detail", response = Event.class),
+        @ApiResponse(code = HttpStatus.BAD_REQUEST_400, message = "Invalid group name or event id"),
+        @ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = "Internal server error - Something went bad on the server side.")
+    })
     private String getEventDetails(Request request, Response response) {
         Group group = parseGroup(request);
         Event.EventId eventId = parseEventId(request);
@@ -92,6 +154,30 @@ public class EventDeadLettersRoutes implements Routes {
             .block();
     }
 
+    @DELETE
+    @Path("/groups/" + GROUP_PARAM + "/events/" + EVENT_ID_PARAM)
+    @ApiOperation(value = "Deletes an event")
+    @ApiImplicitParams({
+        @ApiImplicitParam(
+            required = true,
+            name = "group",
+            paramType = "path parameter",
+            dataType = "String",
+            defaultValue = "none",
+            value = "Compulsory. Needs to be a valid group name"),
+        @ApiImplicitParam(
+            required = true,
+            name = "eventId",
+            paramType = "path parameter",
+            dataType = "String",
+            defaultValue = "none",
+            value = "Compulsory. Needs to be a valid eventId")
+    })
+    @ApiResponses(value = {
+        @ApiResponse(code = HttpStatus.NO_CONTENT_204, message = "OK - Event deleted"),
+        @ApiResponse(code = HttpStatus.BAD_REQUEST_400, message = "Invalid group name or event id"),
+        @ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = "Internal server error - Something went bad on the server side.")
+    })
     private Response deleteEvent(Request request, Response response) {
         Group group = parseGroup(request);
         Event.EventId eventId = parseEventId(request);

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/EventDeadLettersRoutes.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/EventDeadLettersRoutes.java
@@ -19,12 +19,17 @@
 
 package org.apache.james.webadmin.routes;
 
+import java.util.UUID;
+
 import javax.inject.Inject;
 
+import org.apache.james.mailbox.events.Event;
 import org.apache.james.mailbox.events.EventDeadLetters;
 import org.apache.james.mailbox.events.Group;
 import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.utils.ErrorResponder;
 import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
 
 import com.github.steveash.guavate.Guavate;
 
@@ -34,6 +39,7 @@ import spark.Service;
 
 public class EventDeadLettersRoutes implements Routes {
     private static final String BASE_PATH = "/events/deadLetter";
+    private static final String GROUP_PARAM = ":group";
 
     private final EventDeadLetters deadLetters;
     private final JsonTransformer jsonTransformer;
@@ -52,6 +58,7 @@ public class EventDeadLettersRoutes implements Routes {
     @Override
     public void define(Service service) {
         service.get(BASE_PATH + "/groups", this::listGroups, jsonTransformer);
+        service.get(BASE_PATH + "/groups/" + GROUP_PARAM + "/events", this::listFailedEvents, jsonTransformer);
     }
 
     private Iterable<String> listGroups(Request request, Response response) {
@@ -59,5 +66,28 @@ public class EventDeadLettersRoutes implements Routes {
             .map(Group::asString)
             .collect(Guavate.toImmutableList())
             .block();
+    }
+
+    private Iterable<String> listFailedEvents(Request request, Response response) {
+        Group group = parseGroup(request);
+        return deadLetters.failedEventIds(group)
+            .map(Event.EventId::getId)
+            .map(UUID::toString)
+            .collect(Guavate.toImmutableList())
+            .block();
+    }
+
+    private Group parseGroup(Request request) {
+        String groupAsString = request.params(GROUP_PARAM);
+        try {
+            return Group.deserialize(groupAsString);
+        } catch (Exception e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .message("Can not deserialize the supplied group: " + groupAsString)
+                .cause(e)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .haltError();
+        }
     }
 }

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
@@ -197,7 +197,7 @@ class EventDeadLettersRoutesTest {
             .then()
                 .statusCode(HttpStatus.OK_200)
                 .contentType(ContentType.JSON)
-                .body(".", contains(UUID_1));
+                .body(".", containsInAnyOrder(UUID_1));
         }
 
         @Test
@@ -210,7 +210,7 @@ class EventDeadLettersRoutesTest {
             .then()
                 .statusCode(HttpStatus.OK_200)
                 .contentType(ContentType.JSON)
-                .body(".", contains(UUID_1));
+                .body(".", containsInAnyOrder(UUID_1));
         }
 
         @Test

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
@@ -1,0 +1,145 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.routes;
+
+import static io.restassured.RestAssured.when;
+import static org.apache.james.webadmin.WebAdminServer.NO_CONFIGURATION;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+
+import org.apache.james.core.User;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.events.Event;
+import org.apache.james.mailbox.events.EventBusTestFixture;
+import org.apache.james.mailbox.events.EventDeadLetters;
+import org.apache.james.mailbox.events.MailboxListener;
+import org.apache.james.mailbox.events.MemoryEventDeadLetters;
+import org.apache.james.mailbox.inmemory.InMemoryId;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.store.event.EventFactory;
+import org.apache.james.metrics.logger.DefaultMetricFactory;
+import org.apache.james.webadmin.WebAdminServer;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+class EventDeadLettersRoutesTest {
+    private static final String BOB = "bob@apache.org";
+    private static final String UUID_1 = "6e0dd59d-660e-4d9b-b22f-0354479f47b4";
+    private static final String UUID_2 = "6e0dd59d-660e-4d9b-b22f-0354479f47b5";
+    private static final MailboxListener.MailboxAdded EVENT_1 = EventFactory.mailboxAdded()
+        .eventId(Event.EventId.of(UUID_1))
+        .user(User.fromUsername(BOB))
+        .sessionId(MailboxSession.SessionId.of(452))
+        .mailboxId(InMemoryId.of(453))
+        .mailboxPath(MailboxPath.forUser(BOB, "Important-mailbox"))
+        .build();
+    private static final MailboxListener.MailboxAdded EVENT_2 = EventFactory.mailboxAdded()
+        .eventId(Event.EventId.of(UUID_2))
+        .user(User.fromUsername(BOB))
+        .sessionId(MailboxSession.SessionId.of(455))
+        .mailboxId(InMemoryId.of(456))
+        .mailboxPath(MailboxPath.forUser(BOB, "project-3"))
+        .build();
+
+    private WebAdminServer webAdminServer;
+    private EventDeadLetters deadLetters;
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        deadLetters = new MemoryEventDeadLetters();
+        JsonTransformer jsonTransformer = new JsonTransformer();
+
+        webAdminServer = WebAdminUtils.createWebAdminServer(
+            new DefaultMetricFactory(),
+            new EventDeadLettersRoutes(
+                deadLetters,
+                jsonTransformer));
+        webAdminServer.configure(NO_CONFIGURATION);
+        webAdminServer.await();
+
+        RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer).build();
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @AfterEach
+    void tearDown() {
+        webAdminServer.destroy();
+    }
+
+    @Nested
+    class ListGroups {
+        @Test
+        void getGroupsShouldReturnEmptyWhenNone() {
+            when()
+                .get("/events/deadLetter/groups")
+            .then()
+                .statusCode(HttpStatus.OK_200)
+                .contentType(ContentType.JSON)
+                .body(".", hasSize(0));
+        }
+
+        @Test
+        void getGroupsShouldReturnGroupsOfContainedEvents() {
+            deadLetters.store(new EventBusTestFixture.GroupA(), EVENT_1).block();
+
+            when()
+                .get("/events/deadLetter/groups")
+            .then()
+                .statusCode(HttpStatus.OK_200)
+                .contentType(ContentType.JSON)
+                .body(".", contains(EventBusTestFixture.GroupA.class.getName()));
+        }
+
+        @Test
+        void getGroupsShouldReturnGroupsOfContainedEventsWithoutDuplicates() {
+            deadLetters.store(new EventBusTestFixture.GroupA(), EVENT_1).block();
+            deadLetters.store(new EventBusTestFixture.GroupA(), EVENT_2).block();
+
+            when()
+                .get("/events/deadLetter/groups")
+            .then()
+                .statusCode(HttpStatus.OK_200)
+                .contentType(ContentType.JSON)
+                .body(".", contains(EventBusTestFixture.GroupA.class.getName()));
+        }
+
+        @Test
+        void getGroupsShouldReturnGroupsOfAllContainedEvents() {
+            deadLetters.store(new EventBusTestFixture.GroupA(), EVENT_1).block();
+            deadLetters.store(new EventBusTestFixture.GroupB(), EVENT_2).block();
+
+            when()
+                .get("/events/deadLetter/groups")
+            .then()
+                .statusCode(HttpStatus.OK_200)
+                .contentType(ContentType.JSON)
+                .body(".", containsInAnyOrder(EventBusTestFixture.GroupA.class.getName(), EventBusTestFixture.GroupB.class.getName()));
+        }
+    }
+}

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
@@ -285,7 +285,7 @@ class EventDeadLettersRoutesTest {
             deadLetters.store(new EventBusTestFixture.GroupA(), EVENT_1).block();
 
             when()
-                .delete("/events/deadLetter/groups/" + new EventBusTestFixture.GroupA().asString() + "/events/" + UUID_1)
+                .delete("/events/deadLetter/groups/" + SERIALIZED_GROUP_A + "/events/" + UUID_1)
             .then()
                 .statusCode(HttpStatus.NO_CONTENT_204);
         }
@@ -293,7 +293,7 @@ class EventDeadLettersRoutesTest {
         @Test
         void deleteShouldReturnOkWhenEventNotFound() {
             when()
-                .delete("/events/deadLetter/groups/" + new EventBusTestFixture.GroupA().asString() + "/events/" + UUID_1)
+                .delete("/events/deadLetter/groups/" + SERIALIZED_GROUP_A + "/events/" + UUID_1)
             .then()
                 .statusCode(HttpStatus.NO_CONTENT_204);
         }
@@ -313,7 +313,7 @@ class EventDeadLettersRoutesTest {
         @Test
         void deleteShouldFailWhenInvalidEventId() {
             when()
-                .delete("/events/deadLetter/groups/" + new EventBusTestFixture.GroupA().asString() + "/events/invalid")
+                .delete("/events/deadLetter/groups/" + SERIALIZED_GROUP_A + "/events/invalid")
             .then()
                 .statusCode(HttpStatus.BAD_REQUEST_400)
                 .contentType(ContentType.JSON)
@@ -327,10 +327,10 @@ class EventDeadLettersRoutesTest {
             deadLetters.store(new EventBusTestFixture.GroupA(), EVENT_1).block();
 
             with()
-                .delete("/events/deadLetter/groups/" + new EventBusTestFixture.GroupA().asString() + "/events/" + UUID_1);
+                .delete("/events/deadLetter/groups/" + SERIALIZED_GROUP_A + "/events/" + UUID_1);
 
             when()
-                .get("/events/deadLetter/groups/" + new EventBusTestFixture.GroupA().asString() + "/events/" + UUID_1)
+                .get("/events/deadLetter/groups/" + SERIALIZED_GROUP_A + "/events/" + UUID_1)
             .then()
                 .statusCode(HttpStatus.NOT_FOUND_404);
         }

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
@@ -134,7 +134,7 @@ class EventDeadLettersRoutesTest {
             .then()
                 .statusCode(HttpStatus.OK_200)
                 .contentType(ContentType.JSON)
-                .body(".", contains(EventBusTestFixture.GroupA.class.getName()));
+                .body(".", containsInAnyOrder(EventBusTestFixture.GroupA.class.getName()));
         }
 
         @Test
@@ -147,7 +147,7 @@ class EventDeadLettersRoutesTest {
             .then()
                 .statusCode(HttpStatus.OK_200)
                 .contentType(ContentType.JSON)
-                .body(".", contains(EventBusTestFixture.GroupA.class.getName()));
+                .body(".", containsInAnyOrder(EventBusTestFixture.GroupA.class.getName()));
         }
 
         @Test

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
@@ -235,7 +235,7 @@ class EventDeadLettersRoutesTest {
             deadLetters.store(new EventBusTestFixture.GroupA(), EVENT_1).block();
 
             String response = when()
-                .get("/events/deadLetter/groups/" + new EventBusTestFixture.GroupA().asString() + "/events/" + UUID_1)
+                .get("/events/deadLetter/groups/" + SERIALIZED_GROUP_A + "/events/" + UUID_1)
             .then()
                 .statusCode(HttpStatus.OK_200)
                 .contentType(ContentType.JSON)
@@ -248,7 +248,7 @@ class EventDeadLettersRoutesTest {
         @Test
         void getEventShouldReturn404WhenNotFound() {
             when()
-                .get("/events/deadLetter/groups/" + new EventBusTestFixture.GroupA().asString() + "/events/" + UUID_1)
+                .get("/events/deadLetter/groups/" + SERIALIZED_GROUP_A + "/events/" + UUID_1)
             .then()
                 .statusCode(HttpStatus.NOT_FOUND_404);
         }
@@ -256,7 +256,7 @@ class EventDeadLettersRoutesTest {
         @Test
         void getEventShouldFailWhenInvalidEventId() {
             when()
-                .get("/events/deadLetter/groups/" + new EventBusTestFixture.GroupA().asString() + "/events/invalid")
+                .get("/events/deadLetter/groups/" + SERIALIZED_GROUP_A + "/events/invalid")
             .then()
                 .statusCode(HttpStatus.BAD_REQUEST_400)
                 .contentType(ContentType.JSON)

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.webadmin.routes;
 
 import static io.restassured.RestAssured.when;
+import static io.restassured.RestAssured.with;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.apache.james.webadmin.WebAdminServer.NO_CONFIGURATION;
 import static org.hamcrest.Matchers.contains;
@@ -273,6 +274,64 @@ class EventDeadLettersRoutesTest {
                 .body("statusCode", is(400))
                 .body("type", is(ErrorResponder.ErrorType.INVALID_ARGUMENT.getType()))
                 .body("message", is("Can not deserialize the supplied group: invalid"));
+        }
+    }
+
+    @Nested
+    class Delete {
+        @Test
+        void deleteShouldReturnOk() {
+            deadLetters.store(new EventBusTestFixture.GroupA(), EVENT_1).block();
+
+            when()
+                .delete("/events/deadLetter/groups/" + new EventBusTestFixture.GroupA().asString() + "/events/" + UUID_1)
+            .then()
+                .statusCode(HttpStatus.NO_CONTENT_204);
+        }
+
+        @Test
+        void deleteShouldReturnOkWhenEventNotFound() {
+            when()
+                .delete("/events/deadLetter/groups/" + new EventBusTestFixture.GroupA().asString() + "/events/" + UUID_1)
+            .then()
+                .statusCode(HttpStatus.NO_CONTENT_204);
+        }
+
+        @Test
+        void deleteShouldFailWhenInvalidGroup() {
+            when()
+                .delete("/events/deadLetter/groups/invalid/events/" + UUID_1)
+            .then()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .contentType(ContentType.JSON)
+                .body("statusCode", is(400))
+                .body("type", is(ErrorResponder.ErrorType.INVALID_ARGUMENT.getType()))
+                .body("message", is("Can not deserialize the supplied group: invalid"));
+        }
+
+        @Test
+        void deleteShouldFailWhenInvalidEventId() {
+            when()
+                .delete("/events/deadLetter/groups/" + new EventBusTestFixture.GroupA().asString() + "/events/invalid")
+            .then()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .contentType(ContentType.JSON)
+                .body("statusCode", is(400))
+                .body("type", is(ErrorResponder.ErrorType.INVALID_ARGUMENT.getType()))
+                .body("message", is("Can not deserialize the supplied eventId: invalid"));
+        }
+
+        @Test
+        void deleteShouldRemoveEvent() {
+            deadLetters.store(new EventBusTestFixture.GroupA(), EVENT_1).block();
+
+            with()
+                .delete("/events/deadLetter/groups/" + new EventBusTestFixture.GroupA().asString() + "/events/" + UUID_1);
+
+            when()
+                .get("/events/deadLetter/groups/" + new EventBusTestFixture.GroupA().asString() + "/events/" + UUID_1)
+            .then()
+                .statusCode(HttpStatus.NOT_FOUND_404);
         }
     }
 }

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
@@ -85,6 +85,7 @@ class EventDeadLettersRoutesTest {
         "     \"sessionId\":452" +
         "  }" +
         "}";
+    public static final String SERIALIZED_GROUP_A = new EventBusTestFixture.GroupA().asString();
 
     private WebAdminServer webAdminServer;
     private EventDeadLetters deadLetters;
@@ -181,7 +182,7 @@ class EventDeadLettersRoutesTest {
         @Test
         void listEventsShouldReturnEmptyWhenNone() {
             when()
-                .get("/events/deadLetter/groups/" + new EventBusTestFixture.GroupA().asString() + "/events")
+                .get("/events/deadLetter/groups/" + SERIALIZED_GROUP_A + "/events")
             .then()
                 .statusCode(HttpStatus.OK_200)
                 .contentType(ContentType.JSON)
@@ -193,7 +194,7 @@ class EventDeadLettersRoutesTest {
             deadLetters.store(new EventBusTestFixture.GroupA(), EVENT_1).block();
 
             when()
-                .get("/events/deadLetter/groups/" + new EventBusTestFixture.GroupA().asString() + "/events")
+                .get("/events/deadLetter/groups/" + SERIALIZED_GROUP_A + "/events")
             .then()
                 .statusCode(HttpStatus.OK_200)
                 .contentType(ContentType.JSON)
@@ -206,7 +207,7 @@ class EventDeadLettersRoutesTest {
             deadLetters.store(new EventBusTestFixture.GroupB(), EVENT_2).block();
 
             when()
-                .get("/events/deadLetter/groups/" + new EventBusTestFixture.GroupA().asString() + "/events")
+                .get("/events/deadLetter/groups/" + SERIALIZED_GROUP_A + "/events")
             .then()
                 .statusCode(HttpStatus.OK_200)
                 .contentType(ContentType.JSON)
@@ -219,7 +220,7 @@ class EventDeadLettersRoutesTest {
             deadLetters.store(new EventBusTestFixture.GroupA(), EVENT_2).block();
 
             when()
-                .get("/events/deadLetter/groups/" + new EventBusTestFixture.GroupA().asString() + "/events")
+                .get("/events/deadLetter/groups/" + SERIALIZED_GROUP_A + "/events")
             .then()
                 .statusCode(HttpStatus.OK_200)
                 .contentType(ContentType.JSON)

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -2434,7 +2434,7 @@ failing, then the event will be stored in the "Event Dead Letter". This API allo
 This endpoint allows discovering the list of groups.
 
 ```
-curl -XGET http://ip:port//events/deadLetter/groups
+curl -XGET http://ip:port/events/deadLetter/groups
 ```
 
 Will return a list of group names that can be further used to interact with the dead letter API:
@@ -2452,7 +2452,7 @@ Response codes:
 This endpoint allows listing failed events for a given group:
 
 ```
-curl -XGET http://ip:port//events/deadLetter/groups/org.apache.james.mailbox.events.EventBusTestFixture$GroupA/events
+curl -XGET http://ip:port/events/deadLetter/groups/org.apache.james.mailbox.events.EventBusTestFixture$GroupA/events
 ```
 
 Will return a list of event ids:
@@ -2469,7 +2469,7 @@ Response codes:
 ### Getting event details
 
 ```
-curl -XGET http://ip:port//events/deadLetter/groups/org.apache.james.mailbox.events.EventBusTestFixture$GroupA/events/6e0dd59d-660e-4d9b-b22f-0354479f47b4
+curl -XGET http://ip:port/events/deadLetter/groups/org.apache.james.mailbox.events.EventBusTestFixture$GroupA/events/6e0dd59d-660e-4d9b-b22f-0354479f47b4
 ```
 
 Will return the full JSON associated with this event.
@@ -2482,7 +2482,7 @@ Response codes:
 ### Deleting an event
 
 ```
-curl -XDELETE http://ip:port//events/deadLetter/groups/org.apache.james.mailbox.events.EventBusTestFixture$GroupA/events/6e0dd59d-660e-4d9b-b22f-0354479f47b4
+curl -XDELETE http://ip:port/events/deadLetter/groups/org.apache.james.mailbox.events.EventBusTestFixture$GroupA/events/6e0dd59d-660e-4d9b-b22f-0354479f47b4
 ```
 
 Will delete this event.

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -43,6 +43,7 @@ as exposed above). To avoid information duplication, this is ommited on endpoint
  - [Administrating DLP Configuration](#Administrating_dlp_configuration)
  - [Administrating Sieve quotas](#Administrating_Sieve_quotas)
  - [ReIndexing](#ReIndexing)
+ - [Event Dead Letter](#Event_Dead_Letter)
  - [Task management](#Task_management)
  - [Cassandra extra operations](#Cassandra_extra_operations)
 
@@ -2412,6 +2413,88 @@ The scheduled task will have the following type `MessageIdReIndexingTask` and th
 ```
 
 Warning: During the re-indexing, the result of search operations might be altered.
+
+## Event Dead letter
+
+The EventBus allows to register 'group listeners' that are called in a (potentially) distributed fashion. These group
+listeners enable the implementation of some advanced mailbox manager feature like indexing, spam reporting, quota management
+and the like.
+
+Upon exceptions, a bounded number of retries is performed (with exponential backoff delays). If after those retries the listener is still
+failing, then the event will be stored in the "Event Dead Letter". This API allows diagnosing issues, as well as performing event replay (not implemented yet).
+
+ - [Listing groups](#Listing_groups)
+ - [Listing failed events](#Listing_failed_events)
+ - [Getting event details](#Getting_event_details)
+ - [Deleting an event](#Deleting_an_event)
+ - [Rescheduling group execution](#Rescheduling_group_execution)
+
+### Listing groups
+
+This endpoint allows discovering the list of groups.
+
+```
+curl -XGET http://ip:port//events/deadLetter/groups
+```
+
+Will return a list of group names that can be further used to interact with the dead letter API:
+
+```
+["org.apache.james.mailbox.events.EventBusTestFixture$GroupA", "org.apache.james.mailbox.events.GenericGroup-abc"]
+```
+
+Response codes:
+
+ - 200: Success. A list of group names is returned.
+
+### Listing failed events
+
+This endpoint allows listing failed events for a given group:
+
+```
+curl -XGET http://ip:port//events/deadLetter/groups/org.apache.james.mailbox.events.EventBusTestFixture$GroupA/events
+```
+
+Will return a list of event ids:
+
+```
+["6e0dd59d-660e-4d9b-b22f-0354479f47b4", "58a8f59d-660e-4d9b-b22f-0354486322a2"]
+```
+
+Response codes:
+
+ - 200: Success. A list of event ids is returned.
+ - 400: Invalid group name
+
+### Getting event details
+
+```
+curl -XGET http://ip:port//events/deadLetter/groups/org.apache.james.mailbox.events.EventBusTestFixture$GroupA/events/6e0dd59d-660e-4d9b-b22f-0354479f47b4
+```
+
+Will return the full JSON associated with this event.
+
+Response codes:
+
+ - 200: Success. A JSON representing this event is returned.
+ - 400: Invalid group name or eventId
+
+### Deleting an event
+
+```
+curl -XDELETE http://ip:port//events/deadLetter/groups/org.apache.james.mailbox.events.EventBusTestFixture$GroupA/events/6e0dd59d-660e-4d9b-b22f-0354479f47b4
+```
+
+Will delete this event.
+
+Response codes:
+
+ - 204: Success
+ - 400: Invalid group name or eventId
+
+### Rescheduling group execution
+
+Not implemented yet.
 
 ## Task management
 

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -2420,7 +2420,7 @@ The EventBus allows to register 'group listeners' that are called in a (potentia
 listeners enable the implementation of some advanced mailbox manager feature like indexing, spam reporting, quota management
 and the like.
 
-Upon exceptions, a bounded number of retries is performed (with exponential backoff delays). If after those retries the listener is still
+Upon exceptions, a bounded number of retries are performed (with exponential backoff delays). If after those retries the listener is still
 failing, then the event will be stored in the "Event Dead Letter". This API allows diagnosing issues, as well as performing event replay (not implemented yet).
 
  - [Listing groups](#Listing_groups)


### PR DESCRIPTION
The trickiest part is about group parsing...

Then I implemented the routes for:
 - Listing groups
 - Retrieving events that a given group failed to execute
 - Retrieving an event JSON - I reused the Scala code here...
 - Deleting an event

I do think we miss some documentation on event json structure...