### PR TITLE
JAMES-2761 Avoid uneeded mailbox path resolution upon unsolicited res…

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -307,7 +307,7 @@ public abstract class AbstractMailboxProcessor<M extends ImapRequest> extends Ab
     
     private MessageManager getMailbox(ImapSession session, SelectedMailbox selected) throws MailboxException {
         final MailboxManager mailboxManager = getMailboxManager();
-        return mailboxManager.getMailbox(selected.getPath(), ImapSessionUtils.getMailboxSession(session));
+        return mailboxManager.getMailbox(selected.getMailboxId(), ImapSessionUtils.getMailboxSession(session));
     }
 
     private void addRecentResponses(SelectedMailbox selected, ImapProcessor.Responder responder) {
@@ -416,7 +416,7 @@ public abstract class AbstractMailboxProcessor<M extends ImapRequest> extends Ab
             result = null;
         } else {
             final MailboxManager mailboxManager = getMailboxManager();
-            result = mailboxManager.getMailbox(selectedMailbox.getPath(), ImapSessionUtils.getMailboxSession(session));
+            result = mailboxManager.getMailbox(selectedMailbox.getMailboxId(), ImapSessionUtils.getMailboxSession(session));
         }
         return result;
     }

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/SearchProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/SearchProcessorTest.java
@@ -196,7 +196,6 @@ public class SearchProcessorTest {
 
     @SuppressWarnings("unchecked")
     private void expectsGetSelectedMailbox() throws Exception {
-        when(mailboxManager.getMailbox(mailboxPath, mailboxSession)).thenReturn(mailbox, mailbox);
         when(mailboxManager.getMailbox(mailboxId, mailboxSession)).thenReturn(mailbox, mailbox);
         when(session.getSelected()).thenReturn(selectedMailbox);
         when(selectedMailbox.isRecentUidRemoved()).thenReturn(false);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/SearchProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/SearchProcessorTest.java
@@ -58,11 +58,13 @@ import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MailboxSessionUtil;
 import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.SearchQuery;
 import org.apache.james.mailbox.model.SearchQuery.AddressType;
 import org.apache.james.mailbox.model.SearchQuery.Criterion;
 import org.apache.james.mailbox.model.SearchQuery.DateResolution;
+import org.apache.james.mailbox.model.TestId;
 import org.apache.james.metrics.api.NoopMetricFactory;
 import org.junit.After;
 import org.junit.Before;
@@ -100,6 +102,7 @@ public class SearchProcessorTest {
             new SearchQuery.UidRange(MessageUid.of(42), MessageUid.of(1048)) };
     
     private static final MailboxPath mailboxPath = new MailboxPath("namespace", "user", "name");
+    private static final MailboxId mailboxId = TestId.of(18);
 
     SearchProcessor processor;
     ImapProcessor next;
@@ -125,6 +128,7 @@ public class SearchProcessorTest {
         mailboxManager = mock(MailboxManager.class);
         mailboxSession = MailboxSessionUtil.create("user");
         selectedMailbox = mock(SelectedMailbox.class);
+        when(selectedMailbox.getMailboxId()).thenReturn(mailboxId);
         
         processor = new SearchProcessor(next,  mailboxManager, serverResponseFactory, new NoopMetricFactory());
         expectOk();
@@ -193,6 +197,7 @@ public class SearchProcessorTest {
     @SuppressWarnings("unchecked")
     private void expectsGetSelectedMailbox() throws Exception {
         when(mailboxManager.getMailbox(mailboxPath, mailboxSession)).thenReturn(mailbox, mailbox);
+        when(mailboxManager.getMailbox(mailboxId, mailboxSession)).thenReturn(mailbox, mailbox);
         when(session.getSelected()).thenReturn(selectedMailbox);
         when(selectedMailbox.isRecentUidRemoved()).thenReturn(false);
         when(selectedMailbox.isSizeChanged()).thenReturn(false);


### PR DESCRIPTION
…ponses

Unsolicited responses are generated for each command, and were retrieving mailbox details twice
 - One time when retrieving details of the selected mailbox
 - One time when retrieving the mailbox from the mailboxPath

Also this closes an inconsistency window upon mailbox renames.