### PR TITLE
James-2936 Creating a mailbox using consecutive delimiter character leads to creation of list of unnamed mailbox

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/exception/HasEmptyMailboxNameInHierarchyException.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/exception/HasEmptyMailboxNameInHierarchyException.java
@@ -1,0 +1,35 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.exception;
+
+public class HasEmptyMailboxNameInHierarchyException extends MailboxNameException {
+    public HasEmptyMailboxNameInHierarchyException() {
+        super();
+    }
+
+    public HasEmptyMailboxNameInHierarchyException(String message) {
+        super(message);
+    }
+
+    public HasEmptyMailboxNameInHierarchyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxPath.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxPath.java
@@ -148,10 +148,11 @@ public class MailboxPath {
     }
 
     public boolean hasEmptyNameInHierarchy(char pathDelimiter) {
+        String delimiterString = String.valueOf(pathDelimiter);
         return this.name.isEmpty()
-            || this.name.contains("..")
-            || this.name.startsWith(".")
-            || this.name.endsWith(".");
+            || this.name.contains(delimiterString + delimiterString)
+            || this.name.startsWith(delimiterString)
+            || this.name.endsWith(delimiterString);
     }
 
     public String asString() {

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxPath.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxPath.java
@@ -147,6 +147,12 @@ public class MailboxPath {
         return this;
     }
 
+    public boolean hasEmptyNameInHierarchy(char pathDelimiter) {
+        return this.name.isEmpty()
+            || this.name.contains("..")
+            || this.name.startsWith(".")
+            || this.name.endsWith(".");
+    }
 
     public String asString() {
         return namespace + ":" + user + ":" + name;

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -261,6 +261,68 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
                 .isInstanceOf(HasEmptyMailboxNameInHierarchyException.class);
         }
 
+        @Test
+        void renamingMailboxShouldNotThrowWhenNameWithoutEmptyHierarchicalLevel() throws Exception {
+            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+
+            String mailboxName =  "a.b.c";
+
+            MailboxPath originPath = MailboxPath.forUser(USER_1, "origin");
+            mailboxManager.createMailbox(originPath, session);
+
+            assertThatCode(() -> mailboxManager.renameMailbox(originPath, MailboxPath.forUser(USER_1, mailboxName), session)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void renamingMailboxShouldNotThrowWhenNameWithASingleToBeNormalizedTrailingDelimiter() throws Exception {
+            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+
+            String mailboxName =  "a.b.";
+
+            MailboxPath originPath = MailboxPath.forUser(USER_1, "origin");
+            mailboxManager.createMailbox(originPath, session);
+
+            assertThatCode(() -> mailboxManager.renameMailbox(originPath, MailboxPath.forUser(USER_1, mailboxName), session)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void renamingMailboxShouldThrowWhenNameWithMoreThanOneTrailingDelimiter() throws Exception {
+            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+
+            String mailboxName =  "a..";
+
+            MailboxPath originPath = MailboxPath.forUser(USER_1, "origin");
+            mailboxManager.createMailbox(originPath, session);
+
+            assertThatThrownBy(() -> mailboxManager.renameMailbox(originPath, MailboxPath.forUser(USER_1, mailboxName), session))
+                .isInstanceOf(HasEmptyMailboxNameInHierarchyException.class);
+        }
+
+        @Test
+        void renamingMailboxShouldThrowWhenNameWithHeadingDelimiter() throws Exception {
+            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+
+            String mailboxName =  ".a";
+
+            MailboxPath originPath = MailboxPath.forUser(USER_1, "origin");
+            mailboxManager.createMailbox(originPath, session);
+
+            assertThatThrownBy(() -> mailboxManager.renameMailbox(originPath, MailboxPath.forUser(USER_1, mailboxName), session))
+                .isInstanceOf(HasEmptyMailboxNameInHierarchyException.class);
+        }
+
+        @Test
+        void renamingMailboxShouldThrowWhenNameWithEmptyHierarchicalLevel() throws Exception {
+            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+
+            String mailboxName =  "a..b";
+
+            MailboxPath originPath = MailboxPath.forUser(USER_1, "origin");
+            mailboxManager.createMailbox(originPath, session);
+
+            assertThatThrownBy(() -> mailboxManager.renameMailbox(originPath, MailboxPath.forUser(USER_1, mailboxName), session))
+                .isInstanceOf(HasEmptyMailboxNameInHierarchyException.class);
+        }
     }
 
     @Nested

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxPathTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxPathTest.java
@@ -154,7 +154,7 @@ public class MailboxPathTest {
     }
 
     @Test
-    public void hasEmptyNameInHierarchyShouldBeTrueIfPathWithAnEmptyNamesBetweenTwoNames() {
+    public void hasEmptyNameInHierarchyShouldBeTrueIfPathWithAnEmptyNameBetweenTwoNames() {
         assertThat(MailboxPath.forUser("user", "a..b")
             .hasEmptyNameInHierarchy('.'))
             .isTrue();

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxPathTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxPathTest.java
@@ -126,6 +126,62 @@ public class MailboxPathTest {
     }
 
     @Test
+    public void hasEmptyNameInHierarchyShouldBeFalseIfSingleLevelPath() {
+        assertThat(MailboxPath.forUser("user", "a")
+            .hasEmptyNameInHierarchy('.'))
+            .isFalse();
+    }
+
+    @Test
+    public void hasEmptyNameInHierarchyShouldBeFalseIfNestedLevelWithNonEmptyNames() {
+        assertThat(MailboxPath.forUser("user", "a.b.c")
+            .hasEmptyNameInHierarchy('.'))
+            .isFalse();
+    }
+
+    @Test
+    public void hasEmptyNameInHierarchyShouldBeTrueIfEmptyPath() {
+        assertThat(MailboxPath.forUser("user", "")
+            .hasEmptyNameInHierarchy('.'))
+            .isTrue();
+    }
+
+    @Test
+    public void hasEmptyNameInHierarchyShouldBeTrueIfPathWithTwoEmptyNames() {
+        assertThat(MailboxPath.forUser("user", ".")
+            .hasEmptyNameInHierarchy('.'))
+            .isTrue();
+    }
+
+    @Test
+    public void hasEmptyNameInHierarchyShouldBeTrueIfPathWithAnEmptyNamesBetweenTwoNames() {
+        assertThat(MailboxPath.forUser("user", "a..b")
+            .hasEmptyNameInHierarchy('.'))
+            .isTrue();
+    }
+
+    @Test
+    public void hasEmptyNameInHierarchyShouldBeTrueIfPathWithHeadingEmptyNames() {
+        assertThat(MailboxPath.forUser("user", "..a")
+            .hasEmptyNameInHierarchy('.'))
+            .isTrue();
+    }
+
+    @Test
+    public void hasEmptyNameInHierarchyShouldBeTrueIfPathWithATrailingEmptyName() {
+        assertThat(MailboxPath.forUser("user", "a.")
+            .hasEmptyNameInHierarchy('.'))
+            .isTrue();
+    }
+
+    @Test
+    public void hasEmptyNameInHierarchyShouldBeTrueIfPathWithTrailingEmptyNames() {
+        assertThat(MailboxPath.forUser("user", "a..")
+            .hasEmptyNameInHierarchy('.'))
+            .isTrue();
+    }
+
+    @Test
     public void isInboxShouldReturnTrueWhenINBOX() {
         MailboxPath mailboxPath = new MailboxPath(MailboxConstants.USER_NAMESPACE, "user", DefaultMailboxes.INBOX);
         assertThat(mailboxPath.isInbox()).isTrue();


### PR DESCRIPTION


creating a mailbox with consecutive `..` or one heading `.` create a list of mailbox with empty names.
for example for the mailbox `a..b` it create the mailboxes :

    `a`
    `a.`

    `a..b`

We will now refuse to create mailboxes with a hierarchy with empty names.
So we will reject the creation/renaming of mailbox with a name containing at least an heading delimiter character, or 2 or more consecutive delimiter character.

Note that we will still allow a trailing delimiter character which is removed during the sanitization step.
