### PR TITLE
JAMES-2899  Use boundedElastic schedulers in place of elastic ones

### DIFF
--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/CassandraTableManager.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/CassandraTableManager.java
@@ -59,7 +59,7 @@ public class CassandraTableManager {
     public void clearAllTables() {
         CassandraAsyncExecutor executor = new CassandraAsyncExecutor(session);
         Flux.fromIterable(module.moduleTables())
-                .publishOn(Schedulers.elastic())
+                .publishOn(Schedulers.boundedElastic())
                 .map(CassandraTable::getName)
                 .flatMap(name -> truncate(executor, name))
                 .then()

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/utils/CassandraAsyncExecutor.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/utils/CassandraAsyncExecutor.java
@@ -44,7 +44,7 @@ public class CassandraAsyncExecutor {
     public Mono<ResultSet> execute(Statement statement) {
         return Mono.defer(() -> Mono.fromFuture(FutureConverter
                 .toCompletableFuture(session.executeAsync(statement)))
-                .publishOn(Schedulers.elastic()));
+                .publishOn(Schedulers.boundedElastic()));
     }
 
     public Mono<Boolean> executeReturnApplied(Statement statement) {

--- a/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/ClientProvider.java
+++ b/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/ClientProvider.java
@@ -60,8 +60,8 @@ public class ClientProvider implements Provider<RestHighLevelClient> {
         return Mono.fromCallable(() -> connectToCluster(configuration))
             .doOnError(e -> LOGGER.warn("Error establishing ElasticSearch connection. Next retry scheduled in {}",
                 DurationFormatUtils.formatDurationWords(waitDelay.toMillis(), suppressLeadingZeroElements, suppressTrailingZeroElements), e))
-            .retryBackoff(configuration.getMaxRetries(), waitDelay, forever, Schedulers.elastic())
-            .publishOn(Schedulers.elastic())
+            .retryBackoff(configuration.getMaxRetries(), waitDelay, forever, Schedulers.boundedElastic())
+            .publishOn(Schedulers.boundedElastic())
             .block();
     }
 

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConnectionFactory.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConnectionFactory.java
@@ -60,6 +60,6 @@ public class RabbitMQConnectionFactory {
     Mono<Connection> connectionMono() {
         Duration forever = Duration.ofMillis(Long.MAX_VALUE);
         return Mono.fromCallable(connectionFactory::newConnection)
-            .retryBackoff(configuration.getMaxRetries(), Duration.ofMillis(configuration.getMinDelayInMs()), forever, Schedulers.elastic());
+            .retryBackoff(configuration.getMaxRetries(), Duration.ofMillis(configuration.getMinDelayInMs()), forever, Schedulers.boundedElastic());
     }
 }

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
@@ -72,7 +72,7 @@ public class ReactorRabbitMQChannelPool implements ChannelPool {
             return Mono.fromCallable(connection::openChannel)
                 .map(maybeChannel ->
                     maybeChannel.orElseThrow(() -> new RuntimeException("RabbitMQ reached to maximum opened channels, cannot get more channels")))
-                .retryBackoff(MAX_RETRIES, RETRY_FIRST_BACK_OFF, FOREVER, Schedulers.elastic())
+                .retryBackoff(MAX_RETRIES, RETRY_FIRST_BACK_OFF, FOREVER, Schedulers.boundedElastic())
                 .doOnError(throwable -> LOGGER.error("error when creating new channel", throwable));
         }
 

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/SimpleChannelPool.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/SimpleChannelPool.java
@@ -87,13 +87,13 @@ public class SimpleChannelPool implements RabbitMQChannelPool {
         Duration initialDelay = Duration.ofMillis(100);
         Duration forever = Duration.ofMillis(Long.MAX_VALUE);
         return Mono.defer(this::getOpenChannel)
-            .retryBackoff(numRetries, initialDelay, forever, Schedulers.elastic());
+            .retryBackoff(numRetries, initialDelay, forever, Schedulers.boundedElastic());
     }
 
     private Mono<Channel> getOpenChannel() {
         Channel previous = channelReference.get();
         return Mono.justOrEmpty(previous)
-            .publishOn(Schedulers.elastic())
+            .publishOn(Schedulers.boundedElastic())
             .filter(Channel::isOpen)
             .switchIfEmpty(connectionPool.getResilientConnection()
                 .flatMap(connection -> Mono.fromCallable(connection::createChannel)))

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/SimpleConnectionPool.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/SimpleConnectionPool.java
@@ -57,7 +57,7 @@ public class SimpleConnectionPool implements AutoCloseable {
         Duration initialDelay = Duration.ofMillis(100);
         Duration forever = Duration.ofMillis(Long.MAX_VALUE);
         return Mono.defer(this::getOpenConnection)
-            .retryBackoff(numRetries, initialDelay, forever, Schedulers.elastic());
+            .retryBackoff(numRetries, initialDelay, forever, Schedulers.boundedElastic());
     }
 
     private Mono<Connection> getOpenConnection() {

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/DefaultMailboxBackup.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/DefaultMailboxBackup.java
@@ -114,7 +114,7 @@ public class DefaultMailboxBackup implements MailboxBackup {
         }
 
         return Mono.fromRunnable(Throwing.runnable(() -> archiveRestorer.restore(user, source)).sneakyThrow())
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .doOnError(e -> LOGGER.error("Error during account restoration for user : " + user, e))
             .doOnTerminate(Throwing.runnable(source::close).sneakyThrow())
             .thenReturn(BackupStatus.DONE)

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
@@ -233,7 +233,7 @@ public class CassandraMessageDAO {
 
     public Flux<MessageResult> retrieveMessages(List<ComposedMessageIdWithMetaData> messageIds, FetchType fetchType, Limit limit) {
         return Flux.fromStream(limit.applyOnStream(messageIds.stream().distinct()))
-            .publishOn(Schedulers.elastic())
+            .publishOn(Schedulers.boundedElastic())
             .flatMap(id -> retrieveRow(id, fetchType)
                 .flatMap(resultSet -> message(resultSet, id, fetchType)), configuration.getMessageReadChunkSize());
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
@@ -91,7 +91,7 @@ public class CassandraMessageIdMapper implements MessageIdMapper {
     @Override
     public List<MailboxMessage> find(Collection<MessageId> messageIds, FetchType fetchType) {
         return Flux.fromStream(messageIds.stream())
-            .publishOn(Schedulers.elastic())
+            .publishOn(Schedulers.boundedElastic())
             .flatMap(messageId -> imapUidDAO.retrieve((CassandraMessageId) messageId, Optional.empty()), cassandraConfiguration.getMessageReadChunkSize())
             .collectList()
             .flatMapMany(composedMessageIds -> messageDAO.retrieveMessages(composedMessageIds, fetchType, Limit.unlimited()))
@@ -177,7 +177,7 @@ public class CassandraMessageIdMapper implements MessageIdMapper {
     public void delete(Multimap<MessageId, MailboxId> ids) {
         Flux.fromIterable(ids.asMap()
             .entrySet())
-            .publishOn(Schedulers.elastic())
+            .publishOn(Schedulers.boundedElastic())
             .flatMap(entry -> deleteAsMono(entry.getKey(), entry.getValue()), cassandraConfiguration.getExpungeChunkSize())
             .then()
             .block();

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraModSeqProvider.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraModSeqProvider.java
@@ -192,7 +192,7 @@ public class CassandraModSeqProvider implements ModSeqProvider {
         Duration forever = Duration.ofMillis(Long.MAX_VALUE);
         return tryFindThenUpdateOnce(mailboxId)
             .single()
-            .retryBackoff(maxModSeqRetries, Duration.ofMillis(2), forever, Schedulers.elastic());
+            .retryBackoff(maxModSeqRetries, Duration.ofMillis(2), forever, Schedulers.boundedElastic());
     }
 
     private Mono<ModSeq> tryFindThenUpdateOnce(CassandraId mailboxId) {

--- a/mailbox/event/event-memory/src/main/java/org/apache/james/mailbox/events/delivery/EventDelivery.java
+++ b/mailbox/event/event-memory/src/main/java/org/apache/james/mailbox/events/delivery/EventDelivery.java
@@ -89,7 +89,7 @@ public interface EventDelivery {
             @Override
             public Mono<Void> doRetry(Mono<Void> executionResult, Event event) {
                 return executionResult
-                    .retryBackoff(retryBackoff.getMaxRetries(), retryBackoff.getFirstBackoff(), FOREVER, retryBackoff.getJitterFactor(), Schedulers.elastic())
+                    .retryBackoff(retryBackoff.getMaxRetries(), retryBackoff.getFirstBackoff(), FOREVER, retryBackoff.getJitterFactor(), Schedulers.boundedElastic())
                     .doOnError(throwable -> LOGGER.error("listener {} exceeded maximum retry({}) to handle event {}",
                         mailboxListener.getClass().getCanonicalName(),
                         retryBackoff.getMaxRetries(),

--- a/mailbox/event/event-memory/src/main/java/org/apache/james/mailbox/events/delivery/InVmEventDelivery.java
+++ b/mailbox/event/event-memory/src/main/java/org/apache/james/mailbox/events/delivery/InVmEventDelivery.java
@@ -71,13 +71,13 @@ public class InVmEventDelivery implements EventDelivery {
         Mono<Void> deliveryToListener = Mono.fromRunnable(() -> doDeliverToListener(listener, event))
             .doOnError(throwable -> structuredLogger(event, listener)
                 .log(logger -> logger.error("Error while processing listener", throwable)))
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .then();
 
         return deliveryOption.getRetrier().doRetry(deliveryToListener, event)
             .onErrorResume(throwable -> deliveryOption.getPermanentFailureHandler().handle(event))
             .subscribeWith(MonoProcessor.create())
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .then();
     }
 

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/EventDispatcher.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/EventDispatcher.java
@@ -80,7 +80,7 @@ class EventDispatcher {
             .concat(
                 dispatchToLocalListeners(event, keys),
                 dispatchToRemoteListeners(serializeEvent(event), keys))
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .doOnError(throwable -> LOGGER.error("error while dispatching event", throwable))
             .then()
             .subscribeWith(MonoProcessor.create());

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupRegistration.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupRegistration.java
@@ -139,7 +139,7 @@ class GroupRegistration implements Registration {
         int currentRetryCount = getRetryCount(acknowledgableDelivery);
 
         return delayGenerator.delayIfHaveTo(currentRetryCount)
-            .publishOn(Schedulers.elastic())
+            .publishOn(Schedulers.boundedElastic())
             .flatMap(any -> Mono.fromRunnable(Throwing.runnable(() -> runListener(event))))
             .onErrorResume(throwable -> retryHandler.handleRetry(event, currentRetryCount, throwable))
             .then(Mono.fromRunnable(acknowledgableDelivery::ack));

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/KeyRegistrationHandler.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/KeyRegistrationHandler.java
@@ -130,7 +130,7 @@ class KeyRegistrationHandler {
                     .log(logger -> logger.error("Exception happens when handling event", e)))
                 .onErrorResume(e -> Mono.empty())
                 .then())
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .then();
     }
 

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/WaitDelayGenerator.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/WaitDelayGenerator.java
@@ -59,7 +59,7 @@ class WaitDelayGenerator {
         }
 
         return countRetryMono
-            .delayElement(generateDelay(retryCount), Schedulers.elastic());
+            .delayElement(generateDelay(retryCount), Schedulers.boundedElastic());
     }
 
     @VisibleForTesting

--- a/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/LocalListenerRegistryTest.java
+++ b/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/LocalListenerRegistryTest.java
@@ -247,7 +247,7 @@ class LocalListenerRegistryTest {
             LocalListenerRegistry.LocalRegistration registration5 = testee.addListener(KEY_1, listener5);
 
             Mono<List<MailboxListener>> listeners = testee.getLocalMailboxListeners(KEY_1)
-                .publishOn(Schedulers.elastic())
+                .publishOn(Schedulers.boundedElastic())
                 .delayElements(Duration.ofMillis(100))
                 .collectList();
 

--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVault.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVault.java
@@ -154,7 +154,7 @@ public class BlobStoreDeletedMessageVault implements DeletedMessageVault {
             .flatMap(storageInformation -> Mono.from(messageMetadataVault.remove(storageInformation.getBucketName(), user, messageId))
                 .thenReturn(storageInformation))
             .flatMap(storageInformation -> blobStore.delete(storageInformation.getBucketName(), storageInformation.getBlobId()))
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(Schedulers.boundedElastic());
     }
 
     @Override

--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BlobStoreVaultGarbageCollectionTask.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BlobStoreVaultGarbageCollectionTask.java
@@ -88,7 +88,7 @@ public class BlobStoreVaultGarbageCollectionTask implements Task {
     public Result run() {
         retentionOperation
             .doOnNext(deletedBuckets::add)
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .then()
             .block();
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/PreDeletionHooks.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/PreDeletionHooks.java
@@ -50,7 +50,7 @@ public class PreDeletionHooks {
 
     public Mono<Void> runHooks(PreDeletionHook.DeleteOperation deleteOperation) {
         return Flux.fromIterable(hooks)
-            .publishOn(Schedulers.elastic())
+            .publishOn(Schedulers.boundedElastic())
             .flatMap(hook -> metricFactory.runPublishingTimerMetric(PRE_DELETION_HOOK_METRIC_NAME,
                 Mono.from(hook.notifyDelete(deleteOperation))), CONCURRENCY)
             .then();

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -772,7 +772,7 @@ public class StoreMessageManager implements MessageManager {
         MessageMapper messageMapper = mapperFactory.getMessageMapper(session);
 
         DeleteOperation deleteOperation = Flux.fromIterable(MessageRange.toRanges(uids))
-            .publishOn(Schedulers.elastic())
+            .publishOn(Schedulers.boundedElastic())
             .flatMap(range -> Mono.fromCallable(() -> messageMapper.findInMailbox(mailbox, range, FetchType.Metadata, UNLIMITED))
                 .flatMapMany(iterator -> Flux.fromStream(Iterators.toStream(iterator))))
             .map(mailboxMessage -> MetadataWithMailboxId.from(mailboxMessage.metaData(), mailboxMessage.getMailboxId()))

--- a/pom.xml
+++ b/pom.xml
@@ -659,7 +659,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>Californium-SR10</version>
+                <version>Dysprosium-RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -2104,11 +2104,6 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
                 <version>${netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.projectreactor.rabbitmq</groupId>
-                <artifactId>reactor-rabbitmq</artifactId>
-                <version>1.2.0.RELEASE</version>
             </dependency>
             <dependency>
                 <groupId>javax.activation</groupId>

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/Store.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/Store.java
@@ -118,7 +118,7 @@ public interface Store<T, I> {
         @Override
         public Mono<T> read(I blobIds) {
             return Flux.fromIterable(blobIds.asMap().entrySet())
-                .publishOn(Schedulers.elastic())
+                .publishOn(Schedulers.boundedElastic())
                 .flatMapSequential(
                     entry -> blobStore.readBytes(blobStore.getDefaultBucketName(), entry.getValue())
                         .zipWith(Mono.just(entry.getKey())))

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAO.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAO.java
@@ -186,7 +186,7 @@ public class ObjectStorageBlobsDAO implements BlobStore {
     public Mono<Void> deleteBucket(BucketName bucketName) {
         ObjectStorageBucketName resolvedBucketName = bucketNameResolver.resolve(bucketName);
         return Mono.<Void>fromRunnable(() -> blobStore.deleteContainer(resolvedBucketName.asString()))
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(Schedulers.boundedElastic());
     }
 
     public PayloadCodec getPayloadCodec() {
@@ -196,7 +196,7 @@ public class ObjectStorageBlobsDAO implements BlobStore {
     @VisibleForTesting
     Mono<Void> deleteAllBuckets() {
         return Flux.fromIterable(blobStore.list())
-            .publishOn(Schedulers.elastic())
+            .publishOn(Schedulers.boundedElastic())
             .filter(storageMetadata -> storageMetadata.getType().equals(StorageType.CONTAINER))
             .map(StorageMetadata::getName)
             .doOnNext(blobStore::deleteContainer)
@@ -207,6 +207,6 @@ public class ObjectStorageBlobsDAO implements BlobStore {
     public Mono<Void> delete(BucketName bucketName, BlobId blobId) {
         ObjectStorageBucketName resolvedBucketName = bucketNameResolver.resolve(bucketName);
         return Mono.<Void>fromRunnable(() -> blobStore.removeBlob(resolvedBucketName.asString(), blobId.asString()))
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(Schedulers.boundedElastic());
     }
 }

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/StreamCompatibleBlobPutter.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/StreamCompatibleBlobPutter.java
@@ -52,14 +52,14 @@ public class StreamCompatibleBlobPutter implements BlobPutter {
     @Override
     public void putDirectly(ObjectStorageBucketName bucketName, Blob blob) {
         Mono.fromRunnable(() -> blobStore.putBlob(bucketName.asString(), blob))
-            .publishOn(Schedulers.elastic())
+            .publishOn(Schedulers.boundedElastic())
             .retryWhen(Retry.onlyIf(retryContext -> needToCreateBucket(retryContext.exception(), bucketName))
                 .exponentialBackoff(FIRST_BACK_OFF, FOREVER)
-                .withBackoffScheduler(Schedulers.elastic())
+                .withBackoffScheduler(Schedulers.boundedElastic())
                 .retryMax(MAX_RETRIES)
                 .doOnRetry(retryContext -> blobStore.createContainerInLocation(DEFAULT_LOCATION, bucketName.asString())))
             .retryWhen(Retry.onlyIf(RetryContext -> isPutMethod(RetryContext.exception()))
-                .withBackoffScheduler(Schedulers.elastic())
+                .withBackoffScheduler(Schedulers.boundedElastic())
                 .exponentialBackoff(FIRST_BACK_OFF, FOREVER)
                 .retryMax(RETRY_ONE_LAST_TIME_ON_CONCURRENT_SAVING))
             .block();

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/aws/AwsS3ObjectStorage.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/aws/AwsS3ObjectStorage.java
@@ -177,11 +177,11 @@ public class AwsS3ObjectStorage {
 
         private Mono<Void> putWithRetry(ObjectStorageBucketName bucketName, AwsS3AuthConfiguration configuration, Blob blob, File file, int tried) {
             return Mono.<Void>fromRunnable(Throwing.runnable(() -> put(bucketName, configuration, blob, file)).sneakyThrow())
-                .publishOn(Schedulers.elastic())
+                .publishOn(Schedulers.boundedElastic())
                 .retryWhen(Retry
                     .<Void>onlyIf(retryContext -> needToCreateBucket(retryContext.exception()))
                     .exponentialBackoff(FIRST_BACK_OFF, FOREVER)
-                    .withBackoffScheduler(Schedulers.elastic())
+                    .withBackoffScheduler(Schedulers.boundedElastic())
                     .retryMax(MAX_RETRY_ON_EXCEPTION)
                     .doOnRetry(retryContext -> createBucket(bucketName, configuration)));
         }

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAOTest.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobsDAOTest.java
@@ -178,7 +178,7 @@ public class ObjectStorageBlobsDAOTest implements MetricableBlobStoreContract {
         // String need to be big enough to get async thread busy hence could not return result instantly
         Mono<BlobId> blobIdFuture = testee
             .save(testee.getDefaultBucketName(), BIG_STRING.getBytes(StandardCharsets.UTF_8))
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(Schedulers.boundedElastic());
         assertThat(blobIdFuture.toFuture()).isNotCompleted();
     }
 
@@ -186,7 +186,7 @@ public class ObjectStorageBlobsDAOTest implements MetricableBlobStoreContract {
     void saveStringShouldNotCompleteWhenDoesNotAwait() {
         Mono<BlobId> blobIdFuture = testee
             .save(testee.getDefaultBucketName(), BIG_STRING)
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(Schedulers.boundedElastic());
         assertThat(blobIdFuture.toFuture()).isNotCompleted();
     }
 
@@ -194,14 +194,14 @@ public class ObjectStorageBlobsDAOTest implements MetricableBlobStoreContract {
     void saveInputStreamShouldNotCompleteWhenDoesNotAwait() {
         Mono<BlobId> blobIdFuture = testee
             .save(testee.getDefaultBucketName(), new ByteArrayInputStream(BIG_STRING.getBytes(StandardCharsets.UTF_8)))
-            .subscribeOn(Schedulers.elastic());
+            .subscribeOn(Schedulers.boundedElastic());
         assertThat(blobIdFuture.toFuture()).isNotCompleted();
     }
 
     @Test
     void readBytesShouldNotCompleteWhenDoesNotAwait() {
         BlobId blobId = testee().save(testee.getDefaultBucketName(), BIG_STRING).block();
-        Mono<byte[]> resultFuture = testee.readBytes(testee.getDefaultBucketName(), blobId).subscribeOn(Schedulers.elastic());
+        Mono<byte[]> resultFuture = testee.readBytes(testee.getDefaultBucketName(), blobId).subscribeOn(Schedulers.boundedElastic());
         assertThat(resultFuture.toFuture()).isNotCompleted();
     }
 }

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/ResilientClusterProvider.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/ResilientClusterProvider.java
@@ -52,8 +52,8 @@ public class ResilientClusterProvider implements Provider<Cluster> {
         Duration forever = Duration.ofMillis(Long.MAX_VALUE);
         cluster = Mono.fromCallable(getClusterRetryCallable(configuration))
             .doOnError(e -> LOGGER.warn("Error establishing Cassandra connection. Next retry scheduled in {} ms", waitDelay, e))
-            .retryBackoff(configuration.getMaxRetry(), waitDelay, forever, Schedulers.elastic())
-            .publishOn(Schedulers.elastic())
+            .retryBackoff(configuration.getMaxRetry(), waitDelay, forever, Schedulers.boundedElastic())
+            .publishOn(Schedulers.boundedElastic())
             .block();
     }
 

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/StartUpChecksPerformer.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/StartUpChecksPerformer.java
@@ -84,7 +84,7 @@ public class StartUpChecksPerformer {
 
         public List<StartUpCheck.CheckResult> check() {
             return Flux.fromIterable(startUpChecks)
-                .publishOn(Schedulers.elastic())
+                .publishOn(Schedulers.boundedElastic())
                 .map(this::checkQuietly)
                 .collect(Guavate.toImmutableList())
                 .block();

--- a/server/container/guice/memory-guice/src/test/java/org/apache/james/GuiceLifecycleHeathCheckTest.java
+++ b/server/container/guice/memory-guice/src/test/java/org/apache/james/GuiceLifecycleHeathCheckTest.java
@@ -122,7 +122,7 @@ class GuiceLifecycleHeathCheckTest {
 
                 stopMono = Mono.fromRunnable(server::stop);
                 stopMono
-                    .publishOn(Schedulers.elastic())
+                    .publishOn(Schedulers.boundedElastic())
                     .subscribeWith(MonoProcessor.create());
 
                 when()

--- a/server/container/util/src/main/java/org/apache/james/util/Runnables.java
+++ b/server/container/util/src/main/java/org/apache/james/util/Runnables.java
@@ -31,9 +31,9 @@ public class Runnables {
 
     public static void runParallel(Flux<Runnable> runnables) {
         runnables
-            .publishOn(Schedulers.elastic())
+            .publishOn(Schedulers.boundedElastic())
             .parallel()
-            .runOn(Schedulers.elastic())
+            .runOn(Schedulers.boundedElastic())
             .flatMap(runnable -> {
                 runnable.run();
                 return Mono.empty();

--- a/server/container/util/src/test/java/org/apache/james/util/ReactorUtilsTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/ReactorUtilsTest.java
@@ -85,7 +85,7 @@ class ReactorUtilsTest {
         void givenAFluxOnOneByteShouldConsumeOnlyTheReadBytesAndThePrefetch() throws IOException, InterruptedException {
             AtomicInteger generateElements = new AtomicInteger(0);
             Flux<ByteBuffer> source = Flux.range(0, 10)
-                .subscribeOn(Schedulers.elastic())
+                .subscribeOn(Schedulers.boundedElastic())
                 .limitRate(2)
                 .doOnRequest(request -> generateElements.getAndAdd((int) request))
                 .map(index -> new byte[] {(byte) (int) index})
@@ -104,7 +104,7 @@ class ReactorUtilsTest {
         void givenAFluxOf3BytesShouldConsumeOnlyTheReadBytesAndThePrefetch() throws IOException, InterruptedException {
             AtomicInteger generateElements = new AtomicInteger(0);
             Flux<ByteBuffer> source = Flux.just(new byte[] {0, 1, 2}, new byte[] {3, 4, 5}, new byte[] {6, 7, 8})
-                    .subscribeOn(Schedulers.elastic())
+                    .subscribeOn(Schedulers.boundedElastic())
                     .map(ByteBuffer::wrap)
                     .limitRate(2)
                     .doOnRequest(request -> generateElements.getAndAdd((int) request));
@@ -122,7 +122,7 @@ class ReactorUtilsTest {
         void givenAFluxOf3BytesWithAnEmptyByteArrayShouldConsumeOnlyTheReadBytesAndThePrefetch() throws IOException, InterruptedException {
             AtomicInteger generateElements = new AtomicInteger(0);
             Flux<ByteBuffer> source = Flux.just(new byte[] {0, 1, 2}, new byte[] {}, new byte[] {3, 4, 5}, new byte[] {6, 7, 8}, new byte[] {9, 10, 11})
-                    .subscribeOn(Schedulers.elastic())
+                    .subscribeOn(Schedulers.boundedElastic())
                     .map(ByteBuffer::wrap)
                     .limitRate(2)
                     .doOnRequest(request -> generateElements.getAndAdd((int) request));
@@ -140,7 +140,7 @@ class ReactorUtilsTest {
         void givenAnEmptyFluxShouldConsumeOnlyThePrefetch() throws IOException, InterruptedException {
             AtomicInteger generateElements = new AtomicInteger(0);
             Flux<ByteBuffer> source = Flux.<byte[]>empty()
-                    .subscribeOn(Schedulers.elastic())
+                    .subscribeOn(Schedulers.boundedElastic())
                     .map(ByteBuffer::wrap)
                     .limitRate(2)
                     .doOnRequest(request -> generateElements.getAndAdd((int) request));

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailSpooler.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailSpooler.java
@@ -118,7 +118,7 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
             .publishOn(spooler)
             .flatMap(this::handleOnQueueItem)
             .onErrorContinue((throwable, item) -> LOGGER.error("Exception processing mail while spooling {}", item, throwable))
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .subscribe();
     }
 
@@ -138,7 +138,7 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
     private Mono<Void> processMail(MailQueueItem queueItem) {
         Mail mail = queueItem.getMail();
         return Mono.fromRunnable(() -> LOGGER.debug("==== Begin processing mail {} ====", mail.getName()))
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .then(Mono.fromCallable(() -> performProcessMail(mail)))
             .flatMap(any -> acknowledgeItem(queueItem, true))
             .onErrorResume(any -> acknowledgeItem(queueItem, false))

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/DeliveryRunnable.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/DeliveryRunnable.java
@@ -81,7 +81,7 @@ public class DeliveryRunnable implements Disposable {
     }
 
     public void start() {
-        Scheduler remoteDeliveryScheduler = Schedulers.newElastic("RemoteDelivery");
+        Scheduler remoteDeliveryScheduler = Schedulers.newBoundedElastic(Schedulers.DEFAULT_BOUNDED_ELASTIC_SIZE, Schedulers.DEFAULT_BOUNDED_ELASTIC_QUEUESIZE, "RemoteDelivery");
         disposable = Flux.from(queue.deQueue())
             .publishOn(remoteDeliveryScheduler)
             .flatMap(this::runStep)

--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/DelayedMailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/DelayedMailQueueContract.java
@@ -47,7 +47,7 @@ public interface DelayedMailQueueContract {
             5L,
             TimeUnit.SECONDS);
 
-        Mono<MailQueue.MailQueueItem> next = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.elastic()).next();
+        Mono<MailQueue.MailQueueItem> next = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.boundedElastic()).next();
         assertThatThrownBy(() -> next.block(Duration.ofSeconds(1)))
             .isInstanceOf(RuntimeException.class);
     }
@@ -72,7 +72,7 @@ public interface DelayedMailQueueContract {
             365 * 10,
             TimeUnit.DAYS);
 
-        Mono<MailQueue.MailQueueItem> next = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.elastic()).next();
+        Mono<MailQueue.MailQueueItem> next = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.boundedElastic()).next();
         assertThatThrownBy(() -> next.block(Duration.ofSeconds(1)))
             .isInstanceOf(RuntimeException.class);
     }
@@ -84,7 +84,7 @@ public interface DelayedMailQueueContract {
             .build(),
             ChronoUnit.FOREVER.getDuration());
 
-        Mono<MailQueue.MailQueueItem> next = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.elastic()).next();
+        Mono<MailQueue.MailQueueItem> next = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.boundedElastic()).next();
         assertThatThrownBy(() -> next.block(Duration.ofSeconds(1)))
             .isInstanceOf(RuntimeException.class);
     }

--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/DelayedPriorityMailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/DelayedPriorityMailQueueContract.java
@@ -53,7 +53,7 @@ public interface DelayedPriorityMailQueueContract extends DelayedMailQueueContra
 
         Thread.sleep(unit.toMillis(2 * delay));
 
-        Iterator<MailQueue.MailQueueItem> mailQueueItems = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.elastic()).toIterable().iterator();
+        Iterator<MailQueue.MailQueueItem> mailQueueItems = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.boundedElastic()).toIterable().iterator();
         MailQueue.MailQueueItem item1 = mailQueueItems.next();
         item1.done(true);
         MailQueue.MailQueueItem item2 = mailQueueItems.next();
@@ -79,7 +79,7 @@ public interface DelayedPriorityMailQueueContract extends DelayedMailQueueContra
             delay,
             unit);
 
-        Iterator<MailQueue.MailQueueItem> mailQueueItems = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.elastic()).toIterable().iterator();
+        Iterator<MailQueue.MailQueueItem> mailQueueItems = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.boundedElastic()).toIterable().iterator();
         MailQueue.MailQueueItem item1 = mailQueueItems.next();
         item1.done(true);
         MailQueue.MailQueueItem item2 = mailQueueItems.next();

--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/MailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/MailQueueContract.java
@@ -331,7 +331,7 @@ public interface MailQueueContract {
             .name(secondExpectedName)
             .build());
 
-        Iterator<MailQueue.MailQueueItem> items = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.elastic()).toIterable().iterator();
+        Iterator<MailQueue.MailQueueItem> items = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.boundedElastic()).toIterable().iterator();
         MailQueue.MailQueueItem mailQueueItem1 = items.next();
         mailQueueItem1.done(true);
         MailQueue.MailQueueItem mailQueueItem2 = items.next();
@@ -350,7 +350,7 @@ public interface MailQueueContract {
             .build());
 
         Iterator<MailQueue.MailQueueItem> items = Flux.from(getMailQueue().deQueue())
-            .subscribeOn(Schedulers.elastic()).toIterable().iterator();
+            .subscribeOn(Schedulers.boundedElastic()).toIterable().iterator();
         MailQueue.MailQueueItem mailQueueItem1 = items.next();
         MailQueue.MailQueueItem mailQueueItem2 = items.next();
         mailQueueItem1.done(true);
@@ -369,7 +369,7 @@ public interface MailQueueContract {
             .name("name2")
             .build());
 
-        Iterator<MailQueue.MailQueueItem> items = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.elastic()).toIterable().iterator();
+        Iterator<MailQueue.MailQueueItem> items = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.boundedElastic()).toIterable().iterator();
         MailQueue.MailQueueItem mailQueueItem1 = items.next();
         MailQueue.MailQueueItem mailQueueItem2 = items.next();
         mailQueueItem2.done(true);
@@ -384,7 +384,7 @@ public interface MailQueueContract {
             .name("name1")
             .build());
 
-        Iterator<MailQueue.MailQueueItem> items = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.elastic()).toIterable().iterator();
+        Iterator<MailQueue.MailQueueItem> items = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.boundedElastic()).toIterable().iterator();
         MailQueue.MailQueueItem mailQueueItem1 = items.next();
         mailQueueItem1.done(false);
         MailQueue.MailQueueItem mailQueueItem2 = items.next();
@@ -400,7 +400,7 @@ public interface MailQueueContract {
             .build());
 
         LinkedBlockingQueue<MailQueue.MailQueueItem> queue = new LinkedBlockingQueue<>(1);
-        Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.elastic()).subscribe(Throwing.consumer(queue::put));
+        Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.boundedElastic()).subscribe(Throwing.consumer(queue::put));
         queue.take();
 
         assertThat(queue.poll(2, TimeUnit.SECONDS)).isNull();
@@ -408,7 +408,7 @@ public interface MailQueueContract {
 
     @Test
     default void deQueueShouldBlockWhenNoMail() {
-        Mono<MailQueue.MailQueueItem> item = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.elastic()).next();
+        Mono<MailQueue.MailQueueItem> item = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.boundedElastic()).next();
 
         assertThatThrownBy(() -> item.block(Duration.ofSeconds(2)))
             .isInstanceOf(RuntimeException.class);
@@ -439,7 +439,7 @@ public interface MailQueueContract {
         LinkedBlockingQueue<MailQueue.MailQueueItem> itemQueue = new LinkedBlockingQueue<>(1);
         Flux.from(testee
             .deQueue())
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .flatMap(e -> {
                 try {
                     itemQueue.put(e);
@@ -481,7 +481,7 @@ public interface MailQueueContract {
         int operationCount = 15;
         int totalDequeuedMessages = 50;
         LinkedBlockingDeque<MailQueue.MailQueueItem> deque = new LinkedBlockingDeque<>();
-        Flux.from(testee.deQueue()).subscribeOn(Schedulers.elastic()).doOnNext(deque::addFirst).subscribe();
+        Flux.from(testee.deQueue()).subscribeOn(Schedulers.boundedElastic()).doOnNext(deque::addFirst).subscribe();
         ConcurrentTestRunner.builder()
             .operation((threadNumber, step) -> {
                 if (step % 3 == 0) {

--- a/server/queue/queue-api/src/test/java/org/apache/james/queue/api/PriorityMailQueueContract.java
+++ b/server/queue/queue-api/src/test/java/org/apache/james/queue/api/PriorityMailQueueContract.java
@@ -117,7 +117,7 @@ public interface PriorityMailQueueContract {
             .attribute(mailPriority(1))
             .build());
 
-        Iterator<MailQueue.MailQueueItem> mailQueueItems = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.elastic()).toIterable().iterator();
+        Iterator<MailQueue.MailQueueItem> mailQueueItems = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.boundedElastic()).toIterable().iterator();
         MailQueue.MailQueueItem mailQueueItem1 = mailQueueItems.next();
         mailQueueItem1.done(true);
         MailQueue.MailQueueItem mailQueueItem2 = mailQueueItems.next();
@@ -137,7 +137,7 @@ public interface PriorityMailQueueContract {
             .attribute(mailPriority(8))
             .build());
 
-        Iterator<MailQueue.MailQueueItem> mailQueueItems = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.elastic()).toIterable().iterator();
+        Iterator<MailQueue.MailQueueItem> mailQueueItems = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.boundedElastic()).toIterable().iterator();
         MailQueue.MailQueueItem mailQueueItem1 = mailQueueItems.next();
         mailQueueItem1.done(true);
         MailQueue.MailQueueItem mailQueueItem2 = mailQueueItems.next();
@@ -161,7 +161,7 @@ public interface PriorityMailQueueContract {
             .attribute(mailPriority(6))
             .build());
 
-        Iterator<MailQueue.MailQueueItem> mailQueueItems = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.elastic()).toIterable().iterator();
+        Iterator<MailQueue.MailQueueItem> mailQueueItems = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.boundedElastic()).toIterable().iterator();
         MailQueue.MailQueueItem mailQueueItem1 = mailQueueItems.next();
         mailQueueItem1.done(true);
         MailQueue.MailQueueItem mailQueueItem2 = mailQueueItems.next();
@@ -187,7 +187,7 @@ public interface PriorityMailQueueContract {
             .attribute(mailPriority(6))
             .build());
 
-        Iterator<MailQueue.MailQueueItem> mailQueueItems = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.elastic()).toIterable().iterator();
+        Iterator<MailQueue.MailQueueItem> mailQueueItems = Flux.from(getMailQueue().deQueue()).subscribeOn(Schedulers.boundedElastic()).toIterable().iterator();
         MailQueue.MailQueueItem mailQueueItem1 = mailQueueItems.next();
         mailQueueItem1.done(true);
         MailQueue.MailQueueItem mailQueueItem2 = mailQueueItems.next();

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailDelete.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueMailDelete.java
@@ -62,7 +62,7 @@ public class CassandraMailQueueMailDelete {
     void updateBrowseStart(MailQueueName mailQueueName) {
         findNewBrowseStart(mailQueueName)
             .flatMap(newBrowseStart -> updateNewBrowseStart(mailQueueName, newBrowseStart))
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .subscribe();
     }
 

--- a/server/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQExclusiveConsumer.java
+++ b/server/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQExclusiveConsumer.java
@@ -90,7 +90,7 @@ public class RabbitMQExclusiveConsumer implements Closeable {
     }
 
     protected Scheduler createScheduler(String name) {
-        return Schedulers.newElastic(name);
+        return Schedulers.newBoundedElastic(Schedulers.DEFAULT_BOUNDED_ELASTIC_SIZE, Schedulers.DEFAULT_BOUNDED_ELASTIC_QUEUESIZE, name);
     }
 
 

--- a/server/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQTerminationSubscriber.java
+++ b/server/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQTerminationSubscriber.java
@@ -89,14 +89,14 @@ public class RabbitMQTerminationSubscriber implements TerminationSubscriber, Sta
         sendQueue = UnicastProcessor.create();
         sendQueueHandle = sender
             .send(sendQueue)
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .subscribe();
 
         Receiver receiver = RabbitFlux.createReceiver(new ReceiverOptions().connectionMono(connectionMono));
         listener = DirectProcessor.create();
         listenQueueHandle = receiver
             .consumeAutoAck(queueName)
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .concatMap(this::toEvent)
             .subscribe(listener::onNext);
     }

--- a/server/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueue.java
+++ b/server/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueue.java
@@ -189,7 +189,6 @@ public class RabbitMQWorkQueue implements WorkQueue, Startable {
     @Override
     @PreDestroy
     public void close() {
-        System.out.println("close");
         Optional.ofNullable(receiverHandle).ifPresent(Disposable::dispose);
         Optional.ofNullable(sendCancelRequestsQueueHandle).ifPresent(Disposable::dispose);
         Optional.ofNullable(cancelRequestListenerHandle).ifPresent(Disposable::dispose);

--- a/server/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueue.java
+++ b/server/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueue.java
@@ -106,7 +106,7 @@ public class RabbitMQWorkQueue implements WorkQueue, Startable {
     private void consumeWorkqueue() {
         receiver = new RabbitMQExclusiveConsumer(new ReceiverOptions().connectionMono(connectionMono));
         receiver.consumeExclusiveManualAck(QUEUE_NAME, new ConsumeOptions())
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .flatMap(this::executeTask)
             .subscribe();
     }
@@ -140,7 +140,7 @@ public class RabbitMQWorkQueue implements WorkQueue, Startable {
         sendCancelRequestsQueue = UnicastProcessor.create();
         sendCancelRequestsQueueHandle = cancelRequestSender
             .send(sendCancelRequestsQueue.map(this::makeCancelRequestMessage))
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .subscribe();
     }
 
@@ -148,7 +148,7 @@ public class RabbitMQWorkQueue implements WorkQueue, Startable {
         RabbitFlux
             .createReceiver(new ReceiverOptions().connectionMono(connectionMono))
             .consumeAutoAck(queueName)
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .map(this::readCancelRequestMessage)
             .doOnNext(worker::cancelTask)
             .subscribe();

--- a/server/task-distributed/src/main/scala/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueueSupplier.scala
+++ b/server/task-distributed/src/main/scala/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueueSupplier.scala
@@ -23,13 +23,13 @@ import javax.inject.Inject
 import org.apache.james.backends.rabbitmq.SimpleConnectionPool
 import org.apache.james.eventsourcing.EventSourcingSystem
 import org.apache.james.server.task.json.JsonTaskSerializer
+import org.apache.james.task.SerialTaskManagerWorker
 import org.apache.james.task.eventsourcing.{WorkQueueSupplier, WorkerStatusListener}
-import org.apache.james.task.{SerialTaskManagerWorker, WorkQueue}
 
 @Inject
 class RabbitMQWorkQueueSupplier(private val rabbitMQConnectionPool: SimpleConnectionPool,
                                 private val jsonTaskSerializer: JsonTaskSerializer) extends WorkQueueSupplier {
-  override def apply(eventSourcingSystem: EventSourcingSystem): WorkQueue = {
+  override def apply(eventSourcingSystem: EventSourcingSystem): RabbitMQWorkQueue = {
     val listener = WorkerStatusListener(eventSourcingSystem)
     val worker = new SerialTaskManagerWorker(listener)
     val rabbitMQWorkQueue = new RabbitMQWorkQueue(worker, rabbitMQConnectionPool, jsonTaskSerializer)

--- a/server/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/DistributedTaskManagerTest.java
+++ b/server/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/DistributedTaskManagerTest.java
@@ -21,6 +21,7 @@ package org.apache.james.task.eventsourcing.distributed;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -33,6 +34,8 @@ import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.init.CassandraZonedDateTimeModule;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.backends.rabbitmq.SimpleConnectionPool;
+import org.apache.james.eventsourcing.EventSourcingSystem;
 import org.apache.james.eventsourcing.eventstore.EventStore;
 import org.apache.james.eventsourcing.eventstore.cassandra.CassandraEventStoreExtension;
 import org.apache.james.eventsourcing.eventstore.cassandra.CassandraEventStoreModule;
@@ -49,6 +52,7 @@ import org.apache.james.task.TaskExecutionDetails;
 import org.apache.james.task.TaskId;
 import org.apache.james.task.TaskManager;
 import org.apache.james.task.TaskManagerContract;
+import org.apache.james.task.WorkQueue;
 import org.apache.james.task.eventsourcing.EventSourcingTaskManager;
 import org.apache.james.task.eventsourcing.Hostname;
 import org.apache.james.task.eventsourcing.TaskExecutionDetailsProjection;
@@ -60,13 +64,37 @@ import org.apache.james.task.eventsourcing.cassandra.CassandraTaskExecutionDetai
 import com.github.steveash.guavate.Guavate;
 import org.awaitility.Awaitility;
 import org.awaitility.Duration;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 @ExtendWith(CountDownLatchExtension.class)
 class DistributedTaskManagerTest implements TaskManagerContract {
+
+    private static class TrackedRabbitMQWorkQueueSupplier implements WorkQueueSupplier {
+        private final List<RabbitMQWorkQueue> workQueues;
+        private final RabbitMQWorkQueueSupplier supplier;
+
+        TrackedRabbitMQWorkQueueSupplier(SimpleConnectionPool rabbitConnectionPool, JsonTaskSerializer taskSerializer) {
+            workQueues = new ArrayList<>();
+            supplier = new RabbitMQWorkQueueSupplier(rabbitConnectionPool, taskSerializer);
+        }
+
+        @Override
+        public WorkQueue apply(EventSourcingSystem eventSourcingSystem) {
+            RabbitMQWorkQueue workQueue = supplier.apply(eventSourcingSystem);
+            workQueues.add(workQueue);
+            return workQueue;
+        }
+
+        void stopWorkQueues() {
+            workQueues.forEach(RabbitMQWorkQueue::close);
+            workQueues.clear();
+        }
+    }
 
     private static final JsonTaskSerializer TASK_SERIALIZER = new JsonTaskSerializer(
         TestTaskDTOModules.COMPLETED_TASK_MODULE,
@@ -96,13 +124,21 @@ class DistributedTaskManagerTest implements TaskManagerContract {
     private final CassandraTaskExecutionDetailsProjectionDAO cassandraTaskExecutionDetailsProjectionDAO = new CassandraTaskExecutionDetailsProjectionDAO(cassandra.getConf(), cassandra.getTypesProvider());
     private final TaskExecutionDetailsProjection executionDetailsProjection = new CassandraTaskExecutionDetailsProjection(cassandraTaskExecutionDetailsProjectionDAO);
 
-    private WorkQueueSupplier workQueueSupplier;
+    private TrackedRabbitMQWorkQueueSupplier workQueueSupplier;
     private EventStore eventStore;
+    private List<RabbitMQTerminationSubscriber> terminationSubscribers;
 
     @BeforeEach
     void setUp(EventStore eventStore) {
-        workQueueSupplier = new RabbitMQWorkQueueSupplier(rabbitMQExtension.getRabbitConnectionPool(), TASK_SERIALIZER);
+        workQueueSupplier = new TrackedRabbitMQWorkQueueSupplier(rabbitMQExtension.getRabbitConnectionPool(), TASK_SERIALIZER);
         this.eventStore = eventStore;
+        terminationSubscribers = new ArrayList<>();
+    }
+
+    @AfterEach
+    void tearDown() {
+        terminationSubscribers.forEach(RabbitMQTerminationSubscriber::close);
+        workQueueSupplier.stopWorkQueues();
     }
 
     public EventSourcingTaskManager taskManager() {
@@ -111,6 +147,7 @@ class DistributedTaskManagerTest implements TaskManagerContract {
 
     private EventSourcingTaskManager taskManager(Hostname hostname) {
         RabbitMQTerminationSubscriber terminationSubscriber = new RabbitMQTerminationSubscriber(rabbitMQExtension.getRabbitConnectionPool(), EVENT_SERIALIZER);
+        terminationSubscribers.add(terminationSubscriber);
         terminationSubscriber.start();
         return new EventSourcingTaskManager(workQueueSupplier, eventStore, executionDetailsProjection, hostname, terminationSubscriber);
     }
@@ -254,5 +291,4 @@ class DistributedTaskManagerTest implements TaskManagerContract {
                 });
         }
     }
-
 }

--- a/server/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/RabbitMQTerminationSubscriberTest.java
+++ b/server/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/RabbitMQTerminationSubscriberTest.java
@@ -62,7 +62,7 @@ class RabbitMQTerminationSubscriberTest implements TerminationSubscriberContract
         sendEvents(subscriber1, COMPLETED_EVENT);
 
         List<List<Event>> listenedEvents = Flux.just(subscriber1, subscriber2)
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .flatMap(this::collectEvents)
             .collectList()
             .block();

--- a/server/task/src/main/java/org/apache/james/task/MemoryTaskManager.java
+++ b/server/task/src/main/java/org/apache/james/task/MemoryTaskManager.java
@@ -142,7 +142,7 @@ public class MemoryTaskManager implements TaskManager {
     @Override
     public TaskExecutionDetails await(TaskId id, Duration timeout) throws TaskNotFoundException, ReachedTimeoutException {
         try {
-            return Flux.interval(NOW, AWAIT_POLLING_DURATION, Schedulers.elastic())
+            return Flux.interval(NOW, AWAIT_POLLING_DURATION, Schedulers.boundedElastic())
                 .map(ignored -> getExecutionDetails(id))
                 .filter(details -> details.getStatus().isFinished())
                 .blockFirst(timeout);

--- a/server/task/src/main/java/org/apache/james/task/MemoryWorkQueue.java
+++ b/server/task/src/main/java/org/apache/james/task/MemoryWorkQueue.java
@@ -37,7 +37,7 @@ public class MemoryWorkQueue implements WorkQueue {
         this.tasks = new LinkedBlockingQueue<>();
         this.subscription = Mono.fromCallable(tasks::take)
             .repeat()
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .flatMapSequential(this::dispatchTaskToWorker)
             .subscribe();
     }

--- a/server/task/src/main/scala/org/apache/james/task/eventsourcing/EventSourcingTaskManager.scala
+++ b/server/task/src/main/scala/org/apache/james/task/eventsourcing/EventSourcingTaskManager.scala
@@ -110,7 +110,7 @@ class EventSourcingTaskManager @Inject @VisibleForTesting private[eventsourcing]
         .then(details)
 
       Flux.merge(findEvent, details)
-        .subscribeOn(Schedulers.elastic)
+        .subscribeOn(Schedulers.boundedElastic)
         .blockFirst(timeout)
     } catch {
       case _: IllegalStateException => throw new ReachedTimeoutException

--- a/server/task/src/test/java/org/apache/james/task/eventsourcing/TerminationSubscriberContract.java
+++ b/server/task/src/test/java/org/apache/james/task/eventsourcing/TerminationSubscriberContract.java
@@ -99,7 +99,7 @@ public interface TerminationSubscriberContract {
         sendEvents(subscriber, COMPLETED_EVENT, FAILED_EVENT, CANCELLED_EVENT);
 
         List<List<Event>> listenedEvents = Flux.range(0, 2)
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .flatMap(ignored -> collectEvents(subscriber))
             .collectList()
             .block();
@@ -116,7 +116,7 @@ public interface TerminationSubscriberContract {
 
         List<Event> listenedEvents = Mono.delay(DELAY_BEFORE_PUBLISHING.plus(DELAY_BETWEEN_EVENTS.multipliedBy(3).dividedBy(2)))
             .then(Mono.defer(() -> collectEvents(subscriber)))
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .block();
         assertThat(listenedEvents).containsExactly(FAILED_EVENT, CANCELLED_EVENT);
     }
@@ -128,7 +128,7 @@ public interface TerminationSubscriberContract {
 
     default Mono<List<Event>> collectEvents(TerminationSubscriber subscriber) {
         return Flux.from(subscriber.listenEvents())
-            .subscribeOn(Schedulers.elastic())
+            .subscribeOn(Schedulers.boundedElastic())
             .take(DELAY_BEFORE_PUBLISHING.plus(DELAY_BETWEEN_EVENTS.multipliedBy(7)))
             .collectList();
     }
@@ -136,7 +136,7 @@ public interface TerminationSubscriberContract {
     default void sendEvents(TerminationSubscriber subscriber, Event... events) {
         Mono.delay(DELAY_BEFORE_PUBLISHING)
             .flatMapMany(ignored -> Flux.fromArray(events)
-                .subscribeOn(Schedulers.elastic())
+                .subscribeOn(Schedulers.boundedElastic())
                 .delayElements(DELAY_BETWEEN_EVENTS)
                 .doOnNext(subscriber::handle))
             .subscribe();


### PR DESCRIPTION
The elastic schedulers are unbounded and can create too much threads.
The new release of reactor has brought a bounded elastic scheduler and recommend using it in place of the elastic one : https://projectreactor.io/docs/core/release/reference/index.html#schedulers