### PR TITLE
MAILBOX-383 Manage dependencies between all startable components

### DIFF
--- a/mailbox/event/event-rabbitmq/pom.xml
+++ b/mailbox/event/event-rabbitmq/pom.xml
@@ -63,6 +63,10 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-lifecycle-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-testing</artifactId>
             <scope>test</scope>
         </dependency>

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/RabbitMQEventBus.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/RabbitMQEventBus.java
@@ -26,18 +26,18 @@ import javax.inject.Inject;
 
 import org.apache.james.backend.rabbitmq.RabbitMQConnectionFactory;
 import org.apache.james.event.json.EventSerializer;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.metrics.api.MetricFactory;
 
 import com.github.fge.lambdas.Throwing;
 import com.google.common.base.Preconditions;
 import com.rabbitmq.client.Connection;
-
 import reactor.core.publisher.Mono;
 import reactor.rabbitmq.RabbitFlux;
 import reactor.rabbitmq.Sender;
 import reactor.rabbitmq.SenderOptions;
 
-public class RabbitMQEventBus implements EventBus {
+public class RabbitMQEventBus implements EventBus, Startable {
     private static final String NOT_RUNNING_ERROR_MESSAGE = "Event Bus is not running";
     static final String MAILBOX_EVENT = "mailboxEvent";
     static final String MAILBOX_EVENT_EXCHANGE_NAME = MAILBOX_EVENT + "-exchange";

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/data/CassandraDomainListModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/data/CassandraDomainListModule.java
@@ -25,7 +25,7 @@ import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.domainlist.api.DomainList;
 import org.apache.james.domainlist.cassandra.CassandraDomainList;
 import org.apache.james.domainlist.lib.DomainListConfiguration;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
 import org.apache.james.utils.ConfigurationPerformer;
 
@@ -79,7 +79,7 @@ public class CassandraDomainListModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(CassandraDomainList.class);
         }
     }

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/data/CassandraRecipientRewriteTableModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/data/CassandraRecipientRewriteTableModule.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.backends.cassandra.components.CassandraModule;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.rrt.api.RecipientRewriteTable;
 import org.apache.james.rrt.cassandra.CassandraMappingsSourcesDAO;
 import org.apache.james.rrt.cassandra.CassandraRRTModule;
@@ -73,7 +73,7 @@ public class CassandraRecipientRewriteTableModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(CassandraRecipientRewriteTable.class);
         }
     }

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/data/CassandraUsersRepositoryModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/data/CassandraUsersRepositoryModule.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.backends.cassandra.components.CassandraModule;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.cassandra.CassandraUsersRepository;
@@ -68,7 +68,7 @@ public class CassandraUsersRepositoryModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(CassandraUsersRepository.class);
         }
     }

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraSessionModule.java
@@ -36,7 +36,7 @@ import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManage
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager.SchemaState;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
 import org.apache.james.core.healthcheck.HealthCheck;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.mailbox.store.BatchSizes;
 import org.apache.james.server.CassandraProbe;
 import org.apache.james.util.Host;
@@ -176,7 +176,7 @@ public class CassandraSessionModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of();
         }
     }

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/metrics/CassandraMetricsModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/metrics/CassandraMetricsModule.java
@@ -21,7 +21,7 @@ package org.apache.james.modules.metrics;
 
 import java.util.List;
 
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.utils.ConfigurationPerformer;
 
 import com.codahale.metrics.MetricRegistry;
@@ -64,7 +64,7 @@ public class CassandraMetricsModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of();
         }
     }

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraMessageIdManagerInjectionTest.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraMessageIdManagerInjectionTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mailbox.store.search.PDFTextExtractor;
@@ -71,7 +71,7 @@ class CassandraMessageIdManagerInjectionTest {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of();
         }
     }

--- a/server/container/guice/cassandra-ldap-guice/src/main/java/org/apache/james/data/LdapUsersRepositoryModule.java
+++ b/server/container/guice/cassandra-ldap-guice/src/main/java/org/apache/james/data/LdapUsersRepositoryModule.java
@@ -21,7 +21,7 @@ package org.apache.james.data;
 import java.util.List;
 
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.ldap.LdapRepositoryConfiguration;
@@ -76,7 +76,7 @@ public class LdapUsersRepositoryModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(ReadOnlyUsersLDAPRepository.class);
         }
     }

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/event/RabbitMQEventBusModule.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/event/RabbitMQEventBusModule.java
@@ -22,7 +22,7 @@ package org.apache.james.modules.event;
 import java.util.List;
 
 import org.apache.james.event.json.EventSerializer;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.mailbox.events.EventBus;
 import org.apache.james.mailbox.events.MailboxIdRegistrationKey;
 import org.apache.james.mailbox.events.RabbitMQEventBus;
@@ -68,8 +68,8 @@ public class RabbitMQEventBusModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
-            return ImmutableList.of();
+        public List<Class<? extends Startable>> forClasses() {
+            return ImmutableList.of(RabbitMQEventBus.class);
         }
     }
 }

--- a/server/container/guice/configuration/src/main/java/org/apache/james/utils/ConfigurationPerformer.java
+++ b/server/container/guice/configuration/src/main/java/org/apache/james/utils/ConfigurationPerformer.java
@@ -21,12 +21,20 @@ package org.apache.james.utils;
 
 import java.util.List;
 
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 
 public interface ConfigurationPerformer {
 
     void initModule();
 
-    List<Class<? extends Configurable>> forClasses();
+    /**
+     * In order to initialize components in the right order, every
+     * {@link ConfigurationPerformer} is supposed to declare which
+     * classes it will initialize.
+     *
+     * @return the list of Classes that this object will initialize.
+     *  The list should never be empty.
+     */
+    List<Class<? extends Startable>> forClasses();
 
 }

--- a/server/container/guice/es-metric-reporter/src/main/java/org/apache/james/modules/server/ElasticSearchMetricReporterModule.java
+++ b/server/container/guice/es-metric-reporter/src/main/java/org/apache/james/modules/server/ElasticSearchMetricReporterModule.java
@@ -24,9 +24,7 @@ import java.util.List;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.HierarchicalConfiguration;
-import org.apache.commons.lang.NotImplementedException;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.metrics.es.ESMetricReporter;
 import org.apache.james.metrics.es.ESReporterConfiguration;
 import org.apache.james.utils.ConfigurationPerformer;
@@ -87,7 +85,7 @@ public class ElasticSearchMetricReporterModule extends AbstractModule {
     }
 
     @Singleton
-    public static class ESMetricReporterStarter implements ConfigurationPerformer, Configurable {
+    public static class ESMetricReporterStarter implements ConfigurationPerformer {
 
         private final ESMetricReporter esMetricReporter;
 
@@ -102,13 +100,8 @@ public class ElasticSearchMetricReporterModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
-            return ImmutableList.of(ESMetricReporterStarter.class);
-        }
-
-        @Override
-        public void configure(HierarchicalConfiguration config) throws ConfigurationException {
-            throw new NotImplementedException();
+        public List<Class<? extends Startable>> forClasses() {
+            return ImmutableList.of(ESMetricReporter.class);
         }
     }
 

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/modules/CommonServicesModule.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/modules/CommonServicesModule.java
@@ -54,7 +54,7 @@ public class CommonServicesModule extends AbstractModule {
     
     @Override
     protected void configure() {
-        install(new ConfigurablesModule());
+        install(new StartablesModule());
         install(new PreDestroyModule());
         install(new DNSServiceModule());
         install(new AsyncTasksExecutorModule());

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/modules/server/DNSServiceModule.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/modules/server/DNSServiceModule.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.dnsservice.dnsjava.DNSJavaService;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
 import org.apache.james.utils.ConfigurationPerformer;
 
@@ -66,7 +66,7 @@ public class DNSServiceModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(DNSJavaService.class);
         }
     }

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/modules/server/DropWizardMetricsModule.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/modules/server/DropWizardMetricsModule.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.metrics.api.GaugeRegistry;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.metrics.dropwizard.DropWizardGaugeRegistry;
@@ -75,7 +76,7 @@ public class DropWizardMetricsModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(DropWizardInitializer.class);
         }
     }

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/modules/server/MailStoreRepositoryModule.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/modules/server/MailStoreRepositoryModule.java
@@ -21,7 +21,7 @@ package org.apache.james.modules.server;
 
 import java.util.List;
 
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.mailrepository.api.MailRepositoryProvider;
 import org.apache.james.mailrepository.api.MailRepositoryStore;
 import org.apache.james.mailrepository.file.FileMailRepositoryProvider;
@@ -75,7 +75,7 @@ public class MailStoreRepositoryModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(MemoryMailRepositoryStore.class);
         }
     }

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/utils/ConfigurationsPerformer.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/utils/ConfigurationsPerformer.java
@@ -23,17 +23,17 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 
 import com.google.inject.Inject;
 
 public class ConfigurationsPerformer {
 
     private final Set<ConfigurationPerformer> configurationPerformers;
-    private final Configurables configurables;
+    private final Startables configurables;
 
     @Inject
-    public ConfigurationsPerformer(Set<ConfigurationPerformer> configurationPerformers, Configurables configurables) {
+    public ConfigurationsPerformer(Set<ConfigurationPerformer> configurationPerformers, Startables configurables) {
         this.configurationPerformers = configurationPerformers;
         this.configurables = configurables;
     }
@@ -53,7 +53,7 @@ public class ConfigurationsPerformer {
             .collect(Collectors.toSet());
     }
 
-    private Stream<ConfigurationPerformer> configurationPerformerFor(Class<? extends Configurable> configurable) {
+    private Stream<ConfigurationPerformer> configurationPerformerFor(Class<? extends Startable> configurable) {
         return configurationPerformers.stream()
                 .filter(x -> x.forClasses().contains(configurable));
     }

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/utils/Startables.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/utils/Startables.java
@@ -21,24 +21,24 @@ package org.apache.james.utils;
 
 import java.util.Set;
 
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
-public class Configurables {
+public class Startables {
 
-    private final Set<Class<? extends Configurable>> configurables;
+    private final Set<Class<? extends Startable>> startables;
 
-    public Configurables() {
-        this.configurables = Sets.newLinkedHashSet();
+    public Startables() {
+        this.startables = Sets.newLinkedHashSet();
     }
 
-    public void add(Class<? extends Configurable> configurable) {
-        configurables.add(configurable);
+    public void add(Class<? extends Startable> configurable) {
+        startables.add(configurable);
     }
 
-    public Set<Class<? extends Configurable>> get() {
-        return ImmutableSet.copyOf(configurables);
+    public Set<Class<? extends Startable>> get() {
+        return ImmutableSet.copyOf(startables);
     }
 }

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/modules/ConfigurationsPerformerTest.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/modules/ConfigurationsPerformerTest.java
@@ -28,6 +28,7 @@ import javax.inject.Inject;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.utils.ConfigurationPerformer;
 import org.apache.james.utils.ConfigurationsPerformer;
 import org.junit.Test;
@@ -42,7 +43,7 @@ public class ConfigurationsPerformerTest {
 
     @Test
     public void initModulesShouldNotFailWhenBindingsInWrongOrder() throws Exception {
-        Injector injector = Guice.createInjector(new ConfigurablesModule(),
+        Injector injector = Guice.createInjector(new StartablesModule(),
                 new UnorderedBindingsModule());
 
         injector.getInstance(ConfigurationsPerformer.class).initModules();
@@ -51,7 +52,7 @@ public class ConfigurationsPerformerTest {
         assertThat(injector.getInstance(B.class).isConfigured()).isTrue();
     }
 
-    private static class UnorderedBindingsModule extends ConfigurablesModule {
+    private static class UnorderedBindingsModule extends StartablesModule {
 
         @Override
         protected void configure() {
@@ -83,7 +84,7 @@ public class ConfigurationsPerformerTest {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(A.class);
         }
     }
@@ -107,7 +108,7 @@ public class ConfigurationsPerformerTest {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(B.class);
         }
     }
@@ -163,7 +164,7 @@ public class ConfigurationsPerformerTest {
 
     @Test
     public void initModulesShouldBePerformedOneTimeWhenConfigurableModuleContainsMultipleDependencies() throws Exception {
-        Injector injector = Guice.createInjector(new ConfigurablesModule(),
+        Injector injector = Guice.createInjector(new StartablesModule(),
                 new DualResponsibilityConfigurationPerformerModule());
 
         injector.getInstance(ConfigurationsPerformer.class).initModules();
@@ -201,12 +202,12 @@ public class ConfigurationsPerformerTest {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(A.class, B.class);
         }
     }
 
-    private static class DualResponsibilityConfigurationPerformerModule extends ConfigurablesModule {
+    private static class DualResponsibilityConfigurationPerformerModule extends StartablesModule {
 
         @Override
         protected void configure() {

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/utils/ConfigurablesTest.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/utils/ConfigurablesTest.java
@@ -29,11 +29,11 @@ import org.junit.Test;
 
 public class ConfigurablesTest {
 
-    private Configurables sut;
+    private Startables sut;
 
     @Before
     public void setup() {
-        sut = new Configurables();
+        sut = new Startables();
     }
 
     @Test

--- a/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JMXServer.java
+++ b/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JMXServer.java
@@ -34,12 +34,13 @@ import javax.management.remote.JMXConnectorServer;
 import javax.management.remote.JMXConnectorServerFactory;
 import javax.management.remote.JMXServiceURL;
 
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.util.RestrictingRMISocketFactory;
 
 import com.github.fge.lambdas.Throwing;
 import com.google.common.collect.ImmutableMap;
 
-public class JMXServer {
+public class JMXServer implements Startable {
     private final JmxConfiguration jmxConfiguration;
     private final Set<String> registeredKeys;
     private final Object lock;

--- a/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JMXServerModule.java
+++ b/server/container/guice/jmx/src/main/java/org/apache/james/modules/server/JMXServerModule.java
@@ -34,7 +34,7 @@ import org.apache.james.adapter.mailbox.ReIndexerManagement;
 import org.apache.james.adapter.mailbox.ReIndexerManagementMBean;
 import org.apache.james.domainlist.api.DomainListManagementMBean;
 import org.apache.james.domainlist.lib.DomainListManagement;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.mailbox.copier.MailboxCopier;
 import org.apache.james.mailbox.indexer.ReIndexer;
 import org.apache.james.mailbox.tools.copier.MailboxCopierImpl;
@@ -165,8 +165,8 @@ public class JMXServerModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
-            return ImmutableList.of();
+        public List<Class<? extends Startable>> forClasses() {
+            return ImmutableList.of(JMXServer.class);
         }
     }
 

--- a/server/container/guice/jpa-common-guice/src/main/java/org/apache/james/modules/data/JPADomainListModule.java
+++ b/server/container/guice/jpa-common-guice/src/main/java/org/apache/james/modules/data/JPADomainListModule.java
@@ -24,7 +24,7 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.domainlist.api.DomainList;
 import org.apache.james.domainlist.jpa.JPADomainList;
 import org.apache.james.domainlist.lib.DomainListConfiguration;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
 import org.apache.james.utils.ConfigurationPerformer;
 
@@ -77,7 +77,7 @@ public class JPADomainListModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(JPADomainList.class);
         }
     }

--- a/server/container/guice/jpa-common-guice/src/main/java/org/apache/james/modules/data/JPARecipientRewriteTableModule.java
+++ b/server/container/guice/jpa-common-guice/src/main/java/org/apache/james/modules/data/JPARecipientRewriteTableModule.java
@@ -21,7 +21,7 @@ package org.apache.james.modules.data;
 import java.util.List;
 
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.rrt.api.RecipientRewriteTable;
 import org.apache.james.rrt.jpa.JPARecipientRewriteTable;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
@@ -65,7 +65,7 @@ public class JPARecipientRewriteTableModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(JPARecipientRewriteTable.class);
         }
     }

--- a/server/container/guice/jpa-common-guice/src/main/java/org/apache/james/modules/data/JPAUsersRepositoryModule.java
+++ b/server/container/guice/jpa-common-guice/src/main/java/org/apache/james/modules/data/JPAUsersRepositoryModule.java
@@ -21,7 +21,7 @@ package org.apache.james.modules.data;
 import java.util.List;
 
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.jpa.JPAUsersRepository;
@@ -65,7 +65,7 @@ public class JPAUsersRepositoryModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(JPAUsersRepository.class);
         }
     }

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/DefaultEventModule.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/DefaultEventModule.java
@@ -24,7 +24,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.mailbox.events.EventBus;
 import org.apache.james.mailbox.events.EventDeadLetters;
 import org.apache.james.mailbox.events.InVMEventBus;
@@ -84,8 +84,8 @@ public class DefaultEventModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
-            return ImmutableList.of();
+        public List<Class<? extends Startable>> forClasses() {
+            return ImmutableList.of(MailboxListenersLoaderImpl.class);
         }
     }
 }

--- a/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/CamelMailetContainerModule.java
+++ b/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/CamelMailetContainerModule.java
@@ -30,7 +30,7 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.domainlist.api.DomainList;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.mailetcontainer.api.MailProcessor;
 import org.apache.james.mailetcontainer.api.MailetLoader;
 import org.apache.james.mailetcontainer.api.MatcherLoader;
@@ -216,7 +216,7 @@ public class CamelMailetContainerModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(CamelCompositeProcessor.class, JamesMailSpooler.class, JamesMailetContext.class);
         }
     }

--- a/server/container/guice/memory-guice/src/main/java/org/apache/james/modules/data/MemoryDataModule.java
+++ b/server/container/guice/memory-guice/src/main/java/org/apache/james/modules/data/MemoryDataModule.java
@@ -27,7 +27,7 @@ import org.apache.james.dlp.eventsourcing.EventSourcingDLPConfigurationStore;
 import org.apache.james.domainlist.api.DomainList;
 import org.apache.james.domainlist.lib.DomainListConfiguration;
 import org.apache.james.domainlist.memory.MemoryDomainList;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.mailrepository.api.MailRepositoryUrlStore;
 import org.apache.james.mailrepository.memory.MemoryMailRepositoryUrlStore;
 import org.apache.james.rrt.api.RecipientRewriteTable;
@@ -109,7 +109,7 @@ public class MemoryDataModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(MemoryDomainList.class, MemoryRecipientRewriteTable.class);
         }
     }

--- a/server/container/guice/memory-guice/src/test/java/org/apache/james/GuiceJamesServerTest.java
+++ b/server/container/guice/memory-guice/src/test/java/org/apache/james/GuiceJamesServerTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mailbox.store.search.PDFTextExtractor;
 import org.apache.james.modules.TestJMAPServerModule;
@@ -66,7 +66,7 @@ class GuiceJamesServerTest {
             }
 
             @Override
-            public List<Class<? extends Configurable>> forClasses() {
+            public List<Class<? extends Startable>> forClasses() {
                 return ImmutableList.of();
             }
         };

--- a/server/container/guice/protocols/imap/src/main/java/org/apache/james/modules/protocols/IMAPServerModule.java
+++ b/server/container/guice/protocols/imap/src/main/java/org/apache/james/modules/protocols/IMAPServerModule.java
@@ -28,7 +28,7 @@ import org.apache.james.imap.main.DefaultImapDecoderFactory;
 import org.apache.james.imap.processor.main.DefaultImapProcessorFactory;
 import org.apache.james.imapserver.netty.IMAPServerFactory;
 import org.apache.james.imapserver.netty.OioIMAPServerFactory;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.SubscriptionManager;
 import org.apache.james.mailbox.events.EventBus;
@@ -111,7 +111,7 @@ public class IMAPServerModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(IMAPServerFactory.class);
         }
     }

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPModule.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPModule.java
@@ -37,7 +37,7 @@ import org.apache.james.jmap.send.PostDequeueDecoratorFactory;
 import org.apache.james.jmap.utils.HtmlTextExtractor;
 import org.apache.james.jmap.utils.JsoupHtmlTextExtractor;
 import org.apache.james.jwt.JwtConfiguration;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxManager.SearchCapabilities;
 import org.apache.james.mailbox.events.MailboxListener;
@@ -166,7 +166,7 @@ public class JMAPModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of();
         }
     }

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/modules/protocols/JMAPServerModule.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/modules/protocols/JMAPServerModule.java
@@ -27,7 +27,7 @@ import org.apache.james.jmap.JMAPConfiguration;
 import org.apache.james.jmap.JMAPModule;
 import org.apache.james.jmap.JMAPServer;
 import org.apache.james.jmap.crypto.JamesSignatureHandler;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.utils.ConfigurationPerformer;
 import org.apache.james.utils.GuiceProbe;
 import org.apache.james.utils.JmapGuiceProbe;
@@ -84,7 +84,7 @@ public class JMAPServerModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(JMAPServer.class);
         }
     }

--- a/server/container/guice/protocols/lmtp/src/main/java/org/apache/james/modules/protocols/LMTPServerModule.java
+++ b/server/container/guice/protocols/lmtp/src/main/java/org/apache/james/modules/protocols/LMTPServerModule.java
@@ -21,7 +21,7 @@ package org.apache.james.modules.protocols;
 
 import java.util.List;
 
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.lmtpserver.netty.LMTPServerFactory;
 import org.apache.james.lmtpserver.netty.OioLMTPServerFactory;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
@@ -70,7 +70,7 @@ public class LMTPServerModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(LMTPServerFactory.class);
         }
     }

--- a/server/container/guice/protocols/managedsieve/src/main/java/org/apache/james/modules/protocols/ManageSieveServerModule.java
+++ b/server/container/guice/protocols/managedsieve/src/main/java/org/apache/james/modules/protocols/ManageSieveServerModule.java
@@ -20,7 +20,7 @@ package org.apache.james.modules.protocols;
 
 import java.util.List;
 
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.managesieve.api.commands.CoreCommands;
 import org.apache.james.managesieve.core.CoreProcessor;
 import org.apache.james.managesieveserver.netty.ManageSieveServerFactory;
@@ -67,7 +67,7 @@ public class ManageSieveServerModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(ManageSieveServerFactory.class);
         }
     }

--- a/server/container/guice/protocols/pop/src/main/java/org/apache/james/modules/protocols/POP3ServerModule.java
+++ b/server/container/guice/protocols/pop/src/main/java/org/apache/james/modules/protocols/POP3ServerModule.java
@@ -21,7 +21,7 @@ package org.apache.james.modules.protocols;
 
 import java.util.List;
 
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.pop3server.netty.OioPOP3ServerFactory;
 import org.apache.james.pop3server.netty.POP3ServerFactory;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
@@ -69,7 +69,7 @@ public class POP3ServerModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(POP3ServerFactory.class);
         }
     }

--- a/server/container/guice/protocols/smtp/src/main/java/org/apache/james/modules/protocols/SMTPServerModule.java
+++ b/server/container/guice/protocols/smtp/src/main/java/org/apache/james/modules/protocols/SMTPServerModule.java
@@ -21,7 +21,7 @@ package org.apache.james.modules.protocols;
 
 import java.util.List;
 
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
 import org.apache.james.smtpserver.SendMailHandler;
 import org.apache.james.smtpserver.netty.OioSMTPServerFactory;
@@ -76,7 +76,7 @@ public class SMTPServerModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(SMTPServerFactory.class);
         }
     }

--- a/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/WebAdminServerModule.java
+++ b/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/WebAdminServerModule.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.james.jwt.JwtTokenVerifier;
-import org.apache.james.lifecycle.api.Configurable;
+import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.utils.ConfigurationPerformer;
 import org.apache.james.utils.GuiceProbe;
 import org.apache.james.utils.PropertiesProvider;
@@ -145,7 +145,7 @@ public class WebAdminServerModule extends AbstractModule {
         }
 
         @Override
-        public List<Class<? extends Configurable>> forClasses() {
+        public List<Class<? extends Startable>> forClasses() {
             return ImmutableList.of(WebAdminServer.class);
         }
     }

--- a/server/container/lifecycle-api/src/main/java/org/apache/james/lifecycle/api/Startable.java
+++ b/server/container/lifecycle-api/src/main/java/org/apache/james/lifecycle/api/Startable.java
@@ -16,25 +16,7 @@
  * specific language governing permissions and limitations      *
  * under the License.                                           *
  ****************************************************************/
-
 package org.apache.james.lifecycle.api;
 
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.HierarchicalConfiguration;
-
-/**
- * Classes which needs to access the configuration should implement this
- */
-public interface Configurable extends Startable {
-
-    /**
-     * Configure the object. Be aware that no services are injected when this is
-     * called. If you need to access injected stuff do it in a method annotated
-     * with @PostConstruct
-     * 
-     * @param config
-     * @throws ConfigurationException
-     */
-    void configure(HierarchicalConfiguration config) throws ConfigurationException;
-
+public interface Startable {
 }

--- a/server/container/metrics/metrics-es-reporter/pom.xml
+++ b/server/container/metrics/metrics-es-reporter/pom.xml
@@ -36,6 +36,10 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-lifecycle-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-util</artifactId>
         </dependency>
         <dependency>

--- a/server/container/metrics/metrics-es-reporter/src/main/java/org/apache/james/metrics/es/ESMetricReporter.java
+++ b/server/container/metrics/metrics-es-reporter/src/main/java/org/apache/james/metrics/es/ESMetricReporter.java
@@ -26,11 +26,13 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
+import org.apache.james.lifecycle.api.Startable;
+
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
 import com.linagora.elasticsearch.metrics.ElasticsearchReporter;
 
-public class ESMetricReporter {
+public class ESMetricReporter implements Startable {
 
     private final Optional<ElasticsearchReporter> reporter;
     private final ESReporterConfiguration esReporterConfiguration;


### PR DESCRIPTION
	Make it clear that all startable resources should be handled by ConfigurationsPerformer.
	Also, checked all previous Configurable to return the right types so that
	dependency-aware injection does work.