### PR TITLE
JAMES-2959 SieveQuotaRoutes should return bad request when invalid body

### DIFF
--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/SieveQuotaRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/SieveQuotaRoutes.java
@@ -34,7 +34,6 @@ import org.apache.james.sieverepository.api.SieveQuotaRepository;
 import org.apache.james.sieverepository.api.exception.QuotaNotFoundException;
 import org.apache.james.webadmin.Routes;
 import org.apache.james.webadmin.utils.ErrorResponder;
-import org.apache.james.webadmin.utils.JsonExtractor;
 import org.apache.james.webadmin.utils.JsonTransformer;
 import org.apache.james.webadmin.utils.Responses;
 import org.eclipse.jetty.http.HttpStatus;
@@ -63,13 +62,11 @@ public class SieveQuotaRoutes implements Routes {
 
     private final SieveQuotaRepository sieveQuotaRepository;
     private final JsonTransformer jsonTransformer;
-    private final JsonExtractor<Long> jsonExtractor;
 
     @Inject
     public SieveQuotaRoutes(SieveQuotaRepository sieveQuotaRepository, JsonTransformer jsonTransformer) {
         this.sieveQuotaRepository = sieveQuotaRepository;
         this.jsonTransformer = jsonTransformer;
-        this.jsonExtractor = new JsonExtractor<>(Long.class);
     }
 
     @Override

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/SieveQuotaRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/SieveQuotaRoutes.java
@@ -34,13 +34,10 @@ import org.apache.james.sieverepository.api.SieveQuotaRepository;
 import org.apache.james.sieverepository.api.exception.QuotaNotFoundException;
 import org.apache.james.webadmin.Routes;
 import org.apache.james.webadmin.utils.ErrorResponder;
-import org.apache.james.webadmin.utils.JsonExtractException;
 import org.apache.james.webadmin.utils.JsonExtractor;
 import org.apache.james.webadmin.utils.JsonTransformer;
 import org.apache.james.webadmin.utils.Responses;
 import org.eclipse.jetty.http.HttpStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
 
@@ -63,7 +60,6 @@ public class SieveQuotaRoutes implements Routes {
     private static final String USER_ID = "userId";
     private static final String USER_SIEVE_QUOTA_PATH = Joiner.on(SEPARATOR).join(ROOT_PATH, "users", ":" + USER_ID);
     private static final String REQUESTED_SIZE = "requestedSize";
-    private static final Logger LOGGER = LoggerFactory.getLogger(SieveQuotaRoutes.class);
 
     private final SieveQuotaRepository sieveQuotaRepository;
     private final JsonTransformer jsonTransformer;
@@ -123,19 +119,9 @@ public class SieveQuotaRoutes implements Routes {
     })
     public void defineUpdateGlobalSieveQuota(Service service) {
         service.put(DEFAULT_QUOTA_PATH, (request, response) -> {
-            try {
-                QuotaSize requestedSize = extractRequestedQuotaSizeFromRequest(request);
-                sieveQuotaRepository.setDefaultQuota(requestedSize);
-                return Responses.returnNoContent(response);
-            } catch (JsonExtractException e) {
-                LOGGER.info("Malformed JSON", e);
-                throw ErrorResponder.builder()
-                    .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
-                    .statusCode(HttpStatus.BAD_REQUEST_400)
-                    .message("Malformed JSON")
-                    .cause(e)
-                    .haltError();
-            }
+            QuotaSize requestedSize = extractRequestedQuotaSizeFromRequest(request);
+            sieveQuotaRepository.setDefaultQuota(requestedSize);
+            return Responses.returnNoContent(response);
         }, jsonTransformer);
     }
 
@@ -193,19 +179,9 @@ public class SieveQuotaRoutes implements Routes {
     public void defineUpdatePerUserSieveQuota(Service service) {
         service.put(USER_SIEVE_QUOTA_PATH, (request, response) -> {
             User userId = User.fromUsername(request.params(USER_ID));
-            try {
-                QuotaSize requestedSize = extractRequestedQuotaSizeFromRequest(request);
-                sieveQuotaRepository.setQuota(userId, requestedSize);
-                return Responses.returnNoContent(response);
-            } catch (JsonExtractException e) {
-                LOGGER.info("Malformed JSON", e);
-                throw ErrorResponder.builder()
-                    .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
-                    .statusCode(HttpStatus.BAD_REQUEST_400)
-                    .message("Malformed JSON")
-                    .cause(e)
-                    .haltError();
-            }
+            QuotaSize requestedSize = extractRequestedQuotaSizeFromRequest(request);
+            sieveQuotaRepository.setQuota(userId, requestedSize);
+            return Responses.returnNoContent(response);
         }, jsonTransformer);
     }
 
@@ -230,8 +206,8 @@ public class SieveQuotaRoutes implements Routes {
         });
     }
 
-    private QuotaSize extractRequestedQuotaSizeFromRequest(Request request) throws JsonExtractException {
-        Long requestedSize = jsonExtractor.parse(request.body());
+    private QuotaSize extractRequestedQuotaSizeFromRequest(Request request) {
+        long requestedSize = extractNumberFromRequestBody(request);
         if (requestedSize < 0) {
             throw ErrorResponder.builder()
                 .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
@@ -240,5 +216,18 @@ public class SieveQuotaRoutes implements Routes {
                 .haltError();
         }
         return QuotaSize.size(requestedSize);
+    }
+
+    private long extractNumberFromRequestBody(Request request) {
+        String body = request.body();
+        try {
+            return Long.parseLong(body);
+        } catch (NumberFormatException e) {
+            throw ErrorResponder.builder()
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .message(String.format("unrecognized integer number '%s'", body))
+                .haltError();
+        }
     }
 }

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/SieveQuotaRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/SieveQuotaRoutesTest.java
@@ -99,9 +99,18 @@ class SieveQuotaRoutesTest {
     }
 
     @Test
-    void updateGlobalSieveQuotaShouldReturn400WhenMalformedJSON() {
+    void updateGlobalSieveQuotaShouldReturn400WhenInvalidNumberFormatInTheBody() {
         given()
             .body("invalid")
+            .put("/sieve/quota/default")
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400);
+    }
+
+    @Test
+    void updateGlobalSieveQuotaShouldReturn400WhenInvalidIntegerFormatInTheBody() {
+        given()
+            .body("1900.999")
             .put("/sieve/quota/default")
         .then()
             .statusCode(HttpStatus.BAD_REQUEST_400);
@@ -174,9 +183,18 @@ class SieveQuotaRoutesTest {
     }
 
     @Test
-    void updatePerUserSieveQuotaShouldReturn400WhenMalformedJSON() {
+    void updatePerUserSieveQuotaShouldReturn400WhenInvalidNumberFormatInTheBody() {
         given()
             .body("invalid")
+            .put("/sieve/quota/users/" + USER_A.asString())
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400);
+    }
+
+    @Test
+    void updatePerUserSieveQuotaShouldReturn400WhenInvalidIntegerFormatInTheBody() {
+        given()
+            .body("89884743.9999")
             .put("/sieve/quota/users/" + USER_A.asString())
         .then()
             .statusCode(HttpStatus.BAD_REQUEST_400);

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/SieveQuotaRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/SieveQuotaRoutesTest.java
@@ -21,6 +21,7 @@ package org.apache.james.webadmin.routes;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import org.apache.james.core.User;
 import org.apache.james.core.quota.QuotaSize;
@@ -104,7 +105,8 @@ class SieveQuotaRoutesTest {
             .body("invalid")
             .put("/sieve/quota/default")
         .then()
-            .statusCode(HttpStatus.BAD_REQUEST_400);
+            .statusCode(HttpStatus.BAD_REQUEST_400)
+            .body("message", is("unrecognized integer number 'invalid'"));
     }
 
     @Test
@@ -113,7 +115,8 @@ class SieveQuotaRoutesTest {
             .body("1900.999")
             .put("/sieve/quota/default")
         .then()
-            .statusCode(HttpStatus.BAD_REQUEST_400);
+            .statusCode(HttpStatus.BAD_REQUEST_400)
+            .body("message", is("unrecognized integer number '1900.999'"));
     }
 
     @Test
@@ -188,7 +191,8 @@ class SieveQuotaRoutesTest {
             .body("invalid")
             .put("/sieve/quota/users/" + USER_A.asString())
         .then()
-            .statusCode(HttpStatus.BAD_REQUEST_400);
+            .statusCode(HttpStatus.BAD_REQUEST_400)
+            .body("message", is("unrecognized integer number 'invalid'"));
     }
 
     @Test
@@ -197,7 +201,8 @@ class SieveQuotaRoutesTest {
             .body("89884743.9999")
             .put("/sieve/quota/users/" + USER_A.asString())
         .then()
-            .statusCode(HttpStatus.BAD_REQUEST_400);
+            .statusCode(HttpStatus.BAD_REQUEST_400)
+            .body("message", is("unrecognized integer number '89884743.9999'"));
     }
 
     @Test


### PR DESCRIPTION
- Invalid body: invalid number format, invalid integer format
- Remove the unnecessary json extraction of a single long value. Just
use Long.parseLong() directly