### PR TITLE
JAMES-2857 Remove bundle and felix plugin from build

### DIFF
--- a/mailbox/api/pom.xml
+++ b/mailbox/api/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-mailbox-api</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
     <name>Apache James :: Mailbox :: API</name>
 
     <dependencies>

--- a/mailbox/caching/pom.xml
+++ b/mailbox/caching/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-mailbox-caching</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
     <name>Apache James :: Mailbox :: Caching</name>
 
     <description>JAMES-2703 This maven module is deprecated and will be removed straight after upcoming James 3.4.0 release, unless it finds a maintainer.

--- a/mailbox/jpa/pom.xml
+++ b/mailbox/jpa/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-mailbox-jpa</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
     <name>Apache James :: Mailbox :: JPA</name>
 
     <dependencies>

--- a/mailbox/lucene/pom.xml
+++ b/mailbox/lucene/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-mailbox-lucene</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
     <name>Apache James :: Mailbox :: Lucene Index</name>
 
     <dependencies>

--- a/mailbox/maildir/pom.xml
+++ b/mailbox/maildir/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-mailbox-maildir</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
     <name>Apache James :: Mailbox :: Maildir</name>
 
     <dependencies>

--- a/mailbox/memory/pom.xml
+++ b/mailbox/memory/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-mailbox-memory</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
     <name>Apache James :: Mailbox :: In Memory</name>
 
     <dependencies>

--- a/mailbox/pom.xml
+++ b/mailbox/pom.xml
@@ -110,11 +110,6 @@
                     </descriptorRefs>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
         </plugins>
     </build>
 

--- a/mailbox/spring/pom.xml
+++ b/mailbox/spring/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-mailbox-spring</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
     <name>Apache James :: Mailbox :: Spring</name>
 
     <dependencies>

--- a/mailbox/store/pom.xml
+++ b/mailbox/store/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-james-mailbox-store</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
     <name>Apache James :: Mailbox :: Store Framework</name>
 
     <dependencies>

--- a/mailbox/zoo-seq-provider/pom.xml
+++ b/mailbox/zoo-seq-provider/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>zookeeper-sequence-provider</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
     <name>Apache James :: Mailbox :: Zookeeper Sequence Provider</name>
     <description>High performance distribuited sequence provider based on ZooKeepr</description>
 

--- a/mailet/ai/pom.xml
+++ b/mailet/ai/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-mailet-ai</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: AI Mailets</name>
     <description>Collects mail processors making use of artificial intelligence (AI) methods.</description>

--- a/mailet/api/pom.xml
+++ b/mailet/api/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-mailet-api</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Mailet API</name>
     <description>The Apache Mailet API is a flexible specification for mail processing agents.</description>

--- a/mailet/base/pom.xml
+++ b/mailet/base/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-mailet-base</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Basic Mailet Toolkit</name>
     <description>Apache James Basic Mailet Toolkit is a collection of utilities and lightweight framework
@@ -122,16 +122,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Export-Package>org.apache.mailet.base.*</Export-Package>
-                    </instructions>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>${james.groupId}</groupId>
                 <artifactId>maven-mailetdocs-plugin</artifactId>

--- a/mailet/crypto/pom.xml
+++ b/mailet/crypto/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-mailet-crypto</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Crypto Mailets</name>
     <description>Apache James Cryptographic Mailets is a collection of mailets which use cryptography.
@@ -66,15 +66,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <configuration>
-                    <instructions>
-                        <Export-Package>org.apache.james.mailet.crypto.*</Export-Package>
-                    </instructions>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>${james.groupId}</groupId>
                 <artifactId>maven-mailetdocs-plugin</artifactId>

--- a/mailet/pom.xml
+++ b/mailet/pom.xml
@@ -76,11 +76,6 @@
         </pluginManagement>
         <plugins>
             <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
                 <inherited>true</inherited>

--- a/mailet/standard/pom.xml
+++ b/mailet/standard/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-mailet-standard</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Standard Mailets</name>
     <description>Apache James Standard Mailets is a rich collection of general purpose mailets

--- a/mailet/test/pom.xml
+++ b/mailet/test/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>apache-mailet-test</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Test helpers for Mailet</name>
     <description>Apache James Mailet Test is a collection of utilities to help testing mailets.</description>
@@ -124,16 +124,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Export-Package>org.apache.mailet.base.*</Export-Package>
-                    </instructions>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>${james.groupId}</groupId>
                 <artifactId>maven-mailetdocs-plugin</artifactId>

--- a/mpt/antlib/pom.xml
+++ b/mpt/antlib/pom.xml
@@ -131,6 +131,7 @@ to the library requiring no extra coding.</description>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>${felix.plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>

--- a/mpt/core/pom.xml
+++ b/mpt/core/pom.xml
@@ -109,6 +109,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>${felix.plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>

--- a/mpt/mavenplugin/pom.xml
+++ b/mpt/mavenplugin/pom.xml
@@ -87,29 +87,6 @@ to the library requiring no extra coding.</description>
                     -->
                 </configuration>
             </plugin>
-            <!--
-                <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <version>1.4.3</version>
-                <executions>
-                <execution>
-                <id>bundle-manifest</id>
-                <phase>process-classes</phase>
-                <goals>
-                <goal>manifest</goal>
-                </goals>
-                </execution>
-                </executions>
-                <extensions>true</extensions>
-                <configuration>
-                <instructions>
-                <Export-Package>org.apache.james.mpt.maven</Export-Package>
-                <Embed-Dependency>*;scope=runtime</Embed-Dependency>
-                </instructions>
-                </configuration>
-                </plugin>
-            -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/mpt/pom.xml
+++ b/mpt/pom.xml
@@ -52,6 +52,7 @@
     </issueManagement>
 
     <properties>
+        <felix.plugin.version>3.3.0</felix.plugin.version>
         <commons-lang.version>2.6</commons-lang.version>
         <derby.version>10.14.2.0</derby.version>
         <guice.version>4.0</guice.version>

--- a/pom.xml
+++ b/pom.xml
@@ -614,7 +614,6 @@
         <org.osgi.core.version>5.0.0</org.osgi.core.version>
         <cucumber.version>2.4.0</cucumber.version>
 
-        <felix.version>4.0.3</felix.version>
         <pax-logging-api.version>1.6.4</pax-logging-api.version>
         <jackson.version>2.9.9</jackson.version>
         <feign.version>10.3.0</feign.version>
@@ -2275,11 +2274,6 @@
                 <version>1.0.3</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>org.apache.felix.framework</artifactId>
-                <version>${felix.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient-osgi</artifactId>
                 <version>${apache.httpcomponents.version}</version>
@@ -2700,12 +2694,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.3.0</version>
-                    <extensions>true</extensions>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>1.8</version>
@@ -3108,19 +3096,6 @@
                                         <goals>
                                             <goal>javacc</goal>
                                             <goal>jjtree-javacc</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore />
-                                    </action>
-                                </pluginExecution>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.apache.felix</groupId>
-                                        <artifactId>maven-bundle-plugin</artifactId>
-                                        <versionRange>[2.3.4,)</versionRange>
-                                        <goals>
-                                            <goal>manifest</goal>
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>

--- a/protocols/api/pom.xml
+++ b/protocols/api/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>protocols-api</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Protocols :: API</name>
 

--- a/protocols/imap/pom.xml
+++ b/protocols/imap/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>protocols-imap</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Protocols :: IMAP</name>
 

--- a/protocols/lmtp/pom.xml
+++ b/protocols/lmtp/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>protocols-lmtp</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Protocols :: LMTP</name>
 

--- a/protocols/managesieve/pom.xml
+++ b/protocols/managesieve/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>protocols-managesieve</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Protocols :: ManageSieve</name>
 

--- a/protocols/netty/pom.xml
+++ b/protocols/netty/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>protocols-netty</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Protocols :: Netty Implementation</name>
 

--- a/protocols/pom.xml
+++ b/protocols/pom.xml
@@ -45,14 +45,4 @@
         <module>smtp</module>
     </modules>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/protocols/pop3/pom.xml
+++ b/protocols/pop3/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>protocols-pop3</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Protocols :: POP3</name>
 

--- a/protocols/smtp/pom.xml
+++ b/protocols/smtp/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>protocols-smtp</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Protocols :: SMTP</name>
 

--- a/server/app/pom.xml
+++ b/server/app/pom.xml
@@ -29,7 +29,7 @@
     </parent>
 
     <artifactId>james-server-app</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: App</name>
     <description>An advanced email server / Spring version</description>
@@ -494,11 +494,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>appassembler-maven-plugin</artifactId>

--- a/server/container/cli-integration/pom.xml
+++ b/server/container/cli-integration/pom.xml
@@ -90,14 +90,4 @@
             <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/cli/pom.xml
+++ b/server/container/cli/pom.xml
@@ -92,11 +92,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/server/container/core/pom.xml
+++ b/server/container/core/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-core</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Core</name>
 
@@ -132,11 +132,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/server/container/filesystem-api/pom.xml
+++ b/server/container/filesystem-api/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-filesystem-api</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Filesystem API</name>
 
@@ -75,11 +75,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>

--- a/server/container/guice/cassandra-guice/pom.xml
+++ b/server/container/guice/cassandra-guice/pom.xml
@@ -345,11 +345,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/server/container/guice/cassandra-ldap-guice/pom.xml
+++ b/server/container/guice/cassandra-ldap-guice/pom.xml
@@ -184,11 +184,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
         </plugins>
     </build>
 

--- a/server/container/guice/cassandra-rabbitmq-guice/pom.xml
+++ b/server/container/guice/cassandra-rabbitmq-guice/pom.xml
@@ -190,11 +190,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/server/container/guice/cassandra-rabbitmq-ldap-guice/pom.xml
+++ b/server/container/guice/cassandra-rabbitmq-ldap-guice/pom.xml
@@ -125,11 +125,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/server/container/guice/configuration/pom.xml
+++ b/server/container/guice/configuration/pom.xml
@@ -59,15 +59,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/guice-common/pom.xml
+++ b/server/container/guice/guice-common/pom.xml
@@ -199,15 +199,4 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/jmx/pom.xml
+++ b/server/container/guice/jmx/pom.xml
@@ -109,15 +109,4 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/jpa-common-guice/pom.xml
+++ b/server/container/guice/jpa-common-guice/pom.xml
@@ -62,15 +62,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/jpa-guice/pom.xml
+++ b/server/container/guice/jpa-guice/pom.xml
@@ -232,11 +232,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
         </plugins>
     </build>
 

--- a/server/container/guice/jpa-smtp-mariadb/pom.xml
+++ b/server/container/guice/jpa-smtp-mariadb/pom.xml
@@ -124,11 +124,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
         </plugins>
     </build>
 

--- a/server/container/guice/jpa-smtp/pom.xml
+++ b/server/container/guice/jpa-smtp/pom.xml
@@ -157,11 +157,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
         </plugins>
     </build>
 

--- a/server/container/guice/mailbox/pom.xml
+++ b/server/container/guice/mailbox/pom.xml
@@ -81,15 +81,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/mailet/pom.xml
+++ b/server/container/guice/mailet/pom.xml
@@ -99,15 +99,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/memory-guice/pom.xml
+++ b/server/container/guice/memory-guice/pom.xml
@@ -224,12 +224,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/server/container/guice/onami/pom.xml
+++ b/server/container/guice/onami/pom.xml
@@ -53,15 +53,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/protocols/imap/pom.xml
+++ b/server/container/guice/protocols/imap/pom.xml
@@ -53,15 +53,4 @@
             <artifactId>guice-multibindings</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/protocols/jmap/pom.xml
+++ b/server/container/guice/protocols/jmap/pom.xml
@@ -100,15 +100,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/protocols/lmtp/pom.xml
+++ b/server/container/guice/protocols/lmtp/pom.xml
@@ -49,15 +49,4 @@
             <artifactId>guice-multibindings</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/protocols/managedsieve/pom.xml
+++ b/server/container/guice/protocols/managedsieve/pom.xml
@@ -57,15 +57,4 @@
             <artifactId>protocols-managesieve</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/protocols/netty/pom.xml
+++ b/server/container/guice/protocols/netty/pom.xml
@@ -49,15 +49,4 @@
             <artifactId>guice-multibindings</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/protocols/pop/pom.xml
+++ b/server/container/guice/protocols/pop/pom.xml
@@ -49,15 +49,4 @@
             <artifactId>guice-multibindings</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/protocols/smtp/pom.xml
+++ b/server/container/guice/protocols/smtp/pom.xml
@@ -49,15 +49,4 @@
             <artifactId>guice-multibindings</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/protocols/webadmin-cassandra/pom.xml
+++ b/server/container/guice/protocols/webadmin-cassandra/pom.xml
@@ -53,15 +53,4 @@
             <artifactId>guice-multibindings</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/protocols/webadmin-data/pom.xml
+++ b/server/container/guice/protocols/webadmin-data/pom.xml
@@ -53,15 +53,4 @@
             <artifactId>guice-multibindings</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/protocols/webadmin-mailbox/pom.xml
+++ b/server/container/guice/protocols/webadmin-mailbox/pom.xml
@@ -53,15 +53,4 @@
             <artifactId>guice-multibindings</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/protocols/webadmin-mailqueue/pom.xml
+++ b/server/container/guice/protocols/webadmin-mailqueue/pom.xml
@@ -55,15 +55,4 @@
             <artifactId>guice-multibindings</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/protocols/webadmin-mailrepository/pom.xml
+++ b/server/container/guice/protocols/webadmin-mailrepository/pom.xml
@@ -55,15 +55,4 @@
             <artifactId>guice-multibindings</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/protocols/webadmin-swagger/pom.xml
+++ b/server/container/guice/protocols/webadmin-swagger/pom.xml
@@ -53,15 +53,4 @@
             <artifactId>guice-multibindings</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/guice/protocols/webadmin/pom.xml
+++ b/server/container/guice/protocols/webadmin/pom.xml
@@ -49,15 +49,4 @@
             <artifactId>guice-multibindings</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/lifecycle-api/pom.xml
+++ b/server/container/lifecycle-api/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-lifecycle-api</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Lifecycle API</name>
 
@@ -60,15 +60,4 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/mailbox-adapter/pom.xml
+++ b/server/container/mailbox-adapter/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-mailbox-adapter</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Mailbox Adapter</name>
 
@@ -87,15 +87,5 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/server/container/mailbox-jmx/pom.xml
+++ b/server/container/mailbox-jmx/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-mailbox-jmx</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Mailbox :: JMX</name>
 
@@ -89,15 +89,4 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/container/metrics/metrics-es-reporter/pom.xml
+++ b/server/container/metrics/metrics-es-reporter/pom.xml
@@ -110,13 +110,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/server/container/spring/pom.xml
+++ b/server/container/spring/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-spring</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Container Spring</name>
 
@@ -202,10 +202,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>

--- a/server/container/util/pom.xml
+++ b/server/container/util/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-util</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Common Utilities</name>
 
@@ -124,14 +124,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/server/data/data-api/pom.xml
+++ b/server/data/data-api/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-data-api</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Data  :: API</name>
 
@@ -92,11 +92,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>

--- a/server/data/data-cassandra/pom.xml
+++ b/server/data/data-cassandra/pom.xml
@@ -160,10 +160,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/server/data/data-file/pom.xml
+++ b/server/data/data-file/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-data-file</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Data :: File Persistence</name>
 
@@ -157,11 +157,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/server/data/data-jdbc/pom.xml
+++ b/server/data/data-jdbc/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-data-jdbc</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Data :: JDBC Persistence</name>
 
@@ -163,15 +163,4 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/data/data-jmap-cassandra/pom.xml
+++ b/server/data/data-jmap-cassandra/pom.xml
@@ -121,10 +121,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/server/data/data-jpa/pom.xml
+++ b/server/data/data-jpa/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-data-jpa</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Data :: JPA Persistence</name>
 
@@ -185,11 +185,6 @@
                         <phase>process-classes</phase>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/server/data/data-ldap/pom.xml
+++ b/server/data/data-ldap/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-data-ldap</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Data :: LDAP Implementation</name>
 
@@ -99,15 +99,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/server/data/data-library/pom.xml
+++ b/server/data/data-library/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-data-library</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Data :: Library</name>
 
@@ -159,11 +159,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>

--- a/server/data/data-memory/pom.xml
+++ b/server/data/data-memory/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-data-memory</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Data  :: MEMORY</name>
 
@@ -127,11 +127,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>

--- a/server/dns-service/dnsservice-api/pom.xml
+++ b/server/dns-service/dnsservice-api/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-dnsservice-api</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: DNS Service :: API</name>
 
@@ -62,11 +62,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>

--- a/server/dns-service/dnsservice-dnsjava/pom.xml
+++ b/server/dns-service/dnsservice-dnsjava/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-dnsservice-dnsjava</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: DNS Service :: Implementation</name>
 
@@ -94,15 +94,5 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/server/dns-service/dnsservice-library/pom.xml
+++ b/server/dns-service/dnsservice-library/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-dnsservice-library</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: DNS Service :: Library</name>
 
@@ -69,15 +69,5 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/server/dns-service/dnsservice-test/pom.xml
+++ b/server/dns-service/dnsservice-test/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-dnsservice-test</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: DNS Service :: Test</name>
 
@@ -64,11 +64,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>

--- a/server/karaf/integration/pom.xml
+++ b/server/karaf/integration/pom.xml
@@ -18,6 +18,7 @@
         <karaf.tooling.exam.container.version>2.3.0</karaf.tooling.exam.container.version>
         <pax-swissbox-tinybundles.version>1.3.1</pax-swissbox-tinybundles.version>
         <url.version>1.4.0</url.version>
+        <felix.version>4.0.3</felix.version>
     </properties>
 
     <dependencies>
@@ -34,6 +35,7 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.framework</artifactId>
+            <version>${felix.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/server/mailet/integration-testing/pom.xml
+++ b/server/mailet/integration-testing/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-mailets-integration-testing</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Mailets Integration Testing</name>
 

--- a/server/mailet/mailetcontainer-api/pom.xml
+++ b/server/mailet/mailetcontainer-api/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-mailetcontainer-api</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Mailetcontainer API</name>
 
@@ -55,11 +55,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>

--- a/server/mailet/mailetcontainer-camel/pom.xml
+++ b/server/mailet/mailetcontainer-camel/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-mailetcontainer-camel</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Mailetcontainer Camel</name>
 
@@ -184,14 +184,5 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/server/mailet/mailets/pom.xml
+++ b/server/mailet/mailets/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-mailets</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Mailets</name>
 
@@ -290,10 +290,6 @@
                 <configuration>
                     <outputDirectory>target/mailetdocs</outputDirectory>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/server/mailrepository/mailrepository-api/pom.xml
+++ b/server/mailrepository/mailrepository-api/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-mailrepository-api</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: MailRepository :: API</name>
 
@@ -87,11 +87,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>

--- a/server/mailrepository/mailrepository-cassandra/pom.xml
+++ b/server/mailrepository/mailrepository-cassandra/pom.xml
@@ -113,11 +113,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/server/mailrepository/mailrepository-memory/pom.xml
+++ b/server/mailrepository/mailrepository-memory/pom.xml
@@ -77,11 +77,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -140,25 +140,6 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>versions-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <!-- During release:perform, enable the "release" profile -->
-                    <releaseProfiles>with-assembly</releaseProfiles>
-                    <goals>deploy assembly:single</goals>
-                </configuration>
-            </plugin>
-        </plugins>
     </build>
 
 </project>

--- a/server/protocols/fetchmail/pom.xml
+++ b/server/protocols/fetchmail/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-fetchmail</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: FetchMail</name>
 
@@ -86,15 +86,5 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/server/protocols/protocols-imap4/pom.xml
+++ b/server/protocols/protocols-imap4/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-protocols-imap4</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: IMAP</name>
 
@@ -102,14 +102,5 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/server/protocols/protocols-library/pom.xml
+++ b/server/protocols/protocols-library/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-protocols-library</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Protocols Library</name>
 
@@ -102,10 +102,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/server/protocols/protocols-lmtp/pom.xml
+++ b/server/protocols/protocols-lmtp/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-protocols-lmtp</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: LMTP</name>
 
@@ -124,14 +124,5 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/server/protocols/protocols-pop3/pom.xml
+++ b/server/protocols/protocols-pop3/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-protocols-pop3</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: POP3</name>
 
@@ -161,14 +161,5 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/server/protocols/protocols-smtp/pom.xml
+++ b/server/protocols/protocols-smtp/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-protocols-smtp</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: SMTP</name>
 
@@ -235,14 +235,5 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/server/queue/queue-activemq/pom.xml
+++ b/server/queue/queue-activemq/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-queue-activemq</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Mail Queue :: ActiveMQ</name>
 
@@ -156,15 +156,5 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/server/queue/queue-api/pom.xml
+++ b/server/queue/queue-api/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-queue-api</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Mail Queue :: API</name>
 
@@ -119,10 +119,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/server/queue/queue-file/pom.xml
+++ b/server/queue/queue-file/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-queue-file</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Mail Queue :: File</name>
 
@@ -109,10 +109,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>

--- a/server/queue/queue-jms/pom.xml
+++ b/server/queue/queue-jms/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-queue-jms</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Mail Queue :: JMS</name>
 
@@ -159,13 +159,4 @@
             <artifactId>threeten-extra</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/server/queue/queue-rabbitmq/pom.xml
+++ b/server/queue/queue-rabbitmq/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>james-server-queue-rabbitmq</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <name>Apache James :: Server :: Mail Queue :: RabbitMQ</name>
 


### PR DESCRIPTION
Bundle and felix maven bundle product are being use to expose OSGI modules,
that we are no longer supporting (disabled build).

Note that some module have bundle definition, and some other don't, which is a major inconsistency
in our maven build structure I am willing to rationnalize.

Moreover this has a performance impact upon build (~1 minute on 8 cores)