### PR TITLE
JAMES-2733 Improve RabbitMQ MailQueue getSize performance

### DIFF
--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/BucketSizeDAO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/BucketSizeDAO.java
@@ -1,0 +1,106 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.queue.rabbitmq.view.cassandra;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.decr;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.incr;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.update;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.BucketSizeTable.BUCKET_ID;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.BucketSizeTable.MAIL_COUNT;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.BucketSizeTable.QUEUE_NAME;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.BucketSizeTable.TABLE_NAME;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.BucketSizeTable.TIME_RANGE_START;
+
+import java.util.Date;
+
+import javax.inject.Inject;
+
+import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
+import org.apache.james.queue.rabbitmq.MailQueueName;
+import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.Assignment;
+
+import reactor.core.publisher.Mono;
+
+class BucketSizeDAO {
+    private final CassandraAsyncExecutor executor;
+    private final PreparedStatement increment;
+    private final PreparedStatement decrement;
+    private final PreparedStatement select;
+
+    @Inject
+    BucketSizeDAO(Session session) {
+        this.executor = new CassandraAsyncExecutor(session);
+
+        this.increment = prepareUpdate(session, incr(MAIL_COUNT));
+        this.decrement = prepareUpdate(session, decr(MAIL_COUNT));
+        this.select = prepareSelect(session);
+    }
+
+    private PreparedStatement prepareUpdate(Session session, Assignment assignment) {
+        return session.prepare(
+            update(TABLE_NAME)
+                .with(assignment)
+                .where(eq(QUEUE_NAME, bindMarker(QUEUE_NAME)))
+                .and(eq(TIME_RANGE_START, bindMarker(TIME_RANGE_START)))
+                .and(eq(BUCKET_ID, bindMarker(BUCKET_ID))));
+    }
+
+    private PreparedStatement prepareSelect(Session session) {
+        return session.prepare(
+            select(MAIL_COUNT)
+                .from(TABLE_NAME)
+                .where(eq(QUEUE_NAME, bindMarker(QUEUE_NAME)))
+                .and(eq(TIME_RANGE_START, bindMarker(TIME_RANGE_START)))
+                .and(eq(BUCKET_ID, bindMarker(BUCKET_ID))));
+    }
+
+    Mono<Long> getMailCount(MailQueueName queueName, BucketedSlices.Slice slice, BucketedSlices.BucketId bucketId) {
+        return executor.executeSingleRowOptional(
+            select.bind()
+                .setString(QUEUE_NAME, queueName.asString())
+                .setTimestamp(TIME_RANGE_START, Date.from(slice.getStartSliceInstant()))
+                .setInt(BUCKET_ID, bucketId.getValue()))
+            .map(maybeRow -> maybeRow.map(row -> row.getLong(MAIL_COUNT)))
+            .map(maybeCount -> maybeCount.orElse(0L));
+    }
+
+    Mono<Void> increment(MailQueueName queueName, BucketedSlices.Slice slice, BucketedSlices.BucketId bucketId) {
+        return executor.executeVoid(
+            increment.bind()
+                .setString(QUEUE_NAME, queueName.asString())
+                .setTimestamp(TIME_RANGE_START, Date.from(slice.getStartSliceInstant()))
+                .setInt(BUCKET_ID, bucketId.getValue()));
+    }
+
+    Mono<Void> decrement(MailQueueName queueName, BucketedSlices.Slice slice, BucketedSlices.BucketId bucketId) {
+        return executor.executeVoid(
+            decrement.bind()
+                .setString(QUEUE_NAME, queueName.asString())
+                .setTimestamp(TIME_RANGE_START, Date.from(slice.getStartSliceInstant()))
+                .setInt(BUCKET_ID, bucketId.getValue()));
+    }
+}

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailStore.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailStore.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.configuration.CassandraMailQueueViewConfiguration;
+import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices.BucketId;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.EnqueuedItemWithSlicingContext;
 import org.apache.mailet.Mail;
@@ -37,16 +38,20 @@ public class CassandraMailQueueMailStore {
 
     private final EnqueuedMailsDAO enqueuedMailsDao;
     private final BrowseStartDAO browseStartDao;
+    private final BucketSizeDAO bucketSizeDAO;
+    private final EnqueueIdToBucketDAO enqueueIdToBucketDAO;
     private final CassandraMailQueueViewConfiguration configuration;
     private final Clock clock;
 
     @Inject
     CassandraMailQueueMailStore(EnqueuedMailsDAO enqueuedMailsDao,
                                 BrowseStartDAO browseStartDao,
-                                CassandraMailQueueViewConfiguration configuration,
+                                BucketSizeDAO bucketSizeDAO, EnqueueIdToBucketDAO enqueueIdToBucketDAO, CassandraMailQueueViewConfiguration configuration,
                                 Clock clock) {
         this.enqueuedMailsDao = enqueuedMailsDao;
         this.browseStartDao = browseStartDao;
+        this.bucketSizeDAO = bucketSizeDAO;
+        this.enqueueIdToBucketDAO = enqueueIdToBucketDAO;
         this.configuration = configuration;
         this.clock = clock;
     }
@@ -54,7 +59,12 @@ public class CassandraMailQueueMailStore {
     Mono<Void> storeMail(EnqueuedItem enqueuedItem) {
         EnqueuedItemWithSlicingContext enqueuedItemAndSlicing = addSliceContext(enqueuedItem);
 
-        return enqueuedMailsDao.insert(enqueuedItemAndSlicing);
+        BucketedSlices.Slice slice = BucketedSlices.Slice.of(enqueuedItemAndSlicing.getSlicingContext().getTimeRangeStart());
+        BucketId bucketId = enqueuedItemAndSlicing.getSlicingContext().getBucketId();
+
+        return enqueuedMailsDao.insert(enqueuedItemAndSlicing)
+            .then(enqueueIdToBucketDAO.registerBucket(enqueuedItem.getMailQueueName(), enqueuedItem.getEnqueueId(), slice, bucketId))
+            .then(bucketSizeDAO.increment(enqueuedItem.getMailQueueName(), slice, bucketId));
     }
 
     Mono<Void> initializeBrowseStart(MailQueueName mailQueueName) {

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
@@ -95,7 +95,9 @@ public class CassandraMailQueueView implements MailQueueView {
 
     @Override
     public long getSize() {
-        return cassandraMailQueueBrowser.browseReferences(mailQueueName).count().block();
+        return cassandraMailQueueBrowser.getSize(mailQueueName)
+            .blockOptional()
+            .orElse(0L);
     }
 
     @Override
@@ -119,7 +121,8 @@ public class CassandraMailQueueView implements MailQueueView {
     }
 
     private Mono<Void> delete(EnqueueId enqueueId) {
-        return cassandraMailQueueMailDelete.considerDeleted(enqueueId, mailQueueName);
+        return cassandraMailQueueMailDelete.considerDeleted(enqueueId, mailQueueName)
+            .then();
     }
 
     @Override

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
@@ -84,11 +84,11 @@ public interface CassandraMailQueueViewModule {
         String MAIL_COUNT = "mailCount";
     }
 
-    interface MailKeyToBucketTable {
-        String TABLE_NAME = "bucketSize";
+    interface EnqueueIdToBucketTable {
+        String TABLE_NAME = "mailKeyToBucket";
 
         String QUEUE_NAME = "queueName";
-        String MAIL_KEY = "mailKey";
+        String ENQUEUE_ID = "enqueueId";
 
         String TIME_RANGE_START = "timeRangeStart";
         String BUCKET_ID = "bucketId";
@@ -149,13 +149,13 @@ public interface CassandraMailQueueViewModule {
             .addPartitionKey(BucketSizeTable.BUCKET_ID, cint())
             .addColumn(BucketSizeTable.MAIL_COUNT, counter()))
 
-        .table(MailKeyToBucketTable.TABLE_NAME)
+        .table(EnqueueIdToBucketTable.TABLE_NAME)
         .comment("Given a mailKey, resolve the bucket it belongs to")
         .statement(statement -> statement
-            .addPartitionKey(MailKeyToBucketTable.QUEUE_NAME, text())
-            .addPartitionKey(MailKeyToBucketTable.MAIL_KEY, text())
-            .addColumn(MailKeyToBucketTable.TIME_RANGE_START, timestamp())
-            .addColumn(MailKeyToBucketTable.BUCKET_ID, cint()))
+            .addPartitionKey(EnqueueIdToBucketTable.QUEUE_NAME, text())
+            .addPartitionKey(EnqueueIdToBucketTable.ENQUEUE_ID, uuid())
+            .addColumn(EnqueueIdToBucketTable.TIME_RANGE_START, timestamp())
+            .addColumn(EnqueueIdToBucketTable.BUCKET_ID, cint()))
 
         .build();
 }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
@@ -149,5 +149,13 @@ public interface CassandraMailQueueViewModule {
             .addPartitionKey(BucketSizeTable.BUCKET_ID, cint())
             .addColumn(BucketSizeTable.MAIL_COUNT, counter()))
 
+        .table(MailKeyToBucketTable.TABLE_NAME)
+        .comment("Given a mailKey, resolve the bucket it belongs to")
+        .statement(statement -> statement
+            .addPartitionKey(MailKeyToBucketTable.QUEUE_NAME, text())
+            .addPartitionKey(MailKeyToBucketTable.MAIL_KEY, text())
+            .addColumn(MailKeyToBucketTable.TIME_RANGE_START, timestamp())
+            .addColumn(MailKeyToBucketTable.BUCKET_ID, cint()))
+
         .build();
 }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewModule.java
@@ -21,6 +21,7 @@ package org.apache.james.queue.rabbitmq.view.cassandra;
 
 import static com.datastax.driver.core.DataType.blob;
 import static com.datastax.driver.core.DataType.cint;
+import static com.datastax.driver.core.DataType.counter;
 import static com.datastax.driver.core.DataType.list;
 import static com.datastax.driver.core.DataType.map;
 import static com.datastax.driver.core.DataType.text;
@@ -73,6 +74,26 @@ public interface CassandraMailQueueViewModule {
         String ENQUEUE_ID = "enqueueId";
     }
 
+    interface BucketSizeTable {
+        String TABLE_NAME = "bucketSize";
+
+        String QUEUE_NAME = "queueName";
+        String TIME_RANGE_START = "timeRangeStart";
+        String BUCKET_ID = "bucketId";
+
+        String MAIL_COUNT = "mailCount";
+    }
+
+    interface MailKeyToBucketTable {
+        String TABLE_NAME = "bucketSize";
+
+        String QUEUE_NAME = "queueName";
+        String MAIL_KEY = "mailKey";
+
+        String TIME_RANGE_START = "timeRangeStart";
+        String BUCKET_ID = "bucketId";
+    }
+
     CassandraModule MODULE = CassandraModule
         .type(EnqueuedMailsTable.HEADER_TYPE)
             .statement(statement -> statement
@@ -119,6 +140,14 @@ public interface CassandraMailQueueViewModule {
         .statement(statement -> statement
             .addPartitionKey(DeletedMailTable.QUEUE_NAME, text())
             .addPartitionKey(DeletedMailTable.ENQUEUE_ID, uuid()))
+
+        .table(BucketSizeTable.TABLE_NAME)
+        .comment("Holds the count of remaining email per bucket")
+        .statement(statement -> statement
+            .addPartitionKey(BucketSizeTable.QUEUE_NAME, text())
+            .addPartitionKey(BucketSizeTable.TIME_RANGE_START, timestamp())
+            .addPartitionKey(BucketSizeTable.BUCKET_ID, cint())
+            .addColumn(BucketSizeTable.MAIL_COUNT, counter()))
 
         .build();
 }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueueIdToBucketDAO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueueIdToBucketDAO.java
@@ -1,0 +1,93 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.queue.rabbitmq.view.cassandra;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.EnqueueIdToBucketTable.BUCKET_ID;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.EnqueueIdToBucketTable.ENQUEUE_ID;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.EnqueueIdToBucketTable.QUEUE_NAME;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.EnqueueIdToBucketTable.TABLE_NAME;
+import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.EnqueueIdToBucketTable.TIME_RANGE_START;
+
+import java.util.Date;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
+import org.apache.james.queue.rabbitmq.EnqueueId;
+import org.apache.james.queue.rabbitmq.MailQueueName;
+import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices.BucketId;
+import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices.Slice;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+
+import reactor.core.publisher.Mono;
+
+class EnqueueIdToBucketDAO {
+    private final CassandraAsyncExecutor executor;
+    private final PreparedStatement selectOne;
+    private final PreparedStatement insertOne;
+
+    @Inject
+    EnqueueIdToBucketDAO(Session session) {
+        this.executor = new CassandraAsyncExecutor(session);
+
+        this.selectOne = prepareSelect(session);
+        this.insertOne = prepareInsert(session);
+    }
+
+    private PreparedStatement prepareInsert(Session session) {
+        return session.prepare(insertInto(TABLE_NAME)
+            .value(QUEUE_NAME, bindMarker(QUEUE_NAME))
+            .value(ENQUEUE_ID, bindMarker(ENQUEUE_ID))
+            .value(TIME_RANGE_START, bindMarker(TIME_RANGE_START))
+            .value(BUCKET_ID, bindMarker(BUCKET_ID)));
+    }
+
+    private PreparedStatement prepareSelect(Session session) {
+        return session.prepare(select()
+            .from(TABLE_NAME)
+            .where(eq(QUEUE_NAME, bindMarker(QUEUE_NAME)))
+            .and(eq(ENQUEUE_ID, bindMarker(ENQUEUE_ID))));
+    }
+
+    Mono<Void> registerBucket(MailQueueName mailQueueName, EnqueueId enqueueId, Slice slice, BucketId bucketId) {
+        return executor.executeVoid(insertOne.bind()
+            .setString(QUEUE_NAME, mailQueueName.asString())
+            .setUUID(ENQUEUE_ID, enqueueId.asUUID())
+            .setTimestamp(TIME_RANGE_START, Date.from(slice.getStartSliceInstant()))
+            .setInt(BUCKET_ID, bucketId.getValue()));
+    }
+
+    Mono<Pair<Slice, BucketId>> retrieveBucket(MailQueueName mailQueueName, EnqueueId enqueueId) {
+        return executor.executeSingleRowOptional(
+            selectOne.bind()
+                .setString(QUEUE_NAME, mailQueueName.asString())
+                .setUUID(ENQUEUE_ID, enqueueId.asUUID()))
+            .flatMap(maybeRow -> Mono.justOrEmpty(maybeRow.map(row -> Pair.of(
+                Slice.of(row.getTimestamp(TIME_RANGE_START).toInstant()),
+                BucketId.of(row.getInt(BUCKET_ID))))));
+    }
+}

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/BucketSizeDAOTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/BucketSizeDAOTest.java
@@ -1,0 +1,92 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.queue.rabbitmq.view.cassandra;
+
+import static org.apache.james.queue.rabbitmq.view.cassandra.MailQueueViewFixture.BUCKET_ID;
+import static org.apache.james.queue.rabbitmq.view.cassandra.MailQueueViewFixture.QUEUE_NAME;
+import static org.apache.james.queue.rabbitmq.view.cassandra.MailQueueViewFixture.SLICE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class BucketSizeDAOTest {
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(
+        CassandraModule.aggregateModules(CassandraSchemaVersionModule.MODULE, CassandraMailQueueViewModule.MODULE));
+
+    private BucketSizeDAO testee;
+
+    @BeforeEach
+    void setUp() {
+        testee = new BucketSizeDAO(cassandraCluster.getCassandraCluster().getConf());
+    }
+
+    @Test
+    void getMailCountShouldReturnZeroWhenNotYetInteractions() {
+        Optional<Long> maybeSize = testee.getMailCount(QUEUE_NAME, SLICE, BUCKET_ID).blockOptional();
+
+        assertThat(maybeSize).contains(0L);
+    }
+
+    @Test
+    void getMailCountShouldReturnIncrementedValue() {
+        testee.increment(QUEUE_NAME, SLICE, BUCKET_ID).block();
+
+        Optional<Long> maybeSize = testee.getMailCount(QUEUE_NAME, SLICE, BUCKET_ID).blockOptional();
+
+        assertThat(maybeSize).contains(1L);
+    }
+
+    @Test
+    void incrementIsNotIdempotent() {
+        testee.increment(QUEUE_NAME, SLICE, BUCKET_ID).block();
+        testee.increment(QUEUE_NAME, SLICE, BUCKET_ID).block();
+
+        Optional<Long> maybeSize = testee.getMailCount(QUEUE_NAME, SLICE, BUCKET_ID).blockOptional();
+
+        assertThat(maybeSize).contains(2L);
+    }
+
+    @Test
+    void decrementShouldRevertIncrement() {
+        testee.increment(QUEUE_NAME, SLICE, BUCKET_ID).block();
+        testee.decrement(QUEUE_NAME, SLICE, BUCKET_ID).block();
+
+        Optional<Long> maybeSize = testee.getMailCount(QUEUE_NAME, SLICE, BUCKET_ID).blockOptional();
+
+        assertThat(maybeSize).contains(0L);
+    }
+
+    @Test
+    void decrementShouldBeAppliedWhenZero() {
+        testee.decrement(QUEUE_NAME, SLICE, BUCKET_ID).block();
+
+        Optional<Long> maybeSize = testee.getMailCount(QUEUE_NAME, SLICE, BUCKET_ID).blockOptional();
+
+        assertThat(maybeSize).contains(-1L);
+    }
+}

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewTestFactory.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueViewTestFactory.java
@@ -49,11 +49,12 @@ public class CassandraMailQueueViewTestFactory {
         EnqueuedMailsDAO enqueuedMailsDao = new EnqueuedMailsDAO(session, typesProvider, blobIdFactory);
         BrowseStartDAO browseStartDao = new BrowseStartDAO(session);
         DeletedMailsDAO deletedMailsDao = new DeletedMailsDAO(session);
+        BucketSizeDAO bucketSizeDAO = new BucketSizeDAO(session);
+        EnqueueIdToBucketDAO enqueueIdToBucketDAO = new EnqueueIdToBucketDAO(session);
 
-        CassandraMailQueueBrowser cassandraMailQueueBrowser = new CassandraMailQueueBrowser(browseStartDao, deletedMailsDao, enqueuedMailsDao, mimeMessageStoreFactory, configuration, clock);
-        CassandraMailQueueMailStore cassandraMailQueueMailStore = new CassandraMailQueueMailStore(enqueuedMailsDao, browseStartDao, configuration, clock);
-        CassandraMailQueueMailDelete cassandraMailQueueMailDelete = new CassandraMailQueueMailDelete(deletedMailsDao, browseStartDao, cassandraMailQueueBrowser, configuration);
-
+        CassandraMailQueueBrowser cassandraMailQueueBrowser = new CassandraMailQueueBrowser(browseStartDao, deletedMailsDao, enqueuedMailsDao, bucketSizeDAO, mimeMessageStoreFactory, configuration, clock);
+        CassandraMailQueueMailStore cassandraMailQueueMailStore = new CassandraMailQueueMailStore(enqueuedMailsDao, browseStartDao, bucketSizeDAO, enqueueIdToBucketDAO, configuration, clock);
+        CassandraMailQueueMailDelete cassandraMailQueueMailDelete = new CassandraMailQueueMailDelete(deletedMailsDao, browseStartDao, bucketSizeDAO, enqueueIdToBucketDAO, cassandraMailQueueBrowser, configuration);
 
         EventsourcingConfigurationManagement eventsourcingConfigurationManagement = new EventsourcingConfigurationManagement(new CassandraEventStore(new EventStoreDao(session,
             new JsonEventSerializer(ImmutableSet.of(CassandraMailQueueViewConfigurationModule.MAIL_QUEUE_VIEW_CONFIGURATION)))));

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAOTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAOTest.java
@@ -19,13 +19,14 @@
 
 package org.apache.james.queue.rabbitmq.view.cassandra;
 
+import static org.apache.james.queue.rabbitmq.view.cassandra.MailQueueViewFixture.ENQUEUE_ID_1;
+import static org.apache.james.queue.rabbitmq.view.cassandra.MailQueueViewFixture.ENQUEUE_ID_2;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
-import org.apache.james.queue.rabbitmq.EnqueueId;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,8 +36,6 @@ class DeletedMailsDAOTest {
 
     private static final MailQueueName OUT_GOING_1 = MailQueueName.fromString("OUT_GOING_1");
     private static final MailQueueName OUT_GOING_2 = MailQueueName.fromString("OUT_GOING_2");
-    private static final EnqueueId ENQUEUE_ID_1 = EnqueueId.ofSerialized("110e8400-e29b-11d4-a716-446655440000");
-    private static final EnqueueId ENQUEUE_ID_2 = EnqueueId.ofSerialized("464765a0-e4e7-11e4-aba4-710c1de3782b");
 
     @RegisterExtension
     static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueueIdToBucketDAOTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueueIdToBucketDAOTest.java
@@ -1,0 +1,93 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.queue.rabbitmq.view.cassandra;
+
+import static org.apache.james.queue.rabbitmq.view.cassandra.MailQueueViewFixture.BUCKET_ID;
+import static org.apache.james.queue.rabbitmq.view.cassandra.MailQueueViewFixture.BUCKET_ID_2;
+import static org.apache.james.queue.rabbitmq.view.cassandra.MailQueueViewFixture.ENQUEUE_ID_1;
+import static org.apache.james.queue.rabbitmq.view.cassandra.MailQueueViewFixture.ENQUEUE_ID_2;
+import static org.apache.james.queue.rabbitmq.view.cassandra.MailQueueViewFixture.QUEUE_NAME;
+import static org.apache.james.queue.rabbitmq.view.cassandra.MailQueueViewFixture.SLICE;
+import static org.apache.james.queue.rabbitmq.view.cassandra.MailQueueViewFixture.SLICE_2;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class EnqueueIdToBucketDAOTest {
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(
+        CassandraModule.aggregateModules(CassandraSchemaVersionModule.MODULE, CassandraMailQueueViewModule.MODULE));
+
+    private EnqueueIdToBucketDAO testee;
+
+    @BeforeEach
+    void setUp() {
+        testee = new EnqueueIdToBucketDAO(cassandraCluster.getCassandraCluster().getConf());
+    }
+
+    @Test
+    void retrieveBucketShouldReturnEmptyWhenNoCorrespondingEntry() {
+        Optional<Pair<BucketedSlices.Slice, BucketedSlices.BucketId>> maybeBucketAndSlice =
+            testee.retrieveBucket(QUEUE_NAME, ENQUEUE_ID_1).blockOptional();
+
+        assertThat(maybeBucketAndSlice).isEmpty();
+    }
+
+    @Test
+    void retrieveBucketShouldReturnRegisteredSliceAndBucket() {
+        testee.registerBucket(QUEUE_NAME, ENQUEUE_ID_1, SLICE, BUCKET_ID).block();
+
+        Optional<Pair<BucketedSlices.Slice, BucketedSlices.BucketId>> maybeBucketAndSlice =
+            testee.retrieveBucket(QUEUE_NAME, ENQUEUE_ID_1).blockOptional();
+
+        assertThat(maybeBucketAndSlice).contains(Pair.of(SLICE, BUCKET_ID));
+    }
+
+    @Test
+    void registerBucketShouldOverridePrviouslyStoredData() {
+        testee.registerBucket(QUEUE_NAME, ENQUEUE_ID_1, SLICE, BUCKET_ID).block();
+        testee.registerBucket(QUEUE_NAME, ENQUEUE_ID_1, SLICE_2, BUCKET_ID_2).block();
+
+        Optional<Pair<BucketedSlices.Slice, BucketedSlices.BucketId>> maybeBucketAndSlice =
+            testee.retrieveBucket(QUEUE_NAME, ENQUEUE_ID_1).blockOptional();
+
+        assertThat(maybeBucketAndSlice).contains(Pair.of(SLICE_2, BUCKET_ID_2));
+    }
+
+    @Test
+    void dataShouldBeIsolatedByEnqueueId() {
+        testee.registerBucket(QUEUE_NAME, ENQUEUE_ID_1, SLICE, BUCKET_ID).block();
+        testee.registerBucket(QUEUE_NAME, ENQUEUE_ID_2, SLICE_2, BUCKET_ID_2).block();
+
+        Optional<Pair<BucketedSlices.Slice, BucketedSlices.BucketId>> maybeBucketAndSlice =
+            testee.retrieveBucket(QUEUE_NAME, ENQUEUE_ID_1).blockOptional();
+
+        assertThat(maybeBucketAndSlice).contains(Pair.of(SLICE, BUCKET_ID));
+    }
+}

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueueIdToBucketDAOTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueueIdToBucketDAOTest.java
@@ -70,7 +70,7 @@ class EnqueueIdToBucketDAOTest {
     }
 
     @Test
-    void registerBucketShouldOverridePrviouslyStoredData() {
+    void registerBucketShouldOverridePreviouslyStoredData() {
         testee.registerBucket(QUEUE_NAME, ENQUEUE_ID_1, SLICE, BUCKET_ID).block();
         testee.registerBucket(QUEUE_NAME, ENQUEUE_ID_1, SLICE_2, BUCKET_ID_2).block();
 

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/EnqueuedMailsDaoTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.queue.rabbitmq.view.cassandra;
 
+import static org.apache.james.queue.rabbitmq.view.cassandra.MailQueueViewFixture.ENQUEUE_ID_1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
@@ -33,7 +34,6 @@ import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.mail.MimeMessagePartsId;
-import org.apache.james.queue.rabbitmq.EnqueueId;
 import org.apache.james.queue.rabbitmq.EnqueuedItem;
 import org.apache.james.queue.rabbitmq.MailQueueName;
 import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices.BucketId;
@@ -47,7 +47,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class EnqueuedMailsDaoTest {
 
     private static final MailQueueName OUT_GOING_1 = MailQueueName.fromString("OUT_GOING_1");
-    private static final EnqueueId ENQUEUE_ID = EnqueueId.ofSerialized("110e8400-e29b-11d4-a716-446655440000");
     private static final String NAME = "name";
     private static int BUCKET_ID_VALUE = 10;
     private static final BucketId BUCKET_ID = BucketId.of(BUCKET_ID_VALUE);
@@ -80,7 +79,7 @@ class EnqueuedMailsDaoTest {
     void insertShouldWork() throws Exception {
         testee.insert(EnqueuedItemWithSlicingContext.builder()
                 .enqueuedItem(EnqueuedItem.builder()
-                    .enqueueId(ENQUEUE_ID)
+                    .enqueueId(ENQUEUE_ID_1)
                     .mailQueueName(OUT_GOING_1)
                     .mail(FakeMail.builder()
                         .name(NAME)
@@ -103,7 +102,7 @@ class EnqueuedMailsDaoTest {
     void selectEnqueuedMailsShouldWork() throws Exception {
         testee.insert(EnqueuedItemWithSlicingContext.builder()
                 .enqueuedItem(EnqueuedItem.builder()
-                    .enqueueId(ENQUEUE_ID)
+                    .enqueueId(ENQUEUE_ID_1)
                     .mailQueueName(OUT_GOING_1)
                     .mail(FakeMail.builder()
                         .name(NAME)
@@ -117,7 +116,7 @@ class EnqueuedMailsDaoTest {
 
         testee.insert(EnqueuedItemWithSlicingContext.builder()
                 .enqueuedItem(EnqueuedItem.builder()
-                    .enqueueId(ENQUEUE_ID)
+                    .enqueueId(ENQUEUE_ID_1)
                     .mailQueueName(OUT_GOING_1)
                     .mail(FakeMail.builder()
                         .name(NAME)
@@ -142,7 +141,7 @@ class EnqueuedMailsDaoTest {
                     softly.assertThat(slicingContext.getTimeRangeStart()).isEqualTo(NOW.truncatedTo(ChronoUnit.MILLIS));
                     softly.assertThat(enqueuedItem.getMailQueueName()).isEqualTo(OUT_GOING_1);
                     softly.assertThat(enqueuedItem.getEnqueuedTime()).isEqualTo(NOW.truncatedTo(ChronoUnit.MILLIS));
-                    softly.assertThat(enqueuedItem.getEnqueueId()).isEqualTo(ENQUEUE_ID);
+                    softly.assertThat(enqueuedItem.getEnqueueId()).isEqualTo(ENQUEUE_ID_1);
                     softly.assertThat(enqueuedItem.getMail().getName()).isEqualTo(NAME);
                     softly.assertThat(enqueuedItem.getPartsId()).isEqualTo(MIME_MESSAGE_PARTS_ID);
                 });

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/MailQueueViewFixture.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/view/cassandra/MailQueueViewFixture.java
@@ -1,0 +1,38 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.queue.rabbitmq.view.cassandra;
+
+import java.time.Instant;
+
+import org.apache.james.queue.rabbitmq.EnqueueId;
+import org.apache.james.queue.rabbitmq.MailQueueName;
+import org.apache.james.queue.rabbitmq.view.cassandra.model.BucketedSlices;
+
+public interface MailQueueViewFixture {
+    MailQueueName QUEUE_NAME = MailQueueName.fromString("mq");
+    EnqueueId ENQUEUE_ID_1 = EnqueueId.ofSerialized("110e8400-e29b-11d4-a716-446655440000");
+    EnqueueId ENQUEUE_ID_2 = EnqueueId.ofSerialized("464765a0-e4e7-11e4-aba4-710c1de3782b");
+    Instant SLICE_INSTANT = Instant.parse("2018-05-20T12:00:00.000Z");
+    Instant SLICE_INSTANT_2 = Instant.parse("2018-06-20T12:00:00.000Z");
+    BucketedSlices.Slice SLICE = BucketedSlices.Slice.of(SLICE_INSTANT);
+    BucketedSlices.Slice SLICE_2 = BucketedSlices.Slice.of(SLICE_INSTANT_2);
+    BucketedSlices.BucketId BUCKET_ID = BucketedSlices.BucketId.of(2);
+    BucketedSlices.BucketId BUCKET_ID_2 = BucketedSlices.BucketId.of(3);
+}


### PR DESCRIPTION
Reopen of https://github.com/linagora/james-project/pull/2332

Choices:

 - Count size by bucket, not by slice. Rationals: this avoids all writes to go at a given time all to the same Cassandra node (scalability issues)
 - Denormalize EnQueueId -> Slice+bucket. Upon dequeue this information needs to be read. Impact expected on performance: low. This needs to be checked. Rationals:
     - Not expose cassandra specific concerns to Rabbit (bucket&slice)
     - For concistency reasons, we publish to rabbit first, then save in the cassandra view. This avoids "concistency issues": if a mail is saved in the view and not published to rabbit, it will never be cleaned up...