### PR TITLE
Revert "JAMES-2733 RabbitMQ should not dequeue deleted elements"

### DIFF
--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
@@ -34,7 +34,6 @@ import org.apache.mailet.Mail;
 
 import com.github.fge.lambdas.consumers.ThrowingConsumer;
 import com.rabbitmq.client.Delivery;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.rabbitmq.AcknowledgableDelivery;
@@ -81,20 +80,8 @@ class Dequeuer {
             .filter(getResponse -> getResponse.getBody() != null);
     }
 
-    Flux<? extends MailQueue.MailQueueItem> deQueue() {
-        return flux.flatMap(this::loadItem)
-            .flatMap(this::filterIfDeleted);
-    }
-
-    private Mono<RabbitMQMailQueueItem> filterIfDeleted(RabbitMQMailQueueItem item) {
-        return mailQueueView.isPresent(item.getMail())
-            .flatMap(isPresent -> {
-                if (isPresent) {
-                    return Mono.just(item);
-                }
-                item.done(true);
-                return Mono.empty();
-            });
+    Flux<MailQueue.MailQueueItem> deQueue() {
+        return flux.flatMap(this::loadItem);
     }
 
     private Mono<RabbitMQMailQueueItem> loadItem(AcknowledgableDelivery response) {

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
@@ -233,6 +233,14 @@ public class RabbitMQMailQueueTest implements ManageableMailQueueContract, MailQ
 
     }
 
+    @Disabled("JAMES-2733 Deleted elements are still dequeued")
+    @Test
+    @Override
+    public void deletedElementsShouldNotBeDequeued() {
+
+    }
+
+
     private void enqueueSomeMails(Function<Integer, String> namePattern, int emailCount) {
         IntStream.rangeClosed(1, emailCount)
             .forEach(Throwing.intConsumer(i -> enQueue(defaultMail()


### PR DESCRIPTION
Found the malicious commit introducing the issue :
```
[ERROR]   ForwardSmtpTest.forwardingAnEmailShouldWork:79 » ConditionTimeout Assertion co...
```
Reverted it. Let's see if it goes green !