### PR TITLE
JAMES-2966 bump elastic metrics reporter version to avoid thread leaks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -623,7 +623,7 @@
         <testcontainers.version>1.12.0</testcontainers.version>
         <assertj.version>3.3.0</assertj.version>
         <es.version>2.2.1</es.version>
-        <es-reporter.version>6.0.0-RC2</es-reporter.version>
+        <es-reporter.version>6.0.0-RC3</es-reporter.version>
         <guava.version>25.1-jre</guava.version>
 
         <jutf7.version>1.0.0</jutf7.version>


### PR DESCRIPTION
ESReporter, due to the previous 0-dependency approach, relied on HTTPUrl java lib.

Due to that choice, some dark magic wizardry well-deserving a latin quota, **we are leaking a thread+connection everytime we do a reporting**.

The **no-deps** choice is no longer justify today thus we should port the transport layer of ESReporter to a modern HTTP framework.

use the work done in https://github.com/linagora/elasticsearch-metrics-reporter-java/pull/8