### PR TITLE
JAMES-2731 Improve MailboxPath logging

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/exception/ReadOnlyException.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/exception/ReadOnlyException.java
@@ -23,26 +23,12 @@ import org.apache.james.mailbox.model.MailboxPath;
 
 /**
  * {@link MailboxException} which should get thrown if someone tries to modify a READ-ONLY Mailbox
- * 
- *
  */
 public class ReadOnlyException extends MailboxException {
-
-
-    /**
-     * 
-     */
     private static final long serialVersionUID = 5016914557908202113L;
 
-
-
-    public ReadOnlyException(MailboxPath path, char delimiter) {
-        super(path.getFullName(delimiter));
-    }
-
-
-    public ReadOnlyException(MailboxPath path, char delimiter, Exception e) {
-        super(path.getFullName(delimiter), e);
+    public ReadOnlyException(MailboxPath path) {
+        super(path.asString());
     }
 }
 

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxPath.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxPath.java
@@ -183,7 +183,9 @@ public class MailboxPath {
      * 
      * @param delimiter
      * @return fullName
+     * @deprecated Use {@link MailboxPath#asString()} instead.
      */
+    @Deprecated
     public String getFullName(char delimiter) {
         return namespace + delimiter + name;
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -265,7 +265,7 @@ public class StoreMessageManager implements MessageManager {
     @Override
     public Iterator<MessageUid> expunge(MessageRange set, MailboxSession mailboxSession) throws MailboxException {
         if (!isWriteable(mailboxSession)) {
-            throw new ReadOnlyException(getMailboxPath(), mailboxSession.getPathDelimiter());
+            throw new ReadOnlyException(getMailboxPath());
         }
 
         List<MessageUid> uids = retrieveMessagesMarkedForDeletion(set, mailboxSession);
@@ -329,7 +329,7 @@ public class StoreMessageManager implements MessageManager {
         File file = null;
 
         if (!isWriteable(mailboxSession)) {
-            throw new ReadOnlyException(getMailboxPath(), mailboxSession.getPathDelimiter());
+            throw new ReadOnlyException(getMailboxPath());
         }
 
         try {
@@ -610,7 +610,7 @@ public class StoreMessageManager implements MessageManager {
     public Map<MessageUid, Flags> setFlags(final Flags flags, final FlagsUpdateMode flagsUpdateMode, final MessageRange set, MailboxSession mailboxSession) throws MailboxException {
 
         if (!isWriteable(mailboxSession)) {
-            throw new ReadOnlyException(getMailboxPath(), mailboxSession.getPathDelimiter());
+            throw new ReadOnlyException(getMailboxPath());
         }
 
         trimFlags(flags, mailboxSession);
@@ -644,7 +644,7 @@ public class StoreMessageManager implements MessageManager {
      */
     public List<MessageRange> copyTo(final MessageRange set, final StoreMessageManager toMailbox, final MailboxSession session) throws MailboxException {
         if (!toMailbox.isWriteable(session)) {
-            throw new ReadOnlyException(toMailbox.getMailboxPath(), session.getPathDelimiter());
+            throw new ReadOnlyException(toMailbox.getMailboxPath());
         }
 
         return locker.executeWithLock(session, toMailbox.getMailboxPath(), () -> {
@@ -663,10 +663,10 @@ public class StoreMessageManager implements MessageManager {
      */
     public List<MessageRange> moveTo(final MessageRange set, final StoreMessageManager toMailbox, final MailboxSession session) throws MailboxException {
         if (!isWriteable(session)) {
-            throw new ReadOnlyException(getMailboxPath(), session.getPathDelimiter());
+            throw new ReadOnlyException(getMailboxPath());
         }
         if (!toMailbox.isWriteable(session)) {
-            throw new ReadOnlyException(toMailbox.getMailboxPath(), session.getPathDelimiter());
+            throw new ReadOnlyException(toMailbox.getMailboxPath());
         }
 
         //TODO lock the from mailbox too, in a non-deadlocking manner - how?
@@ -707,7 +707,7 @@ public class StoreMessageManager implements MessageManager {
     protected List<MessageUid> recent(final boolean reset, MailboxSession mailboxSession) throws MailboxException {
         if (reset) {
             if (!isWriteable(mailboxSession)) {
-                throw new ReadOnlyException(getMailboxPath(), mailboxSession.getPathDelimiter());
+                throw new ReadOnlyException(getMailboxPath());
             }
         }
         final MessageMapper messageMapper = mapperFactory.getMessageMapper(mailboxSession);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
 import javax.mail.Flags;
 
 import org.apache.james.imap.api.ImapCommand;
@@ -245,7 +246,7 @@ public abstract class AbstractMailboxProcessor<M extends ImapRequest> extends Ab
             final MessageUid uid = mr.getUid();
             int msn = selected.msn(uid);
             if (msn == SelectedMailbox.NO_SUCH_MESSAGE) {
-                LOGGER.debug("No message found with uid {} in the uid<->msn mapping for mailbox {}. This may be because it was deleted by a concurrent session. So skip it..", uid, selected.getPath().getFullName(mailboxSession.getPathDelimiter()));
+                LOGGER.debug("No message found with uid {} in the uid<->msn mapping for mailbox {}. This may be because it was deleted by a concurrent session. So skip it..", uid, selected.getPath().asString());
                     
 
                 // skip this as it was not found in the mapping

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
@@ -132,7 +132,7 @@ abstract class AbstractSelectionProcessor<M extends AbstractMailboxSelectionRequ
         // 
         // See IMAP-345
         int retryCount = 0;
-        while (unseen(responder, firstUnseen, selected, ImapSessionUtils.getMailboxSession(session)) == false) {
+        while (unseen(responder, firstUnseen, selected) == false) {
             // if we not was able to get find the unseen within 5 retries we should just not send it
             if (retryCount == 5) {
                 LOGGER.info("Unable to uid for unseen message {} in mailbox {}", firstUnseen, selected.getPath());
@@ -355,13 +355,13 @@ abstract class AbstractSelectionProcessor<M extends AbstractMailboxSelectionRequ
         responder.respond(taggedOk);
     }
 
-    private boolean unseen(Responder responder, MessageUid firstUnseen, SelectedMailbox selected, MailboxSession session) throws MailboxException {
+    private boolean unseen(Responder responder, MessageUid firstUnseen, SelectedMailbox selected) throws MailboxException {
         if (firstUnseen != null) {
             final MessageUid unseenUid = firstUnseen;
             int msn = selected.msn(unseenUid);
 
             if (msn == SelectedMailbox.NO_SUCH_MESSAGE) {
-                LOGGER.debug("No message found with uid {} in mailbox {}", unseenUid, selected.getPath().getFullName(session.getPathDelimiter()));
+                LOGGER.debug("No message found with uid {} in mailbox {}", unseenUid, selected.getPath().asString());
                 return false;
             } 
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/StoreProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/StoreProcessor.java
@@ -286,7 +286,7 @@ public class StoreProcessor extends AbstractMailboxProcessor<StoreRequest> {
                 final int msn = selected.msn(uid);
 
                 if (msn == SelectedMailbox.NO_SUCH_MESSAGE) {
-                    LOGGER.debug("No message found with uid {} in the uid<->msn mapping for mailbox {}. This may be because it was deleted by a concurrent session. So skip it..", uid, selected.getPath().getFullName(mailboxSession.getPathDelimiter()));
+                    LOGGER.debug("No message found with uid {} in the uid<->msn mapping for mailbox {}. This may be because it was deleted by a concurrent session. So skip it..", uid, selected.getPath().asString());
                     // skip this as it was not found in the mapping
                     // 
                     // See IMAP-346

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/SimpleMailStore.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/SimpleMailStore.java
@@ -112,7 +112,7 @@ public class SimpleMailStore implements MailStore {
             return usersRepository.getUser(recipient);
         } catch (UsersRepositoryException e) {
             LOGGER.warn("Unable to retrieve username for {}", recipient.asPrettyString(), e);
-            return recipient.toString();
+            return recipient.asString();
         }
     }
 }


### PR DESCRIPTION
getFullName does not include username, so we miss some debugging information.

Using MailboxPath::asString is the right alternative.
