### PR TITLE
JAMES-2620 Build deployment test in parallel

### DIFF
--- a/dockerfiles/compilation/java-8/integration_tests.sh
+++ b/dockerfiles/compilation/java-8/integration_tests.sh
@@ -63,5 +63,5 @@ git clone $ORIGIN/.
 git checkout $SHA1
 
 
-mvn -DskipTests -pl org.apache.james:apache-james-mpt-external-james -am install
-mvn -pl org.apache.james:apache-james-mpt-external-james test -Pintegration-tests
+mvn -T 1C -DskipTests -pl org.apache.james:apache-james-mpt-external-james -am install
+mvn -T 1C -pl org.apache.james:apache-james-mpt-external-james test -Pintegration-tests


### PR DESCRIPTION
This currently takes 2 minutes and is called 5 time by james-jenkins build
pipeline. Significant gains expected.