### PR TITLE
JAMES-2685 Specify host for file URL in LocalFileBlobExport

### DIFF
--- a/server/blob/blob-export-file/src/main/java/org/apache/james/blob/export/file/LocalFileBlobExportMechanism.java
+++ b/server/blob/blob-export-file/src/main/java/org/apache/james/blob/export/file/LocalFileBlobExportMechanism.java
@@ -46,7 +46,7 @@ public class LocalFileBlobExportMechanism implements BlobExportMechanism {
 
     public static class Configuration {
 
-        private static final String DEFAULT_DIRECTORY_LOCATION = "file://var/blobExporting";
+        private static final String DEFAULT_DIRECTORY_LOCATION = "file://127.0.0.1/var/blobExporting";
         public static final Configuration DEFAULT_CONFIGURATION = new Configuration(DEFAULT_DIRECTORY_LOCATION);
 
         private final String exportDirectory;


### PR DESCRIPTION
A fully file url has a pattern: `file://<host>/<path>`. It's okay to go with `file://var/blobExporting` with tests in James.
But for a real deployment, `file://var/blobExporting` is actually making browser point to `file:///blobExporting` (`var` is treated as the host, but the host is unknown, then it omits the host and uses localhost instead). I find it may be awkward when open the mail, and see the url `file://var/blobExporting` but if I open that url in browser, it  navigates to `file:///blobExporting` while what i want is `/var/blobExporting`