### PR TITLE
JAMES-1902 Avoid creating the SPOOL MailQueue upon injection

### DIFF
--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailetContext.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailetContext.java
@@ -72,34 +72,20 @@ public class JamesMailetContext implements MailetContext, Configurable {
      * A hash table of server attributes These are the MailetContext attributes
      */
     private final Map<String, Object> attributes = new ConcurrentHashMap<>();
-    protected DNSService dns;
 
-    private UsersRepository localusers;
-
+    protected final DNSService dns;
+    private final UsersRepository localusers;
+    private final DomainList domains;
+    private final MailQueueFactory<?> mailQueueFactory;
     private MailQueue rootMailQueue;
-
-    private DomainList domains;
-
     private MailAddress postmaster;
 
     @Inject
-    public void retrieveRootMailQueue(MailQueueFactory<?> mailQueueFactory) {
-        this.rootMailQueue = mailQueueFactory.createQueue(MailQueueFactory.SPOOL);
-    }
-
-    @Inject
-    public void setDNSService(DNSService dns) {
+    public JamesMailetContext(DNSService dns, UsersRepository localusers, DomainList domains, MailQueueFactory<?> mailQueueFactory) {
         this.dns = dns;
-    }
-
-    @Inject
-    public void setUsersRepository(UsersRepository localusers) {
         this.localusers = localusers;
-    }
-
-    @Inject
-    public void setDomainList(DomainList domains) {
         this.domains = domains;
+        this.mailQueueFactory = mailQueueFactory;
     }
 
     @Override
@@ -460,6 +446,7 @@ public class JamesMailetContext implements MailetContext, Configurable {
 
     @Override
     public void configure(HierarchicalConfiguration config) throws ConfigurationException {
+        this.rootMailQueue = mailQueueFactory.createQueue(MailQueueFactory.SPOOL);
         try {
 
             // Get postmaster

--- a/server/mailet/mailetcontainer-camel/src/test/java/org/apache/james/mailetcontainer/impl/JamesMailetContextTest.java
+++ b/server/mailet/mailetcontainer-camel/src/test/java/org/apache/james/mailetcontainer/impl/JamesMailetContextTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.mail.internet.MimeMessage;
 
+import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.james.core.Domain;
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.builder.MimeMessageBuilder;
@@ -79,13 +80,12 @@ public class JamesMailetContextTest {
 
         usersRepository = MemoryUsersRepository.withVirtualHosting();
         usersRepository.setDomainList(domainList);
-        testee = new JamesMailetContext();
         MailQueueFactory<MailQueue> mailQueueFactory = mock(MailQueueFactory.class);
         spoolMailQueue = mock(MailQueue.class);
         when(mailQueueFactory.createQueue(MailQueueFactory.SPOOL)).thenReturn(spoolMailQueue);
-        testee.retrieveRootMailQueue(mailQueueFactory);
-        testee.setDomainList(domainList);
-        testee.setUsersRepository(usersRepository);
+        DNSService dnsService = null;
+        testee = new JamesMailetContext(dnsService, usersRepository, domainList, mailQueueFactory);
+        testee.configure(new HierarchicalConfiguration());
         mailAddress = new MailAddress(USERMAIL);
     }
 


### PR DESCRIPTION
Reusing a maybe not yet initialized component is dangerous. We should
rather do this as a startable to ensure initialization is well performed

Additionally, JamesMailetContext should rely of constructor based injected
final fields where possible.

Encoutered issue in Deployment tests:

```
Exception in thread "main" com.google.inject.ProvisionException: Unable to provision, see the following errors:

1) Error in custom provider, feign.RetryableException: No route to host (Host unreachable) executing GET http://rabbitmq:15672/api/queues
  at org.apache.james.modules.server.CamelMailetContainerModule.provideMailetContext(CamelMailetContainerModule.java:69) (via modules: com.google.inject.util.Modules$CombinedModule -> com.google.inject.util.Modules$CombinedModule -> org.apache.james.modules.MailetProcessingModule -> org.apache.james.modules.server.CamelMailetContainerModule)
  while locating org.apache.james.mailetcontainer.impl.JamesMailetContext
  while locating org.apache.mailet.MailetContext
    for the 1st parameter of org.apache.james.mailetcontainer.impl.camel.CamelCompositeProcessor.setMailetContext(CamelCompositeProcessor.java:69)
  at org.apache.james.modules.server.CamelMailetContainerModule.configure(CamelMailetContainerModule.java:81) (via modules: com.google.inject.util.Modules$CombinedModule -> com.google.inject.util.Modules$CombinedModule -> org.apache.james.modules.MailetProcessingModule -> org.apache.james.modules.server.CamelMailetContainerModule)
  while locating org.apache.james.mailetcontainer.impl.camel.CamelCompositeProcessor
    for the 2nd parameter of org.apache.james.modules.server.CamelMailetContainerModule$MailetModuleConfigurationPerformer.<init>(CamelMailetContainerModule.java:132)
  at org.apache.james.modules.server.CamelMailetContainerModule$MailetModuleConfigurationPerformer.class(CamelMailetContainerModule.java:132)
  while locating org.apache.james.modules.server.CamelMailetContainerModule$MailetModuleConfigurationPerformer
  while locating org.apache.james.utils.ConfigurationPerformer annotated with @com.google.inject.internal.Element(setName=,uniqueId=11, type=MULTIBINDER, keyType=)
  while locating java.util.Set<org.apache.james.utils.ConfigurationPerformer>
    for the 1st parameter of org.apache.james.utils.ConfigurationsPerformer.<init>(ConfigurationsPerformer.java:36)
  while locating org.apache.james.utils.ConfigurationsPerformer

1 error
	at com.google.inject.internal.InternalProvisionException.toProvisionException(InternalProvisionException.java:226)
	at com.google.inject.internal.InjectorImpl$1.get(InjectorImpl.java:1053)
	at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1086)
	at org.apache.james.GuiceJamesServer.start(GuiceJamesServer.java:83)
	at org.apache.james.CassandraRabbitMQJamesServerMain.main(CassandraRabbitMQJamesServerMain.java:46)
Caused by: feign.RetryableException: No route to host (Host unreachable) executing GET http://rabbitmq:15672/api/queues
	at feign.FeignException.errorExecuting(FeignException.java:128)
	at feign.SynchronousMethodHandler.executeAndDecode(SynchronousMethodHandler.java:113)
	at feign.SynchronousMethodHandler.invoke(SynchronousMethodHandler.java:78)
	at feign.ReflectiveFeign$FeignInvocationHandler.invoke(ReflectiveFeign.java:103)
	at com.sun.proxy.$Proxy116.listQueues(Unknown Source)
	at org.apache.james.queue.rabbitmq.RabbitMQMailQueueManagement.listCreatedMailQueueNames(RabbitMQMailQueueManagement.java:47)
	at org.apache.james.queue.rabbitmq.RabbitMQMailQueueFactory.getQueueFromRabbitServer(RabbitMQMailQueueFactory.java:162)
	at org.apache.james.queue.rabbitmq.RabbitMQMailQueueFactory.createQueue(RabbitMQMailQueueFactory.java:145)
	at org.apache.james.queue.rabbitmq.RabbitMQMailQueueFactory.createQueue(RabbitMQMailQueueFactory.java:48)
	at org.apache.james.mailetcontainer.impl.JamesMailetContext.retrieveRootMailQueue(JamesMailetContext.java:87)
	at org.apache.james.modules.server.CamelMailetContainerModule.provideMailetContext(CamelMailetContainerModule.java:108)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.google.inject.internal.ProviderMethod$ReflectionProviderMethod.doProvision(ProviderMethod.java:286)
	at com.google.inject.internal.ProviderMethod.doProvision(ProviderMethod.java:173)
	at com.google.inject.internal.InternalProviderInstanceBindingImpl$CyclicFactory.provision(InternalProviderInstanceBindingImpl.java:185)
	at com.google.inject.internal.InternalProviderInstanceBindingImpl$CyclicFactory.get(InternalProviderInstanceBindingImpl.java:162)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:148)
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:39)
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:62)
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:42)
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:65)
	at com.google.inject.internal.SingleMethodInjector.inject(SingleMethodInjector.java:82)
	at com.google.inject.internal.MembersInjectorImpl.injectMembers(MembersInjectorImpl.java:147)
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:124)
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91)
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:306)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:148)
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:39)
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:42)
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:65)
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113)
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91)
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:306)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:148)
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:39)
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:62)
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:42)
	at com.google.inject.internal.RealMultibinder$RealMultibinderProvider.doProvision(RealMultibinder.java:198)
	at com.google.inject.internal.RealMultibinder$RealMultibinderProvider.doProvision(RealMultibinder.java:151)
	at com.google.inject.internal.InternalProviderInstanceBindingImpl$Factory.get(InternalProviderInstanceBindingImpl.java:113)
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:42)
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:65)
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113)
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91)
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:306)
	at com.google.inject.internal.InjectorImpl$1.get(InjectorImpl.java:1050)
	... 3 more
Caused by: java.net.NoRouteToHostException: No route to host (Host unreachable)
	at java.net.PlainSocketImpl.socketConnect(Native Method)
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.net.Socket.connect(Socket.java:589)
	at sun.net.NetworkClient.doConnect(NetworkClient.java:175)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:463)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:558)
	at sun.net.www.http.HttpClient.<init>(HttpClient.java:242)
	at sun.net.www.http.HttpClient.New(HttpClient.java:339)
	at sun.net.www.http.HttpClient.New(HttpClient.java:357)
	at sun.net.www.protocol.http.HttpURLConnection.getNewHttpClient(HttpURLConnection.java:1220)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1156)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1050)
	at sun.net.www.protocol.http.HttpURLConnection.connect(HttpURLConnection.java:984)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1564)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1492)
	at java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:480)
	at feign.Client$Default.convertResponse(Client.java:143)
	at feign.Client$Default.execute(Client.java:68)
	at feign.SynchronousMethodHandler.executeAndDecode(SynchronousMethodHandler.java:108)
	... 53 more
Running: Shell Script
```