### PR TITLE
Build-stability : increase time to wait for docker container to fully…

### DIFF
--- a/server/protocols/jmap-integration-testing/rabbitmq-jmap-integration-testing/src/test/java/org/apache/james/jmap/rabbitmq/ReindexingWithEventDeadLettersTest.java
+++ b/server/protocols/jmap-integration-testing/rabbitmq-jmap-integration-testing/src/test/java/org/apache/james/jmap/rabbitmq/ReindexingWithEventDeadLettersTest.java
@@ -153,7 +153,7 @@ class ReindexingWithEventDeadLettersTest {
 
     private void unpauseElasticSearch() throws Exception {
         elasticSearchContainer.unpause();
-        Thread.sleep(Duration.ONE_SECOND.getValueInMS()); // Docker unpause is asynchronous and we found no way to poll for it
+        Thread.sleep(Duration.FIVE_SECONDS.getValueInMS()); // Docker unpause is asynchronous and we found no way to poll for it
     }
 
     private void aliceSavesADraft() {


### PR DESCRIPTION
… unpause

It seems one second sleep after docker unpause was not enough, could reproduce it crashing sometimes randomly locally. Upgraded it to 5 seconds instead