### PR TITLE
POC Zero downtime ES schema change migration strategy

### DIFF
--- a/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndex.java
+++ b/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndex.java
@@ -61,13 +61,13 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 public class ElasticSearchListeningMessageSearchIndex extends ListeningMessageSearchIndex {
-    public static class ElasticSearchListeningMessageSearchIndexGroup extends Group {
+    public static class ElasticSearchListeningMessageSearchIndexGroupV2 extends Group {
 
     }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ElasticSearchListeningMessageSearchIndex.class);
     private static final String ID_SEPARATOR = ":";
-    private static final Group GROUP = new ElasticSearchListeningMessageSearchIndexGroup();
+    private static final Group GROUP = new ElasticSearchListeningMessageSearchIndexGroupV2();
 
     private final ElasticSearchIndexer elasticSearchIndexer;
     private final ElasticSearchSearcher searcher;

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndexTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndexTest.java
@@ -98,8 +98,8 @@ public class ElasticSearchListeningMessageSearchIndexTest {
 
     @Test
     public void deserializeElasticSearchListeningMessageSearchIndexGroup() throws Exception {
-        assertThat(Group.deserialize("org.apache.james.mailbox.elasticsearch.events.ElasticSearchListeningMessageSearchIndex$ElasticSearchListeningMessageSearchIndexGroup"))
-            .isEqualTo(new ElasticSearchListeningMessageSearchIndex.ElasticSearchListeningMessageSearchIndexGroup());
+        assertThat(Group.deserialize("org.apache.james.mailbox.elasticsearch.events.ElasticSearchListeningMessageSearchIndex$ElasticSearchListeningMessageSearchIndexGroupV2"))
+            .isEqualTo(new ElasticSearchListeningMessageSearchIndex.ElasticSearchListeningMessageSearchIndexGroupV2());
     }
     
     @Test


### PR DESCRIPTION
Rename ElasticSearchListeningMessageSearchIndex Group

This enables zero downtime schema migration.

If momentum builds around that proposal, I will write a full **procedure** page around re-indexing qnd better document that proposal.

ElasticSearch mailbox indexation uses a different group name before and
qfter the schema change

Given a James servers cluster prior the schema change:
 - Configure a new james server that we will name james-new ...
 - ... to be using a new non existing ElasticSearch index
 - james-new uses the same elasticsearch/cassandra/rabbitmq/object-storage
  than james cluster
 - Start james-new
 - james-new will create the new index with the new mapping
 - as james-new relies on a different group than james, james events are
 transmitted to james-new (and vice versa)
 - which means that new events are going to be indexed on james-new
 - trigger a full reindexing on james-new - this causes a moderate latency
  impact on james
 - finally, once fnished, remove james-new and perform a rolling upgrade
 of existing nodes that should now be configured to use the new index