### PR TITLE
JAMES-2675 Rely on ScrollIterable when no limit is specified

### DIFF
--- a/mailbox/plugin/quota-search-elasticsearch-v6/src/test/java/org/apache/james/quota/search/elasticsearch/ElasticSearchQuotaSearcherTest.java
+++ b/mailbox/plugin/quota-search-elasticsearch-v6/src/test/java/org/apache/james/quota/search/elasticsearch/ElasticSearchQuotaSearcherTest.java
@@ -19,10 +19,70 @@
 
 package org.apache.james.quota.search.elasticsearch;
 
+import static org.apache.james.core.CoreFixture.Domains.SIMPSON_COM;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.IntStream;
+
+import org.apache.james.core.User;
+import org.apache.james.core.quota.QuotaSize;
+import org.apache.james.quota.search.Limit;
+import org.apache.james.quota.search.Offset;
+import org.apache.james.quota.search.QuotaQuery;
+import org.apache.james.quota.search.QuotaSearchTestSystem;
 import org.apache.james.quota.search.QuotaSearcherContract;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ElasticSearchQuotaSearchTestSystemExtension.class)
 class ElasticSearchQuotaSearcherTest implements QuotaSearcherContract {
+    @Test
+    void searchShouldNotBeLimitedByElasticSearchDefaultSearchLimit(QuotaSearchTestSystem testSystem) throws Exception {
+        int userCount = 11;
+        testSystem.getDomainList().addDomain(SIMPSON_COM);
+        testSystem.getMaxQuotaManager().setGlobalMaxStorage(QuotaSize.size(100));
 
+        IntStream.range(0, userCount)
+            .boxed()
+            .map(i -> User.fromLocalPartWithDomain("user" + i, SIMPSON_COM))
+            .forEach(user -> provisionUser(testSystem, user));
+        testSystem.await();
+
+        assertThat(
+            testSystem.getQuotaSearcher()
+                .search(QuotaQuery.builder()
+                    .withLimit(Limit.unlimited())
+                    .build()))
+            .hasSize(userCount);
+    }
+
+    @Test
+    void searchShouldNotBeLimitedByElasticSearchDefaultSearchLimitWhenUsingOffset(QuotaSearchTestSystem testSystem) throws Exception {
+        int userCount = 12;
+        testSystem.getDomainList().addDomain(SIMPSON_COM);
+        testSystem.getMaxQuotaManager().setGlobalMaxStorage(QuotaSize.size(100));
+
+        IntStream.range(0, userCount)
+            .boxed()
+            .map(i -> User.fromLocalPartWithDomain("user" + i, SIMPSON_COM))
+            .forEach(user -> provisionUser(testSystem, user));
+        testSystem.await();
+
+        assertThat(
+            testSystem.getQuotaSearcher()
+                .search(QuotaQuery.builder()
+                    .withLimit(Limit.unlimited())
+                    .withOffset(Offset.of(1))
+                    .build()))
+            .hasSize(userCount - 1);
+    }
+
+    private void provisionUser(QuotaSearchTestSystem testSystem, User user) {
+        try {
+            testSystem.getUsersRepository().addUser(user.asString(), PASSWORD);
+            appendMessage(testSystem, user, withSize(49));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/mailbox/plugin/quota-search/src/main/java/org/apache/james/quota/search/Limit.java
+++ b/mailbox/plugin/quota-search/src/main/java/org/apache/james/quota/search/Limit.java
@@ -45,6 +45,10 @@ public class Limit {
         return value;
     }
 
+    public boolean isLimited() {
+        return value.isPresent();
+    }
+
     @Override
     public final boolean equals(Object o) {
         if (o instanceof Limit) {

--- a/mailbox/plugin/quota-search/src/test/java/org/apache/james/quota/search/LimitTest.java
+++ b/mailbox/plugin/quota-search/src/test/java/org/apache/james/quota/search/LimitTest.java
@@ -26,36 +26,48 @@ import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class LimitTest {
+class LimitTest {
     @Test
-    public void shouldMatchBeanContract() {
+    void shouldMatchBeanContract() {
         EqualsVerifier.forClass(Limit.class)
             .verify();
     }
 
     @Test
-    public void getValueShouldReturnEmptyWhenUnlimited() {
+    void getValueShouldReturnEmptyWhenUnlimited() {
         assertThat(Limit.unlimited()
             .getValue())
             .isEmpty();
     }
 
     @Test
-    public void getValueShouldReturnZeroWhenZero() {
+    void getValueShouldReturnZeroWhenZero() {
         assertThat(Limit.of(0)
             .getValue())
             .contains(0);
     }
 
     @Test
-    public void getValueShouldReturnSuppliedValue() {
+    void getValueShouldReturnSuppliedValue() {
         assertThat(Limit.of(3)
             .getValue())
             .contains(3);
     }
 
     @Test
-    public void ofShouldThrowOnNegativeValue() {
+    void isLimitedShouldBeTrueWhenAValueIsSpecified() {
+        assertThat(Limit.of(3).isLimited())
+            .isTrue();
+    }
+
+    @Test
+    void isLimitedShouldBeFalseWhenUnlimited() {
+        assertThat(Limit.unlimited().isLimited())
+            .isFalse();
+    }
+
+    @Test
+    void ofShouldThrowOnNegativeValue() {
         assertThatThrownBy(() -> Limit.of(-1))
             .isInstanceOf(IllegalArgumentException.class);
     }


### PR DESCRIPTION
Otherwise ES default limit of 10 will be applied. A more optimized "search query"
can be used when the limit is specified, avoiding opening a scroll-session.