### PR TITLE
MAILET-164 use a real MDN parser instead of parsing MDN report as a l…

### DIFF
--- a/mailet/base/pom.xml
+++ b/mailet/base/pom.xml
@@ -61,6 +61,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-mdn</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.steveash.guavate</groupId>
             <artifactId>guavate</artifactId>
         </dependency>

--- a/mailet/base/src/main/java/org/apache/mailet/base/AutomaticallySentMailDetectorImpl.java
+++ b/mailet/base/src/main/java/org/apache/mailet/base/AutomaticallySentMailDetectorImpl.java
@@ -19,15 +19,15 @@
 
 package org.apache.mailet.base;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.Arrays;
 
 import javax.mail.MessagingException;
 
 import org.apache.james.core.MailAddress;
+import org.apache.james.mdn.MDNReportParser;
+import org.apache.james.mdn.sending.mode.DispositionSendingMode;
 import org.apache.james.mime4j.MimeException;
 import org.apache.james.mime4j.parser.AbstractContentHandler;
 import org.apache.james.mime4j.parser.MimeStreamParser;
@@ -91,7 +91,13 @@ public class AutomaticallySentMailDetectorImpl implements AutomaticallySentMailD
     @Override
     public boolean isMdnSentAutomatically(Mail mail) throws MessagingException {
         ResultCollector resultCollector = new ResultCollector(false);
-        MimeStreamParser parser = new MimeStreamParser(MimeConfig.PERMISSIVE);
+        MimeStreamParser parser = new MimeStreamParser(MimeConfig.custom()
+            .setMaxContentLen(1024 * 1024) // there's no reason for a mdn report to be bigger than 1MiB
+            .setMaxHeaderCount(-1)
+            .setMaxHeaderLen(-1)
+            .setMaxLineLen(-1)
+            .setHeadlessParsing(mail.getMessage().getContentType())
+            .build());
         parser.setContentHandler(createMdnContentHandler(resultCollector));
         try {
             parser.parse(mail.getMessage().getInputStream());
@@ -108,16 +114,10 @@ public class AutomaticallySentMailDetectorImpl implements AutomaticallySentMailD
             @Override
             public void body(BodyDescriptor bodyDescriptor, InputStream inputStream) throws MimeException, IOException {
                 if (bodyDescriptor.getMimeType().equalsIgnoreCase("message/disposition-notification")) {
-                    try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
-                        String line;
-                        while ((line = reader.readLine()) != null) {
-                            if (line.startsWith("Disposition:")) {
-                                if (line.contains("MDN-sent-automatically") || line.contains("automatic-action")) {
-                                    resultCollector.setResult(true);
-                                }
-                            }
-                        }
-                    }
+                    resultCollector.setResult(new MDNReportParser()
+                        .parse(inputStream, bodyDescriptor.getCharset())
+                        .map(report -> report.getDispositionField().getSendingMode() == DispositionSendingMode.Automatic)
+                        .orElse(false));
                 }
             }
         };

--- a/mailet/base/src/test/java/org/apache/mailet/base/AutomaticallySentMailDetectorImplTest.java
+++ b/mailet/base/src/test/java/org/apache/mailet/base/AutomaticallySentMailDetectorImplTest.java
@@ -36,6 +36,8 @@ import org.apache.james.util.MimeMessageUtil;
 import org.apache.mailet.base.test.FakeMail;
 import org.junit.Test;
 
+import com.google.common.base.Joiner;
+
 public class AutomaticallySentMailDetectorImplTest {
 
     @Test
@@ -238,13 +240,17 @@ public class AutomaticallySentMailDetectorImplTest {
         scriptPart.setDataHandler(
                 new DataHandler(
                         new ByteArrayDataSource(
-                                "Disposition: MDN-sent-automatically",
+                            Joiner.on("\r\n").join(
+                                "Final-Recipient: rfc822;any@any.com",
+                                "Disposition: automatic-action/MDN-sent-automatically; displayed",
+                                ""),
                                 "message/disposition-notification;")
                         ));
         scriptPart.setHeader("Content-Type", "message/disposition-notification");
         multipart.addBodyPart(scriptPart);
         message.setContent(multipart);
-        
+        message.saveChanges();
+
         FakeMail fakeMail = FakeMail.builder()
                 .name("mail")
                 .sender("any@any.com")
@@ -262,12 +268,16 @@ public class AutomaticallySentMailDetectorImplTest {
         scriptPart.setDataHandler(
                 new DataHandler(
                         new ByteArrayDataSource(
-                                "Disposition: MDN-sent-manually",
+                            Joiner.on("\r\n").join(
+                                "Final-Recipient: rfc822;any@any.com",
+                                "Disposition: manual-action/MDN-sent-manually; displayed",
+                                ""),
                                 "message/disposition-notification; charset=UTF-8")
                         ));
         scriptPart.setHeader("Content-Type", "message/disposition-notification");
         multipart.addBodyPart(scriptPart);
         message.setContent(multipart);
+        message.saveChanges();
         
         FakeMail fakeMail = FakeMail.builder()
                 .name("mail")
@@ -292,6 +302,7 @@ public class AutomaticallySentMailDetectorImplTest {
         scriptPart.setHeader("Content-Type", "text/plain");
         multipart.addBodyPart(scriptPart);
         message.setContent(multipart);
+        message.saveChanges();
         
         FakeMail fakeMail = FakeMail.builder()
                 .name("mail")


### PR DESCRIPTION
…ist of headers

	This starts by fixing tests:
		x mdn conformance
		x call to saveChange on message to make things work
	It then introduce our beloved MDN report parser instead of the
	hack we used to parse the report as some mail headers.
	Finally, we also tells MimeMessageParser that we don't provide it
	with the mails header as javax.mail getInputstream return only the mail
	body.