### PR TITLE
JAMES-2809 Skeleton of BlobStoreDeletedMessageVault

### DIFF
--- a/mailbox/plugin/deleted-messages-vault/pom.xml
+++ b/mailbox/plugin/deleted-messages-vault/pom.xml
@@ -82,6 +82,11 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>blob-memory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-core</artifactId>
         </dependency>
         <dependency>

--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/DeletedMessageVault.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/DeletedMessageVault.java
@@ -36,7 +36,5 @@ public interface DeletedMessageVault {
 
     Publisher<DeletedMessage> search(User user, Query query);
 
-    Publisher<User> usersWithVault();
-
     Task deleteExpiredMessagesTask();
 }

--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVault.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVault.java
@@ -1,0 +1,99 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.vault.blob;
+
+import java.io.InputStream;
+
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.james.blob.api.BlobStore;
+import org.apache.james.blob.api.BucketName;
+import org.apache.james.core.User;
+import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.task.Task;
+import org.apache.james.vault.DeletedMessage;
+import org.apache.james.vault.DeletedMessageVault;
+import org.apache.james.vault.metadata.DeletedMessageMetadataVault;
+import org.apache.james.vault.metadata.DeletedMessageWithStorageInformation;
+import org.apache.james.vault.metadata.StorageInformation;
+import org.apache.james.vault.search.Query;
+import org.reactivestreams.Publisher;
+
+import com.google.common.base.Preconditions;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class BlobStoreDeletedMessageVault implements DeletedMessageVault {
+    private final DeletedMessageMetadataVault messageMetadataVault;
+    private final BlobStore blobStore;
+    private final BucketNameGenerator nameGenerator;
+
+    public BlobStoreDeletedMessageVault(DeletedMessageMetadataVault messageMetadataVault, BlobStore blobStore, BucketNameGenerator nameGenerator) {
+        this.messageMetadataVault = messageMetadataVault;
+        this.blobStore = blobStore;
+        this.nameGenerator = nameGenerator;
+    }
+
+    @Override
+    public Publisher<Void> append(User user, DeletedMessage deletedMessage, InputStream mimeMessage) {
+        Preconditions.checkNotNull(user);
+        Preconditions.checkNotNull(deletedMessage);
+        Preconditions.checkNotNull(mimeMessage);
+        BucketName bucketName = nameGenerator.currentBucket();
+        return blobStore.save(bucketName, mimeMessage)
+            .map(blobId -> new StorageInformation(bucketName, blobId))
+            .map(storageInformation -> new DeletedMessageWithStorageInformation(deletedMessage, storageInformation))
+            .flatMap(message -> Mono.from(messageMetadataVault.store(message)))
+            .then();
+    }
+
+    @Override
+    public Publisher<InputStream> loadMimeMessage(User user, MessageId messageId) {
+        Preconditions.checkNotNull(user);
+        Preconditions.checkNotNull(messageId);
+        return Mono.from(messageMetadataVault.retrieveStorageInformation(user, messageId))
+            .map(storageInformation -> blobStore.read(storageInformation.getBucketName(), storageInformation.getBlobId()));
+    }
+
+    @Override
+    public Publisher<DeletedMessage> search(User user, Query query) {
+        Preconditions.checkNotNull(user);
+        Preconditions.checkNotNull(query);
+        return Flux.from(messageMetadataVault.listRelatedBuckets())
+            .concatMap(bucketName -> Flux.from(messageMetadataVault.listMessages(bucketName, user)))
+            .map(DeletedMessageWithStorageInformation::getDeletedMessage)
+            .filter(query.toPredicate());
+    }
+
+    @Override
+    public Publisher<Void> delete(User user, MessageId messageId) {
+        throw new NotImplementedException("Will be implemented later");
+    }
+
+    @Override
+    public Publisher<User> usersWithVault() {
+        throw new NotImplementedException("Will be implemented later");
+    }
+
+    @Override
+    public Task deleteExpiredMessagesTask() {
+        throw new NotImplementedException("Will be implemented later");
+    }
+}

--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVault.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVault.java
@@ -88,11 +88,6 @@ public class BlobStoreDeletedMessageVault implements DeletedMessageVault {
     }
 
     @Override
-    public Publisher<User> usersWithVault() {
-        throw new NotImplementedException("Will be implemented later");
-    }
-
-    @Override
     public Task deleteExpiredMessagesTask() {
         throw new NotImplementedException("Will be implemented later");
     }

--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BucketNameGenerator.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BucketNameGenerator.java
@@ -35,6 +35,6 @@ public class BucketNameGenerator {
         ZonedDateTime now = ZonedDateTime.now(clock);
         int month = now.getMonthValue();
         int year = now.getYear();
-        return BucketName.of(String.format("deletedMessages-%d-%d-01", year, month));
+        return BucketName.of(String.format("deletedMessages-%d-%02d-01", year, month));
     }
 }

--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BucketNameGenerator.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BucketNameGenerator.java
@@ -21,7 +21,6 @@ package org.apache.james.vault.blob;
 
 import java.time.Clock;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoField;
 
 import org.apache.james.blob.api.BucketName;
 

--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BucketNameGenerator.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BucketNameGenerator.java
@@ -1,0 +1,41 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.vault.blob;
+
+import java.time.Clock;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
+
+import org.apache.james.blob.api.BucketName;
+
+public class BucketNameGenerator {
+    private final Clock clock;
+
+    public BucketNameGenerator(Clock clock) {
+        this.clock = clock;
+    }
+
+    public BucketName currentBucket() {
+        ZonedDateTime now = ZonedDateTime.now(clock);
+        int month = now.getMonthValue();
+        int year = now.getYear();
+        return BucketName.of(String.format("deletedMessages-%d-%d-01", year, month));
+    }
+}

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageVaultContract.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageVaultContract.java
@@ -23,9 +23,11 @@ import static org.apache.james.vault.DeletedMessageFixture.CONTENT;
 import static org.apache.james.vault.DeletedMessageFixture.DELETED_MESSAGE;
 import static org.apache.james.vault.DeletedMessageFixture.DELETED_MESSAGE_2;
 import static org.apache.james.vault.DeletedMessageFixture.DELETED_MESSAGE_GENERATOR;
+import static org.apache.james.vault.DeletedMessageFixture.DELETED_MESSAGE_WITH_SUBJECT;
 import static org.apache.james.vault.DeletedMessageFixture.MESSAGE_ID;
 import static org.apache.james.vault.DeletedMessageFixture.NOW;
 import static org.apache.james.vault.DeletedMessageFixture.OLD_DELETED_MESSAGE;
+import static org.apache.james.vault.DeletedMessageFixture.SUBJECT;
 import static org.apache.james.vault.DeletedMessageFixture.USER;
 import static org.apache.james.vault.DeletedMessageFixture.USER_2;
 import static org.apache.james.vault.search.Query.ALL;
@@ -39,6 +41,8 @@ import java.time.Duration;
 import org.apache.james.mailbox.inmemory.InMemoryMessageId;
 import org.apache.james.task.Task;
 import org.apache.james.util.concurrency.ConcurrentTestRunner;
+import org.apache.james.vault.search.CriterionFactory;
+import org.apache.james.vault.search.Query;
 import org.junit.jupiter.api.Test;
 
 import reactor.core.publisher.Flux;
@@ -124,6 +128,18 @@ public interface DeletedMessageVaultContract {
 
         assertThat(Flux.from(getVault().search(USER, ALL)).collectList().block())
             .containsOnly(DELETED_MESSAGE, DELETED_MESSAGE_2);
+    }
+
+    @Test
+    default void searchShouldReturnMatchingItems() {
+        Mono.from(getVault().append(USER, DELETED_MESSAGE_2, new ByteArrayInputStream(CONTENT))).block();
+        Mono.from(getVault().append(USER, DELETED_MESSAGE_WITH_SUBJECT, new ByteArrayInputStream(CONTENT))).block();
+
+        assertThat(
+            Flux.from(getVault().search(USER,
+                Query.of(CriterionFactory.subject().containsIgnoreCase(SUBJECT))))
+                .collectList().block())
+            .containsOnly(DELETED_MESSAGE_WITH_SUBJECT);
     }
 
     @Test

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVaultTest.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVaultTest.java
@@ -110,18 +110,6 @@ class BlobStoreDeletedMessageVaultTest implements DeletedMessageVaultContract {
 
     @Disabled("Will be implemented later")
     @Override
-    public void usersWithVaultShouldReturnEmptyWhenNoItem() {
-
-    }
-
-    @Disabled("Will be implemented later")
-    @Override
-    public void usersWithVaultShouldReturnAllUsers() {
-
-    }
-
-    @Disabled("Will be implemented later")
-    @Override
     public void searchAllShouldNotReturnDeletedItems() {
 
     }
@@ -129,6 +117,12 @@ class BlobStoreDeletedMessageVaultTest implements DeletedMessageVaultContract {
     @Disabled("Will be implemented later")
     @Override
     public void loadMimeMessageShouldReturnEmptyWhenDeleted() {
+
+    }
+
+    @Disabled("Will be implemented later")
+    @Override
+    public void deleteExpiredMessagesTaskShouldDeleteOldMailsWhenRunSeveralTime() {
 
     }
 }

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVaultTest.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVaultTest.java
@@ -1,0 +1,134 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.vault.blob;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.memory.MemoryBlobStore;
+import org.apache.james.vault.DeletedMessageVault;
+import org.apache.james.vault.DeletedMessageVaultContract;
+import org.apache.james.vault.memory.metadata.MemoryDeletedMessageMetadataVault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+
+class BlobStoreDeletedMessageVaultTest implements DeletedMessageVaultContract {
+    private static final Instant NOW = Instant.parse("2007-12-03T10:15:30.00Z");
+    private static final Clock CLOCK = Clock.fixed(NOW, ZoneId.of("UTC"));
+
+    private BlobStoreDeletedMessageVault messageVault;
+
+    @BeforeEach
+    void setUp() {
+        messageVault = new BlobStoreDeletedMessageVault(new MemoryDeletedMessageMetadataVault(),
+            new MemoryBlobStore(new HashBlobId.Factory()),
+            new BucketNameGenerator(CLOCK));
+    }
+
+    @Override
+    public DeletedMessageVault getVault() {
+        return messageVault;
+    }
+
+
+    @Disabled("Will be implemented later")
+    public void deleteShouldThrowOnNullMessageId() {
+
+    }
+
+    @Disabled("Will be implemented later")
+    public void deleteShouldThrowOnNullUser() {
+
+    }
+
+    @Disabled("Will be implemented in JAMES-2811")
+    @Override
+    public void deleteExpiredMessagesTaskShouldCompleteWhenNoMail() {
+
+    }
+
+    @Disabled("Will be implemented in JAMES-2811")
+    @Override
+    public void deleteExpiredMessagesTaskShouldCompleteWhenAllMailsDeleted() {
+
+    }
+
+    @Disabled("Will be implemented in JAMES-2811")
+    @Override
+    public void deleteExpiredMessagesTaskShouldCompleteWhenOnlyRecentMails() {
+
+    }
+
+    @Disabled("Will be implemented in JAMES-2811")
+    @Override
+    public void deleteExpiredMessagesTaskShouldDeleteOldMails() {
+
+    }
+
+    @Disabled("Will be implemented in JAMES-2811")
+    @Override
+    public void deleteExpiredMessagesTaskShouldNotDeleteRecentMails() {
+
+    }
+
+    @Disabled("Will be implemented in JAMES-2811")
+    @Override
+    public void deleteExpiredMessagesTaskShouldDoNothingWhenEmpty() {
+
+    }
+
+    @Disabled("Will be implemented in JAMES-2811")
+    @Override
+    public void deleteExpiredMessagesTaskShouldCompleteWhenOnlyOldMails() {
+
+    }
+
+    @Disabled("Will be implemented later")
+    @Override
+    public void deleteShouldRunSuccessfullyInAConcurrentContext() {
+
+    }
+
+    @Disabled("Will be implemented later")
+    @Override
+    public void usersWithVaultShouldReturnEmptyWhenNoItem() {
+
+    }
+
+    @Disabled("Will be implemented later")
+    @Override
+    public void usersWithVaultShouldReturnAllUsers() {
+
+    }
+
+    @Disabled("Will be implemented later")
+    @Override
+    public void searchAllShouldNotReturnDeletedItems() {
+
+    }
+
+    @Disabled("Will be implemented later")
+    @Override
+    public void loadMimeMessageShouldReturnEmptyWhenDeleted() {
+
+    }
+}

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/blob/BucketNameGeneratorTest.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/blob/BucketNameGeneratorTest.java
@@ -30,10 +30,17 @@ import org.junit.jupiter.api.Test;
 
 class BucketNameGeneratorTest {
     private static final Instant NOW = Instant.parse("2007-12-03T10:15:30.00Z");
+    private static final Instant DATE2 = Instant.parse("2007-07-03T10:15:30.00Z");
     private static final Clock CLOCK = Clock.fixed(NOW, ZoneId.of("UTC"));
 
     @Test
     void currentBucketShouldReturnBucketFormattedOnFirstDayOfMonth() {
+        assertThat(new BucketNameGenerator(CLOCK).currentBucket())
+            .isEqualTo(BucketName.of("deletedMessages-2007-12-01"));
+    }
+
+    @Test
+    void monthShouldBeFormattedWithTwoDigits() {
         assertThat(new BucketNameGenerator(CLOCK).currentBucket())
             .isEqualTo(BucketName.of("deletedMessages-2007-12-01"));
     }

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/blob/BucketNameGeneratorTest.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/blob/BucketNameGeneratorTest.java
@@ -1,0 +1,40 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.vault.blob;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import org.apache.james.blob.api.BucketName;
+import org.junit.jupiter.api.Test;
+
+class BucketNameGeneratorTest {
+    private static final Instant NOW = Instant.parse("2007-12-03T10:15:30.00Z");
+    private static final Clock CLOCK = Clock.fixed(NOW, ZoneId.of("UTC"));
+
+    @Test
+    void currentBucketShouldReturnBucketFormattedOnFirstDayOfMonth() {
+        assertThat(new BucketNameGenerator(CLOCK).currentBucket())
+            .isEqualTo(BucketName.of("deletedMessages-2007-12-01"));
+    }
+}

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/blob/BucketNameGeneratorTest.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/blob/BucketNameGeneratorTest.java
@@ -30,8 +30,9 @@ import org.junit.jupiter.api.Test;
 
 class BucketNameGeneratorTest {
     private static final Instant NOW = Instant.parse("2007-12-03T10:15:30.00Z");
-    private static final Instant DATE2 = Instant.parse("2007-07-03T10:15:30.00Z");
+    private static final Instant DATE_2 = Instant.parse("2007-07-03T10:15:30.00Z");
     private static final Clock CLOCK = Clock.fixed(NOW, ZoneId.of("UTC"));
+    private static final Clock CLOCK_2 = Clock.fixed(DATE_2, ZoneId.of("UTC"));
 
     @Test
     void currentBucketShouldReturnBucketFormattedOnFirstDayOfMonth() {
@@ -41,7 +42,7 @@ class BucketNameGeneratorTest {
 
     @Test
     void monthShouldBeFormattedWithTwoDigits() {
-        assertThat(new BucketNameGenerator(CLOCK).currentBucket())
-            .isEqualTo(BucketName.of("deletedMessages-2007-12-01"));
+        assertThat(new BucketNameGenerator(CLOCK_2).currentBucket())
+            .isEqualTo(BucketName.of("deletedMessages-2007-07-01"));
     }
 }

--- a/server/protocols/webadmin/webadmin-mailbox-deleted-message-vault/src/test/java/org/apache/james/webadmin/vault/routes/DeletedMessagesVaultRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox-deleted-message-vault/src/test/java/org/apache/james/webadmin/vault/routes/DeletedMessagesVaultRoutesTest.java
@@ -2022,7 +2022,7 @@ class DeletedMessagesVaultRoutesTest {
                 vault.append(USER, DELETED_MESSAGE, new ByteArrayInputStream(CONTENT)).block();
                 vault.append(USER, DELETED_MESSAGE_2, new ByteArrayInputStream(CONTENT)).block();
 
-                doReturn(new DeleteByQueryExecutor(vault)).when(vault).getDeleteByQueryExecutor();
+                doReturn(new DeleteByQueryExecutor(vault, vault::usersWithVault)).when(vault).getDeleteByQueryExecutor();
                 doReturn(Flux.error(new RuntimeException("mock exception")))
                     .when(vault)
                     .search(any(), any());
@@ -2057,7 +2057,7 @@ class DeletedMessagesVaultRoutesTest {
                 vault.append(USER, DELETED_MESSAGE, new ByteArrayInputStream(CONTENT)).block();
                 vault.append(USER, DELETED_MESSAGE_2, new ByteArrayInputStream(CONTENT)).block();
 
-                doReturn(new DeleteByQueryExecutor(vault)).when(vault).getDeleteByQueryExecutor();
+                doReturn(new DeleteByQueryExecutor(vault, vault::usersWithVault)).when(vault).getDeleteByQueryExecutor();
                 doReturn(Mono.error(new RuntimeException("mock exception")))
                     .when(vault)
                     .delete(any(), any());


### PR DESCRIPTION
Tested on top of memory, this do not cover retention (see JAMES-2811) nor deletion.

Method DeletedMessageVault::usersWithVault had been removed as it was only used within a vault implementation.