### PR TITLE
JAMES-2813 Significantly reduce integration tests log output

### DIFF
--- a/server/task/src/test/java/org/apache/james/task/TaskManagerContract.java
+++ b/server/task/src/test/java/org/apache/james/task/TaskManagerContract.java
@@ -242,8 +242,7 @@ public interface TaskManagerContract {
                 waitingForResultLatch.await();
                 return Task.Result.COMPLETED;
             }));
-        TaskId waitingId = taskManager.submit(
-            new CompletedTask());
+        TaskId waitingId = taskManager.submit(new CompletedTask());
 
         latch1.await();
 


### PR DESCRIPTION
Upon execution `cassandra-guice` integretion tests I noticed a disapointed non-contextualized stacktrace with an  `InterruptedException` lost in the lmiddle of a reactor stacktrace.

So I turned debug on: `Hooks.onOperatorDebug();`

And got the additional informations to diagnose this:

```
13:28:58.461 [ERROR] r.c.p.Operators - Operator called default onErrorDropped
java.lang.InterruptedException: null
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.reportInterruptAfterWait(AbstractQueuedSynchronizer.java:2014)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2048)
	at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
	at reactor.core.publisher.MonoCallable.subscribe(MonoCallable.java:56)
	at reactor.core.publisher.MonoCallableOnAssembly.subscribe(MonoCallableOnAssembly.java:82)
	at reactor.core.publisher.Mono.subscribe(Mono.java:3852)
	at reactor.core.publisher.FluxRepeatPredicate$RepeatPredicateSubscriber.resubscribe(FluxRepeatPredicate.java:112)
	at reactor.core.publisher.MonoRepeatPredicate.subscribe(MonoRepeatPredicate.java:47)
	at reactor.core.publisher.FluxOnAssembly.subscribe(FluxOnAssembly.java:122)
	at reactor.core.publisher.Flux.subscribe(Flux.java:7921)
	at reactor.core.publisher.FluxSubscribeOn$SubscribeOnSubscriber.run(FluxSubscribeOn.java:194)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:84)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:37)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
Assembly trace from producer [reactor.core.publisher.MonoCallable] :
	reactor.core.publisher.Mono.fromCallable(Mono.java:358)
	org.apache.james.task.MemoryWorkQueue.<init>(MemoryWorkQueue.java:40)
Error has been observed by the following operator(s):
	|_	Mono.fromCallable ⇢ org.apache.james.task.MemoryWorkQueue.<init>(MemoryWorkQueue.java:40)
	|_	Mono.repeat ⇢ org.apache.james.task.MemoryWorkQueue.<init>(MemoryWorkQueue.java:41)
	|_	Flux.subscribeOn ⇢ org.apache.james.task.MemoryWorkQueue.<init>(MemoryWorkQueue.java:42)
	|_	Flux.flatMapSequential ⇢ org.apache.james.task.MemoryWorkQueue.<init>(MemoryWorkQueue.java:43)
``` 

Hence the explanation (commit message) and the fix.