### PR TITLE
JAMES-2794 A complete approach to deletion in RabbitMQ MailQueue

### DIFF
--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/RabbitMQJamesServerReprocessingTest.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/RabbitMQJamesServerReprocessingTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.james;
+
+import static io.restassured.config.ParamConfig.UpdateStrategy.REPLACE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.mailrepository.api.MailRepositoryUrl;
+import org.apache.james.modules.RabbitMQExtension;
+import org.apache.james.modules.TestJMAPServerModule;
+import org.apache.james.modules.protocols.SmtpGuiceProbe;
+import org.apache.james.utils.MailRepositoryProbeImpl;
+import org.apache.james.utils.SMTPMessageSender;
+import org.apache.james.utils.WebAdminGuiceProbe;
+import org.apache.james.webadmin.WebAdminConfiguration;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.awaitility.Awaitility;
+import org.awaitility.Duration;
+import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.restassured.RestAssured;
+import io.restassured.config.ParamConfig;
+import io.restassured.parsing.Parser;
+import io.restassured.specification.RequestSpecification;
+
+class RabbitMQJamesServerReprocessingTest {
+    private static final ConditionFactory AWAIT = Awaitility.await().atMost(Duration.ONE_MINUTE);
+    private static final MailRepositoryUrl SENDER_DENIED = MailRepositoryUrl.from("cassandra://var/mail/sender-denied/");
+    private RabbitMQExtension rabbitMQExtension = new RabbitMQExtension();
+    private RequestSpecification webAdminApi;
+
+    @RegisterExtension
+    JamesServerExtension jamesServerExtension = CassandraRabbitMQJamesServerFixture
+        .baseExtensionBuilder(rabbitMQExtension)
+        .server(configuration -> GuiceJamesServer
+            .forConfiguration(configuration)
+            .combineWith(CassandraRabbitMQJamesServerMain.MODULES)
+            .overrideWith(new TestJMAPServerModule(10))
+            .overrideWith(binder -> binder.bind(WebAdminConfiguration.class).toInstance(WebAdminConfiguration.TEST_CONFIGURATION))
+            .overrideWith(JmapJamesServerContract.DOMAIN_LIST_CONFIGURATION_MODULE))
+        .build();
+
+    @BeforeEach
+    void setUp(GuiceJamesServer server) {
+        RestAssured.defaultParser = Parser.JSON;
+        webAdminApi = WebAdminUtils.spec(server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort())
+            .config(WebAdminUtils.defaultConfig()
+                .paramConfig(new ParamConfig(REPLACE, REPLACE, REPLACE)));
+    }
+
+    @Disabled("JAMES-2733 Reprocessing is broken for RabbitMQ mailQueue - the reprocessed mail name is preserved and" +
+        " is thus considered deleted.")
+    @Test
+    void reprocessingADeniedMailShouldNotLooseIt(GuiceJamesServer server) throws Exception {
+        new SMTPMessageSender("other.com")
+            .connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .sendMessage("denied@other.com", "any@domain.tld");
+
+        MailRepositoryProbeImpl mailRepositoryProbe = server.getProbe(MailRepositoryProbeImpl.class);
+        AWAIT.until(() -> mailRepositoryProbe.listMailKeys(SENDER_DENIED).size() == 1);
+
+        String taskId = webAdminApi
+            .param("action", "reprocess")
+            .patch("/mailRepositories/var%2Fmail%2Fsender-denied/mails")
+            .jsonPath()
+            .get("taskId");
+
+        webAdminApi.get("/tasks/" + taskId + "/await");
+
+        AWAIT.until(() -> mailRepositoryProbe.listMailKeys(SENDER_DENIED).size() == 1);
+        assertThat(mailRepositoryProbe.listMailKeys(SENDER_DENIED)).hasSize(1);
+    }
+}

--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/RabbitMQJamesServerReprocessingTest.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/RabbitMQJamesServerReprocessingTest.java
@@ -83,8 +83,10 @@ class RabbitMQJamesServerReprocessingTest {
             .jsonPath()
             .get("taskId");
 
+        // Awaiting the task ensure the reprocessdid start and that the repository was emptied
         webAdminApi.get("/tasks/" + taskId + "/await");
 
+        // Awaiting that an other mail is present in the mail repository ensures that the reprocessing successfully finished
         AWAIT.until(() -> mailRepositoryProbe.listMailKeys(SENDER_DENIED).size() == 1);
         assertThat(mailRepositoryProbe.listMailKeys(SENDER_DENIED)).hasSize(1);
     }

--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/RabbitMQJamesServerReprocessingTest.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/RabbitMQJamesServerReprocessingTest.java
@@ -35,7 +35,6 @@ import org.awaitility.Awaitility;
 import org.awaitility.Duration;
 import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -69,8 +68,6 @@ class RabbitMQJamesServerReprocessingTest {
                 .paramConfig(new ParamConfig(REPLACE, REPLACE, REPLACE)));
     }
 
-    @Disabled("JAMES-2733 Reprocessing is broken for RabbitMQ mailQueue - the reprocessed mail name is preserved and" +
-        " is thus considered deleted.")
     @Test
     void reprocessingADeniedMailShouldNotLooseIt(GuiceJamesServer server) throws Exception {
         new SMTPMessageSender("other.com")

--- a/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueBlobTest.java
+++ b/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueBlobTest.java
@@ -131,6 +131,13 @@ public class ActiveMQMailQueueBlobTest implements DelayedManageableMailQueueCont
     }
 
     @Test
+    @Override
+    @Disabled("JAMES-2794 This test never finishes")
+    public void enQueueShouldAcceptMailWithDuplicatedNames() {
+
+    }
+
+    @Test
     void computeNextDeliveryTimestampShouldReturnLongMaxWhenOverflow() {
         long deliveryTimestamp = mailQueue.computeNextDeliveryTimestamp(ChronoUnit.FOREVER.getDuration());
 

--- a/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueTest.java
+++ b/server/queue/queue-activemq/src/test/java/org/apache/james/queue/activemq/ActiveMQMailQueueTest.java
@@ -127,6 +127,13 @@ public class ActiveMQMailQueueTest implements DelayedManageableMailQueueContract
 
     @Test
     @Override
+    @Disabled("JAMES-2794 This test never finishes")
+    public void enQueueShouldAcceptMailWithDuplicatedNames() {
+
+    }
+
+    @Test
+    @Override
     @Disabled("JAMES-2544 Mixing concurrent ack/nack might lead to a deadlock")
     public void concurrentEnqueueDequeueWithAckNackShouldNotFail() {
 

--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/MailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/MailQueueContract.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import javax.mail.internet.MimeMessage;
 
@@ -124,12 +125,13 @@ public interface MailQueueContract {
         enQueue(mail);
         enQueue(mail);
 
-        Flux<String> dequeuedItemNames = Flux.from(getMailQueue().deQueue())
+        Stream<String> dequeuedItemNames = Flux.from(getMailQueue().deQueue())
             .take(2)
             .map(MailQueue.MailQueueItem::getMail)
-            .map(Mail::getName);
+            .map(Mail::getName)
+            .toStream();
 
-        assertThat(dequeuedItemNames.toStream()).hasSize(2).containsOnly(name);
+        assertThat(dequeuedItemNames).hasSize(2).containsOnly(name);
     }
 
     @Test

--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/MailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/MailQueueContract.java
@@ -53,6 +53,7 @@ import org.junit.jupiter.api.Test;
 import com.github.fge.lambdas.Throwing;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -107,6 +108,28 @@ public interface MailQueueContract {
         MailQueue.MailQueueItem mailQueueItem = Flux.from(getMailQueue().deQueue()).blockFirst();
         assertThat(mailQueueItem.getMail().getMaybeSender())
             .isEqualTo(MaybeSender.nullSender());
+    }
+
+    @Test
+    default void enQueueShouldAcceptMailWithDuplicatedNames() throws Exception {
+        String name = "name";
+        FakeMail mail = FakeMail.builder()
+            .name(name)
+            .mimeMessage(createMimeMessage())
+            .recipients(RECIPIENT1, RECIPIENT2)
+            .sender(MailAddress.nullSender())
+            .lastUpdated(new Date())
+            .build();
+
+        enQueue(mail);
+        enQueue(mail);
+
+        Flux<String> dequeuedItemNames = Flux.from(getMailQueue().deQueue())
+            .take(2)
+            .map(MailQueue.MailQueueItem::getMail)
+            .map(Mail::getName);
+
+        assertThat(dequeuedItemNames.toStream()).hasSize(2).containsOnly(name);
     }
 
     @Test

--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/ManageableMailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/ManageableMailQueueContract.java
@@ -40,6 +40,7 @@ import org.apache.mailet.Mail;
 import org.apache.mailet.base.MailAddressFixture;
 import org.junit.jupiter.api.Test;
 
+import com.github.fge.lambdas.Throwing;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 
@@ -79,7 +80,9 @@ public interface ManageableMailQueueContract extends MailQueueContract {
     default void dequeueShouldDecreaseQueueSize() throws Exception {
         enQueue(defaultMail().name("name").build());
 
-        Flux.from(getManageableMailQueue().deQueue()).blockFirst().done(true);
+        Flux.from(getManageableMailQueue().deQueue())
+            .doOnNext(Throwing.consumer(item -> item.done(true)))
+            .blockFirst();
 
         long size = getManageableMailQueue().getSize();
 
@@ -90,7 +93,9 @@ public interface ManageableMailQueueContract extends MailQueueContract {
     default void noAckShouldNotDecreaseSize() throws Exception {
         enQueue(defaultMail().name("name").build());
 
-        Flux.from(getManageableMailQueue().deQueue()).blockFirst().done(false);
+        Flux.from(getManageableMailQueue().deQueue())
+            .doOnNext(Throwing.consumer(item -> item.done(false)))
+            .blockFirst();
 
         long size = getManageableMailQueue().getSize();
 

--- a/server/queue/queue-jms/src/test/java/org/apache/james/queue/jms/JMSMailQueueTest.java
+++ b/server/queue/queue-jms/src/test/java/org/apache/james/queue/jms/JMSMailQueueTest.java
@@ -113,4 +113,11 @@ public class JMSMailQueueTest implements DelayedManageableMailQueueContract, Pri
     public void concurrentEnqueueDequeueWithAckNackShouldNotFail() {
 
     }
+
+    @Test
+    @Override
+    @Disabled("JAMES-2794 This test never finishes")
+    public void enQueueShouldAcceptMailWithDuplicatedNames() {
+
+    }
 }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
@@ -47,12 +47,12 @@ class Dequeuer {
 
     private static class RabbitMQMailQueueItem implements MailQueue.MailQueueItem {
         private final Consumer<Boolean> ack;
-        private final EnqueueId enQueueId;
+        private final EnqueueId enqueueId;
         private final Mail mail;
 
-        private RabbitMQMailQueueItem(Consumer<Boolean> ack, EnqueueId enQueueId, Mail mail) {
+        private RabbitMQMailQueueItem(Consumer<Boolean> ack, EnqueueId enqueueId, Mail mail) {
             this.ack = ack;
-            this.enQueueId = enQueueId;
+            this.enqueueId = enqueueId;
             this.mail = mail;
         }
 
@@ -61,8 +61,8 @@ class Dequeuer {
             return mail;
         }
 
-        public EnqueueId getEnQueueId() {
-            return enQueueId;
+        public EnqueueId getEnqueueId() {
+            return enqueueId;
         }
 
         @Override
@@ -94,7 +94,7 @@ class Dequeuer {
     }
 
     private Mono<RabbitMQMailQueueItem> filterIfDeleted(RabbitMQMailQueueItem item) {
-        return mailQueueView.isPresent(item.getEnQueueId())
+        return mailQueueView.isPresent(item.getEnqueueId())
             .flatMap(isPresent -> {
                 if (isPresent) {
                     return Mono.just(item);

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
@@ -89,8 +89,8 @@ class Dequeuer {
     }
 
     Flux<? extends MailQueue.MailQueueItem> deQueue() {
-        return flux.flatMap(this::loadItem)
-            .flatMap(this::filterIfDeleted);
+        return flux.concatMap(this::loadItem)
+            .concatMap(this::filterIfDeleted);
     }
 
     private Mono<RabbitMQMailQueueItem> filterIfDeleted(RabbitMQMailQueueItem item) {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
@@ -71,12 +71,12 @@ class Dequeuer {
         }
     }
 
-    private final Function<MailReferenceDTO, Mail> mailLoader;
+    private final Function<MailReferenceDTO, Pair<EnQueueId, Mail>> mailLoader;
     private final Metric dequeueMetric;
     private final MailReferenceSerializer mailReferenceSerializer;
     private final MailQueueView mailQueueView;
 
-    Dequeuer(MailQueueName name, RabbitClient rabbitClient, Function<MailReferenceDTO, Mail> mailLoader,
+    Dequeuer(MailQueueName name, RabbitClient rabbitClient, Function<MailReferenceDTO, Pair<EnQueueId, Mail>> mailLoader,
              MailReferenceSerializer serializer, MetricFactory metricFactory,
              MailQueueView mailQueueView) {
         this.mailLoader = mailLoader;
@@ -129,9 +129,7 @@ class Dequeuer {
 
     private Pair<EnQueueId, Mail> loadMail(Delivery response) throws MailQueue.MailQueueException {
         MailReferenceDTO mailDTO = toMailReference(response);
-        EnQueueId enQueueId = mailDTO.retrieveEnqueueId();
-        Mail mail = mailLoader.apply(mailDTO);
-        return Pair.of(enQueueId, mail);
+        return mailLoader.apply(mailDTO);
     }
 
     private MailReferenceDTO toMailReference(Delivery getResponse) throws MailQueue.MailQueueException {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
@@ -95,13 +95,15 @@ class Dequeuer {
 
     private Mono<RabbitMQMailQueueItem> filterIfDeleted(RabbitMQMailQueueItem item) {
         return mailQueueView.isPresent(item.getEnqueueId())
-            .flatMap(isPresent -> {
-                if (isPresent) {
-                    return Mono.just(item);
-                }
-                item.done(true);
-                return Mono.empty();
-            });
+            .flatMap(isPresent -> keepWhenPresent(item, isPresent));
+    }
+
+    private Mono<? extends RabbitMQMailQueueItem> keepWhenPresent(RabbitMQMailQueueItem item, Boolean isPresent) {
+        if (isPresent) {
+            return Mono.just(item);
+        }
+        item.done(true);
+        return Mono.empty();
     }
 
     private Mono<RabbitMQMailQueueItem> loadItem(AcknowledgableDelivery response) {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
@@ -100,14 +100,14 @@ class Dequeuer {
     private Mono<RabbitMQMailQueueItem> loadItem(AcknowledgableDelivery response) {
         try {
             Mail mail = loadMail(response);
-            ThrowingConsumer<Boolean> ack = ack(response, response.getEnvelope().getDeliveryTag(), mail);
+            ThrowingConsumer<Boolean> ack = ack(response, mail);
             return Mono.just(new RabbitMQMailQueueItem(ack, mail));
         } catch (MailQueue.MailQueueException e) {
             return Mono.error(e);
         }
     }
 
-    private ThrowingConsumer<Boolean> ack(AcknowledgableDelivery response, long deliveryTag, Mail mail) {
+    private ThrowingConsumer<Boolean> ack(AcknowledgableDelivery response, Mail mail) {
         return success -> {
             if (success) {
                 dequeueMetric.increment();

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
@@ -47,10 +47,10 @@ class Dequeuer {
 
     private static class RabbitMQMailQueueItem implements MailQueue.MailQueueItem {
         private final Consumer<Boolean> ack;
-        private final EnQueueId enQueueId;
+        private final EnqueueId enQueueId;
         private final Mail mail;
 
-        private RabbitMQMailQueueItem(Consumer<Boolean> ack, EnQueueId enQueueId, Mail mail) {
+        private RabbitMQMailQueueItem(Consumer<Boolean> ack, EnqueueId enQueueId, Mail mail) {
             this.ack = ack;
             this.enQueueId = enQueueId;
             this.mail = mail;
@@ -61,7 +61,7 @@ class Dequeuer {
             return mail;
         }
 
-        public EnQueueId getEnQueueId() {
+        public EnqueueId getEnQueueId() {
             return enQueueId;
         }
 
@@ -71,12 +71,12 @@ class Dequeuer {
         }
     }
 
-    private final Function<MailReferenceDTO, Pair<EnQueueId, Mail>> mailLoader;
+    private final Function<MailReferenceDTO, Pair<EnqueueId, Mail>> mailLoader;
     private final Metric dequeueMetric;
     private final MailReferenceSerializer mailReferenceSerializer;
     private final MailQueueView mailQueueView;
 
-    Dequeuer(MailQueueName name, RabbitClient rabbitClient, Function<MailReferenceDTO, Pair<EnQueueId, Mail>> mailLoader,
+    Dequeuer(MailQueueName name, RabbitClient rabbitClient, Function<MailReferenceDTO, Pair<EnqueueId, Mail>> mailLoader,
              MailReferenceSerializer serializer, MetricFactory metricFactory,
              MailQueueView mailQueueView) {
         this.mailLoader = mailLoader;
@@ -106,7 +106,7 @@ class Dequeuer {
 
     private Mono<RabbitMQMailQueueItem> loadItem(AcknowledgableDelivery response) {
         try {
-            Pair<EnQueueId, Mail> idAndMail = loadMail(response);
+            Pair<EnqueueId, Mail> idAndMail = loadMail(response);
             Mail mail = idAndMail.getRight();
             ThrowingConsumer<Boolean> ack = ack(response, mail);
             return Mono.just(new RabbitMQMailQueueItem(ack, idAndMail.getLeft(), mail));
@@ -127,7 +127,7 @@ class Dequeuer {
         };
     }
 
-    private Pair<EnQueueId, Mail> loadMail(Delivery response) throws MailQueue.MailQueueException {
+    private Pair<EnqueueId, Mail> loadMail(Delivery response) throws MailQueue.MailQueueException {
         MailReferenceDTO mailDTO = toMailReference(response);
         return mailLoader.apply(mailDTO);
     }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
@@ -120,7 +120,7 @@ class Dequeuer {
             if (success) {
                 dequeueMetric.increment();
                 response.ack();
-                mailQueueView.delete(DeleteCondition.withName(mailWithEnqueueId.getMail().getName()));
+                mailQueueView.delete(DeleteCondition.withEnqueueId(mailWithEnqueueId.getEnqueueId()));
             } else {
                 response.nack(REQUEUE);
             }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Dequeuer.java
@@ -34,6 +34,7 @@ import org.apache.mailet.Mail;
 
 import com.github.fge.lambdas.consumers.ThrowingConsumer;
 import com.rabbitmq.client.Delivery;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.rabbitmq.AcknowledgableDelivery;
@@ -80,8 +81,20 @@ class Dequeuer {
             .filter(getResponse -> getResponse.getBody() != null);
     }
 
-    Flux<MailQueue.MailQueueItem> deQueue() {
-        return flux.flatMap(this::loadItem);
+    Flux<? extends MailQueue.MailQueueItem> deQueue() {
+        return flux.flatMap(this::loadItem)
+            .flatMap(this::filterIfDeleted);
+    }
+
+    private Mono<RabbitMQMailQueueItem> filterIfDeleted(RabbitMQMailQueueItem item) {
+        return mailQueueView.isPresent(item.getMail())
+            .flatMap(isPresent -> {
+                if (isPresent) {
+                    return Mono.just(item);
+                }
+                item.done(true);
+                return Mono.empty();
+            });
     }
 
     private Mono<RabbitMQMailQueueItem> loadItem(AcknowledgableDelivery response) {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/EnQueueId.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/EnQueueId.java
@@ -17,49 +17,56 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.queue.rabbitmq.view.cassandra.model;
+package org.apache.james.queue.rabbitmq;
 
 import java.util.Objects;
+import java.util.UUID;
 
-import org.apache.mailet.Mail;
-
+import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.base.Preconditions;
 
-public class MailKey {
+public class EnQueueId {
 
-    public static MailKey fromMail(Mail mail) {
-        return of(mail.getName());
+    public static EnQueueId generate() {
+        return of(UUIDs.timeBased());
     }
 
-    public static MailKey of(String mailKey) {
-        return new MailKey(mailKey);
+    public static EnQueueId of(UUID uuid) {
+        Preconditions.checkNotNull(uuid);
+        return new EnQueueId(uuid);
     }
 
-    private final String mailKey;
-
-    private MailKey(String mailKey) {
-        Preconditions.checkNotNull(mailKey);
-        Preconditions.checkArgument(!mailKey.isEmpty());
-
-        this.mailKey = mailKey;
+    public static EnQueueId ofSerialized(String serialized) {
+        Preconditions.checkNotNull(serialized);
+        return of(UUID.fromString(serialized));
     }
 
-    public String getMailKey() {
-        return mailKey;
+    private final UUID id;
+
+    private EnQueueId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID asUUID() {
+        return id;
+    }
+
+    public String serialize() {
+        return id.toString();
     }
 
     @Override
     public final boolean equals(Object o) {
-        if (o instanceof MailKey) {
-            MailKey mailKey1 = (MailKey) o;
+        if (o instanceof EnQueueId) {
+            EnQueueId enQueueId = (EnQueueId) o;
 
-            return Objects.equals(this.mailKey, mailKey1.mailKey);
+            return Objects.equals(this.id, enQueueId.id);
         }
         return false;
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(mailKey);
+        return Objects.hash(id);
     }
 }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/EnqueueId.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/EnqueueId.java
@@ -57,9 +57,9 @@ public class EnqueueId {
     @Override
     public final boolean equals(Object o) {
         if (o instanceof EnqueueId) {
-            EnqueueId enQueueId = (EnqueueId) o;
+            EnqueueId enqueueId = (EnqueueId) o;
 
-            return Objects.equals(this.id, enQueueId.id);
+            return Objects.equals(this.id, enqueueId.id);
         }
         return false;
     }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/EnqueueId.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/EnqueueId.java
@@ -22,13 +22,12 @@ package org.apache.james.queue.rabbitmq;
 import java.util.Objects;
 import java.util.UUID;
 
-import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.base.Preconditions;
 
 public class EnqueueId {
 
     public static EnqueueId generate() {
-        return of(UUIDs.timeBased());
+        return of(UUID.randomUUID());
     }
 
     public static EnqueueId of(UUID uuid) {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/EnqueueId.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/EnqueueId.java
@@ -25,25 +25,25 @@ import java.util.UUID;
 import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.base.Preconditions;
 
-public class EnQueueId {
+public class EnqueueId {
 
-    public static EnQueueId generate() {
+    public static EnqueueId generate() {
         return of(UUIDs.timeBased());
     }
 
-    public static EnQueueId of(UUID uuid) {
+    public static EnqueueId of(UUID uuid) {
         Preconditions.checkNotNull(uuid);
-        return new EnQueueId(uuid);
+        return new EnqueueId(uuid);
     }
 
-    public static EnQueueId ofSerialized(String serialized) {
+    public static EnqueueId ofSerialized(String serialized) {
         Preconditions.checkNotNull(serialized);
         return of(UUID.fromString(serialized));
     }
 
     private final UUID id;
 
-    private EnQueueId(UUID id) {
+    private EnqueueId(UUID id) {
         this.id = id;
     }
 
@@ -57,8 +57,8 @@ public class EnQueueId {
 
     @Override
     public final boolean equals(Object o) {
-        if (o instanceof EnQueueId) {
-            EnQueueId enQueueId = (EnQueueId) o;
+        if (o instanceof EnqueueId) {
+            EnqueueId enQueueId = (EnqueueId) o;
 
             return Objects.equals(this.id, enQueueId.id);
         }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/EnqueuedItem.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/EnqueuedItem.java
@@ -33,7 +33,7 @@ public class EnqueuedItem {
 
         @FunctionalInterface
         interface RequireEnqueueId {
-            RequireMailQueueName enQueueId(EnqueueId id);
+            RequireMailQueueName enqueueId(EnqueueId id);
         }
 
         @FunctionalInterface
@@ -57,20 +57,20 @@ public class EnqueuedItem {
         }
 
         class ReadyToBuild {
-            private final EnqueueId enQueueId;
+            private final EnqueueId enqueueId;
             private final MailQueueName mailQueueName;
             private final Mail mail;
             private final Instant enqueuedTime;
             private final MimeMessagePartsId partsId;
 
-            ReadyToBuild(EnqueueId enQueueId, MailQueueName mailQueueName, Mail mail, Instant enqueuedTime, MimeMessagePartsId partsId) {
-                Preconditions.checkNotNull(enQueueId, "'enQueueId' is mandatory");
+            ReadyToBuild(EnqueueId enqueueId, MailQueueName mailQueueName, Mail mail, Instant enqueuedTime, MimeMessagePartsId partsId) {
+                Preconditions.checkNotNull(enqueueId, "'enqueueId' is mandatory");
                 Preconditions.checkNotNull(mailQueueName, "'mailQueueName' is mandatory");
                 Preconditions.checkNotNull(mail, "'mail' is mandatory");
                 Preconditions.checkNotNull(enqueuedTime, "'enqueuedTime' is mandatory");
                 Preconditions.checkNotNull(partsId, "'partsId' is mandatory");
 
-                this.enQueueId = enQueueId;
+                this.enqueueId = enqueueId;
                 this.mailQueueName = mailQueueName;
                 this.mail = mail;
                 this.enqueuedTime = enqueuedTime;
@@ -78,31 +78,31 @@ public class EnqueuedItem {
             }
 
             public EnqueuedItem build() {
-                return new EnqueuedItem(enQueueId, mailQueueName, mail, enqueuedTime, partsId);
+                return new EnqueuedItem(enqueueId, mailQueueName, mail, enqueuedTime, partsId);
             }
         }
     }
 
     public static Builder.RequireEnqueueId builder() {
-        return enQueueId -> queueName -> mail -> enqueuedTime -> partsId -> new Builder.ReadyToBuild(enQueueId, queueName, mail, enqueuedTime, partsId);
+        return enqueueId -> queueName -> mail -> enqueuedTime -> partsId -> new Builder.ReadyToBuild(enqueueId, queueName, mail, enqueuedTime, partsId);
     }
 
-    private final EnqueueId enQueueId;
+    private final EnqueueId enqueueId;
     private final MailQueueName mailQueueName;
     private final Mail mail;
     private final Instant enqueuedTime;
     private final MimeMessagePartsId partsId;
 
-    EnqueuedItem(EnqueueId enQueueId, MailQueueName mailQueueName, Mail mail, Instant enqueuedTime, MimeMessagePartsId partsId) {
-        this.enQueueId = enQueueId;
+    EnqueuedItem(EnqueueId enqueueId, MailQueueName mailQueueName, Mail mail, Instant enqueuedTime, MimeMessagePartsId partsId) {
+        this.enqueueId = enqueueId;
         this.mailQueueName = mailQueueName;
         this.mail = mail;
         this.enqueuedTime = enqueuedTime;
         this.partsId = partsId;
     }
 
-    public EnqueueId getEnQueueId() {
-        return enQueueId;
+    public EnqueueId getEnqueueId() {
+        return enqueueId;
     }
 
     public MailQueueName getMailQueueName() {
@@ -126,7 +126,7 @@ public class EnqueuedItem {
         if (o instanceof EnqueuedItem) {
             EnqueuedItem that = (EnqueuedItem) o;
 
-            return Objects.equals(this.enQueueId, that.enQueueId)
+            return Objects.equals(this.enqueueId, that.enqueueId)
                 && Objects.equals(this.mailQueueName, that.mailQueueName)
                 && Objects.equals(this.mail, that.mail)
                 && Objects.equals(this.enqueuedTime, that.enqueuedTime)
@@ -137,6 +137,6 @@ public class EnqueuedItem {
 
     @Override
     public final int hashCode() {
-        return Objects.hash(enQueueId, mailQueueName, mail, enqueuedTime, partsId);
+        return Objects.hash(enqueueId, mailQueueName, mail, enqueuedTime, partsId);
     }
 }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/EnqueuedItem.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/EnqueuedItem.java
@@ -33,7 +33,7 @@ public class EnqueuedItem {
 
         @FunctionalInterface
         interface RequireEnqueueId {
-            RequireMailQueueName enQueueId(EnQueueId id);
+            RequireMailQueueName enQueueId(EnqueueId id);
         }
 
         @FunctionalInterface
@@ -57,13 +57,13 @@ public class EnqueuedItem {
         }
 
         class ReadyToBuild {
-            private final EnQueueId enQueueId;
+            private final EnqueueId enQueueId;
             private final MailQueueName mailQueueName;
             private final Mail mail;
             private final Instant enqueuedTime;
             private final MimeMessagePartsId partsId;
 
-            ReadyToBuild(EnQueueId enQueueId, MailQueueName mailQueueName, Mail mail, Instant enqueuedTime, MimeMessagePartsId partsId) {
+            ReadyToBuild(EnqueueId enQueueId, MailQueueName mailQueueName, Mail mail, Instant enqueuedTime, MimeMessagePartsId partsId) {
                 Preconditions.checkNotNull(enQueueId, "'enQueueId' is mandatory");
                 Preconditions.checkNotNull(mailQueueName, "'mailQueueName' is mandatory");
                 Preconditions.checkNotNull(mail, "'mail' is mandatory");
@@ -87,13 +87,13 @@ public class EnqueuedItem {
         return enQueueId -> queueName -> mail -> enqueuedTime -> partsId -> new Builder.ReadyToBuild(enQueueId, queueName, mail, enqueuedTime, partsId);
     }
 
-    private final EnQueueId enQueueId;
+    private final EnqueueId enQueueId;
     private final MailQueueName mailQueueName;
     private final Mail mail;
     private final Instant enqueuedTime;
     private final MimeMessagePartsId partsId;
 
-    EnqueuedItem(EnQueueId enQueueId, MailQueueName mailQueueName, Mail mail, Instant enqueuedTime, MimeMessagePartsId partsId) {
+    EnqueuedItem(EnqueueId enQueueId, MailQueueName mailQueueName, Mail mail, Instant enqueuedTime, MimeMessagePartsId partsId) {
         this.enQueueId = enQueueId;
         this.mailQueueName = mailQueueName;
         this.mail = mail;
@@ -101,7 +101,7 @@ public class EnqueuedItem {
         this.partsId = partsId;
     }
 
-    public EnQueueId getEnQueueId() {
+    public EnqueueId getEnQueueId() {
         return enQueueId;
     }
 

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Enqueuer.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Enqueuer.java
@@ -61,9 +61,9 @@ class Enqueuer {
     }
 
     void enQueue(Mail mail) throws MailQueue.MailQueueException {
-        EnqueueId enQueueId = EnqueueId.generate();
+        EnqueueId enqueueId = EnqueueId.generate();
         saveMail(mail)
-            .map(partIds -> new MailReference(enQueueId, mail, partIds))
+            .map(partIds -> new MailReference(enqueueId, mail, partIds))
             .map(Throwing.function(this::publishReferenceToRabbit).sneakyThrow())
             .flatMap(mailQueueView::storeMail)
             .thenEmpty(Mono.fromRunnable(enqueueMetric::increment))
@@ -82,7 +82,7 @@ class Enqueuer {
         rabbitClient.publish(name, getMailReferenceBytes(mailReference));
 
         return EnqueuedItem.builder()
-            .enQueueId(mailReference.getEnQueueId())
+            .enqueueId(mailReference.getEnqueueId())
             .mailQueueName(name)
             .mail(mailReference.getMail())
             .enqueuedTime(clock.instant())

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Enqueuer.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Enqueuer.java
@@ -61,7 +61,7 @@ class Enqueuer {
     }
 
     void enQueue(Mail mail) throws MailQueue.MailQueueException {
-        EnQueueId enQueueId = EnQueueId.generate();
+        EnqueueId enQueueId = EnqueueId.generate();
         saveMail(mail)
             .map(partIds -> new MailReference(enQueueId, mail, partIds))
             .map(Throwing.function(this::publishReferenceToRabbit).sneakyThrow())

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailLoader.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailLoader.java
@@ -46,7 +46,7 @@ class MailLoader {
             Mail mail = mailReference.getMail();
             MimeMessage mimeMessage = mimeMessageStore.read(mailReference.getPartsId()).block();
             mail.setMessage(mimeMessage);
-            return Pair.of(mailReference.getEnQueueId(), mail);
+            return Pair.of(mailReference.getEnqueueId(), mail);
         } catch (AddressException e) {
             throw new MailQueue.MailQueueException("Failed to parse mail address", e);
         } catch (MessagingException e) {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailLoader.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailLoader.java
@@ -39,7 +39,7 @@ class MailLoader {
         this.blobIdFactory = blobIdFactory;
     }
 
-    Pair<EnQueueId, Mail> load(MailReferenceDTO dto) throws MailQueue.MailQueueException {
+    Pair<EnqueueId, Mail> load(MailReferenceDTO dto) throws MailQueue.MailQueueException {
         try {
             MailReference mailReference = dto.toMailReference(blobIdFactory);
 

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailLoader.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailLoader.java
@@ -23,7 +23,6 @@ import javax.mail.MessagingException;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.MimeMessage;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.Store;
 import org.apache.james.blob.mail.MimeMessagePartsId;
@@ -39,14 +38,14 @@ class MailLoader {
         this.blobIdFactory = blobIdFactory;
     }
 
-    Pair<EnqueueId, Mail> load(MailReferenceDTO dto) throws MailQueue.MailQueueException {
+    MailWithEnqueueId load(MailReferenceDTO dto) throws MailQueue.MailQueueException {
         try {
             MailReference mailReference = dto.toMailReference(blobIdFactory);
 
             Mail mail = mailReference.getMail();
             MimeMessage mimeMessage = mimeMessageStore.read(mailReference.getPartsId()).block();
             mail.setMessage(mimeMessage);
-            return Pair.of(mailReference.getEnqueueId(), mail);
+            return new MailWithEnqueueId(mailReference.getEnqueueId(), mail);
         } catch (AddressException e) {
             throw new MailQueue.MailQueueException("Failed to parse mail address", e);
         } catch (MessagingException e) {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReference.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReference.java
@@ -24,17 +24,17 @@ import org.apache.mailet.Mail;
 
 public class MailReference {
 
-    private final EnQueueId enQueueId;
+    private final EnqueueId enQueueId;
     private final Mail mail;
     private final MimeMessagePartsId partsId;
 
-    public MailReference(EnQueueId enQueueId, Mail mail, MimeMessagePartsId partsId) {
+    public MailReference(EnqueueId enQueueId, Mail mail, MimeMessagePartsId partsId) {
         this.enQueueId = enQueueId;
         this.mail = mail;
         this.partsId = partsId;
     }
 
-    public EnQueueId getEnQueueId() {
+    public EnqueueId getEnQueueId() {
         return enQueueId;
     }
 

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReference.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReference.java
@@ -1,0 +1,48 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.queue.rabbitmq;
+
+import org.apache.james.blob.mail.MimeMessagePartsId;
+import org.apache.mailet.Mail;
+
+public class MailReference {
+
+    private final EnQueueId enQueueId;
+    private final Mail mail;
+    private final MimeMessagePartsId partsId;
+
+    public MailReference(EnQueueId enQueueId, Mail mail, MimeMessagePartsId partsId) {
+        this.enQueueId = enQueueId;
+        this.mail = mail;
+        this.partsId = partsId;
+    }
+
+    public EnQueueId getEnQueueId() {
+        return enQueueId;
+    }
+
+    public Mail getMail() {
+        return mail;
+    }
+
+    public MimeMessagePartsId getPartsId() {
+        return partsId;
+    }
+}

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReference.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReference.java
@@ -24,18 +24,18 @@ import org.apache.mailet.Mail;
 
 public class MailReference {
 
-    private final EnqueueId enQueueId;
+    private final EnqueueId enqueueId;
     private final Mail mail;
     private final MimeMessagePartsId partsId;
 
-    public MailReference(EnqueueId enQueueId, Mail mail, MimeMessagePartsId partsId) {
-        this.enQueueId = enQueueId;
+    public MailReference(EnqueueId enqueueId, Mail mail, MimeMessagePartsId partsId) {
+        this.enqueueId = enqueueId;
         this.mail = mail;
         this.partsId = partsId;
     }
 
-    public EnqueueId getEnQueueId() {
-        return enQueueId;
+    public EnqueueId getEnqueueId() {
+        return enqueueId;
     }
 
     public Mail getMail() {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReferenceDTO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReferenceDTO.java
@@ -199,8 +199,8 @@ class MailReferenceDTO {
         return bodyBlobId;
     }
 
-    EnQueueId retrieveEnqueueId() {
-        return EnQueueId.ofSerialized(enQueueId);
+    EnqueueId retrieveEnqueueId() {
+        return EnqueueId.ofSerialized(enQueueId);
     }
 
     MailReference toMailReference(BlobId.Factory blobIdFactory) {
@@ -209,7 +209,7 @@ class MailReferenceDTO {
             .bodyBlobId(blobIdFactory.from(bodyBlobId))
             .build();
 
-        return new MailReference(EnQueueId.ofSerialized(enQueueId), mailMetadata(), messagePartsId);
+        return new MailReference(EnqueueId.ofSerialized(enQueueId), mailMetadata(), messagePartsId);
     }
 
     private MailImpl mailMetadata() {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReferenceDTO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReferenceDTO.java
@@ -199,10 +199,6 @@ class MailReferenceDTO {
         return bodyBlobId;
     }
 
-    EnqueueId retrieveEnqueueId() {
-        return EnqueueId.ofSerialized(enQueueId);
-    }
-
     MailReference toMailReference(BlobId.Factory blobIdFactory) {
         MimeMessagePartsId messagePartsId = MimeMessagePartsId.builder()
             .headerBlobId(blobIdFactory.from(headerBlobId))

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReferenceDTO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailReferenceDTO.java
@@ -55,7 +55,7 @@ class MailReferenceDTO {
         MimeMessagePartsId partsId = mailReference.getPartsId();
 
         return new MailReferenceDTO(
-            mailReference.getEnQueueId().serialize(),
+            mailReference.getEnqueueId().serialize(),
             Optional.ofNullable(mail.getRecipients()).map(Collection::stream)
                 .orElse(Stream.empty())
                 .map(MailAddress::asString)
@@ -91,7 +91,7 @@ class MailReferenceDTO {
                 .collect(Guavate.toImmutableMap(name, value));
     }
 
-    private final String enQueueId;
+    private final String enqueueId;
     private final ImmutableList<String> recipients;
     private final String name;
     private final Optional<String> sender;
@@ -106,7 +106,7 @@ class MailReferenceDTO {
     private final String bodyBlobId;
 
     @JsonCreator
-    private MailReferenceDTO(@JsonProperty("enQueueId") String enQueueId,
+    private MailReferenceDTO(@JsonProperty("enqueueId") String enqueueId,
                              @JsonProperty("recipients") ImmutableList<String> recipients,
                              @JsonProperty("name") String name,
                              @JsonProperty("sender") Optional<String> sender,
@@ -119,7 +119,7 @@ class MailReferenceDTO {
                              @JsonProperty("perRecipientHeaders") Map<String, HeadersDto> perRecipientHeaders,
                              @JsonProperty("headerBlobId") String headerBlobId,
                              @JsonProperty("bodyBlobId") String bodyBlobId) {
-        this.enQueueId = enQueueId;
+        this.enqueueId = enqueueId;
         this.recipients = recipients;
         this.name = name;
         this.sender = sender;
@@ -134,9 +134,9 @@ class MailReferenceDTO {
         this.bodyBlobId = bodyBlobId;
     }
 
-    @JsonProperty("enQueueId")
-    public String getEnQueueId() {
-        return enQueueId;
+    @JsonProperty("enqueueId")
+    public String getEnqueueId() {
+        return enqueueId;
     }
 
     @JsonProperty("recipients")
@@ -205,7 +205,7 @@ class MailReferenceDTO {
             .bodyBlobId(blobIdFactory.from(bodyBlobId))
             .build();
 
-        return new MailReference(EnqueueId.ofSerialized(enQueueId), mailMetadata(), messagePartsId);
+        return new MailReference(EnqueueId.ofSerialized(enqueueId), mailMetadata(), messagePartsId);
     }
 
     private MailImpl mailMetadata() {
@@ -251,7 +251,7 @@ class MailReferenceDTO {
         if (o instanceof MailReferenceDTO) {
             MailReferenceDTO mailDTO = (MailReferenceDTO) o;
 
-            return Objects.equals(this.enQueueId, mailDTO.enQueueId)
+            return Objects.equals(this.enqueueId, mailDTO.enqueueId)
                 && Objects.equals(this.recipients, mailDTO.recipients)
                 && Objects.equals(this.name, mailDTO.name)
                 && Objects.equals(this.sender, mailDTO.sender)
@@ -270,6 +270,6 @@ class MailReferenceDTO {
 
     @Override
     public final int hashCode() {
-        return Objects.hash(enQueueId, recipients, name, sender, state, errorMessage, lastUpdated, attributes, remoteAddr, remoteHost, perRecipientHeaders, headerBlobId, bodyBlobId);
+        return Objects.hash(enqueueId, recipients, name, sender, state, errorMessage, lastUpdated, attributes, remoteAddr, remoteHost, perRecipientHeaders, headerBlobId, bodyBlobId);
     }
 }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailWithEnqueueId.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/MailWithEnqueueId.java
@@ -1,0 +1,40 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.queue.rabbitmq;
+
+import org.apache.mailet.Mail;
+
+public class MailWithEnqueueId {
+    private final EnqueueId enqueueId;
+    private final Mail mail;
+
+    MailWithEnqueueId(EnqueueId enqueueId, Mail mail) {
+        this.enqueueId = enqueueId;
+        this.mail = mail;
+    }
+
+    public EnqueueId getEnqueueId() {
+        return enqueueId;
+    }
+
+    public Mail getMail() {
+        return mail;
+    }
+}

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueFactory.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueFactory.java
@@ -54,7 +54,7 @@ public class RabbitMQMailQueueFactory implements MailQueueFactory<RabbitMQMailQu
         private final RabbitClient rabbitClient;
         private final Store<MimeMessage, MimeMessagePartsId> mimeMessageStore;
         private final MailReferenceSerializer mailReferenceSerializer;
-        private final Function<MailReferenceDTO, Pair<EnQueueId, Mail>> mailLoader;
+        private final Function<MailReferenceDTO, Pair<EnqueueId, Mail>> mailLoader;
         private final MailQueueView.Factory mailQueueViewFactory;
         private final Clock clock;
         private final MailQueueItemDecoratorFactory decoratorFactory;

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueFactory.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueFactory.java
@@ -30,6 +30,7 @@ import java.util.function.Function;
 import javax.inject.Inject;
 import javax.mail.internet.MimeMessage;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.Store;
 import org.apache.james.blob.mail.MimeMessagePartsId;
@@ -53,7 +54,7 @@ public class RabbitMQMailQueueFactory implements MailQueueFactory<RabbitMQMailQu
         private final RabbitClient rabbitClient;
         private final Store<MimeMessage, MimeMessagePartsId> mimeMessageStore;
         private final MailReferenceSerializer mailReferenceSerializer;
-        private final Function<MailReferenceDTO, Mail> mailLoader;
+        private final Function<MailReferenceDTO, Pair<EnQueueId, Mail>> mailLoader;
         private final MailQueueView.Factory mailQueueViewFactory;
         private final Clock clock;
         private final MailQueueItemDecoratorFactory decoratorFactory;

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueFactory.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueFactory.java
@@ -30,7 +30,6 @@ import java.util.function.Function;
 import javax.inject.Inject;
 import javax.mail.internet.MimeMessage;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.Store;
 import org.apache.james.blob.mail.MimeMessagePartsId;
@@ -40,7 +39,6 @@ import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.queue.api.MailQueueFactory;
 import org.apache.james.queue.api.MailQueueItemDecoratorFactory;
 import org.apache.james.queue.rabbitmq.view.api.MailQueueView;
-import org.apache.mailet.Mail;
 
 import com.github.fge.lambdas.Throwing;
 import com.google.common.annotations.VisibleForTesting;
@@ -54,7 +52,7 @@ public class RabbitMQMailQueueFactory implements MailQueueFactory<RabbitMQMailQu
         private final RabbitClient rabbitClient;
         private final Store<MimeMessage, MimeMessagePartsId> mimeMessageStore;
         private final MailReferenceSerializer mailReferenceSerializer;
-        private final Function<MailReferenceDTO, Pair<EnqueueId, Mail>> mailLoader;
+        private final Function<MailReferenceDTO, MailWithEnqueueId> mailLoader;
         private final MailQueueView.Factory mailQueueViewFactory;
         private final Clock clock;
         private final MailQueueItemDecoratorFactory decoratorFactory;

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/DeleteCondition.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/DeleteCondition.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.queue.api.ManageableMailQueue;
-import org.apache.james.queue.rabbitmq.EnQueueId;
+import org.apache.james.queue.rabbitmq.EnqueueId;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
 
 import com.google.common.base.Preconditions;
@@ -113,13 +113,13 @@ public interface DeleteCondition {
     }
 
     class WithEnqueueId implements DeleteCondition {
-        private final EnQueueId enQueueId;
+        private final EnqueueId enQueueId;
 
-        WithEnqueueId(EnQueueId enQueueId) {
+        WithEnqueueId(EnqueueId enQueueId) {
             this.enQueueId = enQueueId;
         }
 
-        public EnQueueId getEnQueueId() {
+        public EnqueueId getEnQueueId() {
             return enQueueId;
         }
 
@@ -191,7 +191,7 @@ public interface DeleteCondition {
         return new WithName(value);
     }
 
-    static WithEnqueueId withEnqueueId(EnQueueId value) {
+    static WithEnqueueId withEnqueueId(EnqueueId value) {
         Preconditions.checkNotNull(value);
         return new WithEnqueueId(value);
     }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/DeleteCondition.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/DeleteCondition.java
@@ -113,20 +113,20 @@ public interface DeleteCondition {
     }
 
     class WithEnqueueId implements DeleteCondition {
-        private final EnqueueId enQueueId;
+        private final EnqueueId enqueueId;
 
-        WithEnqueueId(EnqueueId enQueueId) {
-            this.enQueueId = enQueueId;
+        WithEnqueueId(EnqueueId enqueueId) {
+            this.enqueueId = enqueueId;
         }
 
-        public EnqueueId getEnQueueId() {
-            return enQueueId;
+        public EnqueueId getEnqueueId() {
+            return enqueueId;
         }
 
         @Override
         public boolean shouldBeDeleted(EnqueuedItem enqueuedItem) {
             Preconditions.checkNotNull(enqueuedItem);
-            return enqueuedItem.getEnQueueId().equals(enQueueId);
+            return enqueuedItem.getEnqueueId().equals(enqueueId);
         }
     }
 

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/DeleteCondition.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/DeleteCondition.java
@@ -24,16 +24,16 @@ import java.util.Objects;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.queue.api.ManageableMailQueue;
 import org.apache.james.queue.rabbitmq.EnQueueId;
-import org.apache.mailet.Mail;
+import org.apache.james.queue.rabbitmq.EnqueuedItem;
 
 import com.google.common.base.Preconditions;
 
 public interface DeleteCondition {
-    boolean shouldBeDeleted(Mail mail);
+    boolean shouldBeDeleted(EnqueuedItem mail);
 
     class All implements DeleteCondition {
         @Override
-        public boolean shouldBeDeleted(Mail mail) {
+        public boolean shouldBeDeleted(EnqueuedItem mail) {
             Preconditions.checkNotNull(mail);
             return true;
         }
@@ -57,9 +57,10 @@ public interface DeleteCondition {
         }
 
         @Override
-        public boolean shouldBeDeleted(Mail mail) {
-            Preconditions.checkNotNull(mail);
-            return mail.getMaybeSender()
+        public boolean shouldBeDeleted(EnqueuedItem enqueuedItem) {
+            Preconditions.checkNotNull(enqueuedItem);
+            return enqueuedItem.getMail()
+                .getMaybeSender()
                 .asString()
                 .equals(senderAsString);
         }
@@ -88,9 +89,11 @@ public interface DeleteCondition {
         }
 
         @Override
-        public boolean shouldBeDeleted(Mail mail) {
-            Preconditions.checkNotNull(mail);
-            return mail.getName().equals(name);
+        public boolean shouldBeDeleted(EnqueuedItem enqueuedItem) {
+            Preconditions.checkNotNull(enqueuedItem);
+            return enqueuedItem.getMail()
+                .getName()
+                .equals(name);
         }
 
         @Override
@@ -112,8 +115,7 @@ public interface DeleteCondition {
     class WithEnqueueId implements DeleteCondition {
         private final EnQueueId enQueueId;
 
-
-        public WithEnqueueId(EnQueueId enQueueId) {
+        WithEnqueueId(EnQueueId enQueueId) {
             this.enQueueId = enQueueId;
         }
 
@@ -122,8 +124,9 @@ public interface DeleteCondition {
         }
 
         @Override
-        public boolean shouldBeDeleted(Mail mail) {
-            throw new NotImplementedException("EnQueueId is not carried as a Mail property");
+        public boolean shouldBeDeleted(EnqueuedItem enqueuedItem) {
+            Preconditions.checkNotNull(enqueuedItem);
+            return enqueuedItem.getEnQueueId().equals(enQueueId);
         }
     }
 
@@ -135,9 +138,11 @@ public interface DeleteCondition {
         }
 
         @Override
-        public boolean shouldBeDeleted(Mail mail) {
-            Preconditions.checkNotNull(mail);
-            return mail.getRecipients()
+        public boolean shouldBeDeleted(EnqueuedItem enqueuedItem) {
+            Preconditions.checkNotNull(enqueuedItem);
+            return enqueuedItem
+                .getMail()
+                .getRecipients()
                 .stream()
                 .anyMatch(mailAddress -> mailAddress.asString().equals(recipientAsString));
         }
@@ -184,6 +189,11 @@ public interface DeleteCondition {
     static WithName withName(String value) {
         Preconditions.checkNotNull(value);
         return new WithName(value);
+    }
+
+    static WithEnqueueId withEnqueueId(EnQueueId value) {
+        Preconditions.checkNotNull(value);
+        return new WithEnqueueId(value);
     }
 
     static DeleteCondition all() {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/DeleteCondition.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/DeleteCondition.java
@@ -29,12 +29,12 @@ import org.apache.james.queue.rabbitmq.EnqueuedItem;
 import com.google.common.base.Preconditions;
 
 public interface DeleteCondition {
-    boolean shouldBeDeleted(EnqueuedItem mail);
+    boolean shouldBeDeleted(EnqueuedItem enqueuedItem);
 
     class All implements DeleteCondition {
         @Override
-        public boolean shouldBeDeleted(EnqueuedItem mail) {
-            Preconditions.checkNotNull(mail);
+        public boolean shouldBeDeleted(EnqueuedItem enqueuedItem) {
+            Preconditions.checkNotNull(enqueuedItem);
             return true;
         }
 

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/DeleteCondition.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/DeleteCondition.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.queue.api.ManageableMailQueue;
+import org.apache.james.queue.rabbitmq.EnQueueId;
 import org.apache.mailet.Mail;
 
 import com.google.common.base.Preconditions;
@@ -86,10 +87,6 @@ public interface DeleteCondition {
             this.name = name;
         }
 
-        public String getName() {
-            return name;
-        }
-
         @Override
         public boolean shouldBeDeleted(Mail mail) {
             Preconditions.checkNotNull(mail);
@@ -109,6 +106,24 @@ public interface DeleteCondition {
         @Override
         public final int hashCode() {
             return Objects.hashCode(name);
+        }
+    }
+
+    class WithEnqueueId implements DeleteCondition {
+        private final EnQueueId enQueueId;
+
+
+        public WithEnqueueId(EnQueueId enQueueId) {
+            this.enQueueId = enQueueId;
+        }
+
+        public EnQueueId getEnQueueId() {
+            return enQueueId;
+        }
+
+        @Override
+        public boolean shouldBeDeleted(Mail mail) {
+            throw new NotImplementedException("EnQueueId is not carried as a Mail property");
         }
     }
 

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/MailQueueView.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/MailQueueView.java
@@ -20,7 +20,7 @@
 package org.apache.james.queue.rabbitmq.view.api;
 
 import org.apache.james.queue.api.ManageableMailQueue;
-import org.apache.james.queue.rabbitmq.EnQueueId;
+import org.apache.james.queue.rabbitmq.EnqueueId;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 
@@ -38,7 +38,7 @@ public interface MailQueueView {
 
     long delete(DeleteCondition deleteCondition);
 
-    Mono<Boolean> isPresent(EnQueueId id);
+    Mono<Boolean> isPresent(EnqueueId id);
 
     ManageableMailQueue.MailQueueIterator browse();
 

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/MailQueueView.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/api/MailQueueView.java
@@ -20,9 +20,9 @@
 package org.apache.james.queue.rabbitmq.view.api;
 
 import org.apache.james.queue.api.ManageableMailQueue;
+import org.apache.james.queue.rabbitmq.EnQueueId;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
 import org.apache.james.queue.rabbitmq.MailQueueName;
-import org.apache.mailet.Mail;
 
 import reactor.core.publisher.Mono;
 
@@ -38,7 +38,7 @@ public interface MailQueueView {
 
     long delete(DeleteCondition deleteCondition);
 
-    Mono<Boolean> isPresent(Mail mail);
+    Mono<Boolean> isPresent(EnQueueId id);
 
     ManageableMailQueue.MailQueueIterator browse();
 

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueBrowser.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueBrowser.java
@@ -139,7 +139,7 @@ public class CassandraMailQueueBrowser {
 
     private Flux<EnqueuedItemWithSlicingContext> browseBucket(MailQueueName queueName, Slice slice, BucketId bucketId) {
         return enqueuedMailsDao.selectEnqueuedMails(queueName, slice, bucketId)
-            .filterWhen(mailReference -> deletedMailsDao.isStillEnqueued(queueName, mailReference.getEnqueuedItem().getEnQueueId()));
+            .filterWhen(mailReference -> deletedMailsDao.isStillEnqueued(queueName, mailReference.getEnqueuedItem().getEnqueueId()));
     }
 
     private Flux<Slice> allSlicesStartingAt(Instant browseStart) {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueBrowser.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueBrowser.java
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -138,7 +139,7 @@ public class CassandraMailQueueBrowser {
 
     private Flux<EnqueuedItemWithSlicingContext> browseBucket(MailQueueName queueName, Slice slice, BucketId bucketId) {
         return enqueuedMailsDao.selectEnqueuedMails(queueName, slice, bucketId)
-            .filterWhen(mailReference -> deletedMailsDao.isStillEnqueued(queueName, mailReference.getEnqueuedItem().getMailKey()));
+            .filterWhen(mailReference -> deletedMailsDao.isStillEnqueued(queueName, mailReference.getEnqueuedItem().getEnQueueId()));
     }
 
     private Flux<Slice> allSlicesStartingAt(Instant browseStart) {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailDelete.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailDelete.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import javax.inject.Inject;
 
-import org.apache.james.queue.rabbitmq.EnQueueId;
+import org.apache.james.queue.rabbitmq.EnqueueId;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.CassandraMailQueueViewConfiguration;
 
@@ -49,13 +49,13 @@ public class CassandraMailQueueMailDelete {
         this.configuration = configuration;
     }
 
-    Mono<Void> considerDeleted(EnQueueId enQueueId, MailQueueName mailQueueName) {
+    Mono<Void> considerDeleted(EnqueueId enQueueId, MailQueueName mailQueueName) {
         return deletedMailsDao
             .markAsDeleted(mailQueueName, enQueueId)
             .doOnNext(ignored -> maybeUpdateBrowseStart(mailQueueName));
     }
 
-    Mono<Boolean> isDeleted(EnQueueId enQueueId, MailQueueName mailQueueName) {
+    Mono<Boolean> isDeleted(EnqueueId enQueueId, MailQueueName mailQueueName) {
         return deletedMailsDao.isDeleted(mailQueueName, enQueueId);
     }
 

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailDelete.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailDelete.java
@@ -49,14 +49,14 @@ public class CassandraMailQueueMailDelete {
         this.configuration = configuration;
     }
 
-    Mono<Void> considerDeleted(EnqueueId enQueueId, MailQueueName mailQueueName) {
+    Mono<Void> considerDeleted(EnqueueId enqueueId, MailQueueName mailQueueName) {
         return deletedMailsDao
-            .markAsDeleted(mailQueueName, enQueueId)
+            .markAsDeleted(mailQueueName, enqueueId)
             .doOnNext(ignored -> maybeUpdateBrowseStart(mailQueueName));
     }
 
-    Mono<Boolean> isDeleted(EnqueueId enQueueId, MailQueueName mailQueueName) {
-        return deletedMailsDao.isDeleted(mailQueueName, enQueueId);
+    Mono<Boolean> isDeleted(EnqueueId enqueueId, MailQueueName mailQueueName) {
+        return deletedMailsDao.isDeleted(mailQueueName, enqueueId);
     }
 
     void updateBrowseStart(MailQueueName mailQueueName) {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailDelete.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailDelete.java
@@ -24,10 +24,9 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import javax.inject.Inject;
 
+import org.apache.james.queue.rabbitmq.EnQueueId;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.CassandraMailQueueViewConfiguration;
-import org.apache.james.queue.rabbitmq.view.cassandra.model.MailKey;
-import org.apache.mailet.Mail;
 
 import reactor.core.publisher.Mono;
 
@@ -49,18 +48,14 @@ public class CassandraMailQueueMailDelete {
         this.configuration = configuration;
     }
 
-    Mono<Void> considerDeleted(Mail mail, MailQueueName mailQueueName) {
-        return considerDeleted(MailKey.fromMail(mail), mailQueueName);
-    }
-
-    Mono<Void> considerDeleted(MailKey mailKey, MailQueueName mailQueueName) {
+    Mono<Void> considerDeleted(EnQueueId enQueueId, MailQueueName mailQueueName) {
         return deletedMailsDao
-            .markAsDeleted(mailQueueName, mailKey)
+            .markAsDeleted(mailQueueName, enQueueId)
             .doOnNext(ignored -> maybeUpdateBrowseStart(mailQueueName));
     }
 
-    Mono<Boolean> isDeleted(Mail mail, MailQueueName mailQueueName) {
-        return deletedMailsDao.isDeleted(mailQueueName, MailKey.fromMail(mail));
+    Mono<Boolean> isDeleted(EnQueueId enQueueId, MailQueueName mailQueueName) {
+        return deletedMailsDao.isDeleted(mailQueueName, enQueueId);
     }
 
     void updateBrowseStart(MailQueueName mailQueueName) {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailDelete.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailDelete.java
@@ -29,6 +29,7 @@ import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.CassandraMailQueueViewConfiguration;
 
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 public class CassandraMailQueueMailDelete {
 
@@ -61,7 +62,8 @@ public class CassandraMailQueueMailDelete {
     void updateBrowseStart(MailQueueName mailQueueName) {
         findNewBrowseStart(mailQueueName)
             .flatMap(newBrowseStart -> updateNewBrowseStart(mailQueueName, newBrowseStart))
-            .block();
+            .subscribeOn(Schedulers.elastic())
+            .subscribe();
     }
 
     private void maybeUpdateBrowseStart(MailQueueName mailQueueName) {
@@ -77,7 +79,7 @@ public class CassandraMailQueueMailDelete {
     }
 
     private Mono<Void> updateNewBrowseStart(MailQueueName mailQueueName, Instant newBrowseStartInstant) {
-        return browseStartDao.updateBrowseStart(mailQueueName, newBrowseStartInstant);
+        return browseStartDao.updateBrowseStart(mailQueueName, newBrowseStartInstant).doOnSuccess(any -> System.out.println("updated"));
     }
 
     private boolean shouldUpdateBrowseStart() {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailDelete.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailDelete.java
@@ -79,7 +79,7 @@ public class CassandraMailQueueMailDelete {
     }
 
     private Mono<Void> updateNewBrowseStart(MailQueueName mailQueueName, Instant newBrowseStartInstant) {
-        return browseStartDao.updateBrowseStart(mailQueueName, newBrowseStartInstant).doOnSuccess(any -> System.out.println("updated"));
+        return browseStartDao.updateBrowseStart(mailQueueName, newBrowseStartInstant);
     }
 
     private boolean shouldUpdateBrowseStart() {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
@@ -22,6 +22,7 @@ package org.apache.james.queue.rabbitmq.view.cassandra;
 import javax.inject.Inject;
 
 import org.apache.james.queue.api.ManageableMailQueue;
+import org.apache.james.queue.rabbitmq.EnQueueId;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.api.DeleteCondition;
@@ -29,8 +30,6 @@ import org.apache.james.queue.rabbitmq.view.api.MailQueueView;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.CassandraMailQueueViewConfiguration;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.EventsourcingConfigurationManagement;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.EnqueuedItemWithSlicingContext;
-import org.apache.james.queue.rabbitmq.view.cassandra.model.MailKey;
-import org.apache.mailet.Mail;
 
 import reactor.core.publisher.Mono;
 
@@ -101,9 +100,9 @@ public class CassandraMailQueueView implements MailQueueView {
 
     @Override
     public long delete(DeleteCondition deleteCondition) {
-        if (deleteCondition instanceof DeleteCondition.WithName) {
-            DeleteCondition.WithName nameDeleteCondition = (DeleteCondition.WithName) deleteCondition;
-            delete(MailKey.of(nameDeleteCondition.getName())).block();
+        if (deleteCondition instanceof DeleteCondition.WithEnqueueId) {
+            DeleteCondition.WithEnqueueId enQueueIdCondition = (DeleteCondition.WithEnqueueId) deleteCondition;
+            delete(enQueueIdCondition.getEnQueueId()).block();
             return 1L;
         }
         return browseThenDelete(deleteCondition);
@@ -113,19 +112,19 @@ public class CassandraMailQueueView implements MailQueueView {
         return cassandraMailQueueBrowser.browseReferences(mailQueueName)
             .map(EnqueuedItemWithSlicingContext::getEnqueuedItem)
             .filter(mailReference -> deleteCondition.shouldBeDeleted(mailReference.getMail()))
-            .flatMap(mailReference -> cassandraMailQueueMailDelete.considerDeleted(mailReference.getMail(), mailQueueName))
+            .flatMap(mailReference -> cassandraMailQueueMailDelete.considerDeleted(mailReference.getEnQueueId(), mailQueueName))
             .count()
             .doOnNext(ignored -> cassandraMailQueueMailDelete.updateBrowseStart(mailQueueName))
             .block();
     }
 
-    private Mono<Void> delete(MailKey mailKey) {
-        return cassandraMailQueueMailDelete.considerDeleted(mailKey, mailQueueName);
+    private Mono<Void> delete(EnQueueId enQueueId) {
+        return cassandraMailQueueMailDelete.considerDeleted(enQueueId, mailQueueName);
     }
 
     @Override
-    public Mono<Boolean> isPresent(Mail mail) {
-        return cassandraMailQueueMailDelete.isDeleted(mail, mailQueueName)
+    public Mono<Boolean> isPresent(EnQueueId id) {
+        return cassandraMailQueueMailDelete.isDeleted(id, mailQueueName)
                 .map(bool -> !bool);
     }
 }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
@@ -101,8 +101,8 @@ public class CassandraMailQueueView implements MailQueueView {
     @Override
     public long delete(DeleteCondition deleteCondition) {
         if (deleteCondition instanceof DeleteCondition.WithEnqueueId) {
-            DeleteCondition.WithEnqueueId enQueueIdCondition = (DeleteCondition.WithEnqueueId) deleteCondition;
-            delete(enQueueIdCondition.getEnQueueId()).block();
+            DeleteCondition.WithEnqueueId enqueueIdCondition = (DeleteCondition.WithEnqueueId) deleteCondition;
+            delete(enqueueIdCondition.getEnqueueId()).block();
             return 1L;
         }
         return browseThenDelete(deleteCondition);
@@ -112,14 +112,14 @@ public class CassandraMailQueueView implements MailQueueView {
         return cassandraMailQueueBrowser.browseReferences(mailQueueName)
             .map(EnqueuedItemWithSlicingContext::getEnqueuedItem)
             .filter(deleteCondition::shouldBeDeleted)
-            .flatMap(mailReference -> cassandraMailQueueMailDelete.considerDeleted(mailReference.getEnQueueId(), mailQueueName))
+            .flatMap(mailReference -> cassandraMailQueueMailDelete.considerDeleted(mailReference.getEnqueueId(), mailQueueName))
             .count()
             .doOnNext(ignored -> cassandraMailQueueMailDelete.updateBrowseStart(mailQueueName))
             .block();
     }
 
-    private Mono<Void> delete(EnqueueId enQueueId) {
-        return cassandraMailQueueMailDelete.considerDeleted(enQueueId, mailQueueName);
+    private Mono<Void> delete(EnqueueId enqueueId) {
+        return cassandraMailQueueMailDelete.considerDeleted(enqueueId, mailQueueName);
     }
 
     @Override

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
@@ -111,7 +111,7 @@ public class CassandraMailQueueView implements MailQueueView {
     private long browseThenDelete(DeleteCondition deleteCondition) {
         return cassandraMailQueueBrowser.browseReferences(mailQueueName)
             .map(EnqueuedItemWithSlicingContext::getEnqueuedItem)
-            .filter(mailReference -> deleteCondition.shouldBeDeleted(mailReference.getMail()))
+            .filter(deleteCondition::shouldBeDeleted)
             .flatMap(mailReference -> cassandraMailQueueMailDelete.considerDeleted(mailReference.getEnQueueId(), mailQueueName))
             .count()
             .doOnNext(ignored -> cassandraMailQueueMailDelete.updateBrowseStart(mailQueueName))

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
@@ -22,7 +22,7 @@ package org.apache.james.queue.rabbitmq.view.cassandra;
 import javax.inject.Inject;
 
 import org.apache.james.queue.api.ManageableMailQueue;
-import org.apache.james.queue.rabbitmq.EnQueueId;
+import org.apache.james.queue.rabbitmq.EnqueueId;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.api.DeleteCondition;
@@ -118,12 +118,12 @@ public class CassandraMailQueueView implements MailQueueView {
             .block();
     }
 
-    private Mono<Void> delete(EnQueueId enQueueId) {
+    private Mono<Void> delete(EnqueueId enQueueId) {
         return cassandraMailQueueMailDelete.considerDeleted(enQueueId, mailQueueName);
     }
 
     @Override
-    public Mono<Boolean> isPresent(EnQueueId id) {
+    public Mono<Boolean> isPresent(EnqueueId id) {
         return cassandraMailQueueMailDelete.isDeleted(id, mailQueueName)
                 .map(bool -> !bool);
     }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
@@ -25,7 +25,7 @@ import static com.datastax.driver.core.DataType.list;
 import static com.datastax.driver.core.DataType.map;
 import static com.datastax.driver.core.DataType.text;
 import static com.datastax.driver.core.DataType.timestamp;
-import static com.datastax.driver.core.DataType.timeuuid;
+import static com.datastax.driver.core.DataType.uuid;
 import static com.datastax.driver.core.schemabuilder.SchemaBuilder.frozen;
 
 import org.apache.james.backends.cassandra.components.CassandraModule;
@@ -88,7 +88,7 @@ public interface CassandraMailQueueViewModule {
             .addPartitionKey(EnqueuedMailsTable.QUEUE_NAME, text())
             .addPartitionKey(EnqueuedMailsTable.TIME_RANGE_START, timestamp())
             .addPartitionKey(EnqueuedMailsTable.BUCKET_ID, cint())
-            .addClusteringColumn(EnqueuedMailsTable.ENQUEUE_ID, timeuuid())
+            .addClusteringColumn(EnqueuedMailsTable.ENQUEUE_ID, uuid())
             .addColumn(EnqueuedMailsTable.ENQUEUED_TIME, timestamp())
             .addColumn(EnqueuedMailsTable.NAME, text())
             .addColumn(EnqueuedMailsTable.STATE, text())
@@ -118,7 +118,7 @@ public interface CassandraMailQueueViewModule {
         .options(options -> options)
         .statement(statement -> statement
             .addPartitionKey(DeletedMailTable.QUEUE_NAME, text())
-            .addPartitionKey(DeletedMailTable.ENQUEUE_ID, timeuuid()))
+            .addPartitionKey(DeletedMailTable.ENQUEUE_ID, uuid()))
 
         .build();
 }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
@@ -25,6 +25,7 @@ import static com.datastax.driver.core.DataType.list;
 import static com.datastax.driver.core.DataType.map;
 import static com.datastax.driver.core.DataType.text;
 import static com.datastax.driver.core.DataType.timestamp;
+import static com.datastax.driver.core.DataType.timeuuid;
 import static com.datastax.driver.core.schemabuilder.SchemaBuilder.frozen;
 
 import org.apache.james.backends.cassandra.components.CassandraModule;
@@ -32,14 +33,15 @@ import org.apache.james.backends.cassandra.components.CassandraModule;
 public interface CassandraMailQueueViewModule {
 
     interface EnqueuedMailsTable {
-        String TABLE_NAME = "enqueuedMails";
+        String TABLE_NAME = "enqueuedMailsV2";
 
         String QUEUE_NAME = "queueName";
         String TIME_RANGE_START = "timeRangeStart";
         String BUCKET_ID = "bucketId";
 
         String ENQUEUED_TIME = "enqueuedTime";
-        String MAIL_KEY = "mailKey";
+        String ENQUEUE_ID = "enqueueId";
+        String NAME = "name";
         String HEADER_BLOB_ID = "headerBlobId";
         String BODY_BLOB_ID = "bodyBlobId";
         String STATE = "state";
@@ -65,10 +67,10 @@ public interface CassandraMailQueueViewModule {
     }
 
     interface DeletedMailTable {
-        String TABLE_NAME = "deletedMails";
+        String TABLE_NAME = "deletedMailsV2";
 
         String QUEUE_NAME = "queueName";
-        String MAIL_KEY = "mailKey";
+        String ENQUEUE_ID = "enqueueId";
     }
 
     CassandraModule MODULE = CassandraModule
@@ -86,8 +88,9 @@ public interface CassandraMailQueueViewModule {
             .addPartitionKey(EnqueuedMailsTable.QUEUE_NAME, text())
             .addPartitionKey(EnqueuedMailsTable.TIME_RANGE_START, timestamp())
             .addPartitionKey(EnqueuedMailsTable.BUCKET_ID, cint())
-            .addClusteringColumn(EnqueuedMailsTable.MAIL_KEY, text())
+            .addClusteringColumn(EnqueuedMailsTable.ENQUEUE_ID, timeuuid())
             .addColumn(EnqueuedMailsTable.ENQUEUED_TIME, timestamp())
+            .addColumn(EnqueuedMailsTable.NAME, text())
             .addColumn(EnqueuedMailsTable.STATE, text())
             .addColumn(EnqueuedMailsTable.HEADER_BLOB_ID, text())
             .addColumn(EnqueuedMailsTable.BODY_BLOB_ID, text())
@@ -115,7 +118,7 @@ public interface CassandraMailQueueViewModule {
         .options(options -> options)
         .statement(statement -> statement
             .addPartitionKey(DeletedMailTable.QUEUE_NAME, text())
-            .addPartitionKey(DeletedMailTable.MAIL_KEY, text()))
+            .addPartitionKey(DeletedMailTable.ENQUEUE_ID, timeuuid()))
 
         .build();
 }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAO.java
@@ -64,21 +64,21 @@ public class DeletedMailsDAO {
             .and(eq(ENQUEUE_ID, bindMarker(ENQUEUE_ID))));
     }
 
-    Mono<Void> markAsDeleted(MailQueueName mailQueueName, EnqueueId enQueueId) {
+    Mono<Void> markAsDeleted(MailQueueName mailQueueName, EnqueueId enqueueId) {
         return executor.executeVoid(insertOne.bind()
             .setString(QUEUE_NAME, mailQueueName.asString())
-            .setUUID(ENQUEUE_ID, enQueueId.asUUID()));
+            .setUUID(ENQUEUE_ID, enqueueId.asUUID()));
     }
 
-    Mono<Boolean> isDeleted(MailQueueName mailQueueName, EnqueueId enQueueId) {
+    Mono<Boolean> isDeleted(MailQueueName mailQueueName, EnqueueId enqueueId) {
         return executor.executeReturnExists(
             selectOne.bind()
                 .setString(QUEUE_NAME, mailQueueName.asString())
-                .setUUID(ENQUEUE_ID, enQueueId.asUUID()));
+                .setUUID(ENQUEUE_ID, enqueueId.asUUID()));
     }
 
-    Mono<Boolean> isStillEnqueued(MailQueueName mailQueueName, EnqueueId enQueueId) {
-        return isDeleted(mailQueueName, enQueueId)
+    Mono<Boolean> isStillEnqueued(MailQueueName mailQueueName, EnqueueId enqueueId) {
+        return isDeleted(mailQueueName, enqueueId)
             .map(b -> !b);
     }
 }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAO.java
@@ -30,7 +30,7 @@ import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueV
 import javax.inject.Inject;
 
 import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
-import org.apache.james.queue.rabbitmq.EnQueueId;
+import org.apache.james.queue.rabbitmq.EnqueueId;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 
 import com.datastax.driver.core.PreparedStatement;
@@ -64,20 +64,20 @@ public class DeletedMailsDAO {
             .and(eq(ENQUEUE_ID, bindMarker(ENQUEUE_ID))));
     }
 
-    Mono<Void> markAsDeleted(MailQueueName mailQueueName, EnQueueId enQueueId) {
+    Mono<Void> markAsDeleted(MailQueueName mailQueueName, EnqueueId enQueueId) {
         return executor.executeVoid(insertOne.bind()
             .setString(QUEUE_NAME, mailQueueName.asString())
             .setUUID(ENQUEUE_ID, enQueueId.asUUID()));
     }
 
-    Mono<Boolean> isDeleted(MailQueueName mailQueueName, EnQueueId enQueueId) {
+    Mono<Boolean> isDeleted(MailQueueName mailQueueName, EnqueueId enQueueId) {
         return executor.executeReturnExists(
             selectOne.bind()
                 .setString(QUEUE_NAME, mailQueueName.asString())
                 .setUUID(ENQUEUE_ID, enQueueId.asUUID()));
     }
 
-    Mono<Boolean> isStillEnqueued(MailQueueName mailQueueName, EnQueueId enQueueId) {
+    Mono<Boolean> isStillEnqueued(MailQueueName mailQueueName, EnqueueId enQueueId) {
         return isDeleted(mailQueueName, enQueueId)
             .map(b -> !b);
     }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDAO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDAO.java
@@ -27,10 +27,11 @@ import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueV
 import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.EnqueuedMailsTable.BODY_BLOB_ID;
 import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.EnqueuedMailsTable.BUCKET_ID;
 import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.EnqueuedMailsTable.ENQUEUED_TIME;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.EnqueuedMailsTable.ENQUEUE_ID;
 import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.EnqueuedMailsTable.ERROR_MESSAGE;
 import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.EnqueuedMailsTable.HEADER_BLOB_ID;
 import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.EnqueuedMailsTable.LAST_UPDATED;
-import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.EnqueuedMailsTable.MAIL_KEY;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.EnqueuedMailsTable.NAME;
 import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.EnqueuedMailsTable.PER_RECIPIENT_SPECIFIC_HEADERS;
 import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.EnqueuedMailsTable.QUEUE_NAME;
 import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.EnqueuedMailsTable.RECIPIENTS;
@@ -97,7 +98,8 @@ public class EnqueuedMailsDAO {
             .value(QUEUE_NAME, bindMarker(QUEUE_NAME))
             .value(TIME_RANGE_START, bindMarker(TIME_RANGE_START))
             .value(BUCKET_ID, bindMarker(BUCKET_ID))
-            .value(MAIL_KEY, bindMarker(MAIL_KEY))
+            .value(ENQUEUE_ID, bindMarker(ENQUEUE_ID))
+            .value(NAME, bindMarker(NAME))
             .value(HEADER_BLOB_ID, bindMarker(HEADER_BLOB_ID))
             .value(BODY_BLOB_ID, bindMarker(BODY_BLOB_ID))
             .value(ENQUEUED_TIME, bindMarker(ENQUEUED_TIME))
@@ -123,7 +125,8 @@ public class EnqueuedMailsDAO {
             .setTimestamp(TIME_RANGE_START, Date.from(slicingContext.getTimeRangeStart()))
             .setInt(BUCKET_ID, slicingContext.getBucketId().getValue())
             .setTimestamp(ENQUEUED_TIME, Date.from(enqueuedItem.getEnqueuedTime()))
-            .setString(MAIL_KEY, mail.getName())
+            .setUUID(ENQUEUE_ID, enqueuedItem.getEnQueueId().asUUID())
+            .setString(NAME, mail.getName())
             .setString(HEADER_BLOB_ID, mimeMessagePartsId.getHeaderBlobId().asString())
             .setString(BODY_BLOB_ID, mimeMessagePartsId.getBodyBlobId().asString())
             .setString(STATE, mail.getState())

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDAO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDAO.java
@@ -125,7 +125,7 @@ public class EnqueuedMailsDAO {
             .setTimestamp(TIME_RANGE_START, Date.from(slicingContext.getTimeRangeStart()))
             .setInt(BUCKET_ID, slicingContext.getBucketId().getValue())
             .setTimestamp(ENQUEUED_TIME, Date.from(enqueuedItem.getEnqueuedTime()))
-            .setUUID(ENQUEUE_ID, enqueuedItem.getEnQueueId().asUUID())
+            .setUUID(ENQUEUE_ID, enqueuedItem.getEnqueueId().asUUID())
             .setString(NAME, mail.getName())
             .setString(HEADER_BLOB_ID, mimeMessagePartsId.getHeaderBlobId().asString())
             .setString(BODY_BLOB_ID, mimeMessagePartsId.getBodyBlobId().asString())

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoUtil.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoUtil.java
@@ -81,7 +81,7 @@ public class EnqueuedMailsDaoUtil {
 
     static EnqueuedItemWithSlicingContext toEnqueuedMail(Row row, BlobId.Factory blobFactory) {
         MailQueueName queueName = MailQueueName.fromString(row.getString(QUEUE_NAME));
-        EnqueueId enQueueId = EnqueueId.of(row.getUUID(ENQUEUE_ID));
+        EnqueueId enqueueId = EnqueueId.of(row.getUUID(ENQUEUE_ID));
         Instant timeRangeStart = row.getTimestamp(TIME_RANGE_START).toInstant();
         BucketedSlices.BucketId bucketId = BucketedSlices.BucketId.of(row.getInt(BUCKET_ID));
         Instant enqueuedTime = row.getTimestamp(ENQUEUED_TIME).toInstant();
@@ -122,7 +122,7 @@ public class EnqueuedMailsDaoUtil {
             .addAttributes(toAttributes(rawAttributes))
             .build();
         EnqueuedItem enqueuedItem = EnqueuedItem.builder()
-            .enQueueId(enQueueId)
+            .enqueueId(enqueueId)
             .mailQueueName(queueName)
             .mail(mail)
             .enqueuedTime(enqueuedTime)

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoUtil.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoUtil.java
@@ -58,7 +58,7 @@ import org.apache.james.backends.cassandra.init.CassandraTypesProvider;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.james.core.MailAddress;
-import org.apache.james.queue.rabbitmq.EnQueueId;
+import org.apache.james.queue.rabbitmq.EnqueueId;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices;
@@ -81,7 +81,7 @@ public class EnqueuedMailsDaoUtil {
 
     static EnqueuedItemWithSlicingContext toEnqueuedMail(Row row, BlobId.Factory blobFactory) {
         MailQueueName queueName = MailQueueName.fromString(row.getString(QUEUE_NAME));
-        EnQueueId enQueueId = EnQueueId.of(row.getUUID(ENQUEUE_ID));
+        EnqueueId enQueueId = EnqueueId.of(row.getUUID(ENQUEUE_ID));
         Instant timeRangeStart = row.getTimestamp(TIME_RANGE_START).toInstant();
         BucketedSlices.BucketId bucketId = BucketedSlices.BucketId.of(row.getInt(BUCKET_ID));
         Instant enqueuedTime = row.getTimestamp(ENQUEUED_TIME).toInstant();

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/EnqueuedItemTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/EnqueuedItemTest.java
@@ -59,7 +59,7 @@ class EnqueuedItemTest {
     @Test
     void buildShouldThrowWhenEnqueueIdIsNull() {
         assertThatThrownBy(() -> EnqueuedItem.builder()
-                .enQueueId(null)
+                .enqueueId(null)
                 .mailQueueName(mailQueueName)
                 .mail(mail)
                 .enqueuedTime(enqueuedTime)
@@ -71,7 +71,7 @@ class EnqueuedItemTest {
     @Test
     void buildShouldThrowWhenMailQueueNameIsNull() {
         assertThatThrownBy(() -> EnqueuedItem.builder()
-                .enQueueId(EnqueueId.generate())
+                .enqueueId(EnqueueId.generate())
                 .mailQueueName(null)
                 .mail(mail)
                 .enqueuedTime(enqueuedTime)
@@ -83,7 +83,7 @@ class EnqueuedItemTest {
     @Test
     void buildShouldThrowWhenMailIsNull() {
         assertThatThrownBy(() -> EnqueuedItem.builder()
-                .enQueueId(EnqueueId.generate())
+                .enqueueId(EnqueueId.generate())
                 .mailQueueName(mailQueueName)
                 .mail(null)
                 .enqueuedTime(enqueuedTime)
@@ -95,7 +95,7 @@ class EnqueuedItemTest {
     @Test
     void buildShouldThrowWhenEnqueuedTimeIsNull() {
         assertThatThrownBy(() -> EnqueuedItem.builder()
-                .enQueueId(EnqueueId.generate())
+                .enqueueId(EnqueueId.generate())
                 .mailQueueName(mailQueueName)
                 .mail(mail)
                 .enqueuedTime(null)
@@ -107,7 +107,7 @@ class EnqueuedItemTest {
     @Test
     void buildShouldThrowWhenMimeMessagePartsIdIsNull() {
         assertThatThrownBy(() -> EnqueuedItem.builder()
-                .enQueueId(EnqueueId.generate())
+                .enqueueId(EnqueueId.generate())
                 .mailQueueName(mailQueueName)
                 .mail(mail)
                 .enqueuedTime(enqueuedTime)

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/EnqueuedItemTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/EnqueuedItemTest.java
@@ -71,7 +71,7 @@ class EnqueuedItemTest {
     @Test
     void buildShouldThrowWhenMailQueueNameIsNull() {
         assertThatThrownBy(() -> EnqueuedItem.builder()
-                .enQueueId(EnQueueId.generate())
+                .enQueueId(EnqueueId.generate())
                 .mailQueueName(null)
                 .mail(mail)
                 .enqueuedTime(enqueuedTime)
@@ -83,7 +83,7 @@ class EnqueuedItemTest {
     @Test
     void buildShouldThrowWhenMailIsNull() {
         assertThatThrownBy(() -> EnqueuedItem.builder()
-                .enQueueId(EnQueueId.generate())
+                .enQueueId(EnqueueId.generate())
                 .mailQueueName(mailQueueName)
                 .mail(null)
                 .enqueuedTime(enqueuedTime)
@@ -95,7 +95,7 @@ class EnqueuedItemTest {
     @Test
     void buildShouldThrowWhenEnqueuedTimeIsNull() {
         assertThatThrownBy(() -> EnqueuedItem.builder()
-                .enQueueId(EnQueueId.generate())
+                .enQueueId(EnqueueId.generate())
                 .mailQueueName(mailQueueName)
                 .mail(mail)
                 .enqueuedTime(null)
@@ -107,7 +107,7 @@ class EnqueuedItemTest {
     @Test
     void buildShouldThrowWhenMimeMessagePartsIdIsNull() {
         assertThatThrownBy(() -> EnqueuedItem.builder()
-                .enQueueId(EnQueueId.generate())
+                .enQueueId(EnqueueId.generate())
                 .mailQueueName(mailQueueName)
                 .mail(mail)
                 .enqueuedTime(enqueuedTime)

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/EnqueuedItemTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/EnqueuedItemTest.java
@@ -22,6 +22,7 @@ package org.apache.james.queue.rabbitmq;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Instant;
+
 import javax.mail.MessagingException;
 
 import org.apache.james.blob.api.HashBlobId;
@@ -56,8 +57,21 @@ class EnqueuedItemTest {
     }
 
     @Test
+    void buildShouldThrowWhenEnqueueIdIsNull() {
+        assertThatThrownBy(() -> EnqueuedItem.builder()
+                .enQueueId(null)
+                .mailQueueName(mailQueueName)
+                .mail(mail)
+                .enqueuedTime(enqueuedTime)
+                .mimeMessagePartsId(partsId)
+                .build())
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
     void buildShouldThrowWhenMailQueueNameIsNull() {
         assertThatThrownBy(() -> EnqueuedItem.builder()
+                .enQueueId(EnQueueId.generate())
                 .mailQueueName(null)
                 .mail(mail)
                 .enqueuedTime(enqueuedTime)
@@ -69,6 +83,7 @@ class EnqueuedItemTest {
     @Test
     void buildShouldThrowWhenMailIsNull() {
         assertThatThrownBy(() -> EnqueuedItem.builder()
+                .enQueueId(EnQueueId.generate())
                 .mailQueueName(mailQueueName)
                 .mail(null)
                 .enqueuedTime(enqueuedTime)
@@ -80,6 +95,7 @@ class EnqueuedItemTest {
     @Test
     void buildShouldThrowWhenEnqueuedTimeIsNull() {
         assertThatThrownBy(() -> EnqueuedItem.builder()
+                .enQueueId(EnQueueId.generate())
                 .mailQueueName(mailQueueName)
                 .mail(mail)
                 .enqueuedTime(null)
@@ -91,6 +107,7 @@ class EnqueuedItemTest {
     @Test
     void buildShouldThrowWhenMimeMessagePartsIdIsNull() {
         assertThatThrownBy(() -> EnqueuedItem.builder()
+                .enQueueId(EnQueueId.generate())
                 .mailQueueName(mailQueueName)
                 .mail(mail)
                 .enqueuedTime(enqueuedTime)

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/MailDTOTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/MailDTOTest.java
@@ -46,6 +46,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 class MailDTOTest {
+    static final EnQueueId EN_QUEUE_ID = EnQueueId.ofSerialized("110e8400-e29b-11d4-a716-446655440000");
     static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
     static final Date LAST_UPDATED = Date.from(Instant.parse("2016-09-08T14:25:52.000Z"));
 
@@ -85,6 +86,7 @@ class MailDTOTest {
 
     private MailReferenceDTO mailDTO1() throws MessagingException {
         return MailReferenceDTO.fromMail(
+            EN_QUEUE_ID,
             FakeMail.builder()
                 .name("mail-name-558")
                 .recipients(MailAddressFixture.RECIPIENT1, MailAddressFixture.RECIPIENT2)
@@ -117,6 +119,7 @@ class MailDTOTest {
         mail.setState(null);
         mail.setLastUpdated(null);
         return MailReferenceDTO.fromMail(
+            EN_QUEUE_ID,
             mail,
             MimeMessagePartsId.builder()
                 .headerBlobId(BLOB_ID_FACTORY.from("210e7136-ede3-44eb-9495-3ed816d6e23b"))

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/MailDTOTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/MailDTOTest.java
@@ -85,7 +85,8 @@ class MailDTOTest {
     }
 
     private MailReferenceDTO mailDTO1() throws MessagingException {
-        return MailReferenceDTO.fromMail(
+        return MailReferenceDTO.fromMailReference(
+            new MailReference(
             EN_QUEUE_ID,
             FakeMail.builder()
                 .name("mail-name-558")
@@ -109,21 +110,22 @@ class MailDTOTest {
             MimeMessagePartsId.builder()
                 .headerBlobId(BLOB_ID_FACTORY.from("210e7136-ede3-44eb-9495-3ed816d6e23b"))
                 .bodyBlobId(BLOB_ID_FACTORY.from("ef46c026-7819-4048-b562-3a37469191ed"))
-                .build());
+                .build()));
     }
 
-    private MailReferenceDTO mailDTOMin() throws MessagingException {
+    private MailReferenceDTO mailDTOMin() {
         MailImpl mail = MailImpl.builder()
             .name("mail-name-558")
             .build();
         mail.setState(null);
         mail.setLastUpdated(null);
-        return MailReferenceDTO.fromMail(
-            EN_QUEUE_ID,
-            mail,
-            MimeMessagePartsId.builder()
-                .headerBlobId(BLOB_ID_FACTORY.from("210e7136-ede3-44eb-9495-3ed816d6e23b"))
-                .bodyBlobId(BLOB_ID_FACTORY.from("ef46c026-7819-4048-b562-3a37469191ed"))
-                .build());
+        return MailReferenceDTO.fromMailReference(
+            new MailReference(
+                EN_QUEUE_ID,
+                mail,
+                MimeMessagePartsId.builder()
+                    .headerBlobId(BLOB_ID_FACTORY.from("210e7136-ede3-44eb-9495-3ed816d6e23b"))
+                    .bodyBlobId(BLOB_ID_FACTORY.from("ef46c026-7819-4048-b562-3a37469191ed"))
+                    .build()));
     }
 }

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/MailDTOTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/MailDTOTest.java
@@ -46,7 +46,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 class MailDTOTest {
-    static final EnQueueId EN_QUEUE_ID = EnQueueId.ofSerialized("110e8400-e29b-11d4-a716-446655440000");
+    static final EnqueueId EN_QUEUE_ID = EnqueueId.ofSerialized("110e8400-e29b-11d4-a716-446655440000");
     static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
     static final Date LAST_UPDATED = Date.from(Instant.parse("2016-09-08T14:25:52.000Z"));
 

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
@@ -231,13 +231,6 @@ public class RabbitMQMailQueueTest implements ManageableMailQueueContract, MailQ
 
     }
 
-    @Test
-    @Override
-    @Disabled("JAMES-2794 This test never finishes")
-    public void enQueueShouldAcceptMailWithDuplicatedNames() {
-
-    }
-
     private void enqueueSomeMails(Function<Integer, String> namePattern, int emailCount) {
         IntStream.rangeClosed(1, emailCount)
             .forEach(Throwing.intConsumer(i -> enQueue(defaultMail()

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
@@ -231,6 +231,13 @@ public class RabbitMQMailQueueTest implements ManageableMailQueueContract, MailQ
 
     }
 
+    @Test
+    @Override
+    @Disabled("JAMES-2794 This test never finishes")
+    public void enQueueShouldAcceptMailWithDuplicatedNames() {
+
+    }
+
     private void enqueueSomeMails(Function<Integer, String> namePattern, int emailCount) {
         IntStream.rangeClosed(1, emailCount)
             .forEach(Throwing.intConsumer(i -> enQueue(defaultMail()

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
@@ -231,14 +231,6 @@ public class RabbitMQMailQueueTest implements ManageableMailQueueContract, MailQ
 
     }
 
-    @Disabled("JAMES-2733 Deleted elements are still dequeued")
-    @Test
-    @Override
-    public void deletedElementsShouldNotBeDequeued() {
-
-    }
-
-
     private void enqueueSomeMails(Function<Integer, String> namePattern, int emailCount) {
         IntStream.rangeClosed(1, emailCount)
             .forEach(Throwing.intConsumer(i -> enQueue(defaultMail()

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/api/DeleteConditionTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/api/DeleteConditionTest.java
@@ -42,8 +42,8 @@ class DeleteConditionTest {
     private static final String ADDRESS_2 = "any2@toto.com";
     private static final String NAME = "name";
     private static final String VALUE = "value";
-    private static final EnqueueId EN_QUEUE_ID_1 = EnqueueId.ofSerialized("110e8400-e29b-11d4-a716-446655440000");
-    private static final EnqueueId EN_QUEUE_ID_2 = EnqueueId.ofSerialized("464765a0-e4e7-11e4-aba4-710c1de3782b");
+    private static final EnqueueId ENQUEUE_ID_1 = EnqueueId.ofSerialized("110e8400-e29b-11d4-a716-446655440000");
+    private static final EnqueueId ENQUEUE_ID_2 = EnqueueId.ofSerialized("464765a0-e4e7-11e4-aba4-710c1de3782b");
     private static final MailQueueName OUT_GOING_1 = MailQueueName.fromString("OUT_GOING_1");
     private static final Instant ENQUEUE_TIME = Instant.now();
     private static final MimeMessagePartsId MESSAGE_PARTS_ID = MimeMessagePartsId.builder()
@@ -57,7 +57,7 @@ class DeleteConditionTest {
         void allShouldReturnTrue() throws Exception {
             assertThat(
                 DeleteCondition.all()
-                    .shouldBeDeleted(enQueueItemForMail(FakeMail.builder().name("name").build())))
+                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder().name("name").build())))
                 .isTrue();
         }
 
@@ -87,7 +87,7 @@ class DeleteConditionTest {
         @Test
         void shouldBeDeletedShouldReturnTrueWhenSameId() throws Exception {
             EnqueuedItem enqueuedItem = EnqueuedItem.builder()
-                .enQueueId(EN_QUEUE_ID_1)
+                .enqueueId(ENQUEUE_ID_1)
                 .mailQueueName(OUT_GOING_1)
                 .mail(FakeMail.builder()
                     .name("name")
@@ -97,14 +97,14 @@ class DeleteConditionTest {
                 .mimeMessagePartsId(MESSAGE_PARTS_ID)
                 .build();
 
-            assertThat(DeleteCondition.withEnqueueId(EN_QUEUE_ID_1).shouldBeDeleted(enqueuedItem))
+            assertThat(DeleteCondition.withEnqueueId(ENQUEUE_ID_1).shouldBeDeleted(enqueuedItem))
                 .isTrue();
         }
 
         @Test
         void shouldBeDeletedShouldReturnFalseWhenDifferentId() throws Exception {
             EnqueuedItem enqueuedItem = EnqueuedItem.builder()
-                .enQueueId(EN_QUEUE_ID_2)
+                .enqueueId(ENQUEUE_ID_2)
                 .mailQueueName(OUT_GOING_1)
                 .mail(FakeMail.builder()
                     .name("name")
@@ -114,7 +114,7 @@ class DeleteConditionTest {
                 .mimeMessagePartsId(MESSAGE_PARTS_ID)
                 .build();
 
-            assertThat(DeleteCondition.withEnqueueId(EN_QUEUE_ID_1).shouldBeDeleted(enqueuedItem))
+            assertThat(DeleteCondition.withEnqueueId(ENQUEUE_ID_1).shouldBeDeleted(enqueuedItem))
                 .isFalse();
         }
     }
@@ -140,7 +140,7 @@ class DeleteConditionTest {
         void withSenderShouldReturnTrueWhenSameAddress() throws Exception {
             assertThat(
                 DeleteCondition.withSender(ADDRESS)
-                    .shouldBeDeleted(enQueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
                         .name("name")
                         .sender(ADDRESS)
                         .build())))
@@ -151,7 +151,7 @@ class DeleteConditionTest {
         void withSenderShouldReturnFalseWhenDifferentAddress() throws Exception {
             assertThat(
                 DeleteCondition.withSender(ADDRESS)
-                    .shouldBeDeleted(enQueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
                         .name("name")
                         .sender(ADDRESS_2)
                         .recipient(ADDRESS)
@@ -163,7 +163,7 @@ class DeleteConditionTest {
         void withSenderShouldNotThrowOnNullSender() throws Exception {
             assertThat(
                 DeleteCondition.withSender(ADDRESS)
-                    .shouldBeDeleted(enQueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
                         .name("name")
                         .sender(MailAddress.nullSender())
                         .build())))
@@ -174,7 +174,7 @@ class DeleteConditionTest {
         void withSenderShouldAllowNullSenderMatchingNullSender() throws Exception {
             assertThat(
                 DeleteCondition.withSender(MailAddress.NULL_SENDER_AS_STRING)
-                    .shouldBeDeleted(enQueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
                         .name("name")
                         .sender(MailAddress.nullSender())
                         .build())))
@@ -208,7 +208,7 @@ class DeleteConditionTest {
         void withNameShouldReturnTrueWhenSameName() throws Exception {
             assertThat(
                 DeleteCondition.withName(NAME)
-                    .shouldBeDeleted(enQueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
                         .name(NAME)
                         .build())))
                 .isTrue();
@@ -218,7 +218,7 @@ class DeleteConditionTest {
         void withSenderShouldReturnFalseWhenDifferentAddress() throws Exception {
             assertThat(
                 DeleteCondition.withName(NAME)
-                    .shouldBeDeleted(enQueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
                         .name("other")
                         .build())))
                 .isFalse();
@@ -251,7 +251,7 @@ class DeleteConditionTest {
         void withRecipientShouldReturnTrueWhenSameAddress() throws Exception {
             assertThat(
                 DeleteCondition.withRecipient(ADDRESS)
-                    .shouldBeDeleted(enQueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
                         .name("name")
                         .recipient(ADDRESS)
                         .build())))
@@ -262,7 +262,7 @@ class DeleteConditionTest {
         void withRecipientShouldReturnTrueWhenAtListOneMatches() throws Exception {
             assertThat(
                 DeleteCondition.withRecipient(ADDRESS)
-                    .shouldBeDeleted(enQueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
                         .name("name")
                         .recipients(ADDRESS, ADDRESS_2)
                         .build())))
@@ -273,7 +273,7 @@ class DeleteConditionTest {
         void withRecipientShouldReturnFalseWhenDifferentAddress() throws Exception {
             assertThat(
                 DeleteCondition.withRecipient(ADDRESS)
-                    .shouldBeDeleted(enQueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
                         .name("name")
                         .sender(ADDRESS)
                         .recipient(ADDRESS_2)
@@ -285,7 +285,7 @@ class DeleteConditionTest {
         void withRecipientShouldReturnFalseWhenNoRecipient() throws Exception {
             assertThat(
                 DeleteCondition.withRecipient(ADDRESS)
-                    .shouldBeDeleted(enQueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
                         .name("name")
                         .build())))
                 .isFalse();
@@ -318,9 +318,9 @@ class DeleteConditionTest {
         }
     }
 
-    private EnqueuedItem enQueueItemForMail(FakeMail mail) {
+    private EnqueuedItem enqueueItemForMail(FakeMail mail) {
         return EnqueuedItem.builder()
-            .enQueueId(EN_QUEUE_ID_1)
+            .enqueueId(ENQUEUE_ID_1)
             .mailQueueName(OUT_GOING_1)
             .mail(mail)
             .enqueuedTime(ENQUEUE_TIME)

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/api/DeleteConditionTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/api/DeleteConditionTest.java
@@ -57,7 +57,7 @@ class DeleteConditionTest {
         void allShouldReturnTrue() throws Exception {
             assertThat(
                 DeleteCondition.all()
-                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder().name("name").build())))
+                    .shouldBeDeleted(enqueuedItemForMail(FakeMail.builder().name("name").build())))
                 .isTrue();
         }
 
@@ -140,7 +140,7 @@ class DeleteConditionTest {
         void withSenderShouldReturnTrueWhenSameAddress() throws Exception {
             assertThat(
                 DeleteCondition.withSender(ADDRESS)
-                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueuedItemForMail(FakeMail.builder()
                         .name("name")
                         .sender(ADDRESS)
                         .build())))
@@ -151,7 +151,7 @@ class DeleteConditionTest {
         void withSenderShouldReturnFalseWhenDifferentAddress() throws Exception {
             assertThat(
                 DeleteCondition.withSender(ADDRESS)
-                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueuedItemForMail(FakeMail.builder()
                         .name("name")
                         .sender(ADDRESS_2)
                         .recipient(ADDRESS)
@@ -163,7 +163,7 @@ class DeleteConditionTest {
         void withSenderShouldNotThrowOnNullSender() throws Exception {
             assertThat(
                 DeleteCondition.withSender(ADDRESS)
-                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueuedItemForMail(FakeMail.builder()
                         .name("name")
                         .sender(MailAddress.nullSender())
                         .build())))
@@ -174,7 +174,7 @@ class DeleteConditionTest {
         void withSenderShouldAllowNullSenderMatchingNullSender() throws Exception {
             assertThat(
                 DeleteCondition.withSender(MailAddress.NULL_SENDER_AS_STRING)
-                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueuedItemForMail(FakeMail.builder()
                         .name("name")
                         .sender(MailAddress.nullSender())
                         .build())))
@@ -208,7 +208,7 @@ class DeleteConditionTest {
         void withNameShouldReturnTrueWhenSameName() throws Exception {
             assertThat(
                 DeleteCondition.withName(NAME)
-                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueuedItemForMail(FakeMail.builder()
                         .name(NAME)
                         .build())))
                 .isTrue();
@@ -218,7 +218,7 @@ class DeleteConditionTest {
         void withSenderShouldReturnFalseWhenDifferentAddress() throws Exception {
             assertThat(
                 DeleteCondition.withName(NAME)
-                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueuedItemForMail(FakeMail.builder()
                         .name("other")
                         .build())))
                 .isFalse();
@@ -251,7 +251,7 @@ class DeleteConditionTest {
         void withRecipientShouldReturnTrueWhenSameAddress() throws Exception {
             assertThat(
                 DeleteCondition.withRecipient(ADDRESS)
-                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueuedItemForMail(FakeMail.builder()
                         .name("name")
                         .recipient(ADDRESS)
                         .build())))
@@ -262,7 +262,7 @@ class DeleteConditionTest {
         void withRecipientShouldReturnTrueWhenAtListOneMatches() throws Exception {
             assertThat(
                 DeleteCondition.withRecipient(ADDRESS)
-                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueuedItemForMail(FakeMail.builder()
                         .name("name")
                         .recipients(ADDRESS, ADDRESS_2)
                         .build())))
@@ -273,7 +273,7 @@ class DeleteConditionTest {
         void withRecipientShouldReturnFalseWhenDifferentAddress() throws Exception {
             assertThat(
                 DeleteCondition.withRecipient(ADDRESS)
-                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueuedItemForMail(FakeMail.builder()
                         .name("name")
                         .sender(ADDRESS)
                         .recipient(ADDRESS_2)
@@ -285,7 +285,7 @@ class DeleteConditionTest {
         void withRecipientShouldReturnFalseWhenNoRecipient() throws Exception {
             assertThat(
                 DeleteCondition.withRecipient(ADDRESS)
-                    .shouldBeDeleted(enqueueItemForMail(FakeMail.builder()
+                    .shouldBeDeleted(enqueuedItemForMail(FakeMail.builder()
                         .name("name")
                         .build())))
                 .isFalse();
@@ -318,7 +318,7 @@ class DeleteConditionTest {
         }
     }
 
-    private EnqueuedItem enqueueItemForMail(FakeMail mail) {
+    private EnqueuedItem enqueuedItemForMail(FakeMail mail) {
         return EnqueuedItem.builder()
             .enqueueId(ENQUEUE_ID_1)
             .mailQueueName(OUT_GOING_1)

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/api/DeleteConditionTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/api/DeleteConditionTest.java
@@ -28,7 +28,7 @@ import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.mail.MimeMessagePartsId;
 import org.apache.james.core.MailAddress;
 import org.apache.james.queue.api.ManageableMailQueue;
-import org.apache.james.queue.rabbitmq.EnQueueId;
+import org.apache.james.queue.rabbitmq.EnqueueId;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.mailet.base.test.FakeMail;
@@ -42,8 +42,8 @@ class DeleteConditionTest {
     private static final String ADDRESS_2 = "any2@toto.com";
     private static final String NAME = "name";
     private static final String VALUE = "value";
-    private static final EnQueueId EN_QUEUE_ID_1 = EnQueueId.ofSerialized("110e8400-e29b-11d4-a716-446655440000");
-    private static final EnQueueId EN_QUEUE_ID_2 = EnQueueId.ofSerialized("464765a0-e4e7-11e4-aba4-710c1de3782b");
+    private static final EnqueueId EN_QUEUE_ID_1 = EnqueueId.ofSerialized("110e8400-e29b-11d4-a716-446655440000");
+    private static final EnqueueId EN_QUEUE_ID_2 = EnqueueId.ofSerialized("464765a0-e4e7-11e4-aba4-710c1de3782b");
     private static final MailQueueName OUT_GOING_1 = MailQueueName.fromString("OUT_GOING_1");
     private static final Instant ENQUEUE_TIME = Instant.now();
     private static final MimeMessagePartsId MESSAGE_PARTS_ID = MimeMessagePartsId.builder()
@@ -76,7 +76,7 @@ class DeleteConditionTest {
     }
 
     @Nested
-    class WithEnQueueIdTest {
+    class WithEnqueueIdTest {
         @Test
         void withSenderShouldThrowOnNullCondition() {
             assertThatThrownBy(() ->

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAOTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAOTest.java
@@ -25,7 +25,7 @@ import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
-import org.apache.james.queue.rabbitmq.EnQueueId;
+import org.apache.james.queue.rabbitmq.EnqueueId;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,8 +35,8 @@ class DeletedMailsDAOTest {
 
     private static final MailQueueName OUT_GOING_1 = MailQueueName.fromString("OUT_GOING_1");
     private static final MailQueueName OUT_GOING_2 = MailQueueName.fromString("OUT_GOING_2");
-    private static final EnQueueId EN_QUEUE_ID_1 = EnQueueId.ofSerialized("110e8400-e29b-11d4-a716-446655440000");
-    private static final EnQueueId EN_QUEUE_ID_2 = EnQueueId.ofSerialized("464765a0-e4e7-11e4-aba4-710c1de3782b");
+    private static final EnqueueId ENQUEUE_ID_1 = EnqueueId.ofSerialized("110e8400-e29b-11d4-a716-446655440000");
+    private static final EnqueueId ENQUEUE_ID_2 = EnqueueId.ofSerialized("464765a0-e4e7-11e4-aba4-710c1de3782b");
 
     @RegisterExtension
     static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(
@@ -54,14 +54,14 @@ class DeletedMailsDAOTest {
     @Test
     void markAsDeletedShouldWork() {
         Boolean isDeletedBeforeMark = testee
-                .isDeleted(OUT_GOING_1, EN_QUEUE_ID_1)
+                .isDeleted(OUT_GOING_1, ENQUEUE_ID_1)
                 .block();
         assertThat(isDeletedBeforeMark).isFalse();
 
-        testee.markAsDeleted(OUT_GOING_1, EN_QUEUE_ID_1).block();
+        testee.markAsDeleted(OUT_GOING_1, ENQUEUE_ID_1).block();
 
         Boolean isDeletedAfterMark = testee
-            .isDeleted(OUT_GOING_1, EN_QUEUE_ID_1)
+            .isDeleted(OUT_GOING_1, ENQUEUE_ID_1)
             .block();
 
         assertThat(isDeletedAfterMark).isTrue();
@@ -69,10 +69,10 @@ class DeletedMailsDAOTest {
 
     @Test
     void checkDeletedShouldReturnFalseWhenTableDoesntContainBothMailQueueAndMailKey() {
-        testee.markAsDeleted(OUT_GOING_2, EN_QUEUE_ID_2).block();
+        testee.markAsDeleted(OUT_GOING_2, ENQUEUE_ID_2).block();
 
         Boolean isDeleted = testee
-            .isDeleted(OUT_GOING_1, EN_QUEUE_ID_1)
+            .isDeleted(OUT_GOING_1, ENQUEUE_ID_1)
             .block();
 
         assertThat(isDeleted).isFalse();
@@ -80,10 +80,10 @@ class DeletedMailsDAOTest {
 
     @Test
     void checkDeletedShouldReturnFalseWhenTableContainsMailQueueButNotMailKey() {
-        testee.markAsDeleted(OUT_GOING_1, EN_QUEUE_ID_2).block();
+        testee.markAsDeleted(OUT_GOING_1, ENQUEUE_ID_2).block();
 
         Boolean isDeleted = testee
-            .isDeleted(OUT_GOING_1, EN_QUEUE_ID_1)
+            .isDeleted(OUT_GOING_1, ENQUEUE_ID_1)
             .block();
 
         assertThat(isDeleted).isFalse();
@@ -91,10 +91,10 @@ class DeletedMailsDAOTest {
 
     @Test
     void checkDeletedShouldReturnFalseWhenTableContainsMailKeyButNotMailQueue() {
-        testee.markAsDeleted(OUT_GOING_2, EN_QUEUE_ID_1).block();
+        testee.markAsDeleted(OUT_GOING_2, ENQUEUE_ID_1).block();
 
         Boolean isDeleted = testee
-            .isDeleted(OUT_GOING_1, EN_QUEUE_ID_1)
+            .isDeleted(OUT_GOING_1, ENQUEUE_ID_1)
             .block();
 
         assertThat(isDeleted).isFalse();
@@ -102,10 +102,10 @@ class DeletedMailsDAOTest {
 
     @Test
     void checkDeletedShouldReturnTrueWhenTableContainsMailItem() {
-        testee.markAsDeleted(OUT_GOING_1, EN_QUEUE_ID_1).block();
+        testee.markAsDeleted(OUT_GOING_1, ENQUEUE_ID_1).block();
 
         Boolean isDeleted = testee
-            .isDeleted(OUT_GOING_1, EN_QUEUE_ID_1)
+            .isDeleted(OUT_GOING_1, ENQUEUE_ID_1)
             .block();
 
         assertThat(isDeleted).isTrue();

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoTest.java
@@ -30,12 +30,12 @@ import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.mail.MimeMessagePartsId;
+import org.apache.james.queue.rabbitmq.EnQueueId;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices.BucketId;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices.Slice;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.EnqueuedItemWithSlicingContext;
-import org.apache.james.queue.rabbitmq.view.cassandra.model.MailKey;
 import org.apache.mailet.base.test.FakeMail;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,7 +44,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class EnqueuedMailsDaoTest {
 
     private static final MailQueueName OUT_GOING_1 = MailQueueName.fromString("OUT_GOING_1");
-    private static final MailKey MAIL_KEY_1 = MailKey.of("mailkey1");
+    private static final EnQueueId EN_QUEUE_ID = EnQueueId.ofSerialized("110e8400-e29b-11d4-a716-446655440000");
+    private static final String NAME = "name";
     private static int BUCKET_ID_VALUE = 10;
     private static final BucketId BUCKET_ID = BucketId.of(BUCKET_ID_VALUE);
     private static final Instant NOW = Instant.now();
@@ -75,9 +76,10 @@ class EnqueuedMailsDaoTest {
     void insertShouldWork() throws Exception {
         testee.insert(EnqueuedItemWithSlicingContext.builder()
                 .enqueuedItem(EnqueuedItem.builder()
+                    .enQueueId(EN_QUEUE_ID)
                     .mailQueueName(OUT_GOING_1)
                     .mail(FakeMail.builder()
-                        .name(MAIL_KEY_1.getMailKey())
+                        .name(NAME)
                         .build())
                     .enqueuedTime(NOW)
                     .mimeMessagePartsId(MIME_MESSAGE_PARTS_ID)
@@ -97,9 +99,10 @@ class EnqueuedMailsDaoTest {
     void selectEnqueuedMailsShouldWork() throws Exception {
         testee.insert(EnqueuedItemWithSlicingContext.builder()
                 .enqueuedItem(EnqueuedItem.builder()
+                    .enQueueId(EN_QUEUE_ID)
                     .mailQueueName(OUT_GOING_1)
                     .mail(FakeMail.builder()
-                        .name(MAIL_KEY_1.getMailKey())
+                        .name(NAME)
                         .build())
                     .enqueuedTime(NOW)
                     .mimeMessagePartsId(MIME_MESSAGE_PARTS_ID)
@@ -110,9 +113,10 @@ class EnqueuedMailsDaoTest {
 
         testee.insert(EnqueuedItemWithSlicingContext.builder()
                 .enqueuedItem(EnqueuedItem.builder()
+                    .enQueueId(EN_QUEUE_ID)
                     .mailQueueName(OUT_GOING_1)
                     .mail(FakeMail.builder()
-                        .name(MAIL_KEY_1.getMailKey())
+                        .name(NAME)
                         .build())
                     .enqueuedTime(NOW)
                     .mimeMessagePartsId(MIME_MESSAGE_PARTS_ID)
@@ -134,7 +138,8 @@ class EnqueuedMailsDaoTest {
                     softly.assertThat(slicingContext.getTimeRangeStart()).isEqualTo(NOW);
                     softly.assertThat(enqueuedItem.getMailQueueName()).isEqualTo(OUT_GOING_1);
                     softly.assertThat(enqueuedItem.getEnqueuedTime()).isEqualTo(NOW);
-                    softly.assertThat(enqueuedItem.getMailKey()).isEqualTo(MAIL_KEY_1);
+                    softly.assertThat(enqueuedItem.getEnQueueId()).isEqualTo(EN_QUEUE_ID);
+                    softly.assertThat(enqueuedItem.getMail().getName()).isEqualTo(NAME);
                     softly.assertThat(enqueuedItem.getPartsId()).isEqualTo(MIME_MESSAGE_PARTS_ID);
                 });
             });

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoTest.java
@@ -30,7 +30,7 @@ import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.mail.MimeMessagePartsId;
-import org.apache.james.queue.rabbitmq.EnQueueId;
+import org.apache.james.queue.rabbitmq.EnqueueId;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices.BucketId;
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class EnqueuedMailsDaoTest {
 
     private static final MailQueueName OUT_GOING_1 = MailQueueName.fromString("OUT_GOING_1");
-    private static final EnQueueId EN_QUEUE_ID = EnQueueId.ofSerialized("110e8400-e29b-11d4-a716-446655440000");
+    private static final EnqueueId ENQUEUE_ID = EnqueueId.ofSerialized("110e8400-e29b-11d4-a716-446655440000");
     private static final String NAME = "name";
     private static int BUCKET_ID_VALUE = 10;
     private static final BucketId BUCKET_ID = BucketId.of(BUCKET_ID_VALUE);
@@ -76,7 +76,7 @@ class EnqueuedMailsDaoTest {
     void insertShouldWork() throws Exception {
         testee.insert(EnqueuedItemWithSlicingContext.builder()
                 .enqueuedItem(EnqueuedItem.builder()
-                    .enQueueId(EN_QUEUE_ID)
+                    .enQueueId(ENQUEUE_ID)
                     .mailQueueName(OUT_GOING_1)
                     .mail(FakeMail.builder()
                         .name(NAME)
@@ -99,7 +99,7 @@ class EnqueuedMailsDaoTest {
     void selectEnqueuedMailsShouldWork() throws Exception {
         testee.insert(EnqueuedItemWithSlicingContext.builder()
                 .enqueuedItem(EnqueuedItem.builder()
-                    .enQueueId(EN_QUEUE_ID)
+                    .enQueueId(ENQUEUE_ID)
                     .mailQueueName(OUT_GOING_1)
                     .mail(FakeMail.builder()
                         .name(NAME)
@@ -113,7 +113,7 @@ class EnqueuedMailsDaoTest {
 
         testee.insert(EnqueuedItemWithSlicingContext.builder()
                 .enqueuedItem(EnqueuedItem.builder()
-                    .enQueueId(EN_QUEUE_ID)
+                    .enQueueId(ENQUEUE_ID)
                     .mailQueueName(OUT_GOING_1)
                     .mail(FakeMail.builder()
                         .name(NAME)
@@ -138,7 +138,7 @@ class EnqueuedMailsDaoTest {
                     softly.assertThat(slicingContext.getTimeRangeStart()).isEqualTo(NOW);
                     softly.assertThat(enqueuedItem.getMailQueueName()).isEqualTo(OUT_GOING_1);
                     softly.assertThat(enqueuedItem.getEnqueuedTime()).isEqualTo(NOW);
-                    softly.assertThat(enqueuedItem.getEnQueueId()).isEqualTo(EN_QUEUE_ID);
+                    softly.assertThat(enqueuedItem.getEnQueueId()).isEqualTo(ENQUEUE_ID);
                     softly.assertThat(enqueuedItem.getMail().getName()).isEqualTo(NAME);
                     softly.assertThat(enqueuedItem.getPartsId()).isEqualTo(MIME_MESSAGE_PARTS_ID);
                 });

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoTest.java
@@ -76,7 +76,7 @@ class EnqueuedMailsDaoTest {
     void insertShouldWork() throws Exception {
         testee.insert(EnqueuedItemWithSlicingContext.builder()
                 .enqueuedItem(EnqueuedItem.builder()
-                    .enQueueId(ENQUEUE_ID)
+                    .enqueueId(ENQUEUE_ID)
                     .mailQueueName(OUT_GOING_1)
                     .mail(FakeMail.builder()
                         .name(NAME)
@@ -99,7 +99,7 @@ class EnqueuedMailsDaoTest {
     void selectEnqueuedMailsShouldWork() throws Exception {
         testee.insert(EnqueuedItemWithSlicingContext.builder()
                 .enqueuedItem(EnqueuedItem.builder()
-                    .enQueueId(ENQUEUE_ID)
+                    .enqueueId(ENQUEUE_ID)
                     .mailQueueName(OUT_GOING_1)
                     .mail(FakeMail.builder()
                         .name(NAME)
@@ -113,7 +113,7 @@ class EnqueuedMailsDaoTest {
 
         testee.insert(EnqueuedItemWithSlicingContext.builder()
                 .enqueuedItem(EnqueuedItem.builder()
-                    .enQueueId(ENQUEUE_ID)
+                    .enqueueId(ENQUEUE_ID)
                     .mailQueueName(OUT_GOING_1)
                     .mail(FakeMail.builder()
                         .name(NAME)
@@ -138,7 +138,7 @@ class EnqueuedMailsDaoTest {
                     softly.assertThat(slicingContext.getTimeRangeStart()).isEqualTo(NOW);
                     softly.assertThat(enqueuedItem.getMailQueueName()).isEqualTo(OUT_GOING_1);
                     softly.assertThat(enqueuedItem.getEnqueuedTime()).isEqualTo(NOW);
-                    softly.assertThat(enqueuedItem.getEnQueueId()).isEqualTo(ENQUEUE_ID);
+                    softly.assertThat(enqueuedItem.getEnqueueId()).isEqualTo(ENQUEUE_ID);
                     softly.assertThat(enqueuedItem.getMail().getName()).isEqualTo(NAME);
                     softly.assertThat(enqueuedItem.getPartsId()).isEqualTo(MIME_MESSAGE_PARTS_ID);
                 });

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/model/EnQueueIdTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/model/EnQueueIdTest.java
@@ -19,15 +19,43 @@
 
 package org.apache.james.queue.rabbitmq.view.cassandra.model;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import org.apache.james.queue.rabbitmq.EnQueueId;
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-class MailKeyTest {
+class EnQueueIdTest {
+    private static final UUID UUID_1 = UUID.fromString("110e8400-e29b-11d4-a716-446655440000");
 
     @Test
     void shouldMatchBeanContract() {
-        EqualsVerifier.forClass(MailKey.class)
+        EqualsVerifier.forClass(EnQueueId.class)
             .verify();
+    }
+
+    @Test
+    void ofSerializedShouldDeserializeTheGivenEnqueueId() {
+        assertThat(EnQueueId.ofSerialized(UUID_1.toString()))
+            .isEqualTo(EnQueueId.of(UUID_1));
+    }
+
+    @Test
+    void serializeShouldReturnAStringRepresentation() {
+        EnQueueId enQueueId = EnQueueId.of(UUID_1);
+
+        assertThat(enQueueId.serialize())
+            .isEqualTo(UUID_1.toString());
+    }
+
+    @Test
+    void ofSerializedShouldRevertSerialize() {
+        EnQueueId enQueueId = EnQueueId.of(UUID_1);
+
+        assertThat(EnQueueId.ofSerialized(enQueueId.serialize()))
+            .isEqualTo(enQueueId);
     }
 }

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/model/EnqueueIdTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/model/EnqueueIdTest.java
@@ -45,17 +45,17 @@ class EnqueueIdTest {
 
     @Test
     void serializeShouldReturnAStringRepresentation() {
-        EnqueueId enQueueId = EnqueueId.of(UUID_1);
+        EnqueueId enqueueId = EnqueueId.of(UUID_1);
 
-        assertThat(enQueueId.serialize())
+        assertThat(enqueueId.serialize())
             .isEqualTo(UUID_1.toString());
     }
 
     @Test
     void ofSerializedShouldRevertSerialize() {
-        EnqueueId enQueueId = EnqueueId.of(UUID_1);
+        EnqueueId enqueueId = EnqueueId.of(UUID_1);
 
-        assertThat(EnqueueId.ofSerialized(enQueueId.serialize()))
-            .isEqualTo(enQueueId);
+        assertThat(EnqueueId.ofSerialized(enqueueId.serialize()))
+            .isEqualTo(enqueueId);
     }
 }

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/model/EnqueueIdTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/model/EnqueueIdTest.java
@@ -23,29 +23,29 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.UUID;
 
-import org.apache.james.queue.rabbitmq.EnQueueId;
+import org.apache.james.queue.rabbitmq.EnqueueId;
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-class EnQueueIdTest {
+class EnqueueIdTest {
     private static final UUID UUID_1 = UUID.fromString("110e8400-e29b-11d4-a716-446655440000");
 
     @Test
     void shouldMatchBeanContract() {
-        EqualsVerifier.forClass(EnQueueId.class)
+        EqualsVerifier.forClass(EnqueueId.class)
             .verify();
     }
 
     @Test
     void ofSerializedShouldDeserializeTheGivenEnqueueId() {
-        assertThat(EnQueueId.ofSerialized(UUID_1.toString()))
-            .isEqualTo(EnQueueId.of(UUID_1));
+        assertThat(EnqueueId.ofSerialized(UUID_1.toString()))
+            .isEqualTo(EnqueueId.of(UUID_1));
     }
 
     @Test
     void serializeShouldReturnAStringRepresentation() {
-        EnQueueId enQueueId = EnQueueId.of(UUID_1);
+        EnqueueId enQueueId = EnqueueId.of(UUID_1);
 
         assertThat(enQueueId.serialize())
             .isEqualTo(UUID_1.toString());
@@ -53,9 +53,9 @@ class EnQueueIdTest {
 
     @Test
     void ofSerializedShouldRevertSerialize() {
-        EnQueueId enQueueId = EnQueueId.of(UUID_1);
+        EnqueueId enQueueId = EnqueueId.of(UUID_1);
 
-        assertThat(EnQueueId.ofSerialized(enQueueId.serialize()))
+        assertThat(EnqueueId.ofSerialized(enQueueId.serialize()))
             .isEqualTo(enQueueId);
     }
 }

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/model/EnqueuedItemWithSlicingContextTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/model/EnqueuedItemWithSlicingContextTest.java
@@ -27,7 +27,7 @@ import javax.mail.MessagingException;
 
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.mail.MimeMessagePartsId;
-import org.apache.james.queue.rabbitmq.EnQueueId;
+import org.apache.james.queue.rabbitmq.EnqueueId;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.mailet.base.test.FakeMail;
@@ -42,7 +42,7 @@ class EnqueuedItemWithSlicingContextTest {
 
     private EnqueuedItemWithSlicingContextTest() throws MessagingException {
         enqueuedItem = EnqueuedItem.builder()
-            .enQueueId(EnQueueId.generate())
+            .enQueueId(EnqueueId.generate())
             .mailQueueName(MailQueueName.fromString("mailQueueName"))
                 .mail(FakeMail.builder()
                         .name("name")

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/model/EnqueuedItemWithSlicingContextTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/model/EnqueuedItemWithSlicingContextTest.java
@@ -42,7 +42,7 @@ class EnqueuedItemWithSlicingContextTest {
 
     private EnqueuedItemWithSlicingContextTest() throws MessagingException {
         enqueuedItem = EnqueuedItem.builder()
-            .enQueueId(EnqueueId.generate())
+            .enqueueId(EnqueueId.generate())
             .mailQueueName(MailQueueName.fromString("mailQueueName"))
                 .mail(FakeMail.builder()
                         .name("name")

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/model/EnqueuedItemWithSlicingContextTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/model/EnqueuedItemWithSlicingContextTest.java
@@ -22,10 +22,12 @@ package org.apache.james.queue.rabbitmq.view.cassandra.model;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Instant;
+
 import javax.mail.MessagingException;
 
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.mail.MimeMessagePartsId;
+import org.apache.james.queue.rabbitmq.EnQueueId;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.mailet.base.test.FakeMail;
@@ -40,7 +42,8 @@ class EnqueuedItemWithSlicingContextTest {
 
     private EnqueuedItemWithSlicingContextTest() throws MessagingException {
         enqueuedItem = EnqueuedItem.builder()
-                .mailQueueName(MailQueueName.fromString("mailQueueName"))
+            .enQueueId(EnQueueId.generate())
+            .mailQueueName(MailQueueName.fromString("mailQueueName"))
                 .mail(FakeMail.builder()
                         .name("name")
                         .build())

--- a/server/queue/queue-rabbitmq/src/test/resources/json/mail1.json
+++ b/server/queue/queue-rabbitmq/src/test/resources/json/mail1.json
@@ -1,4 +1,5 @@
 {
+  "enQueueId": "110e8400-e29b-11d4-a716-446655440000",
   "recipients": [
     "recipient1@localhost",
     "recipient2@localhost"

--- a/server/queue/queue-rabbitmq/src/test/resources/json/mail1.json
+++ b/server/queue/queue-rabbitmq/src/test/resources/json/mail1.json
@@ -1,5 +1,5 @@
 {
-  "enQueueId": "110e8400-e29b-11d4-a716-446655440000",
+  "enqueueId": "110e8400-e29b-11d4-a716-446655440000",
   "recipients": [
     "recipient1@localhost",
     "recipient2@localhost"

--- a/server/queue/queue-rabbitmq/src/test/resources/json/mail_min.json
+++ b/server/queue/queue-rabbitmq/src/test/resources/json/mail_min.json
@@ -1,5 +1,5 @@
 {
-  "enQueueId": "110e8400-e29b-11d4-a716-446655440000",
+  "enqueueId": "110e8400-e29b-11d4-a716-446655440000",
   "recipients":[],
   "name":"mail-name-558",
   "sender":null,

--- a/server/queue/queue-rabbitmq/src/test/resources/json/mail_min.json
+++ b/server/queue/queue-rabbitmq/src/test/resources/json/mail_min.json
@@ -1,4 +1,5 @@
 {
+  "enQueueId": "110e8400-e29b-11d4-a716-446655440000",
   "recipients":[],
   "name":"mail-name-558",
   "sender":null,

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -17,6 +17,41 @@ Changes to apply between 3.3.x and 3.4.x will be reported here.
 Change list:
 
  - [Upgrade to ElasticSearch 6.3](#upgrade-to-elasticsearch-6.3)
+ 
+#### Enqueuing several time a mail with the same name
+
+Date: XX/06/2019
+
+SHA-1: XXXXX
+
+JIRA: https://issues.apache.org/jira/browse/JAMES-2794
+
+Concerned products: (experimental) RabbitMQ MailQueue
+
+RabbitMQ mail queue combines RabbitMQ with projections in Cassandra to offer advanced management capabilities expected from
+a mail queue (browse, delete, size, clear). In these projections, the mails are identified by there name. Thus enqueuing a
+mail that had already been processed will lead the given email to be considered already deleted and it will be discarded 
+and lost.
+
+This is an issue, as several other components build features around submitting a mail several time with the name. 
+
+For instance:
+
+ - MailRepository reprocessing
+ - RemoteDelivery bouncing under some configurations
+ - RecipientRewriteTable rewriting to a remote server
+
+We thus changed the table structure of RabbitMQ mail queue projections to be built around an EnqueueId. This additional 
+level of indirection allows several enqueues with the same name.
+
+Upgrade to the newest James server needs to be performed with an empty MailQueue.
+
+To do so:
+
+ - Given a distributed Guice James server
+ - Stop incoming traffic
+ - Monitor the mailQueues and wait them to be empty (spool & outgoing)
+ - Once empty, upgrade James server and re-enable incoming traffic.
 
 #### Upgrade to ElasticSearch 6.3
 

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -18,7 +18,7 @@ Change list:
 
  - [Upgrade to ElasticSearch 6.3](#upgrade-to-elasticsearch-6.3)
  
-#### Enqueuing several time a mail with the same name
+#### Enqueuing several times a mail with the same name
 
 Date: XX/06/2019
 


### PR DESCRIPTION
This work proposes to use a per-enqueue identifier as a projection key for the MailQueueView. This leverage issues when enqueuing several emails with the same name (only the first one is dequeued, subsequent emails are discarded)

This solves bugs previously encountered when:
 - Reprocessing
 - RRT to remote servers
 - RemoteDelivery bouncing

Note that this work introduces breaking changes that need to be discussed.

Note that some build stability issues tackled at the end of this PR also affects master with a much lower percentage (1 operation and not 2 can lead to reorder)