### PR TITLE
JAMES-2806 bucket memory implementation for BlobStore + contract

### DIFF
--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobStore.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobStore.java
@@ -36,4 +36,6 @@ public interface BlobStore {
     default Mono<BlobId> save(BucketName bucketName, String data) {
         return save(bucketName, data.getBytes(StandardCharsets.UTF_8));
     }
+
+    Mono<Void> deleteBucket(BucketName bucketName);
 }

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/MetricableBlobStore.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/MetricableBlobStore.java
@@ -70,4 +70,9 @@ public class MetricableBlobStore implements BlobStore {
         return metricFactory
             .runPublishingTimerMetric(READ_TIMER_NAME, () -> blobStoreImpl.read(bucketName, blobId));
     }
+
+    @Override
+    public Mono<Void> deleteBucket(BucketName bucketName) {
+        return blobStoreImpl.deleteBucket(bucketName);
+    }
 }

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/MetricableBlobStore.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/MetricableBlobStore.java
@@ -36,6 +36,7 @@ public class MetricableBlobStore implements BlobStore {
     static final String SAVE_INPUT_STREAM_TIMER_NAME = BLOB_STORE_METRIC_PREFIX + "saveInputStream";
     static final String READ_BYTES_TIMER_NAME = BLOB_STORE_METRIC_PREFIX + "readBytes";
     static final String READ_TIMER_NAME = BLOB_STORE_METRIC_PREFIX + "read";
+    static final String DELETE_TIMER_NAME = BLOB_STORE_METRIC_PREFIX + "delete";
 
     private final MetricFactory metricFactory;
     private final BlobStore blobStoreImpl;
@@ -73,6 +74,7 @@ public class MetricableBlobStore implements BlobStore {
 
     @Override
     public Mono<Void> deleteBucket(BucketName bucketName) {
-        return blobStoreImpl.deleteBucket(bucketName);
+        return metricFactory
+            .runPublishingTimerMetric(DELETE_TIMER_NAME, () -> blobStoreImpl.deleteBucket(bucketName));
     }
 }

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/BucketBlobStoreContract.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/BucketBlobStoreContract.java
@@ -1,0 +1,106 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.blob.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import org.apache.james.util.concurrency.ConcurrentTestRunner;
+import org.junit.jupiter.api.Test;
+
+public interface BucketBlobStoreContract {
+    String SHORT_STRING = "toto";
+    byte[] SHORT_BYTEARRAY = SHORT_STRING.getBytes(StandardCharsets.UTF_8);
+    BucketName CUSTOM = BucketName.of("custom");
+
+    BlobStore testee();
+
+    BlobId.Factory blobIdFactory();
+
+    @Test
+    default void saveBytesShouldThrowWhenNullBucketName() {
+        assertThatThrownBy(() -> testee().save(null, SHORT_BYTEARRAY).block())
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    default void saveStringShouldThrowWhenNullBucketName() {
+        assertThatThrownBy(() -> testee().save(null, SHORT_STRING).block())
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    default void saveInputStreamShouldThrowWhenNullBucketName() {
+        assertThatThrownBy(() -> testee().save(null, new ByteArrayInputStream(SHORT_BYTEARRAY)).block())
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    default void readShouldThrowWhenNullBucketName() {
+        BlobId blobId = testee().save(BucketName.DEFAULT, SHORT_BYTEARRAY).block();
+        assertThatThrownBy(() -> testee().read(null, blobId))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    default void readBytesStreamShouldThrowWhenNullBucketName() {
+        BlobId blobId = testee().save(BucketName.DEFAULT, SHORT_BYTEARRAY).block();
+        assertThatThrownBy(() -> testee().readBytes(null, blobId).block())
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    default void readStringShouldThrowWhenBucketDoesNotExist() {
+        BlobId blobId = testee().save(BucketName.DEFAULT, SHORT_BYTEARRAY).block();
+        assertThatThrownBy(() -> testee().read(CUSTOM, blobId))
+            .isInstanceOf(ObjectStoreException.class);
+    }
+
+    @Test
+    default void readBytesStreamShouldThrowWhenBucketDoesNotExist() {
+        BlobId blobId = testee().save(BucketName.DEFAULT, SHORT_BYTEARRAY).block();
+        assertThatThrownBy(() -> testee().readBytes(CUSTOM, blobId).block())
+            .isInstanceOf(ObjectStoreException.class);
+    }
+
+    @Test
+    default void shouldBeAbleToSaveDataInMultipleBuckets() {
+        BlobId blobIdDefault = testee().save(BucketName.DEFAULT, SHORT_BYTEARRAY).block();
+        BlobId blobIdCustom = testee().save(CUSTOM, SHORT_BYTEARRAY).block();
+
+        byte[] bytesDefault = testee().readBytes(BucketName.DEFAULT, blobIdDefault).block();
+        byte[] bytesCustom = testee().readBytes(CUSTOM, blobIdCustom).block();
+
+        assertThat(bytesDefault).isEqualTo(bytesCustom);
+    }
+
+    @Test
+    default void saveConcurrentlyWithNonPreExistingBucketShouldNotFail() throws Exception {
+        ConcurrentTestRunner.builder()
+            .operation(((threadNumber, step) -> testee().save(CUSTOM, SHORT_STRING + threadNumber + step).block()))
+            .threadCount(10)
+            .operationCount(10)
+            .runSuccessfullyWithin(Duration.ofMinutes(1));
+    }
+}

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/MetricableBlobStoreContract.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/MetricableBlobStoreContract.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.blob.api;
 
+import static org.apache.james.blob.api.MetricableBlobStore.DELETE_TIMER_NAME;
 import static org.apache.james.blob.api.MetricableBlobStore.READ_BYTES_TIMER_NAME;
 import static org.apache.james.blob.api.MetricableBlobStore.READ_TIMER_NAME;
 import static org.apache.james.blob.api.MetricableBlobStore.SAVE_BYTES_TIMER_NAME;
@@ -99,6 +100,19 @@ public interface MetricableBlobStoreContract extends BlobStoreContract {
         testee().read(BucketName.DEFAULT, blobId);
 
         assertThat(metricsTestExtension.getMetricFactory().executionTimesFor(READ_TIMER_NAME))
+            .hasSize(2);
+    }
+
+    @Test
+    default void deleteBucketShouldPublishDeleteTimerMetrics() {
+        BucketName bucketName = BucketName.of("custom");
+        testee().save(BucketName.DEFAULT, BYTES_CONTENT).block();
+        testee().save(bucketName, BYTES_CONTENT).block();
+
+        testee().deleteBucket(BucketName.DEFAULT);
+        testee().deleteBucket(bucketName);
+
+        assertThat(metricsTestExtension.getMetricFactory().executionTimesFor(DELETE_TIMER_NAME))
             .hasSize(2);
     }
 }

--- a/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/CassandraBlobsDAO.java
+++ b/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/CassandraBlobsDAO.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.backends.cassandra.init.configuration.CassandraConfiguration;
 import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
@@ -217,5 +218,10 @@ public class CassandraBlobsDAO implements BlobStore {
         Preconditions.checkNotNull(data);
         return Mono.fromCallable(() -> IOUtils.toByteArray(data))
             .flatMap(this::saveAsMono);
+    }
+
+    @Override
+    public Mono<Void> deleteBucket(BucketName bucketName) {
+        throw new NotImplementedException("not implemented");
     }
 }

--- a/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBlobsDAOTest.java
+++ b/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraBlobsDAOTest.java
@@ -35,6 +35,7 @@ import org.apache.james.blob.api.MetricableBlobStore;
 import org.apache.james.blob.api.MetricableBlobStoreContract;
 import org.apache.james.util.ZeroedInputStream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -68,6 +69,12 @@ public class CassandraBlobsDAOTest implements MetricableBlobStoreContract {
     @Override
     public BlobId.Factory blobIdFactory() {
         return new HashBlobId.Factory();
+    }
+
+    @Override
+    @Disabled("JAMES-2806: delete bucket not implemented yet for Cassandra")
+    public void deleteBucketShouldPublishDeleteTimerMetrics() {
+
     }
 
     @Test

--- a/server/blob/blob-memory/src/main/java/org/apache/james/blob/memory/MemoryBlobStore.java
+++ b/server/blob/blob-memory/src/main/java/org/apache/james/blob/memory/MemoryBlobStore.java
@@ -23,7 +23,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 
 import javax.inject.Inject;
 
@@ -35,31 +34,41 @@ import org.apache.james.blob.api.BucketName;
 import org.apache.james.blob.api.ObjectStoreException;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Table;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public class MemoryBlobStore implements BlobStore {
-    private final ConcurrentHashMap<BlobId, byte[]> blobs;
     private final BlobId.Factory factory;
+    private final Table<BucketName, BlobId, byte[]> blobs;
 
     @Inject
     public MemoryBlobStore(BlobId.Factory factory) {
         this.factory = factory;
-        blobs = new ConcurrentHashMap<>();
+        blobs = HashBasedTable.create();
     }
 
     @Override
     public Mono<BlobId> save(BucketName bucketName, byte[] data) {
+        Preconditions.checkNotNull(bucketName);
         Preconditions.checkNotNull(data);
+
         BlobId blobId = factory.forPayload(data);
 
-        blobs.put(blobId, data);
-
-        return Mono.just(blobId);
+        return Mono.fromCallable(() -> {
+            synchronized (blobs) {
+                blobs.put(bucketName, blobId, data);
+                return blobId;
+            }
+        });
     }
 
     @Override
     public Mono<BlobId> save(BucketName bucketName, InputStream data) {
+        Preconditions.checkNotNull(bucketName);
         Preconditions.checkNotNull(data);
         try {
             byte[] bytes = IOUtils.toByteArray(data);
@@ -71,12 +80,14 @@ public class MemoryBlobStore implements BlobStore {
 
     @Override
     public Mono<byte[]> readBytes(BucketName bucketName, BlobId blobId) {
-        return Mono.fromCallable(() -> retrieveStoredValue(blobId));
+        Preconditions.checkNotNull(bucketName);
+        return Mono.fromCallable(() -> retrieveStoredValue(bucketName, blobId));
     }
 
     @Override
     public InputStream read(BucketName bucketName, BlobId blobId) {
-        return new ByteArrayInputStream(retrieveStoredValue(blobId));
+        Preconditions.checkNotNull(bucketName);
+        return new ByteArrayInputStream(retrieveStoredValue(bucketName, blobId));
     }
 
     @Override
@@ -84,8 +95,10 @@ public class MemoryBlobStore implements BlobStore {
         throw new NotImplementedException("not implemented");
     }
 
-    private byte[] retrieveStoredValue(BlobId blobId) {
-        return Optional.ofNullable(blobs.get(blobId))
-            .orElseThrow(() -> new ObjectStoreException("unable to find blob with id " + blobId));
+    private byte[] retrieveStoredValue(BucketName bucketName, BlobId blobId) {
+        synchronized (blobs) {
+            return Optional.ofNullable(blobs.get(bucketName, blobId))
+                .orElseThrow(() -> new ObjectStoreException("Unable to find blob with id " + blobId + " in bucket " + bucketName.asString()));
+        }
     }
 }

--- a/server/blob/blob-memory/src/main/java/org/apache/james/blob/memory/MemoryBlobStore.java
+++ b/server/blob/blob-memory/src/main/java/org/apache/james/blob/memory/MemoryBlobStore.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import javax.inject.Inject;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BucketName;
@@ -35,10 +34,8 @@ import org.apache.james.blob.api.ObjectStoreException;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Table;
 
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public class MemoryBlobStore implements BlobStore {
@@ -92,7 +89,13 @@ public class MemoryBlobStore implements BlobStore {
 
     @Override
     public Mono<Void> deleteBucket(BucketName bucketName) {
-        throw new NotImplementedException("not implemented");
+        Preconditions.checkNotNull(bucketName);
+
+        return Mono.fromRunnable(() -> {
+            synchronized (blobs) {
+                blobs.row(bucketName).clear();
+            }
+        });
     }
 
     private byte[] retrieveStoredValue(BucketName bucketName, BlobId blobId) {

--- a/server/blob/blob-memory/src/main/java/org/apache/james/blob/memory/MemoryBlobStore.java
+++ b/server/blob/blob-memory/src/main/java/org/apache/james/blob/memory/MemoryBlobStore.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BucketName;
@@ -76,6 +77,11 @@ public class MemoryBlobStore implements BlobStore {
     @Override
     public InputStream read(BucketName bucketName, BlobId blobId) {
         return new ByteArrayInputStream(retrieveStoredValue(blobId));
+    }
+
+    @Override
+    public Mono<Void> deleteBucket(BucketName bucketName) {
+        throw new NotImplementedException("not implemented");
     }
 
     private byte[] retrieveStoredValue(BlobId blobId) {

--- a/server/blob/blob-memory/src/test/java/org/apache/james/blob/memory/MemoryBlobStoreTest.java
+++ b/server/blob/blob-memory/src/test/java/org/apache/james/blob/memory/MemoryBlobStoreTest.java
@@ -21,12 +21,13 @@ package org.apache.james.blob.memory;
 
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
+import org.apache.james.blob.api.BucketBlobStoreContract;
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.MetricableBlobStore;
 import org.apache.james.blob.api.MetricableBlobStoreContract;
 import org.junit.jupiter.api.BeforeEach;
 
-public class MemoryBlobStoreTest implements MetricableBlobStoreContract {
+public class MemoryBlobStoreTest implements MetricableBlobStoreContract, BucketBlobStoreContract {
 
     private static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
     private BlobStore blobStore;

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAO.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAO.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.util.Optional;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BucketName;
@@ -146,6 +147,11 @@ public class ObjectStorageBlobsDAO implements BlobStore {
                 cause);
         }
 
+    }
+
+    @Override
+    public Mono<Void> deleteBucket(BucketName bucketName) {
+        throw new NotImplementedException("not implemented");
     }
 
     public void deleteContainer() {

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAOTest.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAOTest.java
@@ -45,6 +45,7 @@ import org.apache.james.blob.objectstorage.swift.UserHeaderName;
 import org.apache.james.blob.objectstorage.swift.UserName;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -108,6 +109,12 @@ public class ObjectStorageBlobsDAOTest implements MetricableBlobStoreContract {
     @Override
     public BlobId.Factory blobIdFactory() {
         return new HashBlobId.Factory();
+    }
+
+    @Override
+    @Disabled("JAMES-2806: delete bucket not implemented yet for ObjectStorage")
+    public void deleteBucketShouldPublishDeleteTimerMetrics() {
+
     }
 
     @Test

--- a/server/blob/blob-union/src/main/java/org/apache/james/blob/union/UnionBlobStore.java
+++ b/server/blob/blob-union/src/main/java/org/apache/james/blob/union/UnionBlobStore.java
@@ -137,6 +137,13 @@ public class UnionBlobStore implements BlobStore {
         }
     }
 
+    @Override
+    public Mono<Void> deleteBucket(BucketName bucketName) {
+        return Mono.defer(() -> currentBlobStore.deleteBucket(bucketName))
+            .and(legacyBlobStore.deleteBucket(bucketName))
+            .onErrorResume(this::logAndReturnEmpty);
+    }
+
     private InputStream readFallBackIfEmptyResult(BucketName bucketName, BlobId blobId) {
         return Optional.ofNullable(currentBlobStore.read(bucketName, blobId))
             .map(PushbackInputStream::new)

--- a/server/blob/blob-union/src/test/java/org/apache/james/blob/union/UnionBlobStoreTest.java
+++ b/server/blob/blob-union/src/test/java/org/apache/james/blob/union/UnionBlobStoreTest.java
@@ -82,6 +82,11 @@ class UnionBlobStoreTest implements BlobStoreContract {
         }
 
         @Override
+        public Mono<Void> deleteBucket(BucketName bucketName) {
+            return Mono.error(new RuntimeException("broken everywhere"));
+        }
+
+        @Override
         public String toString() {
             return MoreObjects.toStringHelper(this)
                 .toString();
@@ -113,6 +118,11 @@ class UnionBlobStoreTest implements BlobStoreContract {
         @Override
         public InputStream read(BucketName bucketName, BlobId blobId) {
             throw new RuntimeException("broken everywhere");
+        }
+
+        @Override
+        public Mono<Void> deleteBucket(BucketName bucketName) {
+            return Mono.error(new RuntimeException("broken everywhere"));
         }
 
         @Override


### PR DESCRIPTION
I feel like I cannot test in the contract if the bucket creation was a success or not... Do I need? Should we add then a `getBucket` API in BlobStore? Or should I return a `Bucket` after creation (which might require the interface to be created) ? 