### PR TITLE
JAMES-2855 Upgrade commons-compress 1.18 -> 1.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2215,7 +2215,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.18</version>
+                <version>1.19</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
[CVE-2019-12402] Apache Commons Compress denial of service vulnerability
Severity: Low

Versions Affected:
Apache Commons Compress 1.15 to 1.18

Description:
The file name encoding algorithm used internally in Apache Commons
Compress can get into an infinite loop when faced with specially
crafted inputs. This can lead to a denial of service attack if an
attacker can choose the file names inside of an archive created by
Compress.

Mitigation:
Commons Compress users should upgrade to 1.19 or later.

Impact on James: Non affected. The only end-user exposed functionality
relying on commons-compress is experimental, and relies on randomly generated
file name (Deleted messages export & messageIds for name generation)