### PR TITLE
Since java 9 there's a release parameter that do exactly what animal-…

### DIFF
--- a/dockerfiles/compilation/java-8/Dockerfile
+++ b/dockerfiles/compilation/java-8/Dockerfile
@@ -2,19 +2,19 @@
 #
 # VERSION	1.0
 
-FROM openjdk:8u171-jdk
+FROM adoptopenjdk:11-jdk-hotspot
 
 ENV GIT_VERSION 1:2.11.0-3
 
-# Install Maven
-WORKDIR /root
-RUN wget https://archive.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz
-RUN tar -xvf apache-maven-3.5.4-bin.tar.gz
-RUN ln -s /root/apache-maven-3.5.4/bin/mvn /usr/bin/mvn
-
 # Install git
 RUN apt-get update
-RUN apt-get install -y git
+RUN apt-get install -y git wget unzip
+
+# Install Maven
+WORKDIR /root
+RUN wget https://archive.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz
+RUN tar -xvf apache-maven-3.6.1-bin.tar.gz
+RUN ln -s /root/apache-maven-3.6.1/bin/mvn /usr/bin/mvn
 
 # Copy the script
 COPY compile.sh /root/compile.sh

--- a/pom.xml
+++ b/pom.xml
@@ -576,7 +576,7 @@
             otherwise the set values are used by default.
         -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <target.jdk>1.8</target.jdk>
+        <target.jdk>8</target.jdk>
         <james-skin.version>1.9-SNAPSHOT</james-skin.version>
         <!--
             This property contains the directory where to deploy when running using "-Psite-reports" profile
@@ -2713,6 +2713,7 @@
                         <optimize>true</optimize>
                         <source>${target.jdk}</source>
                         <target>${target.jdk}</target>
+                        <release>${target.jdk}</release>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -3088,11 +3089,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>animal-sniffer-maven-plugin</artifactId>
-                    <version>1.16</version>
-                </plugin>
-                <plugin>
                     <groupId>pl.project13.maven</groupId>
                     <artifactId>git-commit-id-plugin</artifactId>
                     <version>3.0.0</version>
@@ -3181,26 +3177,6 @@
                         <version>1.7</version>
                     </dependency>
                 </dependencies>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <configuration>
-                    <signature>
-                        <groupId>org.codehaus.mojo.signature</groupId>
-                        <artifactId>java18</artifactId>
-                        <version>1.0</version>
-                    </signature>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>check_java_8</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <phase>test</phase>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/server/container/spring/pom.xml
+++ b/server/container/spring/pom.xml
@@ -200,19 +200,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>check_java_8</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/data/data-jpa/pom.xml
+++ b/server/data/data-jpa/pom.xml
@@ -190,16 +190,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>check_java_8</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/server/queue/queue-file/pom.xml
+++ b/server/queue/queue-file/pom.xml
@@ -107,19 +107,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>check_java_8</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>


### PR DESCRIPTION
…sniffer does

	The idea is to leverage a java > 8 compiler to gain greater compile speed,
	to replace the slow animal-sniffer plugin and to still generate artifacts
	for Java 8