### PR TITLE
JAMES-XXXX Exclude ActiveMQ from distributed James products

### DIFF
--- a/server/container/guice/cassandra-rabbitmq-guice/pom.xml
+++ b/server/container/guice/cassandra-rabbitmq-guice/pom.xml
@@ -108,6 +108,12 @@
         <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>james-server-cassandra-guice</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>${james.groupId}</groupId>
+                    <artifactId>james-server-guice-activemq</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>


### PR DESCRIPTION
Context: I did an attempt several months before to solve this with a split between guice building blocs and products but it was overall rejected. This is a quick-win regarding this issue.

```
Before: 
118M    target/james-server-cassandra-rabbitmq-guice.lib/
361 depedencies

After:
106M    target/james-server-cassandra-rabbitmq-guice.lib/
339 deps
```

10% Lib size reduction