### PR TITLE
JAMES-2855 Generate javadoc for MPT cote upon site phase

### DIFF
--- a/mpt/core/pom.xml
+++ b/mpt/core/pom.xml
@@ -116,7 +116,7 @@
                             <goal>javadoc</goal>
                             <goal>jar</goal>
                         </goals>
-                        <phase>package</phase>
+                        <phase>site</phase>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Generating javadoc is taking 40s and is called 7 time in the CI, thus this
make us loose around 6 minutes on each build.