### PR TITLE
JAMES-2906 Add update flag test for ES

### DIFF
--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/AbstractMessageSearchIndexTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/AbstractMessageSearchIndexTest.java
@@ -520,6 +520,22 @@ public abstract class AbstractMessageSearchIndexTest {
         assertThat(messageSearchIndex.search(session, mailbox, searchQuery))
             .containsOnly(m6.getUid());
     }
+
+    @Test
+    public void flagUpdateShouldReturnUidOfMessagesMarkedAsSeenAfterMessageUpdatedWithFlagSeen() throws MailboxException {
+        inboxMessageManager.setFlags(
+            new Flags(Flags.Flag.SEEN),
+            MessageManager.FlagsUpdateMode.ADD,
+            MessageRange.one(m5.getUid()),
+            session);
+
+        await();
+
+        SearchQuery searchQuery = new SearchQuery(SearchQuery.flagIsSet(Flags.Flag.SEEN));
+
+        assertThat(messageSearchIndex.search(session, mailbox, searchQuery))
+            .containsOnly(m5.getUid(), m6.getUid());
+    }
     
     @Test
     public void multimailboxSearchShouldReturnUidOfMessageMarkedAsSeenInAllMailboxes() throws MailboxException {

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/AbstractMessageSearchIndexTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/AbstractMessageSearchIndexTest.java
@@ -522,7 +522,7 @@ public abstract class AbstractMessageSearchIndexTest {
     }
 
     @Test
-    public void flagUpdateShouldReturnUidOfMessagesMarkedAsSeenAfterMessageUpdatedWithFlagSeen() throws MailboxException {
+    public void searchShouldReturnSeenMessagesWhenFlagsGotUpdated() throws MailboxException {
         inboxMessageManager.setFlags(
             new Flags(Flags.Flag.SEEN),
             MessageManager.FlagsUpdateMode.ADD,
@@ -534,7 +534,7 @@ public abstract class AbstractMessageSearchIndexTest {
         SearchQuery searchQuery = new SearchQuery(SearchQuery.flagIsSet(Flags.Flag.SEEN));
 
         assertThat(messageSearchIndex.search(session, mailbox, searchQuery))
-            .containsOnly(m5.getUid(), m6.getUid());
+            .contains(m5.getUid());
     }
     
     @Test


### PR DESCRIPTION
Related to #2745 

We actually lacked a flag update test on ES. Works on master but definitely not in the current POC _source removal. But should add it anyway !