### PR TITLE
JAMES-2858 Fix plugin cannot found issue maven-mailetdocs-plugin -> mailetdocs-m…

### DIFF
--- a/mailet/base/pom.xml
+++ b/mailet/base/pom.xml
@@ -134,7 +134,7 @@
             </plugin>
             <plugin>
                 <groupId>${james.groupId}</groupId>
-                <artifactId>maven-mailetdocs-plugin</artifactId>
+                <artifactId>mailetdocs-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/mailet/crypto/pom.xml
+++ b/mailet/crypto/pom.xml
@@ -77,7 +77,7 @@
             </plugin>
             <plugin>
                 <groupId>${james.groupId}</groupId>
-                <artifactId>maven-mailetdocs-plugin</artifactId>
+                <artifactId>mailetdocs-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/mailet/pom.xml
+++ b/mailet/pom.xml
@@ -69,8 +69,7 @@
             <plugins>
                 <plugin>
                     <groupId>${james.groupId}</groupId>
-                    <artifactId>maven-mailetdocs-plugin</artifactId>
-                    <version>${plugin.mailetdocs.version}</version>
+                    <artifactId>mailetdocs-maven-plugin</artifactId>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/mailet/pom.xml
+++ b/mailet/pom.xml
@@ -70,6 +70,7 @@
                 <plugin>
                     <groupId>${james.groupId}</groupId>
                     <artifactId>mailetdocs-maven-plugin</artifactId>
+                    <version>${project.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/mailet/standard/pom.xml
+++ b/mailet/standard/pom.xml
@@ -148,7 +148,7 @@
         <plugins>
             <plugin>
                 <groupId>${james.groupId}</groupId>
-                <artifactId>maven-mailetdocs-plugin</artifactId>
+                <artifactId>mailetdocs-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/mailet/test/pom.xml
+++ b/mailet/test/pom.xml
@@ -136,7 +136,7 @@
             </plugin>
             <plugin>
                 <groupId>${james.groupId}</groupId>
-                <artifactId>maven-mailetdocs-plugin</artifactId>
+                <artifactId>mailetdocs-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -628,7 +628,6 @@
         <guava.version>25.1-jre</guava.version>
 
         <jutf7.version>1.0.0</jutf7.version>
-        <plugin.mailetdocs.version>0.1</plugin.mailetdocs.version>
         <httpclient-osgi.version>4.5.1</httpclient-osgi.version>
         <apache.httpcomponents.version>4.5.9</apache.httpcomponents.version>
         <!-- maven-mailetdocs-plugin artifacts -->

--- a/server/mailet/mailets/pom.xml
+++ b/server/mailet/mailets/pom.xml
@@ -285,8 +285,7 @@
         <plugins>
             <plugin>
                 <groupId>${james.groupId}</groupId>
-                <artifactId>maven-mailetdocs-plugin</artifactId>
-                <version>0.1</version>
+                <artifactId>mailetdocs-maven-plugin</artifactId>
                 <configuration>
                     <outputDirectory>target/mailetdocs</outputDirectory>
                 </configuration>


### PR DESCRIPTION
…aven-plugin

Since I updated Intellij, I kept getting sync errors that it couldn't find the plugin `maven-mailetdocs-plugin` from the parent pom 1.2 (quite the old version of james...)... Then I saw that we have a module `mailetdocs-maven-plugin` in James that seems to be it, so I replaced the artifactId. 

Not sure if we should keep that or not but with that, my Intellij doesn't give me sync errors every time I update deps in a pom or switch between branches... Let me know what you think of this please !