### PR TITLE
James 2813 remove default type from task

### DIFF
--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/migration/Migration.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/migration/Migration.java
@@ -20,13 +20,24 @@
 package org.apache.james.backends.cassandra.migration;
 
 import org.apache.james.task.Task;
+import org.apache.james.task.TaskType;
 
 public interface Migration {
 
     void apply() throws InterruptedException;
 
     default Task asTask() {
-        return this::runTask;
+        return new Task() {
+            @Override
+            public Result run() throws InterruptedException {
+                return runTask();
+            }
+
+            @Override
+            public TaskType type() {
+                return Task.UNKNOWN;
+            }
+        };
     }
 
     default Task.Result runTask() throws InterruptedException {

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/migration/Migration.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/migration/Migration.java
@@ -35,7 +35,7 @@ public interface Migration {
 
             @Override
             public TaskType type() {
-                return Task.UNKNOWN;
+                return TaskType.of("migration_sub_task");
             }
         };
     }

--- a/server/container/cli-integration/pom.xml
+++ b/server/container/cli-integration/pom.xml
@@ -65,7 +65,12 @@
             <artifactId>james-server-memory-guice</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-task-api</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>testing-base</artifactId>

--- a/server/container/cli-integration/src/test/java/org/apache/james/cli/ReindexCommandIntegrationTest.java
+++ b/server/container/cli-integration/src/test/java/org/apache/james/cli/ReindexCommandIntegrationTest.java
@@ -31,6 +31,7 @@ import org.apache.james.mailbox.model.MailboxConstants;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.store.search.ListeningMessageSearchIndex;
 import org.apache.james.modules.server.JMXServerModule;
+import org.apache.james.task.MemoryReferenceTask;
 import org.apache.james.task.Task;
 import org.junit.After;
 import org.junit.Before;
@@ -50,8 +51,8 @@ public class ReindexCommandIntegrationTest {
     @Before
     public void setUp() throws Exception {
         reIndexer = mock(ReIndexer.class);
-        when(reIndexer.reIndex()).thenReturn(() -> Task.Result.COMPLETED);
-        when(reIndexer.reIndex(any(MailboxPath.class))).thenReturn(() -> Task.Result.COMPLETED);
+        when(reIndexer.reIndex()).thenReturn(new MemoryReferenceTask(() -> Task.Result.COMPLETED));
+        when(reIndexer.reIndex(any(MailboxPath.class))).thenReturn(new MemoryReferenceTask(() -> Task.Result.COMPLETED));
         guiceJamesServer = memoryJmap.jmapServer(new JMXServerModule(),
             binder -> binder.bind(ListeningMessageSearchIndex.class).toInstance(mock(ListeningMessageSearchIndex.class)))
             .overrideWith(binder -> binder.bind(ReIndexer.class)

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/CleanupTasksPerformer.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/CleanupTasksPerformer.java
@@ -25,6 +25,7 @@ import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
 import org.apache.james.task.Task;
+import org.apache.james.task.TaskType;
 import org.apache.james.util.Runnables;
 
 import com.github.fge.lambdas.Throwing;
@@ -33,7 +34,9 @@ import reactor.core.publisher.Flux;
 public class CleanupTasksPerformer {
 
     public interface CleanupTask extends Task {
-
+        default TaskType type() {
+            return TaskType.of("cleanup_task");
+        }
     }
 
     private final Set<CleanupTask> cleanupTasks;

--- a/server/protocols/webadmin/webadmin-core/pom.xml
+++ b/server/protocols/webadmin/webadmin-core/pom.xml
@@ -59,6 +59,12 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-task-api</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-task-memory</artifactId>
             <scope>test</scope>
         </dependency>

--- a/server/task/task-api/src/main/java/org/apache/james/task/Task.java
+++ b/server/task/task-api/src/main/java/org/apache/james/task/Task.java
@@ -92,10 +92,7 @@ public interface Task {
      */
     Result run() throws InterruptedException;
 
-
-    default TaskType type() {
-        return UNKNOWN;
-    }
+    TaskType type();
 
     default Optional<TaskExecutionDetails.AdditionalInformation> details() {
         return Optional.empty();

--- a/server/task/task-api/src/test/java/org/apache/james/task/MemoryReferenceTask.java
+++ b/server/task/task-api/src/test/java/org/apache/james/task/MemoryReferenceTask.java
@@ -20,17 +20,27 @@ package org.apache.james.task;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.function.ThrowingSupplier;
+
 public class MemoryReferenceTask implements Task {
     public static final TaskType TYPE = TaskType.of("memory-reference-task");
-    private final Task task;
+    private final ThrowingSupplier<Result>  task;
 
-    public MemoryReferenceTask(Task task) {
+    public MemoryReferenceTask(ThrowingSupplier<Result> task) {
         this.task = task;
     }
 
     @Override
     public Result run() throws InterruptedException {
-        return task.run();
+        try {
+            return task.get();
+        }
+        catch (InterruptedException e) {
+            throw e;
+        }
+        catch (Throwable throwable) {
+            throw new RuntimeException(throwable);
+        }
     }
 
     @Override

--- a/server/task/task-api/src/test/java/org/apache/james/task/MemoryReferenceTask.java
+++ b/server/task/task-api/src/test/java/org/apache/james/task/MemoryReferenceTask.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.function.ThrowingSupplier;
 
 public class MemoryReferenceTask implements Task {
     public static final TaskType TYPE = TaskType.of("memory-reference-task");
-    private final ThrowingSupplier<Result>  task;
+    private final ThrowingSupplier<Result> task;
 
     public MemoryReferenceTask(ThrowingSupplier<Result> task) {
         this.task = task;
@@ -34,11 +34,9 @@ public class MemoryReferenceTask implements Task {
     public Result run() throws InterruptedException {
         try {
             return task.get();
-        }
-        catch (InterruptedException e) {
+        } catch (InterruptedException e) {
             throw e;
-        }
-        catch (Throwable throwable) {
+        } catch (Throwable throwable) {
             throw new RuntimeException(throwable);
         }
     }

--- a/server/task/task-memory/src/test/java/org/apache/james/task/SerialTaskManagerWorkerTest.java
+++ b/server/task/task-memory/src/test/java/org/apache/james/task/SerialTaskManagerWorkerTest.java
@@ -94,11 +94,11 @@ class SerialTaskManagerWorkerTest {
         CountDownLatch latch = new CountDownLatch(1);
         CountDownLatch taskLaunched = new CountDownLatch(1);
 
-        Task inProgressTask = () -> {
+        Task inProgressTask = new MemoryReferenceTask(() -> {
             taskLaunched.countDown();
             await(latch);
             return Task.Result.COMPLETED;
-        };
+        });
 
         TaskWithId taskWithId = new TaskWithId(id, inProgressTask);
 
@@ -116,11 +116,11 @@ class SerialTaskManagerWorkerTest {
         AtomicInteger counter = new AtomicInteger(0);
         CountDownLatch latch = new CountDownLatch(1);
 
-        Task inProgressTask = () -> {
+        Task inProgressTask = new MemoryReferenceTask(() -> {
             await(latch);
             counter.incrementAndGet();
             return Task.Result.COMPLETED;
-        };
+        });
 
         TaskWithId taskWithId = new TaskWithId(id, inProgressTask);
 

--- a/server/task/task-memory/src/test/java/org/apache/james/task/TaskWithIdTest.java
+++ b/server/task/task-memory/src/test/java/org/apache/james/task/TaskWithIdTest.java
@@ -28,8 +28,8 @@ public class TaskWithIdTest {
     @Test
     public void twoTasksWithSameIdShouldBeEqual() {
         TaskId id = TaskId.generateTaskId();
-        Task task1 = () -> Task.Result.COMPLETED;
-        Task task2 = () -> Task.Result.COMPLETED;
+        Task task1 = new MemoryReferenceTask(() -> Task.Result.COMPLETED);
+        Task task2 = new MemoryReferenceTask(() -> Task.Result.COMPLETED);
         TaskWithId taskWithId1 = new TaskWithId(id, task1);
         TaskWithId taskWithId2 = new TaskWithId(id, task2);
         assertThat(taskWithId1).isEqualTo(taskWithId2);
@@ -39,7 +39,7 @@ public class TaskWithIdTest {
     public void sameTaskWithDifferentIdShouldNotBeEqual() {
         TaskId id1 = TaskId.generateTaskId();
         TaskId id2 = TaskId.generateTaskId();
-        Task task = () -> Task.Result.COMPLETED;
+        Task task = new MemoryReferenceTask(() -> Task.Result.COMPLETED);
         TaskWithId taskWithId1 = new TaskWithId(id1, task);
         TaskWithId taskWithId2 = new TaskWithId(id2, task);
         assertThat(taskWithId1).isNotEqualTo(taskWithId2);

--- a/server/task/task-memory/src/test/java/org/apache/james/task/eventsourcing/EventSourcingTaskManagerTest.java
+++ b/server/task/task-memory/src/test/java/org/apache/james/task/eventsourcing/EventSourcingTaskManagerTest.java
@@ -26,6 +26,7 @@ import org.apache.james.eventsourcing.eventstore.EventStore;
 import org.apache.james.eventsourcing.eventstore.memory.InMemoryEventStore;
 import org.apache.james.task.CountDownLatchExtension;
 import org.apache.james.task.Hostname;
+import org.apache.james.task.MemoryReferenceTask;
 import org.apache.james.task.MemoryWorkQueue;
 import org.apache.james.task.SerialTaskManagerWorker;
 import org.apache.james.task.Task;
@@ -75,7 +76,7 @@ class EventSourcingTaskManagerTest implements TaskManagerContract {
 
     @Test
     void createdTaskShouldKeepOriginHostname() {
-        TaskId taskId = taskManager.submit(() -> Task.Result.COMPLETED);
+        TaskId taskId = taskManager.submit(new MemoryReferenceTask(() -> Task.Result.COMPLETED));
         TaskAggregateId aggregateId = new TaskAggregateId(taskId);
         assertThat(eventStore.getEventsOfAggregate(aggregateId).getEvents())
                 .filteredOn(event -> event instanceof Created)
@@ -85,7 +86,7 @@ class EventSourcingTaskManagerTest implements TaskManagerContract {
 
     @Test
     void startedTaskShouldKeepOriginHostname() {
-        TaskId taskId = taskManager.submit(() -> Task.Result.COMPLETED);
+        TaskId taskId = taskManager.submit(new MemoryReferenceTask(() -> Task.Result.COMPLETED));
         TaskAggregateId aggregateId = new TaskAggregateId(taskId);
 
         CALMLY_AWAIT.untilAsserted(() ->
@@ -97,10 +98,10 @@ class EventSourcingTaskManagerTest implements TaskManagerContract {
 
     @Test
     void cancelRequestedTaskShouldKeepOriginHostname() {
-        TaskId taskId = taskManager.submit(() -> {
+        TaskId taskId = taskManager.submit(new MemoryReferenceTask(() -> {
             Thread.sleep(100);
             return Task.Result.COMPLETED;
-        });
+        }));
         taskManager.cancel(taskId);
 
         TaskAggregateId aggregateId = new TaskAggregateId(taskId);


### PR DESCRIPTION
Task::type method should not have default value

This will force implementations to specify their type, that they can omit today, resulting on use of default value.

Such Task will then not be serializable as serialization relies on task type to identify deserializer.

For the sake of development safety, we should get rid of that behavior. We should propose a convenient way to create a task from a lambda (runnable) in tests, which can very well be done via a devoted TestTask wrapping such a lambda.

The intent of this TestTask is to be able to write tests easily but I won't work when you need serialization.

DoD: All tests should pass, Tasks in test must use only the lambda-based task and it should be impossible to have a Task without an explicit type.