### PR TITLE
JAMES-2754 james-server-webadmin-data dependency is not required for …

### DIFF
--- a/mpt/impl/imap-mailbox/external-james/pom.xml
+++ b/mpt/impl/imap-mailbox/external-james/pom.xml
@@ -41,10 +41,6 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-webadmin-data</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-testing</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
…external James

It pull many dependencies in for validation deployment tests, which result in 40 projects being recompiled each time.
Removing it results in only 19 projects being compiled.