### PR TITLE
Avoid reading mailbox twice when retrieving all mailboxes

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
@@ -29,6 +29,7 @@ import org.apache.james.mailbox.exception.BadCredentialsException;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.MailboxExistsException;
 import org.apache.james.mailbox.exception.MailboxNotFoundException;
+import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxMetaData;
 import org.apache.james.mailbox.model.MailboxPath;
@@ -146,6 +147,8 @@ public interface MailboxManager extends RequestAware, RightManager, MailboxAnnot
     MessageManager getMailbox(MailboxId mailboxId, MailboxSession session) throws MailboxException;
 
     Set<MessageManager> getMailboxes(Collection<MailboxId> mailboxIds, MailboxSession session) throws MailboxException;
+
+    List<MailboxCounters> getMailboxCounters(Collection<MailboxId> mailboxIds, MailboxSession session) throws MailboxException;
 
     /**
      * Creates a new mailbox. Any intermediary mailboxes missing from the

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
@@ -19,9 +19,11 @@
 
 package org.apache.james.mailbox;
 
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.apache.james.mailbox.exception.BadCredentialsException;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -142,6 +144,8 @@ public interface MailboxManager extends RequestAware, RightManager, MailboxAnnot
      *            when the given mailbox does not exist
      */
     MessageManager getMailbox(MailboxId mailboxId, MailboxSession session) throws MailboxException;
+
+    Set<MessageManager> getMailboxes(Collection<MailboxId> mailboxIds, MailboxSession session) throws MailboxException;
 
     /**
      * Creates a new mailbox. Any intermediary mailboxes missing from the

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxACL.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxACL.java
@@ -539,6 +539,11 @@ public class MailboxACL {
                 return this;
             }
 
+            public Builder forOwner() {
+                key = OWNER_KEY;
+                return this;
+            }
+
             public Builder key(EntryKey key) {
                 this.key = key;
                 return this;

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxCounters.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxCounters.java
@@ -29,6 +29,12 @@ public class MailboxCounters {
     public static class Builder {
         private Optional<Long> count = Optional.empty();
         private Optional<Long> unseen = Optional.empty();
+        private Optional<MailboxId> mailboxId = Optional.empty();
+
+        public Builder mailboxId(MailboxId mailboxId) {
+            this.mailboxId = Optional.of(mailboxId);
+            return this;
+        }
 
         public Builder count(long count) {
             this.count = Optional.of(count);
@@ -43,7 +49,8 @@ public class MailboxCounters {
         public MailboxCounters build() {
             Preconditions.checkState(count.isPresent(), "count is compulsory");
             Preconditions.checkState(unseen.isPresent(), "unseen is compulsory");
-            return new MailboxCounters(count.get(), unseen.get());
+            Preconditions.checkState(mailboxId.isPresent(), "mailboxId is compulsory");
+            return new MailboxCounters(mailboxId.get(), count.get(), unseen.get());
         }
     }
 
@@ -51,12 +58,18 @@ public class MailboxCounters {
         return new Builder();
     }
 
+    private final MailboxId mailboxId;
     private final long count;
     private final long unseen;
 
-    private MailboxCounters(long count, long unseen) {
+    private MailboxCounters(MailboxId mailboxId, long count, long unseen) {
+        this.mailboxId = mailboxId;
         this.count = count;
         this.unseen = unseen;
+    }
+
+    public MailboxId getMailboxId() {
+        return mailboxId;
     }
 
     public long getCount() {
@@ -73,13 +86,14 @@ public class MailboxCounters {
             MailboxCounters that = (MailboxCounters) o;
 
             return Objects.equal(this.count, that.count)
-                && Objects.equal(this.unseen, that.unseen);
+                && Objects.equal(this.unseen, that.unseen)
+                && Objects.equal(this.mailboxId, that.mailboxId);
         }
         return false;
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hashCode(count, unseen);
+        return Objects.hashCode(count, unseen, mailboxId);
     }
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxMetaData.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxMetaData.java
@@ -62,7 +62,7 @@ public class MailboxMetaData implements Comparable<MailboxMetaData> {
     }
 
     public static MailboxMetaData unselectableMailbox(MailboxPath path, MailboxId mailboxId, char delimiter) {
-        return new MailboxMetaData(path, mailboxId, delimiter, Children.CHILDREN_ALLOWED_BUT_UNKNOWN, Selectability.NONE);
+        return new MailboxMetaData(path, mailboxId, delimiter, Children.CHILDREN_ALLOWED_BUT_UNKNOWN, Selectability.NONE, new MailboxACL());
     }
 
     private final MailboxPath path;
@@ -70,15 +70,20 @@ public class MailboxMetaData implements Comparable<MailboxMetaData> {
     private final Children inferiors;
     private final Selectability selectability;
     private final MailboxId mailboxId;
+    private final MailboxACL resolvedAcls;
 
-    public MailboxMetaData(MailboxPath path, MailboxId mailboxId, char delimiter, Children inferiors, Selectability selectability) {
+    public MailboxMetaData(MailboxPath path, MailboxId mailboxId, char delimiter, Children inferiors, Selectability selectability, MailboxACL resolvedAcls) {
         this.path = path;
         this.mailboxId = mailboxId;
         this.delimiter = delimiter;
         this.inferiors = inferiors;
         this.selectability = selectability;
+        this.resolvedAcls = resolvedAcls;
     }
 
+    public MailboxACL getResolvedAcls() {
+        return resolvedAcls;
+    }
 
     /**
      * Gets the inferiors status of this mailbox.

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -1408,6 +1408,42 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
+        void getMailboxesShouldReturnRequestedMailboxes() throws Exception {
+            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+
+            MailboxPath mailboxPath1 = MailboxPath.forUser(USER_1, "mbx1");
+            MailboxPath mailboxPath2 = MailboxPath.forUser(USER_1, "mbx2");
+            Optional<MailboxId> mailboxId1 = mailboxManager.createMailbox(mailboxPath1, session);
+            Optional<MailboxId> mailboxId2 = mailboxManager.createMailbox(mailboxPath2, session);
+
+            assertThat(mailboxManager.getMailboxes(ImmutableList.of(mailboxId1.get(), mailboxId2.get()), session))
+                .extracting(MessageManager::getId)
+                .containsExactlyInAnyOrder(mailboxId1.get(), mailboxId2.get());
+        }
+
+        @Test
+        void getMailboxesShouldReturnOnlyRequestedMailbox() throws Exception {
+            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+
+            MailboxPath mailboxPath1 = MailboxPath.forUser(USER_1, "mbx1");
+            MailboxPath mailboxPath2 = MailboxPath.forUser(USER_1, "mbx2");
+            Optional<MailboxId> mailboxId1 = mailboxManager.createMailbox(mailboxPath1, session);
+            Optional<MailboxId> mailboxId2 = mailboxManager.createMailbox(mailboxPath2, session);
+
+            assertThat(mailboxManager.getMailboxes(ImmutableList.of(mailboxId1.get()), session))
+                .extracting(MessageManager::getId)
+                .containsExactlyInAnyOrder(mailboxId1.get());
+        }
+
+        @Test
+        void getMailboxesShouldEmptyWhenNoMailboxIds() throws Exception {
+            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+
+            assertThat(mailboxManager.getMailboxes(ImmutableList.of(), session))
+                .isEmpty();
+        }
+
+        @Test
         void user1ShouldNotBeAbleToCreateInboxTwice() throws Exception {
             session = mailboxManager.createSystemSession(USER_1);
             mailboxManager.startProcessingRequest(session);

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -895,6 +895,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void searchShouldReturnACL() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Namespace));
+            assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
             session = mailboxManager.createSystemSession(USER_1);
             Optional<MailboxId> inboxId = mailboxManager.createMailbox(MailboxPath.inbox(session), session);
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -936,7 +936,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             MailboxSession session1 = mailboxManager.createSystemSession(USER_1);
             MailboxSession session2 = mailboxManager.createSystemSession(USER_2);
             MailboxPath inbox1 = MailboxPath.inbox(session1);
-            mailboxManager.createMailbox(inbox1, session1);
+            Optional<MailboxId> mailboxIdInbox1 = mailboxManager.createMailbox(inbox1, session1);
             mailboxManager.setRights(inbox1,
                 MailboxACL.EMPTY.apply(MailboxACL.command()
                     .forUser(USER_2)
@@ -1242,7 +1242,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             MailboxSession session1 = mailboxManager.createSystemSession(USER_1);
             MailboxSession session2 = mailboxManager.createSystemSession(USER_2);
             MailboxPath inbox1 = MailboxPath.inbox(session1);
-            mailboxManager.createMailbox(inbox1, session1);
+            Optional<MailboxId> mailboxIdInbox1 = mailboxManager.createMailbox(inbox1, session1);
             mailboxManager.setRights(inbox1,
                 MailboxACL.EMPTY.apply(MailboxACL.command()
                     .forUser(USER_2)
@@ -1274,7 +1274,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             MailboxSession session1 = mailboxManager.createSystemSession(USER_1);
             MailboxSession session2 = mailboxManager.createSystemSession(USER_2);
             MailboxPath inbox1 = MailboxPath.inbox(session1);
-            mailboxManager.createMailbox(inbox1, session1);
+            Optional<MailboxId> mailboxIdInbox1 = mailboxManager.createMailbox(inbox1, session1);
             mailboxManager.setRights(inbox1,
                 MailboxACL.EMPTY.apply(MailboxACL.command()
                     .forUser(USER_2)
@@ -1289,6 +1289,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
             assertThat(mailboxCounters)
                 .isEqualTo(MailboxCounters.builder()
+                    .mailboxId(mailboxIdInbox1.get())
                     .count(0)
                     .unseen(0)
                     .build());
@@ -1300,7 +1301,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             MailboxSession session1 = mailboxManager.createSystemSession(USER_1);
             MailboxSession session2 = mailboxManager.createSystemSession(USER_2);
             MailboxPath inbox1 = MailboxPath.inbox(session1);
-            mailboxManager.createMailbox(inbox1, session1);
+            Optional<MailboxId> mailboxIdInbox1 = mailboxManager.createMailbox(inbox1, session1);
             mailboxManager.setRights(inbox1,
                 MailboxACL.EMPTY.apply(MailboxACL.command()
                     .forUser(USER_2)
@@ -1318,6 +1319,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
             assertThat(mailboxCounters)
                 .isEqualTo(MailboxCounters.builder()
+                    .mailboxId(mailboxIdInbox1.get())
                     .count(1)
                     .unseen(1)
                     .build());

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -1507,7 +1507,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        void getMailboxesShouldReturnRequestedMailboxes() throws Exception {
+        protected void getMailboxesShouldReturnRequestedMailboxes() throws Exception {
             MailboxSession session = mailboxManager.createSystemSession(USER_1);
 
             MailboxPath mailboxPath1 = MailboxPath.forUser(USER_1, "mbx1");
@@ -1521,7 +1521,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        void getMailboxesShouldReturnOnlyRequestedMailbox() throws Exception {
+        protected void getMailboxesShouldReturnOnlyRequestedMailbox() throws Exception {
             MailboxSession session = mailboxManager.createSystemSession(USER_1);
 
             MailboxPath mailboxPath1 = MailboxPath.forUser(USER_1, "mbx1");

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -1326,6 +1326,75 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
+        void getMailboxCountersShouldReturnStoredValue() throws Exception {
+            assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
+            MailboxSession session1 = mailboxManager.createSystemSession(USER_1);
+            MailboxPath inbox1 = MailboxPath.inbox(session1);
+            Optional<MailboxId> mailboxIdInbox1 = mailboxManager.createMailbox(inbox1, session1);
+
+            mailboxManager.getMailbox(inbox1, session1)
+                .appendMessage(AppendCommand.builder()
+                    .recent()
+                    .build(message), session1);
+
+            List<MailboxCounters> mailboxCounters = mailboxManager.getMailboxCounters(ImmutableList.of(mailboxIdInbox1.get()), session1);
+
+            assertThat(mailboxCounters)
+                .containsExactlyInAnyOrder(MailboxCounters.builder()
+                    .mailboxId(mailboxIdInbox1.get())
+                    .count(1)
+                    .unseen(1)
+                    .build());
+        }
+
+        @Test
+        void getMailboxCountersShouldReturnStoredValues() throws Exception {
+            assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
+            MailboxSession session1 = mailboxManager.createSystemSession(USER_1);
+            MailboxPath inbox1 = MailboxPath.inbox(session1);
+            Optional<MailboxId> mailboxIdInbox1 = mailboxManager.createMailbox(inbox1, session1);
+            MailboxPath mailbox = MailboxPath.forUser(session1.getUser().asString(), "mailbox");
+            Optional<MailboxId> mailboxId = mailboxManager.createMailbox(mailbox, session1);
+
+            mailboxManager.getMailbox(inbox1, session1)
+                .appendMessage(AppendCommand.builder()
+                    .recent()
+                    .build(message), session1);
+
+            List<MailboxCounters> mailboxCounters = mailboxManager.getMailboxCounters(ImmutableList.of(mailboxIdInbox1.get(), mailboxId.get()), session1);
+
+            assertThat(mailboxCounters)
+                .containsExactlyInAnyOrder(
+                    MailboxCounters.builder()
+                        .mailboxId(mailboxIdInbox1.get())
+                        .count(1)
+                        .unseen(1)
+                        .build(),
+                    MailboxCounters.builder()
+                        .mailboxId(mailboxId.get())
+                        .count(0)
+                        .unseen(0)
+                        .build());
+        }
+
+        @Test
+        void getMailboxCountersShouldReturnEmptyWhenNoIdRequested() throws Exception {
+            assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
+            MailboxSession session1 = mailboxManager.createSystemSession(USER_1);
+            MailboxPath inbox1 = MailboxPath.inbox(session1);
+            Optional<MailboxId> mailboxIdInbox1 = mailboxManager.createMailbox(inbox1, session1);
+
+            mailboxManager.getMailbox(inbox1, session1)
+                .appendMessage(AppendCommand.builder()
+                    .recent()
+                    .build(message), session1);
+
+            List<MailboxCounters> mailboxCounters = mailboxManager.getMailboxCounters(ImmutableList.of(), session1);
+
+            assertThat(mailboxCounters).isEmpty();
+        }
+
+        @Test
         @SuppressWarnings("unchecked")
         void getMetaDataShouldReturnDefaultValueWhenNoReadRight() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
@@ -75,9 +75,7 @@ public class CassandraMailboxCounterDAO {
                 .where(eq(CassandraMailboxCountersTable.MAILBOX_ID, bindMarker(CassandraMailboxCountersTable.MAILBOX_ID))));
     }
 
-    public Mono<MailboxCounters> retrieveMailboxCounters(Mailbox mailbox) throws MailboxException {
-        CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
-
+    public Mono<MailboxCounters> retrieveMailboxCounters(CassandraId mailboxId) {
         return cassandraAsyncExecutor.executeSingleRow(bindWithMailbox(mailboxId, readStatement))
             .map(row ->  MailboxCounters.builder()
                 .mailboxId(mailboxId)

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
@@ -39,6 +39,7 @@ import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.Assignment;
+
 import reactor.core.publisher.Mono;
 
 public class CassandraMailboxCounterDAO {
@@ -79,6 +80,7 @@ public class CassandraMailboxCounterDAO {
 
         return cassandraAsyncExecutor.executeSingleRow(bindWithMailbox(mailboxId, readStatement))
             .map(row ->  MailboxCounters.builder()
+                .mailboxId(mailboxId)
                 .count(row.getLong(CassandraMailboxCountersTable.COUNT))
                 .unseen(row.getLong(CassandraMailboxCountersTable.UNSEEN))
                 .build());

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mailbox.cassandra.mail;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -41,6 +42,7 @@ import org.apache.james.mailbox.model.ComposedMessageId;
 import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxCounters;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.UpdatedFlags;
@@ -60,6 +62,7 @@ import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 public class CassandraMessageMapper implements MessageMapper {
     public static final Logger LOGGER = LoggerFactory.getLogger(CassandraMessageMapper.class);
@@ -127,13 +130,28 @@ public class CassandraMessageMapper implements MessageMapper {
 
     @Override
     public MailboxCounters getMailboxCounters(Mailbox mailbox) throws MailboxException {
-        return mailboxCounterDAO.retrieveMailboxCounters(mailbox)
+        CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
+        return getMailboxCounters(mailboxId)
+                .block();
+    }
+
+    private Mono<MailboxCounters> getMailboxCounters(CassandraId mailboxId) {
+        return mailboxCounterDAO.retrieveMailboxCounters(mailboxId)
                 .defaultIfEmpty(MailboxCounters.builder()
-                    .mailboxId(mailbox.getMailboxId())
+                    .mailboxId(mailboxId)
                     .count(0)
                     .unseen(0)
-                    .build())
-                .block();
+                    .build());
+    }
+
+    @Override
+    public List<MailboxCounters> getMailboxCounters(Collection<MailboxId> mailboxIds) {
+        return Flux.fromIterable(mailboxIds)
+            .publishOn(Schedulers.boundedElastic())
+            .map(id -> (CassandraId) id)
+            .concatMap(this::getMailboxCounters)
+            .toStream()
+            .collect(Guavate.toImmutableList());
     }
 
     @Override

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -62,10 +62,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public class CassandraMessageMapper implements MessageMapper {
-    public static final MailboxCounters INITIAL_COUNTERS =  MailboxCounters.builder()
-        .count(0L)
-        .unseen(0L)
-        .build();
     public static final Logger LOGGER = LoggerFactory.getLogger(CassandraMessageMapper.class);
 
     private final CassandraModSeqProvider modSeqProvider;
@@ -132,7 +128,11 @@ public class CassandraMessageMapper implements MessageMapper {
     @Override
     public MailboxCounters getMailboxCounters(Mailbox mailbox) throws MailboxException {
         return mailboxCounterDAO.retrieveMailboxCounters(mailbox)
-                .defaultIfEmpty(INITIAL_COUNTERS)
+                .defaultIfEmpty(MailboxCounters.builder()
+                    .mailboxId(mailbox.getMailboxId())
+                    .count(0)
+                    .unseen(0)
+                    .build())
                 .block();
     }
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAOTest.java
@@ -87,6 +87,7 @@ class CassandraMailboxCounterDAOTest {
 
         assertThat(testee.retrieveMailboxCounters(mailbox).block())
             .isEqualTo(MailboxCounters.builder()
+                .mailboxId(MAILBOX_ID)
                 .count(0L)
                 .unseen(1L)
                 .build());
@@ -98,6 +99,7 @@ class CassandraMailboxCounterDAOTest {
 
         assertThat(testee.retrieveMailboxCounters(mailbox).block())
             .isEqualTo(MailboxCounters.builder()
+                .mailboxId(MAILBOX_ID)
                 .count(1L)
                 .unseen(0L)
                 .build());
@@ -110,6 +112,7 @@ class CassandraMailboxCounterDAOTest {
 
         assertThat(testee.retrieveMailboxCounters(mailbox).block())
             .isEqualTo(MailboxCounters.builder()
+                .mailboxId(MAILBOX_ID)
                 .count(1L)
                 .unseen(1L)
                 .build());

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAOTest.java
@@ -64,7 +64,7 @@ class CassandraMailboxCounterDAOTest {
 
     @Test
     void retrieveMailboxCounterShouldReturnEmptyByDefault() throws Exception {
-        assertThat(testee.retrieveMailboxCounters(mailbox).hasElement().block()).isFalse();
+        assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).hasElement().block()).isFalse();
     }
 
     @Test
@@ -85,7 +85,7 @@ class CassandraMailboxCounterDAOTest {
     void incrementUnseenShouldAddOneWhenAbsentOnMailboxCounters() throws Exception {
         testee.incrementUnseen(MAILBOX_ID).block();
 
-        assertThat(testee.retrieveMailboxCounters(mailbox).block())
+        assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).block())
             .isEqualTo(MailboxCounters.builder()
                 .mailboxId(MAILBOX_ID)
                 .count(0L)
@@ -97,7 +97,7 @@ class CassandraMailboxCounterDAOTest {
     void incrementCountShouldAddOneWhenAbsentOnMailboxCounters() throws Exception {
         testee.incrementCount(MAILBOX_ID).block();
 
-        assertThat(testee.retrieveMailboxCounters(mailbox).block())
+        assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).block())
             .isEqualTo(MailboxCounters.builder()
                 .mailboxId(MAILBOX_ID)
                 .count(1L)
@@ -110,7 +110,7 @@ class CassandraMailboxCounterDAOTest {
         testee.incrementCount(MAILBOX_ID).block();
         testee.incrementUnseen(MAILBOX_ID).block();
 
-        assertThat(testee.retrieveMailboxCounters(mailbox).block())
+        assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).block())
             .isEqualTo(MailboxCounters.builder()
                 .mailboxId(MAILBOX_ID)
                 .count(1L)

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMessageMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMessageMapper.java
@@ -76,6 +76,7 @@ public class JPAMessageMapper extends JPATransactionalMapper implements MessageM
     @Override
     public MailboxCounters getMailboxCounters(Mailbox mailbox) throws MailboxException {
         return MailboxCounters.builder()
+            .mailboxId(mailbox.getMailboxId())
             .count(countMessagesInMailbox(mailbox))
             .unseen(countUnseenMessagesInMailbox(mailbox))
             .build();

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMessageMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMessageMapper.java
@@ -18,6 +18,7 @@
  ****************************************************************/
 package org.apache.james.mailbox.jpa.mail;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -41,6 +42,7 @@ import org.apache.james.mailbox.jpa.mail.model.openjpa.JPAMailboxMessage;
 import org.apache.james.mailbox.jpa.mail.model.openjpa.JPAStreamingMailboxMessage;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxCounters;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.MessageRange.Type;
@@ -55,6 +57,7 @@ import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.utils.ApplicableFlagCalculator;
 import org.apache.openjpa.persistence.ArgumentException;
 
+import com.github.fge.lambdas.Throwing;
 import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
@@ -122,24 +125,46 @@ public class JPAMessageMapper extends JPATransactionalMapper implements MessageM
 
     @Override
     public long countMessagesInMailbox(Mailbox mailbox) throws MailboxException {
+        JPAId mailboxId = (JPAId) mailbox.getMailboxId();
+        return countMessagesInMailbox(mailboxId);
+    }
+
+    private long countMessagesInMailbox(JPAId mailboxId) throws MailboxException {
         try {
-            JPAId mailboxId = (JPAId) mailbox.getMailboxId();
             return (Long) getEntityManager().createNamedQuery("countMessagesInMailbox")
                     .setParameter("idParam", mailboxId.getRawId()).getSingleResult();
         } catch (PersistenceException e) {
-            throw new MailboxException("Count of messages failed in mailbox " + mailbox, e);
+            throw new MailboxException("Count of messages failed in mailbox " + mailboxId, e);
         }
     }
 
     @Override
     public long countUnseenMessagesInMailbox(Mailbox mailbox) throws MailboxException {
+        JPAId mailboxId = (JPAId) mailbox.getMailboxId();
+        return countUnseenMessagesInMailbox(mailboxId);
+    }
+
+    private long countUnseenMessagesInMailbox(JPAId mailboxId) throws MailboxException {
         try {
-            JPAId mailboxId = (JPAId) mailbox.getMailboxId();
             return (Long) getEntityManager().createNamedQuery("countUnseenMessagesInMailbox")
                     .setParameter("idParam", mailboxId.getRawId()).getSingleResult();
         } catch (PersistenceException e) {
-            throw new MailboxException("Count of useen messages failed in mailbox " + mailbox, e);
+            throw new MailboxException("Count of useen messages failed in mailbox " + mailboxId, e);
         }
+    }
+
+    @Override
+    public List<MailboxCounters> getMailboxCounters(Collection<MailboxId> mailboxIds) throws MailboxException {
+        return mailboxIds.stream()
+            .map(id -> (JPAId) id)
+            .map(Throwing.<JPAId, MailboxCounters>function(
+                id -> MailboxCounters.builder()
+                    .mailboxId(id)
+                    .count(countMessagesInMailbox(id))
+                    .unseen(countUnseenMessagesInMailbox(id))
+                    .build())
+                .sneakyThrow())
+            .collect(Guavate.toImmutableList());
     }
 
     @Override

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMessageMapper.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMessageMapper.java
@@ -157,6 +157,6 @@ public class TransactionalMessageMapper implements MessageMapper {
 
     @Override
     public List<MailboxCounters> getMailboxCounters(Collection<MailboxId> mailboxIds) throws MailboxException {
-        throw new NotImplementedException("not implemented");
+        return messageMapper.getMailboxCounters(mailboxIds);
     }
 }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMessageMapper.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMessageMapper.java
@@ -54,6 +54,7 @@ public class TransactionalMessageMapper implements MessageMapper {
     @Override
     public MailboxCounters getMailboxCounters(Mailbox mailbox) throws MailboxException {
         return MailboxCounters.builder()
+            .mailboxId(mailbox.getMailboxId())
             .count(countMessagesInMailbox(mailbox))
             .unseen(countUnseenMessagesInMailbox(mailbox))
             .build();

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMessageMapper.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMessageMapper.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mailbox.jpa.mail;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,7 @@ import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxCounters;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.UpdatedFlags;
@@ -151,5 +153,10 @@ public class TransactionalMessageMapper implements MessageMapper {
     @Override
     public Flags getApplicableFlag(Mailbox mailbox) throws MailboxException {
         return messageMapper.getApplicableFlag(mailbox);
+    }
+
+    @Override
+    public List<MailboxCounters> getMailboxCounters(Collection<MailboxId> mailboxIds) throws MailboxException {
+        throw new NotImplementedException("not implemented");
     }
 }

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMessageMapper.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMessageMapper.java
@@ -24,6 +24,7 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -35,6 +36,7 @@ import javax.mail.Flags;
 import javax.mail.Flags.Flag;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -43,6 +45,8 @@ import org.apache.james.mailbox.maildir.MaildirMessageName;
 import org.apache.james.mailbox.maildir.MaildirStore;
 import org.apache.james.mailbox.maildir.mail.model.MaildirMailboxMessage;
 import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxCounters;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.MessageRange.Type;
@@ -146,6 +150,11 @@ public class MaildirMessageMapper extends AbstractMessageMapper {
         } else {
             return result.get(0).getUid();
         }
+    }
+
+    @Override
+    public List<MailboxCounters> getMailboxCounters(Collection<MailboxId> mailboxIds) {
+        throw new NotImplementedException("Not available as maildir relies on mailboxPath");
     }
 
     @Override

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/DomainUserMaildirMailboxManagerTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/DomainUserMaildirMailboxManagerTest.java
@@ -39,7 +39,22 @@ public class DomainUserMaildirMailboxManagerTest extends MailboxManagerTest<Stor
     class BasicFeaturesTests extends MailboxManagerTest<StoreMailboxManager>.BasicFeaturesTests {
         @Disabled("MAILBOX-389 Mailbox rename fails with Maildir")
         @Test
+        @Override
         protected void renameMailboxShouldChangeTheMailboxPathOfAMailbox() {
+        }
+
+        @Disabled("JAMES-2632 Not supported")
+        @Override
+        @Test
+        protected void getMailboxesShouldReturnRequestedMailboxes() {
+
+        }
+
+        @Disabled("JAMES-2632 Not supported")
+        @Override
+        @Test
+        protected void getMailboxesShouldReturnOnlyRequestedMailbox() {
+
         }
     }
 

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerTest.java
@@ -39,7 +39,22 @@ public class FullUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreM
     class BasicFeaturesTests extends MailboxManagerTest<StoreMailboxManager>.BasicFeaturesTests {
         @Disabled("MAILBOX-389 Mailbox rename fails with Maildir")
         @Test
+        @Override
         protected void renameMailboxShouldChangeTheMailboxPathOfAMailbox() {
+        }
+
+        @Disabled("JAMES-2632 Not supported")
+        @Override
+        @Test
+        protected void getMailboxesShouldReturnRequestedMailboxes() {
+
+        }
+
+        @Disabled("JAMES-2632 Not supported")
+        @Override
+        @Test
+        protected void getMailboxesShouldReturnOnlyRequestedMailbox() {
+
         }
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -59,6 +59,7 @@ import org.apache.james.mailbox.model.MailboxACL.Right;
 import org.apache.james.mailbox.model.MailboxAnnotation;
 import org.apache.james.mailbox.model.MailboxAnnotationKey;
 import org.apache.james.mailbox.model.MailboxConstants;
+import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxMetaData;
 import org.apache.james.mailbox.model.MailboxMetaData.Selectability;
@@ -808,5 +809,11 @@ public class StoreMailboxManager implements MailboxManager {
         MailboxMapper mapper = mailboxSessionMapperFactory.getMailboxMapper(session);
         Mailbox mailbox = mapper.findMailboxByPath(mailboxPath);
         return mapper.hasChildren(mailbox, session.getPathDelimiter());
+    }
+
+    @Override
+    public List<MailboxCounters> getMailboxCounters(Collection<MailboxId> mailboxIds, MailboxSession session) throws MailboxException {
+        MessageMapper messageMapper = mailboxSessionMapperFactory.getMessageMapper(session);
+        return messageMapper.getMailboxCounters(mailboxIds);
     }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -104,6 +104,7 @@ import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -120,11 +121,6 @@ import reactor.core.scheduler.Schedulers;
  * 
  */
 public class StoreMessageManager implements MessageManager {
-    private static final MailboxCounters ZERO_MAILBOX_COUNTERS = MailboxCounters.builder()
-        .count(0)
-        .unseen(0)
-        .build();
-
     /**
      * The minimal Permanent flags the {@link MessageManager} must support. <br>
      * 
@@ -243,7 +239,11 @@ public class StoreMessageManager implements MessageManager {
         if (storeRightManager.hasRight(mailbox, MailboxACL.Right.Read, mailboxSession)) {
             return mapperFactory.createMessageMapper(mailboxSession).getMailboxCounters(mailbox);
         }
-        return ZERO_MAILBOX_COUNTERS;
+        return MailboxCounters.builder()
+            .mailboxId(mailbox.getMailboxId())
+            .unseen(0)
+            .count(0)
+            .build();
     }
 
     /**

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AbstractMessageMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AbstractMessageMapper.java
@@ -71,6 +71,7 @@ public abstract class AbstractMessageMapper extends TransactionalMapper implemen
     @Override
     public MailboxCounters getMailboxCounters(Mailbox mailbox) throws MailboxException {
         return MailboxCounters.builder()
+            .mailboxId(mailbox.getMailboxId())
             .count(countMessagesInMailbox(mailbox))
             .unseen(countUnseenMessagesInMailbox(mailbox))
             .build();

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MailboxMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MailboxMapper.java
@@ -18,7 +18,10 @@
  ****************************************************************/
 package org.apache.james.mailbox.store.mail;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import org.apache.james.mailbox.acl.ACLDiff;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -29,6 +32,9 @@ import org.apache.james.mailbox.model.MailboxACL.Right;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.store.transaction.Mapper;
+
+import com.github.fge.lambdas.Throwing;
+import com.github.steveash.guavate.Guavate;
 
 /**
  * Mapper for {@link Mailbox} actions. A {@link MailboxMapper} has a lifecycle from the start of a request 
@@ -75,6 +81,14 @@ public interface MailboxMapper extends Mapper {
      */
     Mailbox findMailboxById(MailboxId mailboxId)
             throws MailboxException, MailboxNotFoundException;
+
+    default Set<Mailbox> findMailboxesById(Collection<MailboxId> mailboxIds) throws MailboxException {
+        return mailboxIds.stream()
+            .flatMap(Throwing.<MailboxId, Stream<Mailbox>>function(
+                id -> Stream.of(findMailboxById(id)))
+                .orReturn(Stream.of()))
+            .collect(Guavate.toImmutableSet());
+    }
 
     /**
      * Return a List of {@link Mailbox} for the given userName and matching the right

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
@@ -18,6 +18,7 @@
  ****************************************************************/
 package org.apache.james.mailbox.store.mail;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +30,7 @@ import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxCounters;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.UpdatedFlags;
@@ -83,6 +85,8 @@ public interface MessageMapper extends Mapper {
             throws MailboxException;
 
     MailboxCounters getMailboxCounters(Mailbox mailbox) throws MailboxException;
+
+    List<MailboxCounters> getMailboxCounters(Collection<MailboxId> mailboxIds) throws MailboxException;
 
     /**
      * Delete the given {@link MailboxMessage}

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxMessageResultIteratorTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxMessageResultIteratorTest.java
@@ -93,6 +93,7 @@ public class StoreMailboxMessageResultIteratorTest {
         @Override
         public MailboxCounters getMailboxCounters(Mailbox mailbox) throws MailboxException {
             return MailboxCounters.builder()
+                .mailboxId(mailbox.getMailboxId())
                 .count(countMessagesInMailbox(mailbox))
                 .unseen(countUnseenMessagesInMailbox(mailbox))
                 .build();

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxMessageResultIteratorTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxMessageResultIteratorTest.java
@@ -22,6 +22,7 @@ package org.apache.james.mailbox.store;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -38,6 +39,7 @@ import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxCounters;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.MessageResult.FetchGroup;
@@ -97,6 +99,11 @@ public class StoreMailboxMessageResultIteratorTest {
                 .count(countMessagesInMailbox(mailbox))
                 .unseen(countUnseenMessagesInMailbox(mailbox))
                 .build();
+        }
+
+        @Override
+        public List<MailboxCounters> getMailboxCounters(Collection<MailboxId> mailboxIds) throws MailboxException {
+            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -191,7 +198,7 @@ public class StoreMailboxMessageResultIteratorTest {
 
         @Override
         public Flags getApplicableFlag(Mailbox mailbox) throws MailboxException {
-            throw new NotImplementedException("Not implemented");
+            throw new UnsupportedOperationException();
         }
     }
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMapperTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import java.util.Set;
 
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.MailboxExistsException;
@@ -34,6 +35,8 @@ import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * Generic purpose tests for your implementation MailboxMapper.
@@ -236,6 +239,17 @@ public abstract class MailboxMapperTest {
         saveAll();
         Mailbox actual = mailboxMapper.findMailboxById(benwaInboxMailbox.getMailboxId());
         MailboxAssert.assertThat(actual).isEqualTo(benwaInboxMailbox);
+    }
+
+    @Test
+    public void findMailboxesByIdShouldReturnExistingMailbox() throws MailboxException {
+        saveAll();
+
+        Set<Mailbox> mailboxes = mailboxMapper.findMailboxesById(ImmutableList.of(benwaInboxMailbox.getMailboxId(), benwaWorkMailbox.getMailboxId()));
+
+        assertThat(mailboxes)
+            .extracting(Mailbox::getMailboxId)
+            .containsExactlyInAnyOrder(benwaInboxMailbox.getMailboxId(), benwaWorkMailbox.getMailboxId());
     }
     
     @Test

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -41,6 +41,7 @@ import org.apache.james.mailbox.MessageManager.FlagsUpdateMode;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.MessageMetaData;
@@ -123,6 +124,23 @@ public abstract class MessageMapperTest {
     public void mailboxContainingMessagesShouldHaveTheGoodMessageCount() throws MailboxException {
         saveMessages();
         assertThat(messageMapper.countMessagesInMailbox(benwaInboxMailbox)).isEqualTo(5);
+    }
+
+    @Test
+    public void getMailboxCountersShouldReturnStoredValue() throws MailboxException {
+        saveMessages();
+        assertThat(messageMapper.getMailboxCounters(ImmutableList.of(benwaInboxMailbox.getMailboxId(), benwaWorkMailbox.getMailboxId())))
+            .containsExactlyInAnyOrder(
+                MailboxCounters.builder()
+                    .mailboxId(benwaInboxMailbox.getMailboxId())
+                    .count(5)
+                    .unseen(5)
+                    .build(),
+                MailboxCounters.builder()
+                    .mailboxId(benwaWorkMailbox.getMailboxId())
+                    .count(1)
+                    .unseen(1)
+                    .build());
     }
 
     @Test

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/ListProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/ListProcessor.java
@@ -40,6 +40,7 @@ import org.apache.james.imap.message.response.ListResponse;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxConstants;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxMetaData;
@@ -123,7 +124,7 @@ public class ListProcessor extends AbstractMailboxProcessor<ListRequest> {
                 MailboxId mailboxId = null;
                 results = new ArrayList<>(1);
                 results.add(new MailboxMetaData(rootPath, mailboxId, mailboxSession.getPathDelimiter(),
-                    MailboxMetaData.Children.CHILDREN_ALLOWED_BUT_UNKNOWN, MailboxMetaData.Selectability.NOSELECT));
+                    MailboxMetaData.Children.CHILDREN_ALLOWED_BUT_UNKNOWN, MailboxMetaData.Selectability.NOSELECT, new MailboxACL()));
             } else {
                 // If the mailboxPattern is fully qualified, ignore the
                 // reference name.

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/DefaultMailboxesProvisioningFilter.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/DefaultMailboxesProvisioningFilter.java
@@ -35,6 +35,7 @@ import org.apache.james.mailbox.DefaultMailboxes;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.SubscriptionManager;
+import org.apache.james.mailbox.exception.InboxAlreadyCreated;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.MailboxExistsException;
 import org.apache.james.mailbox.model.MailboxId;
@@ -114,7 +115,7 @@ public class DefaultMailboxesProvisioningFilter implements Filter {
                 subscriptionManager.subscribe(session, mailboxPath.getName());
             }
             LOGGER.info("Provisioning {}. {} created.", mailboxPath, mailboxId);
-        } catch (MailboxExistsException e) {
+        } catch (MailboxExistsException | InboxAlreadyCreated e) {
             LOGGER.info("Mailbox {} have been created concurrently", mailboxPath);
         } catch (MailboxException e) {
             throw new RuntimeException(e);

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMailboxesMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMailboxesMethod.java
@@ -157,15 +157,14 @@ public class GetMailboxesMethod implements Method {
         List<MailboxMetaData> userMailboxes = getAllMailboxesMetaData(mailboxSession);
         QuotaLoader quotaLoader = new QuotaLoaderWithDefaultPreloaded(quotaRootResolver, quotaManager, mailboxSession);
         ImmutableList<MailboxId> mailboxIds = userMailboxes.stream().map(MailboxMetaData::getId).collect(Guavate.toImmutableList());
-        Set<MessageManager> messageManagers = mailboxManager.getMailboxes(mailboxIds, mailboxSession);
         Map<MailboxId, MailboxCounters> mailboxCounters = retrieveMailboxCounters(mailboxSession, mailboxIds);
 
-        return messageManagers
+        return userMailboxes
             .stream()
-            .map(messageManager -> mailboxFactory.builder()
-                .messageManager(messageManager)
+            .map(mailbox -> mailboxFactory.builder()
+                .mailboxMetadata(mailbox)
                 .session(mailboxSession)
-                .usingPreLoadedMailboxCounter(mailboxCounters.get(messageManager.getId()))
+                .usingPreLoadedMailboxCounter(mailboxCounters.get(mailbox.getId()))
                 .usingPreloadedMailboxesMetadata(Optional.of(userMailboxes))
                 .quotaLoader(quotaLoader)
                 .build())

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMailboxesMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMailboxesMethod.java
@@ -21,8 +21,10 @@ package org.apache.james.jmap.draft.methods;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -39,6 +41,7 @@ import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxMetaData;
 import org.apache.james.mailbox.model.search.MailboxQuery;
@@ -53,6 +56,7 @@ import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
@@ -136,12 +140,14 @@ public class GetMailboxesMethod implements Method {
 
     private Stream<Mailbox> retrieveSpecificMailboxes(MailboxSession mailboxSession, ImmutableList<MailboxId> mailboxIds) throws MailboxException {
         Set<MessageManager> mailboxes = mailboxManager.getMailboxes(mailboxIds, mailboxSession);
+        Map<MailboxId, MailboxCounters> mailboxCounters = retrieveMailboxCounters(mailboxSession, mailboxIds);
 
         return mailboxes
             .stream()
             .map(messageManager -> mailboxFactory.builder()
                 .messageManager(messageManager)
                 .session(mailboxSession)
+                .usingPreLoadedMailboxCounter(mailboxCounters.get(messageManager.getId()))
                 .usingPreloadedMailboxesMetadata(NO_PRELOADED_METADATA)
                 .build())
             .flatMap(OptionalUtils::toStream);
@@ -152,16 +158,26 @@ public class GetMailboxesMethod implements Method {
         QuotaLoader quotaLoader = new QuotaLoaderWithDefaultPreloaded(quotaRootResolver, quotaManager, mailboxSession);
         ImmutableList<MailboxId> mailboxIds = userMailboxes.stream().map(MailboxMetaData::getId).collect(Guavate.toImmutableList());
         Set<MessageManager> messageManagers = mailboxManager.getMailboxes(mailboxIds, mailboxSession);
+        Map<MailboxId, MailboxCounters> mailboxCounters = retrieveMailboxCounters(mailboxSession, mailboxIds);
 
         return messageManagers
             .stream()
             .map(messageManager -> mailboxFactory.builder()
                 .messageManager(messageManager)
                 .session(mailboxSession)
+                .usingPreLoadedMailboxCounter(mailboxCounters.get(messageManager.getId()))
                 .usingPreloadedMailboxesMetadata(Optional.of(userMailboxes))
                 .quotaLoader(quotaLoader)
                 .build())
             .flatMap(OptionalUtils::toStream);
+    }
+
+    private ImmutableMap<MailboxId, MailboxCounters> retrieveMailboxCounters(MailboxSession mailboxSession, ImmutableList<MailboxId> mailboxIds) throws MailboxException {
+        return mailboxManager.getMailboxCounters(mailboxIds, mailboxSession)
+            .stream()
+            .collect(Guavate.toImmutableMap(
+                MailboxCounters::getMailboxId,
+                Function.identity()));
     }
 
     private List<MailboxMetaData> getAllMailboxesMetaData(MailboxSession mailboxSession) throws MailboxException {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMailboxesMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMailboxesMethod.java
@@ -37,6 +37,7 @@ import org.apache.james.jmap.draft.utils.quotas.QuotaLoader;
 import org.apache.james.jmap.draft.utils.quotas.QuotaLoaderWithDefaultPreloaded;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxMetaData;
@@ -128,32 +129,34 @@ public class GetMailboxesMethod implements Method {
 
     private Stream<Mailbox> retrieveMailboxes(Optional<ImmutableList<MailboxId>> mailboxIds, MailboxSession mailboxSession) throws MailboxException {
         return mailboxIds
-            .map(ids -> retrieveSpecificMailboxes(mailboxSession, ids))
+            .map(Throwing.<ImmutableList<MailboxId>, Stream<Mailbox>>function(ids -> retrieveSpecificMailboxes(mailboxSession, ids)).sneakyThrow())
             .orElseGet(Throwing.supplier(() -> retrieveAllMailboxes(mailboxSession)).sneakyThrow());
     }
 
 
-    private Stream<Mailbox> retrieveSpecificMailboxes(MailboxSession mailboxSession, ImmutableList<MailboxId> mailboxIds) {
-        return mailboxIds
+    private Stream<Mailbox> retrieveSpecificMailboxes(MailboxSession mailboxSession, ImmutableList<MailboxId> mailboxIds) throws MailboxException {
+        Set<MessageManager> mailboxes = mailboxManager.getMailboxes(mailboxIds, mailboxSession);
+
+        return mailboxes
             .stream()
-            .map(mailboxId -> mailboxFactory.builder()
-                .id(mailboxId)
+            .map(messageManager -> mailboxFactory.builder()
+                .messageManager(messageManager)
                 .session(mailboxSession)
                 .usingPreloadedMailboxesMetadata(NO_PRELOADED_METADATA)
-                .build()
-            )
+                .build())
             .flatMap(OptionalUtils::toStream);
     }
 
     private Stream<Mailbox> retrieveAllMailboxes(MailboxSession mailboxSession) throws MailboxException {
         List<MailboxMetaData> userMailboxes = getAllMailboxesMetaData(mailboxSession);
         QuotaLoader quotaLoader = new QuotaLoaderWithDefaultPreloaded(quotaRootResolver, quotaManager, mailboxSession);
+        ImmutableList<MailboxId> mailboxIds = userMailboxes.stream().map(MailboxMetaData::getId).collect(Guavate.toImmutableList());
+        Set<MessageManager> messageManagers = mailboxManager.getMailboxes(mailboxIds, mailboxSession);
 
-        return userMailboxes
+        return messageManagers
             .stream()
-            .map(MailboxMetaData::getId)
-            .map(mailboxId -> mailboxFactory.builder()
-                .id(mailboxId)
+            .map(messageManager -> mailboxFactory.builder()
+                .messageManager(messageManager)
                 .session(mailboxSession)
                 .usingPreloadedMailboxesMetadata(Optional.of(userMailboxes))
                 .quotaLoader(quotaLoader)

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/MailboxFactory.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/MailboxFactory.java
@@ -37,17 +37,22 @@ import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.Role;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.MailboxNotFoundException;
+import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxMetaData;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.quota.QuotaManager;
 import org.apache.james.mailbox.quota.QuotaRootResolver;
+import org.apache.james.util.OptionalUtils;
 
 import com.github.fge.lambdas.Throwing;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.primitives.Booleans;
+
+import reactor.core.publisher.Mono;
 
 public class MailboxFactory {
     private final MailboxManager mailboxManager;
@@ -58,7 +63,8 @@ public class MailboxFactory {
         private final MailboxFactory mailboxFactory;
         private QuotaLoader quotaLoader;
         private MailboxSession session;
-        private MailboxId id;
+        private Optional<MailboxId> id = Optional.empty();
+        private Optional<MailboxMetaData> mailboxMetaData = Optional.empty();
         private Optional<MessageManager> messageManager = Optional.empty();
         private Optional<MailboxCounters> preLoadedMailboxCounter = Optional.empty();
         private Optional<List<MailboxMetaData>> userMailboxesMetadata = Optional.empty();
@@ -69,7 +75,7 @@ public class MailboxFactory {
         }
 
         public MailboxBuilder id(MailboxId id) {
-            this.id = id;
+            this.id = Optional.of(id);
             return this;
         }
 
@@ -79,8 +85,12 @@ public class MailboxFactory {
         }
 
         public MailboxBuilder messageManager(MessageManager messageManager) {
-            this.id = messageManager.getId();
             this.messageManager = Optional.of(messageManager);
+            return this;
+        }
+
+        public MailboxBuilder mailboxMetadata(MailboxMetaData mailboxMetaData) {
+            this.mailboxMetaData = Optional.of(mailboxMetaData);
             return this;
         }
 
@@ -100,19 +110,56 @@ public class MailboxFactory {
         }
 
         public Optional<Mailbox> build() {
-            Preconditions.checkNotNull(id);
             Preconditions.checkNotNull(session);
 
             try {
-                MessageManager mailbox = messageManager.orElseGet(Throwing.supplier(
-                    () -> mailboxFactory.mailboxManager.getMailbox(id, session))
-                    .sneakyThrow());
-                return Optional.of(mailboxFactory.fromMessageManager(mailbox, userMailboxesMetadata, preLoadedMailboxCounter, quotaLoader, session));
+                MailboxId mailboxId = computeMailboxId();
+                Mono<MessageManager> mailbox = mailbox(mailboxId).cache();
+
+                MailboxACL mailboxACL = mailboxMetaData.map(MailboxMetaData::getResolvedAcls)
+                    .orElseGet(Throwing.supplier(() -> retrieveCachedMailbox(mailboxId, mailbox).getResolvedAcl(session)).sneakyThrow());
+
+                MailboxPath mailboxPath = mailboxMetaData.map(MailboxMetaData::getPath)
+                    .orElseGet(Throwing.supplier(() -> retrieveCachedMailbox(mailboxId, mailbox).getMailboxPath()).sneakyThrow());
+
+                MailboxCounters mailboxCounters = preLoadedMailboxCounter
+                    .orElseGet(Throwing.supplier(() -> retrieveCachedMailbox(mailboxId, mailbox).getMailboxCounters(session)).sneakyThrow());
+
+                return Optional.of(mailboxFactory.from(
+                    mailboxId,
+                    mailboxPath,
+                    mailboxCounters,
+                    mailboxACL,
+                    userMailboxesMetadata,
+                    quotaLoader,
+                    session));
             } catch (MailboxNotFoundException e) {
                 return Optional.empty();
             } catch (MailboxException e) {
                 throw new RuntimeException(e);
             }
+        }
+
+        private MailboxId computeMailboxId() {
+            int idCount = Booleans.countTrue(id.isPresent(), mailboxMetaData.isPresent(), messageManager.isPresent());
+            Preconditions.checkState(idCount == 1, "You need exectly one 'id', 'messageManager' and 'mailboxMetaData'");
+            return OptionalUtils.or(
+                id,
+                messageManager.map(MessageManager::getId),
+                mailboxMetaData.map(MailboxMetaData::getId))
+                .get();
+        }
+
+        private Mono<MessageManager> mailbox(MailboxId mailboxId) {
+            return Mono.justOrEmpty(messageManager)
+                .switchIfEmpty(Mono.fromCallable(() -> mailboxFactory.mailboxManager.getMailbox(mailboxId, session)));
+        }
+
+        private MessageManager retrieveCachedMailbox(MailboxId mailboxId, Mono<MessageManager> mailbox) throws MailboxNotFoundException {
+            return mailbox
+                .onErrorResume(MailboxNotFoundException.class, any -> Mono.empty())
+                .blockOptional()
+                .orElseThrow(() -> new MailboxNotFoundException(mailboxId));
         }
     }
 
@@ -128,25 +175,24 @@ public class MailboxFactory {
         return new MailboxBuilder(this, defaultQuotaLoader);
     }
 
-    private Mailbox fromMessageManager(MessageManager messageManager,
-                                       Optional<List<MailboxMetaData>> userMailboxesMetadata,
-                                       Optional<MailboxCounters> preLoadedMailboxCounters,
-                                       QuotaLoader quotaLoader,
-                                       MailboxSession mailboxSession) throws MailboxException {
-        MailboxPath mailboxPath = messageManager.getMailboxPath();
+    private Mailbox from(MailboxId mailboxId,
+                         MailboxPath mailboxPath,
+                         MailboxCounters mailboxCounters,
+                         MailboxACL resolvedAcl,
+                         Optional<List<MailboxMetaData>> userMailboxesMetadata,
+                         QuotaLoader quotaLoader,
+                         MailboxSession mailboxSession) throws MailboxException {
         boolean isOwner = mailboxPath.belongsTo(mailboxSession);
         Optional<Role> role = Role.from(mailboxPath.getName());
-        MailboxCounters mailboxCounters = preLoadedMailboxCounters
-            .orElseGet(Throwing.supplier(() -> messageManager.getMailboxCounters(mailboxSession)).sneakyThrow());
 
-        Rights rights = Rights.fromACL(messageManager.getResolvedAcl(mailboxSession))
+        Rights rights = Rights.fromACL(resolvedAcl)
             .removeEntriesFor(Username.forMailboxPath(mailboxPath));
         Username username = Username.fromSession(mailboxSession);
 
         Quotas quotas = quotaLoader.getQuotas(mailboxPath);
 
         return Mailbox.builder()
-            .id(messageManager.getId())
+            .id(mailboxId)
             .name(getName(mailboxPath, mailboxSession))
             .parentId(getParentIdFromMailboxPath(mailboxPath, userMailboxesMetadata, mailboxSession).orElse(null))
             .role(role)

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/MailboxFactory.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/MailboxFactory.java
@@ -44,6 +44,7 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.quota.QuotaManager;
 import org.apache.james.mailbox.quota.QuotaRootResolver;
 
+import com.github.fge.lambdas.Throwing;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
@@ -58,6 +59,7 @@ public class MailboxFactory {
         private QuotaLoader quotaLoader;
         private MailboxSession session;
         private MailboxId id;
+        private Optional<MessageManager> messageManager = Optional.empty();
         private Optional<List<MailboxMetaData>> userMailboxesMetadata = Optional.empty();
 
         private MailboxBuilder(MailboxFactory mailboxFactory, QuotaLoader quotaLoader) {
@@ -67,6 +69,12 @@ public class MailboxFactory {
 
         public MailboxBuilder id(MailboxId id) {
             this.id = id;
+            return this;
+        }
+
+        public MailboxBuilder messageManager(MessageManager messageManager) {
+            this.id = messageManager.getId();
+            this.messageManager = Optional.of(messageManager);
             return this;
         }
 
@@ -90,7 +98,9 @@ public class MailboxFactory {
             Preconditions.checkNotNull(session);
 
             try {
-                MessageManager mailbox = mailboxFactory.mailboxManager.getMailbox(id, session);
+                MessageManager mailbox = messageManager.orElseGet(Throwing.supplier(
+                    () -> mailboxFactory.mailboxManager.getMailbox(id, session))
+                    .sneakyThrow());
                 return Optional.of(mailboxFactory.fromMessageManager(mailbox, userMailboxesMetadata, quotaLoader, session));
             } catch (MailboxNotFoundException e) {
                 return Optional.empty();


### PR DESCRIPTION
We were reading the metadata,
Then fetching mailboxes one by one.