### PR TITLE
Add a build argument for Spring Dockerfile version

### DIFF
--- a/dockerfiles/run/spring/Dockerfile
+++ b/dockerfiles/run/spring/Dockerfile
@@ -17,8 +17,10 @@ EXPOSE 25 110 143 465 587 993 4000
 
 WORKDIR /root
 
+ARG VERSION=3.5.0-SNAPSHOT
+
 # Get data we need to run James : build results and configuration
-ADD destination/james-server-app-3.5.0-SNAPSHOT-app.zip /root/james-server-app-3.5.0-SNAPSHOT-app.zip
+ADD "destination/james-server-app-$VERSION-app.zip" "/root/james-server-app-$VERSION-app.zip"
 ADD destination/conf /root/conf
 ADD destination/glowroot/plugins /root/glowroot/plugins
 ADD destination/glowroot/glowroot.jar /root/glowroot/glowroot.jar
@@ -32,16 +34,16 @@ VOLUME /root/conf
 VOLUME /root/glowroot/plugins
 
 # Unzip build result
-RUN unzip james-server-app-3.5.0-SNAPSHOT-app.zip
+RUN unzip "james-server-app-$VERSION-app.zip"
 
 # Copy configuration.
 # Warning : we want to use the wrapper.conf file we just compiled.
-RUN cp james-server-app-3.5.0-SNAPSHOT/conf/wrapper.conf .
-RUN rm -r james-server-app-3.5.0-SNAPSHOT/conf/*
-RUN cp -r conf/* james-server-app-3.5.0-SNAPSHOT/conf
-RUN cp wrapper.conf james-server-app-3.5.0-SNAPSHOT/conf
+RUN cp "james-server-app-$VERSION/conf/wrapper.conf" .
+RUN rm -r "james-server-app-$VERSION/conf" && mkdir "james-server-app-$VERSION/conf"
+RUN cp -r conf/* "james-server-app-$VERSION/conf"
+RUN cp wrapper.conf "james-server-app-$VERSION/conf"
 
 ENV PATH "$PATH:/root/glowroot/lib"
 
-WORKDIR /root/james-server-app-3.5.0-SNAPSHOT/bin
+WORKDIR "/root/james-server-app-$VERSION/bin"
 ENTRYPOINT /root/run_james.sh


### PR DESCRIPTION
Upon a release we need to change simultaneously maven version and the one
within Spring dockerfile (which relies on hard-coded version positionned
by the assembly plugin). This results in broken build post-release as well
as difficulties into building a specific tag when forgotten.

With this changeset we can specify a build argument upon Spring docker
image creation from CI environment, in order to use the right version
without needing code changes. As version can be detected from build files,
this means that we will avoid that pitfall.