### PR TITLE
MAILBOX-373 deadLetter::remove operation was not bound

### DIFF
--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/EventDeadLettersRedeliverService.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/EventDeadLettersRedeliverService.java
@@ -52,10 +52,8 @@ public class EventDeadLettersRedeliverService {
 
     private Mono<Task.Result> redeliverGroupEvents(Group group, Event event, EventDeadLetters.InsertionId insertionId) {
         return eventBus.reDeliver(group, event)
-            .then(Mono.fromCallable(() -> {
-                deadLetters.remove(group, insertionId);
-                return Task.Result.COMPLETED;
-            }))
+            .then(deadLetters.remove(group, insertionId)
+                .then(Mono.just(Task.Result.COMPLETED)))
             .onErrorResume(e -> {
                 LOGGER.error("Error while performing redelivery of event: {} for group: {}",
                     event.getEventId().toString(), group.asString(), e);

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/EventDeadLettersRedeliverService.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/EventDeadLettersRedeliverService.java
@@ -52,8 +52,8 @@ public class EventDeadLettersRedeliverService {
 
     private Mono<Task.Result> redeliverGroupEvents(Group group, Event event, EventDeadLetters.InsertionId insertionId) {
         return eventBus.reDeliver(group, event)
-            .then(deadLetters.remove(group, insertionId)
-                .then(Mono.just(Task.Result.COMPLETED)))
+            .then(deadLetters.remove(group, insertionId))
+            .thenReturn(Task.Result.COMPLETED)
             .onErrorResume(e -> {
                 LOGGER.error("Error while performing redelivery of event: {} for group: {}",
                     event.getEventId().toString(), group.asString(), e);


### PR DESCRIPTION
 - Depending of deadLetter implementation, the computation might not have been triggered.
 - Asynchronous isseus might have arised: the task could very well complete before the event to be removed, resulting in broken assertions