### PR TITLE
JAMES-2717 Fasten ElasticSearch backend tests by reusing forks

### DIFF
--- a/backends-common/elasticsearch/pom.xml
+++ b/backends-common/elasticsearch/pom.xml
@@ -99,4 +99,16 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <reuseForks>true</reuseForks>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Init of the docker engine is done 5 times, as well as starting the
ElasticSearch singleton. Re-using forks allows doing this only once using
mvn to run tests.

(easy win!)