### PR TITLE
JAMES-2717 Enable parrallel inMemory testing in MPT IMAP Lucene tests

### DIFF
--- a/mpt/impl/imap-mailbox/lucenesearch/pom.xml
+++ b/mpt/impl/imap-mailbox/lucenesearch/pom.xml
@@ -76,4 +76,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <reuseForks>true</reuseForks>
+                    <forkCount>1C</forkCount>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
InMemory RAMDirectory mostly contributes the desired isolation. Time enhancement is
achieved through the now possible parrallel test execution.

Test time went (locally) from 7:06 to 3:19