### PR TITLE
JAMES-2872 fix documentation docker compilation

### DIFF
--- a/dockerfiles/site/website/Dockerfile
+++ b/dockerfiles/site/website/Dockerfile
@@ -2,17 +2,17 @@
 #
 # VERSION	1.0
 
-FROM openjdk:8u171-jdk
-
-# Install Maven
-WORKDIR /root
-RUN wget https://archive.apache.org/dist/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz
-RUN tar -xvf apache-maven-3.5.2-bin.tar.gz
-RUN ln -s /root/apache-maven-3.5.2/bin/mvn /usr/bin/mvn
+FROM adoptopenjdk:11-jdk-hotspot
 
 # Install git
 RUN apt-get update
-RUN apt-get install -y git
+RUN apt-get install -y git wget unzip
+
+# Install Maven
+WORKDIR /root
+RUN wget https://archive.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz
+RUN tar -xvf apache-maven-3.6.1-bin.tar.gz
+RUN ln -s /root/apache-maven-3.6.1/bin/mvn /usr/bin/mvn
 
 # Copy the script
 COPY compile.sh /root/compile.sh

--- a/pom.xml
+++ b/pom.xml
@@ -2971,20 +2971,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.7</version>
-                    <configuration>
-                        <aggregate>true</aggregate>
-                        <!--
-                            Whether to remove GPL licensed files from the generated report. This is required to distribute
-                            the report as part of a distribution, which is licensed under the ASL, or a similar license,
-                            which is incompatible with the GPL
-                        -->
-                        <omitGplFiles>true</omitGplFiles>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>1.6.0</version>
                 </plugin>
@@ -3345,10 +3331,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.rat</groupId>


### PR DESCRIPTION
Well after this: https://github.com/linagora/james-project/commit/0ff5716977ba6446f2044036087569fc94da682c we need also to upgrade the java version of the Dockerfile to generate the website, or it fails.

I removed as well the plugin `cobertura-maven-plugin`. This plugin is for generating coverage testing reports, which we don't seem to really use, but also this plugin has not been maintained for a long time (2015), and is using some jar tools that was part of java jdk-8 but has been removed in upper versions. So in short, this plugin makes the doc generation fails with java 11, so I removed it