### PR TITLE
JAMES-2704 Random storing can leave some mailboxes empty

### DIFF
--- a/server/mailet/integration-testing/src/test/java/org/apache/james/smtp/SmtpRandomStoringTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/smtp/SmtpRandomStoringTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
+
 import javax.mail.MessagingException;
 
 import org.apache.james.MemoryJamesServerMain;
@@ -51,7 +52,6 @@ import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.IMAPMessageReader;
 import org.apache.james.utils.SMTPMessageSender;
 import org.apache.mailet.Mail;
-
 import org.awaitility.Duration;
 import org.awaitility.core.ConditionFactory;
 import org.junit.After;
@@ -186,13 +186,8 @@ public class SmtpRandomStoringTest {
 
     private Long numberOfMessagesInMailbox(IMAPMessageReader imapMessageReader, String mailbox) {
         try {
-            long numberOfMails = imapMessageReader
+            return imapMessageReader
                 .getMessageCount(mailbox);
-
-            assertThat(numberOfMails)
-                .isGreaterThan(0);
-
-            return numberOfMails;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This mailet assigns emails between 4 to 8 mailboxes. However, there is no
coordination, hence some mailboxes can be left empty.

This do not plays well with the cache on routing info in that mailet: some
auto provisionned inboxes or not yet created mailboxes might get ignored.

Furthermore, that assertion was hidden 3 method call deep the callstack, violating the rule
"one assertion per test, explicit and at the end on the main testing method".

As such it deserves to be removed.

Note: the main assertion "given 100 mail, we will assign and store it between
400 and 800 times" still stands.

Encountered master build CI error:

```
[null] Assertion condition defined as a lambda expression in org.apache.james.smtp.SmtpRandomStoringTest 
[null] Expecting:
[null]  <0L>
[null] to be greater than:
[null]  <0L>  within 10 seconds.
[null] 	at org.apache.james.smtp.SmtpRandomStoringTest.sendingOneHundredMessagesShouldBeRandomlyAssignedToEveryMailboxesOfEveryUsers(SmtpRandomStoringTest.java:156)
[null] Caused by: java.lang.AssertionError: 
[null] 
[null] Expecting:
[null]  <0L>
[null] to be greater than:
[null]  <0L> 
```