### PR TITLE
[NO_REVIEW] JAMES-2375 DSNBounce mailet do not provide a subject

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
@@ -220,8 +220,7 @@ public class DSNBounce extends GenericMailet implements RedirectNotify {
 
     @Override
     public Optional<MailAddress> getSender() throws MessagingException {
-        return SpecialAddressesUtils.from(this)
-                .getFirstSpecialAddressIfMatchingOrGivenAddress(getInitParameters().getSender(), RedirectNotify.SENDER_ALLOWED_SPECIALS);
+        return SpecialAddressesUtils.from(this).getFirstSpecialAddressIfMatchingOrGivenAddress(Optional.of(getInitParameters().getSender().orElse("postmaster")), RedirectNotify.SENDER_ALLOWED_SPECIALS);
     }
 
     @Override
@@ -454,6 +453,6 @@ public class DSNBounce extends GenericMailet implements RedirectNotify {
 
     @Override
     public MimeMessageModifier getMimeMessageModifier(Mail newMail, Mail originalMail) throws MessagingException {
-        return new MimeMessageModifier(originalMail.getMessage());
+        return new MimeMessageModifier(newMail.getMessage());
     }
 }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
@@ -220,7 +220,9 @@ public class DSNBounce extends GenericMailet implements RedirectNotify {
 
     @Override
     public Optional<MailAddress> getSender() throws MessagingException {
-        return SpecialAddressesUtils.from(this).getFirstSpecialAddressIfMatchingOrGivenAddress(Optional.of(getInitParameters().getSender().orElse("postmaster")), RedirectNotify.SENDER_ALLOWED_SPECIALS);
+        return SpecialAddressesUtils.from(this).getFirstSpecialAddressIfMatchingOrGivenAddress(
+                Optional.of(getInitParameters().getSender().orElse("postmaster")),
+                RedirectNotify.SENDER_ALLOWED_SPECIALS);
     }
 
     @Override

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/redirect/AddressExtractor.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/redirect/AddressExtractor.java
@@ -108,7 +108,7 @@ public class AddressExtractor {
             }
             return new MailAddress(address);
         } catch (Exception e) {
-            throw new MessagingException("Exception thrown parsing: " + address.getAddress());
+            throw new MessagingException("Exception thrown parsing: " + address.getAddress(), e);
         }
     }
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/util/SenderUtils.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/util/SenderUtils.java
@@ -41,7 +41,7 @@ public class SenderUtils {
     public Optional<MailAddress> getSender(Mail originalMail) throws MessagingException {
         if (sender.isPresent()) {
             if (isUnalteredOrSender(sender.get())) {
-                return Optional.empty();
+                return originalMail.getMaybeSender().asOptional();
             }
         }
         return sender;

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
@@ -526,10 +526,9 @@ public class DSNBounceTest {
                 .build();
 
         dsnBounce.service(mail);
-        
-        assertThat(fakeMailContext.getSentMails())
-        .hasSize(1)
-        .allSatisfy(sentMail -> assertThat(sentMail.getSubject()).contains("pre My subject"));
+
+        assertThat(fakeMailContext.getSentMails()).hasSize(1).allSatisfy(
+                sentMail -> assertThat(sentMail.getSubject()).contains("pre My subject"));
     }
 
     @Test
@@ -555,7 +554,8 @@ public class DSNBounceTest {
         assertThat(sentMails).hasSize(1);
         SentMail sentMail = sentMails.get(0);
 
-        assertThat(sentMail.getMsg().getFrom()).containsOnly(fakeMailContext.getPostmaster().toInternetAddress());
+        assertThat(sentMail.getMsg().getFrom())
+                .containsOnly(fakeMailContext.getPostmaster().toInternetAddress());
         assertThat(sentMail.getRecipients()).containsOnly(mail.getSender());
     }
 

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
@@ -527,11 +527,9 @@ public class DSNBounceTest {
 
         dsnBounce.service(mail);
         
-
-        List<SentMail> sentMails = fakeMailContext.getSentMails();
-        assertThat(sentMails).hasSize(1);
-        SentMail sentMail = sentMails.get(0);
-        assertThat(sentMail.getSubject().orElse(null)).isEqualTo("pre My subject");
+        assertThat(fakeMailContext.getSentMails())
+        .hasSize(1)
+        .allSatisfy(sentMail -> assertThat(sentMail.getSubject()).contains("pre My subject"));
     }
 
     @Test

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
@@ -67,12 +67,15 @@ public class DSNBounceTest {
 
     private DSNBounce dsnBounce;
     private FakeMailContext fakeMailContext;
+    private MailAddress postmaster;
 
     @Before
     public void setUp() throws Exception {
+        postmaster = new MailAddress("postmaster@domain.com");
+        
         DNSService dnsService = mock(DNSService.class);
         dsnBounce = new DSNBounce(dnsService, DateFormats.getRFC822FormatForTimeZone(TimeZone.getTimeZone("UTC")));
-        fakeMailContext = FakeMailContext.defaultContext();
+        fakeMailContext = FakeMailContext.builder().postmaster(postmaster).build();
 
         InetAddress localHost = InetAddress.getLocalHost();
         when(dnsService.getLocalHost())
@@ -523,7 +526,121 @@ public class DSNBounceTest {
                 .build();
 
         dsnBounce.service(mail);
+        
 
-        assertThat(mail.getMessage().getSubject()).isEqualTo("pre My subject");
+        List<SentMail> sentMails = fakeMailContext.getSentMails();
+        assertThat(sentMails).hasSize(1);
+        SentMail sentMail = sentMails.get(0);
+        assertThat(sentMail.getSubject().orElse(null)).isEqualTo("pre My subject");
+    }
+
+    @Test
+    public void dsnBounceShouldAllowSenderSpecialPostmaster() throws Exception {
+        
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+                .mailetName(MAILET_NAME)
+                .mailetContext(fakeMailContext)
+                .setProperty("sender", "postmaster")
+                .build();
+        dsnBounce.init(mailetConfig);
+
+        FakeMail mail = FakeMail.builder()
+                .name(MAILET_NAME)
+                .sender(MailAddressFixture.ANY_AT_JAMES)
+                .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                    .setSubject("My subject"))
+                .build();
+
+        dsnBounce.service(mail);
+
+        List<SentMail> sentMails = fakeMailContext.getSentMails();
+        assertThat(sentMails).hasSize(1);
+        SentMail sentMail = sentMails.get(0);
+
+        assertThat(sentMail.getMsg().getFrom()).containsOnly(fakeMailContext.getPostmaster().toInternetAddress());
+        assertThat(sentMail.getRecipients()).containsOnly(mail.getSender());
+    }
+
+    @Test
+    public void dsnBounceShouldAllowSenderSpecialSender() throws Exception {
+
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+                .mailetName(MAILET_NAME)
+                .mailetContext(fakeMailContext)
+                .setProperty("sender", "sender")
+                .setProperty("prefix", "pre")
+                .build();
+        dsnBounce.init(mailetConfig);
+
+        FakeMail mail = FakeMail.builder()
+                .name(MAILET_NAME)
+                .sender(MailAddressFixture.ANY_AT_JAMES)
+                .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                        .setSubject("My subject"))
+                .build();
+
+        dsnBounce.service(mail);
+
+        List<SentMail> sentMails = fakeMailContext.getSentMails();
+        assertThat(sentMails).hasSize(1);
+        SentMail sentMail = sentMails.get(0);
+
+        assertThat(sentMail.getMsg().getFrom()).containsOnly(mail.getSender().toInternetAddress());
+        assertThat(sentMail.getRecipients()).containsOnly(mail.getSender());
+    }
+
+    @Test
+    public void dsnBounceShouldAllowSenderSpecialUnaltered() throws Exception {
+
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+                .mailetName(MAILET_NAME)
+                .mailetContext(fakeMailContext)
+                .setProperty("sender", "unaltered")
+                .build();
+        dsnBounce.init(mailetConfig);
+
+        FakeMail mail = FakeMail.builder()
+                .name(MAILET_NAME)
+                .sender(MailAddressFixture.ANY_AT_JAMES)
+                .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                        .setSubject("My subject"))
+                .build();
+
+        dsnBounce.service(mail);
+
+        List<SentMail> sentMails = fakeMailContext.getSentMails();
+        assertThat(sentMails).hasSize(1);
+        SentMail sentMail = sentMails.get(0);
+
+        assertThat(sentMail.getMsg().getFrom()).containsOnly(mail.getSender().toInternetAddress());
+        assertThat(sentMail.getRecipients()).containsOnly(mail.getSender());
+    }
+
+    @Test
+    public void dsnBounceShouldAllowSenderSpecialAddress() throws Exception {
+
+        MailAddress bounceSender = new MailAddress("bounces@domain.com");
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+                .mailetName(MAILET_NAME)
+                .mailetContext(fakeMailContext)
+                .setProperty("sender", bounceSender.asPrettyString())
+                .build();
+        dsnBounce.init(mailetConfig);
+
+        FakeMail mail = FakeMail.builder()
+                .name(MAILET_NAME)
+                .sender(MailAddressFixture.ANY_AT_JAMES)
+                .mimeMessage(MimeMessageBuilder.mimeMessageBuilder()
+                        .setSubject("My subject"))
+                .build();
+
+        dsnBounce.service(mail);
+
+        List<SentMail> sentMails = fakeMailContext.getSentMails();
+        assertThat(sentMails).hasSize(1);
+        SentMail sentMail = sentMails.get(0);
+
+        assertThat(sentMail.getMsg().getFrom()).containsOnly(bounceSender.toInternetAddress());
+        assertThat(sentMail.getRecipients()).containsOnly(mail.getSender());
     }
 }


### PR DESCRIPTION
Subject empty fixed, Sender empty when you do not provide sender
property fixed too

See original PR: https://github.com/apache/james-project/pull/162