### PR TITLE
JAMES-2775 Linshare should be stopped in integration tests

### DIFF
--- a/server/container/guice/blob-export-guice/src/test/java/org/apache/james/modules/LinshareGuiceExtension.java
+++ b/server/container/guice/blob-export-guice/src/test/java/org/apache/james/modules/LinshareGuiceExtension.java
@@ -55,4 +55,9 @@ public class LinshareGuiceExtension implements GuiceModuleTestExtension {
             }
         );
     }
+
+    public void stopDockerLinshare() {
+        linshareExtension.getLinshare()
+            .stop();
+    }
 }

--- a/server/container/guice/blob-export-guice/src/test/java/org/apache/james/modules/LinshareGuiceExtension.java
+++ b/server/container/guice/blob-export-guice/src/test/java/org/apache/james/modules/LinshareGuiceExtension.java
@@ -41,6 +41,12 @@ public class LinshareGuiceExtension implements GuiceModuleTestExtension {
     }
 
     @Override
+    public void afterAll(ExtensionContext extensionContext) throws Exception {
+        linshareExtension.getLinshare()
+            .stop();
+    }
+
+    @Override
     public Module getModule() {
         return Modules.combine(
             binder -> binder.bind(BlobExportImplChoice.class)
@@ -54,10 +60,5 @@ public class LinshareGuiceExtension implements GuiceModuleTestExtension {
                 }
             }
         );
-    }
-
-    public void stopDockerLinshare() {
-        linshareExtension.getLinshare()
-            .stop();
     }
 }

--- a/server/container/guice/memory-guice/src/test/java/org/apache/james/LinshareBlobExportMechanismProvidingTest.java
+++ b/server/container/guice/memory-guice/src/test/java/org/apache/james/LinshareBlobExportMechanismProvidingTest.java
@@ -22,7 +22,6 @@ package org.apache.james;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.james.modules.LinshareGuiceExtension;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -35,11 +34,6 @@ class LinshareBlobExportMechanismProvidingTest {
         .server(configuration -> GuiceJamesServer.forConfiguration(configuration)
             .combineWith(MemoryJamesServerMain.IN_MEMORY_SERVER_AGGREGATE_MODULE))
         .build();
-
-    @AfterAll
-    static void afterAll() {
-        linshareGuiceExtension.stopDockerLinshare();
-    }
 
     @Test
     void memoryJamesServerShouldStartWithLinShareBlobExportMechanism(GuiceJamesServer server) {

--- a/server/container/guice/memory-guice/src/test/java/org/apache/james/LinshareBlobExportMechanismProvidingTest.java
+++ b/server/container/guice/memory-guice/src/test/java/org/apache/james/LinshareBlobExportMechanismProvidingTest.java
@@ -22,6 +22,7 @@ package org.apache.james;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.james.modules.LinshareGuiceExtension;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -34,6 +35,11 @@ class LinshareBlobExportMechanismProvidingTest {
         .server(configuration -> GuiceJamesServer.forConfiguration(configuration)
             .combineWith(MemoryJamesServerMain.IN_MEMORY_SERVER_AGGREGATE_MODULE))
         .build();
+
+    @AfterAll
+    static void afterAll() {
+        linshareGuiceExtension.stopDockerLinshare();
+    }
 
     @Test
     void memoryJamesServerShouldStartWithLinShareBlobExportMechanism(GuiceJamesServer server) {

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/CassandraLinshareBlobExportMechanismIntegrationTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/CassandraLinshareBlobExportMechanismIntegrationTest.java
@@ -35,13 +35,14 @@ import org.apache.james.modules.mailbox.PreDeletionHooksConfiguration;
 import org.apache.james.vault.DeletedMessageVaultHook;
 import org.apache.james.vault.MailRepositoryDeletedMessageVault;
 import org.apache.james.webadmin.WebAdminConfiguration;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class CassandraLinshareBlobExportMechanismIntegrationTest extends LinshareBlobExportMechanismIntegrationTest {
 
     private static final long LIMIT_TO_10_MESSAGES = 10;
 
-    private final LinshareGuiceExtension linshareGuiceExtension = new LinshareGuiceExtension();
+    private static final LinshareGuiceExtension linshareGuiceExtension = new LinshareGuiceExtension();
 
     @RegisterExtension
     JamesServerExtension testExtension = new JamesServerBuilder()
@@ -61,4 +62,10 @@ public class CassandraLinshareBlobExportMechanismIntegrationTest extends Linshar
                     .toInstance(new MailRepositoryDeletedMessageVault.Configuration(MailRepositoryUrl.from("cassandra://var/deletedMessages/user")));
             }))
         .build();
+
+    @AfterAll
+    static void afterAll() {
+        linshareGuiceExtension.stopDockerLinshare();
+    }
+
 }

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/CassandraLinshareBlobExportMechanismIntegrationTest.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/CassandraLinshareBlobExportMechanismIntegrationTest.java
@@ -35,7 +35,6 @@ import org.apache.james.modules.mailbox.PreDeletionHooksConfiguration;
 import org.apache.james.vault.DeletedMessageVaultHook;
 import org.apache.james.vault.MailRepositoryDeletedMessageVault;
 import org.apache.james.webadmin.WebAdminConfiguration;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class CassandraLinshareBlobExportMechanismIntegrationTest extends LinshareBlobExportMechanismIntegrationTest {
@@ -62,10 +61,4 @@ public class CassandraLinshareBlobExportMechanismIntegrationTest extends Linshar
                     .toInstance(new MailRepositoryDeletedMessageVault.Configuration(MailRepositoryUrl.from("cassandra://var/deletedMessages/user")));
             }))
         .build();
-
-    @AfterAll
-    static void afterAll() {
-        linshareGuiceExtension.stopDockerLinshare();
-    }
-
 }

--- a/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/java/org/apache/james/jmap/memory/MemoryLinshareBlobExportMechanismIntegrationTest.java
+++ b/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/java/org/apache/james/jmap/memory/MemoryLinshareBlobExportMechanismIntegrationTest.java
@@ -32,7 +32,6 @@ import org.apache.james.modules.mailbox.PreDeletionHooksConfiguration;
 import org.apache.james.vault.DeletedMessageVaultHook;
 import org.apache.james.vault.MailRepositoryDeletedMessageVault;
 import org.apache.james.webadmin.WebAdminConfiguration;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class MemoryLinshareBlobExportMechanismIntegrationTest extends LinshareBlobExportMechanismIntegrationTest {
@@ -57,9 +56,4 @@ class MemoryLinshareBlobExportMechanismIntegrationTest extends LinshareBlobExpor
                     .toInstance(new MailRepositoryDeletedMessageVault.Configuration(MailRepositoryUrl.from("memory://var/deletedMessages/user")));
             }))
         .build();
-
-    @AfterAll
-    static void afterAll() {
-        linshareGuiceExtension.stopDockerLinshare();
-    }
 }

--- a/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/java/org/apache/james/jmap/memory/MemoryLinshareBlobExportMechanismIntegrationTest.java
+++ b/server/protocols/jmap-integration-testing/memory-jmap-integration-testing/src/test/java/org/apache/james/jmap/memory/MemoryLinshareBlobExportMechanismIntegrationTest.java
@@ -32,13 +32,14 @@ import org.apache.james.modules.mailbox.PreDeletionHooksConfiguration;
 import org.apache.james.vault.DeletedMessageVaultHook;
 import org.apache.james.vault.MailRepositoryDeletedMessageVault;
 import org.apache.james.webadmin.WebAdminConfiguration;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class MemoryLinshareBlobExportMechanismIntegrationTest extends LinshareBlobExportMechanismIntegrationTest {
 
     private static final int LIMIT_TO_10_MESSAGES = 10;
 
-    private final LinshareGuiceExtension linshareGuiceExtension = new LinshareGuiceExtension();
+    private static final LinshareGuiceExtension linshareGuiceExtension = new LinshareGuiceExtension();
 
     @RegisterExtension
     JamesServerExtension jamesServerExtension = new JamesServerBuilder()
@@ -56,4 +57,9 @@ class MemoryLinshareBlobExportMechanismIntegrationTest extends LinshareBlobExpor
                     .toInstance(new MailRepositoryDeletedMessageVault.Configuration(MailRepositoryUrl.from("memory://var/deletedMessages/user")));
             }))
         .build();
+
+    @AfterAll
+    static void afterAll() {
+        linshareGuiceExtension.stopDockerLinshare();
+    }
 }


### PR DESCRIPTION
Because there is only one test class in integration tests module need this docker. When it finishes, we can stop docker linshare to save some resources