### PR TITLE
JAMES-2855 Using recursive comparaison on Mail with assertj upgrade

### DIFF
--- a/mailet/api/src/main/java/org/apache/mailet/Mail.java
+++ b/mailet/api/src/main/java/org/apache/mailet/Mail.java
@@ -230,13 +230,6 @@ public interface Mail extends Serializable, Cloneable {
     void setState(String state);
 
     /**
-     * Returns the attributes of this message.
-     *
-     * @return the attributes of this message
-     */
-    Map<AttributeName, Attribute> getAttributes();
-
-    /**
      * Get the stream of all attributes
      */
     Stream<Attribute> attributes();

--- a/mailet/standard/src/test/java/org/apache/james/transport/mailets/StripAttachmentTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/mailets/StripAttachmentTest.java
@@ -108,7 +108,10 @@ class StripAttachmentTest {
 
         mailet.service(mail);
 
-        assertThat(mail).isEqualToIgnoringGivenFields(expectedMail, "msg");
+        assertThat(mail)
+            .usingRecursiveComparison()
+            .ignoringFields("msg")
+            .isEqualTo(expectedMail);
         assertThat(mail.getMessage().getContent()).isEqualTo("simple text");
     }
     

--- a/mailet/test/src/main/java/org/apache/mailet/base/test/FakeMail.java
+++ b/mailet/test/src/main/java/org/apache/mailet/base/test/FakeMail.java
@@ -430,11 +430,6 @@ public class FakeMail implements Mail {
     }
 
     @Override
-    public Map<AttributeName, Attribute> getAttributes() {
-        return attributes;
-    }
-
-    @Override
     public Stream<Attribute> attributes() {
         return attributes.values().stream();
     }

--- a/server/container/core/src/main/java/org/apache/james/server/core/MailImpl.java
+++ b/server/container/core/src/main/java/org/apache/james/server/core/MailImpl.java
@@ -664,11 +664,6 @@ public class MailImpl implements Disposable, Mail {
         message = null;
     }
 
-    @Override
-    public Map<AttributeName, Attribute> getAttributes() {
-        return attributes;
-    }
-
     /**
      * <p>
      * This method is necessary, when Mail repositories needs to deal explicitly

--- a/server/container/core/src/test/java/org/apache/james/server/core/MailImplTest.java
+++ b/server/container/core/src/test/java/org/apache/james/server/core/MailImplTest.java
@@ -95,7 +95,10 @@ public class MailImplTest extends ContractMailTest {
             .build();
 
         MailImpl expected = newMail();
-        assertThat(mail).isEqualToIgnoringGivenFields(expected, "sender", "name", "recipients", "lastUpdated");
+        assertThat(mail)
+            .usingRecursiveComparison()
+            .ignoringFields("sender", "name", "recipients", "lastUpdated")
+            .isEqualTo(expected);
         assertThat(mail.getLastUpdated()).isCloseTo(new Date(), TimeUnit.SECONDS.toMillis(1));
     }
 
@@ -129,7 +132,10 @@ public class MailImplTest extends ContractMailTest {
             .mimeMessage(emptyMessage)
             .build();
 
-        assertThat(mail).isEqualToIgnoringGivenFields(expected, "message", "lastUpdated");
+        assertThat(mail)
+            .usingRecursiveComparison()
+            .ignoringFields("message", "lastUpdated")
+            .isEqualTo(expected);
         assertThat(mail.getLastUpdated()).isCloseTo(new Date(), TimeUnit.SECONDS.toMillis(1));
     }
 
@@ -155,7 +161,11 @@ public class MailImplTest extends ContractMailTest {
 
         MailImpl duplicate = MailImpl.duplicate(mail);
 
-        assertThat(duplicate).isNotSameAs(mail).isEqualToIgnoringGivenFields(mail, "message", "name");
+        assertThat(duplicate)
+            .isNotSameAs(mail)
+            .usingRecursiveComparison()
+            .ignoringFields("message", "name")
+            .isEqualTo(mail);
         assertThat(duplicate.getName()).isNotEqualTo(name);
         assertThat(duplicate.getMessage().getInputStream()).hasSameContentAs(mail.getMessage().getInputStream());
     }
@@ -318,7 +328,8 @@ public class MailImplTest extends ContractMailTest {
 
         assertThat(unserialized)
             .isInstanceOf(MailImpl.class)
-            .isEqualToComparingFieldByField(mail);
+            .usingRecursiveComparison()
+            .isEqualTo(mail);
     }
 
     @Test
@@ -339,7 +350,8 @@ public class MailImplTest extends ContractMailTest {
 
         assertThat(unserialized)
             .isInstanceOf(MailImpl.class)
-            .isEqualToComparingFieldByField(mail);
+            .usingRecursiveComparison()
+            .isEqualTo(mail);
     }
 
     @Test
@@ -360,6 +372,7 @@ public class MailImplTest extends ContractMailTest {
 
         assertThat(unserialized)
             .isInstanceOf(MailImpl.class)
-            .isEqualToComparingFieldByField(mail);
+            .usingRecursiveComparison()
+            .isEqualTo(mail);
     }
 }


### PR DESCRIPTION
To fix this commit : https://github.com/linagora/james-project/pull/2593/commits/010347983b7747ceff504b4ef8fe41221c1f20eb
as we shouldn't give public access to the `attributes` internal map of a Mail