### PR TITLE
JAMES-2079 ElasticSearch indexing RAW HTML & plain text is not required

### DIFF
--- a/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/MailboxMappingFactory.java
+++ b/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/MailboxMappingFactory.java
@@ -26,7 +26,6 @@ import static org.apache.james.backends.es.NodeMappingFactory.ANALYZER;
 import static org.apache.james.backends.es.NodeMappingFactory.BOOLEAN;
 import static org.apache.james.backends.es.NodeMappingFactory.FIELDS;
 import static org.apache.james.backends.es.NodeMappingFactory.FORMAT;
-import static org.apache.james.backends.es.NodeMappingFactory.IGNORE_ABOVE;
 import static org.apache.james.backends.es.NodeMappingFactory.KEYWORD;
 import static org.apache.james.backends.es.NodeMappingFactory.LONG;
 import static org.apache.james.backends.es.NodeMappingFactory.NESTED;
@@ -305,11 +304,6 @@ public class MailboxMappingFactory {
                                     .field(ANALYZER, STANDARD)
                                     .field(SEARCH_ANALYZER, KEEP_MAIL_AND_URL)
                                 .endObject()
-                                .startObject(RAW)
-                                    .field(TYPE, KEYWORD)
-                                    .field(NORMALIZER, CASE_INSENSITIVE)
-                                    .field(IGNORE_ABOVE, MAXIMUM_TERM_LENGTH)
-                                .endObject()
                             .endObject()
                         .endObject()
 
@@ -321,11 +315,6 @@ public class MailboxMappingFactory {
                                     .field(TYPE, TEXT)
                                     .field(ANALYZER, STANDARD)
                                     .field(SEARCH_ANALYZER, KEEP_MAIL_AND_URL)
-                                .endObject()
-                                .startObject(RAW)
-                                    .field(TYPE, KEYWORD)
-                                    .field(NORMALIZER, CASE_INSENSITIVE)
-                                    .field(IGNORE_ABOVE, MAXIMUM_TERM_LENGTH)
                                 .endObject()
                             .endObject()
                         .endObject()


### PR DESCRIPTION
RAW is kept for sorting (ie what is done with subject).

It results in duplicated storage, requiring additional indexing job and
wasting precious index space. Especially for fields that we can expect
to be large.