### PR TITLE
MAILBOX-380 Bind CassandraEventsDeadLetters inside cassandra-guice

### DIFF
--- a/mailbox/event/event-cassandra/src/main/java/org/apache/james/mailbox/events/CassandraEventDeadLetters.java
+++ b/mailbox/event/event-cassandra/src/main/java/org/apache/james/mailbox/events/CassandraEventDeadLetters.java
@@ -32,8 +32,8 @@ public class CassandraEventDeadLetters implements EventDeadLetters {
     private final CassandraEventDeadLettersGroupDAO cassandraEventDeadLettersGroupDAO;
 
     @Inject
-    public CassandraEventDeadLetters(CassandraEventDeadLettersDAO cassandraEventDeadLettersDAO,
-                                     CassandraEventDeadLettersGroupDAO cassandraEventDeadLettersGroupDAO) {
+    CassandraEventDeadLetters(CassandraEventDeadLettersDAO cassandraEventDeadLettersDAO,
+                              CassandraEventDeadLettersGroupDAO cassandraEventDeadLettersGroupDAO) {
         this.cassandraEventDeadLettersDAO = cassandraEventDeadLettersDAO;
         this.cassandraEventDeadLettersGroupDAO = cassandraEventDeadLettersGroupDAO;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -780,6 +780,11 @@
             </dependency>
             <dependency>
                 <groupId>${james.groupId}</groupId>
+                <artifactId>apache-james-mailbox-event-cassandra</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${james.groupId}</groupId>
                 <artifactId>apache-james-mailbox-event-json</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/server/container/guice/cassandra-guice/pom.xml
+++ b/server/container/guice/cassandra-guice/pom.xml
@@ -57,6 +57,10 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-mailbox-event-cassandra</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>apache-james-mailbox-cassandra</artifactId>
             <type>test-jar</type>
             <scope>test</scope>

--- a/server/container/guice/cassandra-guice/pom.xml
+++ b/server/container/guice/cassandra-guice/pom.xml
@@ -57,10 +57,6 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
-            <artifactId>apache-james-mailbox-event-cassandra</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
             <artifactId>apache-james-mailbox-cassandra</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
@@ -78,6 +74,10 @@
             <artifactId>apache-james-mailbox-elasticsearch</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-mailbox-event-cassandra</artifactId>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraDeadLetterModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraDeadLetterModule.java
@@ -1,0 +1,46 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.mailbox;
+
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.mailbox.events.CassandraEventDeadLetters;
+import org.apache.james.mailbox.events.CassandraEventDeadLettersDAO;
+import org.apache.james.mailbox.events.CassandraEventDeadLettersGroupDAO;
+import org.apache.james.mailbox.events.CassandraEventDeadLettersModule;
+import org.apache.james.mailbox.events.EventDeadLetters;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
+
+public class CassandraDeadLetterModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(CassandraEventDeadLettersGroupDAO.class).in(Scopes.SINGLETON);
+        bind(CassandraEventDeadLettersDAO.class).in(Scopes.SINGLETON);
+        bind(CassandraEventDeadLetters.class).in(Scopes.SINGLETON);
+
+        bind(EventDeadLetters.class).to(CassandraEventDeadLetters.class);
+
+        Multibinder.newSetBinder(binder(), CassandraModule.class)
+            .addBinding()
+            .toInstance(CassandraEventDeadLettersModule.MODULE);
+    }
+}

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraMailboxModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraMailboxModule.java
@@ -105,6 +105,7 @@ public class CassandraMailboxModule extends AbstractModule {
     protected void configure() {
         install(new DefaultEventModule());
         install(new CassandraQuotaModule());
+        install(new CassandraDeadLetterModule());
 
         bind(CassandraApplicableFlagDAO.class).in(Scopes.SINGLETON);
         bind(CassandraAttachmentDAO.class).in(Scopes.SINGLETON);

--- a/server/container/guice/jpa-guice/src/main/java/org/apache/james/JPAJamesServerMain.java
+++ b/server/container/guice/jpa-guice/src/main/java/org/apache/james/JPAJamesServerMain.java
@@ -26,6 +26,7 @@ import org.apache.james.modules.data.SieveJPARepositoryModules;
 import org.apache.james.modules.mailbox.DefaultEventModule;
 import org.apache.james.modules.mailbox.JPAMailboxModule;
 import org.apache.james.modules.mailbox.LuceneSearchMailboxModule;
+import org.apache.james.modules.mailbox.MemoryDeadLetterModule;
 import org.apache.james.modules.protocols.IMAPServerModule;
 import org.apache.james.modules.protocols.LMTPServerModule;
 import org.apache.james.modules.protocols.ManageSieveServerModule;
@@ -85,6 +86,7 @@ public class JPAJamesServerMain {
         new RawPostDequeueDecoratorModule(),
         new SieveJPARepositoryModules(),
         new DefaultEventModule(),
+        new MemoryDeadLetterModule(),
         new SpamAssassinListenerModule());
 
     public static final Module JPA_MODULE_AGGREGATE = Modules.combine(JPA_SERVER_MODULE, PROTOCOLS);

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/DefaultEventModule.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/DefaultEventModule.java
@@ -24,10 +24,8 @@ import javax.inject.Inject;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.mailbox.events.EventBus;
-import org.apache.james.mailbox.events.EventDeadLetters;
 import org.apache.james.mailbox.events.InVMEventBus;
 import org.apache.james.mailbox.events.MailboxListener;
-import org.apache.james.mailbox.events.MemoryEventDeadLetters;
 import org.apache.james.mailbox.events.RetryBackoffConfiguration;
 import org.apache.james.mailbox.events.delivery.EventDelivery;
 import org.apache.james.mailbox.events.delivery.InVmEventDelivery;
@@ -51,9 +49,7 @@ public class DefaultEventModule extends AbstractModule {
         bind(MailboxListenersLoaderImpl.class).in(Scopes.SINGLETON);
         bind(InVmEventDelivery.class).in(Scopes.SINGLETON);
         bind(InVMEventBus.class).in(Scopes.SINGLETON);
-        bind(MemoryEventDeadLetters.class).in(Scopes.SINGLETON);
 
-        bind(EventDeadLetters.class).to(MemoryEventDeadLetters.class);
         Multibinder.newSetBinder(binder(), GuiceProbe.class).addBinding().to(EventDeadLettersProbe.class);
         bind(MailboxListenersLoader.class).to(MailboxListenersLoaderImpl.class);
         bind(EventDelivery.class).to(InVmEventDelivery.class);

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MemoryDeadLetterModule.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MemoryDeadLetterModule.java
@@ -1,0 +1,34 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.mailbox;
+
+import org.apache.james.mailbox.events.EventDeadLetters;
+import org.apache.james.mailbox.events.MemoryEventDeadLetters;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+
+public class MemoryDeadLetterModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(MemoryEventDeadLetters.class).in(Scopes.SINGLETON);
+        bind(EventDeadLetters.class).to(MemoryEventDeadLetters.class);
+    }
+}

--- a/server/container/guice/memory-guice/src/main/java/org/apache/james/modules/mailbox/MemoryMailboxModule.java
+++ b/server/container/guice/memory-guice/src/main/java/org/apache/james/modules/mailbox/MemoryMailboxModule.java
@@ -78,6 +78,7 @@ public class MemoryMailboxModule extends AbstractModule {
     @Override
     protected void configure() {
         install(new DefaultEventModule());
+        install(new MemoryDeadLetterModule());
         install(new MemoryQuotaModule());
         install(new MemoryQuotaSearchModule());
 


### PR DESCRIPTION
This requires dead letter default memory binding to not be included in
default event module.

Also, the event bus does not require to be part of TLD mailbox implementation
bindings.