### PR TITLE
Improve ES container methods semantic

### DIFF
--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/DockerElasticSearch.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/DockerElasticSearch.java
@@ -105,13 +105,15 @@ public class DockerElasticSearch {
     }
 
     public void cleanUpData() {
-        assertThat(esAPI().deleteAllIndexes().status())
-            .isEqualTo(HttpStatus.SC_OK);
+        if (esAPI().deleteAllIndexes().status() != HttpStatus.SC_OK) {
+            throw new IllegalStateException("Failed to delete all data from ElasticSearch");
+        }
     }
 
-    public void awaitForElasticSearch() {
-        assertThat(esAPI().flush().status())
-            .isEqualTo(HttpStatus.SC_OK);
+    public void flushIndices() {
+        if (esAPI().flush().status() != HttpStatus.SC_OK) {
+            throw new IllegalStateException("Failed to flush ElasticSearch");
+        }
     }
 
     public ClientProvider clientProvider() {

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/DockerElasticSearchRule.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/DockerElasticSearchRule.java
@@ -40,7 +40,7 @@ public class DockerElasticSearchRule extends ExternalResource {
     }
     
     public void awaitForElasticSearch() {
-        dockerElasticSearch.awaitForElasticSearch();
+        dockerElasticSearch.flushIndices();
     }
 
     public DockerElasticSearch getDockerElasticSearch() {

--- a/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/ElasticSearchQuotaSearchTestSystemExtension.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/ElasticSearchQuotaSearchTestSystemExtension.java
@@ -86,7 +86,7 @@ public class ElasticSearchQuotaSearchTestSystemExtension implements ParameterRes
                 usersRepository,
                 domainList,
                 resources.getCurrentQuotaManager(),
-                elasticSearch::awaitForElasticSearch);
+                elasticSearch::flushIndices);
         } catch (Exception e) {
             throw new ParameterResolutionException("Error while resolving parameter", e);
         }

--- a/mpt/impl/imap-mailbox/elasticsearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/host/ElasticSearchHostSystem.java
+++ b/mpt/impl/imap-mailbox/elasticsearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/host/ElasticSearchHostSystem.java
@@ -134,6 +134,6 @@ public class ElasticSearchHostSystem extends JamesImapHostSystem {
 
     @Override
     protected void await() {
-        dockerElasticSearch.awaitForElasticSearch();
+        dockerElasticSearch.flushIndices();
     }
 }

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/DockerElasticSearchExtension.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/DockerElasticSearchExtension.java
@@ -55,7 +55,7 @@ public class DockerElasticSearchExtension implements GuiceModuleTestExtension {
 
     @Override
     public void await() {
-        getDockerES().awaitForElasticSearch();
+        getDockerES().flushIndices();
     }
 
     private ElasticSearchConfiguration getElasticSearchConfigurationForDocker() {

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/DockerElasticSearchRule.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/DockerElasticSearchRule.java
@@ -39,7 +39,7 @@ public class DockerElasticSearchRule implements GuiceModuleTestRule {
 
     @Override
     public void await() {
-        elasticSearch.awaitForElasticSearch();
+        elasticSearch.flushIndices();
     }
 
     @Override

--- a/server/container/metrics/metrics-es-reporter/src/test/java/org/apache/james/metric/es/DockerElasticSearchExtension.java
+++ b/server/container/metrics/metrics-es-reporter/src/test/java/org/apache/james/metric/es/DockerElasticSearchExtension.java
@@ -45,7 +45,7 @@ public class DockerElasticSearchExtension implements AfterAllCallback, BeforeAll
 
     @Override
     public void beforeEach(ExtensionContext context) throws Exception {
-        elasticSearch.awaitForElasticSearch();
+        elasticSearch.flushIndices();
     }
 
     @Override

--- a/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraStepdefs.java
+++ b/server/protocols/jmap-integration-testing/cassandra-jmap-integration-testing/src/test/java/org/apache/james/jmap/cassandra/cucumber/CassandraStepdefs.java
@@ -86,7 +86,7 @@ public class CassandraStepdefs {
             .overrideWith((binder) -> binder.bind(PersistenceAdapter.class).to(MemoryPersistenceAdapter.class))
             .overrideWith(binder -> Multibinder.newSetBinder(binder, CleanupTasksPerformer.CleanupTask.class).addBinding().to(CassandraTruncateTableTask.class))
             .overrideWith((binder -> binder.bind(CleanupTasksPerformer.class).asEagerSingleton()));
-        mainStepdefs.awaitMethod = () -> elasticSearch.getDockerEs().awaitForElasticSearch();
+        mainStepdefs.awaitMethod = () -> elasticSearch.getDockerEs().flushIndices();
         mainStepdefs.init();
     }
 

--- a/server/protocols/jmap-integration-testing/rabbitmq-jmap-integration-testing/src/test/java/org/apache/james/jmap/rabbitmq/cucumber/awss3/RabbitMQAwsS3Stepdefs.java
+++ b/server/protocols/jmap-integration-testing/rabbitmq-jmap-integration-testing/src/test/java/org/apache/james/jmap/rabbitmq/cucumber/awss3/RabbitMQAwsS3Stepdefs.java
@@ -95,7 +95,7 @@ public class RabbitMQAwsS3Stepdefs {
                 .overrideWith((binder) -> binder.bind(PersistenceAdapter.class).to(MemoryPersistenceAdapter.class))
                 .overrideWith(binder -> Multibinder.newSetBinder(binder, CleanupTasksPerformer.CleanupTask.class).addBinding().to(CassandraTruncateTableTask.class))
                 .overrideWith((binder -> binder.bind(CleanupTasksPerformer.class).asEagerSingleton()));
-        mainStepdefs.awaitMethod = () -> elasticSearch.getDockerEs().awaitForElasticSearch();
+        mainStepdefs.awaitMethod = () -> elasticSearch.getDockerEs().flushIndices();
         mainStepdefs.init();
     }
 

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/ElasticSearchQuotaSearchExtension.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/ElasticSearchQuotaSearchExtension.java
@@ -89,7 +89,7 @@ public class ElasticSearchQuotaSearchExtension implements ParameterResolver, Bef
                 usersRepository,
                 domainList,
                 resources.getCurrentQuotaManager(),
-                elasticSearch::awaitForElasticSearch);
+                elasticSearch::flushIndices);
 
             restQuotaSearchTestSystem = new WebAdminQuotaSearchTestSystem(quotaSearchTestSystem);
         } catch (Exception e) {


### PR DESCRIPTION
        Throw a IllegalStateException when flush fails and be honest
        about the fact we flush indices (and nothing in elasticsearch doc
        says that it make anything more synchronous)

        Also throw IllegalStateException when cleanup fails