### PR TITLE
JAMES-2171 Fasten ElasticSearchIntegrationTest

### DIFF
--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/DockerElasticSearch.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/DockerElasticSearch.java
@@ -31,6 +31,7 @@ import org.apache.james.util.docker.RateLimiters;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import feign.Feign;
 import feign.Logger;
@@ -66,6 +67,7 @@ public class DockerElasticSearch {
 
     public DockerElasticSearch(String imageName) {
         this.eSContainer = new DockerGenericContainer(imageName)
+            .withTmpFs(ImmutableMap.of("/usr/share/elasticsearch/data", "rw,size=200m"))
             .withExposedPorts(ES_HTTP_PORT)
             .withEnv("discovery.type", "single-node")
             .withAffinityToContainer()

--- a/backends-common/rabbitmq/src/test/java/org/apache/james/backend/rabbitmq/DockerRabbitMQ.java
+++ b/backends-common/rabbitmq/src/test/java/org/apache/james/backend/rabbitmq/DockerRabbitMQ.java
@@ -80,13 +80,12 @@ public class DockerRabbitMQ {
         this.hostNameSuffix = clusterIdentity.orElse(UUID.randomUUID().toString());
         this.rabbitHostName = hostName(hostNamePrefix);
         this.container = new GenericContainer<>(Images.RABBITMQ)
-                .withCreateContainerCmdModifier(cmd -> cmd.withName(this.rabbitHostName))
-                .withCreateContainerCmdModifier(cmd -> cmd.withHostName(this.rabbitHostName))
-                .withExposedPorts(DEFAULT_RABBITMQ_PORT, DEFAULT_RABBITMQ_ADMIN_PORT)
-                .waitingFor(waitStrategy())
-                .withLogConsumer(frame -> LOGGER.debug(frame.getUtf8String()))
-                .withCreateContainerCmdModifier(cmd -> cmd.getHostConfig()
-                    .withTmpFs(ImmutableMap.of("/var/lib/rabbitmq/mnesia", "rw,noexec,nosuid,size=100m")));
+            .withCreateContainerCmdModifier(cmd -> cmd.withName(this.rabbitHostName))
+            .withCreateContainerCmdModifier(cmd -> cmd.withHostName(this.rabbitHostName))
+            .withExposedPorts(DEFAULT_RABBITMQ_PORT, DEFAULT_RABBITMQ_ADMIN_PORT)
+            .waitingFor(waitStrategy())
+            .withLogConsumer(frame -> LOGGER.debug(frame.getUtf8String()))
+            .withTmpFs(ImmutableMap.of("/var/lib/rabbitmq/mnesia", "rw,noexec,nosuid,size=100m"));
         net.ifPresent(this.container::withNetwork);
         erlangCookie.ifPresent(cookie -> this.container.withEnv(RABBITMQ_ERLANG_COOKIE, cookie));
         this.nodeName = DEFAULT_RABBIT_NODE_NAME_PREFIX + "@" + this.rabbitHostName;

--- a/server/testing/src/main/java/org/apache/james/util/docker/DockerGenericContainer.java
+++ b/server/testing/src/main/java/org/apache/james/util/docker/DockerGenericContainer.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.Socket;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 
 import javax.net.SocketFactory;
 
@@ -65,7 +66,7 @@ public class DockerGenericContainer implements TestRule {
             logAndCheckSkipTest(e);
         }
     }
-    
+
     private void logAndCheckSkipTest(IllegalStateException e) {
         LOGGER.error("Cannot initial a docker container", e);
         if (e.getMessage().startsWith(NO_DOCKER_ENVIRONMENT)) {
@@ -87,6 +88,11 @@ public class DockerGenericContainer implements TestRule {
 
     public DockerGenericContainer withEnv(String key, String value) {
         container.addEnv(key, value);
+        return this;
+    }
+
+    public DockerGenericContainer withTmpFs(Map<String, String> mapping) {
+        container.withTmpFs(mapping);
         return this;
     }
 


### PR DESCRIPTION
Each of the 111 test case creates 13 messages that are then parsed by Tika
and indexed sequentially (InVmEventBus).

Using a TMPFS based file system showed a x6 indexation time improvement
locally and significantly improved indexation time for mailbox/elasticsearch