### PR TITLE
MAILBOX-374 Increase sleep time while await listener execution

### DIFF
--- a/mpt/impl/imap-mailbox/rabbitmq/src/test/java/org/apache/james/mpt/imapmailbox/rabbitmq/host/RabbitMQEventBusHostSystem.java
+++ b/mpt/impl/imap-mailbox/rabbitmq/src/test/java/org/apache/james/mpt/imapmailbox/rabbitmq/host/RabbitMQEventBusHostSystem.java
@@ -134,7 +134,7 @@ public class RabbitMQEventBusHostSystem extends JamesImapHostSystem {
     @Override
     protected void await() {
         try {
-            TimeUnit.SECONDS.sleep(1);
+            TimeUnit.SECONDS.sleep(5);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
One second turned out to be a bit short for executing the related listeners
on all environments.

I did observe this on the last fail master build....

```
[null] [ERROR] testQuotaScript  Time elapsed: 1.074 s  <<< ERROR!
[null] org.apache.james.mpt.protocol.ProtocolSession$InvalidServerResponseException: 
[null] 
[null] Location: /org/apache/james/imap/scripts/Quota.test:85
[null] LastClientMsg: A006 GETQUOTAROOT #private.imapuser.test
[null] Expected: '\* QUOTA #private&imapuser \(MESSAGE 7 4096\)'
[null] Actual   : '* QUOTA #private&imapuser (MESSAGE 8 4096)'
[null] 	at org.apache.james.mpt.imapmailbox.suite.QuotaTest.testQuotaScript(QuotaTest.java:62)
```