### PR TITLE
[Git] Ignore glowroot folder for docker compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ dependency-reduced-pom.xml
 dockerfiles/run/**/*.lib
 dockerfiles/run/**/*.jar
 dockerfiles/run/**/keystore
+dockerfiles/run/**/glowroot
 .m2
 test-run.log


### PR DESCRIPTION
Very simple PR... just tired of having the glowroot folder polluting my Git after I compile docker images of James locally