### PR TITLE
JAMES-2751 Apply docker cassandra restart policy to jmap integration …

### DIFF
--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/DockerCassandraRule.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/DockerCassandraRule.java
@@ -32,7 +32,7 @@ import com.google.inject.util.Modules;
 
 public class DockerCassandraRule implements GuiceModuleTestRule {
 
-    private org.apache.james.backends.cassandra.DockerCassandraRule cassandraContainer = new org.apache.james.backends.cassandra.DockerCassandraRule();
+    private org.apache.james.backends.cassandra.DockerCassandraRule cassandraContainer = new org.apache.james.backends.cassandra.DockerCassandraRule().allowRestart();
 
     @Override
     public Statement apply(Statement base, Description description) {


### PR DESCRIPTION
…tests

Not really convinced that it really adds a benefit to the build... The build times on my local are around the same for the jmap integration tests. But let's see if the CI likes it or not