### PR TITLE
JAMES-2759 Update reactor-rabbitmq to 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -670,7 +670,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>Californium-SR8</version>
+                <version>Californium-SR9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -670,7 +670,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>Californium-SR3</version>
+                <version>Californium-SR8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2140,7 +2140,7 @@
             <dependency>
                 <groupId>io.projectreactor.rabbitmq</groupId>
                 <artifactId>reactor-rabbitmq</artifactId>
-                <version>1.0.0.RELEASE</version>
+                <version>1.2.0.RELEASE</version>
             </dependency>
             <dependency>
                 <groupId>javax.activation</groupId>

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAOTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAOTest.java
@@ -23,6 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.MailKey;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,7 +39,9 @@ class DeletedMailsDAOTest {
     private static final MailKey MAIL_KEY_2 = MailKey.of("mailkey2");
 
     @RegisterExtension
-    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(CassandraMailQueueViewModule.MODULE);
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(CassandraModule.aggregateModules(
+        CassandraMailQueueViewModule.MODULE,
+        CassandraSchemaVersionModule.MODULE));
 
     private DeletedMailsDAO testee;
 

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAOTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAOTest.java
@@ -23,8 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
-import org.apache.james.backends.cassandra.components.CassandraModule;
-import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.MailKey;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,9 +37,7 @@ class DeletedMailsDAOTest {
     private static final MailKey MAIL_KEY_2 = MailKey.of("mailkey2");
 
     @RegisterExtension
-    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(CassandraModule.aggregateModules(
-        CassandraMailQueueViewModule.MODULE,
-        CassandraSchemaVersionModule.MODULE));
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(CassandraMailQueueViewModule.MODULE);
 
     private DeletedMailsDAO testee;
 


### PR DESCRIPTION
reactor-rabbitmq is used by the RabbitMQ eventBus and the RabbitMQ queue

Recent 1.2.0 version ships loads of bigfixes that can help us improve build overall stability: https://github.com/reactor/reactor-rabbitmq/releases

 - Channels are leaking when CancelCallback is used
 - Allow customization of channel creation for sending
 - Retry automatically on ack/nack failure
 - Enforce queue specification semantics for server-named, non-durable, exclusive, auto-delete queue creation