### PR TITLE
JAMES-2865 Allow soft-fail for SMTP mock behaviour

### DIFF
--- a/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/MockMessageHandler.java
+++ b/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/MockMessageHandler.java
@@ -46,8 +46,7 @@ public class MockMessageHandler implements MessageHandler {
         void behave(T input) throws RejectException;
     }
 
-    class MockBehavior<T> implements Behavior<T> {
-
+    static class MockBehavior<T> implements Behavior<T> {
         private final MockSMTPBehavior behavior;
 
         MockBehavior(MockSMTPBehavior behavior) {
@@ -64,22 +63,21 @@ public class MockMessageHandler implements MessageHandler {
         }
     }
 
-    class SMTPBehaviorRepositoryUpdater<T> implements Behavior<T> {
+    static class BehaviorDecorator<T> implements Behavior<T> {
+        private final Behavior<T> behavior;
+        private final Runnable decorator;
 
-        private final SMTPBehaviorRepository behaviorRepository;
-        private final MockBehavior<T> actualBehavior;
-
-        SMTPBehaviorRepositoryUpdater(SMTPBehaviorRepository behaviorRepository, MockSMTPBehavior behavior) {
-            this.behaviorRepository = behaviorRepository;
-            this.actualBehavior = new MockBehavior<>(behavior);
+        BehaviorDecorator(Behavior<T> behavior, Runnable decorator) {
+            this.behavior = behavior;
+            this.decorator = decorator;
         }
 
         @Override
         public void behave(T input) throws RejectException {
             try {
-                actualBehavior.behave(input);
+                behavior.behave(input);
             } finally {
-                behaviorRepository.decreaseRemainingAnswers(actualBehavior.behavior);
+                decorator.run();
             }
         }
     }
@@ -130,7 +128,8 @@ public class MockMessageHandler implements MessageHandler {
             .filter(behavior -> behavior.getCommand().equals(data))
             .filter(behavior -> behavior.getCondition().matches(dataLine))
             .findFirst()
-            .map(mockBehavior -> new SMTPBehaviorRepositoryUpdater<>(behaviorRepository, mockBehavior));
+            .map(behavior -> new BehaviorDecorator<>(new MockBehavior<>(behavior),
+                () -> behaviorRepository.decreaseRemainingAnswers(behavior)));
     }
 
     @Override

--- a/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/MockSMTPServer.java
+++ b/server/mailet/mock-smtp-server/src/main/java/org/apache/james/mock/smtp/server/MockSMTPServer.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.james.mock.smtp.server.model.Mail;
 import org.apache.james.util.Port;
 import org.subethamail.smtp.server.SMTPServer;
+import org.subethamail.smtp.server.Session;
 
 class MockSMTPServer {
 
@@ -36,7 +37,7 @@ class MockSMTPServer {
 
     MockSMTPServer(SMTPBehaviorRepository behaviorRepository) {
         this.mailRepository = new ReceivedMailRepository();
-        this.server = new SMTPServer(ctx -> new MockMessageHandler(mailRepository, behaviorRepository));
+        this.server = new SMTPServer(ctx -> new MockMessageHandler(mailRepository, behaviorRepository, (Session) ctx));
         this.server.setPort(0);
     }
 

--- a/server/mailet/mock-smtp-server/src/test/java/org/apache/james/mock/smtp/server/MockSMTPServerTest.java
+++ b/server/mailet/mock-smtp-server/src/test/java/org/apache/james/mock/smtp/server/MockSMTPServerTest.java
@@ -449,13 +449,14 @@ class MockSMTPServerTest {
             }
 
             Awaitility.await().atMost(Duration.TEN_SECONDS)
-                .untilAsserted(() ->
-                    assertThat(mockServer.listReceivedMails()).hasSize(1)
-                        .allSatisfy(Throwing.consumer(mail -> assertThat(mail.getEnvelope())
-                            .isEqualTo(new Mail.Envelope.Builder()
-                                .from(new MailAddress(BOB))
-                                .addRecipient(new MailAddress(ALICE))
-                                .build()))));
+                .until(() -> mockServer.listReceivedMails().size() == 1);
+
+            assertThat(mockServer.listReceivedMails()).hasSize(1)
+                .allSatisfy(Throwing.consumer(mail -> assertThat(mail.getEnvelope())
+                    .isEqualTo(new Mail.Envelope.Builder()
+                        .from(new MailAddress(BOB))
+                        .addRecipient(new MailAddress(ALICE))
+                        .build())));
         }
     }
 


### PR DESCRIPTION
This allows complex assertions when Bob is rejected but not Alice.

SMTPClient aborts delivery upon first encountered error hence my choice to send the email manually over a network socket.