### PR TITLE
JAMES-2751 Refactoring: add a force restart policy in Docker Cassandra

### DIFF
--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/CassandraRestartExtension.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/CassandraRestartExtension.java
@@ -24,10 +24,16 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 public class CassandraRestartExtension implements BeforeAllCallback, BeforeEachCallback {
+    private boolean forceRestart = false;
+
+    public CassandraRestartExtension forceRestart() {
+        forceRestart = true;
+        return this;
+    }
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) {
-        DockerCassandraSingleton.restartAfterMaxTestsPlayed();
+        DockerCassandraSingleton.restartAfterMaxTestsPlayed(forceRestart);
     }
 
     @Override

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandraRule.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandraRule.java
@@ -48,8 +48,8 @@ public class DockerCassandraRule implements TestRule {
 
     public void start() {
         DockerCassandraSingleton.singleton.start();
-        DockerCassandraSingleton.incrementTestsPlayed();
         if (allowRestart) {
+            DockerCassandraSingleton.incrementTestsPlayed();
             DockerCassandraSingleton.restartAfterMaxTestsPlayed(forceRestart);
         }
     }

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandraRule.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandraRule.java
@@ -29,9 +29,15 @@ import org.testcontainers.containers.GenericContainer;
 public class DockerCassandraRule implements TestRule {
 
     private boolean allowRestart = false;
+    private boolean forceRestart = false;
 
     public DockerCassandraRule allowRestart() {
         allowRestart = true;
+        return this;
+    }
+
+    public DockerCassandraRule forceRestart() {
+        forceRestart = true;
         return this;
     }
 
@@ -44,7 +50,7 @@ public class DockerCassandraRule implements TestRule {
         DockerCassandraSingleton.singleton.start();
         DockerCassandraSingleton.incrementTestsPlayed();
         if (allowRestart) {
-            DockerCassandraSingleton.restartAfterMaxTestsPlayed();
+            DockerCassandraSingleton.restartAfterMaxTestsPlayed(forceRestart);
         }
     }
 

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandraSingleton.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandraSingleton.java
@@ -35,8 +35,8 @@ public class DockerCassandraSingleton {
     }
 
     // Call this method to ensure that cassandra is restarted every MAX_TEST_PLAYED tests
-    public static void restartAfterMaxTestsPlayed() {
-        if (testsPlayedCount > MAX_TEST_PLAYED) {
+    public static void restartAfterMaxTestsPlayed(boolean forceRestart) {
+        if (forceRestart || testsPlayedCount > MAX_TEST_PLAYED) {
             testsPlayedCount = 0;
             restart();
         }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdToImapUidDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdToImapUidDAOTest.java
@@ -46,11 +46,13 @@ import com.datastax.driver.core.utils.UUIDs;
 
 import reactor.core.publisher.Flux;
 
-@ExtendWith(CassandraRestartExtension.class)
 class CassandraMessageIdToImapUidDAOTest {
     public static final CassandraModule MODULE = CassandraModule.aggregateModules(
             CassandraSchemaVersionModule.MODULE,
             CassandraMessageModule.MODULE);
+
+    @RegisterExtension
+    static CassandraRestartExtension cassandraRestartExtension = new CassandraRestartExtension().forceRestart();
 
     @RegisterExtension
     static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(MODULE);


### PR DESCRIPTION
Trying to get rid of this kind of error : 

```
[217370df8625d8292821c199b2c2dfd45fb0d0f2] [ERROR] Failures: 
[217370df8625d8292821c199b2c2dfd45fb0d0f2] [ERROR]   CassandraMessageIdToImapUidDAOTest.updateShouldUpdateDraftFlag:278 
[217370df8625d8292821c199b2c2dfd45fb0d0f2] Expecting:
[217370df8625d8292821c199b2c2dfd45fb0d0f2]   <[ComposedMessageIdWithMetaData{composedMessageId=ComposedMessageId{mailboxId=CassandraId{id=e3436d61-6a47-11e9-89e1-fdb0c5d8e998}, messageId=CassandraMessageId{uuid=e3436d60-6a47-11e9-89e1-fdb0c5d8e998}, uid=MessageUid{uid=1}}, flags=, modSeq=1}]>
[217370df8625d8292821c199b2c2dfd45fb0d0f2] to contain only:
[217370df8625d8292821c199b2c2dfd45fb0d0f2]   <[ComposedMessageIdWithMetaData{composedMessageId=ComposedMessageId{mailboxId=CassandraId{id=e3436d61-6a47-11e9-89e1-fdb0c5d8e998}, messageId=CassandraMessageId{uuid=e3436d60-6a47-11e9-89e1-fdb0c5d8e998}, uid=MessageUid{uid=1}}, flags=\Draft, modSeq=2}]>
[217370df8625d8292821c199b2c2dfd45fb0d0f2] elements not found:
[217370df8625d8292821c199b2c2dfd45fb0d0f2]   <[ComposedMessageIdWithMetaData{composedMessageId=ComposedMessageId{mailboxId=CassandraId{id=e3436d61-6a47-11e9-89e1-fdb0c5d8e998}, messageId=CassandraMessageId{uuid=e3436d60-6a47-11e9-89e1-fdb0c5d8e998}, uid=MessageUid{uid=1}}, flags=\Draft, modSeq=2}]>
[217370df8625d8292821c199b2c2dfd45fb0d0f2] and elements not expected:
[217370df8625d8292821c199b2c2dfd45fb0d0f2]   <[ComposedMessageIdWithMetaData{composedMessageId=ComposedMessageId{mailboxId=CassandraId{id=e3436d61-6a47-11e9-89e1-fdb0c5d8e998}, messageId=CassandraMessageId{uuid=e3436d60-6a47-11e9-89e1-fdb0c5d8e998}, uid=MessageUid{uid=1}}, flags=, modSeq=1}]>
```

After we put back fork execution tests in the `mailbox/cassandra` module, we could observe that this error came back as well for `CassandraMessageIdToImapUidDAOTest` . Trying to see if can be avoided by forcing a restart of the Docker Cassandra