### PR TITLE
IMAPMessageReader should disconnect when closed, not launch t IMAP CLOSE command

### DIFF
--- a/server/testing/src/main/java/org/apache/james/utils/IMAPMessageReader.java
+++ b/server/testing/src/main/java/org/apache/james/utils/IMAPMessageReader.java
@@ -193,7 +193,7 @@ public class IMAPMessageReader extends ExternalResource implements Closeable, Af
     @Override
     public void close() throws IOException {
         if (imapClient.isConnected()) {
-            imapClient.close();
+            imapClient.disconnect();
         }
     }
 


### PR DESCRIPTION
Let's see what the CI think about it