### PR TITLE
JAMES-2691 add graphana board for elasticsearch rate MailboxListeners

### DIFF
--- a/grafana-reporting/MailboxListeners rate-1552903378376.json
+++ b/grafana-reporting/MailboxListeners rate-1552903378376.json
@@ -1,0 +1,824 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Elasticsearch",
+      "fill": 1,
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 23,
+      "legend": {
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "dsType": "elasticsearch",
+          "metrics": [
+            {
+              "field": "mean_rate",
+              "id": "1",
+              "meta": {},
+              "pipelineAgg": "3",
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "m15_rate",
+              "id": "3",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "m5_rate",
+              "id": "4",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "m1_rate",
+              "id": "5",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            }
+          ],
+          "query": "name:mailbox-listener-ElasticSearchListeningMessageSearchIndex",
+          "refId": "A",
+          "timeField": "@timestamp"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "ElasticSearch indexing",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Elasticsearch",
+      "fill": 1,
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "legend": {
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "dsType": "elasticsearch",
+          "metrics": [
+            {
+              "field": "mean_rate",
+              "id": "1",
+              "meta": {},
+              "pipelineAgg": "3",
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "m15_rate",
+              "id": "3",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "m5_rate",
+              "id": "4",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "m1_rate",
+              "id": "5",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            }
+          ],
+          "query": "name:mailbox-listener-ElasticSearchQuotaMailboxListener",
+          "refId": "A",
+          "timeField": "@timestamp"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Quota Search ElasticSearch indexing",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Elasticsearch",
+      "fill": 1,
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 11,
+      "legend": {
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "dsType": "elasticsearch",
+          "metrics": [
+            {
+              "field": "mean_rate",
+              "id": "1",
+              "meta": {},
+              "pipelineAgg": "3",
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "m15_rate",
+              "id": "3",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "m5_rate",
+              "id": "4",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "m1_rate",
+              "id": "5",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            }
+          ],
+          "query": "name:mailbox-listener-SpamAssassinListener",
+          "refId": "A",
+          "timeField": "@timestamp"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "SpamAssassin HAM/SPAM reporting",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Elasticsearch",
+      "fill": 1,
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 0,
+        "y": 11
+      },
+      "id": 10,
+      "legend": {
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "dsType": "elasticsearch",
+          "metrics": [
+            {
+              "field": "mean_rate",
+              "id": "1",
+              "meta": {},
+              "pipelineAgg": "3",
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "m15_rate",
+              "id": "3",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "m5_rate",
+              "id": "4",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "m1_rate",
+              "id": "5",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            }
+          ],
+          "query": "name:mailbox-listener-ListeningCurrentQuotaUpdater",
+          "refId": "A",
+          "timeField": "@timestamp"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Quota updates",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Elasticsearch",
+      "fill": 1,
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 8,
+        "y": 11
+      },
+      "id": 6,
+      "legend": {
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "dsType": "elasticsearch",
+          "metrics": [
+            {
+              "field": "mean_rate",
+              "id": "1",
+              "meta": {},
+              "pipelineAgg": "3",
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "m15_rate",
+              "id": "3",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "m5_rate",
+              "id": "4",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "m1_rate",
+              "id": "5",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            }
+          ],
+          "query": "name:mailbox-listener-MailboxAnnotationListener",
+          "refId": "A",
+          "timeField": "@timestamp"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Mailbox annotations",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Elasticsearch",
+      "fill": 1,
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 16,
+        "y": 11
+      },
+      "id": 24,
+      "legend": {
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "dsType": "elasticsearch",
+          "metrics": [
+            {
+              "field": "mean_rate",
+              "id": "1",
+              "meta": {},
+              "pipelineAgg": "3",
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "m15_rate",
+              "id": "3",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "m5_rate",
+              "id": "4",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "m1_rate",
+              "id": "5",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            }
+          ],
+          "query": "name: mailbox-listener-QuotaThresholdCrossingListener",
+          "refId": "A",
+          "timeField": "@timestamp"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Quota mailing",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "MailboxListeners rate",
+  "uid": "EM-tudqik",
+  "version": 3
+}

--- a/grafana-reporting/README.md
+++ b/grafana-reporting/README.md
@@ -34,7 +34,8 @@ Note that you need to run a guice version of James.
  - Cassandra driver statistics
  - Tika HTTP client statistics
  - SpamAssassin TCP client statistics
- - Mailbox listeners statistics
+ - Mailbox listeners statistics execution times
+ - Mailbox listeners requests rate
  - MailQueue enqueue/dequeue timer & counter statistics
  - BlobStore timer statistics
  - Statistics about pre-deletion hooks execution times

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/events/MailboxListener.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/events/MailboxListener.java
@@ -64,14 +64,7 @@ public interface MailboxListener {
     }
 
 
-    /**
-     * Indicate if the event is taken into account by the listener.
-     * Is used internally by the event(Event event) method.
-     *
-     * @param event not null
-     * @return isUsed
-     */
-    default boolean isUsed(Event event) {
+    default boolean isHandling(Event event) {
         return true;
     }
 

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/events/MailboxListener.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/events/MailboxListener.java
@@ -63,6 +63,18 @@ public interface MailboxListener {
         return ExecutionMode.SYNCHRONOUS;
     }
 
+
+    /**
+     * Indicate if the event is taken into account by the listener.
+     * Is used internally by the event(Event event) method.
+     *
+     * @param event not null
+     * @return isUsed
+     */
+    default boolean isUsed(Event event) {
+        return true;
+    }
+
     /**
      * Informs this listener about the given event.
      *

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerStressTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerStressTest.java
@@ -89,7 +89,6 @@ public abstract class MailboxManagerStressTest<T extends MailboxManager> {
                     return;
                 }
 
-
                 try {
                     MailboxSession mailboxSession = mailboxManager.createSystemSession(username);
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/ErrorHandlingContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/ErrorHandlingContract.java
@@ -52,6 +52,11 @@ interface ErrorHandlingContract extends EventBusContract {
         }
 
         @Override
+        public boolean isUsed(Event event) {
+            return true;
+        }
+
+        @Override
         public void event(Event event) {
             timeElapsed.add(Instant.now());
             throw new RuntimeException("throw to trigger reactor retry");

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/ErrorHandlingContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/ErrorHandlingContract.java
@@ -52,7 +52,7 @@ interface ErrorHandlingContract extends EventBusContract {
         }
 
         @Override
-        public boolean isUsed(Event event) {
+        public boolean isHandling(Event event) {
             return true;
         }
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/EventBusTestFixture.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/EventBusTestFixture.java
@@ -20,6 +20,7 @@
 package org.apache.james.mailbox.events;
 
 import static com.jayway.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -93,6 +94,7 @@ public interface EventBusTestFixture {
     Event.EventId EVENT_ID_2 = Event.EventId.of("5a7a9f3f-5f03-44be-b457-a51e93760645");
     MailboxListener.MailboxEvent EVENT = new MailboxListener.MailboxAdded(SESSION_ID, USER, MAILBOX_PATH, TEST_ID, EVENT_ID);
     MailboxListener.MailboxEvent EVENT_2 = new MailboxListener.MailboxAdded(SESSION_ID, USER, MAILBOX_PATH, TEST_ID, EVENT_ID_2);
+    MailboxListener.MailboxRenamed EVENT_UNSUPPORTED_BY_LISTENER = new MailboxListener.MailboxRenamed(SESSION_ID, USER, MAILBOX_PATH, TEST_ID, MAILBOX_PATH, EVENT_ID_2);
 
     java.time.Duration ONE_SECOND = java.time.Duration.ofSeconds(1);
     java.time.Duration THIRTY_SECONDS = java.time.Duration.ofSeconds(30);
@@ -114,6 +116,7 @@ public interface EventBusTestFixture {
     static MailboxListener newListener() {
         MailboxListener listener = mock(MailboxListener.class);
         when(listener.getExecutionMode()).thenReturn(MailboxListener.ExecutionMode.SYNCHRONOUS);
+        when(listener.isHandling(any(MailboxListener.MailboxAdded.class))).thenReturn(true);
         return listener;
     }
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/EventBusTestFixture.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/EventBusTestFixture.java
@@ -44,6 +44,11 @@ public interface EventBusTestFixture {
         private final AtomicInteger calls = new AtomicInteger(0);
 
         @Override
+        public boolean isUsed(Event event) {
+            return true;
+        }
+
+        @Override
         public void event(Event event) {
             calls.incrementAndGet();
         }
@@ -58,6 +63,11 @@ public interface EventBusTestFixture {
 
         EventMatcherThrowingListener(ImmutableSet<Event> eventsCauseThrowing) {
             this.eventsCauseThrowing = eventsCauseThrowing;
+        }
+
+        @Override
+        public boolean isUsed(Event event) {
+            return true;
         }
 
         @Override

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/EventBusTestFixture.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/EventBusTestFixture.java
@@ -44,7 +44,7 @@ public interface EventBusTestFixture {
         private final AtomicInteger calls = new AtomicInteger(0);
 
         @Override
-        public boolean isUsed(Event event) {
+        public boolean isHandling(Event event) {
             return true;
         }
 
@@ -66,7 +66,7 @@ public interface EventBusTestFixture {
         }
 
         @Override
-        public boolean isUsed(Event event) {
+        public boolean isHandling(Event event) {
             return true;
         }
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/GroupContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/GroupContract.java
@@ -22,6 +22,7 @@ package org.apache.james.mailbox.events;
 import static org.apache.james.mailbox.events.EventBusTestFixture.EVENT;
 import static org.apache.james.mailbox.events.EventBusTestFixture.EVENT_2;
 import static org.apache.james.mailbox.events.EventBusTestFixture.EVENT_ID;
+import static org.apache.james.mailbox.events.EventBusTestFixture.EVENT_UNSUPPORTED_BY_LISTENER;
 import static org.apache.james.mailbox.events.EventBusTestFixture.FIVE_HUNDRED_MS;
 import static org.apache.james.mailbox.events.EventBusTestFixture.GROUP_A;
 import static org.apache.james.mailbox.events.EventBusTestFixture.GROUP_B;
@@ -142,6 +143,18 @@ public interface GroupContract {
 
             MailboxListener.Added noopEvent = new MailboxListener.Added(MailboxSession.SessionId.of(18), User.fromUsername("bob"), MailboxPath.forUser("bob", "mailbox"), TestId.of(58), ImmutableSortedMap.of(), Event.EventId.random());
             eventBus().dispatch(noopEvent, NO_KEYS).block();
+
+            verify(listener, after(FIVE_HUNDRED_MS.toMillis()).never())
+                .event(any());
+        }
+
+        @Test
+        default void groupListenersShouldReceiveOnlyHandledEvents() throws Exception {
+            MailboxListener listener = newListener();
+
+            eventBus().register(listener, GROUP_A);
+
+            eventBus().dispatch(EVENT_UNSUPPORTED_BY_LISTENER, NO_KEYS).block();
 
             verify(listener, after(FIVE_HUNDRED_MS.toMillis()).never())
                 .event(any());

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/GroupContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/GroupContract.java
@@ -72,7 +72,7 @@ public interface GroupContract {
                 }
 
                 @Override
-                public boolean isUsed(Event event) {
+                public boolean isHandling(Event event) {
                     return true;
                 }
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/GroupContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/GroupContract.java
@@ -72,6 +72,11 @@ public interface GroupContract {
                 }
 
                 @Override
+                public boolean isUsed(Event event) {
+                    return true;
+                }
+
+                @Override
                 public void event(Event event) throws Exception {
                     if (nbCalls.get() - finishedExecutions.get() > EventBus.EXECUTION_RATE) {
                         rateExceeded.set(true);

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/KeyContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/KeyContract.java
@@ -21,6 +21,7 @@ package org.apache.james.mailbox.events;
 
 import static org.apache.james.mailbox.events.EventBusTestFixture.EVENT;
 import static org.apache.james.mailbox.events.EventBusTestFixture.EVENT_2;
+import static org.apache.james.mailbox.events.EventBusTestFixture.EVENT_UNSUPPORTED_BY_LISTENER;
 import static org.apache.james.mailbox.events.EventBusTestFixture.FIVE_HUNDRED_MS;
 import static org.apache.james.mailbox.events.EventBusTestFixture.KEY_1;
 import static org.apache.james.mailbox.events.EventBusTestFixture.KEY_2;
@@ -91,6 +92,18 @@ public interface KeyContract extends EventBusContract {
 
             MailboxListener.Added noopEvent = new MailboxListener.Added(MailboxSession.SessionId.of(18), User.fromUsername("bob"), MailboxPath.forUser("bob", "mailbox"), TestId.of(58), ImmutableSortedMap.of(), Event.EventId.random());
             eventBus().dispatch(noopEvent, KEY_1).block();
+
+            verify(listener, after(FIVE_HUNDRED_MS.toMillis()).never())
+                .event(any());
+        }
+
+       @Test
+        default void registeredListenersShouldReceiveOnlyHandledEvents() throws Exception {
+            MailboxListener listener = newListener();
+
+            eventBus().register(listener, KEY_1);
+
+            eventBus().dispatch(EVENT_UNSUPPORTED_BY_LISTENER, KEY_1).block();
 
             verify(listener, after(FIVE_HUNDRED_MS.toMillis()).never())
                 .event(any());

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/util/EventCollector.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/util/EventCollector.java
@@ -43,6 +43,11 @@ public class EventCollector implements MailboxListener.GroupMailboxListener {
     }
 
     @Override
+    public boolean isUsed(Event event) {
+        return true;
+    }
+
+    @Override
     public void event(Event event) {
         events.add(event);
     }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/util/EventCollector.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/util/EventCollector.java
@@ -43,7 +43,7 @@ public class EventCollector implements MailboxListener.GroupMailboxListener {
     }
 
     @Override
-    public boolean isUsed(Event event) {
+    public boolean isHandling(Event event) {
         return true;
     }
 

--- a/mailbox/caching/src/main/java/org/apache/james/mailbox/caching/CacheInvalidatingMailboxListener.java
+++ b/mailbox/caching/src/main/java/org/apache/james/mailbox/caching/CacheInvalidatingMailboxListener.java
@@ -48,9 +48,7 @@ public class CacheInvalidatingMailboxListener implements MailboxListener.GroupMa
 
     @Override
     public void event(Event event) {
-        if (isHandling(event)) {
             mailboxEvent((MailboxEvent) event);
-        }
     }
 
     private void mailboxEvent(MailboxEvent event) {

--- a/mailbox/caching/src/main/java/org/apache/james/mailbox/caching/CacheInvalidatingMailboxListener.java
+++ b/mailbox/caching/src/main/java/org/apache/james/mailbox/caching/CacheInvalidatingMailboxListener.java
@@ -42,13 +42,13 @@ public class CacheInvalidatingMailboxListener implements MailboxListener.GroupMa
     }
 
     @Override
-    public boolean isUsed(Event event) {
+    public boolean isHandling(Event event) {
         return event instanceof MailboxEvent;
     }
 
     @Override
     public void event(Event event) {
-        if (isUsed(event)) {
+        if (isHandling(event)) {
             mailboxEvent((MailboxEvent) event);
         }
     }

--- a/mailbox/caching/src/main/java/org/apache/james/mailbox/caching/CacheInvalidatingMailboxListener.java
+++ b/mailbox/caching/src/main/java/org/apache/james/mailbox/caching/CacheInvalidatingMailboxListener.java
@@ -41,10 +41,14 @@ public class CacheInvalidatingMailboxListener implements MailboxListener.GroupMa
         eventBus.register(this);
     }
 
+    @Override
+    public boolean isUsed(Event event) {
+        return event instanceof MailboxEvent;
+    }
 
     @Override
     public void event(Event event) {
-        if (event instanceof MailboxEvent) {
+        if (isUsed(event)) {
             mailboxEvent((MailboxEvent) event);
         }
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/MailboxOperationLoggingListener.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/MailboxOperationLoggingListener.java
@@ -45,6 +45,11 @@ public class MailboxOperationLoggingListener implements MailboxListener.GroupMai
     }
 
     @Override
+    public boolean isUsed(Event event) {
+        return event instanceof MailboxRenamed || event instanceof MailboxDeletion || event instanceof MailboxAdded;
+    }
+
+    @Override
     public void event(Event event) {
         if (event instanceof MailboxRenamed) {
             MailboxRenamed mailboxRenamed = (MailboxRenamed) event;

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/MailboxOperationLoggingListener.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/MailboxOperationLoggingListener.java
@@ -45,7 +45,7 @@ public class MailboxOperationLoggingListener implements MailboxListener.GroupMai
     }
 
     @Override
-    public boolean isUsed(Event event) {
+    public boolean isHandling(Event event) {
         return event instanceof MailboxRenamed || event instanceof MailboxDeletion || event instanceof MailboxAdded;
     }
 

--- a/mailbox/event/event-memory/src/main/java/org/apache/james/mailbox/events/delivery/InVmEventDelivery.java
+++ b/mailbox/event/event-memory/src/main/java/org/apache/james/mailbox/events/delivery/InVmEventDelivery.java
@@ -83,19 +83,21 @@ public class InVmEventDelivery implements EventDelivery {
     }
 
     private void doDeliverToListener(MailboxListener mailboxListener, Event event) {
-        TimeMetric timer = metricFactory.timer(timerName(mailboxListener));
-        try (Closeable mdc = MDCBuilder.create()
+        if (mailboxListener.isUsed(event)) {
+            TimeMetric timer = metricFactory.timer(timerName(mailboxListener));
+            try (Closeable mdc = MDCBuilder.create()
                 .addContext(EventBus.StructuredLoggingFields.EVENT_ID, event.getEventId())
                 .addContext(EventBus.StructuredLoggingFields.EVENT_CLASS, event.getClass())
                 .addContext(EventBus.StructuredLoggingFields.USER, event.getUser())
                 .addContext(EventBus.StructuredLoggingFields.LISTENER_CLASS, mailboxListener.getClass())
                 .build()) {
 
-            mailboxListener.event(event);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        } finally {
-            timer.stopAndPublish();
+                mailboxListener.event(event);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            } finally {
+                timer.stopAndPublish();
+            }
         }
     }
 

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/MailboxListenerExecutor.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/MailboxListenerExecutor.java
@@ -35,16 +35,18 @@ public class MailboxListenerExecutor {
     }
 
     void execute(MailboxListener listener, MDCBuilder mdcBuilder, Event event) throws Exception {
-        TimeMetric timer = metricFactory.timer(timerName(listener));
-        try (Closeable mdc = mdcBuilder
+        if (listener.isUsed(event)) {
+            TimeMetric timer = metricFactory.timer(timerName(listener));
+            try (Closeable mdc = mdcBuilder
                 .addContext(EventBus.StructuredLoggingFields.EVENT_ID, event.getEventId())
                 .addContext(EventBus.StructuredLoggingFields.EVENT_CLASS, event.getClass())
                 .addContext(EventBus.StructuredLoggingFields.USER, event.getUser())
                 .addContext(EventBus.StructuredLoggingFields.LISTENER_CLASS, listener.getClass())
                 .build()) {
-            listener.event(event);
-        } finally {
-            timer.stopAndPublish();
+                listener.event(event);
+            } finally {
+                timer.stopAndPublish();
+            }
         }
     }
 }

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/MailboxListenerExecutor.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/MailboxListenerExecutor.java
@@ -35,18 +35,22 @@ public class MailboxListenerExecutor {
     }
 
     void execute(MailboxListener listener, MDCBuilder mdcBuilder, Event event) throws Exception {
-        if (listener.isUsed(event)) {
+        if (listener.isHandling(event)) {
             TimeMetric timer = metricFactory.timer(timerName(listener));
-            try (Closeable mdc = mdcBuilder
-                .addContext(EventBus.StructuredLoggingFields.EVENT_ID, event.getEventId())
-                .addContext(EventBus.StructuredLoggingFields.EVENT_CLASS, event.getClass())
-                .addContext(EventBus.StructuredLoggingFields.USER, event.getUser())
-                .addContext(EventBus.StructuredLoggingFields.LISTENER_CLASS, listener.getClass())
-                .build()) {
+            try (Closeable mdc = buildMDC(listener, mdcBuilder, event)) {
                 listener.event(event);
             } finally {
                 timer.stopAndPublish();
             }
         }
+    }
+
+    private Closeable buildMDC(MailboxListener listener, MDCBuilder mdcBuilder, Event event) {
+        return mdcBuilder
+            .addContext(EventBus.StructuredLoggingFields.EVENT_ID, event.getEventId())
+            .addContext(EventBus.StructuredLoggingFields.EVENT_CLASS, event.getClass())
+            .addContext(EventBus.StructuredLoggingFields.USER, event.getUser())
+            .addContext(EventBus.StructuredLoggingFields.LISTENER_CLASS, listener.getClass())
+            .build();
     }
 }

--- a/mailbox/plugin/quota-search-elasticsearch/src/main/java/org/apache/james/quota/search/elasticsearch/events/ElasticSearchQuotaMailboxListener.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/main/java/org/apache/james/quota/search/elasticsearch/events/ElasticSearchQuotaMailboxListener.java
@@ -53,13 +53,13 @@ public class ElasticSearchQuotaMailboxListener implements MailboxListener.GroupM
     }
 
     @Override
-    public boolean isUsed(Event event) {
+    public boolean isHandling(Event event) {
         return event instanceof QuotaUsageUpdatedEvent;
     }
 
     @Override
     public void event(Event event) throws JsonProcessingException {
-        if (isUsed(event)) {
+        if (isHandling(event)) {
             handleEvent(event.getUser(), (QuotaUsageUpdatedEvent) event);
         }
     }

--- a/mailbox/plugin/quota-search-elasticsearch/src/main/java/org/apache/james/quota/search/elasticsearch/events/ElasticSearchQuotaMailboxListener.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/main/java/org/apache/james/quota/search/elasticsearch/events/ElasticSearchQuotaMailboxListener.java
@@ -53,8 +53,13 @@ public class ElasticSearchQuotaMailboxListener implements MailboxListener.GroupM
     }
 
     @Override
+    public boolean isUsed(Event event) {
+        return event instanceof QuotaUsageUpdatedEvent;
+    }
+
+    @Override
     public void event(Event event) throws JsonProcessingException {
-        if (event instanceof QuotaUsageUpdatedEvent) {
+        if (isUsed(event)) {
             handleEvent(event.getUser(), (QuotaUsageUpdatedEvent) event);
         }
     }

--- a/mailbox/plugin/quota-search-elasticsearch/src/main/java/org/apache/james/quota/search/elasticsearch/events/ElasticSearchQuotaMailboxListener.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/main/java/org/apache/james/quota/search/elasticsearch/events/ElasticSearchQuotaMailboxListener.java
@@ -32,7 +32,8 @@ import org.apache.james.quota.search.elasticsearch.json.QuotaRatioToElasticSearc
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 public class ElasticSearchQuotaMailboxListener implements MailboxListener.GroupMailboxListener {
-    public static class ElasticSearchQuotaMailboxListenerGroup extends Group {}
+    public static class ElasticSearchQuotaMailboxListenerGroup extends Group {
+    }
 
     private static final Group GROUP = new ElasticSearchQuotaMailboxListenerGroup();
 
@@ -41,8 +42,8 @@ public class ElasticSearchQuotaMailboxListener implements MailboxListener.GroupM
 
     @Inject
     public ElasticSearchQuotaMailboxListener(
-            @Named(QuotaRatioElasticSearchConstants.InjectionNames.QUOTA_RATIO) ElasticSearchIndexer indexer,
-            QuotaRatioToElasticSearchJson quotaRatioToElasticSearchJson) {
+        @Named(QuotaRatioElasticSearchConstants.InjectionNames.QUOTA_RATIO) ElasticSearchIndexer indexer,
+        QuotaRatioToElasticSearchJson quotaRatioToElasticSearchJson) {
         this.indexer = indexer;
         this.quotaRatioToElasticSearchJson = quotaRatioToElasticSearchJson;
     }
@@ -59,13 +60,11 @@ public class ElasticSearchQuotaMailboxListener implements MailboxListener.GroupM
 
     @Override
     public void event(Event event) throws JsonProcessingException {
-        if (isHandling(event)) {
-            handleEvent(event.getUser(), (QuotaUsageUpdatedEvent) event);
-        }
+        handleEvent(event.getUser(), (QuotaUsageUpdatedEvent) event);
     }
 
     private void handleEvent(User user, QuotaUsageUpdatedEvent event) throws JsonProcessingException {
         indexer.index(user.asString(),
-                quotaRatioToElasticSearchJson.convertToJson(user.asString(), event));
+            quotaRatioToElasticSearchJson.convertToJson(user.asString(), event));
     }
 }

--- a/mailbox/plugin/spamassassin/src/main/java/org/apache/james/mailbox/spamassassin/SpamAssassinListener.java
+++ b/mailbox/plugin/spamassassin/src/main/java/org/apache/james/mailbox/spamassassin/SpamAssassinListener.java
@@ -82,13 +82,20 @@ public class SpamAssassinListener implements SpamEventListener {
     }
 
     @Override
+    public boolean isUsed(Event event) {
+        return event instanceof MessageMoveEvent || event instanceof Added;
+    }
+
+    @Override
     public void event(Event event) throws MailboxException {
-        MailboxSession session = mailboxManager.createSystemSession(getClass().getCanonicalName());
-        if (event instanceof MessageMoveEvent) {
-            handleMessageMove(event, session, (MessageMoveEvent) event);
-        }
-        if (event instanceof Added) {
-            handleAdded(event, session, (Added) event);
+        if (isUsed(event)) {
+            MailboxSession session = mailboxManager.createSystemSession(getClass().getCanonicalName());
+            if (event instanceof MessageMoveEvent) {
+                handleMessageMove(event, session, (MessageMoveEvent) event);
+            }
+            if (event instanceof Added) {
+                handleAdded(event, session, (Added) event);
+            }
         }
     }
 

--- a/mailbox/plugin/spamassassin/src/main/java/org/apache/james/mailbox/spamassassin/SpamAssassinListener.java
+++ b/mailbox/plugin/spamassassin/src/main/java/org/apache/james/mailbox/spamassassin/SpamAssassinListener.java
@@ -82,20 +82,19 @@ public class SpamAssassinListener implements SpamEventListener {
     }
 
     @Override
-    public boolean isUsed(Event event) {
+    public boolean isHandling(Event event) {
         return event instanceof MessageMoveEvent || event instanceof Added;
     }
 
     @Override
     public void event(Event event) throws MailboxException {
-        if (isUsed(event)) {
+        if (event instanceof MessageMoveEvent) {
             MailboxSession session = mailboxManager.createSystemSession(getClass().getCanonicalName());
-            if (event instanceof MessageMoveEvent) {
-                handleMessageMove(event, session, (MessageMoveEvent) event);
-            }
-            if (event instanceof Added) {
-                handleAdded(event, session, (Added) event);
-            }
+            handleMessageMove(event, session, (MessageMoveEvent) event);
+        }
+        if (event instanceof Added) {
+            MailboxSession session = mailboxManager.createSystemSession(getClass().getCanonicalName());
+            handleAdded(event, session, (Added) event);
         }
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/ListeningCurrentQuotaUpdater.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/ListeningCurrentQuotaUpdater.java
@@ -60,19 +60,24 @@ public class ListeningCurrentQuotaUpdater implements MailboxListener.GroupMailbo
     }
 
     @Override
+    public boolean isUsed(Event event) {
+        return event instanceof Added || event instanceof Expunged || event instanceof MailboxDeletion;
+    }
+
+    @Override
     public void event(Event event) throws MailboxException {
-        if (event instanceof Added) {
-            Added addedEvent = (Added) event;
-            QuotaRoot quotaRoot = quotaRootResolver.getQuotaRoot(addedEvent.getMailboxId());
-            handleAddedEvent(addedEvent, quotaRoot);
-        } else if (event instanceof Expunged) {
-            Expunged expungedEvent = (Expunged) event;
-            QuotaRoot quotaRoot = quotaRootResolver.getQuotaRoot(expungedEvent.getMailboxId());
-            handleExpungedEvent(expungedEvent, quotaRoot);
-        } else if (event instanceof MailboxDeletion) {
-            MailboxDeletion mailboxDeletionEvent = (MailboxDeletion) event;
-            handleMailboxDeletionEvent(mailboxDeletionEvent);
-        }
+            if (event instanceof Added) {
+                Added addedEvent = (Added) event;
+                QuotaRoot quotaRoot = quotaRootResolver.getQuotaRoot(addedEvent.getMailboxId());
+                handleAddedEvent(addedEvent, quotaRoot);
+            } else if (event instanceof Expunged) {
+                Expunged expungedEvent = (Expunged) event;
+                QuotaRoot quotaRoot = quotaRootResolver.getQuotaRoot(expungedEvent.getMailboxId());
+                handleExpungedEvent(expungedEvent, quotaRoot);
+            } else if (event instanceof MailboxDeletion) {
+                MailboxDeletion mailboxDeletionEvent = (MailboxDeletion) event;
+                handleMailboxDeletionEvent(mailboxDeletionEvent);
+            }
     }
 
     private void handleExpungedEvent(Expunged expunged, QuotaRoot quotaRoot) throws MailboxException {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/ListeningCurrentQuotaUpdater.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/ListeningCurrentQuotaUpdater.java
@@ -60,7 +60,7 @@ public class ListeningCurrentQuotaUpdater implements MailboxListener.GroupMailbo
     }
 
     @Override
-    public boolean isUsed(Event event) {
+    public boolean isHandling(Event event) {
         return event instanceof Added || event instanceof Expunged || event instanceof MailboxDeletion;
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/ListeningMessageSearchIndex.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/ListeningMessageSearchIndex.java
@@ -43,8 +43,6 @@ import com.google.common.collect.ImmutableList;
 /**
  * {@link MessageSearchIndex} which needs to get registered as global {@link MailboxListener} and so get
  * notified about message changes. This will then allow to update the underlying index.
- * 
- *
  */
 public abstract class ListeningMessageSearchIndex implements MessageSearchIndex, MailboxListener.GroupMailboxListener {
     private static final Logger LOGGER = LoggerFactory.getLogger(ListeningMessageSearchIndex.class);
@@ -70,11 +68,9 @@ public abstract class ListeningMessageSearchIndex implements MessageSearchIndex,
      */
     @Override
     public void event(Event event) throws Exception {
-        if (isHandling(event)) {
-            handleMailboxEvent(event,
-                sessionProvider.createSystemSession(event.getUser().asString()),
-                (MailboxEvent) event);
-        }
+        handleMailboxEvent(event,
+            sessionProvider.createSystemSession(event.getUser().asString()),
+            (MailboxEvent) event);
     }
 
     private void handleMailboxEvent(Event event, MailboxSession session, MailboxEvent mailboxEvent) throws Exception {
@@ -103,7 +99,7 @@ public abstract class ListeningMessageSearchIndex implements MessageSearchIndex,
     private Stream<MailboxMessage> retrieveMailboxMessages(MailboxSession session, Mailbox mailbox, MessageRange range) {
         try {
             return Iterators.toStream(factory.getMessageMapper(session)
-                    .findInMailbox(mailbox, range, FetchType.Full, UNLIMITED));
+                .findInMailbox(mailbox, range, FetchType.Full, UNLIMITED));
         } catch (Exception e) {
             LOGGER.error("Could not retrieve message {} in mailbox {}", range.toString(), mailbox.getMailboxId().serialize(), e);
             return Stream.empty();
@@ -122,8 +118,8 @@ public abstract class ListeningMessageSearchIndex implements MessageSearchIndex,
     /**
      * Delete the concerned UIDs for the given {@link Mailbox} from the index
      *
-     * @param session The mailbox session performing the expunge
-     * @param mailbox mailbox on which the expunge was performed
+     * @param session      The mailbox session performing the expunge
+     * @param mailbox      mailbox on which the expunge was performed
      * @param expungedUids UIDS to be deleted
      */
     public abstract void delete(MailboxSession session, Mailbox mailbox, Collection<MessageUid> expungedUids) throws Exception;
@@ -135,12 +131,12 @@ public abstract class ListeningMessageSearchIndex implements MessageSearchIndex,
      * @param mailbox mailbox on which the expunge was performed
      */
     public abstract void deleteAll(MailboxSession session, Mailbox mailbox) throws Exception;
-    
+
     /**
      * Update the messages concerned by the updated flags list for the given {@link Mailbox}
      *
-     * @param session session that performed the update
-     * @param mailbox mailbox containing the updated messages
+     * @param session          session that performed the update
+     * @param mailbox          mailbox containing the updated messages
      * @param updatedFlagsList list of flags that were updated
      */
     public abstract void update(MailboxSession session, Mailbox mailbox, List<UpdatedFlags> updatedFlagsList) throws Exception;

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/ListeningMessageSearchIndex.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/ListeningMessageSearchIndex.java
@@ -59,13 +59,18 @@ public abstract class ListeningMessageSearchIndex implements MessageSearchIndex,
         this.sessionProvider = sessionProvider;
     }
 
+    @Override
+    public boolean isUsed(Event event) {
+        return INTERESTING_EVENTS.contains(event.getClass());
+    }
+
     /**
      * Process the {@link Event} and update the index if
      * something relevant is received
      */
     @Override
     public void event(Event event) throws Exception {
-        if (INTERESTING_EVENTS.contains(event.getClass())) {
+        if (isUsed(event)) {
             handleMailboxEvent(event,
                 sessionProvider.createSystemSession(event.getUser().asString()),
                 (MailboxEvent) event);

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/ListeningMessageSearchIndex.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/ListeningMessageSearchIndex.java
@@ -60,7 +60,7 @@ public abstract class ListeningMessageSearchIndex implements MessageSearchIndex,
     }
 
     @Override
-    public boolean isUsed(Event event) {
+    public boolean isHandling(Event event) {
         return INTERESTING_EVENTS.contains(event.getClass());
     }
 
@@ -70,7 +70,7 @@ public abstract class ListeningMessageSearchIndex implements MessageSearchIndex,
      */
     @Override
     public void event(Event event) throws Exception {
-        if (isUsed(event)) {
+        if (isHandling(event)) {
             handleMailboxEvent(event,
                 sessionProvider.createSystemSession(event.getUser().asString()),
                 (MailboxEvent) event);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/IdleProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/IdleProcessor.java
@@ -170,8 +170,13 @@ public class IdleProcessor extends AbstractMailboxProcessor<IdleRequest> impleme
         }
 
         @Override
+        public boolean isUsed(Event event) {
+            return event instanceof Added || event instanceof Expunged || event instanceof FlagsUpdated;
+        }
+
+        @Override
         public void event(Event event) {
-            if (event instanceof Added || event instanceof Expunged || event instanceof FlagsUpdated) {
+            if (isUsed(event)) {
                 unsolicitedResponses(session, responder, false);
             }
         }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/IdleProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/IdleProcessor.java
@@ -170,13 +170,13 @@ public class IdleProcessor extends AbstractMailboxProcessor<IdleRequest> impleme
         }
 
         @Override
-        public boolean isUsed(Event event) {
+        public boolean isHandling(Event event) {
             return event instanceof Added || event instanceof Expunged || event instanceof FlagsUpdated;
         }
 
         @Override
         public void event(Event event) {
-            if (isUsed(event)) {
+            if (isHandling(event)) {
                 unsolicitedResponses(session, responder, false);
             }
         }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/IdleProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/IdleProcessor.java
@@ -176,9 +176,7 @@ public class IdleProcessor extends AbstractMailboxProcessor<IdleRequest> impleme
 
         @Override
         public void event(Event event) {
-            if (isHandling(event)) {
                 unsolicitedResponses(session, responder, false);
-            }
         }
 
         @Override

--- a/server/container/guice/mailbox/src/test/java/org/apache/james/modules/mailbox/NoopMailboxListener.java
+++ b/server/container/guice/mailbox/src/test/java/org/apache/james/modules/mailbox/NoopMailboxListener.java
@@ -34,7 +34,7 @@ public class NoopMailboxListener implements MailboxListener.GroupMailboxListener
 
 
     @Override
-    public boolean isUsed(Event event) {
+    public boolean isHandling(Event event) {
         return true;
     }
 

--- a/server/container/guice/mailbox/src/test/java/org/apache/james/modules/mailbox/NoopMailboxListener.java
+++ b/server/container/guice/mailbox/src/test/java/org/apache/james/modules/mailbox/NoopMailboxListener.java
@@ -32,6 +32,12 @@ public class NoopMailboxListener implements MailboxListener.GroupMailboxListener
         return GROUP;
     }
 
+
+    @Override
+    public boolean isUsed(Event event) {
+        return true;
+    }
+
     @Override
     public void event(Event event) {
     }

--- a/src/site/xdoc/server/metrics.xml
+++ b/src/site/xdoc/server/metrics.xml
@@ -66,6 +66,7 @@
                     <li>Tika HTTP client statistics</li>
                     <li>SpamAssassin TCP client statistics</li>
                     <li>Mailbox listeners statistics time percentiles</li>
+                    <li>Mailbox listeners statistics requests rate</li>
                     <li>Pre-deletion hooks execution statistics time percentiles</li>
                 </ul>
 


### PR DESCRIPTION
In James, we have many metrics to monitor the time spend in different components.

But we miss to measure the ElasticSearch requests.

In this ticket, you will:

- add measures on ElasticSearch requests

- add a Grafana board to show this measures



With @rouazana we thought that only the graphana board was missing.
Did we miss something ?