### PR TITLE
Revert "MAILBOX-381 Push cast utils as a main method of AttributeValue"

### DIFF
--- a/mailet/api/pom.xml
+++ b/mailet/api/pom.xml
@@ -112,6 +112,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/mailet/api/src/main/java/org/apache/mailet/AttributeUtils.java
+++ b/mailet/api/src/main/java/org/apache/mailet/AttributeUtils.java
@@ -35,9 +35,8 @@ public class AttributeUtils {
      * Returns an empty optional upon missing attribute or type mismatch.
      */
     public static <T> Optional<T> getValueAndCastFromMail(Mail mail, AttributeName name, Class<T> type) {
-        return mail.getAttribute(name)
-            .map(Attribute::getValue)
-            .flatMap(attributeValue -> attributeValue.valueAs(type));
+        return getAttributeValueFromMail(mail, name)
+                .flatMap(value -> tryToCast(type, value));
     }
 
     /**
@@ -46,8 +45,23 @@ public class AttributeUtils {
      * Returns an empty optional upon missing attribute
      */
     public static Optional<?> getAttributeValueFromMail(Mail mail, AttributeName name) {
-        return mail.getAttribute(name)
-                .map(Attribute::getValue)
-                .map(AttributeValue::getValue);
+        return mail
+                .getAttribute(name)
+                .map(AttributeUtils::getAttributeValue);
+    }
+
+    /**
+     * Returns the raw value of an Attribute
+     */
+    public static Object getAttributeValue(Attribute attribute) {
+        return attribute.getValue().getValue();
+    }
+
+    private static <T> Optional<T> tryToCast(Class<T> type, Object value) {
+        if (type.isInstance(value)) {
+            return Optional.of(type.cast(value));
+        } else {
+            return Optional.empty();
+        }
     }
 }

--- a/mailet/api/src/main/java/org/apache/mailet/AttributeUtils.java
+++ b/mailet/api/src/main/java/org/apache/mailet/AttributeUtils.java
@@ -21,6 +21,8 @@ package org.apache.mailet;
 
 import java.util.Optional;
 
+import org.apache.james.util.OptionalUtils;
+
 /** 
  * Attribute
  * 
@@ -36,7 +38,7 @@ public class AttributeUtils {
      */
     public static <T> Optional<T> getValueAndCastFromMail(Mail mail, AttributeName name, Class<T> type) {
         return getAttributeValueFromMail(mail, name)
-                .flatMap(value -> tryToCast(type, value));
+                .flatMap(value -> OptionalUtils.cast(type, value));
     }
 
     /**
@@ -55,13 +57,5 @@ public class AttributeUtils {
      */
     public static Object getAttributeValue(Attribute attribute) {
         return attribute.getValue().getValue();
-    }
-
-    private static <T> Optional<T> tryToCast(Class<T> type, Object value) {
-        if (type.isInstance(value)) {
-            return Optional.of(type.cast(value));
-        } else {
-            return Optional.empty();
-        }
     }
 }

--- a/mailet/api/src/main/java/org/apache/mailet/AttributeValue.java
+++ b/mailet/api/src/main/java/org/apache/mailet/AttributeValue.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.james.mailbox.model.MessageIdDto;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -206,18 +207,6 @@ public class AttributeValue<T> {
 
     public T value() {
         return value;
-    }
-
-    public <T> Optional<T> valueAs(Class<T> type) {
-        return tryToCast(type, value);
-    }
-
-    private static <T> Optional<T> tryToCast(Class<T> type, Object value) {
-        if (type.isInstance(value)) {
-            return Optional.of(type.cast(value));
-        } else {
-            return Optional.empty();
-        }
     }
 
     //FIXME : poor performance

--- a/mailet/api/src/test/java/org/apache/mailet/AttributeUtilsTest.java
+++ b/mailet/api/src/test/java/org/apache/mailet/AttributeUtilsTest.java
@@ -1,0 +1,53 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.mailet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+class AttributeUtilsTest {
+    @Test
+    void getValueAndCastFromMailShouldCastValueWhenRightType() {
+        Attribute attribute = Attribute.convertToAttribute("name", "value");
+        Mail mail = mock(Mail.class);
+        when(mail.getAttribute(attribute.getName())).thenReturn(Optional.of(attribute));
+
+        assertThat(AttributeUtils.getValueAndCastFromMail(mail, attribute.getName(), String.class))
+            .contains("value");
+    }
+
+    @Test
+    void getValueAndCastFromMailShouldReturnEmptyWhenWrongType() {
+        Attribute attribute = Attribute.convertToAttribute("name", "value");
+        Mail mail = mock(Mail.class);
+        when(mail.getAttribute(attribute.getName())).thenReturn(Optional.of(attribute));
+
+        assertThat(AttributeUtils.getValueAndCastFromMail(mail, attribute.getName(), Boolean.class))
+            .isEmpty();
+    }
+
+
+
+}

--- a/mailet/api/src/test/java/org/apache/mailet/AttributeValueTest.java
+++ b/mailet/api/src/test/java/org/apache/mailet/AttributeValueTest.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 
 import org.apache.james.mailbox.model.MessageIdDto;
 import org.apache.james.mailbox.model.TestMessageId;
+
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -637,18 +638,6 @@ class AttributeValueTest {
     void fromJsonStringShouldThrowOnMissingValueField() {
         assertThatIllegalStateException()
             .isThrownBy(() -> AttributeValue.fromJsonString("{\"serializer\":\"MapSerializer\"}"));
-    }
-
-    @Test
-    void valueAsShouldCastValueWhenRightType() {
-        assertThat(AttributeValue.of("value").valueAs(String.class))
-            .contains("value");
-    }
-
-    @Test
-    void valueAsShouldReturnEmptyWhenWrongType() {
-        assertThat(AttributeValue.of("value").valueAs(Boolean.class))
-            .isEmpty();
     }
 
     private static class TestArbitrarySerializable implements ArbitrarySerializable<TestArbitrarySerializable> {

--- a/server/container/util/src/main/java/org/apache/james/util/OptionalUtils.java
+++ b/server/container/util/src/main/java/org/apache/james/util/OptionalUtils.java
@@ -56,6 +56,14 @@ public class OptionalUtils {
             .orElse(ImmutableSet.of());
     }
 
+    public static <T> Optional<T> cast(Class<T> type, Object value) {
+        if (type.isInstance(value)) {
+            return Optional.of(type.cast(value));
+        } else {
+            return Optional.empty();
+        }
+    }
+
     @SafeVarargs
     public static <T> Optional<T> or(Optional<T>... optionals) {
         return orStream(Arrays.stream(optionals));

--- a/server/container/util/src/test/java/org/apache/james/util/OptionalUtilsTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/OptionalUtilsTest.java
@@ -279,4 +279,15 @@ public class OptionalUtilsTest {
             .isTrue();
     }
 
+    @Test
+    void castShouldCastValueWhenRightType() {
+        assertThat(OptionalUtils.cast(String.class, "value"))
+                .contains("value");
+    }
+
+    @Test
+    void castShouldReturnEmptyWhenWrongType() {
+        assertThat(OptionalUtils.cast(Boolean.class, "value"))
+                .isEmpty();
+    }
 }

--- a/server/mailrepository/deleted-messages-vault-repository/src/main/java/org/apache/james/vault/MailConverter.java
+++ b/server/mailrepository/deleted-messages-vault-repository/src/main/java/org/apache/james/vault/MailConverter.java
@@ -33,6 +33,7 @@ import org.apache.james.core.User;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.server.core.MailImpl;
+import org.apache.james.util.OptionalUtils;
 import org.apache.mailet.AttributeName;
 import org.apache.mailet.AttributeUtils;
 import org.apache.mailet.AttributeValue;
@@ -111,7 +112,7 @@ class MailConverter {
         Optional<String> optional = Optional.of(object)
             .filter(obj -> obj instanceof AttributeValue)
             .map(AttributeValue.class::cast)
-            .flatMap(attributeValue -> attributeValue.valueAs(String.class));
+            .flatMap(attributeValue -> OptionalUtils.cast(String.class, attributeValue.value()));
 
         return optional
             .orElseThrow(() -> new IllegalArgumentException("mail should have a 'subject' attribute being of type 'Optional<String>"));
@@ -150,7 +151,7 @@ class MailConverter {
         Optional<String> serializedMailboxId = Optional.of(object)
             .filter(obj -> obj instanceof AttributeValue)
             .map(AttributeValue.class::cast)
-            .flatMap(attributeValue -> attributeValue.valueAs(String.class));
+            .flatMap(attributeValue -> OptionalUtils.cast(String.class, attributeValue.value()));
 
         return serializedMailboxId
             .map(mailboxIdFactory::fromString)

--- a/server/mailrepository/deleted-messages-vault-repository/src/test/java/org/apache/james/vault/SerializableDateTest.java
+++ b/server/mailrepository/deleted-messages-vault-repository/src/test/java/org/apache/james/vault/SerializableDateTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.ZonedDateTime;
 
+import org.apache.james.util.OptionalUtils;
 import org.apache.mailet.AttributeValue;
 import org.junit.jupiter.api.Test;
 
@@ -36,8 +37,7 @@ class SerializableDateTest {
     void serializeBackAndForthShouldPreserveDate() {
         JsonNode serializableDate = AttributeValue.of(new SerializableDate(DATE)).toJson();
 
-        ZonedDateTime deserializedDate = AttributeValue.fromJson(serializableDate)
-            .valueAs(SerializableDate.class)
+        ZonedDateTime deserializedDate = OptionalUtils.cast(SerializableDate.class, AttributeValue.fromJson(serializableDate).value())
             .get()
             .getValue();
 

--- a/server/mailrepository/deleted-messages-vault-repository/src/test/java/org/apache/james/vault/SerializableUserTest.java
+++ b/server/mailrepository/deleted-messages-vault-repository/src/test/java/org/apache/james/vault/SerializableUserTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.james.core.User;
+import org.apache.james.util.OptionalUtils;
 import org.apache.mailet.AttributeValue;
 import org.junit.jupiter.api.Test;
 
@@ -35,8 +36,7 @@ class SerializableUserTest {
     void serializeBackAndForthShouldPreserveUser() {
         JsonNode serializableUser = AttributeValue.of(new SerializableUser(USER)).toJson();
 
-        User user = AttributeValue.fromJson(serializableUser)
-            .valueAs(SerializableUser.class)
+        User user = OptionalUtils.cast(SerializableUser.class, AttributeValue.fromJson(serializableUser).value())
             .get()
             .getValue();
 


### PR DESCRIPTION
Things discussed in the past: it breaks `AttributeValue`'s SRP