### PR TITLE
Upgrade Linshare images from 2.2.3 to 2.3.2

### DIFF
--- a/third-party/linshare/src/test/java/org/apache/james/linshare/Linshare.java
+++ b/third-party/linshare/src/test/java/org/apache/james/linshare/Linshare.java
@@ -94,7 +94,7 @@ public class Linshare {
 
     @SuppressWarnings("resource")
     private GenericContainer<?> createDockerDatabase() {
-        return new GenericContainer<>("linagora/linshare-database:2.2")
+        return new GenericContainer<>("linagora/linshare-database:2.3.2")
             .withLogConsumer(frame -> LOGGER.debug("<linshare-database> " + frame.getUtf8String()))
             .withNetworkAliases("database", "linshare_database")
             .withEnv("PGDATA", "/var/lib/postgresql/data/pgdata")
@@ -155,7 +155,7 @@ public class Linshare {
 
     @SuppressWarnings("resource")
     private GenericContainer<?> createLinshareBackendInit() {
-        return new GenericContainer<>("linagora/linshare-init:2.2")
+        return new GenericContainer<>("linagora/linshare-init:2.3.2")
             .withNetworkAliases("init")
             .withLogConsumer(frame -> LOGGER.debug("<linshare-init> " + frame.getUtf8String()))
             .withEnv("LS_HOST", "backend")

--- a/third-party/linshare/src/test/resources/backend/Dockerfile
+++ b/third-party/linshare/src/test/resources/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM linagora/linshare-backend:2.2.3
+FROM linagora/linshare-backend:2.3.2
 
 COPY conf/catalina.properties /usr/local/tomcat/conf/catalina.properties
 COPY conf/log4j.properties /etc/linshare/log4j.properties


### PR DESCRIPTION
**Note**: need to wait a bit for this to pass, there is an issue that needs to be solved first on LinShare concerning the rejection on some special characters like '@' => https://ci.linagora.com/linagora/lgs/linshare/products/linshare-core/issues/729