### PR TITLE
JAMES-2563 ElasticSearch health checks

### DIFF
--- a/backends-common/elasticsearch/pom.xml
+++ b/backends-common/elasticsearch/pom.xml
@@ -100,11 +100,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/backends-common/elasticsearch/pom.xml
+++ b/backends-common/elasticsearch/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
-            <version>6.3.2</version>
+            <version>6.4.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/backends-common/elasticsearch/pom.xml
+++ b/backends-common/elasticsearch/pom.xml
@@ -30,6 +30,10 @@
     <dependencies>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-util</artifactId>
         </dependency>
         <dependency>
@@ -94,6 +98,11 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/ElasticSearchHealthCheck.java
+++ b/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/ElasticSearchHealthCheck.java
@@ -76,9 +76,8 @@ public class ElasticSearchHealthCheck implements HealthCheck {
     Result toHealthCheckResult(ClusterHealthResponse response) {
         switch (response.getStatus()) {
             case GREEN:
-                return Result.healthy(COMPONENT_NAME);
             case YELLOW:
-                return Result.degraded(COMPONENT_NAME, response.getClusterName() + " status is YELLOW");
+                return Result.healthy(COMPONENT_NAME);
             case RED:
                 return Result.unhealthy(COMPONENT_NAME, response.getClusterName() + " status is RED");
             default:

--- a/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/ElasticSearchHealthCheck.java
+++ b/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/ElasticSearchHealthCheck.java
@@ -1,0 +1,79 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.es;
+
+import java.util.Set;
+import javax.inject.Inject;
+
+import org.apache.james.core.healthcheck.ComponentName;
+import org.apache.james.core.healthcheck.HealthCheck;
+import org.apache.james.core.healthcheck.Result;
+
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.Requests;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Health check for Elasticsearch
+ */
+public class ElasticSearchHealthCheck implements HealthCheck {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ElasticSearchHealthCheck.class);
+    private static final ComponentName COMPONENT_NAME = new ComponentName("Elasticsearch backend");
+    private final Set<IndexName> indexNames;
+
+    private final Client client;
+
+    private final long requestTimeout;
+
+    @Inject
+    public ElasticSearchHealthCheck(Client client, Set<IndexName> indexNames, long requestTimeout) {
+        this.client = client;
+        this.indexNames = indexNames;
+        this.requestTimeout = requestTimeout;
+    }
+
+    @Override
+    public ComponentName componentName() {
+        return COMPONENT_NAME;
+    }
+
+    @Override
+    public Result check() {
+        ClusterHealthRequest request =
+                Requests.clusterHealthRequest(indexNames.stream().map(IndexName::getValue).toArray(String[]::new));
+        ClusterHealthResponse response =
+                this.client.admin().cluster().health(request).actionGet(requestTimeout);
+
+        switch (response.getStatus()) {
+            case GREEN:
+            case YELLOW:
+                return Result.healthy(COMPONENT_NAME);
+            case RED:
+            default:
+                return Result.unhealthy(COMPONENT_NAME);
+        }
+
+    }
+}

--- a/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/ElasticSearchHealthCheck.java
+++ b/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/ElasticSearchHealthCheck.java
@@ -59,7 +59,10 @@ public class ElasticSearchHealthCheck implements HealthCheck {
 
     @Override
     public Result check() {
-        ClusterHealthRequest request = Requests.clusterHealthRequest(indexNames.stream().map(IndexName::getValue).toArray(String[]::new));
+        String[] indices = indexNames.stream()
+            .map(IndexName::getValue)
+            .toArray(String[]::new);
+        ClusterHealthRequest request = Requests.clusterHealthRequest(indices);
 
         try {
             ClusterHealthResponse response = client.cluster()

--- a/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/ElasticSearchIndexer.java
+++ b/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/ElasticSearchIndexer.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -72,7 +73,8 @@ public class ElasticSearchIndexer {
             new IndexRequest(aliasName.getValue())
                 .type(NodeMappingFactory.DEFAULT_MAPPING_NAME)
                 .id(id)
-                .source(content, XContentType.JSON));
+                .source(content, XContentType.JSON),
+            RequestOptions.DEFAULT);
     }
 
     public Optional<BulkResponse> update(List<UpdatedRepresentation> updatedDocumentParts) throws IOException {
@@ -84,7 +86,7 @@ public class ElasticSearchIndexer {
                     NodeMappingFactory.DEFAULT_MAPPING_NAME,
                     updatedDocumentPart.getId())
                 .doc(updatedDocumentPart.getUpdatedDocumentPart(), XContentType.JSON)));
-            return Optional.of(client.bulk(request));
+            return Optional.of(client.bulk(request, RequestOptions.DEFAULT));
         } catch (ValidationException e) {
             LOGGER.warn("Error while updating index", e);
             return Optional.empty();

--- a/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/IndexCreationFactory.java
+++ b/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/IndexCreationFactory.java
@@ -30,6 +30,7 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.slf4j.Logger;
@@ -97,13 +98,14 @@ public class IndexCreationFactory {
                         new IndicesAliasesRequest().addAliasAction(
                             new AliasActions(AliasActions.Type.ADD)
                                 .index(indexName.getValue())
-                                .alias(aliasName.getValue())));
+                                .alias(aliasName.getValue())),
+                        RequestOptions.DEFAULT);
             }
         }
 
         private boolean aliasExist(RestHighLevelClient client, AliasName aliasName) throws IOException {
             return client.indices()
-                .existsAlias(new GetAliasesRequest().aliases(aliasName.getValue()));
+                .existsAlias(new GetAliasesRequest().aliases(aliasName.getValue()), RequestOptions.DEFAULT);
         }
 
         private void createIndexIfNeeded(RestHighLevelClient client, IndexName indexName, XContentBuilder settings) throws IOException {
@@ -111,7 +113,7 @@ public class IndexCreationFactory {
                 client.indices()
                     .create(
                         new CreateIndexRequest(indexName.getValue())
-                            .source(settings));
+                            .source(settings), RequestOptions.DEFAULT);
             } catch (ElasticsearchStatusException exception) {
                 if (exception.getMessage().contains(INDEX_ALREADY_EXISTS_EXCEPTION_MESSAGE)) {
                     LOGGER.info("Index [{}] already exist", indexName);

--- a/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/NodeMappingFactory.java
+++ b/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/NodeMappingFactory.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 
 import org.apache.http.HttpStatus;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -59,6 +60,8 @@ public class NodeMappingFactory {
         return client;
     }
 
+    // ElasticSearch 6.3.2 does not support field master_timeout that is set up by 6.4.3 REST client when relying on getMapping
+    @SuppressWarnings("deprecation")
     public static boolean mappingAlreadyExist(RestHighLevelClient client, IndexName indexName) throws IOException {
         try {
             client.getLowLevelClient().performRequest("GET", indexName.getValue() + "/_mapping/" + NodeMappingFactory.DEFAULT_MAPPING_NAME);
@@ -75,7 +78,8 @@ public class NodeMappingFactory {
         client.indices().putMapping(
             new PutMappingRequest(indexName.getValue())
                 .type(NodeMappingFactory.DEFAULT_MAPPING_NAME)
-                .source(mappingsSources));
+                .source(mappingsSources),
+            RequestOptions.DEFAULT);
     }
 
 }

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/ClientProviderImplConnectionTest.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/ClientProviderImplConnectionTest.java
@@ -26,6 +26,7 @@ import org.apache.james.util.docker.DockerContainer;
 import org.apache.james.util.docker.Images;
 import org.awaitility.Awaitility;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -97,7 +98,8 @@ public class ClientProviderImplConnectionTest {
         try (RestHighLevelClient client = clientProvider.get()) {
             client.search(
                 new SearchRequest()
-                    .source(new SearchSourceBuilder().query(QueryBuilders.existsQuery("any"))));
+                    .source(new SearchSourceBuilder().query(QueryBuilders.existsQuery("any"))),
+                RequestOptions.DEFAULT);
             return true;
         } catch (Exception e) {
             LOGGER.info("Caught exception while trying to connect", e);

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/DockerElasticSearch.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/DockerElasticSearch.java
@@ -114,12 +114,23 @@ public class DockerElasticSearch {
         }
     }
 
+    public ElasticSearchConfiguration configuration(Optional<Duration> requestTimeout) {
+        return ElasticSearchConfiguration.builder()
+            .addHost(getHttpHost())
+            .requestTimeout(requestTimeout)
+            .build();
+    }
+
     public ElasticSearchConfiguration configuration() {
-        return ElasticSearchConfiguration.builder().addHost(getHttpHost()).build();
+        return configuration(Optional.empty());
     }
 
     public ClientProvider clientProvider() {
-        return new ClientProvider(configuration());
+        return new ClientProvider(configuration(Optional.empty()));
+    }
+
+    public ClientProvider clientProvider(Duration requestTimeout) {
+        return new ClientProvider(configuration(Optional.of(requestTimeout)));
     }
 
     private ElasticSearchAPI esAPI() {

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/DockerElasticSearch.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/DockerElasticSearch.java
@@ -19,6 +19,9 @@
 
 package org.apache.james.backends.es;
 
+import java.time.Duration;
+import java.util.Optional;
+
 import org.apache.http.HttpStatus;
 import org.apache.james.util.Host;
 import org.apache.james.util.docker.DockerContainer;

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/DockerElasticSearchRule.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/DockerElasticSearchRule.java
@@ -26,7 +26,7 @@ public class DockerElasticSearchRule extends ExternalResource {
     private final DockerElasticSearch dockerElasticSearch = DockerElasticSearchSingleton.INSTANCE;
 
     @Override
-    protected void before() throws Throwable {
+    protected void before() {
         dockerElasticSearch.start();
     }
 

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/DockerElasticSearchSingleton.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/DockerElasticSearchSingleton.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.backends.es;
 
-import java.time.Duration;
-
 public class DockerElasticSearchSingleton {
     public static DockerElasticSearch INSTANCE = new DockerElasticSearch();
 

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/DockerElasticSearchSingleton.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/DockerElasticSearchSingleton.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.backends.es;
 
+import java.time.Duration;
+
 public class DockerElasticSearchSingleton {
     public static DockerElasticSearch INSTANCE = new DockerElasticSearch();
 

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/ElasticSearchHealthCheckConnectionTest.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/ElasticSearchHealthCheckConnectionTest.java
@@ -1,0 +1,69 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.backends.es;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.james.util.docker.Images;
+import org.apache.james.util.docker.RateLimiters;
+import org.apache.james.util.docker.SwarmGenericContainer;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.Client;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ElasticSearchHealthCheckConnectionTest {
+
+    private static final int ES_APPLICATIVE_PORT = 9300;
+    private static final Set<IndexName> indices = new HashSet<>();
+
+    private static final WaitStrategy WAIT_STRATEGY = Wait.forHttp("/").forPort(ES_APPLICATIVE_PORT).withRateLimiter(RateLimiters.DEFAULT);
+
+    @Rule
+    public SwarmGenericContainer elasticSearchContainer = new SwarmGenericContainer(Images.ELASTICSEARCH)
+        .withAffinityToContainer().withExposedPorts(ES_APPLICATIVE_PORT).waitingFor(WAIT_STRATEGY);
+
+    @Test
+    public void testHealthCheckValidation() {
+        ClientProviderImpl clientProvider = ClientProviderImpl.forHost(elasticSearchContainer.getContainerIp(), ES_APPLICATIVE_PORT);
+        Client client = clientProvider.get();
+        indices.add(new IndexName("healthcheck"));
+        ElasticSearchHealthCheck elasticSearchHealthCheck = new ElasticSearchHealthCheck(client, indices, 1000);
+
+        String content = "{\"message\": \"trying out Elasticsearch Healthcheck\"}";
+
+        IndexRequest testHealthCheckIndexRequest = new IndexRequest("healthcheck");
+        testHealthCheckIndexRequest.source(content);
+        client.index(testHealthCheckIndexRequest);
+
+        assertThat(elasticSearchHealthCheck.check().isHealthy()).isTrue();
+
+        elasticSearchContainer.pause();
+
+        assertThat(elasticSearchHealthCheck.check().isUnHealthy()).isTrue();
+
+    }
+
+
+}

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/ElasticSearchHealthCheckConnectionTest.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/ElasticSearchHealthCheckConnectionTest.java
@@ -38,7 +38,7 @@ public class ElasticSearchHealthCheckConnectionTest {
     private static final int ES_APPLICATIVE_PORT = 9300;
     private static final Set<IndexName> indices = new HashSet<>();
 
-    private static final WaitStrategy WAIT_STRATEGY = Wait.forHttp("/").forPort(ES_APPLICATIVE_PORT).withRateLimiter(RateLimiters.DEFAULT);
+    private static final WaitStrategy WAIT_STRATEGY = Wait.forHttp("/").forPort(ES_APPLICATIVE_PORT).withRateLimiter(RateLimiters.TWENTIES_PER_SECOND);
 
     @Rule
     public SwarmGenericContainer elasticSearchContainer = new SwarmGenericContainer(Images.ELASTICSEARCH)

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/ElasticSearchHealthCheckTest.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/ElasticSearchHealthCheckTest.java
@@ -57,7 +57,7 @@ public class ElasticSearchHealthCheckTest {
     public void checkShouldReturnHealthyWhenElasticSearchClusterHealthStatusIsYellow() {
         FakeClusterHealthResponse response = new FakeClusterHealthResponse(ClusterHealthStatus.YELLOW);
 
-        assertThat(healthCheck.toHealthCheckResult(response).isDegraded()).isTrue();
+        assertThat(healthCheck.toHealthCheckResult(response).isHealthy()).isTrue();
     }
 
     private static class FakeClusterHealthResponse extends ClusterHealthResponse {

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/ElasticSearchHealthCheckTest.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/ElasticSearchHealthCheckTest.java
@@ -1,0 +1,125 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.backends.es;
+
+import org.apache.james.core.healthcheck.HealthCheck;
+import org.apache.james.core.healthcheck.Result;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.client.AdminClient;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.ClusterAdminClient;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.HashSet;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ElasticSearchHealthCheckTest {
+
+    @Mock
+    private Client client;
+
+    @Mock
+    private AdminClient adminClient;
+
+    @Mock
+    private ClusterAdminClient clusterAdminClient;
+
+    private HealthCheck healthCheck;
+
+    @Before
+    public void setup() {
+        HashSet<IndexName> indexNames = new HashSet<>();
+        MockitoAnnotations.initMocks(this);
+        when(this.client.admin()).thenReturn(adminClient);
+        when(this.adminClient.cluster()).thenReturn(clusterAdminClient);
+        healthCheck = new ElasticSearchHealthCheck(client, indexNames, 1000);
+    }
+
+    @Test
+    public void checkShouldReturnHealthyWhenElasticSearchClusterHealthStatusIsGreen() {
+        PlainActionFuture<ClusterHealthResponse> responseFuture = new PlainActionFuture<>();
+        responseFuture.onResponse(new FakeClusterHealthResponse());
+
+        when(this.clusterAdminClient.health(any(ClusterHealthRequest.class))).thenReturn(responseFuture);
+
+        Result check = healthCheck.check();
+        assertThat(check.isHealthy()).isTrue();
+    }
+
+    @Test
+    public void checkShouldReturnUnHealthyWhenElasticSearchClusterHealthStatusIsRed() {
+        PlainActionFuture<ClusterHealthResponse> responseFuture = new PlainActionFuture<>();
+        responseFuture.onResponse(new FakeClusterHealthResponse(ClusterHealthStatus.RED));
+
+        when(this.clusterAdminClient.health(any(ClusterHealthRequest.class))).thenReturn(responseFuture);
+
+        Result check = healthCheck.check();
+        assertThat(check.isUnHealthy()).isTrue();
+    }
+
+    @Test
+    public void checkShouldReturnHealthyWhenElasticSearchClusterHealthStatusIsYellow() {
+        PlainActionFuture<ClusterHealthResponse> responseFuture = new PlainActionFuture<>();
+        responseFuture.onResponse(new FakeClusterHealthResponse(ClusterHealthStatus.YELLOW));
+
+        when(this.clusterAdminClient.health(any(ClusterHealthRequest.class))).thenReturn(responseFuture);
+
+        Result check = healthCheck.check();
+        assertThat(check.isHealthy()).isTrue();
+    }
+
+    private class FakeClusterHealthResponse extends ClusterHealthResponse {
+
+        private final ClusterHealthStatus status;
+
+        private FakeClusterHealthResponse() {
+            this(ClusterHealthStatus.GREEN);
+        }
+
+        private FakeClusterHealthResponse(ClusterHealthStatus clusterHealthStatus) {
+            super("fake-cluster", new String[0],
+                    new ClusterState(new ClusterName("fake-cluster"), 0, null, null, RoutingTable.builder().build(),
+                            DiscoveryNodes.builder().build(),
+                            ClusterBlocks.builder().build(), null, false));
+            this.status = clusterHealthStatus;
+        }
+
+        @Override
+        public ClusterHealthStatus getStatus() {
+            return this.status;
+        }
+
+    }
+
+}

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/ElasticSearchIndexerTest.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/ElasticSearchIndexerTest.java
@@ -31,6 +31,7 @@ import org.awaitility.Duration;
 import org.awaitility.core.ConditionFactory;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -82,7 +83,8 @@ public class ElasticSearchIndexerTest {
         
         SearchResponse searchResponse = client.search(
             new SearchRequest(INDEX_NAME.getValue())
-                .source(new SearchSourceBuilder().query(QueryBuilders.matchQuery("message", "trying"))));
+                .source(new SearchSourceBuilder().query(QueryBuilders.matchQuery("message", "trying"))),
+            RequestOptions.DEFAULT);
         assertThat(searchResponse.getHits().getTotalHits()).isEqualTo(1);
     }
     
@@ -106,12 +108,14 @@ public class ElasticSearchIndexerTest {
 
         SearchResponse searchResponse = client.search(
             new SearchRequest(INDEX_NAME.getValue())
-                .source(new SearchSourceBuilder().query(QueryBuilders.matchQuery("message", "mastering"))));
+                .source(new SearchSourceBuilder().query(QueryBuilders.matchQuery("message", "mastering"))),
+            RequestOptions.DEFAULT);
         assertThat(searchResponse.getHits().getTotalHits()).isEqualTo(1);
 
         SearchResponse searchResponse2 = client.search(
             new SearchRequest(INDEX_NAME.getValue())
-                .source(new SearchSourceBuilder().query(QueryBuilders.matchQuery("field", "unchanged"))));
+                .source(new SearchSourceBuilder().query(QueryBuilders.matchQuery("field", "unchanged"))),
+            RequestOptions.DEFAULT);
         assertThat(searchResponse2.getHits().getTotalHits()).isEqualTo(1);
     }
 
@@ -153,7 +157,8 @@ public class ElasticSearchIndexerTest {
         CALMLY_AWAIT.atMost(Duration.TEN_SECONDS)
             .until(() -> client.search(
                     new SearchRequest(INDEX_NAME.getValue())
-                        .source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery())))
+                        .source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery())),
+                    RequestOptions.DEFAULT)
                 .getHits().getTotalHits() == 0);
     }
 
@@ -180,8 +185,9 @@ public class ElasticSearchIndexerTest {
         
         CALMLY_AWAIT.atMost(Duration.TEN_SECONDS)
             .until(() -> client.search(
-                new SearchRequest(INDEX_NAME.getValue())
-                    .source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery())))
+                    new SearchRequest(INDEX_NAME.getValue())
+                        .source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery())),
+                    RequestOptions.DEFAULT)
                 .getHits().getTotalHits() == 1);
     }
     
@@ -198,7 +204,8 @@ public class ElasticSearchIndexerTest {
         
         SearchResponse searchResponse = client.search(
             new SearchRequest(INDEX_NAME.getValue())
-                .source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery())));
+                .source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery())),
+            RequestOptions.DEFAULT);
         assertThat(searchResponse.getHits().getTotalHits()).isEqualTo(0);
     }
 
@@ -225,7 +232,8 @@ public class ElasticSearchIndexerTest {
 
         SearchResponse searchResponse = client.search(
             new SearchRequest(INDEX_NAME.getValue())
-                .source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery())));
+                .source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery())),
+            RequestOptions.DEFAULT);
         assertThat(searchResponse.getHits().getTotalHits()).isEqualTo(1);
     }
     

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/search/ScrolledSearchTest.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/search/ScrolledSearchTest.java
@@ -34,6 +34,7 @@ import org.awaitility.Duration;
 import org.awaitility.core.ConditionFactory;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -73,7 +74,7 @@ public class ScrolledSearchTest {
     }
 
     @Test
-    public void scrollIterableShouldWorkWhenEmpty() throws Exception {
+    public void scrollIterableShouldWorkWhenEmpty() {
         SearchRequest searchRequest = new SearchRequest(INDEX_NAME.getValue())
             .scroll(TIMEOUT)
             .source(new SearchSourceBuilder()
@@ -90,7 +91,8 @@ public class ScrolledSearchTest {
         client.index(new IndexRequest(INDEX_NAME.getValue())
                 .type(NodeMappingFactory.DEFAULT_MAPPING_NAME)
                 .id(id)
-                .source(MESSAGE, "Sample message"));
+                .source(MESSAGE, "Sample message"),
+            RequestOptions.DEFAULT);
 
         elasticSearch.awaitForElasticSearch();
         WAIT_CONDITION.untilAsserted(() -> hasIdsInIndex(client, id));
@@ -112,13 +114,15 @@ public class ScrolledSearchTest {
         client.index(new IndexRequest(INDEX_NAME.getValue())
                 .type(NodeMappingFactory.DEFAULT_MAPPING_NAME)
                 .id(id1)
-                .source(MESSAGE, "Sample message"));
+                .source(MESSAGE, "Sample message"),
+            RequestOptions.DEFAULT);
 
         String id2 = "2";
         client.index(new IndexRequest(INDEX_NAME.getValue())
                 .type(NodeMappingFactory.DEFAULT_MAPPING_NAME)
                 .id(id2)
-                .source(MESSAGE, "Sample message"));
+                .source(MESSAGE, "Sample message"),
+            RequestOptions.DEFAULT);
 
         elasticSearch.awaitForElasticSearch();
         WAIT_CONDITION.untilAsserted(() -> hasIdsInIndex(client, id1, id2));
@@ -140,19 +144,22 @@ public class ScrolledSearchTest {
         client.index(new IndexRequest(INDEX_NAME.getValue())
                 .type(NodeMappingFactory.DEFAULT_MAPPING_NAME)
                 .id(id1)
-                .source(MESSAGE, "Sample message"));
+                .source(MESSAGE, "Sample message"),
+            RequestOptions.DEFAULT);
 
         String id2 = "2";
         client.index(new IndexRequest(INDEX_NAME.getValue())
                 .type(NodeMappingFactory.DEFAULT_MAPPING_NAME)
                 .id(id2)
-                .source(MESSAGE, "Sample message"));
+                .source(MESSAGE, "Sample message"),
+            RequestOptions.DEFAULT);
 
         String id3 = "3";
         client.index(new IndexRequest(INDEX_NAME.getValue())
                 .type(NodeMappingFactory.DEFAULT_MAPPING_NAME)
                 .id(id3)
-                .source(MESSAGE, "Sample message"));
+                .source(MESSAGE, "Sample message"),
+            RequestOptions.DEFAULT);
 
         elasticSearch.awaitForElasticSearch();
         WAIT_CONDITION.untilAsserted(() -> hasIdsInIndex(client, id1, id2, id3));
@@ -174,7 +181,7 @@ public class ScrolledSearchTest {
             .source(new SearchSourceBuilder()
                 .query(QueryBuilders.matchAllQuery()));
 
-        SearchHit[] hits = client.search(searchRequest)
+        SearchHit[] hits = client.search(searchRequest, RequestOptions.DEFAULT)
             .getHits()
             .getHits();
 

--- a/mailbox/plugin/quota-search-elasticsearch/src/main/java/org/apache/james/quota/search/elasticsearch/ElasticSearchQuotaSearcher.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/main/java/org/apache/james/quota/search/elasticsearch/ElasticSearchQuotaSearcher.java
@@ -34,6 +34,7 @@ import org.apache.james.core.User;
 import org.apache.james.quota.search.QuotaQuery;
 import org.apache.james.quota.search.QuotaSearcher;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.search.SearchHit;
@@ -88,7 +89,7 @@ public class ElasticSearchQuotaSearcher implements QuotaSearcher {
             .types(NodeMappingFactory.DEFAULT_MAPPING_NAME)
             .source(searchSourceBuilder);
 
-        return Arrays.stream(client.search(searchRequest)
+        return Arrays.stream(client.search(searchRequest, RequestOptions.DEFAULT)
             .getHits()
             .getHits());
     }

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/ElasticSearchClientModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/ElasticSearchClientModule.java
@@ -19,11 +19,22 @@
 
 package org.apache.james.modules.mailbox;
 
+import java.util.Set;
+
 import org.apache.james.backends.es.ClientProvider;
+import org.apache.james.backends.es.ElasticSearchHealthCheck;
+import org.apache.james.backends.es.IndexName;
+import org.apache.james.core.healthcheck.HealthCheck;
+import org.apache.james.mailbox.elasticsearch.ElasticSearchMailboxConfiguration;
+import org.apache.james.quota.search.elasticsearch.ElasticSearchQuotaConfiguration;
 import org.elasticsearch.client.RestHighLevelClient;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
 import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.Multibinder;
 
 public class ElasticSearchClientModule extends AbstractModule {
 
@@ -31,6 +42,18 @@ public class ElasticSearchClientModule extends AbstractModule {
     protected void configure() {
         bind(ClientProvider.class).in(Scopes.SINGLETON);
         bind(RestHighLevelClient.class).toProvider(ClientProvider.class);
+
+        Multibinder.newSetBinder(binder(), HealthCheck.class)
+            .addBinding()
+            .to(ElasticSearchHealthCheck.class);
     }
 
+    @Provides
+    @Singleton
+    Set<IndexName> provideIndexNames(ElasticSearchMailboxConfiguration mailboxConfiguration,
+                                     ElasticSearchQuotaConfiguration quotaConfiguration) {
+        return ImmutableSet.of(
+            mailboxConfiguration.getIndexMailboxName(),
+            quotaConfiguration.getIndexQuotaRatioName());
+    }
 }


### PR DESCRIPTION
I spent my lunch giving a second life to https://github.com/linagora/james-project/pull/1812

 - Rebase it post 6.3.2 upgrade
 - Update the High level rest client enough to use health API endpoint
 - Then revisit a bit the code to match our standard.

I kept past history in order for people to easily see the work I did, but we should squash this in 3 commits upon merge.