### PR TITLE
 JAMES-2774 Channel Pool for RabbitMQEvenBus

### DIFF
--- a/mailbox/event/event-rabbitmq/pom.xml
+++ b/mailbox/event/event-rabbitmq/pom.xml
@@ -98,6 +98,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/ReactorRabbitMQChannelPool.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/ReactorRabbitMQChannelPool.java
@@ -1,0 +1,130 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.events;
+
+import java.time.Duration;
+import java.util.function.BiConsumer;
+
+import org.apache.commons.pool2.BasePooledObjectFactory;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
+import reactor.core.scheduler.Schedulers;
+import reactor.rabbitmq.ChannelPool;
+
+class ReactorRabbitMQChannelPool implements ChannelPool {
+
+    static class ChannelFactory extends BasePooledObjectFactory<Channel> {
+
+        private static final Logger LOGGER = LoggerFactory.getLogger(ChannelFactory.class);
+
+        private static final int MAX_RETRIES = 5;
+        private static final Duration RETRY_FIRST_BACK_OFF = Duration.ofMillis(100);
+        private static final Duration FOREVER = Duration.ofMillis(Long.MAX_VALUE);
+
+        private final Mono<Connection> connectionMono;
+
+        ChannelFactory(Mono<Connection> connectionMono) {
+            this.connectionMono = connectionMono;
+        }
+
+        @Override
+        public Channel create() throws Exception {
+            return connectionMono
+                .flatMap(this::openChannel)
+                .block();
+        }
+
+        private Mono<Channel> openChannel(Connection connection) {
+            return Mono.fromCallable(connection::openChannel)
+                .map(maybeChannel ->
+                    maybeChannel.orElseThrow(() -> new RuntimeException("RabbitMQ reached to maximum opened channels, cannot get more channels")))
+                .retryBackoff(MAX_RETRIES, RETRY_FIRST_BACK_OFF, FOREVER, Schedulers.elastic())
+                .doOnError(throwable -> LOGGER.error("error when creating new channel", throwable));
+        }
+
+        @Override
+        public PooledObject<Channel> wrap(Channel obj) {
+            return new DefaultPooledObject<>(obj);
+        }
+
+        @Override
+        public void destroyObject(PooledObject<Channel> pooledObject) throws Exception {
+            Channel channel = pooledObject.getObject();
+            if (channel.isOpen()) {
+                channel.close();
+            }
+        }
+    }
+
+    private static final long MAXIMUM_BORROW_TIMEOUT_IN_MS = Duration.ofSeconds(5).toMillis();
+
+    private final GenericObjectPool<Channel> pool;
+    private final ChannelFactory channelFactory;
+
+    ReactorRabbitMQChannelPool(Mono<Connection> connectionMono, int poolSize) {
+        this.channelFactory = new ChannelFactory(connectionMono);
+
+        GenericObjectPoolConfig<Channel> config = new GenericObjectPoolConfig<>();
+        config.setMaxTotal(poolSize);
+        this.pool = new GenericObjectPool<>(channelFactory, config);
+    }
+
+    @Override
+    public Mono<? extends Channel> getChannelMono() {
+        return Mono.fromCallable(() -> pool.borrowObject(MAXIMUM_BORROW_TIMEOUT_IN_MS));
+    }
+
+    @Override
+    public BiConsumer<SignalType, Channel> getChannelCloseHandler() {
+        return (signalType, channel) -> {
+            if (!channel.isOpen() || signalType != SignalType.ON_COMPLETE) {
+                invalidateObject(channel);
+                return;
+            }
+            pool.returnObject(channel);
+        };
+    }
+
+    private void invalidateObject(Channel channel) {
+        try {
+            pool.invalidateObject(channel);
+            if (channel.isOpen()) {
+                channel.close();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() {
+        pool.close();
+    }
+}

--- a/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/ChannelPoolContract.java
+++ b/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/ChannelPoolContract.java
@@ -1,0 +1,101 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.Test;
+
+import com.rabbitmq.client.Channel;
+
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
+import reactor.rabbitmq.ChannelPool;
+
+interface ChannelPoolContract {
+
+    ChannelPool getChannelPool(int poolSize);
+
+    @Test
+    default void channelPoolShouldCreateDifferentChannels() {
+        ChannelPool channelPool = getChannelPool(2);
+        Channel channel1 = borrowChannel(channelPool);
+        Channel channel2 = borrowChannel(channelPool);
+
+        assertThat(channel1.getChannelNumber())
+            .isNotEqualTo(channel2.getChannelNumber());
+    }
+
+    @Test
+    default void channelPoolShouldReleaseChannelWhenReturnedToThePool() {
+        ChannelPool channelPool = getChannelPool(2);
+        Mono<? extends Channel> channelMono = channelPool.getChannelMono();
+        Channel channel1 = borrowChannel(channelPool);
+        Channel channel2 = borrowChannel(channelPool);
+
+        returnToThePool(channelPool, channel2);
+        Channel channelAfterReturned = borrowChannel(channelPool);
+
+        assertThat(channelAfterReturned.getChannelNumber())
+            .isEqualTo(channel2.getChannelNumber());
+    }
+
+    @Test
+    default void channelPoolShouldWaitTillTheNextReleaseWhenAllChannelsAreTaken() {
+        ChannelPool channelPool = getChannelPool(2);
+        Mono<? extends Channel> channelMono = channelPool.getChannelMono();
+        Channel channel1 = borrowChannel(channelPool);
+        Channel channel2 = borrowChannel(channelPool);
+
+        Mono.delay(Duration.ofSeconds(2))
+            .doOnSuccess(any -> returnToThePool(channelPool, channel2))
+            .subscribe();
+
+        Channel channelAfterReturned = borrowChannel(channelPool);
+        assertThat(channelAfterReturned.getChannelNumber())
+            .isEqualTo(channel2.getChannelNumber());
+    }
+
+    @Test
+    default void channelPoolShouldThrowAfterTimeoutWhenAllChannelsAreTaken() {
+        ChannelPool channelPool = getChannelPool(2);
+        Mono<? extends Channel> channelMono = channelPool.getChannelMono();
+        Channel channel1 = borrowChannel(channelPool);
+        Channel channel2 = borrowChannel(channelPool);
+
+        assertThatThrownBy(channelMono::block)
+            .isInstanceOf(NoSuchElementException.class)
+            .hasMessage("Timeout waiting for idle object");
+    }
+
+    default Channel borrowChannel(ChannelPool channelPool) {
+        Mono<? extends Channel> channelMono = channelPool.getChannelMono();
+        return channelMono.block();
+    }
+
+    default void returnToThePool(ChannelPool channelPool, Channel channel) {
+        channelPool.getChannelCloseHandler()
+            .accept(SignalType.ON_COMPLETE, channel);
+    }
+}

--- a/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusTest.java
+++ b/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusTest.java
@@ -81,7 +81,6 @@ import reactor.rabbitmq.BindingSpecification;
 import reactor.rabbitmq.ExchangeSpecification;
 import reactor.rabbitmq.QueueSpecification;
 import reactor.rabbitmq.RabbitFlux;
-import reactor.rabbitmq.RabbitFluxException;
 import reactor.rabbitmq.Receiver;
 import reactor.rabbitmq.ReceiverOptions;
 import reactor.rabbitmq.Sender;
@@ -357,7 +356,8 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
                     rabbitMQNetWorkIssueExtension.getRabbitMQ().pause();
 
                     assertThatThrownBy(() -> rabbitMQEventBusWithNetWorkIssue.dispatch(EVENT, NO_KEYS).block())
-                        .isInstanceOf(RabbitFluxException.class);
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("Retries exhausted");
 
                     rabbitMQNetWorkIssueExtension.getRabbitMQ().unpause();
 
@@ -462,7 +462,8 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
                 rabbitMQExtension.getRabbitMQ().pause();
 
                 assertThatThrownBy(() -> eventBus.dispatch(EVENT, NO_KEYS).block())
-                    .isInstanceOf(RabbitFluxException.class);
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Retries exhausted");
 
                 rabbitMQExtension.getRabbitMQ().unpause();
 
@@ -498,7 +499,8 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
                 rabbitMQExtension.getRabbitMQ().pause();
 
                 assertThatThrownBy(() -> eventBus.dispatch(EVENT, NO_KEYS).block())
-                    .isInstanceOf(RabbitFluxException.class);
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Retries exhausted");
 
                 rabbitMQExtension.getRabbitMQ().unpause();
 
@@ -515,7 +517,8 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
                 rabbitMQExtension.getRabbitMQ().pause();
 
                 assertThatThrownBy(() -> eventBus.dispatch(EVENT, NO_KEYS).block())
-                    .isInstanceOf(RabbitFluxException.class);
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Retries exhausted");
 
                 rabbitMQExtension.getRabbitMQ().unpause();
 

--- a/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/ReactorRabbitMQChannelPoolTest.java
+++ b/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/ReactorRabbitMQChannelPoolTest.java
@@ -1,0 +1,87 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.events;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.james.backend.rabbitmq.RabbitMQExtension;
+import org.apache.james.util.concurrency.ConcurrentTestRunner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.fge.lambdas.Throwing;
+import com.rabbitmq.client.Channel;
+
+import reactor.core.publisher.Mono;
+import reactor.rabbitmq.ChannelPool;
+
+class ReactorRabbitMQChannelPoolTest implements ChannelPoolContract {
+
+    @RegisterExtension
+    static RabbitMQExtension rabbitMQExtension = RabbitMQExtension.singletonRabbitMQ();
+
+    private List<ReactorRabbitMQChannelPool> channelPools;
+
+    @BeforeEach
+    void beforeEach() {
+        channelPools = new ArrayList<>();
+    }
+
+    @AfterEach
+    void afterEach() {
+        channelPools.forEach(ReactorRabbitMQChannelPool::close);
+    }
+
+    @Override
+    public ChannelPool getChannelPool(int poolSize) {
+        ReactorRabbitMQChannelPool channelPool = new ReactorRabbitMQChannelPool(
+            rabbitMQExtension.getRabbitConnectionPool().getResilientConnection(),
+            poolSize);
+        channelPools.add(channelPool);
+
+        return channelPool;
+    }
+
+    // Pool wait timeout is an expected exception
+    @Test
+    void concurrentRequestOnChannelMonoLeadToPoolWaitTimeoutException() {
+        Mono<? extends Channel> channelMono = getChannelPool(99).getChannelMono();
+
+        ConcurrentLinkedQueue<Channel> listChannels = new ConcurrentLinkedQueue<>();
+        assertThatThrownBy(() ->
+            ConcurrentTestRunner.builder()
+                .operation((threadNumber, step) -> listChannels.add(channelMono.block()))
+                .threadCount(10)
+                .operationCount(10)
+                .runSuccessfullyWithin(Duration.ofSeconds(30)))
+            .isInstanceOf(ExecutionException.class)
+            .hasMessageContaining("java.util.NoSuchElementException: Timeout waiting for idle object");
+
+        listChannels.forEach(Throwing.consumer(Channel::close));
+    }
+}

--- a/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/ReactorRabbitMQChannelPoolTest.java
+++ b/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/ReactorRabbitMQChannelPoolTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mailbox.events;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
@@ -29,6 +30,7 @@ import java.util.concurrent.ExecutionException;
 
 import org.apache.james.backend.rabbitmq.RabbitMQExtension;
 import org.apache.james.util.concurrency.ConcurrentTestRunner;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,6 +40,7 @@ import com.github.fge.lambdas.Throwing;
 import com.rabbitmq.client.Channel;
 
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
 import reactor.rabbitmq.ChannelPool;
 
 class ReactorRabbitMQChannelPoolTest implements ChannelPoolContract {
@@ -59,12 +62,17 @@ class ReactorRabbitMQChannelPoolTest implements ChannelPoolContract {
 
     @Override
     public ChannelPool getChannelPool(int poolSize) {
-        ReactorRabbitMQChannelPool channelPool = new ReactorRabbitMQChannelPool(
-            rabbitMQExtension.getRabbitConnectionPool().getResilientConnection(),
-            poolSize);
+        ReactorRabbitMQChannelPool channelPool = generateChannelPool(poolSize);
         channelPools.add(channelPool);
 
         return channelPool;
+    }
+
+    @NotNull
+    private ReactorRabbitMQChannelPool generateChannelPool(int poolSize) {
+        return new ReactorRabbitMQChannelPool(
+                rabbitMQExtension.getRabbitConnectionPool().getResilientConnection(),
+                poolSize);
     }
 
     // Pool wait timeout is an expected exception
@@ -81,7 +89,24 @@ class ReactorRabbitMQChannelPoolTest implements ChannelPoolContract {
                 .runSuccessfullyWithin(Duration.ofSeconds(30)))
             .isInstanceOf(ExecutionException.class)
             .hasMessageContaining("java.util.NoSuchElementException: Timeout waiting for idle object");
+    }
 
-        listChannels.forEach(Throwing.consumer(Channel::close));
+    @Test
+    void usedChannelShouldBeClosedWhenPoolIsClosed() {
+        ChannelPool channelPool = generateChannelPool(2);
+        Channel channel = channelPool.getChannelMono().block();
+        assertThat(channel.isOpen()).isTrue();
+        channelPool.close();
+        assertThat(channel.isOpen()).isFalse();
+    }
+
+    @Test
+    void notUsedChannelShouldBeClosedWhenPoolIsClosed() {
+        ChannelPool channelPool = generateChannelPool(2);
+        Channel channel = channelPool.getChannelMono().block();
+        assertThat(channel.isOpen()).isTrue();
+        channelPool.getChannelCloseHandler().accept(SignalType.ON_NEXT, channel);
+        channelPool.close();
+        assertThat(channel.isOpen()).isFalse();
     }
 }

--- a/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/ReactorRabbitMQChannelPoolTest.java
+++ b/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/ReactorRabbitMQChannelPoolTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.ExecutionException;
 
 import org.apache.james.backend.rabbitmq.RabbitMQExtension;
 import org.apache.james.util.concurrency.ConcurrentTestRunner;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -68,7 +67,6 @@ class ReactorRabbitMQChannelPoolTest implements ChannelPoolContract {
         return channelPool;
     }
 
-    @NotNull
     private ReactorRabbitMQChannelPool generateChannelPool(int poolSize) {
         return new ReactorRabbitMQChannelPool(
                 rabbitMQExtension.getRabbitConnectionPool().getResilientConnection(),

--- a/pom.xml
+++ b/pom.xml
@@ -2257,6 +2257,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
+                <artifactId>commons-pool2</artifactId>
+                <version>2.6.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
                 <version>1.4</version>
             </dependency>


### PR DESCRIPTION
The original channel pool from the library doesn't control the number of channels created, there is a moment, if we push that channel pool to a limit, it will create a lot of channels then lead to the situation of channels hungry. 

That channel pool also have a flaw, it use Connection.createConnection() directly in flux mapping, therefore , null mapping exception happen in flux.