### PR TITLE
JAMES-2099 Fix failing dataType resolution with Swagger

### DIFF
--- a/server/protocols/webadmin/webadmin-cassandra/src/main/java/org/apache/james/webadmin/routes/CassandraMailboxMergingRoutes.java
+++ b/server/protocols/webadmin/webadmin-cassandra/src/main/java/org/apache/james/webadmin/routes/CassandraMailboxMergingRoutes.java
@@ -96,7 +96,7 @@ public class CassandraMailboxMergingRoutes implements Routes {
             @ApiImplicitParam(
                 required = true,
                 paramType = "body",
-                dataType = "Mailbox merging request",
+                dataTypeClass = MailboxMergingRequest.class,
                 example = "{\"oldMailboxId\":\"4555-656-4554\",\"oldMailboxId\":\"9693-665-2500\"}",
                 value = "The mailboxes to merge together.")
         })

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/DLPConfigurationRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/DLPConfigurationRoutes.java
@@ -110,7 +110,7 @@ public class DLPConfigurationRoutes implements Routes {
     @ApiOperation(value = "Store a DLP configuration for given senderDomain")
     @ApiImplicitParams({
         @ApiImplicitParam(required = true, dataType = "string", name = "senderDomain", paramType = "path"),
-        @ApiImplicitParam(required = true, dataType = "org.apache.james.webadmin.dto.DLPConfigurationDTO", paramType = "body")
+        @ApiImplicitParam(required = true, dataTypeClass = DLPConfigurationDTO.class, paramType = "body")
     })
     @ApiResponses(value = {
         @ApiResponse(code = HttpStatus.NO_CONTENT_204, message = "OK. DLP configuration is stored."),

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/UserRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/UserRoutes.java
@@ -113,7 +113,7 @@ public class UserRoutes implements Routes {
     @ApiOperation(value = "Creating an user")
     @ApiImplicitParams({
             @ApiImplicitParam(required = true, dataType = "string", name = "username", paramType = "path"),
-            @ApiImplicitParam(required = true, dataType = "org.apache.james.webadmin.dto.AddUserRequest", paramType = "body")
+            @ApiImplicitParam(required = true, dataTypeClass = AddUserRequest.class, paramType = "body")
     })
     @ApiResponses(value = {
             @ApiResponse(code = HttpStatus.NO_CONTENT_204, message = "OK. New user is added."),

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/DomainQuotaRoutes.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/DomainQuotaRoutes.java
@@ -119,7 +119,7 @@ public class DomainQuotaRoutes implements Routes {
     @PUT
     @ApiOperation(value = "Updating count and size at the same time")
     @ApiImplicitParams({
-            @ApiImplicitParam(required = true, dataType = "org.apache.james.webadmin.dto.QuotaDTO", paramType = "body")
+            @ApiImplicitParam(required = true, dataTypeClass = QuotaDTO.class, paramType = "body")
     })
     @ApiResponses(value = {
             @ApiResponse(code = HttpStatus.NO_CONTENT_204, message = "OK. The value has been updated."),

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/GlobalQuotaRoutes.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/GlobalQuotaRoutes.java
@@ -104,7 +104,7 @@ public class GlobalQuotaRoutes implements Routes {
     @PUT
     @ApiOperation(value = "Updating count and size at the same time")
     @ApiImplicitParams({
-            @ApiImplicitParam(required = true, dataType = "org.apache.james.webadmin.dto.QuotaDTO", paramType = "body")
+            @ApiImplicitParam(required = true, dataTypeClass = QuotaDTO.class, paramType = "body")
     })
     @ApiResponses(value = {
             @ApiResponse(code = HttpStatus.NO_CONTENT_204, message = "OK. The value has been updated."),

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/UserQuotaRoutes.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/routes/UserQuotaRoutes.java
@@ -121,7 +121,7 @@ public class UserQuotaRoutes implements Routes {
     @PUT
     @ApiOperation(value = "Updating count and size at the same time")
     @ApiImplicitParams({
-            @ApiImplicitParam(required = true, dataType = "org.apache.james.webadmin.dto.QuotaDTO", paramType = "body")
+            @ApiImplicitParam(required = true, dataTypeClass = QuotaDTO.class, paramType = "body")
     })
     @ApiResponses(value = {
             @ApiResponse(code = HttpStatus.NO_CONTENT_204, message = "OK. The value has been updated."),

--- a/server/protocols/webadmin/webadmin-mailqueue/src/main/java/org/apache/james/webadmin/routes/MailQueueRoutes.java
+++ b/server/protocols/webadmin/webadmin-mailqueue/src/main/java/org/apache/james/webadmin/routes/MailQueueRoutes.java
@@ -267,7 +267,7 @@ public class MailQueueRoutes implements Routes {
         @ApiImplicitParam(required = true, dataType = "string", name = "mailQueueName", paramType = "path"),
         @ApiImplicitParam(
                 required = false, 
-                dataType = "MailAddress", 
+                dataTypeClass = MailAddress.class,
                 name = SENDER_QUERY_PARAM, 
                 paramType = "query",
                 example = "?sender=sender@james.org",


### PR DESCRIPTION
Swagger routes fails at resolving some of our datatypes, resulting in
verbose error logs.

For complicated FQCN, relying on dataTypeClass is a better choice.

Seen in build logs:

```
04:17:31.885 [ERROR] i.s.u.ReflectionUtils - Failed to resolve 'Mailbox merging request' into class
java.lang.ClassNotFoundException: Mailbox merging request
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:583)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	at io.swagger.util.ReflectionUtils.loadClassByName(ReflectionUtils.java:53)
	at io.swagger.util.ReflectionUtils.typeFromString(ReflectionUtils.java:35)
	at io.swagger.jaxrs.Reader.readImplicitParam(Reader.java:479)
	at io.swagger.jaxrs.Reader.processImplicitParams(Reader.java:448)
	at io.swagger.jaxrs.Reader.readImplicitParameters(Reader.java:441)
	at io.swagger.jaxrs.Reader.read(Reader.java:429)
	at io.swagger.jaxrs.Reader.read(Reader.java:176)
	at io.swagger.jaxrs.config.BeanConfig.scanAndRead(BeanConfig.java:242)
	at org.apache.james.webadmin.swagger.SwaggerParser.getBeanConfig(SwaggerParser.java:74)
	at org.apache.james.webadmin.swagger.SwaggerParser.getSwagger(SwaggerParser.java:52)
	at org.apache.james.webadmin.swagger.SwaggerParser.getSwaggerJson(SwaggerParser.java:48)
	at org.apache.james.webadmin.swagger.routes.SwaggerRoutes.lambda$define$0(SwaggerRoutes.java:50)
	at spark.RouteImpl$1.handle(RouteImpl.java:72)
	at spark.http.matching.Routes.execute(Routes.java:61)
	at spark.http.matching.MatcherFilter.doFilter(MatcherFilter.java:134)
	at spark.embeddedserver.jetty.JettyHandler.doHandle(JettyHandler.java:50)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1682)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at org.eclipse.jetty.server.Server.handle(Server.java:505)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:370)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:267)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:305)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:117)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:781)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:917)
	at java.base/java.lang.Thread.run(Thread.java:834)
```