### PR TITLE
Make webadmin IT tests uses the right path

### DIFF
--- a/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/WebAdminServerIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/WebAdminServerIntegrationTest.java
@@ -254,7 +254,9 @@ public class WebAdminServerIntegrationTest {
             .get("taskId");
 
         with()
-            .get("/task/" + taskId + "/await");
+            .get("/tasks/" + taskId + "/await")
+        .then()
+            .body("status", is("completed"));
 
         Awaitility.await()
             .atMost(Duration.TEN_SECONDS)
@@ -275,7 +277,9 @@ public class WebAdminServerIntegrationTest {
             .get("taskId");
 
         with()
-            .get("/task/" + taskId + "/await");
+            .get("/tasks/" + taskId + "/await")
+        .then()
+            .body("status", is("completed"));
 
         when()
             .get(VERSION)


### PR DESCRIPTION
for the record, there are a lot of this failures on CI:
```
[ERROR] Failures: 
[ERROR]   WebAdminServerIntegrationTest.postShouldDoMigrationAndUpdateToTheLatestVersion:285 1 expectation failed.
Response body doesn't match expectation.
Expected: is "{\"version\":7}"
```