### PR TITLE
JAMES-2717 Solve unstable FixingGhostMailboxTest test

### DIFF
--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/DockerElasticSearchExtension.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/DockerElasticSearchExtension.java
@@ -43,6 +43,11 @@ public class DockerElasticSearchExtension implements GuiceModuleTestExtension {
             .toInstance(getElasticSearchConfigurationForDocker());
     }
 
+    @Override
+    public void await() {
+        getDockerES().awaitForElasticSearch();
+    }
+
     private ElasticSearchConfiguration getElasticSearchConfigurationForDocker() {
         return ElasticSearchConfiguration.builder()
             .addHost(getDockerES().getTcpHost())


### PR DESCRIPTION
with DockerES, some time we get this failed test, it doesnt happen on local machine, so I put a wait condition before the assertion to avoid failures on CI

```
[a4b2e332ca3c65e143fb66fb25b49c2594bc6276] [ERROR]   FixingGhostMailboxTest.ghostMailboxBugShouldDiscardOldContent:205 1 expectation failed.
[a4b2e332ca3c65e143fb66fb25b49c2594bc6276] JSON path [0][1].messageIds doesn't match.
[a4b2e332ca3c65e143fb66fb25b49c2594bc6276] Expected: a collection with size <1>
[a4b2e332ca3c65e143fb66fb25b49c2594bc6276]   Actual: []
```