### PR TITLE
JAMES-2241 can reindex header fields with dots after upgrading to ES6

### DIFF
--- a/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/json/HeaderCollection.java
+++ b/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/json/HeaderCollection.java
@@ -74,9 +74,8 @@ public class HeaderCollection {
             String rawHeaderValue = field.getBody();
             String sanitizedValue = MimeUtil.unscrambleHeaderValue(rawHeaderValue);
 
-            if (!headerName.contains(".")) {
-                headers.put(headerName, sanitizedValue);
-            }
+            headers.put(headerName, sanitizedValue);
+
             handleSpecificHeader(headerName, sanitizedValue, rawHeaderValue);
             return this;
         }

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/HeaderCollectionTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/HeaderCollectionTest.java
@@ -116,13 +116,13 @@ class HeaderCollectionTest {
     }
 
     @Test
-    void getHeadersShouldIgnoreHeadersWithDots() {
+    void getHeadersShouldNotIgnoreHeadersWithDots() {
         HeaderCollection headerCollection = HeaderCollection.builder()
             .add(new FieldImpl("a.b.c", "value"))
             .build();
 
         assertThat(headerCollection.getHeaders().get("a.b.c"))
-            .isEmpty();
+            .containsExactly("value");
     }
 
     @Test

--- a/mailbox/scanning-search/src/test/java/org/apache/james/mailbox/store/search/SimpleMessageSearchIndexTest.java
+++ b/mailbox/scanning-search/src/test/java/org/apache/james/mailbox/store/search/SimpleMessageSearchIndexTest.java
@@ -238,4 +238,9 @@ public class SimpleMessageSearchIndexTest extends AbstractMessageSearchIndexTest
     @Override
     public void searchWithTextShouldReturnMailsWhenHtmlBodyMatchesWithStemming() throws Exception {
     }
+
+    @Ignore
+    @Override
+    public void headerWithDotsShouldBeIndexed() throws MailboxException {
+    }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/AbstractMessageSearchIndexTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/AbstractMessageSearchIndexTest.java
@@ -423,6 +423,21 @@ public abstract class AbstractMessageSearchIndexTest {
     }
 
     @Test
+    public void headerWithDotsShouldBeIndexed() throws MailboxException {
+
+        ComposedMessageId mailWithDotsInHeader = myFolderMessageManager.appendMessage(
+            MessageManager.AppendCommand.builder()
+                .build(ClassLoader.getSystemResourceAsStream("eml/headerWithDot.eml")),
+            session);
+        await();
+
+        SearchQuery searchQuery = new SearchQuery(SearchQuery.headerExists("X-header.with.dots"));
+
+        assertThat(messageSearchIndex.search(session, mailbox2, searchQuery))
+            .contains(mailWithDotsInHeader.getUid());
+    }
+
+    @Test
     public void searchShouldBeExactOnEmailAddresses() throws MailboxException {
         Assume.assumeTrue(storeMailboxManager.getSupportedSearchCapabilities().contains(MailboxManager.SearchCapabilities.Text));
 


### PR DESCRIPTION
It seems that from ES 5.0, dots are permitted again in fields names : https://www.elastic.co/guide/en/elasticsearch/reference/2.4/dots-in-names.html