### PR TITLE
JAMES-2733 DeliveryRunnable fails upon acknowledging queue elements

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RemoteDelivery.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RemoteDelivery.java
@@ -62,7 +62,6 @@ import com.google.common.collect.HashMultimap;
  * <p>These are the parameters that control the operation of the RemoteDelivery mailet:
  * <p/>
  * <ul>
- * <li><b>deliveryThreads</b> (required) - an Integer for the number of threads this mailet will use to deliver mail.</li>
  * <li><b>outgoing</b> (required) - a String containing the name of the queue that will hold messages being processed by this mailet.</li>
  * <li><b>bind</b> (optional) - a String describing the local IP address to which the mailet should be bound while delivering
  * emails. This tag is useful for multihomed machines. Default is to bind to the default local address of the machine.<br>

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/RemoteDeliveryConfiguration.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/RemoteDeliveryConfiguration.java
@@ -41,7 +41,6 @@ public class RemoteDeliveryConfiguration {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RemoteDeliveryConfiguration.class);
 
-    public static final String DELIVERY_THREADS = "deliveryThreads";
     public static final String USE_PRIORITY = "usePriority";
     public static final String MAX_DNS_PROBLEM_RETRIES = "maxDnsProblemRetries";
     public static final String HELO_NAME = "heloName";
@@ -79,7 +78,6 @@ public class RemoteDeliveryConfiguration {
     private final long smtpTimeout;
     private final int dnsProblemRetry;
     private final int connectionTimeout;
-    private final int workersThreadCount;
     private final List<Duration> delayTimes;
     private final HeloNameProvider heloNameProvider;
     private final String outGoingQueueName;
@@ -107,7 +105,6 @@ public class RemoteDeliveryConfiguration {
         connectionTimeout = computeConnectionTimeout(mailetConfig);
         dnsProblemRetry = computeDnsProblemRetry(mailetConfig);
         heloNameProvider = new HeloNameProvider(mailetConfig.getInitParameter(HELO_NAME), domainList);
-        workersThreadCount = Integer.valueOf(mailetConfig.getInitParameter(DELIVERY_THREADS));
 
         String gatewayPort = mailetConfig.getInitParameter(GATEWAY_PORT);
         String gateway = mailetConfig.getInitParameter(GATEWAY);
@@ -261,10 +258,6 @@ public class RemoteDeliveryConfiguration {
 
     public int getConnectionTimeout() {
         return connectionTimeout;
-    }
-
-    public int getWorkersThreadCount() {
-        return workersThreadCount;
     }
 
     public Collection<String> getGatewayServer() {

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remote/delivery/BouncerTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remote/delivery/BouncerTest.java
@@ -32,8 +32,6 @@ import javax.mail.MessagingException;
 import javax.mail.SendFailedException;
 
 import org.apache.james.domainlist.api.DomainList;
-import org.apache.james.transport.mailets.remote.delivery.Bouncer;
-import org.apache.james.transport.mailets.remote.delivery.RemoteDeliveryConfiguration;
 import org.apache.mailet.Attribute;
 import org.apache.mailet.AttributeValue;
 import org.apache.mailet.Mail;
@@ -45,8 +43,11 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class BouncerTest {
-    public static final String HELLO_NAME = "hello_name";
-    public static final String BOUNCE_PROCESSOR = "bounce_processor";
+    private static final String HELLO_NAME = "hello_name";
+    private static final FakeMailetConfig DEFAULT_REMOTE_DELIVERY_CONFIG = FakeMailetConfig.builder()
+        .setProperty(RemoteDeliveryConfiguration.HELO_NAME, HELLO_NAME)
+        .build();
+    private static final String BOUNCE_PROCESSOR = "bounce_processor";
 
     private FakeMailContext mailetContext;
 
@@ -58,10 +59,7 @@ public class BouncerTest {
     @Test
     public void bounceShouldCallMailetContextBounceByDefault() throws Exception {
         RemoteDeliveryConfiguration configuration = new RemoteDeliveryConfiguration(
-            FakeMailetConfig.builder()
-                .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
-                .setProperty(RemoteDeliveryConfiguration.HELO_NAME, HELLO_NAME)
-                .build(),
+            DEFAULT_REMOTE_DELIVERY_CONFIG,
             mock(DomainList.class));
         Bouncer testee = new Bouncer(configuration, mailetContext);
 
@@ -84,10 +82,7 @@ public class BouncerTest {
     @Test
     public void bounceShouldIncludeMessagingExceptionMessageByDefault() throws Exception {
         RemoteDeliveryConfiguration configuration = new RemoteDeliveryConfiguration(
-            FakeMailetConfig.builder()
-                .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
-                .setProperty(RemoteDeliveryConfiguration.HELO_NAME, HELLO_NAME)
-                .build(),
+            DEFAULT_REMOTE_DELIVERY_CONFIG,
             mock(DomainList.class));
         Bouncer testee = new Bouncer(configuration, mailetContext);
 
@@ -113,10 +108,7 @@ public class BouncerTest {
     @Test
     public void bounceShouldCustomizeSendFailedExceptionByDefault() throws Exception {
         RemoteDeliveryConfiguration configuration = new RemoteDeliveryConfiguration(
-            FakeMailetConfig.builder()
-                .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
-                .setProperty(RemoteDeliveryConfiguration.HELO_NAME, HELLO_NAME)
-                .build(),
+            DEFAULT_REMOTE_DELIVERY_CONFIG,
             mock(DomainList.class));
         Bouncer testee = new Bouncer(configuration, mailetContext);
 
@@ -142,10 +134,7 @@ public class BouncerTest {
     @Test
     public void bounceShouldCustomizeUnknownHostExceptionByDefault() throws Exception {
         RemoteDeliveryConfiguration configuration = new RemoteDeliveryConfiguration(
-            FakeMailetConfig.builder()
-                .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
-                .setProperty(RemoteDeliveryConfiguration.HELO_NAME, HELLO_NAME)
-                .build(),
+            DEFAULT_REMOTE_DELIVERY_CONFIG,
             mock(DomainList.class));
         Bouncer testee = new Bouncer(configuration, mailetContext);
 
@@ -172,10 +161,7 @@ public class BouncerTest {
     @Test
     public void bounceShouldCustomizeConnectionExceptionByDefault() throws Exception {
         RemoteDeliveryConfiguration configuration = new RemoteDeliveryConfiguration(
-            FakeMailetConfig.builder()
-                .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
-                .setProperty(RemoteDeliveryConfiguration.HELO_NAME, HELLO_NAME)
-                .build(),
+            DEFAULT_REMOTE_DELIVERY_CONFIG,
             mock(DomainList.class));
         Bouncer testee = new Bouncer(configuration, mailetContext);
 
@@ -201,10 +187,7 @@ public class BouncerTest {
     @Test
     public void bounceShouldCustomizeSocketExceptionByDefault() throws Exception {
         RemoteDeliveryConfiguration configuration = new RemoteDeliveryConfiguration(
-            FakeMailetConfig.builder()
-                .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
-                .setProperty(RemoteDeliveryConfiguration.HELO_NAME, HELLO_NAME)
-                .build(),
+            DEFAULT_REMOTE_DELIVERY_CONFIG,
             mock(DomainList.class));
         Bouncer testee = new Bouncer(configuration, mailetContext);
 
@@ -230,10 +213,7 @@ public class BouncerTest {
     @Test
     public void bounceShouldCustomizeNestedMessagingExceptionByDefault() throws Exception {
         RemoteDeliveryConfiguration configuration = new RemoteDeliveryConfiguration(
-            FakeMailetConfig.builder()
-                .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
-                .setProperty(RemoteDeliveryConfiguration.HELO_NAME, HELLO_NAME)
-                .build(),
+            DEFAULT_REMOTE_DELIVERY_CONFIG,
             mock(DomainList.class));
         Bouncer testee = new Bouncer(configuration, mailetContext);
 
@@ -259,10 +239,7 @@ public class BouncerTest {
     @Test
     public void bounceShouldNotBounceWithNoSenderByDefault() throws Exception {
         RemoteDeliveryConfiguration configuration = new RemoteDeliveryConfiguration(
-            FakeMailetConfig.builder()
-                .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
-                .setProperty(RemoteDeliveryConfiguration.HELO_NAME, HELLO_NAME)
-                .build(),
+            DEFAULT_REMOTE_DELIVERY_CONFIG,
             mock(DomainList.class));
         Bouncer testee = new Bouncer(configuration, mailetContext);
 
@@ -278,10 +255,7 @@ public class BouncerTest {
     @Test
     public void bounceShouldSupportExceptionWithoutMessagesByDefault() throws Exception {
         RemoteDeliveryConfiguration configuration = new RemoteDeliveryConfiguration(
-            FakeMailetConfig.builder()
-                .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
-                .setProperty(RemoteDeliveryConfiguration.HELO_NAME, HELLO_NAME)
-                .build(),
+            DEFAULT_REMOTE_DELIVERY_CONFIG,
             mock(DomainList.class));
         Bouncer testee = new Bouncer(configuration, mailetContext);
 
@@ -304,10 +278,7 @@ public class BouncerTest {
     @Test
     public void bounceShouldNotSupportMessagingExceptionWithoutMessagesByDefault() throws Exception {
         RemoteDeliveryConfiguration configuration = new RemoteDeliveryConfiguration(
-            FakeMailetConfig.builder()
-                .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
-                .setProperty(RemoteDeliveryConfiguration.HELO_NAME, HELLO_NAME)
-                .build(),
+            DEFAULT_REMOTE_DELIVERY_CONFIG,
             mock(DomainList.class));
         Bouncer testee = new Bouncer(configuration, mailetContext);
 
@@ -331,7 +302,6 @@ public class BouncerTest {
     public void bounceShouldWorkWhenProcessorSpecified() throws Exception {
         RemoteDeliveryConfiguration configuration = new RemoteDeliveryConfiguration(
             FakeMailetConfig.builder()
-                .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
                 .setProperty(RemoteDeliveryConfiguration.HELO_NAME, HELLO_NAME)
                 .setProperty(RemoteDeliveryConfiguration.BOUNCE_PROCESSOR, BOUNCE_PROCESSOR)
                 .build(),
@@ -358,7 +328,6 @@ public class BouncerTest {
     public void bounceShouldNotBounceWhenNoSenderWhenProcessorSpecified() throws Exception {
         RemoteDeliveryConfiguration configuration = new RemoteDeliveryConfiguration(
             FakeMailetConfig.builder()
-                .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
                 .setProperty(RemoteDeliveryConfiguration.HELO_NAME, HELLO_NAME)
                 .setProperty(RemoteDeliveryConfiguration.BOUNCE_PROCESSOR, BOUNCE_PROCESSOR)
                 .build(),
@@ -376,10 +345,7 @@ public class BouncerTest {
     @Test
     public void bounceShouldDisplayAddressByDefault() throws Exception {
         RemoteDeliveryConfiguration configuration = new RemoteDeliveryConfiguration(
-            FakeMailetConfig.builder()
-                .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
-                .setProperty(RemoteDeliveryConfiguration.HELO_NAME, HELLO_NAME)
-                .build(),
+            DEFAULT_REMOTE_DELIVERY_CONFIG,
             mock(DomainList.class));
         Bouncer testee = new Bouncer(configuration, mailetContext);
 
@@ -404,10 +370,7 @@ public class BouncerTest {
     @Test
     public void bounceShouldDisplayAddressesByDefault() throws Exception {
         RemoteDeliveryConfiguration configuration = new RemoteDeliveryConfiguration(
-            FakeMailetConfig.builder()
-                .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
-                .setProperty(RemoteDeliveryConfiguration.HELO_NAME, HELLO_NAME)
-                .build(),
+            DEFAULT_REMOTE_DELIVERY_CONFIG,
             mock(DomainList.class));
         Bouncer testee = new Bouncer(configuration, mailetContext);
 
@@ -434,7 +397,6 @@ public class BouncerTest {
     public void bounceShouldWorkWhenProcessorSpecifiedAndNoExceptionMessage() throws Exception {
         RemoteDeliveryConfiguration configuration = new RemoteDeliveryConfiguration(
             FakeMailetConfig.builder()
-                .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
                 .setProperty(RemoteDeliveryConfiguration.HELO_NAME, HELLO_NAME)
                 .setProperty(RemoteDeliveryConfiguration.BOUNCE_PROCESSOR, BOUNCE_PROCESSOR)
                 .build(),

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remote/delivery/DeliveryRunnableTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remote/delivery/DeliveryRunnableTest.java
@@ -60,7 +60,6 @@ public class DeliveryRunnableTest {
     @Before
     public void setUp() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.DEBUG, "true")
             .setProperty(RemoteDeliveryConfiguration.DELAY_TIME, "1000,2000,3000,4000,5000")
             .build();

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remote/delivery/MailDelivrerTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remote/delivery/MailDelivrerTest.java
@@ -69,7 +69,6 @@ public class MailDelivrerTest {
         dnsHelper = mock(DnsHelper.class);
         mailDelivrerToHost = mock(MailDelivrerToHost.class);
         RemoteDeliveryConfiguration configuration = new RemoteDeliveryConfiguration(FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.MAX_DNS_PROBLEM_RETRIES, "3")
             .setProperty(RemoteDeliveryConfiguration.DEBUG, "true")
             .build(),

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remote/delivery/RemoteDeliveryConfigurationTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remote/delivery/RemoteDeliveryConfigurationTest.java
@@ -42,7 +42,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isDebugShouldBeFalseByDefault() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build();
 
         assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).isDebug()).isFalse();
@@ -51,7 +50,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isDebugShouldBeTrueIfSpecified() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.DEBUG, "true")
             .build();
 
@@ -61,7 +59,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isDebugShouldBeFalseIfSpecified() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.DEBUG, "false")
             .build();
 
@@ -71,7 +68,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isDebugShouldBeFalseIfParsingException() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.DEBUG, "invalid")
             .build();
 
@@ -81,7 +77,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getSmtpTimeoutShouldReturnDefault() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build();
 
         assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).getSmtpTimeout())
@@ -92,7 +87,6 @@ public class RemoteDeliveryConfigurationTest {
     public void getSmtpTimeoutShouldReturnProvidedValue() {
         int value = 150000;
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.TIMEOUT, String.valueOf(value))
             .build();
 
@@ -103,7 +97,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getSmtpTimeoutShouldReturnDefaultIfParsingException() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.TIMEOUT, "invalid")
             .build();
 
@@ -114,7 +107,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getSmtpTimeoutShouldReturnProvidedValueWhenZero() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.TIMEOUT, "0")
             .build();
 
@@ -125,7 +117,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getSmtpTimeoutShouldReturnProvidedValueWhenNegativeNumber() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.TIMEOUT, "-1")
             .build();
 
@@ -136,7 +127,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getOutGoingQueueNameShouldReturnDefault() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build();
 
         assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).getOutGoingQueueName())
@@ -147,7 +137,6 @@ public class RemoteDeliveryConfigurationTest {
     public void getOutGoingQueueNameShouldReturnProvidedValue() {
         String value = "value";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.OUTGOING, value)
             .build();
 
@@ -158,7 +147,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getConnectionTimeoutShouldReturnDefault() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build();
 
         assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).getConnectionTimeout())
@@ -169,7 +157,6 @@ public class RemoteDeliveryConfigurationTest {
     public void getConnectionTimeoutShouldReturnProvidedValue() {
         int value = 150000;
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.CONNECTIONTIMEOUT, String.valueOf(value))
             .build();
 
@@ -180,7 +167,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getConnectionTimeoutShouldReturnDefaultIfParsingException() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.CONNECTIONTIMEOUT, "invalid")
             .build();
 
@@ -191,7 +177,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getConnectionTimeoutShouldReturnProvidedValueWhenZero() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.CONNECTIONTIMEOUT, "0")
             .build();
 
@@ -202,7 +187,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getConnectionTimeoutShouldReturnProvidedValueWhenNegativeNumber() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.CONNECTIONTIMEOUT, "-1")
             .build();
 
@@ -213,7 +197,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isSendPartialShouldBeFalseByDefault() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build();
 
         assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).isSendPartial()).isFalse();
@@ -222,7 +205,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isSendPartialShouldBeTrueIfSpecified() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.SENDPARTIAL, "true")
             .build();
 
@@ -232,7 +214,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isSendPartialShouldBeFalseIfSpecified() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.SENDPARTIAL, "false")
             .build();
 
@@ -242,7 +223,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isSendPartialShouldBeFalseIfParsingException() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.SENDPARTIAL, "invalid")
             .build();
 
@@ -252,7 +232,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getBounceProcessorShouldReturnNullByDefault() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build();
 
         assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).getBounceProcessor())
@@ -263,7 +242,6 @@ public class RemoteDeliveryConfigurationTest {
     public void getBounceProcessorShouldReturnProvidedValue() {
         String value = "value";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.BOUNCE_PROCESSOR, value)
             .build();
 
@@ -274,7 +252,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isStartTLSShouldBeFalseByDefault() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build();
 
         assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).isStartTLS()).isFalse();
@@ -283,7 +260,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isStartTLSShouldBeTrueIfSpecified() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.START_TLS, "true")
             .build();
 
@@ -293,7 +269,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isStartTLSShouldBeFalseIfSpecified() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.START_TLS, "false")
             .build();
 
@@ -303,7 +278,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isStartTLSShouldBeFalseIfParsingException() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.START_TLS, "invalid")
             .build();
 
@@ -313,7 +287,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isSSLEnableShouldBeFalseByDefault() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build();
 
         assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).isSSLEnable()).isFalse();
@@ -322,7 +295,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isSSLEnableShouldBeTrueIfSpecified() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.SSL_ENABLE, "true")
             .build();
 
@@ -332,7 +304,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isSSLEnableShouldBeFalseIfSpecified() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.SSL_ENABLE, "false")
             .build();
 
@@ -342,7 +313,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isSSLEnableShouldBeFalseIfParsingException() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.SSL_ENABLE, "invalid")
             .build();
 
@@ -352,7 +322,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isBindUsedShouldBeFalseByDefault() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.BIND, "127.0.0.1:25")
             .build();
 
@@ -362,7 +331,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getBindAddressShouldBeNullByDefault() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build();
 
         assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).getBindAddress()).isNull();
@@ -372,7 +340,6 @@ public class RemoteDeliveryConfigurationTest {
     public void getBindAddressShouldReturnProvidedValue() {
         String value = "127.0.0.1:25";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.BIND, value)
             .build();
 
@@ -382,7 +349,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getDnsProblemRetryShouldReturnDefault() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build();
 
         assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).getDnsProblemRetry())
@@ -393,7 +359,6 @@ public class RemoteDeliveryConfigurationTest {
     public void getDnsProblemRetryShouldReturnProvidedValue() {
         int value = 4;
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.MAX_DNS_PROBLEM_RETRIES, String.valueOf(value))
             .build();
 
@@ -404,7 +369,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void constructorShouldThrowOnInvalidDnsRetries() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.MAX_DNS_PROBLEM_RETRIES, "invalid")
             .build();
 
@@ -416,7 +380,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getDnsProblemRetryShouldReturnProvidedValueWhenZero() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.MAX_DNS_PROBLEM_RETRIES, "0")
             .build();
 
@@ -427,7 +390,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getDnsProblemRetryShouldReturnProvidedValueWhenEmpty() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.MAX_DNS_PROBLEM_RETRIES, "")
             .build();
 
@@ -438,7 +400,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getDnsProblemRetryShouldReturnProvidedValueWhenNegativeNumber() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.MAX_DNS_PROBLEM_RETRIES, "-1")
             .build();
 
@@ -447,41 +408,8 @@ public class RemoteDeliveryConfigurationTest {
     }
 
     @Test
-    public void constructorShouldThrowOnNonSpecifiedThreadCount() {
-        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .build();
-
-        expectedException.expect(NumberFormatException.class);
-
-        new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).getWorkersThreadCount();
-    }
-
-    @Test
-    public void getWorkersThreadCountShouldReturnProvidedValue() {
-        int value = 36;
-        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, String.valueOf(value))
-            .build();
-
-        assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).getWorkersThreadCount())
-            .isEqualTo(value);
-    }
-
-    @Test
-    public void constructorShouldThrowOnInvalidThreadCount() {
-        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "invalid")
-            .build();
-
-        expectedException.expect(NumberFormatException.class);
-
-        new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).getWorkersThreadCount();
-    }
-
-    @Test
     public void isUsePriorityShouldBeFalseByDefault() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build();
 
         assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).isUsePriority()).isFalse();
@@ -490,7 +418,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isUsePriorityShouldBeTrueIfSpecified() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.USE_PRIORITY, "true")
             .build();
 
@@ -500,7 +427,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isUsePriorityShouldBeFalseIfSpecified() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.USE_PRIORITY, "false")
             .build();
 
@@ -510,7 +436,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void isUsePriorityShouldBeFalseIfParsingException() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.USE_PRIORITY, "invalid")
             .build();
 
@@ -523,7 +448,6 @@ public class RemoteDeliveryConfigurationTest {
         String value = "value";
         when(domainList.getDefaultDomain()).thenReturn(Domain.of(value));
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build();
 
         assertThat(new RemoteDeliveryConfiguration(mailetConfig, domainList).getHeloNameProvider().getHeloName())
@@ -534,7 +458,6 @@ public class RemoteDeliveryConfigurationTest {
     public void getHeloNameProviderShouldTakeCareOfProvidedValue() {
         String value = "value";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.HELO_NAME, value)
             .build();
 
@@ -545,7 +468,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getJavaxAdditionalPropertiesShouldBeEmptyByDefault() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build();
 
         assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).getJavaxAdditionalProperties())
@@ -557,7 +479,6 @@ public class RemoteDeliveryConfigurationTest {
         String key1 = RemoteDeliveryConfiguration.JAVAX_PREFIX + "property1";
         String value1 = "value1";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(key1, value1)
             .build();
 
@@ -572,7 +493,6 @@ public class RemoteDeliveryConfigurationTest {
         String key2 = RemoteDeliveryConfiguration.JAVAX_PREFIX + "property2";
         String value2 = "value2";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(key1, value1)
             .setProperty(key2, value2)
             .build();
@@ -587,7 +507,6 @@ public class RemoteDeliveryConfigurationTest {
 
         String key1 = RemoteDeliveryConfiguration.JAVAX_PREFIX + "property1";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(key1, null)
             .build();
 
@@ -598,7 +517,6 @@ public class RemoteDeliveryConfigurationTest {
     public void getJavaxAdditionalPropertiesShouldTakeOneEmptyEntryIntoAccount() {
         String key1 = RemoteDeliveryConfiguration.JAVAX_PREFIX + "property1";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(key1, "")
             .build();
 
@@ -609,7 +527,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getGatewayServerShouldBeNullByDefault() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build();
 
         assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).getGatewayServer()).isEmpty();
@@ -619,7 +536,6 @@ public class RemoteDeliveryConfigurationTest {
     public void getGatewayServerShouldReturnProvidedValue() {
         String value = "127.0.0.1";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.GATEWAY, value)
             .build();
 
@@ -632,7 +548,6 @@ public class RemoteDeliveryConfigurationTest {
         String value1 = "127.0.0.1";
         String value2 = "domain";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.GATEWAY, value1 + ',' + value2)
             .build();
 
@@ -645,7 +560,6 @@ public class RemoteDeliveryConfigurationTest {
         String server = "127.0.0.1";
         String port = "2525";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.GATEWAY, server)
             .setProperty(RemoteDeliveryConfiguration.GATEWAY_PORT, port)
             .build();
@@ -660,7 +574,6 @@ public class RemoteDeliveryConfigurationTest {
         String server2 = "domain";
         String port = "2525";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.GATEWAY, server1 + ',' + server2)
             .setProperty(RemoteDeliveryConfiguration.GATEWAY_PORT, port)
             .build();
@@ -672,7 +585,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getAuthUserShouldBeNullByDefault() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build();
 
         assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).getAuthUser()).isNull();
@@ -681,7 +593,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getAuthUserShouldBeNullWhenGatewayIsNotSpecified() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.GATEWAY_USERNAME, "name")
             .build();
 
@@ -692,7 +603,6 @@ public class RemoteDeliveryConfigurationTest {
     public void getAuthUserShouldReturnSpecifiedValueWhenGatewaySpecified() {
         String value = "name";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.GATEWAY_USERNAME, value)
             .setProperty(RemoteDeliveryConfiguration.GATEWAY, "127.0.0.1")
             .build();
@@ -704,7 +614,6 @@ public class RemoteDeliveryConfigurationTest {
     public void getAuthUserShouldReturnSpecifiedEmptyValueWhenGatewaySpecified() {
         String value = "";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.GATEWAY_USERNAME, value)
             .setProperty(RemoteDeliveryConfiguration.GATEWAY, "127.0.0.1")
             .build();
@@ -716,7 +625,6 @@ public class RemoteDeliveryConfigurationTest {
     public void getAuthUserShouldReturnSpecifiedCompatibilityValueWhenGatewaySpecified() {
         String value = "name";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.GATEWAY_USERNAME_COMPATIBILITY, value)
             .setProperty(RemoteDeliveryConfiguration.GATEWAY, "127.0.0.1")
             .build();
@@ -728,7 +636,6 @@ public class RemoteDeliveryConfigurationTest {
     public void getAuthUserShouldReturnSpecifiedEmptyCompatibilityValueWhenGatewaySpecified() {
         String value = "";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.GATEWAY_USERNAME_COMPATIBILITY, value)
             .setProperty(RemoteDeliveryConfiguration.GATEWAY, "127.0.0.1")
             .build();
@@ -741,7 +648,6 @@ public class RemoteDeliveryConfigurationTest {
         String value = "name";
         String compatibilityValue = "compatibilityValue";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.GATEWAY_USERNAME, value)
             .setProperty(RemoteDeliveryConfiguration.GATEWAY_USERNAME_COMPATIBILITY, compatibilityValue)
             .setProperty(RemoteDeliveryConfiguration.GATEWAY, "127.0.0.1")
@@ -753,7 +659,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getAuthPassShouldBeNullByDefault() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build();
 
         assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).getAuthPass()).isNull();
@@ -762,7 +667,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getAuthPassShouldBeNullWhenGatewayIsNotSpecified() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.GATEWAY_PASSWORD, "name")
             .build();
 
@@ -773,7 +677,6 @@ public class RemoteDeliveryConfigurationTest {
     public void getAuthPassShouldReturnSpecifiedValueWhenGatewaySpecified() {
         String value = "name";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.GATEWAY_PASSWORD, value)
             .setProperty(RemoteDeliveryConfiguration.GATEWAY, "127.0.0.1")
             .build();
@@ -785,7 +688,6 @@ public class RemoteDeliveryConfigurationTest {
     public void getAuthPassShouldReturnSpecifiedEmptyValueWhenGatewaySpecified() {
         String value = "";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.GATEWAY_PASSWORD, value)
             .setProperty(RemoteDeliveryConfiguration.GATEWAY, "127.0.0.1")
             .build();
@@ -797,7 +699,6 @@ public class RemoteDeliveryConfigurationTest {
     public void getMaxRetriesShouldReturnProvidedValue() {
         int value = 36;
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.MAX_RETRIES, String.valueOf(value))
             .build();
 
@@ -808,7 +709,6 @@ public class RemoteDeliveryConfigurationTest {
     public void getMaxRetriesShouldReturnOneWhenZero() {
         int value = 0;
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.MAX_RETRIES, String.valueOf(value))
             .build();
 
@@ -819,7 +719,6 @@ public class RemoteDeliveryConfigurationTest {
     public void getMaxRetriesShouldReturnOneWhenNegativeNumber() {
         int value = -1;
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.MAX_RETRIES, String.valueOf(value))
             .build();
 
@@ -829,7 +728,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getMaxRetriesShouldReturnDefaultWhenNoySpecified() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build();
 
         assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).getMaxRetries())
@@ -839,7 +737,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getDelayTimesShouldReturnDefault() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build();
 
         assertThat(new RemoteDeliveryConfiguration(mailetConfig, mock(DomainList.class)).getDelayTimes())
@@ -849,7 +746,6 @@ public class RemoteDeliveryConfigurationTest {
     @Test
     public void getDelayTimesShouldWorkWithDefaultConfiguration() {
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.DELAY_TIME, "5000, 100000, 500000")
             .build();
 
@@ -861,7 +757,6 @@ public class RemoteDeliveryConfigurationTest {
     public void createFinalJavaxPropertiesShouldProvidePropertiesWithMinimalConfiguration() {
         String helo = "domain.com";
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.HELO_NAME, helo)
             .build();
 
@@ -885,7 +780,6 @@ public class RemoteDeliveryConfigurationTest {
         String helo = "domain.com";
         int connectionTimeout = 1856;
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.SSL_ENABLE, "true")
             .setProperty(RemoteDeliveryConfiguration.SENDPARTIAL, "true")
             .setProperty(RemoteDeliveryConfiguration.CONNECTIONTIMEOUT, String.valueOf(connectionTimeout))
@@ -913,7 +807,6 @@ public class RemoteDeliveryConfigurationTest {
         String helo = "domain.com";
         int connectionTimeout = 1856;
         FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.SSL_ENABLE, "true")
             .setProperty(RemoteDeliveryConfiguration.SENDPARTIAL, "true")
             .setProperty(RemoteDeliveryConfiguration.CONNECTIONTIMEOUT, String.valueOf(connectionTimeout))

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remote/delivery/RemoteDeliveryRunningTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remote/delivery/RemoteDeliveryRunningTest.java
@@ -40,8 +40,8 @@ import org.junit.Test;
 import reactor.core.publisher.Flux;
 
 public class RemoteDeliveryRunningTest {
+    private static final String QUEUE_NAME = "queueName";
 
-    public static final String QUEUE_NAME = "queueName";
     private RemoteDelivery remoteDelivery;
     private MailQueue mailQueue;
     private CountDownLatch countDownLatch;
@@ -66,7 +66,6 @@ public class RemoteDeliveryRunningTest {
             return Flux.never();
         });
         remoteDelivery.init(FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.OUTGOING, QUEUE_NAME)
             .setProperty(RemoteDeliveryConfiguration.HELO_NAME, "Hello_name")
             .build());
@@ -76,7 +75,7 @@ public class RemoteDeliveryRunningTest {
     }
 
     @After
-    public void tearDown() throws InterruptedException {
+    public void tearDown() {
         remoteDelivery.destroy();
     }
 

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remote/delivery/RemoteDeliveryRunningTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remote/delivery/RemoteDeliveryRunningTest.java
@@ -62,7 +62,7 @@ public class RemoteDeliveryRunningTest {
     public void remoteDeliveryShouldStart() throws Exception {
         when(mailQueue.deQueue()).thenAnswer(invocation -> {
             countDownLatch.countDown();
-            Thread.sleep(TimeUnit.SECONDS.toMillis(20));
+            Thread.sleep(TimeUnit.SECONDS.toMillis(2));
             return Flux.never();
         });
         remoteDelivery.init(FakeMailetConfig.builder()

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remote/delivery/RemoteDeliveryTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/remote/delivery/RemoteDeliveryTest.java
@@ -111,7 +111,6 @@ public class RemoteDeliveryTest {
     @Test
     public void remoteDeliveryShouldAddEmailToSpool() throws Exception {
         remoteDelivery.init(FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build());
 
         Mail mail = FakeMail.builder().name(MAIL_NAME).recipients(MailAddressFixture.ANY_AT_JAMES).build();
@@ -130,7 +129,6 @@ public class RemoteDeliveryTest {
     @Test
     public void remoteDeliveryShouldSplitMailsByServerWhenNoGateway() throws Exception {
         remoteDelivery.init(FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build());
 
         Mail mail = FakeMail.builder()
@@ -156,7 +154,6 @@ public class RemoteDeliveryTest {
     @Test
     public void remoteDeliveryShouldNotSplitMailsByServerWhenGateway() throws Exception {
         remoteDelivery.init(FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.GATEWAY, MailAddressFixture.JAMES_LOCAL)
             .build());
 
@@ -179,7 +176,6 @@ public class RemoteDeliveryTest {
     @Test
     public void remoteDeliveryShouldGhostMails() throws Exception {
         remoteDelivery.init(FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build());
 
         Mail mail = FakeMail.builder().name(MAIL_NAME).recipients(MailAddressFixture.ANY_AT_JAMES).build();
@@ -191,7 +187,6 @@ public class RemoteDeliveryTest {
     @Test
     public void remoteDeliveryShouldAddPriorityIfSpecified() throws Exception {
         remoteDelivery.init(FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.USE_PRIORITY, "true")
             .build());
 
@@ -211,7 +206,6 @@ public class RemoteDeliveryTest {
     @Test
     public void remoteDeliveryShouldNotForwardMailsWithNoRecipients() throws Exception {
         remoteDelivery.init(FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .build());
 
         Mail mail = FakeMail.builder().name(MAIL_NAME).build();
@@ -223,7 +217,6 @@ public class RemoteDeliveryTest {
     @Test
     public void remoteDeliveryShouldNotForwardMailsWithNoRecipientsWithGateway() throws Exception {
         remoteDelivery.init(FakeMailetConfig.builder()
-            .setProperty(RemoteDeliveryConfiguration.DELIVERY_THREADS, "1")
             .setProperty(RemoteDeliveryConfiguration.GATEWAY, MailAddressFixture.JAMES_LOCAL)
             .build());
 


### PR DESCRIPTION
```
java.lang.IllegalStateException: block()/blockFirst()/blockLast() are blocking, which is not supported in thread RemoteDelivery-6
	at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:77)
	at reactor.core.publisher.Mono.block(Mono.java:1493)
	at org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueView.delete(CassandraMailQueueView.java:106)
	at org.apache.james.queue.rabbitmq.Dequeuer.lambda$ack$1(Dequeuer.java:102)
	at com.github.fge.lambdas.consumers.ThrowingConsumer.accept(ThrowingConsumer.java:22)
	at org.apache.james.queue.rabbitmq.Dequeuer$RabbitMQMailQueueItem.done(Dequeuer.java:62)
	at org.apache.james.queue.api.RawMailQueueItem.done(RawMailQueueItem.java:39)
	at org.apache.james.transport.mailets.remote.delivery.DeliveryRunnable.processMail(DeliveryRunnable.java:108)
	at org.apache.james.transport.mailets.remote.delivery.DeliveryRunnable.runStep(DeliveryRunnable.java:94)
	at reactor.core.publisher.FluxFlatMap$FlatMapMain.onNext(FluxFlatMap.java:350)
	at reactor.core.publisher.FluxPublishOn$PublishOnSubscriber.runAsync(FluxPublishOn.java:398)
	at reactor.core.publisher.FluxPublishOn$PublishOnSubscriber.run(FluxPublishOn.java:484)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:84)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:37)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

Hint: acknowledging the message is blocking...