### PR TITLE
JAMES-2956 Add a test to demonstrate html response for bad request instead of js…

### DIFF
--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MalformedUrlRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MalformedUrlRoutesTest.java
@@ -1,0 +1,107 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.routes;
+
+import static org.apache.james.webadmin.Constants.SEPARATOR;
+import static org.apache.james.webadmin.routes.UserMailboxesRoutes.USERS_BASE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.webadmin.WebAdminServer;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.service.UserMailboxesService;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+class MalformedUrlRoutesTest {
+    private static final String USERNAME = "username";
+    private static final String MALFORMED_MAILBOX_NAME = "inbox%work";
+
+    private WebAdminServer webAdminServer;
+    private UsersRepository usersRepository;
+
+    private void createServer(MailboxManager mailboxManager) throws Exception {
+        usersRepository = mock(UsersRepository.class);
+        when(usersRepository.contains(USERNAME)).thenReturn(true);
+
+        webAdminServer = WebAdminUtils.createWebAdminServer(
+            new UserMailboxesRoutes(new UserMailboxesService(mailboxManager, usersRepository), new JsonTransformer()))
+            .start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        webAdminServer.destroy();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        createServer(InMemoryIntegrationResources.defaultResources().getMailboxManager());
+    }
+
+    @Test
+    @Disabled()
+    void getMailboxesShouldReturnJsonErrorWhenMalformedUrl() throws Exception {
+        String response = executeRawPUT(USERS_BASE + SEPARATOR + USERNAME + SEPARATOR + MALFORMED_MAILBOX_NAME);
+        assertThat(response).doesNotContain("<h1>Bad Message 400</h1><pre>reason: Bad Request</pre>");
+    }
+
+    private String executeRawPUT(String path) throws Exception {
+        String hostname = "localhost";
+        int port = webAdminServer.getPort().getValue();
+
+        InetAddress addr = InetAddress.getByName(hostname);
+        try (Socket socket = new Socket(addr, port);
+             BufferedWriter wr = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8));
+             BufferedReader rd = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
+
+            // Send request
+            wr.write("PUT " + path + " HTTP/1.1\r\n");
+            wr.write("Host: " + hostname + "\r\n");
+            wr.write("Content-Type: " + "application/json" + "\r\n");
+            wr.write("Accept: " + "application/json" + "\r\n");
+            wr.write("\r\n");
+            wr.flush();
+
+            // Get response
+            StringBuffer response = new StringBuffer();
+            rd.lines().forEach(line -> response.append(line + "\r\n"));
+
+            return response.toString();
+
+        }
+    }
+
+}

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -24,6 +24,8 @@ In case of any error, the system will return an error message which is json form
 Also be aware that, in case things go wrong, all endpoints might return a 500 internal error (with a JSON body formatted
 as exposed above). To avoid information duplication, this is ommited on endpoint specific documentation.
 
+Finally, please note that in case of a malformed URL the 400 bad request response will contains an HTML body.
+
 ## Navigation menu
 
  - [HealthCheck](#HealthCheck)


### PR DESCRIPTION
…on ones. When malformed url.



When a malformed url is received by the webadmin server.
A 400 BadRequest is sent with an html body.
We would have preferred to have a JSON response with the same structure of all the error messages in the webadmin.

Unfortunately the fix to this will not be trivial. Because Spark has no way to be notified from this. It's deep into Jetty code with no way to override this behavior.

See : `HttpConnection.onFillable`, the boolean `handle` is set to `false` after a call to `parseRequestBuffer()`.  
So the `Channel.handle` method is never call, neither the filters from Spark.

I would propose to not fix this.
