### PR TITLE
JAMES-2872 fix James 3.3.0 release links on website

### DIFF
--- a/dockerfiles/site/website/Dockerfile
+++ b/dockerfiles/site/website/Dockerfile
@@ -2,17 +2,17 @@
 #
 # VERSION	1.0
 
-FROM openjdk:8u171-jdk
-
-# Install Maven
-WORKDIR /root
-RUN wget https://archive.apache.org/dist/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz
-RUN tar -xvf apache-maven-3.5.2-bin.tar.gz
-RUN ln -s /root/apache-maven-3.5.2/bin/mvn /usr/bin/mvn
+FROM adoptopenjdk:11-jdk-hotspot
 
 # Install git
 RUN apt-get update
-RUN apt-get install -y git
+RUN apt-get install -y git wget unzip
+
+# Install Maven
+WORKDIR /root
+RUN wget https://archive.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz
+RUN tar -xvf apache-maven-3.6.1-bin.tar.gz
+RUN ln -s /root/apache-maven-3.6.1/bin/mvn /usr/bin/mvn
 
 # Copy the script
 COPY compile.sh /root/compile.sh

--- a/pom.xml
+++ b/pom.xml
@@ -2971,20 +2971,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.7</version>
-                    <configuration>
-                        <aggregate>true</aggregate>
-                        <!--
-                            Whether to remove GPL licensed files from the generated report. This is required to distribute
-                            the report as part of a distribution, which is licensed under the ASL, or a similar license,
-                            which is incompatible with the GPL
-                        -->
-                        <omitGplFiles>true</omitGplFiles>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>1.6.0</version>
                 </plugin>
@@ -3345,10 +3331,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.rat</groupId>

--- a/src/site/xdoc/download.xml
+++ b/src/site/xdoc/download.xml
@@ -159,9 +159,9 @@ is found <a href='https://www.apache.org/licenses/exports/'>here</a>.
 
       <ul>
         <li>Source code (ZIP Format):
-          <a href="https://www.apache.org/dyn/closer.lua/james/server/3.3.0/james-server-sources-3.3.0.zip">apache-james-3.3.0-app.zip</a>
-          [<a href="https://apache.org/dist/james/server/3.3.0/james-server-sources-3.3.0.zip.sha1">SHA-1</a>]
-          [<a href="https://apache.org/dist/james/server/3.3.0/james-server-sources-3.3.0.zip.asc">PGP</a>]</li>
+          <a href="https://www.apache.org/dyn/closer.lua/james/server/3.3.0/james-project-3.3.0-src.zip">apache-james-3.3.0-app.zip</a>
+          [<a href="https://apache.org/dist/james/server/3.3.0/james-project-3.3.0-src.zip.sha1">SHA-1</a>]
+          [<a href="https://apache.org/dist/james/server/3.3.0/james-project-3.3.0-src.zip.asc">PGP</a>]</li>
 
         <li>Binary (ZIP Format) for Spring wiring:
           <a href="https://www.apache.org/dyn/closer.lua/james/server/3.3.0/james-server-app-3.3.0-app.zip">apache-james-3.3.0-app.zip</a>
@@ -170,15 +170,15 @@ is found <a href='https://www.apache.org/licenses/exports/'>here</a>.
         </li>
 
         <li>Binary (ZIP Format) for JPA guice wiring:
-          <a href="https://www.apache.org/dyn/closer.lua/james/server/3.3.0/james-jpa-guice-3.3.0.zip">james-jpa-guice-3.3.0.zip</a>
-          [<a href="https://apache.org/dist/james/server/3.3.0/james-jpa-guice-3.3.0.zip.sha1">SHA-1</a>]
-          [<a href="https://apache.org/dist/james/server/3.3.0/james-jpa-guice-3.3.0.zip.asc">PGP</a>]
+          <a href="https://www.apache.org/dyn/closer.lua/james/server/3.3.0/james-server-jpa-guice-3.3.0.zip">james-jpa-guice-3.3.0.zip</a>
+          [<a href="https://apache.org/dist/james/server/3.3.0/james-server-jpa-guice-3.3.0.zip.sha1">SHA-1</a>]
+          [<a href="https://apache.org/dist/james/server/3.3.0/james-server-jpa-guice-3.3.0.zip.asc">PGP</a>]
         </li>
 
         <li>Binary (ZIP Format) for JPA SMTP guice wiring:
-          <a href="https://www.apache.org/dyn/closer.lua/james/server/3.3.0/james-jpa-smtp-guice-3.3.0.zip">james-jpa-smtp-guice-3.3.0.zip</a>
-          [<a href="https://apache.org/dist/james/server/3.3.0/james-jpa-smtp-guice-3.3.0.zip.sha1">SHA-1</a>]
-          [<a href="https://apache.org/dist/james/server/3.3.0/james-jpa-smtp-guice-3.3.0.zip.asc">PGP</a>]
+          <a href="https://www.apache.org/dyn/closer.lua/james/server/3.3.0/james-server-jpa-smtp-guice-3.3.0.zip">james-jpa-smtp-guice-3.3.0.zip</a>
+          [<a href="https://apache.org/dist/james/server/3.3.0/james-server-jpa-smtp-guice-3.3.0.zip.sha1">SHA-1</a>]
+          [<a href="https://apache.org/dist/james/server/3.3.0/james-server-jpa-smtp-guice-3.3.0.zip.asc">PGP</a>]
         </li>
 
       </ul>


### PR DESCRIPTION
What's really important here is https://github.com/linagora/james-project/commit/5671bb593f2869ea2e60c1d7eb184776ee761093 as the two first commits are from https://github.com/linagora/james-project/pull/2627 (but necessary for compiling the website)