### PR TITLE
JAMES-2933 Define mailetdocs-maven-plugin version globally

### DIFF
--- a/mailet/pom.xml
+++ b/mailet/pom.xml
@@ -65,15 +65,6 @@
     </properties>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>${james.groupId}</groupId>
-                    <artifactId>mailetdocs-maven-plugin</artifactId>
-                    <version>${project.version}</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.rat</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2670,6 +2670,11 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>${james.groupId}</groupId>
+                    <artifactId>mailetdocs-maven-plugin</artifactId>
+                    <version>${project.version}</version>
+                </plugin>
                 <!-- Order by groupId / artifactId / scope -->
                 <plugin>
                     <groupId>com.coderplus.maven.plugins</groupId>


### PR DESCRIPTION
It was unspecified for server/mailet/dkim and /server/mailet/mailets

I suspect this could cause IDE integration issues reported on the DEV
mailing list by Jerry Malcolm

cf https://www.mail-archive.com/server-dev@james.apache.org/msg62734.html