### PR TITLE
JAMES-2551 Starting James before rabbitMQ should be supported

### DIFF
--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/CassandraRabbitMQJamesServerFixture.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/CassandraRabbitMQJamesServerFixture.java
@@ -34,10 +34,14 @@ public class CassandraRabbitMQJamesServerFixture {
             .overrideWith(JmapJamesServerContract.DOMAIN_LIST_CONFIGURATION_MODULE);
 
     public static JamesServerBuilder baseExtensionBuilder() {
+        return baseExtensionBuilder(new RabbitMQExtension());
+    }
+
+    public static JamesServerBuilder baseExtensionBuilder(RabbitMQExtension rabbitMQExtension) {
         return new JamesServerBuilder()
             .extension(new DockerElasticSearchExtension())
             .extension(new CassandraExtension())
-            .extension(new RabbitMQExtension())
+            .extension(rabbitMQExtension)
             .server(CONFIGURATION_BUILDER);
     }
 }

--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/RabbitMQJamesServerWithRetryConnectionTest.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/RabbitMQJamesServerWithRetryConnectionTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.james.modules.RabbitMQExtension;
 import org.apache.james.util.concurrent.NamedThreadFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -49,6 +50,11 @@ class RabbitMQJamesServerWithRetryConnectionTest {
     void setUp() {
         ThreadFactory threadFactory = NamedThreadFactory.withClassName(getClass());
         executorService = Executors.newSingleThreadScheduledExecutor(threadFactory);
+    }
+
+    @AfterEach
+    void tearDown() {
+        executorService.shutdownNow();
     }
 
     @Test

--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/RabbitMQJamesServerWithRetryConnectionTest.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/RabbitMQJamesServerWithRetryConnectionTest.java
@@ -60,7 +60,6 @@ class RabbitMQJamesServerWithRetryConnectionTest {
     @Test
     void serverShouldRetryToConnectToCassandraWhenStartService(GuiceJamesServer server) throws Exception {
         rabbitMQExtension.dockerRabbitMQ().pause();
-        Thread.sleep(Duration.ofMillis(500).toMillis());
         waitBeforeExecution(WAITING_TIME, () -> rabbitMQExtension.dockerRabbitMQ().unpause());
 
         server.start();

--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/RabbitMQJamesServerWithRetryConnectionTest.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/RabbitMQJamesServerWithRetryConnectionTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.james;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import org.apache.james.modules.RabbitMQExtension;
+import org.apache.james.util.concurrent.NamedThreadFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class RabbitMQJamesServerWithRetryConnectionTest {
+    private static final long WAITING_TIME = Duration.ofSeconds(10).toMillis();
+
+    private RabbitMQExtension rabbitMQExtension = new RabbitMQExtension();
+    private ExecutorService executorService;
+
+    @RegisterExtension
+    JamesServerExtension jamesServerExtension = CassandraRabbitMQJamesServerFixture
+        .baseExtensionBuilder(rabbitMQExtension)
+        .disableAutoStart()
+        .build();
+
+    @BeforeEach
+    void setUp() {
+        ThreadFactory threadFactory = NamedThreadFactory.withClassName(getClass());
+        executorService = Executors.newFixedThreadPool(1, threadFactory);
+    }
+
+    @Test
+    void serverShouldStartAtDefault(GuiceJamesServer server) throws Exception {
+        server.start();
+
+        assertThat(server.isStarted()).isTrue();
+    }
+
+    @Test
+    void serverShouldRetryToConnectToCassandraWhenStartService(GuiceJamesServer server) throws Exception {
+        rabbitMQExtension.dockerRabbitMQ().pause();
+        Thread.sleep(Duration.ofMillis(500).toMillis());
+        waitBeforeExecution(WAITING_TIME, () -> rabbitMQExtension.dockerRabbitMQ().unpause());
+
+        server.start();
+
+        assertThat(server.isStarted()).isTrue();
+    }
+
+    private void waitBeforeExecution(long waitingTime, Runnable action) {
+        executorService.submit(() -> {
+            try {
+                Thread.sleep(waitingTime);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            action.run();
+        });
+    }
+}

--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/modules/RabbitMQExtension.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/modules/RabbitMQExtension.java
@@ -20,6 +20,7 @@
 package org.apache.james.modules;
 
 import org.apache.james.GuiceModuleTestExtension;
+import org.apache.james.backend.rabbitmq.DockerRabbitMQ;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import com.google.inject.Module;
@@ -41,5 +42,9 @@ public class RabbitMQExtension implements GuiceModuleTestExtension {
     @Override
     public Module getModule() {
         return new TestRabbitMQModule(rabbitMQRule.dockerRabbitMQ());
+    }
+
+    public DockerRabbitMQ dockerRabbitMQ() {
+        return rabbitMQRule.dockerRabbitMQ();
     }
 }


### PR DESCRIPTION
James should await RabbitMQ start

**Why?**

I had this build output:

```
[e9760ff6822c007540e944d09074ab35b8f91847] + docker run --detach=true --name=james-server-cassandra-rabbitmq-james-2764-close-scroll-d07dc959-f7e6-4e5b-ae15-06f2504183c4 --hostname james.linagora.com --expose=143 --expose=587 --publish-all=true --link cassandra-james-2764-close-scroll-d07dc959-f7e6-4e5b-ae15-06f2504183c4:cassandra --link elasticSearch-james-2764-close-scroll-d07dc959-f7e6-4e5b-ae15-06f2504183c4:elasticsearch --link rabbitmq-james-2764-close-scroll-d07dc959-f7e6-4e5b-ae15-06f2504183c4:rabbitmq --link swift-james-2764-close-scroll-d07dc959-f7e6-4e5b-ae15-06f2504183c4:swift james-server-cassandra-rabbitmq-james-2764-close-scroll-d07dc959-f7e6-4e5b-ae15-06f2504183c4
[e9760ff6822c007540e944d09074ab35b8f91847] 268e81986d23b309cf0eee2f835354ec1b96d200d7472f9e3dca2e22deb96ff8
[e9760ff6822c007540e944d09074ab35b8f91847] docker: Error response from daemon: Cannot link to a non running container: /rabbitmq-james-2764-close-scroll-d07dc959-f7e6-4e5b-ae15-06f2504183c4 AS /james-server-cassandra-rabbitmq-james-2764-close-scroll-d07dc959-f7e6-4e5b-ae15-06f2504183c4/rabbitmq.
```

Hence the doubt...