### PR TITLE
JAMES-2927 Avoid null value binding in prepared statements

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
@@ -213,12 +213,15 @@ public class CassandraMessageDAO {
     }
 
     private UDTValue toUDT(MessageAttachment messageAttachment) {
-        return typesProvider.getDefinedUserType(ATTACHMENTS)
+        UDTValue result = typesProvider.getDefinedUserType(ATTACHMENTS)
             .newValue()
             .setString(Attachments.ID, messageAttachment.getAttachmentId().getId())
-            .setString(Attachments.NAME, messageAttachment.getName().orElse(null))
-            .setString(Attachments.CID, messageAttachment.getCid().map(Cid::getValue).orElse(null))
             .setBool(Attachments.IS_INLINE, messageAttachment.isInline());
+        messageAttachment.getName()
+            .ifPresent(name -> result.setString(Attachments.NAME, name));
+        messageAttachment.getCid()
+            .ifPresent(cid -> result.setString(Attachments.CID, cid.getValue()));
+        return result;
     }
 
     private List<UDTValue> buildPropertiesUdt(MailboxMessage message) {


### PR DESCRIPTION
A tumbstone is created when a null value is specified in a prepared statement.

This is due to the fact that null has the meaning `remove` and not the meaning `unspecified`, which is represented by no binding at all.

Of course unwanted tumbstones occurs with a performance cost.

The recommended method for fixing this is to separate nullable parts of the statements in other prepared statements, that can logically grouped together without overhead using batch statements.

Read this for further information: https://thelastpickle.com/blog/2016/09/15/Null-bindings-on-prepared-statements-and-undesired-tombstone-creation.html

To be noted: I won't push this work further for at least a week. So if you want to contribute to it, feel free.
