### PR TITLE
[POC] ES throws when trying to create an index with the value of a previously defined alias

### DIFF
--- a/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/IndexCreationFactory.java
+++ b/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/IndexCreationFactory.java
@@ -115,6 +115,8 @@ public class IndexCreationFactory {
             } catch (ElasticsearchStatusException exception) {
                 if (exception.getMessage().contains(INDEX_ALREADY_EXISTS_EXCEPTION_MESSAGE)) {
                     LOGGER.info("Index [{}] already exist", indexName);
+                } else if (exception.getMessage().contains(INDEX_NAME_EXCEPTION_MESSAGE)) {
+                    LOGGER.info("Index [{}] already exist as alias", indexName);
                 } else {
                     throw exception;
                 }
@@ -170,6 +172,7 @@ public class IndexCreationFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IndexCreationFactory.class);
     private static final String INDEX_ALREADY_EXISTS_EXCEPTION_MESSAGE = "type=resource_already_exists_exception";
+    private static final String INDEX_NAME_EXCEPTION_MESSAGE = "type=invalid_index_name_exception";
 
     private final int nbShards;
     private final int nbReplica;

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/IndexCreationFactoryTest.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/IndexCreationFactoryTest.java
@@ -59,6 +59,15 @@ public class IndexCreationFactoryTest {
             .createIndexAndAliases(client);
     }
 
+
+    @Test
+    public void createIndexAndAliasShouldNotThrowWhenIndexIsSameAsPreviouslyDefinedAlias() {
+        new IndexCreationFactory(ElasticSearchConfiguration.DEFAULT_CONFIGURATION)
+            .useIndex(new IndexName("alias"))
+            .addAlias(ALIAS_NAME)
+            .createIndexAndAliases(client);
+    }
+
     @Test
     public void useIndexShouldThrowWhenNull() {
         assertThatThrownBy(() ->

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/IndexCreationFactoryTest.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/IndexCreationFactoryTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.backends.es;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -53,19 +54,21 @@ public class IndexCreationFactoryTest {
 
     @Test
     public void createIndexAndAliasShouldNotThrowWhenCalledSeveralTime() {
-        new IndexCreationFactory(ElasticSearchConfiguration.DEFAULT_CONFIGURATION)
-            .useIndex(INDEX_NAME)
-            .addAlias(ALIAS_NAME)
-            .createIndexAndAliases(client);
+        assertThatCode(() -> new IndexCreationFactory(ElasticSearchConfiguration.DEFAULT_CONFIGURATION)
+                .useIndex(INDEX_NAME)
+                .addAlias(ALIAS_NAME)
+                .createIndexAndAliases(client))
+            .doesNotThrowAnyException();
     }
 
 
     @Test
     public void createIndexAndAliasShouldNotThrowWhenIndexIsSameAsPreviouslyDefinedAlias() {
-        new IndexCreationFactory(ElasticSearchConfiguration.DEFAULT_CONFIGURATION)
-            .useIndex(new IndexName("alias"))
-            .addAlias(ALIAS_NAME)
-            .createIndexAndAliases(client);
+        assertThatCode(() -> new IndexCreationFactory(ElasticSearchConfiguration.DEFAULT_CONFIGURATION)
+                .useIndex(new IndexName("alias"))
+                .addAlias(ALIAS_NAME)
+                .createIndexAndAliases(client))
+            .doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION
Trying to solve this : 
```
[ERROR] Tests run: 16, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 39.382 s <<< FAILURE! - in org.apache.james.jmap.cassandra.CassandraSetMessagesMethodTest
[ERROR] mailboxIdsShouldBeInDestinationWhenUsingForMove  Time elapsed: 1.001 s  <<< ERROR!
org.elasticsearch.ElasticsearchStatusException: Elasticsearch exception [type=invalid_alias_name_exception, reason=Invalid alias name [quota_ratio_write_alias], an index exists with the same name as the alias]
    at org.apache.james.jmap.methods.integration.SetMessagesMethodTest.setup(SetMessagesMethodTest.java:162)
```

The test is the proof of the issue. No idea though why sometimes in our tests we encounter this case