### PR TITLE
JAMES-2751 Fixing Docker Cassandra restart rule

### DIFF
--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandraRule.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/DockerCassandraRule.java
@@ -20,13 +20,11 @@
 package org.apache.james.backends.cassandra;
 
 import org.apache.james.util.Host;
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+import org.junit.rules.ExternalResource;
 import org.testcontainers.containers.GenericContainer;
 
 
-public class DockerCassandraRule implements TestRule {
+public class DockerCassandraRule extends ExternalResource {
 
     private boolean allowRestart = false;
 
@@ -36,16 +34,15 @@ public class DockerCassandraRule implements TestRule {
     }
 
     @Override
-    public Statement apply(Statement base, Description description) {
-        return base;
+    protected void before() {
+        if (allowRestart) {
+            DockerCassandraSingleton.restartAfterMaxTestsPlayed();
+        }
+        DockerCassandraSingleton.incrementTestsPlayed();
     }
 
     public void start() {
         DockerCassandraSingleton.singleton.start();
-        DockerCassandraSingleton.incrementTestsPlayed();
-        if (allowRestart) {
-            DockerCassandraSingleton.restartAfterMaxTestsPlayed();
-        }
     }
 
     public void stop() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraAuthenticatePlainTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraAuthenticatePlainTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.AuthenticatePlain;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraAuthenticatePlainTest extends AuthenticatePlain {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraAuthenticatedStateTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraAuthenticatedStateTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.AuthenticatedState;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraAuthenticatedStateTest extends AuthenticatedState {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraConcurrentSessionsTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraConcurrentSessionsTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.ConcurrentSessions;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraConcurrentSessionsTest extends ConcurrentSessions {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraCondstoreTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraCondstoreTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.host.JamesImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.Condstore;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraCondstoreTest extends Condstore {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected JamesImapHostSystem createJamesImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraCopyTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraCopyTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.Copy;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraCopyTest extends Copy {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraEventsTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraEventsTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.Events;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraEventsTest extends Events {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraExpungeTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraExpungeTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.Expunge;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraExpungeTest extends Expunge {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraFetchBodySectionTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraFetchBodySectionTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.FetchBodySection;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraFetchBodySectionTest extends FetchBodySection {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraFetchBodyStructureTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraFetchBodyStructureTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.FetchBodyStructure;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraFetchBodyStructureTest extends FetchBodyStructure {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraFetchHeadersTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraFetchHeadersTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.FetchHeaders;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraFetchHeadersTest extends FetchHeaders {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraFetchTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraFetchTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.Fetch;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraFetchTest extends Fetch {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraListingTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraListingTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.Listing;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraListingTest extends Listing {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraListingWithSharingTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraListingWithSharingTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.ListingWithSharingTest;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraListingWithSharingTest extends ListingWithSharingTest {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraMailboxAnnotationTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraMailboxAnnotationTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.MailboxAnnotation;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraMailboxAnnotationTest extends MailboxAnnotation {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraMailboxWithLongNameErrorTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraMailboxWithLongNameErrorTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.MailboxWithLongNameError;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraMailboxWithLongNameErrorTest extends MailboxWithLongNameError {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraMoveTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraMoveTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.Move;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraMoveTest extends Move {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraNonAuthenticatedStateTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraNonAuthenticatedStateTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.NonAuthenticatedState;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraNonAuthenticatedStateTest extends NonAuthenticatedState {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraPartialFetchTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraPartialFetchTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.PartialFetch;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraPartialFetchTest extends PartialFetch {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraQuotaTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraQuotaTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.QuotaTest;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraQuotaTest extends QuotaTest {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraRenameTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraRenameTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.Rename;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraRenameTest extends Rename {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraSearchTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraSearchTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.Search;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraSearchTest extends Search {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraSecurityTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraSecurityTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.Security;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraSecurityTest extends Security {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraSelectTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraSelectTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.Select;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraSelectTest extends Select {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraSelectedInboxTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraSelectedInboxTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.SelectedInbox;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraSelectedInboxTest extends SelectedInbox {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraSelectedStateTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraSelectedStateTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.SelectedState;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraSelectedStateTest extends SelectedState {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraUidSearchOnIndexTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraUidSearchOnIndexTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.UidSearchOnIndex;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraUidSearchOnIndexTest extends UidSearchOnIndex {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraUidSearchTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraUidSearchTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.UidSearch;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraUidSearchTest extends UidSearch {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraUserFlagsSupportTest.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/CassandraUserFlagsSupportTest.java
@@ -24,12 +24,14 @@ import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.cassandra.host.CassandraHostSystemRule;
 import org.apache.james.mpt.imapmailbox.suite.UserFlagsSupport;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class CassandraUserFlagsSupportTest extends UserFlagsSupport {
-    @Rule
     public DockerCassandraRule cassandraServer = new DockerCassandraRule().allowRestart();
-    @Rule
     public CassandraHostSystemRule cassandraHostSystemRule = new CassandraHostSystemRule(cassandraServer);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(cassandraServer).around(cassandraHostSystemRule);
 
     @Override
     protected ImapHostSystem createImapHostSystem() {


### PR DESCRIPTION
After digging again into the issue, I realized that when the DockerCassandraRule got changed from being used as a @ClassRule to a @Rule in https://github.com/linagora/james-project/pull/2313, the restart was not working anymore in fact.

The `start()` method is never invoked for example in test classes implementing the `DockerCassandraRule` in `mailbox/cassandra` module. And maybe that's why our builds are still not stable in this module on the CI. So this is the fix I propose instead of https://github.com/linagora/james-project/pull/2329 (that I will reopen if need be)