### PR TITLE
JAMES-2905 ES authentication configuration

### DIFF
--- a/dockerfiles/run/guice/cassandra-ldap/destination/conf/elasticsearch.properties
+++ b/dockerfiles/run/guice/cassandra-ldap/destination/conf/elasticsearch.properties
@@ -25,6 +25,21 @@
 elasticsearch.masterHost=elasticsearch
 elasticsearch.port=9200
 
+# Optional. Only http or https are accepted, default is http
+# elasticsearch.hostScheme=http
+
+# Optional.
+# Basic auth username to access elasticsearch.
+# Ignore elasticsearch.user and elasticsearch.password to not be using authentication (default behaviour).
+# Otherwise, you need to specify both properties.
+# elasticsearch.user=elasticsearch
+
+# Optional.
+# Basic auth password to access elasticsearch.
+# Ignore elasticsearch.user and elasticsearch.password to not be using authentication (default behaviour).
+# Otherwise, you need to specify both properties.
+# elasticsearch.password=secret
+
 # You can alternatively provide a list of hosts following this format :
 # elasticsearch.hosts=host1:9200,host2:9200
 # elasticsearch.clusterName=cluster

--- a/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/elasticsearch.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/elasticsearch.properties
@@ -24,6 +24,21 @@
 elasticsearch.masterHost=elasticsearch
 elasticsearch.port=9200
 
+# Optional. Only http or https are accepted, default is http
+# elasticsearch.hostScheme=http
+
+# Optional.
+# Basic auth username to access elasticsearch.
+# Ignore elasticsearch.user and elasticsearch.password to not be using authentication (default behaviour).
+# Otherwise, you need to specify both properties.
+# elasticsearch.user=elasticsearch
+
+# Optional.
+# Basic auth password to access elasticsearch.
+# Ignore elasticsearch.user and elasticsearch.password to not be using authentication (default behaviour).
+# Otherwise, you need to specify both properties.
+# elasticsearch.password=secret
+
 # You can alternatively provide a list of hosts following this format :
 # elasticsearch.hosts=host1:9200,host2:9200
 # elasticsearch.clusterName=cluster

--- a/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/elasticsearch.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/elasticsearch.properties
@@ -24,6 +24,21 @@
 elasticsearch.masterHost=elasticsearch
 elasticsearch.port=9200
 
+# Optional. Only http or https are accepted, default is http
+# elasticsearch.hostScheme=http
+
+# Optional.
+# Basic auth username to access elasticsearch.
+# Ignore elasticsearch.user and elasticsearch.password to not be using authentication (default behaviour).
+# Otherwise, you need to specify both properties.
+# elasticsearch.user=elasticsearch
+
+# Optional.
+# Basic auth password to access elasticsearch.
+# Ignore elasticsearch.user and elasticsearch.password to not be using authentication (default behaviour).
+# Otherwise, you need to specify both properties.
+# elasticsearch.password=secret
+
 # You can alternatively provide a list of hosts following this format :
 # elasticsearch.hosts=host1:9200,host2:9200
 # elasticsearch.clusterName=cluster

--- a/dockerfiles/run/guice/cassandra/destination/conf/elasticsearch.properties
+++ b/dockerfiles/run/guice/cassandra/destination/conf/elasticsearch.properties
@@ -25,6 +25,21 @@
 elasticsearch.masterHost=elasticsearch
 elasticsearch.port=9200
 
+# Optional. Only http or https are accepted, default is http
+# elasticsearch.hostScheme=http
+
+# Optional.
+# Basic auth username to access elasticsearch.
+# Ignore elasticsearch.user and elasticsearch.password to not be using authentication (default behaviour).
+# Otherwise, you need to specify both properties.
+# elasticsearch.user=elasticsearch
+
+# Optional.
+# Basic auth password to access elasticsearch.
+# Ignore elasticsearch.user and elasticsearch.password to not be using authentication (default behaviour).
+# Otherwise, you need to specify both properties.
+# elasticsearch.password=secret
+
 # You can alternatively provide a list of hosts following this format :
 # elasticsearch.hosts=host1:9200,host2:9200
 # elasticsearch.clusterName=cluster

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/ElasticSearchStartUpCheck.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/ElasticSearchStartUpCheck.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 import org.apache.james.backends.es.ElasticSearchConfiguration;
 import org.apache.james.lifecycle.api.StartUpCheck;
 import org.elasticsearch.Version;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +50,7 @@ public class ElasticSearchStartUpCheck implements StartUpCheck {
     @Override
     public CheckResult check() {
         try {
-            Version esVersion = client.info()
+            Version esVersion = client.info(RequestOptions.DEFAULT)
                 .getVersion();
             if (esVersion.isCompatible(RECOMMENDED_ES_VERSION)) {
                 return CheckResult.builder()

--- a/src/site/xdoc/server/config-elasticsearch.xml
+++ b/src/site/xdoc/server/config-elasticsearch.xml
@@ -38,6 +38,25 @@
           <dd>Is the IP (or host) of the ElasticSearch master</dd>
           <dt><strong>elasticsearch.port</strong></dt>
           <dd>Is the port of ElasticSearch master</dd>
+
+          <dt><strong>elasticsearch.hostScheme</strong></dt>
+          <dd>Optional. Only http or https are accepted, default is http</dd>
+
+          <dt><strong>elasticsearch.user</strong></dt>
+          <dd>
+              Optional.
+              Basic auth username to access elasticsearch.
+              Ignore elasticsearch.user and elasticsearch.password to not be using authentication (default behaviour).
+              Otherwise, you need to specify both properties.
+          </dd>
+
+          <dt><strong>elasticsearch.password</strong></dt>
+          <dd>
+              Optional.
+              Basic auth password to access elasticsearch.
+              Ignore elasticsearch.user and elasticsearch.password to not be using authentication (default behaviour).
+              Otherwise, you need to specify both properties.
+          </dd>
       </dl>
 
       Or you can connect a cluster by :


### PR DESCRIPTION
The current ES version 6.3.2 doesn't support authentication by default. There is a paid package called xpact should be installed to enable authentication. So no way to test authentication on a real ES server.

With newer version, seem like we can enable this feature https://www.elastic.co/blog/security-for-elasticsearch-is-now-free