### PR TITLE
JAMES-2886 Allow to load extensions in WebAdmin

### DIFF
--- a/dockerfiles/run/guice/cassandra-ldap/destination/conf/extensions.properties
+++ b/dockerfiles/run/guice/cassandra-ldap/destination/conf/extensions.properties
@@ -6,5 +6,5 @@
 
 # Upon injections, the user can reference additional guice modules, that are going to be used only upon extensions instantiation.
 
-#List of fully qualified class names of additional guice modules to be used to instanciate extensions
+#List of coma separated (',') fully qualified class names of additional guice modules to be used to instantiate extensions
 #guice.extension.module=

--- a/dockerfiles/run/guice/cassandra-ldap/destination/conf/webadmin.properties
+++ b/dockerfiles/run/guice/cassandra-ldap/destination/conf/webadmin.properties
@@ -39,3 +39,8 @@ https.enabled=false
 # Defaults to false
 #cors.enable=true
 #cors.origin
+
+# List of fully qualified class names that should be exposed over webadmin
+# in addition to your product default routes. Routes needs to be located
+# within the classpath or in the ./extensions-jars folder.
+#extensions.routes=

--- a/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/extensions.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/extensions.properties
@@ -6,5 +6,5 @@
 
 # Upon injections, the user can reference additional guice modules, that are going to be used only upon extensions instantiation.
 
-#List of fully qualified class names of additional guice modules to be used to instanciate extensions
+#List of coma separated (',') fully qualified class names of additional guice modules to be used to instantiate extensions
 #guice.extension.module=

--- a/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/webadmin.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/webadmin.properties
@@ -39,3 +39,8 @@ https.enabled=false
 # Defaults to false
 #cors.enable=true
 #cors.origin
+
+# List of fully qualified class names that should be exposed over webadmin
+# in addition to your product default routes. Routes needs to be located
+# within the classpath or in the ./extensions-jars folder.
+#extensions.routes=

--- a/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/extensions.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/extensions.properties
@@ -6,5 +6,5 @@
 
 # Upon injections, the user can reference additional guice modules, that are going to be used only upon extensions instantiation.
 
-#List of fully qualified class names of additional guice modules to be used to instanciate extensions
+#List of coma separated (',') fully qualified class names of additional guice modules to be used to instantiate extensions
 #guice.extension.module=

--- a/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/webadmin.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/webadmin.properties
@@ -39,3 +39,8 @@ https.enabled=false
 # Defaults to false
 #cors.enable=true
 #cors.origin
+
+# List of fully qualified class names that should be exposed over webadmin
+# in addition to your product default routes. Routes needs to be located
+# within the classpath or in the ./extensions-jars folder.
+#extensions.routes=

--- a/dockerfiles/run/guice/cassandra/destination/conf/extensions.properties
+++ b/dockerfiles/run/guice/cassandra/destination/conf/extensions.properties
@@ -6,5 +6,5 @@
 
 # Upon injections, the user can reference additional guice modules, that are going to be used only upon extensions instantiation.
 
-#List of fully qualified class names of additional guice modules to be used to instanciate extensions
+#List of coma separated (',') fully qualified class names of additional guice modules to be used to instantiate extensions
 #guice.extension.module=

--- a/dockerfiles/run/guice/cassandra/destination/conf/webadmin.properties
+++ b/dockerfiles/run/guice/cassandra/destination/conf/webadmin.properties
@@ -39,3 +39,8 @@ https.enabled=false
 # Defaults to false
 #cors.enable=true
 #cors.origin
+
+# List of fully qualified class names that should be exposed over webadmin
+# in addition to your product default routes. Routes needs to be located
+# within the classpath or in the ./extensions-jars folder.
+#extensions.routes=

--- a/dockerfiles/run/guice/jpa-smtp/destination/conf/extensions.properties
+++ b/dockerfiles/run/guice/jpa-smtp/destination/conf/extensions.properties
@@ -6,5 +6,5 @@
 
 # Upon injections, the user can reference additional guice modules, that are going to be used only upon extensions instantiation.
 
-#List of fully qualified class names of additional guice modules to be used to instanciate extensions
+#List of coma separated (',') fully qualified class names of additional guice modules to be used to instantiate extensions
 #guice.extension.module=

--- a/dockerfiles/run/guice/jpa/destination/conf/extensions.properties
+++ b/dockerfiles/run/guice/jpa/destination/conf/extensions.properties
@@ -6,5 +6,5 @@
 
 # Upon injections, the user can reference additional guice modules, that are going to be used only upon extensions instantiation.
 
-#List of fully qualified class names of additional guice modules to be used to instanciate extensions
+#List of coma separated (',') fully qualified class names of additional guice modules to be used to instantiate extensions
 #guice.extension.module=

--- a/dockerfiles/run/guice/memory/destination/conf/extensions.properties
+++ b/dockerfiles/run/guice/memory/destination/conf/extensions.properties
@@ -6,5 +6,5 @@
 
 # Upon injections, the user can reference additional guice modules, that are going to be used only upon extensions instantiation.
 
-#List of fully qualified class names of additional guice modules to be used to instanciate extensions
+#List of coma separated (',') fully qualified class names of additional guice modules to be used to instantiate extensions
 #guice.extension.module=

--- a/dockerfiles/run/guice/memory/destination/conf/webadmin.properties
+++ b/dockerfiles/run/guice/memory/destination/conf/webadmin.properties
@@ -39,3 +39,9 @@ https.enabled=false
 # Defaults to false
 #cors.enable=true
 #cors.origin
+
+
+# List of fully qualified class names that should be exposed over webadmin
+# in addition to your product default routes. Routes needs to be located
+# within the classpath or in the ./extensions-jars folder.
+#extensions.routes=

--- a/server/container/guice/guice-utils/src/main/java/org/apache/james/utils/ExtensionConfiguration.java
+++ b/server/container/guice/guice-utils/src/main/java/org/apache/james/utils/ExtensionConfiguration.java
@@ -21,6 +21,7 @@ package org.apache.james.utils;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.commons.configuration2.Configuration;
 
@@ -31,7 +32,9 @@ public class ExtensionConfiguration {
     public static final ExtensionConfiguration DEFAULT = new ExtensionConfiguration(ImmutableList.of());
 
     public static ExtensionConfiguration from(Configuration configuration) {
-        List<String> list = Arrays.asList(configuration.getStringArray("guice.extension.module"));
+        List<String> list = Optional.ofNullable(configuration.getStringArray("guice.extension.module"))
+            .map(Arrays::asList)
+            .orElse(ImmutableList.of());
 
         return new ExtensionConfiguration(list.stream()
             .map(ClassName::new)

--- a/server/container/guice/memory-guice/pom.xml
+++ b/server/container/guice/memory-guice/pom.xml
@@ -193,6 +193,12 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-webadmin-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>testing-base</artifactId>
             <scope>test</scope>
         </dependency>

--- a/server/container/guice/memory-guice/src/test/java/org/apache/james/MyRoute.java
+++ b/server/container/guice/memory-guice/src/test/java/org/apache/james/MyRoute.java
@@ -17,24 +17,23 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.modules.server;
+package org.apache.james;
 
-import org.apache.james.core.healthcheck.HealthCheck;
 import org.apache.james.webadmin.Routes;
-import org.apache.james.webadmin.routes.HealthCheckRoutes;
 
-import com.google.inject.AbstractModule;
-import com.google.inject.Scopes;
-import com.google.inject.multibindings.Multibinder;
+import spark.Service;
 
-public class HealthCheckRoutesModule extends AbstractModule {
+public class MyRoute implements Routes {
+    static final String ENDPOINT = "/myRoutes";
+    static final String SHABANG = "SHABANG";
+
     @Override
-    protected void configure() {
-        bind(HealthCheckRoutes.class).in(Scopes.SINGLETON);
+    public String getBasePath() {
+        return ENDPOINT;
+    }
 
-        Multibinder<Routes> routesMultibinder = Multibinder.newSetBinder(binder(), Routes.class);
-        routesMultibinder.addBinding().to(HealthCheckRoutes.class);
-
-        Multibinder.newSetBinder(binder(), HealthCheck.class);
+    @Override
+    public void define(Service service) {
+        service.get(ENDPOINT, (req, res) -> SHABANG);
     }
 }

--- a/server/container/guice/memory-guice/src/test/java/org/apache/james/WebAdminRoutesExtensionTest.java
+++ b/server/container/guice/memory-guice/src/test/java/org/apache/james/WebAdminRoutesExtensionTest.java
@@ -1,0 +1,64 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import static io.restassured.RestAssured.when;
+import static org.apache.james.MyRoute.SHABANG;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.apache.james.modules.TestJMAPServerModule;
+import org.apache.james.utils.WebAdminGuiceProbe;
+import org.apache.james.webadmin.RandomPortSupplier;
+import org.apache.james.webadmin.WebAdminConfiguration;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.restassured.RestAssured;
+
+class WebAdminRoutesExtensionTest {
+    private static final int LIMIT_TO_10_MESSAGES = 10;
+
+    @RegisterExtension
+    static JamesServerExtension jamesServerExtension = new JamesServerBuilder()
+        .server(configuration -> GuiceJamesServer.forConfiguration(configuration)
+            .combineWith(MemoryJamesServerMain.IN_MEMORY_SERVER_AGGREGATE_MODULE)
+            .overrideWith(new TestJMAPServerModule(LIMIT_TO_10_MESSAGES))
+            .overrideWith(binder -> binder.bind(WebAdminConfiguration.class)
+                .toInstance(WebAdminConfiguration.builder()
+                    .additionalRoute(MyRoute.class.getCanonicalName())
+                    .enabled()
+                    .port(new RandomPortSupplier())
+                    .corsDisabled()
+                    .build())))
+        .build();
+
+
+    @Test
+    void customRoutesShouldBeBound(GuiceJamesServer jamesServer) {
+        WebAdminGuiceProbe probe = jamesServer.getProbe(WebAdminGuiceProbe.class);
+        RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(probe.getWebAdminPort()).build();
+
+        when()
+            .get(MyRoute.ENDPOINT)
+        .then()
+            .body(is(SHABANG));
+    }
+}

--- a/server/container/guice/protocols/webadmin/pom.xml
+++ b/server/container/guice/protocols/webadmin/pom.xml
@@ -38,6 +38,10 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-guice-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-webadmin-core</artifactId>
         </dependency>
         <dependency>

--- a/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/WebAdminServerModule.java
+++ b/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/WebAdminServerModule.java
@@ -22,16 +22,24 @@ package org.apache.james.modules.server;
 import static org.apache.james.webadmin.WebAdminConfiguration.DISABLED_CONFIGURATION;
 
 import java.io.FileNotFoundException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+
+import javax.inject.Named;
 
 import org.apache.commons.configuration2.Configuration;
 import org.apache.james.jwt.JwtTokenVerifier;
 import org.apache.james.lifecycle.api.Startable;
+import org.apache.james.utils.ClassName;
+import org.apache.james.utils.GuiceGenericLoader;
 import org.apache.james.utils.GuiceProbe;
 import org.apache.james.utils.InitialisationOperation;
 import org.apache.james.utils.PropertiesProvider;
 import org.apache.james.utils.WebAdminGuiceProbe;
 import org.apache.james.webadmin.FixedPortSupplier;
+import org.apache.james.webadmin.Routes;
 import org.apache.james.webadmin.TlsConfiguration;
 import org.apache.james.webadmin.WebAdminConfiguration;
 import org.apache.james.webadmin.WebAdminServer;
@@ -43,6 +51,9 @@ import org.apache.james.webadmin.utils.JsonTransformerModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.fge.lambdas.Throwing;
+import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
@@ -78,9 +89,31 @@ public class WebAdminServerModule extends AbstractModule {
 
     @Provides
     @Singleton
+    @Named("webAdminRoutes")
+    public List<Routes> provideRoutes(GuiceGenericLoader loader, WebAdminConfiguration configuration, Set<Routes> routesList) {
+        List<Routes> customRoutes = configuration.getAdditionalRoutes()
+            .stream()
+            .map(ClassName::new)
+            .map(Throwing.function(loader::<Routes>instanciate))
+            .peek(routes -> LOGGER.info("Loading WebAdmin route extension {}", routes.getClass().getCanonicalName()))
+            .collect(Guavate.toImmutableList());
+
+        return ImmutableList.<Routes>builder()
+            .addAll(routesList)
+            .addAll(customRoutes)
+            .build();
+    }
+
+    @Provides
+    @Singleton
     public WebAdminConfiguration provideWebAdminConfiguration(PropertiesProvider propertiesProvider) throws Exception {
         try {
             Configuration configurationFile = propertiesProvider.getConfiguration("webadmin");
+
+            List<String> additionalRoutes = Optional.ofNullable(configurationFile.getStringArray("extensions.routes"))
+                .map(Arrays::asList)
+                .orElse(ImmutableList.of());
+
             return WebAdminConfiguration.builder()
                 .enable(configurationFile.getBoolean("enabled", DEFAULT_DISABLED))
                 .port(new FixedPortSupplier(configurationFile.getInt("port", WebAdminServer.DEFAULT_PORT)))
@@ -88,6 +121,7 @@ public class WebAdminServerModule extends AbstractModule {
                 .enableCORS(configurationFile.getBoolean("cors.enable", DEFAULT_CORS_DISABLED))
                 .urlCORSOrigin(configurationFile.getString("cors.origin", DEFAULT_NO_CORS_ORIGIN))
                 .host(configurationFile.getString("host", WebAdminConfiguration.DEFAULT_HOST))
+                .additionalRoutes(additionalRoutes)
                 .build();
         } catch (FileNotFoundException e) {
             LOGGER.info("No webadmin.properties file. Disabling WebAdmin interface.");

--- a/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/WebAdminServerModule.java
+++ b/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/WebAdminServerModule.java
@@ -111,7 +111,7 @@ public class WebAdminServerModule extends AbstractModule {
             Configuration configurationFile = propertiesProvider.getConfiguration("webadmin");
 
             List<String> additionalRoutes = Optional.ofNullable(configurationFile.getStringArray("extensions.routes"))
-                .map(Arrays::asList)
+                .map(ImmutableList::copyOf)
                 .orElse(ImmutableList.of());
 
             return WebAdminConfiguration.builder()

--- a/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/WebAdminServerModule.java
+++ b/server/container/guice/protocols/webadmin/src/main/java/org/apache/james/modules/server/WebAdminServerModule.java
@@ -22,7 +22,6 @@ package org.apache.james.modules.server;
 import static org.apache.james.webadmin.WebAdminConfiguration.DISABLED_CONFIGURATION;
 
 import java.io.FileNotFoundException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;

--- a/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/AuthorizedEndpointsTest.java
+++ b/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/AuthorizedEndpointsTest.java
@@ -28,9 +28,11 @@ import org.apache.james.GuiceJamesServer;
 import org.apache.james.utils.WebAdminGuiceProbe;
 import org.apache.james.webadmin.WebAdminUtils;
 import org.apache.james.webadmin.routes.HealthCheckRoutes;
+import org.apache.james.webadmin.swagger.routes.SwaggerRoutes;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -65,6 +67,15 @@ public class AuthorizedEndpointsTest {
     public void getHealthchecksShouldNotNeedAuthentication() {
         when()
             .get(HealthCheckRoutes.HEALTHCHECK)
+        .then()
+            .statusCode(not(HttpStatus.UNAUTHORIZED_401));
+    }
+
+    @Ignore("Swagger endpoint is not public despite SwaggerRoutes being an instance of PublicRoutes")
+    @Test
+    public void getSwaggerShouldNotNeedAuthentication() {
+        when()
+            .get(SwaggerRoutes.SWAGGER_ENDPOINT)
         .then()
             .statusCode(not(HttpStatus.UNAUTHORIZED_401));
     }

--- a/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/AuthorizedEndpointsTest.java
+++ b/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/AuthorizedEndpointsTest.java
@@ -32,7 +32,6 @@ import org.apache.james.webadmin.swagger.routes.SwaggerRoutes;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -71,7 +70,6 @@ public class AuthorizedEndpointsTest {
             .statusCode(not(HttpStatus.UNAUTHORIZED_401));
     }
 
-    @Ignore("Swagger endpoint is not public despite SwaggerRoutes being an instance of PublicRoutes")
     @Test
     public void getSwaggerShouldNotNeedAuthentication() {
         when()

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/WebAdminUtils.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/WebAdminUtils.java
@@ -30,6 +30,8 @@ import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.james.util.Port;
 import org.apache.james.webadmin.authentication.NoAuthenticationFilter;
 
+import com.google.common.collect.ImmutableList;
+
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.http.ContentType;
@@ -39,7 +41,7 @@ public class WebAdminUtils {
 
     public static WebAdminServer createWebAdminServer(Routes... routes) {
         return new WebAdminServer(WebAdminConfiguration.TEST_CONFIGURATION,
-            Arrays.asList(routes),
+            ImmutableList.copyOf(routes),
             new NoAuthenticationFilter(),
             new NoopMetricFactory());
     }

--- a/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/WebAdminUtils.java
+++ b/server/protocols/webadmin/webadmin-core/src/test/java/org/apache/james/webadmin/WebAdminUtils.java
@@ -25,13 +25,10 @@ import static io.restassured.config.RestAssuredConfig.newConfig;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Set;
 
 import org.apache.james.metrics.api.NoopMetricFactory;
 import org.apache.james.util.Port;
 import org.apache.james.webadmin.authentication.NoAuthenticationFilter;
-
-import com.github.steveash.guavate.Guavate;
 
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.config.RestAssuredConfig;
@@ -42,23 +39,9 @@ public class WebAdminUtils {
 
     public static WebAdminServer createWebAdminServer(Routes... routes) {
         return new WebAdminServer(WebAdminConfiguration.TEST_CONFIGURATION,
-            privateRoutes(routes),
-            publicRoutes(routes),
+            Arrays.asList(routes),
             new NoAuthenticationFilter(),
             new NoopMetricFactory());
-    }
-
-    private static Set<Routes> privateRoutes(Routes[] routes) {
-        return Arrays.stream(routes)
-                .filter(route -> !(route instanceof PublicRoutes))
-                .collect(Guavate.toImmutableSet());
-    }
-
-    private static Set<PublicRoutes> publicRoutes(Routes[] routes) {
-        return Arrays.stream(routes)
-                .filter(PublicRoutes.class::isInstance)
-                .map(PublicRoutes.class::cast)
-                .collect(Guavate.toImmutableSet());
     }
 
     public static RequestSpecBuilder buildRequestSpecification(WebAdminServer webAdminServer) {

--- a/src/site/xdoc/server/config-webadmin.xml
+++ b/src/site/xdoc/server/config-webadmin.xml
@@ -54,6 +54,9 @@
         <dd>Specify a truststore file for https (default: null)</dd>
         <dt><strong>https.trust.password</strong></dt>
         <dd>Specify the truststore password (default: null)</dd>
+        <dt><strong>extensions.routes</strong></dt>
+        <dd>List of Routes specified as fully qualified class name that should be load in addition to your product routes list. Routes
+            needs to be on the classpath or in the ./extensions-jars folder.</dd>
     </dl>
   </section>
 

--- a/src/site/xdoc/server/config-webadmin.xml
+++ b/src/site/xdoc/server/config-webadmin.xml
@@ -55,7 +55,7 @@
         <dt><strong>https.trust.password</strong></dt>
         <dd>Specify the truststore password (default: null)</dd>
         <dt><strong>extensions.routes</strong></dt>
-        <dd>List of Routes specified as fully qualified class name that should be load in addition to your product routes list. Routes
+        <dd>List of Routes specified as fully qualified class name that should be loaded in addition to your product routes list. Routes
             needs to be on the classpath or in the ./extensions-jars folder.</dd>
     </dl>
   </section>

--- a/src/site/xdoc/server/dev-extend.xml
+++ b/src/site/xdoc/server/dev-extend.xml
@@ -72,6 +72,60 @@
   
   </subsection>
 
+    <subsection name="Extension and Guice wiring">
+
+        <p>This section do not concern the Spring / server/app wiring.</p>
+
+        <p>Guice applications let you load several type of user defined components. These components includes:</p>
+
+        <ul>
+            <li><a href="https://github.com/apache/james-project/blob/master/mailet/api/src/main/java/org/apache/mailet/Mailet.java">Mailets</a></li>
+            <li><a href="https://github.com/apache/james-project/blob/master/mailet/api/src/main/java/org/apache/mailet/Matcher.java">Matchers</a></li>
+            <li><a href="https://github.com/apache/james-project/blob/master/mailbox/api/src/main/java/org/apache/james/mailbox/events/MailboxListener.java">Mailbox Listeners</a></li>
+            <li><a href="https://github.com/apache/james-project/blob/master/mailbox/api/src/main/java/org/apache/james/mailbox/extension/PreDeletionHook.java">PreDeletion hooks</a></li>
+            <li><a href="https://github.com/apache/james-project/blob/master/protocols/api/src/main/java/org/apache/james/protocols/api/handler/ProtocolHandler.java">Protocol handlers</a> (SMTP/LMTP/POP3)</li>
+            <li><a href="https://github.com/apache/james-project/blob/master/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/Routes.java">Additional webAdmin routes</a></li>
+        </ul>
+
+        <p>Given a custom maven module implementing one or more of the following APIs, first create a <b>jar-with-dependencies</b>
+        of your module. Then copy the jar-with-dependencies into the <code>./extensions-jars</code> folder of your guice
+        James server installation.</p>
+
+        <p>Note: Transitive dependency resolution is only done if you are packaging your extension into a jar-with-dependencies.
+        Your extension class-loader will be the modified one (James and extensions-jars content) but James class-loader
+        stays unmodified everywhere else.</p>
+
+        <p>Once done, you need to explicitly require James to load your extensions. This needs to be done in the following
+        configuration files:</p>
+
+        <ul>
+            <li><a href="config-mailetcontainer.html">Mailets</a></li>
+            <li><a href="config-mailetcontainer.html">Matchers</a></li>
+            <li><a href="config-listeners.html">Mailbox Listeners</a></li>
+            <li><a href="config-listeners.html">PreDeletion hooks</a></li>
+            <li>Protocol handlers for <a href="config-smtp.html">SMTP</a>,<a href="config-lmtp.html">LMTP</a>,<a href="config-pop3.html">POP3</a></li>
+            <li><a href="config-webadmin.html">Additional webAdmin routes</a></li>
+        </ul>
+
+        <p>Also, it is possible to register additional Guice bindings, that are applied as a Guice child injector
+        for creating extensions.</p>
+
+        <p>Note: James injector is not altered nor overloaded in any way.</p>
+
+        <p>To do so, write an <a href="https://google.github.io/guice/api-docs/latest/javadoc/index.html?com/google/inject/AbstractModule.html">
+        AbstractModule</a> with the additional guice bindings you need. Then package it as a <b>jar-with-dependencies</b>, and copy the
+        jar-with-dependencies within the <b>extensions-jars</b> folder of your James installation, as you will do for any other extension.</p>
+
+        <p>Then register your additional Guice modules for extensions within the
+        <a href="https://github.com/apache/james-project/tree/master/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/extensions.properties">extensions.properties</a>
+        configuration file.</p>
+
+        <p>Note: No Guice extensions will be applied upon Guice extension module invocation.</p>
+
+        <p>This enables injections defined in your AbstractModule into all extensions.</p>
+
+    </subsection>
+
 </section>
 
 </body>

--- a/src/site/xdoc/server/dev-extend.xml
+++ b/src/site/xdoc/server/dev-extend.xml
@@ -111,9 +111,9 @@
         <p>Also, it is possible to register additional Guice bindings, that are applied as a Guice child injector
         for creating extensions.</p>
 
-        <p>Note: James injector is not altered nor overloaded in any way.</p>
+        <p>Note: Extensions are loaded in their own classpath to avoid breaking James server but they can retrieve James services to implement their business logic.</p>
 
-        <p>To do so, write an <a href="https://google.github.io/guice/api-docs/latest/javadoc/index.html?com/google/inject/AbstractModule.html">
+        <p>To do so, write an <a href="https://google.github.io/guice/api-docs/latest/javadoc/index.html?com/google/inject/Module.html">
         AbstractModule</a> with the additional guice bindings you need. Then package it as a <b>jar-with-dependencies</b>, and copy the
         jar-with-dependencies within the <b>extensions-jars</b> folder of your James installation, as you will do for any other extension.</p>
 

--- a/src/site/xdoc/server/dev-extend.xml
+++ b/src/site/xdoc/server/dev-extend.xml
@@ -74,9 +74,9 @@
 
     <subsection name="Extension and Guice wiring">
 
-        <p>This section do not concern the Spring / server/app wiring.</p>
+        <p>This section does not concern the Spring / server/app wiring.</p>
 
-        <p>Guice applications let you load several type of user defined components. These components includes:</p>
+        <p>Guice applications let you load several type of user defined components. These components include:</p>
 
         <ul>
             <li><a href="https://github.com/apache/james-project/blob/master/mailet/api/src/main/java/org/apache/mailet/Mailet.java">Mailets</a></li>
@@ -87,7 +87,8 @@
             <li><a href="https://github.com/apache/james-project/blob/master/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/Routes.java">Additional webAdmin routes</a></li>
         </ul>
 
-        <p>Given a custom maven module implementing one or more of the following APIs, first create a <b>jar-with-dependencies</b>
+        <p>Given a custom maven module implementing one or more of the following APIs, first create a
+        <a href="https://maven.apache.org/plugins/maven-assembly-plugin/descriptor-refs.html#jar-with-dependencies">jar-with-dependencies</a>
         of your module. Then copy the jar-with-dependencies into the <code>./extensions-jars</code> folder of your guice
         James server installation.</p>
 

--- a/src/site/xdoc/server/dev-extend.xml
+++ b/src/site/xdoc/server/dev-extend.xml
@@ -114,7 +114,7 @@
         <p>Note: Extensions are loaded in their own classpath to avoid breaking James server but they can retrieve James services to implement their business logic.</p>
 
         <p>To do so, write an <a href="https://google.github.io/guice/api-docs/latest/javadoc/index.html?com/google/inject/Module.html">
-        AbstractModule</a> with the additional guice bindings you need. Then package it as a <b>jar-with-dependencies</b>, and copy the
+        Module</a> with the additional guice bindings you need. Then package it as a <b>jar-with-dependencies</b>, and copy the
         jar-with-dependencies within the <b>extensions-jars</b> folder of your James installation, as you will do for any other extension.</p>
 
         <p>Then register your additional Guice modules for extensions within the
@@ -123,7 +123,7 @@
 
         <p>Note: No Guice extensions will be applied upon Guice extension module invocation.</p>
 
-        <p>This enables injections defined in your AbstractModule into all extensions.</p>
+        <p>This enables injections defined in your Module into all extensions.</p>
 
     </subsection>
 


### PR DESCRIPTION
Next step of https://github.com/linagora/james-project/pull/2699 , this work enables one to add new custom routes within the `WebAdmin` protocol from the `extensions-jars` folder.

The example of the ApacheCon preparation can then be handled as **completly indepandantly source code**.