### PR TITLE
WIP - use concatMap to processMail sequentially

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/DeliveryRunnable.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/DeliveryRunnable.java
@@ -84,7 +84,7 @@ public class DeliveryRunnable implements Disposable {
         Scheduler remoteDeliveryScheduler = Schedulers.newElastic("RemoteDelivery");
         disposable = Flux.from(queue.deQueue())
             .publishOn(remoteDeliveryScheduler)
-            .flatMap(this::runStep)
+            .concatMap(this::runStep)
             .onErrorContinue(((throwable, nothing) -> LOGGER.error("Exception caught in RemoteDelivery", throwable)))
             .subscribeOn(remoteDeliveryScheduler)
             .subscribe();


### PR DESCRIPTION
The flags are updated in the `PostDequeueDecorator.done` method.
So to avoid concurrent call to nextModSeq it's prefered to use concatMap