### PR TITLE
JAMES-2917 Rely on ElasticSearch routing key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Changed
-- Multiple changes had been made to enhance ElasticSearch performance:
+- Multiple changes have been made to enhance ElasticSearch performance:
   - Use of routing keys to collocate documents per mailbox
   - Read related [upgrade instructions](upgrade-instructions.md)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+- Multiple changes had been made to enhance ElasticSearch performance:
+  - Use of routing keys to collocate documents per mailbox
+  - Read related [upgrade instructions](upgrade-instructions.md)
+
 ### Removed
 - Classes marked as deprecated whose removal was planned after 3.4.0 release (See JAMES-2703). This includes:
   - SieveDefaultRepository. Please use SieveFileRepository instead.

--- a/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/DocumentId.java
+++ b/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/DocumentId.java
@@ -16,54 +16,44 @@
  * specific language governing permissions and limitations      *
  * under the License.                                           *
  ****************************************************************/
+
 package org.apache.james.backends.es;
 
 import java.util.Objects;
 
 import org.elasticsearch.common.Strings;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
-public class UpdatedRepresentation {
-    private final DocumentId id;
-    private final String updatedDocumentPart;
+public class DocumentId {
 
-    public UpdatedRepresentation(DocumentId id, String updatedDocumentPart) {
-        Preconditions.checkNotNull(id);
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(updatedDocumentPart), "Updated document must be specified");
-        this.id = id;
-        this.updatedDocumentPart = updatedDocumentPart;
+    public static DocumentId fromString(String value) {
+        return new DocumentId(value);
     }
 
-    public DocumentId getId() {
-        return id;
+    private final String value;
+
+    private DocumentId(String value) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(value), "DocumentId must be specified");
+        this.value = value;
     }
 
-    public String getUpdatedDocumentPart() {
-        return updatedDocumentPart;
+    public String asString() {
+        return value;
     }
 
     @Override
     public final boolean equals(Object o) {
-        if (o instanceof UpdatedRepresentation) {
-            UpdatedRepresentation other = (UpdatedRepresentation) o;
-            return Objects.equals(id, other.id)
-                && Objects.equals(updatedDocumentPart, other.updatedDocumentPart);
+        if (o instanceof DocumentId) {
+            DocumentId that = (DocumentId) o;
+
+            return Objects.equals(this.value, that.value);
         }
         return false;
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(id, updatedDocumentPart);
-    }
-
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("id", id)
-            .add("updatedDocumentPart", updatedDocumentPart)
-            .toString();
+        return Objects.hash(value);
     }
 }

--- a/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/ElasticSearchIndexer.java
+++ b/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/ElasticSearchIndexer.java
@@ -64,28 +64,34 @@ public class ElasticSearchIndexer {
         this.aliasName = aliasName;
     }
 
-    public IndexResponse index(String id, String content) throws IOException {
+    public IndexResponse index(DocumentId id, String content, RoutingKey routingKey) throws IOException {
         checkArgument(content);
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Indexing {}: {}", id, StringUtils.left(content, DEBUG_MAX_LENGTH_CONTENT));
-        }
-        return client.index(
-            new IndexRequest(aliasName.getValue())
+        logContent(id, content);
+        return client.index(new IndexRequest(aliasName.getValue())
                 .type(NodeMappingFactory.DEFAULT_MAPPING_NAME)
-                .id(id)
-                .source(content, XContentType.JSON),
+                .id(id.asString())
+                .source(content, XContentType.JSON)
+                .routing(routingKey.asString()),
             RequestOptions.DEFAULT);
     }
 
-    public Optional<BulkResponse> update(List<UpdatedRepresentation> updatedDocumentParts) throws IOException {
+    private void logContent(DocumentId id, String content) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Indexing {}: {}", id.asString(), StringUtils.left(content, DEBUG_MAX_LENGTH_CONTENT));
+        }
+    }
+
+    public Optional<BulkResponse> update(List<UpdatedRepresentation> updatedDocumentParts, RoutingKey routingKey) throws IOException {
         try {
             Preconditions.checkNotNull(updatedDocumentParts);
+            Preconditions.checkNotNull(routingKey);
             BulkRequest request = new BulkRequest();
             updatedDocumentParts.forEach(updatedDocumentPart -> request.add(
                 new UpdateRequest(aliasName.getValue(),
                     NodeMappingFactory.DEFAULT_MAPPING_NAME,
-                    updatedDocumentPart.getId())
-                .doc(updatedDocumentPart.getUpdatedDocumentPart(), XContentType.JSON)));
+                    updatedDocumentPart.getId().asString())
+                .doc(updatedDocumentPart.getUpdatedDocumentPart(), XContentType.JSON)
+                .routing(routingKey.asString())));
             return Optional.of(client.bulk(request, RequestOptions.DEFAULT));
         } catch (ValidationException e) {
             LOGGER.warn("Error while updating index", e);
@@ -93,22 +99,23 @@ public class ElasticSearchIndexer {
         }
     }
 
-    public Optional<BulkResponse> delete(List<String> ids) throws IOException {
+    public Optional<BulkResponse> delete(List<DocumentId> ids, RoutingKey routingKey) throws IOException {
         try {
             BulkRequest request = new BulkRequest();
             ids.forEach(id -> request.add(
                 new DeleteRequest(aliasName.getValue())
                     .type(NodeMappingFactory.DEFAULT_MAPPING_NAME)
-                    .id(id)));
-            return Optional.of(client.bulk(request));
+                    .id(id.asString())
+                    .routing(routingKey.asString())));
+            return Optional.of(client.bulk(request, RequestOptions.DEFAULT));
         } catch (ValidationException e) {
             LOGGER.warn("Error while deleting index", e);
             return Optional.empty();
         }
     }
 
-    public void deleteAllMatchingQuery(QueryBuilder queryBuilder) {
-        deleteByQueryPerformer.perform(queryBuilder).block();
+    public void deleteAllMatchingQuery(QueryBuilder queryBuilder, RoutingKey routingKey) {
+        deleteByQueryPerformer.perform(queryBuilder, routingKey).block();
     }
 
     private void checkArgument(String content) {

--- a/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/NodeMappingFactory.java
+++ b/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/NodeMappingFactory.java
@@ -41,6 +41,8 @@ public class NodeMappingFactory {
     public static final String TEXT = "text";
     public static final String KEYWORD = "keyword";
     public static final String PROPERTIES = "properties";
+    public static final String ROUTING = "_routing";
+    public static final String REQUIRED = "required";
     public static final String DATE = "date";
     public static final String FORMAT = "format";
     public static final String NESTED = "nested";

--- a/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/RoutingKey.java
+++ b/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/RoutingKey.java
@@ -34,9 +34,6 @@ public class RoutingKey {
         return new RoutingKey(value);
     }
 
-    public static RoutingKey useDocumentId(DocumentId documentId) {
-        return fromString(documentId.asString());
-    }
 
     private final String value;
 

--- a/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/RoutingKey.java
+++ b/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/RoutingKey.java
@@ -16,54 +16,47 @@
  * specific language governing permissions and limitations      *
  * under the License.                                           *
  ****************************************************************/
+
 package org.apache.james.backends.es;
 
 import java.util.Objects;
 
 import org.elasticsearch.common.Strings;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
-public class UpdatedRepresentation {
-    private final DocumentId id;
-    private final String updatedDocumentPart;
-
-    public UpdatedRepresentation(DocumentId id, String updatedDocumentPart) {
-        Preconditions.checkNotNull(id);
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(updatedDocumentPart), "Updated document must be specified");
-        this.id = id;
-        this.updatedDocumentPart = updatedDocumentPart;
+public class RoutingKey {
+    public static RoutingKey fromString(String value) {
+        return new RoutingKey(value);
     }
 
-    public DocumentId getId() {
-        return id;
+    public static RoutingKey useDocumentId(DocumentId documentId) {
+        return fromString(documentId.asString());
     }
 
-    public String getUpdatedDocumentPart() {
-        return updatedDocumentPart;
+    private final String value;
+
+    private RoutingKey(String value) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(value), "RoutingKey must be specified");
+        this.value = value;
+    }
+
+    public String asString() {
+        return value;
     }
 
     @Override
     public final boolean equals(Object o) {
-        if (o instanceof UpdatedRepresentation) {
-            UpdatedRepresentation other = (UpdatedRepresentation) o;
-            return Objects.equals(id, other.id)
-                && Objects.equals(updatedDocumentPart, other.updatedDocumentPart);
+        if (o instanceof RoutingKey) {
+            RoutingKey that = (RoutingKey) o;
+
+            return Objects.equals(this.value, that.value);
         }
         return false;
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(id, updatedDocumentPart);
-    }
-
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("id", id)
-            .add("updatedDocumentPart", updatedDocumentPart)
-            .toString();
+        return Objects.hash(value);
     }
 }

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/DocumentIdTest.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/DocumentIdTest.java
@@ -1,0 +1,46 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.es;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class DocumentIdTest {
+    @Test
+    void documentIdShouldRespectBeanContract() {
+        EqualsVerifier.forClass(DocumentId.class)
+            .verify();
+    }
+
+    @Test
+    void fromStringShouldThrowWhenNull() {
+        assertThatThrownBy(() -> DocumentId.fromString(null))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void fromStringShouldThrowWhenEmpty() {
+        assertThatThrownBy(() -> DocumentId.fromString(""))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/ElasticSearchIndexerTest.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/ElasticSearchIndexerTest.java
@@ -44,6 +44,9 @@ import org.junit.Test;
 import com.google.common.collect.ImmutableList;
 
 public class ElasticSearchIndexerTest {
+    public static RoutingKey useDocumentId(DocumentId documentId) {
+        return RoutingKey.fromString(documentId.asString());
+    }
 
     private static final int MINIMUM_BATCH_SIZE = 1;
     private static final IndexName INDEX_NAME = new IndexName("index_name");
@@ -81,7 +84,7 @@ public class ElasticSearchIndexerTest {
         DocumentId documentId = DocumentId.fromString("1");
         String content = "{\"message\": \"trying out Elasticsearch\"}";
         
-        testee.index(documentId, content, RoutingKey.useDocumentId(documentId));
+        testee.index(documentId, content, useDocumentId(documentId));
         elasticSearch.awaitForElasticSearch();
         
         SearchResponse searchResponse = client.search(
@@ -101,10 +104,10 @@ public class ElasticSearchIndexerTest {
     public void updateMessages() throws Exception {
         String content = "{\"message\": \"trying out Elasticsearch\",\"field\":\"Should be unchanged\"}";
 
-        testee.index(DOCUMENT_ID, content, RoutingKey.useDocumentId(DOCUMENT_ID));
+        testee.index(DOCUMENT_ID, content, useDocumentId(DOCUMENT_ID));
         elasticSearch.awaitForElasticSearch();
 
-        testee.update(ImmutableList.of(new UpdatedRepresentation(DOCUMENT_ID, "{\"message\": \"mastering out Elasticsearch\"}")), RoutingKey.useDocumentId(DOCUMENT_ID));
+        testee.update(ImmutableList.of(new UpdatedRepresentation(DOCUMENT_ID, "{\"message\": \"mastering out Elasticsearch\"}")), useDocumentId(DOCUMENT_ID));
         elasticSearch.awaitForElasticSearch();
 
 
@@ -153,7 +156,7 @@ public class ElasticSearchIndexerTest {
     public void deleteByQueryShouldWorkOnSingleMessage() throws Exception {
         DocumentId documentId =  DocumentId.fromString("1:2");
         String content = "{\"message\": \"trying out Elasticsearch\", \"property\":\"1\"}";
-        RoutingKey routingKey = RoutingKey.useDocumentId(documentId);
+        RoutingKey routingKey = useDocumentId(documentId);
 
         testee.index(documentId, content, routingKey);
         elasticSearch.awaitForElasticSearch();
@@ -203,10 +206,10 @@ public class ElasticSearchIndexerTest {
         DocumentId documentId = DocumentId.fromString("1:2");
         String content = "{\"message\": \"trying out Elasticsearch\"}";
 
-        testee.index(documentId, content, RoutingKey.useDocumentId(documentId));
+        testee.index(documentId, content, useDocumentId(documentId));
         elasticSearch.awaitForElasticSearch();
 
-        testee.delete(ImmutableList.of(documentId), RoutingKey.useDocumentId(documentId));
+        testee.delete(ImmutableList.of(documentId), useDocumentId(documentId));
         elasticSearch.awaitForElasticSearch();
         
         SearchResponse searchResponse = client.search(

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/ElasticSearchIndexerTest.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/ElasticSearchIndexerTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.backends.es;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Duration.ONE_HUNDRED_MILLISECONDS;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
@@ -52,6 +53,8 @@ public class ElasticSearchIndexerTest {
         .with().pollInterval(ONE_HUNDRED_MILLISECONDS)
         .and().pollDelay(ONE_HUNDRED_MILLISECONDS)
         .await();
+    private static final RoutingKey ROUTING = RoutingKey.fromString("routing");
+    private static final DocumentId DOCUMENT_ID = DocumentId.fromString("1");
 
     @Rule
     public DockerElasticSearchRule elasticSearch = new DockerElasticSearchRule();
@@ -75,10 +78,10 @@ public class ElasticSearchIndexerTest {
 
     @Test
     public void indexMessageShouldWork() throws Exception {
-        String messageId = "1";
+        DocumentId documentId = DocumentId.fromString("1");
         String content = "{\"message\": \"trying out Elasticsearch\"}";
         
-        testee.index(messageId, content);
+        testee.index(documentId, content, RoutingKey.useDocumentId(documentId));
         elasticSearch.awaitForElasticSearch();
         
         SearchResponse searchResponse = client.search(
@@ -90,19 +93,18 @@ public class ElasticSearchIndexerTest {
     
     @Test
     public void indexMessageShouldThrowWhenJsonIsNull() {
-        assertThatThrownBy(() -> testee.index("1", null))
+        assertThatThrownBy(() -> testee.index(DOCUMENT_ID, null, ROUTING))
             .isInstanceOf(IllegalArgumentException.class);
     }
     
     @Test
     public void updateMessages() throws Exception {
-        String messageId = "1";
         String content = "{\"message\": \"trying out Elasticsearch\",\"field\":\"Should be unchanged\"}";
 
-        testee.index(messageId, content);
+        testee.index(DOCUMENT_ID, content, RoutingKey.useDocumentId(DOCUMENT_ID));
         elasticSearch.awaitForElasticSearch();
 
-        testee.update(ImmutableList.of(new UpdatedRepresentation(messageId, "{\"message\": \"mastering out Elasticsearch\"}")));
+        testee.update(ImmutableList.of(new UpdatedRepresentation(DOCUMENT_ID, "{\"message\": \"mastering out Elasticsearch\"}")), RoutingKey.useDocumentId(DOCUMENT_ID));
         elasticSearch.awaitForElasticSearch();
 
 
@@ -121,37 +123,42 @@ public class ElasticSearchIndexerTest {
 
     @Test
     public void updateMessageShouldThrowWhenJsonIsNull() {
-        assertThatThrownBy(() -> testee.update(ImmutableList.of(new UpdatedRepresentation("1", null))))
+        assertThatThrownBy(() -> testee.update(ImmutableList.of(
+                new UpdatedRepresentation(DOCUMENT_ID, null)), ROUTING))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void updateMessageShouldThrowWhenIdIsNull() {
-        assertThatThrownBy(() -> testee.update(ImmutableList.of(new UpdatedRepresentation(null, "{\"message\": \"mastering out Elasticsearch\"}"))))
-            .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> testee.update(ImmutableList.of(
+                new UpdatedRepresentation(null, "{\"message\": \"mastering out Elasticsearch\"}")), ROUTING))
+            .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     public void updateMessageShouldThrowWhenJsonIsEmpty() {
-        assertThatThrownBy(() -> testee.update(ImmutableList.of(new UpdatedRepresentation("1", ""))))
+        assertThatThrownBy(() -> testee.update(ImmutableList.of(
+                new UpdatedRepresentation(DOCUMENT_ID, "")), ROUTING))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void updateMessageShouldThrowWhenIdIsEmpty() {
-        assertThatThrownBy(() -> testee.update(ImmutableList.of(new UpdatedRepresentation("", "{\"message\": \"mastering out Elasticsearch\"}"))))
-            .isInstanceOf(IllegalArgumentException.class);
+    public void updateMessageShouldThrowWhenRoutingKeyIsNull() {
+        assertThatThrownBy(() -> testee.update(ImmutableList.of(
+                new UpdatedRepresentation(DOCUMENT_ID, "{\"message\": \"mastering out Elasticsearch\"}")), null))
+            .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     public void deleteByQueryShouldWorkOnSingleMessage() throws Exception {
-        String messageId = "1:2";
+        DocumentId documentId =  DocumentId.fromString("1:2");
         String content = "{\"message\": \"trying out Elasticsearch\", \"property\":\"1\"}";
+        RoutingKey routingKey = RoutingKey.useDocumentId(documentId);
 
-        testee.index(messageId, content);
+        testee.index(documentId, content, routingKey);
         elasticSearch.awaitForElasticSearch();
         
-        testee.deleteAllMatchingQuery(termQuery("property", "1"));
+        testee.deleteAllMatchingQuery(termQuery("property", "1"), routingKey);
         elasticSearch.awaitForElasticSearch();
         
         CALMLY_AWAIT.atMost(Duration.TEN_SECONDS)
@@ -164,23 +171,23 @@ public class ElasticSearchIndexerTest {
 
     @Test
     public void deleteByQueryShouldWorkWhenMultipleMessages() throws Exception {
-        String messageId = "1:1";
+        DocumentId documentId = DocumentId.fromString("1:1");
         String content = "{\"message\": \"trying out Elasticsearch\", \"property\":\"1\"}";
         
-        testee.index(messageId, content);
-        
-        String messageId2 = "1:2";
+        testee.index(documentId, content, ROUTING);
+
+        DocumentId documentId2 = DocumentId.fromString("1:2");
         String content2 = "{\"message\": \"trying out Elasticsearch 2\", \"property\":\"1\"}";
         
-        testee.index(messageId2, content2);
-        
-        String messageId3 = "2:3";
+        testee.index(documentId2, content2, ROUTING);
+
+        DocumentId documentId3 = DocumentId.fromString("2:3");
         String content3 = "{\"message\": \"trying out Elasticsearch 3\", \"property\":\"2\"}";
         
-        testee.index(messageId3, content3);
+        testee.index(documentId3, content3, ROUTING);
         elasticSearch.awaitForElasticSearch();
 
-        testee.deleteAllMatchingQuery(termQuery("property", "1"));
+        testee.deleteAllMatchingQuery(termQuery("property", "1"), ROUTING);
         elasticSearch.awaitForElasticSearch();
         
         CALMLY_AWAIT.atMost(Duration.TEN_SECONDS)
@@ -193,13 +200,13 @@ public class ElasticSearchIndexerTest {
     
     @Test
     public void deleteMessage() throws Exception {
-        String messageId = "1:2";
+        DocumentId documentId = DocumentId.fromString("1:2");
         String content = "{\"message\": \"trying out Elasticsearch\"}";
 
-        testee.index(messageId, content);
+        testee.index(documentId, content, RoutingKey.useDocumentId(documentId));
         elasticSearch.awaitForElasticSearch();
 
-        testee.delete(ImmutableList.of(messageId));
+        testee.delete(ImmutableList.of(documentId), RoutingKey.useDocumentId(documentId));
         elasticSearch.awaitForElasticSearch();
         
         SearchResponse searchResponse = client.search(
@@ -211,23 +218,23 @@ public class ElasticSearchIndexerTest {
 
     @Test
     public void deleteShouldWorkWhenMultipleMessages() throws Exception {
-        String messageId = "1:1";
+        DocumentId documentId = DocumentId.fromString("1:1");
         String content = "{\"message\": \"trying out Elasticsearch\", \"mailboxId\":\"1\"}";
 
-        testee.index(messageId, content);
+        testee.index(documentId, content, ROUTING);
 
-        String messageId2 = "1:2";
+        DocumentId documentId2 = DocumentId.fromString("1:2");
         String content2 = "{\"message\": \"trying out Elasticsearch 2\", \"mailboxId\":\"1\"}";
 
-        testee.index(messageId2, content2);
+        testee.index(documentId2, content2, ROUTING);
 
-        String messageId3 = "2:3";
+        DocumentId documentId3 = DocumentId.fromString("2:3");
         String content3 = "{\"message\": \"trying out Elasticsearch 3\", \"mailboxId\":\"2\"}";
 
-        testee.index(messageId3, content3);
+        testee.index(documentId3, content3, ROUTING);
         elasticSearch.awaitForElasticSearch();
 
-        testee.delete(ImmutableList.of(messageId, messageId3));
+        testee.delete(ImmutableList.of(documentId, documentId3), ROUTING);
         elasticSearch.awaitForElasticSearch();
 
         SearchResponse searchResponse = client.search(
@@ -238,12 +245,14 @@ public class ElasticSearchIndexerTest {
     }
     
     @Test
-    public void updateMessagesShouldNotThrowWhenEmptyList() throws Exception {
-        testee.update(ImmutableList.of());
+    public void updateMessagesShouldNotThrowWhenEmptyList() {
+        assertThatCode(() -> testee.update(ImmutableList.of(), ROUTING))
+            .doesNotThrowAnyException();
     }
     
     @Test
-    public void deleteMessagesShouldNotThrowWhenEmptyList() throws Exception {
-        testee.delete(ImmutableList.of());
+    public void deleteMessagesShouldNotThrowWhenEmptyList() {
+        assertThatCode(() -> testee.delete(ImmutableList.of(), ROUTING))
+            .doesNotThrowAnyException();
     }
 }

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/RoutingKeyTest.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/RoutingKeyTest.java
@@ -27,7 +27,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 
 class RoutingKeyTest {
     @Test
-    void documentIdShouldRespectBeanContract() {
+    void routingKeyShouldRespectBeanContract() {
         EqualsVerifier.forClass(RoutingKey.class)
             .verify();
     }

--- a/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/RoutingKeyTest.java
+++ b/backends-common/elasticsearch/src/test/java/org/apache/james/backends/es/RoutingKeyTest.java
@@ -1,0 +1,46 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.es;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class RoutingKeyTest {
+    @Test
+    void documentIdShouldRespectBeanContract() {
+        EqualsVerifier.forClass(RoutingKey.class)
+            .verify();
+    }
+
+    @Test
+    void fromStringShouldThrowWhenNull() {
+        assertThatThrownBy(() -> RoutingKey.fromString(null))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void fromStringShouldThrowWhenEmpty() {
+        assertThatThrownBy(() -> RoutingKey.fromString(""))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/MailboxIdRoutingKeyFactory.java
+++ b/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/MailboxIdRoutingKeyFactory.java
@@ -17,50 +17,14 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.backends.es;
+package org.apache.james.mailbox.elasticsearch;
 
-import java.util.Objects;
+import org.apache.james.backends.es.RoutingKey;
+import org.apache.james.mailbox.model.MailboxId;
 
-import org.elasticsearch.common.Strings;
-
-import com.google.common.base.Preconditions;
-
-public class RoutingKey {
-    public interface Factory<T> {
-        RoutingKey from(T t);
-    }
-
-    public static RoutingKey fromString(String value) {
-        return new RoutingKey(value);
-    }
-
-    public static RoutingKey useDocumentId(DocumentId documentId) {
-        return fromString(documentId.asString());
-    }
-
-    private final String value;
-
-    private RoutingKey(String value) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(value), "RoutingKey must be specified");
-        this.value = value;
-    }
-
-    public String asString() {
-        return value;
-    }
-
+public class MailboxIdRoutingKeyFactory implements RoutingKey.Factory<MailboxId> {
     @Override
-    public final boolean equals(Object o) {
-        if (o instanceof RoutingKey) {
-            RoutingKey that = (RoutingKey) o;
-
-            return Objects.equals(this.value, that.value);
-        }
-        return false;
-    }
-
-    @Override
-    public final int hashCode() {
-        return Objects.hash(value);
+    public RoutingKey from(MailboxId mailboxId) {
+        return RoutingKey.fromString(mailboxId.serialize());
     }
 }

--- a/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/MailboxMappingFactory.java
+++ b/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/MailboxMappingFactory.java
@@ -33,6 +33,8 @@ import static org.apache.james.backends.es.NodeMappingFactory.NESTED;
 import static org.apache.james.backends.es.NodeMappingFactory.NORMALIZER;
 import static org.apache.james.backends.es.NodeMappingFactory.PROPERTIES;
 import static org.apache.james.backends.es.NodeMappingFactory.RAW;
+import static org.apache.james.backends.es.NodeMappingFactory.REQUIRED;
+import static org.apache.james.backends.es.NodeMappingFactory.ROUTING;
 import static org.apache.james.backends.es.NodeMappingFactory.SEARCH_ANALYZER;
 import static org.apache.james.backends.es.NodeMappingFactory.SNOWBALL;
 import static org.apache.james.backends.es.NodeMappingFactory.SPLIT_EMAIL;
@@ -87,6 +89,10 @@ public class MailboxMappingFactory {
                 .startObject()
 
                     .field("dynamic", "strict")
+
+                    .startObject(ROUTING)
+                        .field(REQUIRED, true)
+                    .endObject()
 
                     .startObject(PROPERTIES)
 

--- a/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/search/ElasticSearchSearcher.java
+++ b/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/search/ElasticSearchSearcher.java
@@ -82,9 +82,9 @@ public class ElasticSearchSearcher {
             .orElse(pairStream);
     }
 
-    private SearchRequest prepareSearch(Collection<MailboxId> users, SearchQuery query, Optional<Integer> limit) {
+    private SearchRequest prepareSearch(Collection<MailboxId> mailboxIds, SearchQuery query, Optional<Integer> limit) {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-            .query(queryConverter.from(users, query))
+            .query(queryConverter.from(mailboxIds, query))
             .size(computeRequiredSize(limit))
             .storedFields(STORED_FIELDS);
 
@@ -96,7 +96,12 @@ public class ElasticSearchSearcher {
         return new SearchRequest(aliasName.getValue())
             .types(NodeMappingFactory.DEFAULT_MAPPING_NAME)
             .scroll(TIMEOUT)
-            .source(searchSourceBuilder);
+            .source(searchSourceBuilder)
+            .routing(toRoutingKeys(mailboxIds));
+    }
+
+    private String[] toRoutingKeys(Collection<MailboxId> mailboxIds) {
+        return mailboxIds.stream().map(MailboxId::serialize).toArray(String[]::new);
     }
 
     private int computeRequiredSize(Optional<Integer> limit) {

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/ElasticSearchIntegrationTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/ElasticSearchIntegrationTest.java
@@ -97,6 +97,7 @@ public class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest
             elasticSearch.getDockerElasticSearch().configuration());
 
         InMemoryMessageId.Factory messageIdFactory = new InMemoryMessageId.Factory();
+        MailboxIdRoutingKeyFactory routingKeyFactory = new MailboxIdRoutingKeyFactory();
 
         InMemoryIntegrationResources resources = InMemoryIntegrationResources.builder()
             .preProvisionnedFakeAuthenticator()
@@ -111,9 +112,9 @@ public class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest
                     BATCH_SIZE),
                 new ElasticSearchSearcher(client, new QueryConverter(new CriterionConverter()), SEARCH_SIZE,
                     new InMemoryId.Factory(), messageIdFactory,
-                    MailboxElasticSearchConstants.DEFAULT_MAILBOX_READ_ALIAS),
+                    MailboxElasticSearchConstants.DEFAULT_MAILBOX_READ_ALIAS, routingKeyFactory),
                 new MessageToElasticSearchJson(textExtractor, ZoneId.of("Europe/Paris"), IndexAttachments.YES),
-                preInstanciationStage.getSessionProvider()))
+                preInstanciationStage.getSessionProvider(), routingKeyFactory))
             .noPreDeletionHooks()
             .storeQuotaManager()
             .build();

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/MailboxIdRoutingKeyFactoryTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/MailboxIdRoutingKeyFactoryTest.java
@@ -17,50 +17,18 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.backends.es;
+package org.apache.james.mailbox.elasticsearch;
 
-import java.util.Objects;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.elasticsearch.common.Strings;
+import org.apache.james.backends.es.RoutingKey;
+import org.apache.james.mailbox.model.TestId;
+import org.junit.jupiter.api.Test;
 
-import com.google.common.base.Preconditions;
-
-public class RoutingKey {
-    public interface Factory<T> {
-        RoutingKey from(T t);
-    }
-
-    public static RoutingKey fromString(String value) {
-        return new RoutingKey(value);
-    }
-
-    public static RoutingKey useDocumentId(DocumentId documentId) {
-        return fromString(documentId.asString());
-    }
-
-    private final String value;
-
-    private RoutingKey(String value) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(value), "RoutingKey must be specified");
-        this.value = value;
-    }
-
-    public String asString() {
-        return value;
-    }
-
-    @Override
-    public final boolean equals(Object o) {
-        if (o instanceof RoutingKey) {
-            RoutingKey that = (RoutingKey) o;
-
-            return Objects.equals(this.value, that.value);
-        }
-        return false;
-    }
-
-    @Override
-    public final int hashCode() {
-        return Objects.hash(value);
+class MailboxIdRoutingKeyFactoryTest {
+    @Test
+    void fromShouldRelyOnSerializedMailboxId() {
+        assertThat(new MailboxIdRoutingKeyFactory().from(TestId.of(5)))
+            .isEqualTo(RoutingKey.fromString("5"));
     }
 }

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndexTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndexTest.java
@@ -38,6 +38,7 @@ import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.elasticsearch.IndexAttachments;
 import org.apache.james.mailbox.elasticsearch.MailboxElasticSearchConstants;
+import org.apache.james.mailbox.elasticsearch.MailboxIdRoutingKeyFactory;
 import org.apache.james.mailbox.elasticsearch.MailboxIndexCreationUtil;
 import org.apache.james.mailbox.elasticsearch.json.MessageToElasticSearchJson;
 import org.apache.james.mailbox.elasticsearch.query.CriterionConverter;
@@ -160,7 +161,8 @@ public class ElasticSearchListeningMessageSearchIndexTest {
             ElasticSearchSearcher.DEFAULT_SEARCH_SIZE,
             new InMemoryId.Factory(),
             messageIdFactory,
-            MailboxElasticSearchConstants.DEFAULT_MAILBOX_READ_ALIAS);
+            MailboxElasticSearchConstants.DEFAULT_MAILBOX_READ_ALIAS,
+            new MailboxIdRoutingKeyFactory());
 
         FakeAuthenticator fakeAuthenticator = new FakeAuthenticator();
         fakeAuthenticator.addUser(ManagerTestProvisionner.USER, ManagerTestProvisionner.USER_PASS);
@@ -170,7 +172,7 @@ public class ElasticSearchListeningMessageSearchIndexTest {
         elasticSearchIndexer = new ElasticSearchIndexer(client, MailboxElasticSearchConstants.DEFAULT_MAILBOX_WRITE_ALIAS);
         
         testee = new ElasticSearchListeningMessageSearchIndex(mapperFactory, elasticSearchIndexer, elasticSearchSearcher,
-            messageToElasticSearchJson, sessionProvider);
+            messageToElasticSearchJson, sessionProvider, new MailboxIdRoutingKeyFactory());
         session = sessionProvider.createSystemSession(USERNAME);
 
         mailbox = new Mailbox(MailboxPath.forUser(USERNAME, DefaultMailboxes.INBOX), MAILBOX_ID.id);
@@ -236,7 +238,7 @@ public class ElasticSearchListeningMessageSearchIndexTest {
             IndexAttachments.YES);
 
         testee = new ElasticSearchListeningMessageSearchIndex(mapperFactory, elasticSearchIndexer, elasticSearchSearcher,
-            messageToElasticSearchJson, sessionProvider);
+            messageToElasticSearchJson, sessionProvider, new MailboxIdRoutingKeyFactory());
 
         testee.add(session, mailbox, MESSAGE_WITH_ATTACHMENT);
         elasticSearch.awaitForElasticSearch();

--- a/mailbox/plugin/quota-search-elasticsearch/src/main/java/org/apache/james/quota/search/elasticsearch/QuotaRatioMappingFactory.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/main/java/org/apache/james/quota/search/elasticsearch/QuotaRatioMappingFactory.java
@@ -40,11 +40,11 @@ class QuotaRatioMappingFactory {
         try {
             return jsonBuilder()
                 .startObject()
-                .startObject(ROUTING)
-                    .field(REQUIRED, true)
-                .endObject()
+                    .startObject(ROUTING)
+                        .field(REQUIRED, true)
+                    .endObject()
 
-                .startObject(PROPERTIES)
+                    .startObject(PROPERTIES)
 
                         .startObject(USER)
                             .field(TYPE, KEYWORD)

--- a/mailbox/plugin/quota-search-elasticsearch/src/main/java/org/apache/james/quota/search/elasticsearch/QuotaRatioMappingFactory.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/main/java/org/apache/james/quota/search/elasticsearch/QuotaRatioMappingFactory.java
@@ -22,6 +22,8 @@ package org.apache.james.quota.search.elasticsearch;
 import static org.apache.james.backends.es.NodeMappingFactory.DOUBLE;
 import static org.apache.james.backends.es.NodeMappingFactory.KEYWORD;
 import static org.apache.james.backends.es.NodeMappingFactory.PROPERTIES;
+import static org.apache.james.backends.es.NodeMappingFactory.REQUIRED;
+import static org.apache.james.backends.es.NodeMappingFactory.ROUTING;
 import static org.apache.james.backends.es.NodeMappingFactory.TYPE;
 import static org.apache.james.quota.search.elasticsearch.json.JsonMessageConstants.DOMAIN;
 import static org.apache.james.quota.search.elasticsearch.json.JsonMessageConstants.QUOTA_RATIO;
@@ -38,7 +40,11 @@ class QuotaRatioMappingFactory {
         try {
             return jsonBuilder()
                 .startObject()
-                    .startObject(PROPERTIES)
+                .startObject(ROUTING)
+                    .field(REQUIRED, true)
+                .endObject()
+
+                .startObject(PROPERTIES)
 
                         .startObject(USER)
                             .field(TYPE, KEYWORD)

--- a/mailbox/plugin/quota-search-elasticsearch/src/main/java/org/apache/james/quota/search/elasticsearch/UserRoutingKeyFactory.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/main/java/org/apache/james/quota/search/elasticsearch/UserRoutingKeyFactory.java
@@ -17,50 +17,14 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.backends.es;
+package org.apache.james.quota.search.elasticsearch;
 
-import java.util.Objects;
+import org.apache.james.backends.es.RoutingKey;
+import org.apache.james.core.User;
 
-import org.elasticsearch.common.Strings;
-
-import com.google.common.base.Preconditions;
-
-public class RoutingKey {
-    public interface Factory<T> {
-        RoutingKey from(T t);
-    }
-
-    public static RoutingKey fromString(String value) {
-        return new RoutingKey(value);
-    }
-
-    public static RoutingKey useDocumentId(DocumentId documentId) {
-        return fromString(documentId.asString());
-    }
-
-    private final String value;
-
-    private RoutingKey(String value) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(value), "RoutingKey must be specified");
-        this.value = value;
-    }
-
-    public String asString() {
-        return value;
-    }
-
+public class UserRoutingKeyFactory implements RoutingKey.Factory<User> {
     @Override
-    public final boolean equals(Object o) {
-        if (o instanceof RoutingKey) {
-            RoutingKey that = (RoutingKey) o;
-
-            return Objects.equals(this.value, that.value);
-        }
-        return false;
-    }
-
-    @Override
-    public final int hashCode() {
-        return Objects.hash(value);
+    public RoutingKey from(User user) {
+        return RoutingKey.fromString(user.asString());
     }
 }

--- a/mailbox/plugin/quota-search-elasticsearch/src/main/java/org/apache/james/quota/search/elasticsearch/events/ElasticSearchQuotaMailboxListener.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/main/java/org/apache/james/quota/search/elasticsearch/events/ElasticSearchQuotaMailboxListener.java
@@ -23,7 +23,10 @@ import java.io.IOException;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.apache.james.backends.es.DocumentId;
 import org.apache.james.backends.es.ElasticSearchIndexer;
+import org.apache.james.backends.es.RoutingKey;
+import org.apache.james.core.User;
 import org.apache.james.mailbox.events.Event;
 import org.apache.james.mailbox.events.Group;
 import org.apache.james.mailbox.events.MailboxListener;
@@ -64,7 +67,17 @@ public class ElasticSearchQuotaMailboxListener implements MailboxListener.GroupM
     }
 
     private void handleEvent(QuotaUsageUpdatedEvent event) throws IOException {
-        indexer.index(event.getUser().asString(),
-            quotaRatioToElasticSearchJson.convertToJson(event));
+        User user = event.getUser();
+        indexer.index(toDocumentId(user),
+            quotaRatioToElasticSearchJson.convertToJson(event),
+            toRoutingKey(user));
+    }
+
+    private RoutingKey toRoutingKey(User user) {
+        return RoutingKey.fromString(user.asString());
+    }
+
+    private DocumentId toDocumentId(User user) {
+        return DocumentId.fromString(user.asString());
     }
 }

--- a/mailbox/plugin/quota-search-elasticsearch/src/main/java/org/apache/james/quota/search/elasticsearch/events/ElasticSearchQuotaMailboxListener.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/main/java/org/apache/james/quota/search/elasticsearch/events/ElasticSearchQuotaMailboxListener.java
@@ -42,13 +42,15 @@ public class ElasticSearchQuotaMailboxListener implements MailboxListener.GroupM
 
     private final ElasticSearchIndexer indexer;
     private final QuotaRatioToElasticSearchJson quotaRatioToElasticSearchJson;
+    private final RoutingKey.Factory<User> routingKeyFactory;
 
     @Inject
-    public ElasticSearchQuotaMailboxListener(
-        @Named(QuotaRatioElasticSearchConstants.InjectionNames.QUOTA_RATIO) ElasticSearchIndexer indexer,
-        QuotaRatioToElasticSearchJson quotaRatioToElasticSearchJson) {
+    public ElasticSearchQuotaMailboxListener(@Named(QuotaRatioElasticSearchConstants.InjectionNames.QUOTA_RATIO) ElasticSearchIndexer indexer,
+                                             QuotaRatioToElasticSearchJson quotaRatioToElasticSearchJson,
+                                             RoutingKey.Factory<User> routingKeyFactory) {
         this.indexer = indexer;
         this.quotaRatioToElasticSearchJson = quotaRatioToElasticSearchJson;
+        this.routingKeyFactory = routingKeyFactory;
     }
 
     @Override
@@ -70,11 +72,7 @@ public class ElasticSearchQuotaMailboxListener implements MailboxListener.GroupM
         User user = event.getUser();
         indexer.index(toDocumentId(user),
             quotaRatioToElasticSearchJson.convertToJson(event),
-            toRoutingKey(user));
-    }
-
-    private RoutingKey toRoutingKey(User user) {
-        return RoutingKey.fromString(user.asString());
+            routingKeyFactory.from(user));
     }
 
     private DocumentId toDocumentId(User user) {

--- a/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/ElasticSearchQuotaSearchTestSystemExtension.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/ElasticSearchQuotaSearchTestSystemExtension.java
@@ -70,7 +70,8 @@ public class ElasticSearchQuotaSearchTestSystemExtension implements ParameterRes
             ElasticSearchQuotaMailboxListener listener = new ElasticSearchQuotaMailboxListener(
                 new ElasticSearchIndexer(client,
                     QuotaRatioElasticSearchConstants.DEFAULT_QUOTA_RATIO_WRITE_ALIAS),
-                new QuotaRatioToElasticSearchJson());
+                new QuotaRatioToElasticSearchJson(),
+                new UserRoutingKeyFactory());
 
             resources.getMailboxManager().getEventBus().register(listener);
 

--- a/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/UserRoutingKeyFactoryTest.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/UserRoutingKeyFactoryTest.java
@@ -17,50 +17,18 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.backends.es;
+package org.apache.james.quota.search.elasticsearch;
 
-import java.util.Objects;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.elasticsearch.common.Strings;
+import org.apache.james.backends.es.RoutingKey;
+import org.apache.james.core.User;
+import org.junit.jupiter.api.Test;
 
-import com.google.common.base.Preconditions;
-
-public class RoutingKey {
-    public interface Factory<T> {
-        RoutingKey from(T t);
-    }
-
-    public static RoutingKey fromString(String value) {
-        return new RoutingKey(value);
-    }
-
-    public static RoutingKey useDocumentId(DocumentId documentId) {
-        return fromString(documentId.asString());
-    }
-
-    private final String value;
-
-    private RoutingKey(String value) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(value), "RoutingKey must be specified");
-        this.value = value;
-    }
-
-    public String asString() {
-        return value;
-    }
-
-    @Override
-    public final boolean equals(Object o) {
-        if (o instanceof RoutingKey) {
-            RoutingKey that = (RoutingKey) o;
-
-            return Objects.equals(this.value, that.value);
-        }
-        return false;
-    }
-
-    @Override
-    public final int hashCode() {
-        return Objects.hash(value);
+class UserRoutingKeyFactoryTest {
+    @Test
+    void fromShouldRelyOnUsername() {
+        assertThat(new UserRoutingKeyFactory().from(User.fromUsername("bob")))
+            .isEqualTo(RoutingKey.fromString("bob"));
     }
 }

--- a/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/events/ElasticSearchQuotaMailboxListenerTest.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/events/ElasticSearchQuotaMailboxListenerTest.java
@@ -37,6 +37,7 @@ import org.apache.james.mailbox.quota.QuotaFixture.Sizes;
 import org.apache.james.mailbox.store.event.EventFactory;
 import org.apache.james.quota.search.elasticsearch.QuotaRatioElasticSearchConstants;
 import org.apache.james.quota.search.elasticsearch.QuotaSearchIndexCreationUtil;
+import org.apache.james.quota.search.elasticsearch.UserRoutingKeyFactory;
 import org.apache.james.quota.search.elasticsearch.json.QuotaRatioToElasticSearchJson;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -70,7 +71,8 @@ public class ElasticSearchQuotaMailboxListenerTest {
             new ElasticSearchIndexer(client,
                 QuotaRatioElasticSearchConstants.DEFAULT_QUOTA_RATIO_WRITE_ALIAS,
                 BATCH_SIZE),
-            new QuotaRatioToElasticSearchJson());
+            new QuotaRatioToElasticSearchJson(),
+            new UserRoutingKeyFactory());
     }
 
     @After

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/AbstractMessageSearchIndexTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/AbstractMessageSearchIndexTest.java
@@ -1115,9 +1115,9 @@ public abstract class AbstractMessageSearchIndexTest {
         assertThat(messageSearchIndex.search(session, mailbox, searchQuery))
             .containsExactly(m5.getUid(), m3.getUid(), m2.getUid(), m4.getUid());
         // 5 : "zzz" <mailet-api@james.apache.org>
-        // 3 : "aaa" <server-dev@james.apache.org>
-        // 2 : "abc" <server-dev@james.apache.org>
-        // 4 : "server" <server-dev@james.apache.org>
+        // 3 : "aaa" <a-server-dev@james.apache.org>
+        // 2 : "abc" <b-server-dev@james.apache.org>
+        // 4 : "server" <c-server-dev@james.apache.org>
     }
 
     @Test

--- a/mailbox/store/src/test/resources/eml/mail1.eml
+++ b/mailbox/store/src/test/resources/eml/mail1.eml
@@ -34,7 +34,7 @@ Received: from arcas.apache.org (HELO arcas.apache.org) (140.211.11.28)
     by apache.org (qpsmtpd/0.29) with ESMTP; Thu, 04 Jun 2015 09:23:38 +0000
 Date: Thu, 4 Jun 2015 09:23:37 +0000 (UTC)
 From: "Tellier Benoit (JIRA)" <jira2@apache.org>
-To: "abc" <server-dev@james.apache.org>
+To: "abc" <b-server-dev@james.apache.org>
 Message-ID: <JIRA.12835341.1433409792000.9340.1433409817961@Atlassian.JIRA>
 In-Reply-To: <JIRA.12835341.1433409792000@Atlassian.JIRA>
 References: <JIRA.12835341.1433409792000@Atlassian.JIRA> <JIRA.12835341.1433409792972@arcas>

--- a/mailbox/store/src/test/resources/eml/mail2.eml
+++ b/mailbox/store/src/test/resources/eml/mail2.eml
@@ -34,7 +34,7 @@ Received: from arcas.apache.org (HELO arcas.apache.org) (140.211.11.28)
     by apache.org (qpsmtpd/0.29) with ESMTP; Thu, 04 Jun 2015 09:27:38 +0000
 Date: Thu, 4 Jun 2015 09:27:37 +0000 (UTC)
 From: "efij" <jira1@apache.org>
-To: "aaa" <server-dev@james.apache.org>
+To: "aaa" <a-server-dev@james.apache.org>
 Cc: abc@abc.org
 Message-ID: <JIRA.12781874.1426269127000.9353.1433410057953@Atlassian.JIRA>
 In-Reply-To: <JIRA.12781874.1426269127000@Atlassian.JIRA>

--- a/mailbox/store/src/test/resources/eml/mail3.eml
+++ b/mailbox/store/src/test/resources/eml/mail3.eml
@@ -37,7 +37,7 @@ Received: from arcas.apache.org (HELO arcas.apache.org) (140.211.11.28)
 Date: Tue, 2 Jun 2015 08:16:19 +0000 (UTC)
 From: "abcd" <jira@apache.org>
 Cc: zzz@bcd.org
-To: "server" <server-dev@james.apache.org>
+To: "server" <c-server-dev@james.apache.org>
 Message-ID: <JIRA.12473940.1284322083000.91735.1433232979714@Atlassian.JIRA>
 In-Reply-To: <JIRA.12473940.1284322083000@Atlassian.JIRA>
 References: <JIRA.12473940.1284322083000@Atlassian.JIRA> <JIRA.12473940.1284322083687@arcas>

--- a/mailbox/store/src/test/resources/eml/mail4.eml
+++ b/mailbox/store/src/test/resources/eml/mail4.eml
@@ -36,7 +36,7 @@ Received: from arcas.apache.org (HELO arcas.apache.org) (140.211.11.28)
     by apache.org (qpsmtpd/0.29) with ESMTP; Fri, 15 May 2015 06:36:00 +0000
 Date: Fri, 15 May 2015 06:35:59 +0000 (UTC)
 From: "Eric Charles (JIRA)" <mailet-api@james.apache.org>
-To: "zzz" <mailet-api@james.apache.org>
+To: "zzz" <a-mailet-api@james.apache.org>
 Cc: monkey@any.com
 Bcc: monkey@any.com
 Message-ID: <JIRA.12825882.1430301328000.124152.1431671759942@Atlassian.JIRA>

--- a/mpt/impl/imap-mailbox/elasticsearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/host/ElasticSearchHostSystem.java
+++ b/mpt/impl/imap-mailbox/elasticsearch/src/test/java/org/apache/james/mpt/imapmailbox/elasticsearch/host/ElasticSearchHostSystem.java
@@ -36,6 +36,7 @@ import org.apache.james.imap.processor.main.DefaultImapProcessorFactory;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.elasticsearch.IndexAttachments;
 import org.apache.james.mailbox.elasticsearch.MailboxElasticSearchConstants;
+import org.apache.james.mailbox.elasticsearch.MailboxIdRoutingKeyFactory;
 import org.apache.james.mailbox.elasticsearch.MailboxIndexCreationUtil;
 import org.apache.james.mailbox.elasticsearch.events.ElasticSearchListeningMessageSearchIndex;
 import org.apache.james.mailbox.elasticsearch.json.MessageToElasticSearchJson;
@@ -86,6 +87,7 @@ public class ElasticSearchHostSystem extends JamesImapHostSystem {
                 .build());
 
         InMemoryMessageId.Factory messageIdFactory = new InMemoryMessageId.Factory();
+        MailboxIdRoutingKeyFactory routingKeyFactory = new MailboxIdRoutingKeyFactory();
 
         InMemoryIntegrationResources resources = InMemoryIntegrationResources.builder()
             .authenticator(authenticator)
@@ -99,9 +101,9 @@ public class ElasticSearchHostSystem extends JamesImapHostSystem {
                     MailboxElasticSearchConstants.DEFAULT_MAILBOX_WRITE_ALIAS),
                 new ElasticSearchSearcher(client, new QueryConverter(new CriterionConverter()), ElasticSearchSearcher.DEFAULT_SEARCH_SIZE,
                     new InMemoryId.Factory(), messageIdFactory,
-                    MailboxElasticSearchConstants.DEFAULT_MAILBOX_READ_ALIAS),
+                    MailboxElasticSearchConstants.DEFAULT_MAILBOX_READ_ALIAS, routingKeyFactory),
                 new MessageToElasticSearchJson(new DefaultTextExtractor(), ZoneId.of("Europe/Paris"), IndexAttachments.YES),
-                preInstanciationStage.getSessionProvider()))
+                preInstanciationStage.getSessionProvider(), routingKeyFactory))
             .noPreDeletionHooks()
             .storeQuotaManager()
             .build();

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/ElasticSearchMailboxModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/ElasticSearchMailboxModule.java
@@ -32,11 +32,13 @@ import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.james.backends.es.ElasticSearchConfiguration;
 import org.apache.james.backends.es.ElasticSearchIndexer;
+import org.apache.james.backends.es.RoutingKey;
 import org.apache.james.lifecycle.api.StartUpCheck;
 import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.mailbox.elasticsearch.ElasticSearchMailboxConfiguration;
 import org.apache.james.mailbox.elasticsearch.IndexAttachments;
 import org.apache.james.mailbox.elasticsearch.MailboxElasticSearchConstants;
+import org.apache.james.mailbox.elasticsearch.MailboxIdRoutingKeyFactory;
 import org.apache.james.mailbox.elasticsearch.MailboxIndexCreationUtil;
 import org.apache.james.mailbox.elasticsearch.events.ElasticSearchListeningMessageSearchIndex;
 import org.apache.james.mailbox.elasticsearch.query.QueryConverter;
@@ -55,6 +57,7 @@ import org.slf4j.LoggerFactory;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
 
 public class ElasticSearchMailboxModule extends AbstractModule {
@@ -114,6 +117,8 @@ public class ElasticSearchMailboxModule extends AbstractModule {
         bind(MessageSearchIndex.class).to(ElasticSearchListeningMessageSearchIndex.class);
         bind(ListeningMessageSearchIndex.class).to(ElasticSearchListeningMessageSearchIndex.class);
 
+        bind(new TypeLiteral<RoutingKey.Factory<MailboxId>>() {}).to(MailboxIdRoutingKeyFactory.class);
+
         Multibinder.newSetBinder(binder(), MailboxListener.GroupMailboxListener.class)
             .addBinding()
             .to(ElasticSearchListeningMessageSearchIndex.class);
@@ -143,14 +148,15 @@ public class ElasticSearchMailboxModule extends AbstractModule {
                                                                      QueryConverter queryConverter,
                                                                      MailboxId.Factory mailboxIdFactory,
                                                                      MessageId.Factory messageIdFactory,
-                                                                     ElasticSearchMailboxConfiguration configuration) {
+                                                                     ElasticSearchMailboxConfiguration configuration,
+                                                                     RoutingKey.Factory<MailboxId> routingKeyFactory) {
         return new ElasticSearchSearcher(
             client,
             queryConverter,
             DEFAULT_SEARCH_SIZE,
             mailboxIdFactory,
             messageIdFactory,
-            configuration.getReadAliasMailboxName());
+            configuration.getReadAliasMailboxName(), routingKeyFactory);
     }
 
     @Provides

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/ElasticSearchQuotaSearcherModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/ElasticSearchQuotaSearcherModule.java
@@ -36,6 +36,7 @@ import org.apache.james.quota.search.QuotaSearcher;
 import org.apache.james.quota.search.elasticsearch.ElasticSearchQuotaConfiguration;
 import org.apache.james.quota.search.elasticsearch.ElasticSearchQuotaSearcher;
 import org.apache.james.quota.search.elasticsearch.QuotaSearchIndexCreationUtil;
+import org.apache.james.quota.search.elasticsearch.UserRoutingKeyFactory;
 import org.apache.james.quota.search.elasticsearch.events.ElasticSearchQuotaMailboxListener;
 import org.apache.james.quota.search.elasticsearch.json.QuotaRatioToElasticSearchJson;
 import org.apache.james.utils.InitializationOperation;
@@ -132,6 +133,7 @@ public class ElasticSearchQuotaSearcherModule extends AbstractModule {
         return new ElasticSearchQuotaMailboxListener(
             new ElasticSearchIndexer(client,
                 configuration.getWriteAliasQuotaRatioName()),
-                new QuotaRatioToElasticSearchJson());
+                new QuotaRatioToElasticSearchJson(),
+            new UserRoutingKeyFactory());
     }
 }

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/ElasticSearchQuotaSearchExtension.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/ElasticSearchQuotaSearchExtension.java
@@ -35,6 +35,7 @@ import org.apache.james.quota.search.QuotaSearchTestSystem;
 import org.apache.james.quota.search.elasticsearch.ElasticSearchQuotaSearcher;
 import org.apache.james.quota.search.elasticsearch.QuotaRatioElasticSearchConstants;
 import org.apache.james.quota.search.elasticsearch.QuotaSearchIndexCreationUtil;
+import org.apache.james.quota.search.elasticsearch.UserRoutingKeyFactory;
 import org.apache.james.quota.search.elasticsearch.events.ElasticSearchQuotaMailboxListener;
 import org.apache.james.quota.search.elasticsearch.json.QuotaRatioToElasticSearchJson;
 import org.apache.james.user.memory.MemoryUsersRepository;
@@ -76,7 +77,8 @@ public class ElasticSearchQuotaSearchExtension implements ParameterResolver, Bef
 
             ElasticSearchQuotaMailboxListener listener = new ElasticSearchQuotaMailboxListener(
                 new ElasticSearchIndexer(client, QuotaRatioElasticSearchConstants.DEFAULT_QUOTA_RATIO_WRITE_ALIAS),
-                new QuotaRatioToElasticSearchJson());
+                new QuotaRatioToElasticSearchJson(),
+                new UserRoutingKeyFactory());
 
             resources.getMailboxManager().getEventBus().register(listener);
 

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -16,7 +16,29 @@ Changes to apply between 3.4.x and 3.5.x will be reported here.
 
 Change list:
 
+ - [ElasticSearch performance enhancements](#elasticsearch-performance-enhancements)
  - [JAMES-2703 Post 3.4.0 release removals](#james-2703-post-340-release-removals)
+ 
+### ElasticSearch performance enhancements
+
+Date 10/10/2019
+
+SHA-1 099f54459b
+
+JIRAS:
+ - https://issues.apache.org/jira/browse/JAMES-2917
+
+Concerned product: Guice product relying on ElasticSearch
+
+We significantly improved our usage of ElasticSearch. Underlying changes includes:
+
+ - The use of routing to collocate emails of a same mailbox within a same shard. This enables search queries to avoid cluster
+ level synchronisation, and thus enhance throughput, latencies and scalability.
+
+The downside of these changes is that a reindex is needed:
+ - Delete the indexes use by James
+ - Start James in order to create the missing indexes
+ - Trigger a [Full ReIndexing](https://james.apache.org/server/manage-webadmin.html#ReIndexing_all_mails)
  
 #### JAMES-2703 Post 3.4.0 release removals
 

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -36,7 +36,7 @@ We significantly improved our usage of ElasticSearch. Underlying changes include
  level synchronisation, and thus enhance throughput, latencies and scalability.
 
 The downside of these changes is that a reindex is needed:
- - Delete the indexes use by James
+ - Delete the indexes used by James
  - Start James in order to create the missing indexes
  - Trigger a [Full ReIndexing](https://james.apache.org/server/manage-webadmin.html#ReIndexing_all_mails)
  

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -35,10 +35,11 @@ We significantly improved our usage of ElasticSearch. Underlying changes include
  - The use of routing to collocate emails of a same mailbox within a same shard. This enables search queries to avoid cluster
  level synchronisation, and thus enhance throughput, latencies and scalability.
 
-The downside of these changes is that a reindex is needed:
+The downside of these changes is that a reindex is needed, implying a downtime on search:
  - Delete the indexes used by James
  - Start James in order to create the missing indexes
- - Trigger a [Full ReIndexing](https://james.apache.org/server/manage-webadmin.html#ReIndexing_all_mails)
+ - Trigger a [Full ReIndexing](https://james.apache.org/server/manage-webadmin.html#ReIndexing_all_mails), which can take
+  time to complete.
  
 #### JAMES-2703 Post 3.4.0 release removals
 

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -30,7 +30,7 @@ JIRAS:
 
 Concerned product: Guice product relying on ElasticSearch
 
-We significantly improved our usage of ElasticSearch. Underlying changes includes:
+We significantly improved our usage of ElasticSearch. Underlying changes include:
 
  - The use of routing to collocate emails of a same mailbox within a same shard. This enables search queries to avoid cluster
  level synchronisation, and thus enhance throughput, latencies and scalability.


### PR DESCRIPTION
Our queries are mostly bounded to a mailbox or an user. We can easily
limit the number of ElasticSearch nodes involved in a given query by
grouping the underlying documents on the same node using a routingKey.

Without routing key, each shard needs to execute the query. The coordinator
needs also to be waiting for the slowest shard.

Using the routing key unlocks significant throughput enhancement (proportional
to the number of shard) and also a possible high percentile latencies enhancement. This allows to be more lineary scalable.

However a data reindex is needed.
