### PR TITLE
JAMES-2994 Reprocessing to a non-existing processor triggers an infinite loop

### DIFF
--- a/server/container/guice/memory-guice/src/main/java/org/apache/james/MemoryJamesServerMain.java
+++ b/server/container/guice/memory-guice/src/main/java/org/apache/james/MemoryJamesServerMain.java
@@ -19,7 +19,10 @@
 
 package org.apache.james;
 
+import java.util.Optional;
+
 import org.apache.commons.configuration.DefaultConfigurationBuilder;
+import org.apache.james.jwt.JwtConfiguration;
 import org.apache.james.modules.BlobExportMechanismModule;
 import org.apache.james.modules.BlobMemoryModule;
 import org.apache.james.modules.MailboxModule;
@@ -50,6 +53,9 @@ import org.apache.james.modules.spamassassin.SpamAssassinListenerModule;
 import org.apache.james.modules.vault.DeletedMessageVaultModule;
 import org.apache.james.modules.vault.DeletedMessageVaultRoutesModule;
 import org.apache.james.server.core.configuration.Configuration;
+import org.apache.james.webadmin.WebAdminConfiguration;
+import org.apache.james.webadmin.authentication.AuthenticationFilter;
+import org.apache.james.webadmin.authentication.NoAuthenticationFilter;
 
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
@@ -66,6 +72,16 @@ public class MemoryJamesServerMain {
         new SwaggerRoutesModule(),
         new DLPRoutesModule(),
         new SieveRoutesModule());
+
+
+    public static final JwtConfiguration NO_JWT_CONFIGURATION = new JwtConfiguration(Optional.empty());
+
+    public static final Module WEBADMIN_NO_AUTH_MODULE = Modules.combine(binder -> binder.bind(JwtConfiguration.class).toInstance(NO_JWT_CONFIGURATION),
+        binder -> binder.bind(AuthenticationFilter.class).to(NoAuthenticationFilter.class),
+        binder -> binder.bind(WebAdminConfiguration.class).toInstance(WebAdminConfiguration.TEST_CONFIGURATION));
+
+    public static final Module WEBADMIN_TESTING = Modules.override(WEBADMIN)
+        .with(WEBADMIN_NO_AUTH_MODULE);
 
     public static final Module PROTOCOLS = Modules.combine(
         new IMAPServerModule(),

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/NetworkMatcherIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/NetworkMatcherIntegrationTest.java
@@ -93,7 +93,7 @@ public class NetworkMatcherIntegrationTest {
                 .matcher(RemoteAddrInNetwork.class)
                 .matcherCondition("127.0.0.0/8")
                 .mailet(ToProcessor.class)
-                .addProperty("processor", ProcessorConfiguration.STATE_TRANSPORT))
+                .addProperty("processor", ProcessorConfiguration.TRANSPORT_PROCESSOR))
             .addMailet(toRepository()));
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
@@ -113,7 +113,7 @@ public class NetworkMatcherIntegrationTest {
                 .matcher(RemoteAddrNotInNetwork.class)
                 .matcherCondition("172.0.0.0/8")
                 .mailet(ToProcessor.class)
-                .addProperty("processor", ProcessorConfiguration.STATE_TRANSPORT))
+                .addProperty("processor", ProcessorConfiguration.TRANSPORT_PROCESSOR))
             .addMailet(toRepository()));
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
@@ -133,7 +133,7 @@ public class NetworkMatcherIntegrationTest {
                 .matcher(RemoteAddrInNetwork.class)
                 .matcherCondition("127.0.0.0/2")
                 .mailet(ToProcessor.class)
-                .addProperty("processor", ProcessorConfiguration.STATE_TRANSPORT))
+                .addProperty("processor", ProcessorConfiguration.TRANSPORT_PROCESSOR))
             .addMailet(toRepository()));
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
@@ -153,7 +153,7 @@ public class NetworkMatcherIntegrationTest {
                 .matcher(RemoteAddrInNetwork.class)
                 .matcherCondition("127.0.4.108/8")
                 .mailet(ToProcessor.class)
-                .addProperty("processor", ProcessorConfiguration.STATE_TRANSPORT))
+                .addProperty("processor", ProcessorConfiguration.TRANSPORT_PROCESSOR))
             .addMailet(toRepository()));
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
@@ -173,7 +173,7 @@ public class NetworkMatcherIntegrationTest {
                 .matcher(RemoteAddrInNetwork.class)
                 .matcherCondition("127.255.255.255/8")
                 .mailet(ToProcessor.class)
-                .addProperty("processor", ProcessorConfiguration.STATE_TRANSPORT))
+                .addProperty("processor", ProcessorConfiguration.TRANSPORT_PROCESSOR))
             .addMailet(toRepository()));
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
@@ -193,7 +193,7 @@ public class NetworkMatcherIntegrationTest {
                 .matcher(RemoteAddrInNetwork.class)
                 .matcherCondition("126.0.0.0/4")
                 .mailet(ToProcessor.class)
-                .addProperty("processor", ProcessorConfiguration.STATE_TRANSPORT))
+                .addProperty("processor", ProcessorConfiguration.TRANSPORT_PROCESSOR))
             .addMailet(toRepository()));
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
@@ -213,7 +213,7 @@ public class NetworkMatcherIntegrationTest {
                 .matcher(RemoteAddrInNetwork.class)
                 .matcherCondition("172.0.0.0/8")
                 .mailet(ToProcessor.class)
-                .addProperty("processor", ProcessorConfiguration.STATE_TRANSPORT))
+                .addProperty("processor", ProcessorConfiguration.TRANSPORT_PROCESSOR))
             .addMailet(toRepository()));
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
@@ -237,7 +237,7 @@ public class NetworkMatcherIntegrationTest {
                 .matcher(RemoteAddrNotInNetwork.class)
                 .matcherCondition("127.0.0.0/8")
                 .mailet(ToProcessor.class)
-                .addProperty("processor", ProcessorConfiguration.STATE_TRANSPORT))
+                .addProperty("processor", ProcessorConfiguration.TRANSPORT_PROCESSOR))
             .addMailet(toRepository()));
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SmtpAuthIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/SmtpAuthIntegrationTest.java
@@ -68,7 +68,7 @@ public class SmtpAuthIntegrationTest {
             .addMailet(MailetConfiguration.builder()
                 .matcher(SMTPAuthSuccessful.class)
                 .mailet(ToProcessor.class)
-                .addProperty("processor", ProcessorConfiguration.STATE_TRANSPORT))
+                .addProperty("processor", ProcessorConfiguration.TRANSPORT_PROCESSOR))
             .addMailet(MailetConfiguration.TO_BOUNCE);
 
         MailetContainer.Builder mailetContainer = TemporaryJamesServer.DEFAULT_MAILET_CONTAINER_CONFIGURATION

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/TemporaryJamesServer.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/TemporaryJamesServer.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mailets;
 
+import static org.apache.james.transport.mailets.DlpIntegrationTest.NO_JWT_CONFIGURATION;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -37,6 +39,7 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.IOUtils;
 import org.apache.james.GuiceJamesServer;
 import org.apache.james.MemoryJamesServerMain;
+import org.apache.james.jwt.JwtConfiguration;
 import org.apache.james.mailets.configuration.CommonProcessors;
 import org.apache.james.mailets.configuration.MailetContainer;
 import org.apache.james.mailets.configuration.SmtpConfiguration;
@@ -44,10 +47,13 @@ import org.apache.james.modules.TestJMAPServerModule;
 import org.apache.james.server.core.configuration.Configuration;
 import org.apache.james.utils.GuiceProbe;
 import org.apache.james.webadmin.WebAdminConfiguration;
+import org.apache.james.webadmin.authentication.AuthenticationFilter;
+import org.apache.james.webadmin.authentication.NoAuthenticationFilter;
 import org.junit.rules.TemporaryFolder;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Module;
+import com.google.inject.util.Modules;
 
 public class TemporaryJamesServer {
 
@@ -60,6 +66,13 @@ public class TemporaryJamesServer {
         .putProcessor(CommonProcessors.simpleRoot())
         .putProcessor(CommonProcessors.error())
         .putProcessor(CommonProcessors.transport());
+
+    public static final Module WEBADMIN_IMAP_SMTP_MEMORY_SERVER = Modules.override(
+        MemoryJamesServerMain.SMTP_AND_IMAP_MODULE,
+        MemoryJamesServerMain.WEBADMIN)
+        .with(binder -> binder.bind(JwtConfiguration.class).toInstance(NO_JWT_CONFIGURATION),
+            binder -> binder.bind(AuthenticationFilter.class).to(NoAuthenticationFilter.class),
+            binder -> binder.bind(WebAdminConfiguration.class).toInstance(WebAdminConfiguration.TEST_CONFIGURATION));
 
     public static class Builder {
         private ImmutableList.Builder<Module> overrideModules;

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/TemporaryJamesServer.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/TemporaryJamesServer.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.mailets;
 
-import static org.apache.james.transport.mailets.DlpIntegrationTest.NO_JWT_CONFIGURATION;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -39,7 +37,6 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.IOUtils;
 import org.apache.james.GuiceJamesServer;
 import org.apache.james.MemoryJamesServerMain;
-import org.apache.james.jwt.JwtConfiguration;
 import org.apache.james.mailets.configuration.CommonProcessors;
 import org.apache.james.mailets.configuration.MailetContainer;
 import org.apache.james.mailets.configuration.SmtpConfiguration;
@@ -47,13 +44,10 @@ import org.apache.james.modules.TestJMAPServerModule;
 import org.apache.james.server.core.configuration.Configuration;
 import org.apache.james.utils.GuiceProbe;
 import org.apache.james.webadmin.WebAdminConfiguration;
-import org.apache.james.webadmin.authentication.AuthenticationFilter;
-import org.apache.james.webadmin.authentication.NoAuthenticationFilter;
 import org.junit.rules.TemporaryFolder;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Module;
-import com.google.inject.util.Modules;
 
 public class TemporaryJamesServer {
 
@@ -67,12 +61,6 @@ public class TemporaryJamesServer {
         .putProcessor(CommonProcessors.error())
         .putProcessor(CommonProcessors.transport());
 
-    public static final Module WEBADMIN_IMAP_SMTP_MEMORY_SERVER = Modules.override(
-        MemoryJamesServerMain.SMTP_AND_IMAP_MODULE,
-        MemoryJamesServerMain.WEBADMIN)
-        .with(binder -> binder.bind(JwtConfiguration.class).toInstance(NO_JWT_CONFIGURATION),
-            binder -> binder.bind(AuthenticationFilter.class).to(NoAuthenticationFilter.class),
-            binder -> binder.bind(WebAdminConfiguration.class).toInstance(WebAdminConfiguration.TEST_CONFIGURATION));
 
     public static class Builder {
         private ImmutableList.Builder<Module> overrideModules;

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/configuration/MailetConfiguration.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/configuration/MailetConfiguration.java
@@ -95,7 +95,7 @@ public class MailetConfiguration implements SerializableAsXml {
     public static final MailetConfiguration TO_TRANSPORT = MailetConfiguration.builder()
         .matcher(All.class)
         .mailet(ToProcessor.class)
-        .addProperty("processor", ProcessorConfiguration.STATE_TRANSPORT)
+        .addProperty("processor", ProcessorConfiguration.TRANSPORT_PROCESSOR)
         .build();
 
     public static final MailetConfiguration TO_BOUNCE = MailetConfiguration.builder()

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/configuration/ProcessorConfiguration.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/mailets/configuration/ProcessorConfiguration.java
@@ -28,7 +28,7 @@ import com.google.common.collect.ImmutableList;
 
 public class ProcessorConfiguration implements SerializableAsXml {
 
-    public static final String STATE_TRANSPORT = "transport";
+    public static final String TRANSPORT_PROCESSOR = "transport";
     public static final String STATE_ROOT = "root";
     public static final String STATE_BOUNCES = "bounces";
     public static final String STATE_ERROR = "error";
@@ -39,7 +39,7 @@ public class ProcessorConfiguration implements SerializableAsXml {
     }
 
     public static Builder transport() {
-        return builder().state(STATE_TRANSPORT);
+        return builder().state(TRANSPORT_PROCESSOR);
     }
 
     public static Builder root() {

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/DlpIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/DlpIntegrationTest.java
@@ -20,7 +20,6 @@
 package org.apache.james.transport.mailets;
 
 import static io.restassured.RestAssured.given;
-import static org.apache.james.mailets.TemporaryJamesServer.WEBADMIN_IMAP_SMTP_MEMORY_SERVER;
 import static org.apache.james.mailets.configuration.Constants.DEFAULT_DOMAIN;
 import static org.apache.james.mailets.configuration.Constants.FROM;
 import static org.apache.james.mailets.configuration.Constants.LOCALHOST_IP;
@@ -29,10 +28,8 @@ import static org.apache.james.mailets.configuration.Constants.RECIPIENT;
 import static org.apache.james.mailets.configuration.Constants.RECIPIENT2;
 import static org.apache.james.mailets.configuration.Constants.awaitAtMostOneMinute;
 
-import java.util.Optional;
-
+import org.apache.james.MemoryJamesServerMain;
 import org.apache.james.core.builder.MimeMessageBuilder;
-import org.apache.james.jwt.JwtConfiguration;
 import org.apache.james.mailets.TemporaryJamesServer;
 import org.apache.james.mailets.configuration.MailetConfiguration;
 import org.apache.james.mailets.configuration.MailetContainer;
@@ -53,11 +50,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import com.google.inject.util.Modules;
+
 import io.restassured.specification.RequestSpecification;
 
 public class DlpIntegrationTest {
     public static final String REPOSITORY_PREFIX = "file://var/mail/dlp/quarantine/";
-    public static final JwtConfiguration NO_JWT_CONFIGURATION = new JwtConfiguration(Optional.empty());
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
@@ -81,7 +79,7 @@ public class DlpIntegrationTest {
                         .mailet(Null.class)));
 
         jamesServer = TemporaryJamesServer.builder()
-            .withBase(WEBADMIN_IMAP_SMTP_MEMORY_SERVER)
+            .withBase(Modules.combine(MemoryJamesServerMain.SMTP_AND_IMAP_MODULE, MemoryJamesServerMain.WEBADMIN_TESTING))
             .withMailetContainer(mailets)
             .build(folder);
 

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/DlpIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/DlpIntegrationTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.transport.mailets;
 
 import static io.restassured.RestAssured.given;
+import static org.apache.james.mailets.TemporaryJamesServer.WEBADMIN_IMAP_SMTP_MEMORY_SERVER;
 import static org.apache.james.mailets.configuration.Constants.DEFAULT_DOMAIN;
 import static org.apache.james.mailets.configuration.Constants.FROM;
 import static org.apache.james.mailets.configuration.Constants.LOCALHOST_IP;
@@ -30,7 +31,6 @@ import static org.apache.james.mailets.configuration.Constants.awaitAtMostOneMin
 
 import java.util.Optional;
 
-import org.apache.james.MemoryJamesServerMain;
 import org.apache.james.core.builder.MimeMessageBuilder;
 import org.apache.james.jwt.JwtConfiguration;
 import org.apache.james.mailets.TemporaryJamesServer;
@@ -45,18 +45,13 @@ import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.IMAPMessageReader;
 import org.apache.james.utils.SMTPMessageSender;
 import org.apache.james.utils.WebAdminGuiceProbe;
-import org.apache.james.webadmin.WebAdminConfiguration;
 import org.apache.james.webadmin.WebAdminUtils;
-import org.apache.james.webadmin.authentication.AuthenticationFilter;
-import org.apache.james.webadmin.authentication.NoAuthenticationFilter;
 import org.apache.mailet.base.test.FakeMail;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import com.google.inject.util.Modules;
 
 import io.restassured.specification.RequestSpecification;
 
@@ -86,13 +81,7 @@ public class DlpIntegrationTest {
                         .mailet(Null.class)));
 
         jamesServer = TemporaryJamesServer.builder()
-            .withBase(Modules.override(
-                    MemoryJamesServerMain.SMTP_AND_IMAP_MODULE,
-                    MemoryJamesServerMain.WEBADMIN)
-                .with(
-                    binder -> binder.bind(JwtConfiguration.class).toInstance(NO_JWT_CONFIGURATION),
-                    binder -> binder.bind(AuthenticationFilter.class).to(NoAuthenticationFilter.class),
-                    binder -> binder.bind(WebAdminConfiguration.class).toInstance(WebAdminConfiguration.TEST_CONFIGURATION)))
+            .withBase(WEBADMIN_IMAP_SMTP_MEMORY_SERVER)
             .withMailetContainer(mailets)
             .build(folder);
 

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/MailReprocessingIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/MailReprocessingIntegrationTest.java
@@ -54,7 +54,6 @@ import org.apache.james.webadmin.authentication.NoAuthenticationFilter;
 import org.apache.mailet.base.test.FakeMail;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -190,7 +189,6 @@ public class MailReprocessingIntegrationTest {
         assertThat(containsExactlyOneMail(REPOSITORY_A)).isTrue();
     }
 
-    @Ignore("JAMES-2994 Reprocessing to an unknown processor triggers an infinite loop as the mail is nack")
     @Test
     public void reprocessingShouldProcessAsErrorWhenUnknownMailProcessor() throws Exception {
         // Given an incoming email

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/MailReprocessingIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/MailReprocessingIntegrationTest.java
@@ -146,7 +146,7 @@ public class MailReprocessingIntegrationTest {
     }
 
     @Test
-    public void reprocessingkShouldPreserveStateWhenProcessorIsNotSpecified() throws Exception {
+    public void reprocessingShouldPreserveStateWhenProcessorIsNotSpecified() throws Exception {
         // Given an incoming email
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
             .sendMessage(FakeMail.builder()

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/MailReprocessingIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/MailReprocessingIntegrationTest.java
@@ -20,7 +20,6 @@
 package org.apache.james.transport.mailets;
 
 import static io.restassured.RestAssured.given;
-import static org.apache.james.mailets.TemporaryJamesServer.WEBADMIN_IMAP_SMTP_MEMORY_SERVER;
 import static org.apache.james.mailets.configuration.CommonProcessors.ERROR_REPOSITORY;
 import static org.apache.james.mailets.configuration.Constants.DEFAULT_DOMAIN;
 import static org.apache.james.mailets.configuration.Constants.FROM;
@@ -32,10 +31,8 @@ import static org.apache.james.mailets.configuration.Constants.awaitAtMostOneMin
 import static org.apache.james.mailets.configuration.ProcessorConfiguration.TRANSPORT_PROCESSOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Optional;
-
+import org.apache.james.MemoryJamesServerMain;
 import org.apache.james.core.builder.MimeMessageBuilder;
-import org.apache.james.jwt.JwtConfiguration;
 import org.apache.james.mailets.TemporaryJamesServer;
 import org.apache.james.mailets.configuration.MailetConfiguration;
 import org.apache.james.mailets.configuration.MailetContainer;
@@ -55,12 +52,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import com.google.inject.util.Modules;
+
 import io.restassured.specification.RequestSpecification;
 
 public class MailReprocessingIntegrationTest {
     private static final MailRepositoryUrl REPOSITORY_A = MailRepositoryUrl.from("file://var/mail/a");
     private static final MailRepositoryUrl REPOSITORY_B = MailRepositoryUrl.from("file://var/mail/b");
-    private static final JwtConfiguration NO_JWT_CONFIGURATION = new JwtConfiguration(Optional.empty());
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
@@ -87,7 +85,7 @@ public class MailReprocessingIntegrationTest {
                         .addProperty("repositoryPath", REPOSITORY_B.asString())));
 
         jamesServer = TemporaryJamesServer.builder()
-            .withBase(WEBADMIN_IMAP_SMTP_MEMORY_SERVER)
+            .withBase(Modules.combine(MemoryJamesServerMain.SMTP_AND_IMAP_MODULE, MemoryJamesServerMain.WEBADMIN_TESTING))
             .withMailetContainer(mailets)
             .build(folder);
 

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/MailReprocessingIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/MailReprocessingIntegrationTest.java
@@ -29,7 +29,7 @@ import static org.apache.james.mailets.configuration.Constants.PASSWORD;
 import static org.apache.james.mailets.configuration.Constants.RECIPIENT;
 import static org.apache.james.mailets.configuration.Constants.RECIPIENT2;
 import static org.apache.james.mailets.configuration.Constants.awaitAtMostOneMinute;
-import static org.apache.james.mailets.configuration.ProcessorConfiguration.STATE_TRANSPORT;
+import static org.apache.james.mailets.configuration.ProcessorConfiguration.TRANSPORT_PROCESSOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
@@ -126,7 +126,7 @@ public class MailReprocessingIntegrationTest {
             .spec(specification)
             .param("action", "reprocess")
             .param("queue", MailQueueFactory.SPOOL)
-            .param("processor", STATE_TRANSPORT)
+            .param("processor", TRANSPORT_PROCESSOR)
         .patch("/mailRepositories/" + REPOSITORY_B.getPath().urlEncoded() + "/mails");
 
         // Then I can move it to repository A
@@ -154,7 +154,7 @@ public class MailReprocessingIntegrationTest {
             .spec(specification)
             .param("action", "reprocess")
             .param("queue", MailQueueFactory.SPOOL)
-            .param("processor", STATE_TRANSPORT)
+            .param("processor", TRANSPORT_PROCESSOR)
         .patch("/mailRepositories/" + REPOSITORY_B.getPath().urlEncoded() + "/mails");
 
         // I can move it to repository A

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/MailReprocessingIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/MailReprocessingIntegrationTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.transport.mailets;
 
 import static io.restassured.RestAssured.given;
+import static org.apache.james.mailets.TemporaryJamesServer.WEBADMIN_IMAP_SMTP_MEMORY_SERVER;
 import static org.apache.james.mailets.configuration.CommonProcessors.ERROR_REPOSITORY;
 import static org.apache.james.mailets.configuration.Constants.DEFAULT_DOMAIN;
 import static org.apache.james.mailets.configuration.Constants.FROM;
@@ -33,7 +34,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
 
-import org.apache.james.MemoryJamesServerMain;
 import org.apache.james.core.builder.MimeMessageBuilder;
 import org.apache.james.jwt.JwtConfiguration;
 import org.apache.james.mailets.TemporaryJamesServer;
@@ -47,18 +47,13 @@ import org.apache.james.transport.matchers.All;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.SMTPMessageSender;
 import org.apache.james.utils.WebAdminGuiceProbe;
-import org.apache.james.webadmin.WebAdminConfiguration;
 import org.apache.james.webadmin.WebAdminUtils;
-import org.apache.james.webadmin.authentication.AuthenticationFilter;
-import org.apache.james.webadmin.authentication.NoAuthenticationFilter;
 import org.apache.mailet.base.test.FakeMail;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import com.google.inject.util.Modules;
 
 import io.restassured.specification.RequestSpecification;
 
@@ -92,13 +87,7 @@ public class MailReprocessingIntegrationTest {
                         .addProperty("repositoryPath", REPOSITORY_B.asString())));
 
         jamesServer = TemporaryJamesServer.builder()
-            .withBase(Modules.override(
-                    MemoryJamesServerMain.SMTP_AND_IMAP_MODULE,
-                    MemoryJamesServerMain.WEBADMIN)
-                .with(
-                    binder -> binder.bind(JwtConfiguration.class).toInstance(NO_JWT_CONFIGURATION),
-                    binder -> binder.bind(AuthenticationFilter.class).to(NoAuthenticationFilter.class),
-                    binder -> binder.bind(WebAdminConfiguration.class).toInstance(WebAdminConfiguration.TEST_CONFIGURATION)))
+            .withBase(WEBADMIN_IMAP_SMTP_MEMORY_SERVER)
             .withMailetContainer(mailets)
             .build(folder);
 

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/MailReprocessingIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/MailReprocessingIntegrationTest.java
@@ -197,7 +197,7 @@ public class MailReprocessingIntegrationTest {
             .param("action", "reprocess")
             .param("queue", MailQueueFactory.SPOOL)
             .param("processor", "unknown")
-            .patch("/mailRepositories/" + REPOSITORY_B.getPath().urlEncoded() + "/mails").prettyPeek();
+            .patch("/mailRepositories/" + REPOSITORY_B.getPath().urlEncoded() + "/mails");
 
         // Then I can move it to repository A
         awaitAtMostOneMinute.until(() -> containsExactlyOneMail(ERROR_REPOSITORY));

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/MailReprocessingIntegrationTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/MailReprocessingIntegrationTest.java
@@ -1,0 +1,203 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.mailets;
+
+import static io.restassured.RestAssured.given;
+import static org.apache.james.mailets.configuration.Constants.DEFAULT_DOMAIN;
+import static org.apache.james.mailets.configuration.Constants.FROM;
+import static org.apache.james.mailets.configuration.Constants.LOCALHOST_IP;
+import static org.apache.james.mailets.configuration.Constants.PASSWORD;
+import static org.apache.james.mailets.configuration.Constants.RECIPIENT;
+import static org.apache.james.mailets.configuration.Constants.RECIPIENT2;
+import static org.apache.james.mailets.configuration.Constants.awaitAtMostOneMinute;
+import static org.apache.james.mailets.configuration.ProcessorConfiguration.STATE_TRANSPORT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.apache.james.MemoryJamesServerMain;
+import org.apache.james.core.builder.MimeMessageBuilder;
+import org.apache.james.jwt.JwtConfiguration;
+import org.apache.james.mailets.TemporaryJamesServer;
+import org.apache.james.mailets.configuration.MailetConfiguration;
+import org.apache.james.mailets.configuration.MailetContainer;
+import org.apache.james.mailets.configuration.ProcessorConfiguration;
+import org.apache.james.mailrepository.api.MailRepositoryUrl;
+import org.apache.james.modules.protocols.SmtpGuiceProbe;
+import org.apache.james.queue.api.MailQueueFactory;
+import org.apache.james.transport.matchers.All;
+import org.apache.james.utils.DataProbeImpl;
+import org.apache.james.utils.SMTPMessageSender;
+import org.apache.james.utils.WebAdminGuiceProbe;
+import org.apache.james.webadmin.WebAdminConfiguration;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.authentication.AuthenticationFilter;
+import org.apache.james.webadmin.authentication.NoAuthenticationFilter;
+import org.apache.mailet.base.test.FakeMail;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.google.inject.util.Modules;
+
+import io.restassured.specification.RequestSpecification;
+
+public class MailReprocessingIntegrationTest {
+    private static final MailRepositoryUrl REPOSITORY_A = MailRepositoryUrl.from("file://var/mail/a");
+    private static final MailRepositoryUrl REPOSITORY_B = MailRepositoryUrl.from("file://var/mail/b");
+    private static final JwtConfiguration NO_JWT_CONFIGURATION = new JwtConfiguration(Optional.empty());
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public SMTPMessageSender messageSender = new SMTPMessageSender(DEFAULT_DOMAIN);
+
+    private TemporaryJamesServer jamesServer;
+    private RequestSpecification specification;
+
+    @Before
+    public void createJamesServer() throws Exception {
+        MailetContainer.Builder mailets = TemporaryJamesServer.DEFAULT_MAILET_CONTAINER_CONFIGURATION
+            .putProcessor(ProcessorConfiguration.transport()
+                    .addMailet(MailetConfiguration.BCC_STRIPPER)
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(ToRepository.class)
+                        .addProperty("repositoryPath", REPOSITORY_A.asString())))
+            .putProcessor(ProcessorConfiguration.root()
+                    .addMailet(MailetConfiguration.builder()
+                        .matcher(All.class)
+                        .mailet(ToRepository.class)
+                        .addProperty("repositoryPath", REPOSITORY_B.asString())));
+
+        jamesServer = TemporaryJamesServer.builder()
+            .withBase(Modules.override(
+                    MemoryJamesServerMain.SMTP_AND_IMAP_MODULE,
+                    MemoryJamesServerMain.WEBADMIN)
+                .with(
+                    binder -> binder.bind(JwtConfiguration.class).toInstance(NO_JWT_CONFIGURATION),
+                    binder -> binder.bind(AuthenticationFilter.class).to(NoAuthenticationFilter.class),
+                    binder -> binder.bind(WebAdminConfiguration.class).toInstance(WebAdminConfiguration.TEST_CONFIGURATION)))
+            .withMailetContainer(mailets)
+            .build(folder);
+
+        jamesServer.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addDomain(DEFAULT_DOMAIN)
+            .addUser(FROM, PASSWORD)
+            .addUser(RECIPIENT, PASSWORD)
+            .addUser(RECIPIENT2, PASSWORD);
+
+        specification = WebAdminUtils.spec(jamesServer.getProbe(WebAdminGuiceProbe.class).getWebAdminPort());
+    }
+
+    @After
+    public void tearDown() {
+        jamesServer.shutdown();
+    }
+
+    @Test
+    public void reprocessingShouldAllowToTargetASpecificProcessor() throws Exception {
+        // Given an incoming email
+        messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .sendMessage(FakeMail.builder()
+                .name("name")
+                .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                    .addToRecipient(RECIPIENT)
+                    .setSender(FROM)
+                    .setText("match me"))
+                .sender(FROM)
+                .recipient(RECIPIENT));
+        // Being stored in MailRepository B
+        awaitAtMostOneMinute.until(() -> containsExactlyOneMail(REPOSITORY_B));
+
+        // When I reprocess it
+        given()
+            .spec(specification)
+            .param("action", "reprocess")
+            .param("queue", MailQueueFactory.SPOOL)
+            .param("processor", STATE_TRANSPORT)
+        .patch("/mailRepositories/" + REPOSITORY_B.getPath().urlEncoded() + "/mails");
+
+        // Then I can move it to repository A
+        awaitAtMostOneMinute.until(() -> containsExactlyOneMail(REPOSITORY_A));
+        assertThat(containsExactlyOneMail(REPOSITORY_A)).isTrue();
+    }
+
+    @Test
+    public void reprocessingkShouldPreserveStateWhenProcessorIsNotSpecified() throws Exception {
+        // Given an incoming email
+        messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .sendMessage(FakeMail.builder()
+                .name("name")
+                .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                    .addToRecipient(RECIPIENT)
+                    .setSender(FROM)
+                    .setText("match me"))
+                .sender(FROM)
+                .recipient(RECIPIENT));
+        // Being stored in MailRepository B
+        awaitAtMostOneMinute.until(() -> containsExactlyOneMail(REPOSITORY_B));
+
+        // I reprocess it
+        given()
+            .spec(specification)
+            .param("action", "reprocess")
+            .param("queue", MailQueueFactory.SPOOL)
+            .param("processor", STATE_TRANSPORT)
+        .patch("/mailRepositories/" + REPOSITORY_B.getPath().urlEncoded() + "/mails");
+
+        // I can move it to repository A
+        awaitAtMostOneMinute.until(() -> containsExactlyOneMail(REPOSITORY_A));
+
+        // When I reprocess it without target processor
+        String taskId = given()
+            .spec(specification)
+            .param("action", "reprocess")
+            .param("queue", MailQueueFactory.SPOOL)
+        .patch("/mailRepositories/" + REPOSITORY_A.getPath().urlEncoded() + "/mails")
+            .jsonPath()
+            .get("taskId");
+
+        given()
+            .spec(specification)
+            .get("/tasks/" + taskId + "/await");
+
+        // It then is processed by the transport processor again
+        awaitAtMostOneMinute.until(() -> containsExactlyOneMail(REPOSITORY_A));
+        assertThat(containsExactlyOneMail(REPOSITORY_A)).isTrue();
+    }
+
+    private boolean containsExactlyOneMail(MailRepositoryUrl repositoryUrl) {
+        try {
+            return given()
+                .spec(specification)
+            .get("/mailRepositories/" + repositoryUrl.getPath().urlEncoded() + "/mails")
+                .jsonPath()
+                .getList(".")
+                .size() == 1;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ToRepositoryTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/ToRepositoryTest.java
@@ -114,7 +114,7 @@ public class ToRepositoryTest {
 
         String taskId = with()
             .spec(webAdminAPI)
-            .queryParam("processor", ProcessorConfiguration.STATE_TRANSPORT)
+            .queryParam("processor", ProcessorConfiguration.TRANSPORT_PROCESSOR)
             .queryParam("action", "reprocess")
         .patch(MailRepositoriesRoutes.MAIL_REPOSITORIES
                 + "/" + CUSTOM_REPOSITORY.getPath().urlEncoded()
@@ -145,7 +145,7 @@ public class ToRepositoryTest {
 
         with()
             .spec(webAdminAPI)
-            .queryParam("processor", ProcessorConfiguration.STATE_TRANSPORT)
+            .queryParam("processor", ProcessorConfiguration.TRANSPORT_PROCESSOR)
             .queryParam("action", "reprocess")
             .patch(MailRepositoriesRoutes.MAIL_REPOSITORIES
                 + "/" + CUSTOM_REPOSITORY.getPath().urlEncoded()

--- a/server/mailet/mailetcontainer-camel/src/test/java/org/apache/james/mailetcontainer/lib/AbstractStateCompositeProcessorTest.java
+++ b/server/mailet/mailetcontainer-camel/src/test/java/org/apache/james/mailetcontainer/lib/AbstractStateCompositeProcessorTest.java
@@ -74,8 +74,6 @@ public abstract class AbstractStateCompositeProcessorTest {
             processor.service(mail2);
             processor.service(mail3);
 
-            expectedException.expect(MessagingException.class);
-
             processor.service(mail4);
         } finally {
             processor.dispose();


### PR DESCRIPTION
1. The email with invalid processor is enqueued
2. And dequeues
3. JamesSpooler tries to find its processor
4. And... cannot so it thows...
5. The mail get nack and go back to the queue
6. go to 2.

I decided to not do pre-validation upon reprocessing as the mailet configuration can change between 1. and 2. (stop the server, remove the given processor, then restart the server), which will pass validation, but still will fail at runtime. Thus pre-validation gives a lfalse sens of safety and smooth runtime handling is required anyway. So I contributed it...