### PR TITLE
JAMES-2733 [PROPOSAL] Optimize RabbitMQ MailQueue getSize

### DIFF
--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/ManageableMailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/ManageableMailQueueContract.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
+
 import reactor.core.publisher.Flux;
 
 public interface ManageableMailQueueContract extends MailQueueContract {
@@ -611,6 +612,21 @@ public interface ManageableMailQueueContract extends MailQueueContract {
         getManageableMailQueue().clear();
 
         assertThat(getManageableMailQueue().browse()).isEmpty();
+    }
+
+    @Test
+    default void deletedElementsShouldNotBeDequeued() throws Exception {
+        enQueue(defaultMail()
+            .name("name1")
+            .build());
+        enQueue(defaultMail()
+            .name("name2")
+            .build());
+
+        getManageableMailQueue().remove(ManageableMailQueue.Type.Name, "name1");
+
+        assertThat(Flux.from(getManageableMailQueue().deQueue()).blockFirst().getMail().getName())
+            .isEqualTo("name2");
     }
 
 }

--- a/server/queue/queue-file/src/test/java/org/apache/james/queue/file/FileMailQueueTest.java
+++ b/server/queue/queue-file/src/test/java/org/apache/james/queue/file/FileMailQueueTest.java
@@ -111,4 +111,11 @@ public class FileMailQueueTest implements DelayedManageableMailQueueContract {
     public void concurrentEnqueueDequeueWithAckNackShouldNotFail() {
 
     }
+
+    @Test
+    @Override
+    @Disabled("JAMES-2544 Not supported yet")
+    public void deletedElementsShouldNotBeDequeued() {
+
+    }
 }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
@@ -34,6 +34,7 @@ import org.apache.mailet.Mail;
 
 import com.github.fge.lambdas.consumers.ThrowingConsumer;
 import com.rabbitmq.client.Delivery;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.rabbitmq.AcknowledgableDelivery;
@@ -80,8 +81,20 @@ class Dequeuer {
             .filter(getResponse -> getResponse.getBody() != null);
     }
 
-    Flux<MailQueue.MailQueueItem> deQueue() {
-        return flux.flatMap(this::loadItem);
+    Flux<? extends MailQueue.MailQueueItem> deQueue() {
+        return flux.flatMap(this::loadItem)
+            .flatMap(this::filterIfDeleted);
+    }
+
+    private Mono<RabbitMQMailQueueItem> filterIfDeleted(RabbitMQMailQueueItem item) {
+        return mailQueueView.isPresent(item.getMail())
+            .flatMap(isPresent -> {
+                if (isPresent) {
+                    return Mono.just(item);
+                }
+                item.done(true);
+                return Mono.empty();
+            });
     }
 
     private Mono<RabbitMQMailQueueItem> loadItem(AcknowledgableDelivery response) {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/BucketSizeDAO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/BucketSizeDAO.java
@@ -1,0 +1,106 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.queue.rabbitmq.view.cassandra;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.decr;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.incr;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.update;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.BucketSizeTable.BUCKET_ID;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.BucketSizeTable.MAIL_COUNT;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.BucketSizeTable.QUEUE_NAME;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.BucketSizeTable.TABLE_NAME;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.BucketSizeTable.TIME_RANGE_START;
+
+import java.util.Date;
+
+import javax.inject.Inject;
+
+import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
+import org.apache.james.queue.rabbitmq.MailQueueName;
+import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.Assignment;
+
+import reactor.core.publisher.Mono;
+
+public class BucketSizeDAO {
+    private final CassandraAsyncExecutor executor;
+    private final PreparedStatement increment;
+    private final PreparedStatement decrement;
+    private final PreparedStatement select;
+
+    @Inject
+    BucketSizeDAO(Session session) {
+        this.executor = new CassandraAsyncExecutor(session);
+
+        this.increment = prepareUpdate(session, incr(MAIL_COUNT));
+        this.decrement = prepareUpdate(session, decr(MAIL_COUNT));
+        this.select = prepareSelect(session);
+    }
+
+    private PreparedStatement prepareUpdate(Session session, Assignment assignment) {
+        return session.prepare(
+            update(TABLE_NAME)
+                .with(assignment)
+                .where(eq(QUEUE_NAME, bindMarker(QUEUE_NAME)))
+                .and(eq(TIME_RANGE_START, bindMarker(TIME_RANGE_START)))
+                .and(eq(BUCKET_ID, bindMarker(BUCKET_ID))));
+    }
+
+    private PreparedStatement prepareSelect(Session session) {
+        return session.prepare(
+            select(MAIL_COUNT)
+                .from(TABLE_NAME)
+                .where(eq(QUEUE_NAME, bindMarker(QUEUE_NAME)))
+                .and(eq(TIME_RANGE_START, bindMarker(TIME_RANGE_START)))
+                .and(eq(BUCKET_ID, bindMarker(BUCKET_ID))));
+    }
+
+    Mono<Long> getMailCount(MailQueueName queueName, BucketedSlices.Slice slice, BucketedSlices.BucketId bucketId) {
+        return executor.executeSingleRowOptional(
+            select.bind()
+                .setString(QUEUE_NAME, queueName.asString())
+                .setTimestamp(TIME_RANGE_START, Date.from(slice.getStartSliceInstant()))
+                .setInt(BUCKET_ID, bucketId.getValue()))
+            .map(maybeRow -> maybeRow.map(row -> row.getLong(MAIL_COUNT)))
+            .map(maybeCount -> maybeCount.orElse(0L));
+    }
+
+    Mono<Void> increment(MailQueueName queueName, BucketedSlices.Slice slice, BucketedSlices.BucketId bucketId) {
+        return executor.executeVoid(
+            increment.bind()
+                .setString(QUEUE_NAME, queueName.asString())
+                .setTimestamp(TIME_RANGE_START, Date.from(slice.getStartSliceInstant()))
+                .setInt(BUCKET_ID, bucketId.getValue()));
+    }
+
+    Mono<Void> decrement(MailQueueName queueName, BucketedSlices.Slice slice, BucketedSlices.BucketId bucketId) {
+        return executor.executeVoid(
+            decrement.bind()
+                .setString(QUEUE_NAME, queueName.asString())
+                .setTimestamp(TIME_RANGE_START, Date.from(slice.getStartSliceInstant()))
+                .setInt(BUCKET_ID, bucketId.getValue()));
+    }
+}

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueBrowser.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueBrowser.java
@@ -31,6 +31,7 @@ import javax.inject.Inject;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.blob.api.Store;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.james.blob.mail.MimeMessageStore;
@@ -44,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -79,6 +81,7 @@ public class CassandraMailQueueBrowser {
     private final BrowseStartDAO browseStartDao;
     private final DeletedMailsDAO deletedMailsDao;
     private final EnqueuedMailsDAO enqueuedMailsDao;
+    private final BucketSizeDAO bucketSizeDAO;
     private final Store<MimeMessage, MimeMessagePartsId> mimeMessageStore;
     private final CassandraMailQueueViewConfiguration configuration;
     private final Clock clock;
@@ -87,12 +90,13 @@ public class CassandraMailQueueBrowser {
     CassandraMailQueueBrowser(BrowseStartDAO browseStartDao,
                               DeletedMailsDAO deletedMailsDao,
                               EnqueuedMailsDAO enqueuedMailsDao,
-                              MimeMessageStore.Factory mimeMessageStoreFactory,
+                              BucketSizeDAO bucketSizeDAO, MimeMessageStore.Factory mimeMessageStoreFactory,
                               CassandraMailQueueViewConfiguration configuration,
                               Clock clock) {
         this.browseStartDao = browseStartDao;
         this.deletedMailsDao = deletedMailsDao;
         this.enqueuedMailsDao = enqueuedMailsDao;
+        this.bucketSizeDAO = bucketSizeDAO;
         this.mimeMessageStore = mimeMessageStoreFactory.mimeMessageStore();
         this.configuration = configuration;
         this.clock = clock;
@@ -109,6 +113,18 @@ public class CassandraMailQueueBrowser {
             .flatMapMany(this::allSlicesStartingAt)
             .flatMapSequential(slice -> browseSlice(queueName, slice))
             .subscribeOn(Schedulers.parallel());
+    }
+
+    Mono<Long> getSize(MailQueueName queueName) {
+        return allBuckets(queueName)
+            .flatMap(pair -> bucketSizeDAO.getMailCount(queueName, pair.getKey(), pair.getValue()))
+            .reduce(Long::sum);
+    }
+
+    private Flux<Pair<Slice, BucketId>> allBuckets(MailQueueName queueName) {
+        return browseStartDao.findBrowseStart(queueName)
+            .flatMapMany(this::allSlicesStartingAt)
+            .flatMap(slice -> allBucketIds().map(bucketId -> Pair.of(slice, bucketId)));
     }
 
     private Mono<Mail> toMailFuture(EnqueuedItemWithSlicingContext enqueuedItemWithSlicingContext) {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
@@ -96,7 +96,9 @@ public class CassandraMailQueueView implements MailQueueView {
 
     @Override
     public long getSize() {
-        return cassandraMailQueueBrowser.browseReferences(mailQueueName).count().block();
+        return cassandraMailQueueBrowser.getSize(mailQueueName)
+            .blockOptional()
+            .orElse(0L);
     }
 
     @Override
@@ -120,7 +122,8 @@ public class CassandraMailQueueView implements MailQueueView {
     }
 
     private Mono<Void> delete(MailKey mailKey) {
-        return cassandraMailQueueMailDelete.considerDeleted(mailKey, mailQueueName);
+        return cassandraMailQueueMailDelete.considerDeleted(mailKey, mailQueueName)
+            .then();
     }
 
     @Override

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
@@ -83,7 +83,7 @@ public interface CassandraMailQueueViewModule {
     }
 
     interface MailKeyToBucketTable {
-        String TABLE_NAME = "bucketSize";
+        String TABLE_NAME = "mailKeyToBucket";
 
         String QUEUE_NAME = "queueName";
         String MAIL_KEY = "mailKey";

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
@@ -146,5 +146,13 @@ public interface CassandraMailQueueViewModule {
             .addPartitionKey(BucketSizeTable.BUCKET_ID, cint())
             .addColumn(BucketSizeTable.MAIL_COUNT, counter()))
 
+        .table(MailKeyToBucketTable.TABLE_NAME)
+        .comment("Given a mailKey, resolve the bucket it belongs to")
+        .statement(statement -> statement
+            .addPartitionKey(MailKeyToBucketTable.QUEUE_NAME, text())
+            .addPartitionKey(MailKeyToBucketTable.MAIL_KEY, text())
+            .addColumn(MailKeyToBucketTable.TIME_RANGE_START, timestamp())
+            .addColumn(MailKeyToBucketTable.BUCKET_ID, cint()))
+
         .build();
 }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
@@ -21,6 +21,7 @@ package org.apache.james.queue.rabbitmq.view.cassandra;
 
 import static com.datastax.driver.core.DataType.blob;
 import static com.datastax.driver.core.DataType.cint;
+import static com.datastax.driver.core.DataType.counter;
 import static com.datastax.driver.core.DataType.list;
 import static com.datastax.driver.core.DataType.map;
 import static com.datastax.driver.core.DataType.text;
@@ -71,6 +72,26 @@ public interface CassandraMailQueueViewModule {
         String MAIL_KEY = "mailKey";
     }
 
+    interface BucketSizeTable {
+        String TABLE_NAME = "bucketSize";
+
+        String QUEUE_NAME = "queueName";
+        String TIME_RANGE_START = "timeRangeStart";
+        String BUCKET_ID = "bucketId";
+
+        String MAIL_COUNT = "mailCount";
+    }
+
+    interface MailKeyToBucketTable {
+        String TABLE_NAME = "bucketSize";
+
+        String QUEUE_NAME = "queueName";
+        String MAIL_KEY = "mailKey";
+
+        String TIME_RANGE_START = "timeRangeStart";
+        String BUCKET_ID = "bucketId";
+    }
+
     CassandraModule MODULE = CassandraModule
         .type(EnqueuedMailsTable.HEADER_TYPE)
             .statement(statement -> statement
@@ -116,6 +137,14 @@ public interface CassandraMailQueueViewModule {
         .statement(statement -> statement
             .addPartitionKey(DeletedMailTable.QUEUE_NAME, text())
             .addPartitionKey(DeletedMailTable.MAIL_KEY, text()))
+
+        .table(BucketSizeTable.TABLE_NAME)
+        .comment("Holds the count of remaining email per bucket")
+        .statement(statement -> statement
+            .addPartitionKey(BucketSizeTable.QUEUE_NAME, text())
+            .addPartitionKey(BucketSizeTable.TIME_RANGE_START, timestamp())
+            .addPartitionKey(BucketSizeTable.BUCKET_ID, cint())
+            .addColumn(BucketSizeTable.MAIL_COUNT, counter()))
 
         .build();
 }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/MailKeyToBucketDAO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/MailKeyToBucketDAO.java
@@ -1,0 +1,93 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.queue.rabbitmq.view.cassandra;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.MailKeyToBucketTable.BUCKET_ID;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.MailKeyToBucketTable.MAIL_KEY;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.MailKeyToBucketTable.QUEUE_NAME;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.MailKeyToBucketTable.TABLE_NAME;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.MailKeyToBucketTable.TIME_RANGE_START;
+
+import java.util.Date;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
+import org.apache.james.queue.rabbitmq.MailQueueName;
+import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices.BucketId;
+import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices.Slice;
+import org.apache.james.queue.rabbitmq.view.cassandra.model.MailKey;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+
+import reactor.core.publisher.Mono;
+
+public class MailKeyToBucketDAO {
+    private final CassandraAsyncExecutor executor;
+    private final PreparedStatement selectOne;
+    private final PreparedStatement insertOne;
+
+    @Inject
+    MailKeyToBucketDAO(Session session) {
+        this.executor = new CassandraAsyncExecutor(session);
+
+        this.selectOne = prepareSelectExist(session);
+        this.insertOne = prepareInsert(session);
+    }
+
+    private PreparedStatement prepareInsert(Session session) {
+        return session.prepare(insertInto(TABLE_NAME)
+            .value(QUEUE_NAME, bindMarker(QUEUE_NAME))
+            .value(MAIL_KEY, bindMarker(MAIL_KEY))
+            .value(TIME_RANGE_START, bindMarker(TIME_RANGE_START))
+            .value(BUCKET_ID, bindMarker(BUCKET_ID)));
+    }
+
+    private PreparedStatement prepareSelectExist(Session session) {
+        return session.prepare(select()
+            .from(TABLE_NAME)
+            .where(eq(QUEUE_NAME, bindMarker(QUEUE_NAME)))
+            .and(eq(MAIL_KEY, bindMarker(MAIL_KEY))));
+    }
+
+    Mono<Void> registerBucket(MailQueueName mailQueueName, MailKey mailKey, Slice slice, BucketId bucketId) {
+        return executor.executeVoid(insertOne.bind()
+            .setString(QUEUE_NAME, mailQueueName.asString())
+            .setString(MAIL_KEY, mailKey.getMailKey())
+            .setTimestamp(TIME_RANGE_START, Date.from(slice.getStartSliceInstant()))
+            .setInt(BUCKET_ID, bucketId.getValue()));
+    }
+
+    Mono<Pair<Slice, BucketId>> retrieveBucket(MailQueueName mailQueueName, MailKey mailKey) {
+        return executor.executeSingleRowOptional(
+            selectOne.bind()
+                .setString(QUEUE_NAME, mailQueueName.asString())
+                .setString(MAIL_KEY, mailKey.getMailKey()))
+            .flatMap(maybeRow -> Mono.justOrEmpty(maybeRow.map(row -> Pair.of(
+                Slice.of(row.getTimestamp(TIME_RANGE_START).toInstant()),
+                BucketId.of(row.getInt(BUCKET_ID))))));
+    }
+}

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
@@ -233,6 +233,14 @@ public class RabbitMQMailQueueTest implements ManageableMailQueueContract, MailQ
 
     }
 
+    @Disabled("JAMES-2733 Deleted elements are still dequeued")
+    @Test
+    @Override
+    public void deletedElementsShouldNotBeDequeued() {
+
+    }
+
+
     private void enqueueSomeMails(Function<Integer, String> namePattern, int emailCount) {
         IntStream.rangeClosed(1, emailCount)
             .forEach(Throwing.intConsumer(i -> enQueue(defaultMail()

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
@@ -233,14 +233,6 @@ public class RabbitMQMailQueueTest implements ManageableMailQueueContract, MailQ
 
     }
 
-    @Disabled("JAMES-2733 Deleted elements are still dequeued")
-    @Test
-    @Override
-    public void deletedElementsShouldNotBeDequeued() {
-
-    }
-
-
     private void enqueueSomeMails(Function<Integer, String> namePattern, int emailCount) {
         IntStream.rangeClosed(1, emailCount)
             .forEach(Throwing.intConsumer(i -> enQueue(defaultMail()

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewTestFactory.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewTestFactory.java
@@ -50,11 +50,12 @@ public class CassandraMailQueueViewTestFactory {
         EnqueuedMailsDAO enqueuedMailsDao = new EnqueuedMailsDAO(session, typesProvider, blobIdFactory);
         BrowseStartDAO browseStartDao = new BrowseStartDAO(session);
         DeletedMailsDAO deletedMailsDao = new DeletedMailsDAO(session);
+        BucketSizeDAO bucketSizeDAO = new BucketSizeDAO(session);
+        MailKeyToBucketDAO mailKeyToBucketDAO = new MailKeyToBucketDAO(session);
 
-        CassandraMailQueueBrowser cassandraMailQueueBrowser = new CassandraMailQueueBrowser(browseStartDao, deletedMailsDao, enqueuedMailsDao, mimeMessageStoreFactory, configuration, clock);
-        CassandraMailQueueMailStore cassandraMailQueueMailStore = new CassandraMailQueueMailStore(enqueuedMailsDao, browseStartDao, configuration, clock);
-        CassandraMailQueueMailDelete cassandraMailQueueMailDelete = new CassandraMailQueueMailDelete(deletedMailsDao, browseStartDao, cassandraMailQueueBrowser, configuration, random);
-
+        CassandraMailQueueBrowser cassandraMailQueueBrowser = new CassandraMailQueueBrowser(browseStartDao, deletedMailsDao, enqueuedMailsDao, bucketSizeDAO, mimeMessageStoreFactory, configuration, clock);
+        CassandraMailQueueMailStore cassandraMailQueueMailStore = new CassandraMailQueueMailStore(enqueuedMailsDao, browseStartDao, bucketSizeDAO, mailKeyToBucketDAO, configuration, clock);
+        CassandraMailQueueMailDelete cassandraMailQueueMailDelete = new CassandraMailQueueMailDelete(deletedMailsDao, browseStartDao, bucketSizeDAO, mailKeyToBucketDAO, cassandraMailQueueBrowser, configuration, random);
 
         EventsourcingConfigurationManagement eventsourcingConfigurationManagement = new EventsourcingConfigurationManagement(new CassandraEventStore(new EventStoreDao(session,
             new JsonEventSerializer(ImmutableSet.of(CassandraMailQueueViewConfigurationModule.MAIL_QUEUE_VIEW_CONFIGURATION)))));

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAOTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAOTest.java
@@ -23,6 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.MailKey;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,7 +39,9 @@ class DeletedMailsDAOTest {
     private static final MailKey MAIL_KEY_2 = MailKey.of("mailkey2");
 
     @RegisterExtension
-    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(CassandraMailQueueViewModule.MODULE);
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(CassandraModule.aggregateModules(
+        CassandraMailQueueViewModule.MODULE,
+        CassandraSchemaVersionModule.MODULE));
 
     private DeletedMailsDAO testee;
 


### PR DESCRIPTION
Idea: Use a Per-Bucket mail counter projection

Upon enqueue:

 -  Increment the counter of the bucket the mail is assigned to

Upon dequeue:

 -  Decrement the counter of the bucket the mail is assigned to

Upon get size:

 -  Starting from the browseStart point...
 -  Sum all the bucket counts starting from browseStart

Another projection must be use to retrieve, given a mailKey, the associated bucket+slice.

Work remaining: Write unit tests for DAOs