### PR TITLE
[Refactoring] Moving tests from JUnit 4 to JUnit 5 in mailbox-api module

### DIFF
--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/init/CassandraConfigurationTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/init/CassandraConfigurationTest.java
@@ -23,15 +23,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.james.backends.cassandra.init.configuration.CassandraConfiguration;
-import org.assertj.core.api.JUnitJupiterSoftAssertions;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 class CassandraConfigurationTest {
-    @RegisterExtension
-    JUnitJupiterSoftAssertions softly = new JUnitJupiterSoftAssertions();
 
     @Test
     void cassandraConfigurationShouldRespectBeanContract() {
@@ -213,17 +210,19 @@ class CassandraConfigurationTest {
             .messageAttachmentIdsReadTimeout(messageAttachmentIdReadTimeout)
             .build();
 
-        softly.assertThat(configuration.getAclMaxRetry()).isEqualTo(aclMaxRetry);
-        softly.assertThat(configuration.getModSeqMaxRetry()).isEqualTo(modSeqMaxRetry);
-        softly.assertThat(configuration.getUidMaxRetry()).isEqualTo(uidMaxRetry);
-        softly.assertThat(configuration.getFetchNextPageInAdvanceRow()).isEqualTo(fetchNextPageInAdvanceRow);
-        softly.assertThat(configuration.getFlagsUpdateMessageMaxRetry()).isEqualTo(flagsUpdateMessageMaxRetry);
-        softly.assertThat(configuration.getFlagsUpdateMessageIdMaxRetry()).isEqualTo(flagsUpdateMessageIdMaxRetry);
-        softly.assertThat(configuration.getMessageReadChunkSize()).isEqualTo(messageReadChunkSize);
-        softly.assertThat(configuration.getExpungeChunkSize()).isEqualTo(expungeChunkSize);
-        softly.assertThat(configuration.getBlobPartSize()).isEqualTo(blobPartSize);
-        softly.assertThat(configuration.getAttachmentV2MigrationReadTimeout()).isEqualTo(attachmentV2MigrationReadTimeout);
-        softly.assertThat(configuration.getMessageAttachmentIdsReadTimeout()).isEqualTo(messageAttachmentIdReadTimeout);
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(configuration.getAclMaxRetry()).isEqualTo(aclMaxRetry);
+            softly.assertThat(configuration.getModSeqMaxRetry()).isEqualTo(modSeqMaxRetry);
+            softly.assertThat(configuration.getUidMaxRetry()).isEqualTo(uidMaxRetry);
+            softly.assertThat(configuration.getFetchNextPageInAdvanceRow()).isEqualTo(fetchNextPageInAdvanceRow);
+            softly.assertThat(configuration.getFlagsUpdateMessageMaxRetry()).isEqualTo(flagsUpdateMessageMaxRetry);
+            softly.assertThat(configuration.getFlagsUpdateMessageIdMaxRetry()).isEqualTo(flagsUpdateMessageIdMaxRetry);
+            softly.assertThat(configuration.getMessageReadChunkSize()).isEqualTo(messageReadChunkSize);
+            softly.assertThat(configuration.getExpungeChunkSize()).isEqualTo(expungeChunkSize);
+            softly.assertThat(configuration.getBlobPartSize()).isEqualTo(blobPartSize);
+            softly.assertThat(configuration.getAttachmentV2MigrationReadTimeout()).isEqualTo(attachmentV2MigrationReadTimeout);
+            softly.assertThat(configuration.getMessageAttachmentIdsReadTimeout()).isEqualTo(messageAttachmentIdReadTimeout);
+        });
     }
 
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/ApplicableFlagBuilderTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/ApplicableFlagBuilderTest.java
@@ -22,25 +22,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.mail.Flags;
 
-import org.assertj.core.api.JUnitSoftAssertions;
-import org.junit.Rule;
-import org.junit.Test;
+import org.assertj.core.api.JUnitJupiterSoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.collect.ImmutableList;
 
-public class ApplicableFlagBuilderTest {
+class ApplicableFlagBuilderTest {
 
-    @Rule
-    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
+    @RegisterExtension
+    public final JUnitJupiterSoftAssertions softly = new JUnitJupiterSoftAssertions();
 
     @Test
-    public void shouldAtLeastContainAllDefaultApplicativeFlag() {
+    void shouldAtLeastContainAllDefaultApplicativeFlag() {
         assertThat(ApplicableFlagBuilder.builder().build())
             .isEqualTo(ApplicableFlagBuilder.DEFAULT_APPLICABLE_FLAGS);
     }
 
     @Test
-    public void shouldNeverRetainRecentAndUserFlag() {
+    void shouldNeverRetainRecentAndUserFlag() {
         Flags result = ApplicableFlagBuilder.builder()
             .add(new Flags(Flags.Flag.RECENT))
             .add(new Flags(Flags.Flag.USER))
@@ -51,7 +51,7 @@ public class ApplicableFlagBuilderTest {
     }
 
     @Test
-    public void shouldAddCustomUserFlagIfProvidedToDefaultFlag() {
+    void shouldAddCustomUserFlagIfProvidedToDefaultFlag() {
         Flags result = ApplicableFlagBuilder.builder()
             .add("yolo", "vibe")
             .build();
@@ -62,7 +62,7 @@ public class ApplicableFlagBuilderTest {
     }
 
     @Test
-    public void shouldAcceptUserCustomFlagInsideFlags() {
+    void shouldAcceptUserCustomFlagInsideFlags() {
         Flags result = ApplicableFlagBuilder.builder()
             .add(new Flags("yolo"))
             .build();
@@ -71,7 +71,7 @@ public class ApplicableFlagBuilderTest {
     }
 
     @Test
-    public void shouldAcceptFlagsThatContainMultipleFlag() {
+    void shouldAcceptFlagsThatContainMultipleFlag() {
         Flags flags = FlagsBuilder.builder()
             .add("yolo", "vibes")
             .build();
@@ -85,7 +85,7 @@ public class ApplicableFlagBuilderTest {
     }
 
     @Test
-    public void addShouldAddMultipleFlagsAtOnce() {
+    void addShouldAddMultipleFlagsAtOnce() {
         Flags flags = new Flags("cartman");
         Flags flags2 = new Flags("butters");
         Flags result = ApplicableFlagBuilder.builder()
@@ -97,7 +97,7 @@ public class ApplicableFlagBuilderTest {
     }
 
     @Test
-    public void shouldAcceptMultipleFlagAtOnce() {
+    void shouldAcceptMultipleFlagAtOnce() {
         Flags result = ApplicableFlagBuilder.builder()
             .add("cartman", "butters")
             .add("chef", "randy")
@@ -110,7 +110,7 @@ public class ApplicableFlagBuilderTest {
     }
 
     @Test
-    public void shouldAcceptListOfFlags() throws Exception {
+    void shouldAcceptListOfFlags() throws Exception {
         Flags result = ApplicableFlagBuilder.builder()
             .add(ImmutableList.of(new Flags("cartman"), new Flags("chef")))
             .build();

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/ApplicableFlagBuilderTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/ApplicableFlagBuilderTest.java
@@ -22,16 +22,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.mail.Flags;
 
-import org.assertj.core.api.JUnitJupiterSoftAssertions;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.collect.ImmutableList;
 
 class ApplicableFlagBuilderTest {
-
-    @RegisterExtension
-    public final JUnitJupiterSoftAssertions softly = new JUnitJupiterSoftAssertions();
 
     @Test
     void shouldAtLeastContainAllDefaultApplicativeFlag() {
@@ -46,8 +42,10 @@ class ApplicableFlagBuilderTest {
             .add(new Flags(Flags.Flag.USER))
             .build();
 
-        softly.assertThat(result.contains(Flags.Flag.RECENT)).isFalse();
-        softly.assertThat(result.contains(Flags.Flag.USER)).isFalse();
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(result.contains(Flags.Flag.RECENT)).isFalse();
+            softly.assertThat(result.contains(Flags.Flag.USER)).isFalse();
+        });
     }
 
     @Test
@@ -56,9 +54,11 @@ class ApplicableFlagBuilderTest {
             .add("yolo", "vibe")
             .build();
 
-        softly.assertThat(result.contains(ApplicableFlagBuilder.DEFAULT_APPLICABLE_FLAGS)).isTrue();
-        softly.assertThat(result.contains("yolo")).isTrue();
-        softly.assertThat(result.contains("vibe")).isTrue();
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(result.contains(ApplicableFlagBuilder.DEFAULT_APPLICABLE_FLAGS)).isTrue();
+            softly.assertThat(result.contains("yolo")).isTrue();
+            softly.assertThat(result.contains("vibe")).isTrue();
+        });
     }
 
     @Test
@@ -80,8 +80,10 @@ class ApplicableFlagBuilderTest {
             .add(flags)
             .build();
 
-        softly.assertThat(result.contains("yolo")).isTrue();
-        softly.assertThat(result.contains("vibes")).isTrue();
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(result.contains("yolo")).isTrue();
+            softly.assertThat(result.contains("vibes")).isTrue();
+        });
     }
 
     @Test
@@ -92,8 +94,10 @@ class ApplicableFlagBuilderTest {
                 .add(flags, flags2)
                 .build();
 
-        softly.assertThat(result.contains(flags)).isTrue();
-        softly.assertThat(result.contains(flags2)).isTrue();
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(result.contains(flags)).isTrue();
+            softly.assertThat(result.contains(flags2)).isTrue();
+        });
     }
 
     @Test
@@ -103,10 +107,12 @@ class ApplicableFlagBuilderTest {
             .add("chef", "randy")
             .build();
 
-        softly.assertThat(result.contains("cartman")).isTrue();
-        softly.assertThat(result.contains("butters")).isTrue();
-        softly.assertThat(result.contains("chef")).isTrue();
-        softly.assertThat(result.contains("randy")).isTrue();
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(result.contains("cartman")).isTrue();
+            softly.assertThat(result.contains("butters")).isTrue();
+            softly.assertThat(result.contains("chef")).isTrue();
+            softly.assertThat(result.contains("randy")).isTrue();
+        });
     }
 
     @Test
@@ -115,7 +121,9 @@ class ApplicableFlagBuilderTest {
             .add(ImmutableList.of(new Flags("cartman"), new Flags("chef")))
             .build();
 
-        softly.assertThat(result.contains("cartman")).isTrue();
-        softly.assertThat(result.contains("chef")).isTrue();
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(result.contains("cartman")).isTrue();
+            softly.assertThat(result.contains("chef")).isTrue();
+        });
     }
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/ComposedMessageIdTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/ComposedMessageIdTest.java
@@ -20,14 +20,14 @@
 package org.apache.james.mailbox;
 
 import org.apache.james.mailbox.model.ComposedMessageId;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class ComposedMessageIdTest {
+class ComposedMessageIdTest {
 
     @Test
-    public void composedMessageIdShouldRespectBeanContract() {
+    void composedMessageIdShouldRespectBeanContract() {
         EqualsVerifier.forClass(ComposedMessageId.class)
             .verify();
     }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxExceptionTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxExceptionTest.java
@@ -21,25 +21,25 @@ package org.apache.james.mailbox;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.james.mailbox.exception.MailboxException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Ensure that {@link MailboxException} construction is correct.
  */
-public class MailboxExceptionTest {
+class MailboxExceptionTest {
     
     private static final String EXCEPTION_MESSAGE = "this is an exception message";
     private static final String CAUSE_MESSAGE = "this is a cause";
     private static final Exception EXCEPTION_CAUSE = new Exception(CAUSE_MESSAGE);
     
     @Test
-    public void testMailboxExceptionMessage() {
+    void testMailboxExceptionMessage() {
         MailboxException mbe = new MailboxException(EXCEPTION_MESSAGE);
         assertThat(mbe).hasMessage(EXCEPTION_MESSAGE);
     }
 
     @Test
-    public void testMailboxExceptionCause() {
+    void testMailboxExceptionCause() {
         MailboxException mbe = new MailboxException(EXCEPTION_MESSAGE, EXCEPTION_CAUSE);
         assertThat(mbe).hasMessage(EXCEPTION_MESSAGE).hasCauseExactlyInstanceOf(Exception.class);
         assertThat(mbe.getCause()).hasMessage(CAUSE_MESSAGE);

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -144,7 +144,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
     }
 
     @Test
-    public void creatingConcurrentlyMailboxesWithSameParentShouldNotFail() throws Exception {
+    void creatingConcurrentlyMailboxesWithSameParentShouldNotFail() throws Exception {
         MailboxSession session = mailboxManager.createSystemSession(USER_1);
         String mailboxName = "a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z";
 
@@ -155,7 +155,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
     }
 
     @Test
-    public void createMailboxShouldReturnRightId() throws Exception {
+    void createMailboxShouldReturnRightId() throws Exception {
         session = mailboxManager.createSystemSession(USER_1);
         mailboxManager.startProcessingRequest(session);
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -144,7 +144,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
     }
 
     @Test
-    void creatingConcurrentlyMailboxesWithSameParentShouldNotFail() throws Exception {
+    public void creatingConcurrentlyMailboxesWithSameParentShouldNotFail() throws Exception {
         MailboxSession session = mailboxManager.createSystemSession(USER_1);
         String mailboxName = "a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z";
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -144,7 +144,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
     }
 
     @Test
-    public void creatingConcurrentlyMailboxesWithSameParentShouldNotFail() throws Exception {
+    protected void creatingConcurrentlyMailboxesWithSameParentShouldNotFail() throws Exception {
         MailboxSession session = mailboxManager.createSystemSession(USER_1);
         String mailboxName = "a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z";
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MessageMoveEventTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MessageMoveEventTest.java
@@ -26,16 +26,12 @@ import org.apache.james.mailbox.events.MessageMoveEvent;
 import org.apache.james.mailbox.model.MessageMoves;
 import org.apache.james.mailbox.model.TestId;
 import org.apache.james.mailbox.model.TestMessageId;
-import org.assertj.core.api.JUnitJupiterSoftAssertions;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 class MessageMoveEventTest {
-
-    @RegisterExtension
-    public JUnitJupiterSoftAssertions softly = new JUnitJupiterSoftAssertions();
 
     @Test
     void shouldRespectBeanContract() {
@@ -102,9 +98,11 @@ class MessageMoveEventTest {
             .messageId(messageId)
             .build();
 
-        softly.assertThat(event.getUsername()).isEqualTo(Username.of(username));
-        softly.assertThat(event.getMessageMoves()).isEqualTo(messageMoves);
-        softly.assertThat(event.getMessageIds()).containsExactly(messageId);
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(event.getUsername()).isEqualTo(Username.of(username));
+            softly.assertThat(event.getMessageMoves()).isEqualTo(messageMoves);
+            softly.assertThat(event.getMessageIds()).containsExactly(messageId);
+        });
     }
 
     @Test

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MessageMoveEventTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MessageMoveEventTest.java
@@ -26,31 +26,31 @@ import org.apache.james.mailbox.events.MessageMoveEvent;
 import org.apache.james.mailbox.model.MessageMoves;
 import org.apache.james.mailbox.model.TestId;
 import org.apache.james.mailbox.model.TestMessageId;
-import org.assertj.core.api.JUnitSoftAssertions;
-import org.junit.Rule;
-import org.junit.Test;
+import org.assertj.core.api.JUnitJupiterSoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class MessageMoveEventTest {
+class MessageMoveEventTest {
 
-    @Rule
-    public JUnitSoftAssertions softly = new JUnitSoftAssertions();
+    @RegisterExtension
+    public JUnitJupiterSoftAssertions softly = new JUnitJupiterSoftAssertions();
 
     @Test
-    public void shouldRespectBeanContract() {
+    void shouldRespectBeanContract() {
         EqualsVerifier.forClass(MessageMoveEvent.class).verify();
     }
 
     @Test
-    public void builderShouldThrowWhenSessionIsNull() {
+    void builderShouldThrowWhenSessionIsNull() {
         assertThatThrownBy(() -> MessageMoveEvent.builder()
                 .build())
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void builderShouldThrowWhenMessageMovesIsNull() {
+    void builderShouldThrowWhenMessageMovesIsNull() {
         assertThatThrownBy(() -> MessageMoveEvent.builder()
                 .session(MailboxSessionUtil.create("user@james.org"))
                 .build())
@@ -58,7 +58,7 @@ public class MessageMoveEventTest {
     }
 
     @Test
-    public void builderShouldReturnNoopWhenMessagesIsEmpty() {
+    void builderShouldReturnNoopWhenMessagesIsEmpty() {
         assertThat(MessageMoveEvent.builder()
                 .session(MailboxSessionUtil.create("user@james.org"))
                 .messageMoves(MessageMoves.builder()
@@ -70,7 +70,7 @@ public class MessageMoveEventTest {
     }
 
     @Test
-    public void builderShouldNotBeNoopWhenFieldsAreGiven() {
+    void builderShouldNotBeNoopWhenFieldsAreGiven() {
         MailboxSession session = MailboxSessionUtil.create("user@james.org");
         MessageMoves messageMoves = MessageMoves.builder()
             .targetMailboxIds(TestId.of(2))
@@ -87,7 +87,7 @@ public class MessageMoveEventTest {
     }
 
     @Test
-    public void builderShouldBuildWhenFieldsAreGiven() {
+    void builderShouldBuildWhenFieldsAreGiven() {
         String username = "user@james.org";
         MailboxSession session = MailboxSessionUtil.create(username);
         MessageMoves messageMoves = MessageMoves.builder()
@@ -108,7 +108,7 @@ public class MessageMoveEventTest {
     }
 
     @Test
-    public void isMoveToShouldReturnFalseWhenMailboxIdIsNotInAddedMailboxIds() {
+    void isMoveToShouldReturnFalseWhenMailboxIdIsNotInAddedMailboxIds() {
         MessageMoveEvent event = MessageMoveEvent.builder()
             .session(MailboxSessionUtil.create("user@james.org"))
             .messageMoves(MessageMoves.builder()
@@ -121,7 +121,7 @@ public class MessageMoveEventTest {
     }
 
     @Test
-    public void isMoveToShouldReturnTrueWhenMailboxIdIsInAddedMailboxIds() {
+    void isMoveToShouldReturnTrueWhenMailboxIdIsInAddedMailboxIds() {
         TestId mailboxId = TestId.of(123);
         MessageMoveEvent event = MessageMoveEvent.builder()
             .session(MailboxSessionUtil.create("user@james.org"))
@@ -135,7 +135,7 @@ public class MessageMoveEventTest {
     }
 
     @Test
-    public void isMoveFromShouldReturnFalseWhenMailboxIdIsNotInRemovedMailboxIds() {
+    void isMoveFromShouldReturnFalseWhenMailboxIdIsNotInRemovedMailboxIds() {
         MessageMoveEvent event = MessageMoveEvent.builder()
             .session(MailboxSessionUtil.create("user@james.org"))
             .messageMoves(MessageMoves.builder()
@@ -148,7 +148,7 @@ public class MessageMoveEventTest {
     }
 
     @Test
-    public void isMoveFromShouldReturnTrueWhenMailboxIdIsInRemovedMailboxIds() {
+    void isMoveFromShouldReturnTrueWhenMailboxIdIsInRemovedMailboxIds() {
         TestId mailboxId = TestId.of(123);
         MessageMoveEvent event = MessageMoveEvent.builder()
             .session(MailboxSessionUtil.create("user@james.org"))

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MessageUidTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MessageUidTest.java
@@ -19,14 +19,11 @@
 package org.apache.james.mailbox;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-public class MessageUidTest {
-
-    @Rule public ExpectedException exception = ExpectedException.none();
+class MessageUidTest {
     
     private static final MessageUid _1 = MessageUid.of(1);
     private static final MessageUid _2 = MessageUid.of(2);
@@ -34,24 +31,24 @@ public class MessageUidTest {
     private static final MessageUid _4 = MessageUid.of(4);
 
     @Test
-    public void distanceShouldReturnZeroWhenSameValue() {
+    void distanceShouldReturnZeroWhenSameValue() {
         assertThat(_1.distance(_1)).isEqualTo(0);
     }
 
     @Test
-    public void distanceShouldThrowWhenNullArgument() {
-        exception.expect(NullPointerException.class);
-        _1.distance(null);
+    void distanceShouldThrowWhenNullArgument() {
+        assertThatThrownBy(() -> _1.distance(null))
+            .isInstanceOf(NullPointerException.class);
     }
 
 
     @Test
-    public void distanceShouldReturnPositiveDistanceWhenGreaterArgument() {
+    void distanceShouldReturnPositiveDistanceWhenGreaterArgument() {
         assertThat(_1.distance(_4)).isEqualTo(3);
     }
     
     @Test
-    public void distanceShouldReturnNegativeDistanceWhenSmallerArgument() {
+    void distanceShouldReturnNegativeDistanceWhenSmallerArgument() {
         assertThat(_3.distance(_2)).isEqualTo(-1);
     }
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/RoleTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/RoleTest.java
@@ -23,28 +23,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Locale;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class RoleTest {
+class RoleTest {
 
     @Test
-    public void fromShouldReturnEmptyWhenUnknownValue() {
+    void fromShouldReturnEmptyWhenUnknownValue() {
         assertThat(Role.from("jjjj")).isEqualTo(Optional.empty());
     }
 
     @Test
-    public void fromShouldReturnSomethingWhenXPrefixedRole() {
+    void fromShouldReturnSomethingWhenXPrefixedRole() {
         assertThat(Role.from("x-client-specific-role")).isEqualTo(Optional.of(new Role("x-client-specific-role")));
     }
 
     @Test
-    public void isSystemRoleShouldReturnFalseWhenXPrefixedRole() {
+    void isSystemRoleShouldReturnFalseWhenXPrefixedRole() {
         Role role = Role.from("x-client-specific-role").get();
         assertThat(role.isSystemRole()).isFalse();
     }
 
     @Test
-    public void fromShouldReturnInboxWhenContainsUppercaseValueInTurkish() {
+    void fromShouldReturnInboxWhenContainsUppercaseValueInTurkish() {
         Locale previousLocale = Locale.getDefault();
         Locale.setDefault(Locale.forLanguageTag("tr"));
         try {
@@ -55,124 +55,124 @@ public class RoleTest {
     }
 
     @Test
-    public void isSystemRoleShouldBeTrueWhenInbox() {
+    void isSystemRoleShouldBeTrueWhenInbox() {
         assertThat(Role.INBOX.isSystemRole()).isTrue();
     }
 
     @Test
-    public void isSystemRoleShouldBeTrueWhenArchive() {
+    void isSystemRoleShouldBeTrueWhenArchive() {
         assertThat(Role.ARCHIVE.isSystemRole()).isTrue();
     }
 
     @Test
-    public void isSystemRoleShouldBeTrueWhenDrafts() {
+    void isSystemRoleShouldBeTrueWhenDrafts() {
         assertThat(Role.DRAFTS.isSystemRole()).isTrue();
     }
 
     @Test
-    public void isSystemRoleShouldBeTrueWhenOutbox() {
+    void isSystemRoleShouldBeTrueWhenOutbox() {
         assertThat(Role.OUTBOX.isSystemRole()).isTrue();
     }
 
     @Test
-    public void isSystemRoleShouldBeTrueWhenSent() {
+    void isSystemRoleShouldBeTrueWhenSent() {
         assertThat(Role.SENT.isSystemRole()).isTrue();
     }
 
     @Test
-    public void isSystemRoleShouldBeTrueWhenTrash() {
+    void isSystemRoleShouldBeTrueWhenTrash() {
         assertThat(Role.TRASH.isSystemRole()).isTrue();
     }
 
     @Test
-    public void isSystemRoleShouldBeTrueWhenSpam() {
+    void isSystemRoleShouldBeTrueWhenSpam() {
         assertThat(Role.SPAM.isSystemRole()).isTrue();
     }
 
     @Test
-    public void isSystemRoleShouldBeTrueWhenTemplates() {
+    void isSystemRoleShouldBeTrueWhenTemplates() {
         assertThat(Role.TEMPLATES.isSystemRole()).isTrue();
     }
 
     @Test
-    public void isSystemRoleShouldBeTrueWhenRestoredMessages() {
+    void isSystemRoleShouldBeTrueWhenRestoredMessages() {
         assertThat(Role.RESTORED_MESSAGES.isSystemRole()).isTrue();
     }
 
     @Test
-    public void isSystemRoleShouldBeFalseWhenUserDefinedRole() {
+    void isSystemRoleShouldBeFalseWhenUserDefinedRole() {
         Role userRole = Role.from(Role.USER_DEFINED_ROLE_PREFIX + "myRole").get();
         assertThat(userRole.isSystemRole()).isFalse();
     }
 
     @Test
-    public void theINBOXMailboxNameShouldBeASystemMailbox() {
+    void theINBOXMailboxNameShouldBeASystemMailbox() {
         Role role = Role.from("INBOX").get();
         assertThat(role.isSystemRole()).isTrue();
     }
 
     @Test
-    public void theInBoXMailboxNameShouldBeASystemMailbox() {
+    void theInBoXMailboxNameShouldBeASystemMailbox() {
         Role role = Role.from("InBoX").get();
         assertThat(role.isSystemRole()).isTrue();
     }
 
     @Test
-    public void theDraftsMailboxNameShouldBeASystemMailbox() {
+    void theDraftsMailboxNameShouldBeASystemMailbox() {
         Role role = Role.from("Drafts").get();
         assertThat(role.isSystemRole()).isTrue();
     }
 
     @Test
-    public void theDrAfTsMailboxNameShouldNotBeASystemMailbox() {
+    void theDrAfTsMailboxNameShouldNotBeASystemMailbox() {
         Optional<Role> role = Role.from("DrAfTs");
         assertThat(role).isEmpty();
     }
 
     @Test
-    public void theOutboxMailboxNameShouldBeASystemMailbox() {
+    void theOutboxMailboxNameShouldBeASystemMailbox() {
         Role role = Role.from("Outbox").get();
         assertThat(role.isSystemRole()).isTrue();
     }
 
     @Test
-    public void theOuTbOxMailboxNameShouldNotBeASystemMailbox() {
+    void theOuTbOxMailboxNameShouldNotBeASystemMailbox() {
         Optional<Role> role = Role.from("OuTbOx");
         assertThat(role).isEmpty();
     }
 
     @Test
-    public void theSentMailboxNameShouldBeASystemMailbox() {
+    void theSentMailboxNameShouldBeASystemMailbox() {
         Role role = Role.from("Sent").get();
         assertThat(role.isSystemRole()).isTrue();
     }
 
     @Test
-    public void theSeNtMailboxNameShouldNotBeASystemMailbox() {
+    void theSeNtMailboxNameShouldNotBeASystemMailbox() {
         Optional<Role> role = Role.from("SeNt");
         assertThat(role).isEmpty();
     }
 
     @Test
-    public void theTrashMailboxNameShouldBeASystemMailbox() {
+    void theTrashMailboxNameShouldBeASystemMailbox() {
         Role role = Role.from("Trash").get();
         assertThat(role.isSystemRole()).isTrue();
     }
 
     @Test
-    public void theTrAsHMailboxNameShouldNotBeASystemMailbox() {
+    void theTrAsHMailboxNameShouldNotBeASystemMailbox() {
         Optional<Role> role = Role.from("TrAsH");
         assertThat(role).isEmpty();
     }
 
     @Test
-    public void theRestoredMessagesMailboxNameShouldBeASystemMailbox() {
+    void theRestoredMessagesMailboxNameShouldBeASystemMailbox() {
         Role role = Role.from("Restored-Messages").get();
         assertThat(role.isSystemRole()).isTrue();
     }
 
     @Test
-    public void theReStOrEdMeSsAgEsMailboxNameShouldNotBeASystemMailbox() {
+    void theReStOrEdMeSsAgEsMailboxNameShouldNotBeASystemMailbox() {
         Optional<Role> role = Role.from("ReStOrEd-MeSsAgEs");
         assertThat(role).isEmpty();
     }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/acl/ACLDiffTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/acl/ACLDiffTest.java
@@ -23,14 +23,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.james.mailbox.exception.UnsupportedRightException;
 import org.apache.james.mailbox.model.MailboxACL;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ACLDiffTest {
+class ACLDiffTest {
     private static final MailboxACL.EntryKey ENTRY_KEY = MailboxACL.EntryKey.createGroupEntryKey("any", false);
     private static final MailboxACL.Rfc4314Rights RIGHTS = new MailboxACL.Rfc4314Rights(MailboxACL.Right.Administer);
 
     @Test
-    public void addedEntriesShouldReturnEmptyWhenSameACL() {
+    void addedEntriesShouldReturnEmptyWhenSameACL() {
         ACLDiff aclDiff = ACLDiff.computeDiff(
             MailboxACL.EMPTY,
             MailboxACL.EMPTY);
@@ -39,7 +39,7 @@ public class ACLDiffTest {
     }
 
     @Test
-    public void addedEntriesShouldReturnEmptyWhenSameNonEmptyACL() throws UnsupportedRightException {
+    void addedEntriesShouldReturnEmptyWhenSameNonEmptyACL() throws UnsupportedRightException {
         MailboxACL mailboxACL = MailboxACL.EMPTY.apply(
             MailboxACL.command()
                 .key(ENTRY_KEY)
@@ -52,7 +52,7 @@ public class ACLDiffTest {
     }
 
     @Test
-    public void removedEntriesShouldReturnEmptyWhenSameACL() {
+    void removedEntriesShouldReturnEmptyWhenSameACL() {
         ACLDiff aclDiff = ACLDiff.computeDiff(
             MailboxACL.EMPTY,
             MailboxACL.EMPTY);
@@ -61,7 +61,7 @@ public class ACLDiffTest {
     }
 
     @Test
-    public void removedEntriesShouldReturnEmptyWhenSameNonEmptyACL() throws UnsupportedRightException {
+    void removedEntriesShouldReturnEmptyWhenSameNonEmptyACL() throws UnsupportedRightException {
         MailboxACL mailboxACL = MailboxACL.EMPTY.apply(
             MailboxACL.command()
                 .key(ENTRY_KEY)
@@ -74,7 +74,7 @@ public class ACLDiffTest {
     }
 
     @Test
-    public void changedEntriesShouldReturnEmptyWhenSameACL() {
+    void changedEntriesShouldReturnEmptyWhenSameACL() {
         ACLDiff aclDiff = ACLDiff.computeDiff(
             MailboxACL.EMPTY,
             MailboxACL.EMPTY);
@@ -83,7 +83,7 @@ public class ACLDiffTest {
     }
 
     @Test
-    public void changedEntriesShouldReturnEmptyWhenSameNonEmptyACL() throws UnsupportedRightException {
+    void changedEntriesShouldReturnEmptyWhenSameNonEmptyACL() throws UnsupportedRightException {
         MailboxACL mailboxACL = MailboxACL.EMPTY.apply(
             MailboxACL.command()
                 .key(ENTRY_KEY)
@@ -96,7 +96,7 @@ public class ACLDiffTest {
     }
     
     @Test
-    public void addedEntriesShouldReturnNewEntryWhenAddedEntry() throws Exception {
+    void addedEntriesShouldReturnNewEntryWhenAddedEntry() throws Exception {
         ACLDiff aclDiff = ACLDiff.computeDiff(
             MailboxACL.EMPTY,
             MailboxACL.EMPTY.apply(
@@ -110,7 +110,7 @@ public class ACLDiffTest {
     }
 
     @Test
-    public void changedEntriesShouldReturnEmptyWhenAddedEntry() throws Exception {
+    void changedEntriesShouldReturnEmptyWhenAddedEntry() throws Exception {
         ACLDiff aclDiff = ACLDiff.computeDiff(
             MailboxACL.EMPTY,
             MailboxACL.EMPTY.apply(
@@ -124,7 +124,7 @@ public class ACLDiffTest {
     }
 
     @Test
-    public void removedEntriesShouldReturnEmptyWhenAddedEntry() throws Exception {
+    void removedEntriesShouldReturnEmptyWhenAddedEntry() throws Exception {
         ACLDiff aclDiff = ACLDiff.computeDiff(
             MailboxACL.EMPTY,
             MailboxACL.EMPTY.apply(
@@ -138,7 +138,7 @@ public class ACLDiffTest {
     }
 
     @Test
-    public void addedEntriesShouldReturnEmptyWhenRemovedEntry() throws Exception {
+    void addedEntriesShouldReturnEmptyWhenRemovedEntry() throws Exception {
         ACLDiff aclDiff = ACLDiff.computeDiff(
             MailboxACL.EMPTY.apply(
                 MailboxACL.command()
@@ -152,7 +152,7 @@ public class ACLDiffTest {
     }
 
     @Test
-    public void changedEntriesShouldReturnEmptyWhenRemovedEntry() throws Exception {
+    void changedEntriesShouldReturnEmptyWhenRemovedEntry() throws Exception {
         ACLDiff aclDiff = ACLDiff.computeDiff(
             MailboxACL.EMPTY.apply(
                 MailboxACL.command()
@@ -166,7 +166,7 @@ public class ACLDiffTest {
     }
 
     @Test
-    public void removedEntriesShouldReturnEntryWhenRemovedEntry() throws Exception {
+    void removedEntriesShouldReturnEntryWhenRemovedEntry() throws Exception {
         ACLDiff aclDiff = ACLDiff.computeDiff(
             MailboxACL.EMPTY.apply(
                 MailboxACL.command()
@@ -180,7 +180,7 @@ public class ACLDiffTest {
     }
 
     @Test
-    public void removedEntriesShouldReturnEmptyWhenChangedEntry() throws Exception {
+    void removedEntriesShouldReturnEmptyWhenChangedEntry() throws Exception {
         ACLDiff aclDiff = ACLDiff.computeDiff(
             MailboxACL.EMPTY.apply(
                 MailboxACL.command()
@@ -198,7 +198,7 @@ public class ACLDiffTest {
     }
 
     @Test
-    public void addedEntriesShouldReturnEmptyWhenChangedEntry() throws Exception {
+    void addedEntriesShouldReturnEmptyWhenChangedEntry() throws Exception {
         ACLDiff aclDiff = ACLDiff.computeDiff(
             MailboxACL.EMPTY.apply(
                 MailboxACL.command()
@@ -216,7 +216,7 @@ public class ACLDiffTest {
     }
 
     @Test
-    public void changedEntriesShouldReturnEntryWhenChangedEntry() throws Exception {
+    void changedEntriesShouldReturnEntryWhenChangedEntry() throws Exception {
         ACLDiff aclDiff = ACLDiff.computeDiff(
             MailboxACL.EMPTY.apply(
                 MailboxACL.command()

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/acl/PositiveUserACLChangedTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/acl/PositiveUserACLChangedTest.java
@@ -19,14 +19,14 @@
 
 package org.apache.james.mailbox.acl;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class PositiveUserACLChangedTest {
+class PositiveUserACLChangedTest {
 
     @Test
-    public void shouldMatchBeanContact() {
+    void shouldMatchBeanContact() {
         EqualsVerifier.forClass(PositiveUserACLChanged.class)
             .verify();
     }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/acl/PositiveUserACLDiffTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/acl/PositiveUserACLDiffTest.java
@@ -26,9 +26,9 @@ import org.apache.james.mailbox.model.MailboxACL.Entry;
 import org.apache.james.mailbox.model.MailboxACL.EntryKey;
 import org.apache.james.mailbox.model.MailboxACL.Rfc4314Rights;
 import org.apache.james.mailbox.model.MailboxACL.Right;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class PositiveUserACLDiffTest {
+class PositiveUserACLDiffTest {
 
     private static final EntryKey USER_ENTRY_KEY = EntryKey.createUserEntryKey("user");
     private static final EntryKey NEGATIVE_USER_ENTRY_KEY = EntryKey.createUserEntryKey("user", true);
@@ -36,7 +36,7 @@ public class PositiveUserACLDiffTest {
     private static final Rfc4314Rights RIGHTS = new Rfc4314Rights(Right.Administer);
 
     @Test
-    public void addedEntriesShouldReturnEmptyWhenSameACL() {
+    void addedEntriesShouldReturnEmptyWhenSameACL() {
         PositiveUserACLDiff positiveUserAclDiff = PositiveUserACLDiff.computeDiff(
             MailboxACL.EMPTY,
             MailboxACL.EMPTY);
@@ -45,7 +45,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void addedEntriesShouldReturnEmptyWhenSameNonEmptyACL() throws UnsupportedRightException {
+    void addedEntriesShouldReturnEmptyWhenSameNonEmptyACL() throws UnsupportedRightException {
         MailboxACL mailboxACL = MailboxACL.EMPTY.apply(
             MailboxACL.command()
                 .key(USER_ENTRY_KEY)
@@ -58,7 +58,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void removedEntriesShouldReturnEmptyWhenSameACL() {
+    void removedEntriesShouldReturnEmptyWhenSameACL() {
         PositiveUserACLDiff positiveUserAclDiff = PositiveUserACLDiff.computeDiff(
             MailboxACL.EMPTY,
             MailboxACL.EMPTY);
@@ -67,7 +67,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void removedEntriesShouldReturnEmptyWhenSameNonEmptyACL() throws UnsupportedRightException {
+    void removedEntriesShouldReturnEmptyWhenSameNonEmptyACL() throws UnsupportedRightException {
         MailboxACL mailboxACL = MailboxACL.EMPTY.apply(
             MailboxACL.command()
                 .key(USER_ENTRY_KEY)
@@ -80,7 +80,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void changedEntriesShouldReturnEmptyWhenSameACL() {
+    void changedEntriesShouldReturnEmptyWhenSameACL() {
         PositiveUserACLDiff positiveUserAclDiff = PositiveUserACLDiff.computeDiff(
             MailboxACL.EMPTY,
             MailboxACL.EMPTY);
@@ -89,7 +89,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void changedEntriesShouldReturnEmptyWhenSameNonEmptyACL() throws UnsupportedRightException {
+    void changedEntriesShouldReturnEmptyWhenSameNonEmptyACL() throws UnsupportedRightException {
         MailboxACL mailboxACL = MailboxACL.EMPTY.apply(
             MailboxACL.command()
                 .key(USER_ENTRY_KEY)
@@ -102,7 +102,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void addedEntriesShouldReturnNewEntryWhenAddedEntry() throws Exception {
+    void addedEntriesShouldReturnNewEntryWhenAddedEntry() throws Exception {
         PositiveUserACLDiff positiveUserAclDiff = PositiveUserACLDiff.computeDiff(
             MailboxACL.EMPTY,
             MailboxACL.EMPTY.apply(
@@ -116,7 +116,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void addedEntriesShouldFilterNonUserEntryKey() throws Exception {
+    void addedEntriesShouldFilterNonUserEntryKey() throws Exception {
         PositiveUserACLDiff positiveUserAclDiff = PositiveUserACLDiff.computeDiff(
             MailboxACL.EMPTY,
             MailboxACL.EMPTY.apply(
@@ -130,7 +130,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void addedEntriesShouldFilterNegativeUserEntryKey() throws Exception {
+    void addedEntriesShouldFilterNegativeUserEntryKey() throws Exception {
         PositiveUserACLDiff positiveUserAclDiff = PositiveUserACLDiff.computeDiff(
             MailboxACL.EMPTY,
             MailboxACL.EMPTY.apply(
@@ -144,7 +144,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void changedEntriesShouldReturnEmptyWhenAddedEntry() throws Exception {
+    void changedEntriesShouldReturnEmptyWhenAddedEntry() throws Exception {
         PositiveUserACLDiff positiveUserAclDiff = PositiveUserACLDiff.computeDiff(
             MailboxACL.EMPTY,
             MailboxACL.EMPTY.apply(
@@ -158,7 +158,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void removedEntriesShouldReturnEmptyWhenAddedEntry() throws Exception {
+    void removedEntriesShouldReturnEmptyWhenAddedEntry() throws Exception {
         PositiveUserACLDiff positiveUserAclDiff = PositiveUserACLDiff.computeDiff(
             MailboxACL.EMPTY,
             MailboxACL.EMPTY.apply(
@@ -172,7 +172,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void addedEntriesShouldReturnEmptyWhenRemovedEntry() throws Exception {
+    void addedEntriesShouldReturnEmptyWhenRemovedEntry() throws Exception {
         PositiveUserACLDiff positiveUserAclDiff = PositiveUserACLDiff.computeDiff(
             MailboxACL.EMPTY.apply(
                 MailboxACL.command()
@@ -186,7 +186,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void changedEntriesShouldReturnEmptyWhenRemovedEntry() throws Exception {
+    void changedEntriesShouldReturnEmptyWhenRemovedEntry() throws Exception {
         PositiveUserACLDiff positiveUserAclDiff = PositiveUserACLDiff.computeDiff(
             MailboxACL.EMPTY.apply(
                 MailboxACL.command()
@@ -200,7 +200,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void removedEntriesShouldReturnEntryWhenRemovedEntry() throws Exception {
+    void removedEntriesShouldReturnEntryWhenRemovedEntry() throws Exception {
         PositiveUserACLDiff positiveUserAclDiff = PositiveUserACLDiff.computeDiff(
             MailboxACL.EMPTY.apply(
                 MailboxACL.command()
@@ -214,7 +214,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void removedEntriesShouldFilterNonUserEntry() throws Exception {
+    void removedEntriesShouldFilterNonUserEntry() throws Exception {
         PositiveUserACLDiff positiveUserAclDiff = PositiveUserACLDiff.computeDiff(
             MailboxACL.EMPTY.apply(
                 MailboxACL.command()
@@ -228,7 +228,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void removedEntriesShouldFilterNegativeUserEntry() throws Exception {
+    void removedEntriesShouldFilterNegativeUserEntry() throws Exception {
         PositiveUserACLDiff positiveUserAclDiff = PositiveUserACLDiff.computeDiff(
             MailboxACL.EMPTY.apply(
                 MailboxACL.command()
@@ -242,7 +242,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void removedEntriesShouldReturnEmptyWhenChangedEntry() throws Exception {
+    void removedEntriesShouldReturnEmptyWhenChangedEntry() throws Exception {
         PositiveUserACLDiff positiveUserAclDiff = PositiveUserACLDiff.computeDiff(
             MailboxACL.EMPTY.apply(
                 MailboxACL.command()
@@ -260,7 +260,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void addedEntriesShouldReturnEmptyWhenChangedEntry() throws Exception {
+    void addedEntriesShouldReturnEmptyWhenChangedEntry() throws Exception {
         PositiveUserACLDiff positiveUserAclDiff = PositiveUserACLDiff.computeDiff(
             MailboxACL.EMPTY.apply(
                 MailboxACL.command()
@@ -278,7 +278,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void changedEntriesShouldReturnEntryWhenChangedEntry() throws Exception {
+    void changedEntriesShouldReturnEntryWhenChangedEntry() throws Exception {
         PositiveUserACLDiff positiveUserAclDiff = PositiveUserACLDiff.computeDiff(
             MailboxACL.EMPTY.apply(
                 MailboxACL.command()
@@ -296,7 +296,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void changedEntriesShouldFilterNonUserEntry() throws Exception {
+    void changedEntriesShouldFilterNonUserEntry() throws Exception {
         PositiveUserACLDiff positiveUserAclDiff = PositiveUserACLDiff.computeDiff(
             MailboxACL.EMPTY.apply(
                 MailboxACL.command()
@@ -314,7 +314,7 @@ public class PositiveUserACLDiffTest {
     }
 
     @Test
-    public void changedEntriesShouldFilterNegativeUserEntry() throws Exception {
+    void changedEntriesShouldFilterNegativeUserEntry() throws Exception {
         PositiveUserACLDiff positiveUserAclDiff = PositiveUserACLDiff.computeDiff(
             MailboxACL.EMPTY.apply(
                 MailboxACL.command()

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/acl/SimpleGroupMembershipResolverTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/acl/SimpleGroupMembershipResolverTest.java
@@ -22,20 +22,20 @@ package org.apache.james.mailbox.acl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class SimpleGroupMembershipResolverTest {
+class SimpleGroupMembershipResolverTest {
 
     private SimpleGroupMembershipResolver simpleGroupMembershipResolver;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
        simpleGroupMembershipResolver = new SimpleGroupMembershipResolver();
     }
 
     @Test
-    public void isMemberShouldReturnFalseWhenEmptyResolver() throws Exception {
+    void isMemberShouldReturnFalseWhenEmptyResolver() {
         //When
         boolean actual = simpleGroupMembershipResolver.isMember("user", "group");
         //Then
@@ -43,7 +43,7 @@ public class SimpleGroupMembershipResolverTest {
     }
 
     @Test
-    public void isMemberShouldReturnTrueWhenTheSearchedMembershipIsPresent() throws Exception {
+    void isMemberShouldReturnTrueWhenTheSearchedMembershipIsPresent() {
         //Given
         simpleGroupMembershipResolver.addMembership("group", "user");
         //When
@@ -53,7 +53,7 @@ public class SimpleGroupMembershipResolverTest {
     }
 
     @Test
-    public void addMembershipShouldAddAMembershipWhenNonNullUser() throws Exception {
+    void addMembershipShouldAddAMembershipWhenNonNullUser() {
         //When
         simpleGroupMembershipResolver.addMembership("group", "user");
         boolean actual = simpleGroupMembershipResolver.isMember("user", "group");
@@ -62,7 +62,7 @@ public class SimpleGroupMembershipResolverTest {
     }
 
     @Test
-    public void addMembershipShouldAddAMembershipWithANullUser() throws Exception {
+    void addMembershipShouldAddAMembershipWithANullUser() {
         //Given
         String userAdded = null;
         //When

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/acl/UnionMailboxACLResolverTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/acl/UnionMailboxACLResolverTest.java
@@ -28,10 +28,10 @@ import org.apache.james.mailbox.model.MailboxACL.Entry;
 import org.apache.james.mailbox.model.MailboxACL.EntryKey;
 import org.apache.james.mailbox.model.MailboxACL.NameType;
 import org.apache.james.mailbox.model.MailboxACL.Rfc4314Rights;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class UnionMailboxACLResolverTest {
+class UnionMailboxACLResolverTest {
 
     private static final String GROUP_1 = "group1";
     private static final String GROUP_2 = "group2";
@@ -60,8 +60,8 @@ public class UnionMailboxACLResolverTest {
     private EntryKey group1Key;
     private EntryKey group2Key;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         user1Key = EntryKey.createUserEntryKey(USER_1);
         user2Key = EntryKey.createUserEntryKey(USER_2);
         group1Key = EntryKey.createGroupEntryKey(GROUP_1);
@@ -99,7 +99,7 @@ public class UnionMailboxACLResolverTest {
     }
 
     @Test
-    public void testAppliesNullUser() throws UnsupportedRightException {
+    void testAppliesNullUser() throws UnsupportedRightException {
 
         assertThat(UnionMailboxACLResolver.applies(user1Key, null, groupMembershipResolver, USER_1, false)).isFalse();
         assertThat(UnionMailboxACLResolver.applies(user2Key, null, groupMembershipResolver, USER_1, false)).isFalse();
@@ -111,7 +111,7 @@ public class UnionMailboxACLResolverTest {
     }
 
     @Test
-    public void testAppliesUser() throws UnsupportedRightException {
+    void testAppliesUser() throws UnsupportedRightException {
         /* requester is the resource owner */
         assertThat(UnionMailboxACLResolver.applies(user1Key, user1Key, groupMembershipResolver, USER_1, false)).isTrue();
         assertThat(UnionMailboxACLResolver.applies(user2Key, user1Key, groupMembershipResolver, USER_1, false)).isFalse();
@@ -160,7 +160,7 @@ public class UnionMailboxACLResolverTest {
     }
 
     @Test
-    public void testResolveRightsNullUser() throws UnsupportedRightException {
+    void testResolveRightsNullUser() throws UnsupportedRightException {
 
         assertThat(
             anyoneReadListGlobal.resolveRights(null, groupMembershipResolver, user1Read, USER_1, false)
@@ -399,7 +399,7 @@ public class UnionMailboxACLResolverTest {
     }
 
     @Test
-    public void testResolveRightsNullUserGlobals() throws UnsupportedRightException {
+    void testResolveRightsNullUserGlobals() throws UnsupportedRightException {
         assertThat(
             anyoneReadListGlobal.resolveRights(null, groupMembershipResolver, user1Read, USER_2, false)
                 .contains(MailboxACL.Right.Read))
@@ -424,7 +424,7 @@ public class UnionMailboxACLResolverTest {
 
 
     @Test
-    public void testResolveRightsUserSelfOwner() throws UnsupportedRightException {
+    void testResolveRightsUserSelfOwner() throws UnsupportedRightException {
 
         assertThat(
             anyoneReadListGlobal.resolveRights(USER_1, groupMembershipResolver, user1Read, USER_1, false)
@@ -659,7 +659,7 @@ public class UnionMailboxACLResolverTest {
 
 
     @Test
-    public void testResolveRightsUserNotOwner() throws UnsupportedRightException {
+    void testResolveRightsUserNotOwner() throws UnsupportedRightException {
 
         assertThat(
             anyoneReadListGlobal.resolveRights(USER_1, groupMembershipResolver, user1Read, USER_2, false)
@@ -893,7 +893,7 @@ public class UnionMailboxACLResolverTest {
     }
 
     @Test
-    public void testResolveRightsUserMemberOfOwnerGroup() throws UnsupportedRightException {
+    void testResolveRightsUserMemberOfOwnerGroup() throws UnsupportedRightException {
 
         assertThat(
             anyoneReadListGlobal.resolveRights(USER_1, groupMembershipResolver, user1Read, GROUP_1, true)
@@ -1128,7 +1128,7 @@ public class UnionMailboxACLResolverTest {
 
 
     @Test
-    public void testResolveRightsUserNotMemberOfOwnerGroup() throws UnsupportedRightException {
+    void testResolveRightsUserNotMemberOfOwnerGroup() throws UnsupportedRightException {
 
         assertThat(
             anyoneReadListGlobal.resolveRights(USER_1, groupMembershipResolver, user1Read, GROUP_2, true)

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/extractor/ParsedContentTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/extractor/ParsedContentTest.java
@@ -19,14 +19,14 @@
 
 package org.apache.james.mailbox.extractor;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class ParsedContentTest {
+class ParsedContentTest {
 
     @Test
-    public void shouldMatchBeanContract() {
+    void shouldMatchBeanContract() {
         EqualsVerifier.forClass(ParsedContent.class)
             .verify();
     }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/indexer/ReindexingExecutionFailuresTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/indexer/ReindexingExecutionFailuresTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class ReindexingExecutionFailuresTest {
+class ReindexingExecutionFailuresTest {
 
     @Test
     void shouldRespectBeanContract() {

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/indexer/ReindexingFailureTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/indexer/ReindexingFailureTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class ReindexingFailureTest {
+class ReindexingFailureTest {
 
     @Test
     void shouldRespectBeanContract() {

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/AttachmentIdTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/AttachmentIdTest.java
@@ -24,50 +24,50 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.UUID;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class AttachmentIdTest {
+class AttachmentIdTest {
 
     @Test
-    public void randomShouldGenerateDifferentIds() {
+    void randomShouldGenerateDifferentIds() {
         AttachmentId attachmentId = AttachmentId.random();
         AttachmentId attachmentId2 = AttachmentId.random();
         assertThat(attachmentId.getId()).isNotEqualTo(attachmentId2.getId());
     }
 
     @Test
-    public void fromShouldThrowWhenIdIsNull() {
+    void fromShouldThrowWhenIdIsNull() {
         String value = null;
         assertThatThrownBy(() -> AttachmentId.from(value)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void fromShouldThrowWhenBlobIdIsNull() {
+    void fromShouldThrowWhenBlobIdIsNull() {
         BlobId value = null;
         assertThatThrownBy(() -> AttachmentId.from(value)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void fromShouldThrowWhenIdIsEmpty() {
+    void fromShouldThrowWhenIdIsEmpty() {
         assertThatThrownBy(() -> AttachmentId.from("")).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void fromStringShouldWork() {
+    void fromStringShouldWork() {
         String expectedId = "f07e5a815613c5abeddc4b682247a4c42d8a95df";
         AttachmentId attachmentId = AttachmentId.from(expectedId);
         assertThat(attachmentId.getId()).isEqualTo(expectedId);
     }
 
     @Test
-    public void fromBlobIdShouldWork() {
+    void fromBlobIdShouldWork() {
         String expectedId = "f07e5a815613c5abeddc4b682247a4c42d8a95df";
         AttachmentId attachmentId = AttachmentId.from(BlobId.fromString(expectedId));
         assertThat(attachmentId.getId()).isEqualTo(expectedId);
     }
 
     @Test
-    public void asUUIDShouldReturnAValidUUID() {
+    void asUUIDShouldReturnAValidUUID() {
         AttachmentId attachmentId = AttachmentId.from("magic");
 
         assertThat(attachmentId.asUUID())

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/AttachmentTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/AttachmentTest.java
@@ -21,20 +21,21 @@
 package org.apache.james.mailbox.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class AttachmentTest {
+class AttachmentTest {
 
     private static Charset CHARSET = StandardCharsets.UTF_8;
 
     @Test
-    public void streamShouldBeConsumedOneTime() throws Exception {
+    void streamShouldBeConsumedOneTime() throws Exception {
         String input = "mystream";
         Attachment attachment = Attachment.builder()
                 .bytes(input.getBytes(CHARSET))
@@ -47,7 +48,7 @@ public class AttachmentTest {
     }
 
     @Test
-    public void getByteShouldReturnByteArrayRepresentingTheAttachment() {
+    void getByteShouldReturnByteArrayRepresentingTheAttachment() {
         String input = "mystream";
         Attachment attachment = Attachment.builder()
             .bytes(input.getBytes(CHARSET))
@@ -59,7 +60,7 @@ public class AttachmentTest {
     }
 
     @Test
-    public void streamShouldBeConsumedMoreThanOneTime() throws Exception {
+    void streamShouldBeConsumedMoreThanOneTime() throws Exception {
         String input = "mystream";
         Attachment attachment = Attachment.builder()
                 .bytes(input.getBytes(CHARSET))
@@ -72,52 +73,60 @@ public class AttachmentTest {
         assertThat(IOUtils.toString(stream, CHARSET)).isEqualTo(input);
     }
 
-    @Test (expected = IllegalArgumentException.class)
-    public void builderShouldThrowWhenAttachmentIdIsNull() {
-        Attachment.builder()
-            .attachmentId(null);
-    }
-
-    @Test (expected = IllegalArgumentException.class)
-    public void builderShouldThrowWhenBytesIsNull() {
-        Attachment.builder()
-            .bytes(null);
-    }
-
-    @Test (expected = IllegalArgumentException.class)
-    public void builderShouldThrowWhenTypeIsNull() {
-        Attachment.builder()
-            .type(null);
-    }
-
-    @Test (expected = IllegalArgumentException.class)
-    public void builderShouldThrowWhenTypeIsEmpty() {
-        Attachment.builder()
-            .type("");
-    }
-
-    @Test (expected = IllegalStateException.class)
-    public void buildShouldThrowWhenAttachmentIdIsNotProvided() {
-        Attachment.builder().build();
-    }
-
-    @Test (expected = IllegalStateException.class)
-    public void buildShouldThrowWhenBytesIsNotProvided() {
-        Attachment.builder()
-            .attachmentId(AttachmentId.random())
-            .build();
-    }
-
-    @Test (expected = IllegalStateException.class)
-    public void buildShouldThrowWhenTypeIsNotProvided() {
-        Attachment.builder()
-            .attachmentId(AttachmentId.random())
-            .bytes("mystream".getBytes(CHARSET))
-            .build();
+    @Test
+    void builderShouldThrowWhenAttachmentIdIsNull() {
+        assertThatThrownBy(() -> Attachment.builder()
+                .attachmentId(null))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void buildShouldSetTheSize() {
+    void builderShouldThrowWhenBytesIsNull() {
+        assertThatThrownBy(() -> Attachment.builder()
+                .bytes(null))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void builderShouldThrowWhenTypeIsNull() {
+        assertThatThrownBy(() -> Attachment.builder()
+                .type(null))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void builderShouldThrowWhenTypeIsEmpty() {
+        assertThatThrownBy(() -> Attachment.builder()
+                .type(""))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void buildShouldThrowWhenAttachmentIdIsNotProvided() {
+        assertThatThrownBy(() -> Attachment.builder()
+                .build())
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void buildShouldThrowWhenBytesIsNotProvided() {
+        assertThatThrownBy(() -> Attachment.builder()
+                .attachmentId(AttachmentId.random())
+                .build())
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void buildShouldThrowWhenTypeIsNotProvided() {
+        assertThatThrownBy(() -> Attachment.builder()
+                .attachmentId(AttachmentId.random())
+                .bytes("mystream".getBytes(CHARSET))
+                .build())
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void buildShouldSetTheSize() {
         String input = "mystream";
         Attachment attachment = Attachment.builder()
                 .bytes(input.getBytes(CHARSET))
@@ -128,7 +137,7 @@ public class AttachmentTest {
     }
 
     @Test
-    public void toBlobShouldGenerateTheAttachmentBlob() {
+    void toBlobShouldGenerateTheAttachmentBlob() {
         byte[] bytes = "mystream".getBytes(CHARSET);
         String content = "content";
         Attachment attachment = Attachment.builder()

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/BlobIdTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/BlobIdTest.java
@@ -24,44 +24,44 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class BlobIdTest {
+class BlobIdTest {
 
     @Test
-    public void shouldMatchBeanContact() {
+    void shouldMatchBeanContact() {
         EqualsVerifier.forClass(BlobId.class)
             .verify();
     }
 
     @Test
-    public void fromStringShouldThrowOnNull() {
+    void fromStringShouldThrowOnNull() {
         assertThatThrownBy(() -> BlobId.fromString(null))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void fromStringShouldThrowOnEmpty() {
+    void fromStringShouldThrowOnEmpty() {
         assertThatThrownBy(() -> BlobId.fromString(""))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void asStringShouldReturnUnderlyingId() {
+    void asStringShouldReturnUnderlyingId() {
         assertThat(BlobId.fromString("abc").asString())
             .isEqualTo("abc");
     }
 
     @Test
-    public void fromBytesShouldProduceASHA256() {
+    void fromBytesShouldProduceASHA256() {
         assertThat(BlobId.fromBytes("abc".getBytes(StandardCharsets.UTF_8)).asString())
             .isEqualTo("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
     }
 
     @Test
-    public void fromBytesShouldCalculateSameSha256() {
+    void fromBytesShouldCalculateSameSha256() {
         byte[] bytes = "abc".getBytes(StandardCharsets.UTF_8);
 
         assertThat(BlobId.fromBytes(bytes))

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/BlobTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/BlobTest.java
@@ -24,25 +24,25 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class BlobTest {
+class BlobTest {
 
     public static final BlobId ID = BlobId.fromString("123");
     public static final String CONTENT_TYPE = "text/plain";
     public static final byte[] PAYLOAD = "abc".getBytes(StandardCharsets.UTF_8);
 
     @Test
-    public void shouldMatchBeanContract() {
+    void shouldMatchBeanContract() {
         EqualsVerifier.forClass(Blob.class)
             .withIgnoredFields("payload", "size")
             .verify();
     }
 
     @Test
-    public void buildShouldConstructValidBlob() {
+    void buildShouldConstructValidBlob() {
         assertThat(
             Blob.builder()
                 .id(ID)
@@ -54,7 +54,7 @@ public class BlobTest {
     }
 
     @Test
-    public void buildShouldThrowOnMissingBlobId() {
+    void buildShouldThrowOnMissingBlobId() {
         assertThatThrownBy(() ->
             Blob.builder()
                 .contentType(CONTENT_TYPE)
@@ -64,7 +64,7 @@ public class BlobTest {
     }
 
     @Test
-    public void buildShouldThrowOnMissingContentType() {
+    void buildShouldThrowOnMissingContentType() {
         assertThatThrownBy(() ->
             Blob.builder()
                 .id(ID)
@@ -74,7 +74,7 @@ public class BlobTest {
     }
 
     @Test
-    public void buildShouldThrowOnMissingPayload() {
+    void buildShouldThrowOnMissingPayload() {
         assertThatThrownBy(() ->
             Blob.builder()
                 .id(ID)

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/CidTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/CidTest.java
@@ -20,75 +20,72 @@
 package org.apache.james.mailbox.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Optional;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class CidTest {
-
-    @Rule public ExpectedException expectedException = ExpectedException.none();
+class CidTest {
 
     @Test
-    public void fromShouldThrowWhenNull() {
-        expectedException.expect(IllegalArgumentException.class);
-        Cid.from(null);
+    void fromShouldThrowWhenNull() {
+        assertThatThrownBy(() -> Cid.from(null))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void fromShouldThrowWhenEmpty() {
-        expectedException.expect(IllegalArgumentException.class);
-        Cid.from("");
+    void fromShouldThrowWhenEmpty() {
+        assertThatThrownBy(() -> Cid.from(""))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void fromShouldThrowWhenBlank() {
-        expectedException.expect(IllegalArgumentException.class);
-        Cid.from("    ");
+    void fromShouldThrowWhenBlank() {
+        assertThatThrownBy(() -> Cid.from("    "))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void fromShouldThrowWhenEmptyAfterRemoveTags() {
-        expectedException.expect(IllegalArgumentException.class);
-        Cid.from("<>");
+    void fromShouldThrowWhenEmptyAfterRemoveTags() {
+        assertThatThrownBy(() -> Cid.from("<>"))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void fromShouldThrowWhenBlankAfterRemoveTags() {
-        expectedException.expect(IllegalArgumentException.class);
-        Cid.from("<   >");
+    void fromShouldThrowWhenBlankAfterRemoveTags() {
+        assertThatThrownBy(() -> Cid.from("<   >"))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void fromShouldRemoveTagsWhenExists() {
+    void fromShouldRemoveTagsWhenExists() {
         Cid cid = Cid.from("<123>");
         assertThat(cid.getValue()).isEqualTo("123");
     }
 
     @Test
-    public void fromShouldNotRemoveTagsWhenNone() {
+    void fromShouldNotRemoveTagsWhenNone() {
         Cid cid = Cid.from("123");
         assertThat(cid.getValue()).isEqualTo("123");
     }
 
     @Test
-    public void fromShouldNotRemoveTagsWhenNotEndTag() {
+    void fromShouldNotRemoveTagsWhenNotEndTag() {
         Cid cid = Cid.from("<123");
         assertThat(cid.getValue()).isEqualTo("<123");
     }
 
     @Test
-    public void fromShouldNotRemoveTagsWhenNotStartTag() {
+    void fromShouldNotRemoveTagsWhenNotStartTag() {
         Cid cid = Cid.from("123>");
         assertThat(cid.getValue()).isEqualTo("123>");
     }
 
     @Test
-    public void fromRelaxedNoUnwrapShouldReturnAbsentWhenNull() {
+    void fromRelaxedNoUnwrapShouldReturnAbsentWhenNull() {
         assertThat(Cid.parser()
             .relaxed()
             .parse(null))
@@ -96,7 +93,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromRelaxedNoUnwrapShouldReturnAbsentWhenEmpty() {
+    void fromRelaxedNoUnwrapShouldReturnAbsentWhenEmpty() {
         assertThat(Cid.parser()
             .relaxed()
             .parse(""))
@@ -104,7 +101,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromRelaxedNoUnwrapShouldReturnAbsentWhenBlank() {
+    void fromRelaxedNoUnwrapShouldReturnAbsentWhenBlank() {
         assertThat(Cid.parser()
             .relaxed()
             .parse("     "))
@@ -112,7 +109,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromRelaxedNoUnwrapShouldReturnCidWhenEmptyAfterRemoveTags() {
+    void fromRelaxedNoUnwrapShouldReturnCidWhenEmptyAfterRemoveTags() {
         Optional<Cid> actual = Cid.parser()
             .relaxed()
             .parse("<>");
@@ -121,7 +118,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromRelaxedNoUnwrapShouldReturnCidWhenBlankAfterRemoveTags() {
+    void fromRelaxedNoUnwrapShouldReturnCidWhenBlankAfterRemoveTags() {
         Optional<Cid> actual = Cid.parser()
             .relaxed()
             .parse("<   >");
@@ -130,7 +127,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromRelaxedNoUnwrapShouldNotRemoveTagsWhenExists() {
+    void fromRelaxedNoUnwrapShouldNotRemoveTagsWhenExists() {
         Optional<Cid> actual = Cid.parser()
             .relaxed()
             .parse("<123>");
@@ -139,7 +136,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromRelaxedNoUnwrapShouldNotRemoveTagsWhenNone() {
+    void fromRelaxedNoUnwrapShouldNotRemoveTagsWhenNone() {
         assertThat(Cid.parser()
             .relaxed()
             .parse("123"))
@@ -147,7 +144,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromRelaxedNoUnwrapShouldNotRemoveTagsWhenNotEndTag() {
+    void fromRelaxedNoUnwrapShouldNotRemoveTagsWhenNotEndTag() {
         assertThat(Cid.parser()
             .relaxed()
             .parse("<123"))
@@ -155,7 +152,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromRelaxedNoUnwrapShouldNotRemoveTagsWhenNotStartTag() {
+    void fromRelaxedNoUnwrapShouldNotRemoveTagsWhenNotStartTag() {
         assertThat(Cid.parser()
             .relaxed()
             .parse("123>"))
@@ -164,7 +161,7 @@ public class CidTest {
 
 
     @Test
-    public void fromRelaxedUnwrapShouldReturnAbsentWhenNull() {
+    void fromRelaxedUnwrapShouldReturnAbsentWhenNull() {
         assertThat(Cid.parser()
             .relaxed()
             .unwrap()
@@ -173,7 +170,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromRelaxedUnwrapShouldReturnAbsentWhenEmpty() {
+    void fromRelaxedUnwrapShouldReturnAbsentWhenEmpty() {
         assertThat(Cid.parser()
             .relaxed()
             .unwrap()
@@ -182,7 +179,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromRelaxedUnwrapShouldReturnAbsentWhenBlank() {
+    void fromRelaxedUnwrapShouldReturnAbsentWhenBlank() {
         assertThat(Cid.parser()
             .relaxed()
             .unwrap()
@@ -191,7 +188,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromRelaxedUnwrapShouldReturnAbsentWhenEmptyAfterRemoveTags() {
+    void fromRelaxedUnwrapShouldReturnAbsentWhenEmptyAfterRemoveTags() {
         assertThat(Cid.parser()
             .relaxed()
             .unwrap()
@@ -200,7 +197,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromRelaxedUnwrapShouldReturnAbsentWhenBlankAfterRemoveTags() {
+    void fromRelaxedUnwrapShouldReturnAbsentWhenBlankAfterRemoveTags() {
         assertThat(Cid.parser()
             .relaxed()
             .unwrap()
@@ -209,7 +206,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromRelaxedUnwrapShouldRemoveTagsWhenExists() {
+    void fromRelaxedUnwrapShouldRemoveTagsWhenExists() {
         Optional<Cid> actual = Cid.parser()
             .relaxed()
             .unwrap()
@@ -219,7 +216,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromRelaxedUnwrapShouldNotRemoveTagsWhenNone() {
+    void fromRelaxedUnwrapShouldNotRemoveTagsWhenNone() {
         assertThat(Cid.parser()
             .relaxed()
             .unwrap()
@@ -228,7 +225,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromRelaxedUnwrapShouldNotRemoveTagsWhenNotEndTag() {
+    void fromRelaxedUnwrapShouldNotRemoveTagsWhenNotEndTag() {
         assertThat(Cid.parser()
             .relaxed()
             .unwrap()
@@ -237,7 +234,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromRelaxedUnwrapShouldNotRemoveTagsWhenNotStartTag() {
+    void fromRelaxedUnwrapShouldNotRemoveTagsWhenNotStartTag() {
         assertThat(Cid.parser()
             .relaxed()
             .unwrap()
@@ -246,34 +243,31 @@ public class CidTest {
     }
 
     @Test
-    public void fromStrictNoUnwrapShouldThrowWhenNull() {
-        expectedException.expect(IllegalArgumentException.class);
-
-        Cid.parser()
-            .strict()
-            .parse(null);
+    void fromStrictNoUnwrapShouldThrowWhenNull() {
+        assertThatThrownBy(() -> Cid.parser()
+                .strict()
+                .parse(null))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void fromStrictNoUnwrapShouldThrowWhenEmpty() {
-        expectedException.expect(IllegalArgumentException.class);
-
-        Cid.parser()
-            .strict()
-            .parse("");
+    void fromStrictNoUnwrapShouldThrowWhenEmpty() {
+        assertThatThrownBy(() -> Cid.parser()
+                .strict()
+                .parse(""))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void fromStrinctNoUnwrapShouldThrowWhenBlank() {
-        expectedException.expect(IllegalArgumentException.class);
-
-        Cid.parser()
-            .strict()
-            .parse("   ");
+    void fromStrinctNoUnwrapShouldThrowWhenBlank() {
+        assertThatThrownBy(() -> Cid.parser()
+                .strict()
+                .parse("   "))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void fromStrictNoUnwrapShouldNotRemoveTagWhenEmptyAfterRemoveTags() {
+    void fromStrictNoUnwrapShouldNotRemoveTagWhenEmptyAfterRemoveTags() {
         Optional<Cid> actual = Cid.parser()
             .strict()
             .parse("<>");
@@ -282,7 +276,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromStrictNoUnwrapShouldNotRemoveTagWhenBlankAfterRemoveTags() {
+    void fromStrictNoUnwrapShouldNotRemoveTagWhenBlankAfterRemoveTags() {
         Optional<Cid> actual = Cid.parser()
             .strict()
             .parse("<   >");
@@ -291,7 +285,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromStrictNoUnwrapShouldNotRemoveTagsWhenExists() {
+    void fromStrictNoUnwrapShouldNotRemoveTagsWhenExists() {
         Optional<Cid> actual = Cid.parser()
             .strict()
             .parse("<123>");
@@ -300,7 +294,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromStrictNoUnwrapShouldNotRemoveTagsWhenNone() {
+    void fromStrictNoUnwrapShouldNotRemoveTagsWhenNone() {
         assertThat(Cid.parser()
             .strict()
             .parse("123"))
@@ -308,7 +302,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromStrictNoUnwrapShouldNotRemoveTagsWhenNotEndTag() {
+    void fromStrictNoUnwrapShouldNotRemoveTagsWhenNotEndTag() {
         assertThat(Cid.parser()
             .strict()
             .parse("<123"))
@@ -316,7 +310,7 @@ public class CidTest {
     }
 
     @Test
-    public void fromStrictNoUnwrapShouldNotRemoveTagsWhenNotStartTag() {
+    void fromStrictNoUnwrapShouldNotRemoveTagsWhenNotStartTag() {
         assertThat(Cid.parser()
             .strict()
             .parse("123>"))
@@ -324,7 +318,7 @@ public class CidTest {
     }
 
     @Test
-    public void shouldRespectJavaBeanContract() {
+    void shouldRespectJavaBeanContract() {
         EqualsVerifier.forClass(Cid.class).verify();
     }
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/ComposedMessageIdWithMetaDataTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/ComposedMessageIdWithMetaDataTest.java
@@ -19,44 +19,48 @@
 package org.apache.james.mailbox.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import javax.mail.Flags;
 import javax.mail.Flags.Flag;
 
 import org.apache.james.mailbox.MessageUid;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class ComposedMessageIdWithMetaDataTest {
+class ComposedMessageIdWithMetaDataTest {
 
-    public static final TestId TEST_ID = TestId.of(1L);
-    public static final TestMessageId TEST_MESSAGE_ID = new TestMessageId("2");
-    public static final MessageUid MESSAGE_UID = MessageUid.of(3);
-    public static final ComposedMessageId COMPOSED_MESSAGE_ID = new ComposedMessageId(TEST_ID, TEST_MESSAGE_ID, MESSAGE_UID);
+    private static final TestId TEST_ID = TestId.of(1L);
+    private static final TestMessageId TEST_MESSAGE_ID = new TestMessageId("2");
+    private static final MessageUid MESSAGE_UID = MessageUid.of(3);
+    private static final ComposedMessageId COMPOSED_MESSAGE_ID = new ComposedMessageId(TEST_ID, TEST_MESSAGE_ID, MESSAGE_UID);
 
-    @Test(expected = NullPointerException.class)
-    public void buildShoudThrownWhenComposedMessageIdIsNull() {
-        ComposedMessageIdWithMetaData.builder().build();
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void buildShoudThrownWhenFlagsIsNull() {
-        ComposedMessageIdWithMetaData.builder()
-            .composedMessageId(COMPOSED_MESSAGE_ID)
-            .build();
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void buildShoudThrownWhenModSeqIsNull() {
-        ComposedMessageIdWithMetaData.builder()
-            .composedMessageId(COMPOSED_MESSAGE_ID)
-            .flags(new Flags())
-            .build();
+    @Test
+    void buildShoudThrownWhenComposedMessageIdIsNull() {
+        assertThatThrownBy(() -> ComposedMessageIdWithMetaData.builder().build())
+            .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void buildShoudWork() {
+    void buildShoudThrownWhenFlagsIsNull() {
+        assertThatThrownBy(() -> ComposedMessageIdWithMetaData.builder()
+                .composedMessageId(COMPOSED_MESSAGE_ID)
+                .build())
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void buildShoudThrownWhenModSeqIsNull() {
+        assertThatThrownBy(() -> ComposedMessageIdWithMetaData.builder()
+                .composedMessageId(COMPOSED_MESSAGE_ID)
+                .flags(new Flags())
+                .build())
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void buildShoudWork() {
         Flags flags = new Flags(Flag.RECENT);
         long modSeq = 1;
 
@@ -72,7 +76,7 @@ public class ComposedMessageIdWithMetaDataTest {
     }
 
     @Test
-    public void isMatchingShouldReturnTrueWhenSameMessageId() {
+    void isMatchingShouldReturnTrueWhenSameMessageId() {
         ComposedMessageIdWithMetaData composedMessageIdWithMetaData = ComposedMessageIdWithMetaData.builder()
                 .composedMessageId(new ComposedMessageId(TEST_ID, TEST_MESSAGE_ID, MESSAGE_UID))
                 .flags(new Flags(Flag.RECENT))
@@ -83,7 +87,7 @@ public class ComposedMessageIdWithMetaDataTest {
     }
 
     @Test
-    public void isMatchingShouldReturnFalseWhenOtherMessageId() {
+    void isMatchingShouldReturnFalseWhenOtherMessageId() {
         ComposedMessageIdWithMetaData composedMessageIdWithMetaData = ComposedMessageIdWithMetaData.builder()
                 .composedMessageId(COMPOSED_MESSAGE_ID)
                 .flags(new Flags(Flag.RECENT))
@@ -94,7 +98,7 @@ public class ComposedMessageIdWithMetaDataTest {
     }
 
     @Test
-    public void shouldRespectJavaBeanContract() {
+    void shouldRespectJavaBeanContract() {
         EqualsVerifier.forClass(ComposedMessageIdWithMetaData.class)
             .verify();
     }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxACLEntryKeyTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxACLEntryKeyTest.java
@@ -22,132 +22,131 @@ package org.apache.james.mailbox.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.james.mailbox.exception.UnsupportedRightException;
 import org.apache.james.mailbox.model.MailboxACL.EntryKey;
 import org.apache.james.mailbox.model.MailboxACL.NameType;
 import org.apache.james.mailbox.model.MailboxACL.SpecialName;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class MailboxACLEntryKeyTest {
+class MailboxACLEntryKeyTest {
     private static final String GROUP_1 = "group1";
     private static final String USER_1 = "user1";
 
     @Test
-    public void testUser() throws UnsupportedRightException {
+    void testUser() {
         assertThat(EntryKey.deserialize(USER_1))
             .isEqualTo(new EntryKey(USER_1, NameType.user, false));
     }
 
     @Test
-    public void testNegativeUser() throws UnsupportedRightException {
+    void testNegativeUser() {
         assertThat(EntryKey.deserialize(MailboxACL.DEFAULT_NEGATIVE_MARKER + USER_1))
             .isEqualTo(new EntryKey(USER_1, NameType.user, true));
     }
 
     @Test
-    public void testGroup() throws UnsupportedRightException {
+    void testGroup() {
         assertThat(EntryKey.deserialize(MailboxACL.DEFAULT_GROUP_MARKER + GROUP_1))
             .isEqualTo(new EntryKey(GROUP_1, NameType.group, false));
     }
 
     @Test
-    public void testNegativeGroup() throws UnsupportedRightException {
+    void testNegativeGroup() {
         assertThat(EntryKey.deserialize(String.valueOf(MailboxACL.DEFAULT_NEGATIVE_MARKER) + MailboxACL.DEFAULT_GROUP_MARKER + GROUP_1))
             .isEqualTo(new EntryKey(GROUP_1, NameType.group, true));
     }
 
     @Test
-    public void testOwner() throws UnsupportedRightException {
+    void testOwner() {
         assertThat(EntryKey.deserialize(SpecialName.owner.toString()))
             .isEqualTo(new EntryKey(SpecialName.owner.toString(), NameType.special, false));
     }
 
     @Test
-    public void testNegativeOwner() throws UnsupportedRightException {
+    void testNegativeOwner() {
         assertThat(EntryKey.deserialize(MailboxACL.DEFAULT_NEGATIVE_MARKER + SpecialName.owner.toString()))
             .isEqualTo(new EntryKey(SpecialName.owner.toString(), NameType.special, true));
     }
 
     @Test
-    public void testAnybody() throws UnsupportedRightException {
+    void testAnybody() {
         assertThat(EntryKey.deserialize(SpecialName.anybody.toString()))
             .isEqualTo(new EntryKey(SpecialName.anybody.toString(), NameType.special, false));
     }
 
     @Test
-    public void testNegativeAnybody() throws UnsupportedRightException {
+    void testNegativeAnybody() {
         assertThat(EntryKey.deserialize(MailboxACL.DEFAULT_NEGATIVE_MARKER + SpecialName.anybody.toString()))
             .isEqualTo(new EntryKey(SpecialName.anybody.toString(), NameType.special, true));
     }
 
     @Test
-    public void testAuthenticated() throws UnsupportedRightException {
+    void testAuthenticated() {
         assertThat(EntryKey.deserialize(SpecialName.authenticated.toString()))
             .isEqualTo(new EntryKey(SpecialName.authenticated.toString(), NameType.special, false));
     }
 
     @Test
-    public void testNegativeAuthenticated() throws UnsupportedRightException {
+    void testNegativeAuthenticated() {
         assertThat(EntryKey.deserialize(MailboxACL.DEFAULT_NEGATIVE_MARKER + SpecialName.authenticated.toString()))
             .isEqualTo(new EntryKey(SpecialName.authenticated.toString(), NameType.special, true));
     }
 
     @Test
-    public void testSerializeUser() throws UnsupportedRightException {
+    void testSerializeUser() {
         assertThat(new EntryKey(USER_1, NameType.user, false).serialize())
             .isEqualTo(USER_1);
     }
 
     @Test
-    public void testSerializeNegativeUser() throws UnsupportedRightException {
+    void testSerializeNegativeUser() {
         assertThat(new EntryKey(USER_1, NameType.user, true).serialize())
             .isEqualTo(MailboxACL.DEFAULT_NEGATIVE_MARKER + USER_1);
     }
 
     @Test
-    public void testSerializeGroup() throws UnsupportedRightException {
+    void testSerializeGroup() {
         assertThat(new EntryKey(GROUP_1, NameType.group, false).serialize())
             .isEqualTo(MailboxACL.DEFAULT_GROUP_MARKER + GROUP_1);
     }
 
     @Test
-    public void testSerializeNegativeGroup() throws UnsupportedRightException {
+    void testSerializeNegativeGroup() {
         assertThat(new EntryKey(GROUP_1, NameType.group, true).serialize())
             .isEqualTo(String.valueOf(MailboxACL.DEFAULT_NEGATIVE_MARKER) + MailboxACL.DEFAULT_GROUP_MARKER + GROUP_1);
     }
 
     @Test
-    public void testSerializeOwner() throws UnsupportedRightException {
+    void testSerializeOwner() {
         assertThat(new EntryKey(SpecialName.owner.toString(), NameType.special, false).serialize())
             .isEqualTo(SpecialName.owner.toString());
     }
 
     @Test
-    public void testSerializeNegativeOwner() throws UnsupportedRightException {
+    void testSerializeNegativeOwner() {
         assertThat(new EntryKey(SpecialName.owner.toString(), NameType.special, true).serialize())
             .isEqualTo(MailboxACL.DEFAULT_NEGATIVE_MARKER + SpecialName.owner.toString());
     }
 
     @Test
-    public void testSerializeAnybody() throws UnsupportedRightException {
+    void testSerializeAnybody() {
         assertThat(new EntryKey(SpecialName.anybody.toString(), NameType.special, false).serialize())
             .isEqualTo(SpecialName.anybody.toString());
     }
 
     @Test
-    public void testSerializeNegativeAnybody() throws UnsupportedRightException {
+    void testSerializeNegativeAnybody() {
         assertThat(new EntryKey(SpecialName.anybody.toString(), NameType.special, true).serialize())
             .isEqualTo(MailboxACL.DEFAULT_NEGATIVE_MARKER + SpecialName.anybody.toString());
     }
 
     @Test
-    public void testSerializeAuthenticated() throws UnsupportedRightException {
+    void testSerializeAuthenticated() {
         assertThat(new EntryKey(SpecialName.authenticated.toString(), NameType.special, false).serialize())
             .isEqualTo(SpecialName.authenticated.toString());
     }
 
     @Test
-    public void testSerializeNegativeAuthenticated() throws UnsupportedRightException {
+    void testSerializeNegativeAuthenticated() {
         assertThat(new EntryKey(SpecialName.authenticated.toString(), NameType.special, true).serialize())
             .isEqualTo(MailboxACL.DEFAULT_NEGATIVE_MARKER + SpecialName.authenticated.toString());
     }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxACLTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxACLTest.java
@@ -32,12 +32,12 @@ import org.apache.james.mailbox.model.MailboxACL.EntryKey;
 import org.apache.james.mailbox.model.MailboxACL.NameType;
 import org.apache.james.mailbox.model.MailboxACL.Rfc4314Rights;
 import org.assertj.core.data.MapEntry;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
 
-public class MailboxACLTest {
+class MailboxACLTest {
 
     private static final String USER_1 = "user1";
     private static final String USER_2 = "user2";
@@ -53,8 +53,8 @@ public class MailboxACLTest {
 
     private MailboxACL u1u2g1g2ACL;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
 
         u1u2g1g2Properties = new Properties();
 
@@ -68,7 +68,7 @@ public class MailboxACLTest {
     }
 
     @Test
-    public void testUnionACLNew() throws UnsupportedRightException {
+    void testUnionACLNew() throws UnsupportedRightException {
 
         Map<EntryKey, Rfc4314Rights> expectedEntries = new HashMap<>(u1u2g1g2ACL.getEntries());
         expectedEntries.put(MailboxACL.OWNER_KEY, MailboxACL.FULL_RIGHTS);
@@ -82,7 +82,7 @@ public class MailboxACLTest {
     }
 
     @Test
-    public void testUnionEntryNew() throws UnsupportedRightException {
+    void testUnionEntryNew() throws UnsupportedRightException {
 
         Map<EntryKey, Rfc4314Rights> expectedEntries = new HashMap<>(u1u2g1g2ACL.getEntries());
         expectedEntries.put(MailboxACL.OWNER_KEY, MailboxACL.FULL_RIGHTS);
@@ -95,7 +95,7 @@ public class MailboxACLTest {
     }
 
     @Test
-    public void testUnionACLExisting() throws UnsupportedRightException {
+    void testUnionACLExisting() throws UnsupportedRightException {
 
         Map<EntryKey, Rfc4314Rights> expectedEntries = new HashMap<>(u1u2g1g2ACL.getEntries());
         expectedEntries.put(EntryKey.deserialize(USER_1), Rfc4314Rights.fromSerializedRfc4314Rights(aeik + lprs));
@@ -109,7 +109,7 @@ public class MailboxACLTest {
     }
 
     @Test
-    public void testUnionEntryExisting() throws UnsupportedRightException {
+    void testUnionEntryExisting() throws UnsupportedRightException {
 
         Map<EntryKey, Rfc4314Rights> expectedEntries = new HashMap<>(u1u2g1g2ACL.getEntries());
         expectedEntries.put(EntryKey.deserialize(USER_1), Rfc4314Rights.fromSerializedRfc4314Rights(aeik + lprs));
@@ -122,17 +122,17 @@ public class MailboxACLTest {
     }
 
     @Test
-    public void testUnionACLZero() throws UnsupportedRightException {
+    void testUnionACLZero() throws UnsupportedRightException {
 
     }
 
     @Test
-    public void testUnionEntryZero() throws UnsupportedRightException {
+    void testUnionEntryZero() throws UnsupportedRightException {
 
     }
 
     @Test
-    public void testExceptACLNew() throws UnsupportedRightException {
+    void testExceptACLNew() throws UnsupportedRightException {
 
         /* actually no change expected */
         Map<EntryKey, Rfc4314Rights> expectedEntries = new HashMap<>(u1u2g1g2ACL.getEntries());
@@ -146,7 +146,7 @@ public class MailboxACLTest {
     }
 
     @Test
-    public void testExceptEntryNew() throws UnsupportedRightException {
+    void testExceptEntryNew() throws UnsupportedRightException {
 
         /* actually no change expected */
         Map<EntryKey, Rfc4314Rights> expectedEntries = new HashMap<>(u1u2g1g2ACL.getEntries());
@@ -159,7 +159,7 @@ public class MailboxACLTest {
     }
 
     @Test
-    public void testExceptACLExisting() throws UnsupportedRightException {
+    void testExceptACLExisting() throws UnsupportedRightException {
 
         Map<EntryKey, Rfc4314Rights> expectedEntries = new HashMap<>(u1u2g1g2ACL.getEntries());
         expectedEntries.put(EntryKey.deserialize(USER_1), Rfc4314Rights.fromSerializedRfc4314Rights(ik));
@@ -173,7 +173,7 @@ public class MailboxACLTest {
     }
 
     @Test
-    public void testExceptEntryExisting() throws UnsupportedRightException {
+    void testExceptEntryExisting() throws UnsupportedRightException {
 
         Map<EntryKey, Rfc4314Rights> expectedEntries = new HashMap<>(u1u2g1g2ACL.getEntries());
         expectedEntries.put(EntryKey.deserialize(USER_1), Rfc4314Rights.fromSerializedRfc4314Rights(ik));
@@ -186,7 +186,7 @@ public class MailboxACLTest {
     }
 
     @Test
-    public void testExceptACLFull() throws UnsupportedRightException {
+    void testExceptACLFull() throws UnsupportedRightException {
 
         Map<EntryKey, Rfc4314Rights> expectedEntries = new HashMap<>(u1u2g1g2ACL.getEntries());
         expectedEntries.remove(EntryKey.deserialize(USER_1));
@@ -200,7 +200,7 @@ public class MailboxACLTest {
     }
 
     @Test
-    public void testExceptEntryFull() throws UnsupportedRightException {
+    void testExceptEntryFull() throws UnsupportedRightException {
 
         Map<EntryKey, Rfc4314Rights> expectedEntries = new HashMap<>(u1u2g1g2ACL.getEntries());
         expectedEntries.remove(EntryKey.deserialize(USER_1));
@@ -213,26 +213,26 @@ public class MailboxACLTest {
     }
 
     @Test
-    public void propertiesConstructorShouldAcceptNullValues() throws Exception {
+    void propertiesConstructorShouldAcceptNullValues() throws Exception {
         assertThat(new MailboxACL((Properties) null))
             .isEqualTo(MailboxACL.EMPTY);
     }
 
     @Test
-    public void applyShouldNotThrowWhenRemovingANonExistingEntry() throws Exception {
+    void applyShouldNotThrowWhenRemovingANonExistingEntry() throws Exception {
         assertThat(MailboxACL.EMPTY
             .apply(MailboxACL.command().forUser("bob").noRights().asReplacement()))
             .isEqualTo(MailboxACL.EMPTY);
     }
 
     @Test
-    public void usersACLShouldReturnEmptyMapWhenEmpty() {
+    void usersACLShouldReturnEmptyMapWhenEmpty() {
         assertThat(MailboxACL.EMPTY.ofPositiveNameType(NameType.user))
             .isEmpty();
     }
 
     @Test
-    public void usersACLShouldReturnEmptyMapWhenNoUserEntry() {
+    void usersACLShouldReturnEmptyMapWhenNoUserEntry() {
         MailboxACL mailboxACL = new MailboxACL(
                 ImmutableMap.of(EntryKey.createGroupEntryKey("group"), MailboxACL.FULL_RIGHTS,
                     EntryKey.createGroupEntryKey("group2"), MailboxACL.NO_RIGHTS));
@@ -241,7 +241,7 @@ public class MailboxACLTest {
     }
 
     @Test
-    public void usersACLShouldReturnOnlyUsersMapWhenSomeUserEntries() throws Exception {
+    void usersACLShouldReturnOnlyUsersMapWhenSomeUserEntries() throws Exception {
         MailboxACL.Rfc4314Rights rights = MailboxACL.Rfc4314Rights.fromSerializedRfc4314Rights("aei");
         MailboxACL mailboxACL = new MailboxACL(
             ImmutableMap.of(EntryKey.createUserEntryKey("user1"), MailboxACL.FULL_RIGHTS,
@@ -255,7 +255,7 @@ public class MailboxACLTest {
     }
 
     @Test
-    public void ofPositiveNameTypeShouldFilterOutNegativeEntries() throws Exception {
+    void ofPositiveNameTypeShouldFilterOutNegativeEntries() throws Exception {
         MailboxACL mailboxACL = new MailboxACL(
             ImmutableMap.of(EntryKey.createUserEntryKey("user1", NEGATIVE), MailboxACL.FULL_RIGHTS));
         assertThat(mailboxACL.ofPositiveNameType(NameType.user))

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxAnnotationKeyTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxAnnotationKeyTest.java
@@ -20,109 +20,123 @@
 package org.apache.james.mailbox.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class MailboxAnnotationKeyTest {
-    @Test(expected = IllegalArgumentException.class)
-    public void newInstanceShouldThrowsExceptionWhenKeyDoesNotStartWithSlash() throws Exception {
-        new MailboxAnnotationKey("shared");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void newInstanceShouldThrowsExceptionWhenKeyContainsAsterisk() throws Exception {
-        new MailboxAnnotationKey("/private/key*comment");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void newInstanceShouldThrowsExceptionWhenKeyContainsPercent() throws Exception {
-        new MailboxAnnotationKey("/private/key%comment");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void validKeyShouldThrowsExceptionWhenKeyContainsTwoConsecutiveSlash() throws Exception {
-        new MailboxAnnotationKey("/private//keycomment");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void validKeyShouldThrowsExceptionWhenKeyEndsWithSlash() throws Exception {
-        new MailboxAnnotationKey("/private/keycomment/");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void validKeyShouldThrowsExceptionWhenKeyContainsNonASCII() throws Exception {
-        new MailboxAnnotationKey("/private/key┬ácomment");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void validKeyShouldThrowsExceptionWhenKeyContainsTabCharacter() throws Exception {
-        new MailboxAnnotationKey("/private/key\tcomment");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void newInstanceShouldThrowsExceptionWithEmptyKey() throws Exception {
-        new MailboxAnnotationKey("");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void newInstanceShouldThrowsExceptionWithBlankKey() throws Exception {
-        new MailboxAnnotationKey("    ");
+class MailboxAnnotationKeyTest {
+    @Test
+    void newInstanceShouldThrowsExceptionWhenKeyDoesNotStartWithSlash() {
+        assertThatThrownBy(() -> new MailboxAnnotationKey("shared"))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void newInstanceShouldReturnRightKeyValue() throws Exception {
+    void newInstanceShouldThrowsExceptionWhenKeyContainsAsterisk() {
+        assertThatThrownBy(() -> new MailboxAnnotationKey("/private/key*comment"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void newInstanceShouldThrowsExceptionWhenKeyContainsPercent() {
+        assertThatThrownBy(() -> new MailboxAnnotationKey("/private/key%comment"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void validKeyShouldThrowsExceptionWhenKeyContainsTwoConsecutiveSlash() {
+        assertThatThrownBy(() -> new MailboxAnnotationKey("/private//keycomment"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void validKeyShouldThrowsExceptionWhenKeyEndsWithSlash() {
+        assertThatThrownBy(() -> new MailboxAnnotationKey("/private/keycomment/"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void validKeyShouldThrowsExceptionWhenKeyContainsNonASCII() {
+        assertThatThrownBy(() -> new MailboxAnnotationKey("/private/key┬ácomment"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void validKeyShouldThrowsExceptionWhenKeyContainsTabCharacter() {
+        assertThatThrownBy(() -> new MailboxAnnotationKey("/private/key\tcomment"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void newInstanceShouldThrowsExceptionWithEmptyKey() {
+        assertThatThrownBy(() -> new MailboxAnnotationKey(""))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void newInstanceShouldThrowsExceptionWithBlankKey() {
+        assertThatThrownBy(() -> new MailboxAnnotationKey("    "))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void newInstanceShouldReturnRightKeyValue() {
         MailboxAnnotationKey annotationKey = new MailboxAnnotationKey("/private/comment");
         assertThat(annotationKey.asString()).isEqualTo("/private/comment");
     }
 
     @Test
-    public void keyValueShouldBeCaseInsensitive() throws Exception {
+    void keyValueShouldBeCaseInsensitive() {
         MailboxAnnotationKey annotationKey = new MailboxAnnotationKey("/private/comment");
         MailboxAnnotationKey anotherAnnotationKey = new MailboxAnnotationKey("/PRIVATE/COMMENT");
 
         assertThat(annotationKey).isEqualTo(anotherAnnotationKey);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void newInstanceShouldThrowsExceptionWhenKeyContainsPunctuationCharacters() throws Exception {
-        new MailboxAnnotationKey("/private/+comment");
+    @Test
+    void newInstanceShouldThrowsExceptionWhenKeyContainsPunctuationCharacters() {
+        assertThatThrownBy(() -> new MailboxAnnotationKey("/private/+comment"))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void countSlashShouldReturnRightNumberOfSlash() throws Exception {
+    void countSlashShouldReturnRightNumberOfSlash() {
         MailboxAnnotationKey annotationKey = new MailboxAnnotationKey("/private/comment/user/name");
         assertThat(annotationKey.countComponents()).isEqualTo(4);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void keyMustContainAtLeastTwoComponents() throws Exception {
-        new MailboxAnnotationKey("/private");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void keyVendorShouldThrowsExceptionWithTwoComponents() throws Exception {
-        new MailboxAnnotationKey("/private/vendor");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void keyVendorShouldThrowsExceptionWithThreeComponents() throws Exception {
-        new MailboxAnnotationKey("/shared/vendor/token");
+    @Test
+    void keyMustContainAtLeastTwoComponents() {
+        assertThatThrownBy(() -> new MailboxAnnotationKey("/private"))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void keyVendorShouldOKWithFourComponents() throws Exception {
+    void keyVendorShouldThrowsExceptionWithTwoComponents() {
+        assertThatThrownBy(() -> new MailboxAnnotationKey("/private/vendor"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void keyVendorShouldThrowsExceptionWithThreeComponents() {
+        assertThatThrownBy(() -> new MailboxAnnotationKey("/shared/vendor/token"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void keyVendorShouldOKWithFourComponents() {
         new MailboxAnnotationKey("/shared/vendor/token/comment");
     }
 
     @Test
-    public void isParentOrIsEqualShouldReturnTrueWhenSameKey() {
+    void isParentOrIsEqualShouldReturnTrueWhenSameKey() {
         MailboxAnnotationKey key1 = new MailboxAnnotationKey("/private/comment");
 
         assertThat(key1.isParentOrIsEqual(key1)).isTrue();
     }
 
     @Test
-    public void isParentOrIsEqualShouldReturnTrueWhenParent() {
+    void isParentOrIsEqualShouldReturnTrueWhenParent() {
         MailboxAnnotationKey key1 = new MailboxAnnotationKey("/private/comment");
         MailboxAnnotationKey key2 = new MailboxAnnotationKey("/private/comment/toto");
 
@@ -130,7 +144,7 @@ public class MailboxAnnotationKeyTest {
     }
 
     @Test
-    public void isParentOrIsEqualShouldReturnFalseWhenChild() {
+    void isParentOrIsEqualShouldReturnFalseWhenChild() {
         MailboxAnnotationKey key1 = new MailboxAnnotationKey("/private/comment");
         MailboxAnnotationKey key2 = new MailboxAnnotationKey("/private/comment/toto");
 
@@ -138,7 +152,7 @@ public class MailboxAnnotationKeyTest {
     }
 
     @Test
-    public void isParentOrIsEqualShouldReturnFalseWhenGrandParent() {
+    void isParentOrIsEqualShouldReturnFalseWhenGrandParent() {
         MailboxAnnotationKey key1 = new MailboxAnnotationKey("/private/comment");
         MailboxAnnotationKey key2 = new MailboxAnnotationKey("/private/comment/toto/tata");
 
@@ -146,7 +160,7 @@ public class MailboxAnnotationKeyTest {
     }
 
     @Test
-    public void isParentOrIsEqualShouldReturnFalseWhenCousin() {
+    void isParentOrIsEqualShouldReturnFalseWhenCousin() {
         MailboxAnnotationKey key1 = new MailboxAnnotationKey("/private/comment/tutu");
         MailboxAnnotationKey key2 = new MailboxAnnotationKey("/private/comment/toto/tata");
 
@@ -155,14 +169,14 @@ public class MailboxAnnotationKeyTest {
 
 
     @Test
-    public void isAncestorOrIsEqualShouldReturnTrueWhenSameKey() {
+    void isAncestorOrIsEqualShouldReturnTrueWhenSameKey() {
         MailboxAnnotationKey key1 = new MailboxAnnotationKey("/private/comment");
 
         assertThat(key1.isAncestorOrIsEqual(key1)).isTrue();
     }
 
     @Test
-    public void isAncestorOrIsEqualShouldReturnTrueWhenParent() {
+    void isAncestorOrIsEqualShouldReturnTrueWhenParent() {
         MailboxAnnotationKey key1 = new MailboxAnnotationKey("/private/comment");
         MailboxAnnotationKey key2 = new MailboxAnnotationKey("/private/comment/toto");
 
@@ -170,7 +184,7 @@ public class MailboxAnnotationKeyTest {
     }
 
     @Test
-    public void isAncestorOrIsEqualShouldReturnFalseWhenChild() {
+    void isAncestorOrIsEqualShouldReturnFalseWhenChild() {
         MailboxAnnotationKey key1 = new MailboxAnnotationKey("/private/comment");
         MailboxAnnotationKey key2 = new MailboxAnnotationKey("/private/comment/toto");
 
@@ -178,7 +192,7 @@ public class MailboxAnnotationKeyTest {
     }
 
     @Test
-    public void isAncestorOrIsEqualShouldReturnTrueWhenGrandParent() {
+    void isAncestorOrIsEqualShouldReturnTrueWhenGrandParent() {
         MailboxAnnotationKey key1 = new MailboxAnnotationKey("/private/comment");
         MailboxAnnotationKey key2 = new MailboxAnnotationKey("/private/comment/toto/tata");
 
@@ -186,7 +200,7 @@ public class MailboxAnnotationKeyTest {
     }
 
     @Test
-    public void isAncestorOrIsEqualShouldReturnFalseWhenCousin() {
+    void isAncestorOrIsEqualShouldReturnFalseWhenCousin() {
         MailboxAnnotationKey key1 = new MailboxAnnotationKey("/private/comment/tutu");
         MailboxAnnotationKey key2 = new MailboxAnnotationKey("/private/comment/toto/tata");
 
@@ -194,7 +208,7 @@ public class MailboxAnnotationKeyTest {
     }
 
     @Test
-    public void isAncestorOrIsEqualShouldWorkOnCousinKeyUsingKeyAsAPrefix() {
+    void isAncestorOrIsEqualShouldWorkOnCousinKeyUsingKeyAsAPrefix() {
         MailboxAnnotationKey key1 = new MailboxAnnotationKey("/private/comment/tutu");
         MailboxAnnotationKey key2 = new MailboxAnnotationKey("/private/comment/tututata");
 
@@ -202,7 +216,7 @@ public class MailboxAnnotationKeyTest {
     }
 
     @Test
-    public void isParentOrIsEqualShouldWorkOnCousinKeyUsingKeyAsAPrefix() {
+    void isParentOrIsEqualShouldWorkOnCousinKeyUsingKeyAsAPrefix() {
         MailboxAnnotationKey key1 = new MailboxAnnotationKey("/private/comment/tutu");
         MailboxAnnotationKey key2 = new MailboxAnnotationKey("/private/comment/tututata");
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxAnnotationTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxAnnotationTest.java
@@ -20,63 +20,61 @@
 package org.apache.james.mailbox.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class MailboxAnnotationTest {
+class MailboxAnnotationTest {
     private static final MailboxAnnotationKey ANNOTATION_KEY = new MailboxAnnotationKey("/private/comment");
     private static final String ANNOTATION_VALUE = "anyValue";
 
     @Test
-    public void sizeOfAnnotationShouldBeReturnLengthOfValue() throws Exception {
+    void sizeOfAnnotationShouldBeReturnLengthOfValue() {
         MailboxAnnotation mailboxAnnotation = MailboxAnnotation.newInstance(ANNOTATION_KEY, ANNOTATION_VALUE);
 
         assertThat(mailboxAnnotation.size()).isEqualTo(8);
     }
 
     @Test
-    public void sizeOfNilAnnotationShouldBeZero() throws Exception {
+    void sizeOfNilAnnotationShouldBeZero() {
         MailboxAnnotation mailboxAnnotation = MailboxAnnotation.nil(ANNOTATION_KEY);
 
         assertThat(mailboxAnnotation.size()).isEqualTo(0);
     }
     
-    @Test(expected = NullPointerException.class)
-    public void newInstanceShouldThrowsExceptionWithNullKey() throws Exception {
-        MailboxAnnotation.newInstance(null, null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void newInstanceShouldThrowsExceptionWithNullValue() throws Exception {
-        MailboxAnnotation.newInstance(ANNOTATION_KEY, null);
+    @Test
+    void newInstanceShouldThrowsExceptionWithNullKey() {
+        assertThatThrownBy(() -> MailboxAnnotation.newInstance(null, null))
+            .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void nilInstanceShouldReturnAbsentValue() throws Exception {
+    void newInstanceShouldThrowsExceptionWithNullValue() {
+        assertThatThrownBy(() -> MailboxAnnotation.newInstance(ANNOTATION_KEY, null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void nilInstanceShouldReturnAbsentValue() {
         MailboxAnnotation annotation = MailboxAnnotation.nil(ANNOTATION_KEY);
 
         assertThat(annotation.getValue()).isEmpty();
     }
 
     @Test
-    public void isNilShouldReturnTrueForNilObject() throws Exception {
+    void isNilShouldReturnTrueForNilObject() {
         MailboxAnnotation nilAnnotation = MailboxAnnotation.nil(ANNOTATION_KEY);
         assertThat(nilAnnotation.isNil()).isTrue();
     }
 
     @Test
-    public void isNilShouldReturnFalseForNotNilObject() throws Exception {
+    void isNilShouldReturnFalseForNotNilObject() {
         MailboxAnnotation nilAnnotation = MailboxAnnotation.newInstance(ANNOTATION_KEY, ANNOTATION_VALUE);
         assertThat(nilAnnotation.isNil()).isFalse();
     }
 
-    @Test(expected = NullPointerException.class)
-    public void newInstanceMailboxAnnotationShouldThrowExceptionWithNullValue() throws Exception {
-        MailboxAnnotation.newInstance(ANNOTATION_KEY, null);
-    }
-
     @Test
-    public void newInstanceMailboxAnnotationShouldCreateNewInstance() throws Exception {
+    void newInstanceMailboxAnnotationShouldCreateNewInstance() {
         MailboxAnnotation annotation = MailboxAnnotation.newInstance(ANNOTATION_KEY, ANNOTATION_VALUE);
 
         assertThat(annotation.getKey()).isEqualTo(ANNOTATION_KEY);

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxAssertTests.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxAssertTests.java
@@ -19,64 +19,77 @@
 
 package org.apache.james.mailbox.model;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class MailboxAssertTests {
+import org.junit.jupiter.api.Test;
+
+class MailboxAssertTests {
 
     private static final long UID_VALIDITY = 42;
     private static final TestId MAILBOX_ID = TestId.of(24);
 
     @Test
-    public void isEqualToShouldNotFailWithEqualMailbox() {
+    void isEqualToShouldNotFailWithEqualMailbox() {
         Mailbox mailbox1 = new Mailbox(MailboxPath.forUser("user", "name"), UID_VALIDITY);
         Mailbox mailbox2 = new Mailbox(MailboxPath.forUser("user", "name"), UID_VALIDITY);
         mailbox1.setMailboxId(MAILBOX_ID);
         mailbox2.setMailboxId(MAILBOX_ID);
+
         MailboxAssert.assertThat(mailbox1).isEqualTo(mailbox2);
     }
 
-    @Test(expected = AssertionError.class)
-    public void isEqualToShouldFailWithNotEqualNamespace() {
+    @Test
+    void isEqualToShouldFailWithNotEqualNamespace() {
         Mailbox mailbox1 = new Mailbox(MailboxPath.forUser("user", "name"), UID_VALIDITY);
         Mailbox mailbox2 = new Mailbox(new MailboxPath("other_namespace", "user", "name"), UID_VALIDITY);
         mailbox1.setMailboxId(MAILBOX_ID);
         mailbox2.setMailboxId(MAILBOX_ID);
-        MailboxAssert.assertThat(mailbox1).isEqualTo(mailbox2);
+
+        assertThatThrownBy(() -> MailboxAssert.assertThat(mailbox1).isEqualTo(mailbox2))
+            .isInstanceOf(AssertionError.class);
     }
 
-    @Test(expected = AssertionError.class)
-    public void isEqualToShouldFailWithNotEqualUser() {
+    @Test
+    void isEqualToShouldFailWithNotEqualUser() {
         Mailbox mailbox1 = new Mailbox(MailboxPath.forUser("user", "name"), UID_VALIDITY);
         Mailbox mailbox2 = new Mailbox(new MailboxPath("namespace", "other_user", "name"), UID_VALIDITY);
         mailbox1.setMailboxId(MAILBOX_ID);
         mailbox2.setMailboxId(MAILBOX_ID);
-        MailboxAssert.assertThat(mailbox1).isEqualTo(mailbox2);
+
+        assertThatThrownBy(() -> MailboxAssert.assertThat(mailbox1).isEqualTo(mailbox2))
+            .isInstanceOf(AssertionError.class);
     }
 
-    @Test(expected = AssertionError.class)
-    public void isEqualToShouldFailWithNotEqualName() {
+    @Test
+    void isEqualToShouldFailWithNotEqualName() {
         Mailbox mailbox1 = new Mailbox(MailboxPath.forUser("user", "name"), UID_VALIDITY);
         Mailbox mailbox2 = new Mailbox(new MailboxPath("namespace", "user", "other_name"), UID_VALIDITY);
         mailbox1.setMailboxId(MAILBOX_ID);
         mailbox2.setMailboxId(MAILBOX_ID);
-        MailboxAssert.assertThat(mailbox1).isEqualTo(mailbox2);
+
+        assertThatThrownBy(() -> MailboxAssert.assertThat(mailbox1).isEqualTo(mailbox2))
+            .isInstanceOf(AssertionError.class);
     }
 
-    @Test(expected = AssertionError.class)
-    public void isEqualToShouldFailWithNotEqualId() {
+    @Test
+    void isEqualToShouldFailWithNotEqualId() {
         Mailbox mailbox1 = new Mailbox(MailboxPath.forUser("user", "name"), UID_VALIDITY);
         Mailbox mailbox2 = new Mailbox(MailboxPath.forUser("user", "name"), UID_VALIDITY);
         mailbox1.setMailboxId(MAILBOX_ID);
         mailbox2.setMailboxId(TestId.of(MAILBOX_ID.id + 1));
-        MailboxAssert.assertThat(mailbox1).isEqualTo(mailbox2);
+
+        assertThatThrownBy(() -> MailboxAssert.assertThat(mailbox1).isEqualTo(mailbox2))
+            .isInstanceOf(AssertionError.class);
     }
 
-    @Test(expected = AssertionError.class)
-    public void isEqualToShouldFailWithNotEqualUidValidity() {
+    @Test
+    void isEqualToShouldFailWithNotEqualUidValidity() {
         Mailbox mailbox1 = new Mailbox(MailboxPath.forUser("user", "name"), UID_VALIDITY);
         Mailbox mailbox2 = new Mailbox(MailboxPath.forUser("user", "name"), UID_VALIDITY + 1);
         mailbox1.setMailboxId(MAILBOX_ID);
         mailbox2.setMailboxId(MAILBOX_ID);
-        MailboxAssert.assertThat(mailbox1).isEqualTo(mailbox2);
+
+        assertThatThrownBy(() -> MailboxAssert.assertThat(mailbox1).isEqualTo(mailbox2))
+            .isInstanceOf(AssertionError.class);
     }
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxCountersTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxCountersTest.java
@@ -20,14 +20,14 @@
 
 package org.apache.james.mailbox.model;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class MailboxCountersTest {
+class MailboxCountersTest {
 
     @Test
-    public void mailboxCountersShouldRespectBeanContract() {
+    void mailboxCountersShouldRespectBeanContract() {
         EqualsVerifier.forClass(MailboxCounters.class).verify();
     }
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxPathTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxPathTest.java
@@ -23,20 +23,20 @@ package org.apache.james.mailbox.model;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.james.mailbox.DefaultMailboxes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class MailboxPathTest {
+class MailboxPathTest {
 
     @Test
-    public void shouldMatchBeanContract() {
+    void shouldMatchBeanContract() {
         EqualsVerifier.forClass(MailboxPath.class)
             .verify();
     }
 
     @Test
-    public void getHierarchyLevelsShouldBeOrdered() {
+    void getHierarchyLevelsShouldBeOrdered() {
         assertThat(MailboxPath.forUser("user", "inbox.folder.subfolder")
             .getHierarchyLevels('.'))
             .containsExactly(
@@ -46,7 +46,7 @@ public class MailboxPathTest {
     }
 
     @Test
-    public void getHierarchyLevelsShouldReturnPathWhenOneLevel() {
+    void getHierarchyLevelsShouldReturnPathWhenOneLevel() {
         assertThat(MailboxPath.forUser("user", "inbox")
             .getHierarchyLevels('.'))
             .containsExactly(
@@ -54,7 +54,7 @@ public class MailboxPathTest {
     }
 
     @Test
-    public void getHierarchyLevelsShouldReturnPathWhenEmptyName() {
+    void getHierarchyLevelsShouldReturnPathWhenEmptyName() {
         assertThat(MailboxPath.forUser("user", "")
             .getHierarchyLevels('.'))
             .containsExactly(
@@ -62,7 +62,7 @@ public class MailboxPathTest {
     }
 
     @Test
-    public void getHierarchyLevelsShouldReturnPathWhenNullName() {
+    void getHierarchyLevelsShouldReturnPathWhenNullName() {
         assertThat(MailboxPath.forUser("user", null)
             .getHierarchyLevels('.'))
             .containsExactly(
@@ -70,7 +70,7 @@ public class MailboxPathTest {
     }
 
     @Test
-    public void sanitizeShouldNotThrowOnNullMailboxName() {
+    void sanitizeShouldNotThrowOnNullMailboxName() {
         assertThat(MailboxPath.forUser("user", null)
             .sanitize('.'))
             .isEqualTo(
@@ -78,7 +78,7 @@ public class MailboxPathTest {
     }
 
     @Test
-    public void sanitizeShouldReturnEmptyWhenEmpty() {
+    void sanitizeShouldReturnEmptyWhenEmpty() {
         assertThat(MailboxPath.forUser("user", "")
             .sanitize('.'))
             .isEqualTo(
@@ -86,7 +86,7 @@ public class MailboxPathTest {
     }
 
     @Test
-    public void sanitizeShouldRemoveMaximumOneTrailingDelimiterWhenAlone() {
+    void sanitizeShouldRemoveMaximumOneTrailingDelimiterWhenAlone() {
         assertThat(MailboxPath.forUser("user", ".")
             .sanitize('.'))
             .isEqualTo(
@@ -94,7 +94,7 @@ public class MailboxPathTest {
     }
 
     @Test
-    public void sanitizeShouldPreserveHeadingDelimiter() {
+    void sanitizeShouldPreserveHeadingDelimiter() {
         assertThat(MailboxPath.forUser("user", ".a")
             .sanitize('.'))
             .isEqualTo(
@@ -102,7 +102,7 @@ public class MailboxPathTest {
     }
 
     @Test
-    public void sanitizeShouldRemoveTrailingDelimiter() {
+    void sanitizeShouldRemoveTrailingDelimiter() {
         assertThat(MailboxPath.forUser("user", "a.")
             .sanitize('.'))
             .isEqualTo(
@@ -110,7 +110,7 @@ public class MailboxPathTest {
     }
 
     @Test
-    public void sanitizeShouldRemoveMaximumOneTrailingDelimiter() {
+    void sanitizeShouldRemoveMaximumOneTrailingDelimiter() {
         assertThat(MailboxPath.forUser("user", "a..")
             .sanitize('.'))
             .isEqualTo(
@@ -118,7 +118,7 @@ public class MailboxPathTest {
     }
 
     @Test
-    public void sanitizeShouldPreserveRedundantDelimiters() {
+    void sanitizeShouldPreserveRedundantDelimiters() {
         assertThat(MailboxPath.forUser("user", "a..a")
             .sanitize('.'))
             .isEqualTo(
@@ -126,75 +126,75 @@ public class MailboxPathTest {
     }
 
     @Test
-    public void hasEmptyNameInHierarchyShouldBeFalseIfSingleLevelPath() {
+    void hasEmptyNameInHierarchyShouldBeFalseIfSingleLevelPath() {
         assertThat(MailboxPath.forUser("user", "a")
             .hasEmptyNameInHierarchy('.'))
             .isFalse();
     }
 
     @Test
-    public void hasEmptyNameInHierarchyShouldBeFalseIfNestedLevelWithNonEmptyNames() {
+    void hasEmptyNameInHierarchyShouldBeFalseIfNestedLevelWithNonEmptyNames() {
         assertThat(MailboxPath.forUser("user", "a.b.c")
             .hasEmptyNameInHierarchy('.'))
             .isFalse();
     }
 
     @Test
-    public void hasEmptyNameInHierarchyShouldBeTrueIfEmptyPath() {
+    void hasEmptyNameInHierarchyShouldBeTrueIfEmptyPath() {
         assertThat(MailboxPath.forUser("user", "")
             .hasEmptyNameInHierarchy('.'))
             .isTrue();
     }
 
     @Test
-    public void hasEmptyNameInHierarchyShouldBeTrueIfPathWithTwoEmptyNames() {
+    void hasEmptyNameInHierarchyShouldBeTrueIfPathWithTwoEmptyNames() {
         assertThat(MailboxPath.forUser("user", ".")
             .hasEmptyNameInHierarchy('.'))
             .isTrue();
     }
 
     @Test
-    public void hasEmptyNameInHierarchyShouldBeTrueIfPathWithAnEmptyNameBetweenTwoNames() {
+    void hasEmptyNameInHierarchyShouldBeTrueIfPathWithAnEmptyNameBetweenTwoNames() {
         assertThat(MailboxPath.forUser("user", "a..b")
             .hasEmptyNameInHierarchy('.'))
             .isTrue();
     }
 
     @Test
-    public void hasEmptyNameInHierarchyShouldBeTrueIfPathWithHeadingEmptyNames() {
+    void hasEmptyNameInHierarchyShouldBeTrueIfPathWithHeadingEmptyNames() {
         assertThat(MailboxPath.forUser("user", "..a")
             .hasEmptyNameInHierarchy('.'))
             .isTrue();
     }
 
     @Test
-    public void hasEmptyNameInHierarchyShouldBeTrueIfPathWithATrailingEmptyName() {
+    void hasEmptyNameInHierarchyShouldBeTrueIfPathWithATrailingEmptyName() {
         assertThat(MailboxPath.forUser("user", "a.")
             .hasEmptyNameInHierarchy('.'))
             .isTrue();
     }
 
     @Test
-    public void hasEmptyNameInHierarchyShouldBeTrueIfPathWithTrailingEmptyNames() {
+    void hasEmptyNameInHierarchyShouldBeTrueIfPathWithTrailingEmptyNames() {
         assertThat(MailboxPath.forUser("user", "a..")
             .hasEmptyNameInHierarchy('.'))
             .isTrue();
     }
 
     @Test
-    public void isInboxShouldReturnTrueWhenINBOX() {
+    void isInboxShouldReturnTrueWhenINBOX() {
         MailboxPath mailboxPath = new MailboxPath(MailboxConstants.USER_NAMESPACE, "user", DefaultMailboxes.INBOX);
         assertThat(mailboxPath.isInbox()).isTrue();
     }
 
     @Test
-    public void isInboxShouldReturnTrueWhenINBOXWithOtherCase() {
+    void isInboxShouldReturnTrueWhenINBOXWithOtherCase() {
         MailboxPath mailboxPath = new MailboxPath(MailboxConstants.USER_NAMESPACE, "user", "InBoX");
         assertThat(mailboxPath.isInbox()).isTrue();
     }
 
     @Test
-    public void isInboxShouldReturnFalseWhenOtherThanInbox() {
+    void isInboxShouldReturnFalseWhenOtherThanInbox() {
         MailboxPath mailboxPath = new MailboxPath(MailboxConstants.USER_NAMESPACE, "user", DefaultMailboxes.ARCHIVE);
         assertThat(mailboxPath.isInbox()).isFalse();
     }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MessageAttachmentTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MessageAttachmentTest.java
@@ -20,27 +20,30 @@
 package org.apache.james.mailbox.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class MessageAttachmentTest {
+class MessageAttachmentTest {
 
-    @Test(expected = IllegalStateException.class)
-    public void buildShouldThrowWhenAttachmentIsNotGiven() {
-        MessageAttachment.builder()
-            .build();
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void builderShouldThrowWhenAttachmentIsNull() {
-        MessageAttachment.builder()
-            .attachment(null);
+    @Test
+    void buildShouldThrowWhenAttachmentIsNotGiven() {
+        assertThatThrownBy(() -> MessageAttachment.builder()
+                .build())
+            .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void buildShouldWorkWhenMandatoryAttributesAreGiven() {
+    void builderShouldThrowWhenAttachmentIsNull() {
+        assertThatThrownBy(() -> MessageAttachment.builder()
+                .attachment(null))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void buildShouldWorkWhenMandatoryAttributesAreGiven() {
         Attachment attachment = Attachment.builder()
                 .bytes("content".getBytes())
                 .type("type")
@@ -55,7 +58,7 @@ public class MessageAttachmentTest {
     }
 
     @Test
-    public void buildShouldAcceptIsInlineAndNoCid() {
+    void buildShouldAcceptIsInlineAndNoCid() {
         Attachment attachment = Attachment.builder()
                 .bytes("content".getBytes())
                 .type("type")
@@ -70,7 +73,7 @@ public class MessageAttachmentTest {
     }
 
     @Test
-    public void buildShouldSetAttributesWhenAllAreGiven() {
+    void buildShouldSetAttributesWhenAllAreGiven() {
         Attachment attachment = Attachment.builder()
                 .bytes("content".getBytes())
                 .type("type")
@@ -88,7 +91,7 @@ public class MessageAttachmentTest {
     }
 
     @Test
-    public void isInlinedWithCidShouldReturnTrueWhenIsInlineAndHasCid() throws Exception {
+    void isInlinedWithCidShouldReturnTrueWhenIsInlineAndHasCid() throws Exception {
         Attachment attachment = Attachment.builder()
             .bytes("content".getBytes())
             .type("type")
@@ -105,7 +108,7 @@ public class MessageAttachmentTest {
     }
 
     @Test
-    public void isInlinedWithCidShouldReturnFalseWhenIsNotInline() throws Exception {
+    void isInlinedWithCidShouldReturnFalseWhenIsNotInline() throws Exception {
         Attachment attachment = Attachment.builder()
             .bytes("content".getBytes())
             .type("type")
@@ -122,7 +125,7 @@ public class MessageAttachmentTest {
     }
 
     @Test
-    public void isInlinedWithCidShouldReturnFalseWhenIsInlineButNoCid() throws Exception {
+    void isInlinedWithCidShouldReturnFalseWhenIsInlineButNoCid() throws Exception {
         Attachment attachment = Attachment.builder()
             .bytes("content".getBytes())
             .type("type")

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MessageIdDtoTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MessageIdDtoTest.java
@@ -21,11 +21,11 @@ package org.apache.james.mailbox.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class MessageIdDtoTest {
+class MessageIdDtoTest {
 
     private static final TestMessageId.Factory factory = new TestMessageId.Factory();
     private static final Long SAMPLE_ID_VALUE = 42L;
@@ -33,37 +33,38 @@ public class MessageIdDtoTest {
     private static final TestMessageId SAMPLE_ID = TestMessageId.of(SAMPLE_ID_VALUE);
 
     @Test
-    public void shouldRespectJavaBeanContract() {
+    void shouldRespectJavaBeanContract() {
         EqualsVerifier.forClass(MessageIdDto.class).verify();
     }
 
     @Test
-    public void shouldAcceptStringAndGiveItBack() {
+    void shouldAcceptStringAndGiveItBack() {
         assertThat(new MessageIdDto(SAMPLE_ID_STRING).asString())
             .isEqualTo(SAMPLE_ID_STRING);
     }
 
     @Test
-    public void shouldAcceptMessageIdAndGiveTheRightString() {
+    void shouldAcceptMessageIdAndGiveTheRightString() {
         assertThat(new MessageIdDto(SAMPLE_ID).asString())
             .isEqualTo(SAMPLE_ID_STRING);
     }
 
     @Test
-    public void shouldAcceptMessageIdAndGiveItBack() {
+    void shouldAcceptMessageIdAndGiveItBack() {
         assertThat(new MessageIdDto(SAMPLE_ID).instantiate(factory))
             .isEqualTo(SAMPLE_ID);
     }
 
     @Test
-    public void shouldAcceptStringAndGiveAnInstantiatedMessageId() {
+    void shouldAcceptStringAndGiveAnInstantiatedMessageId() {
         assertThat(new MessageIdDto(SAMPLE_ID_STRING).instantiate(factory))
             .isEqualTo(SAMPLE_ID);
     }
 
     @Test
-    public void shouldThrowAnExceptionOnWronglyFormattedString() {
+    void shouldThrowAnExceptionOnWronglyFormattedString() {
         MessageIdDto messageIdDto = new MessageIdDto("Definitively not a number");
+
         assertThatThrownBy(() -> messageIdDto.instantiate(factory))
             .isInstanceOf(Exception.class);
     }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MessageRangeTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MessageRangeTest.java
@@ -24,13 +24,12 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.james.mailbox.MessageUid;
-import org.apache.james.mailbox.model.MessageRange;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class MessageRangeTest {
+class MessageRangeTest {
 
     @Test
-    public void givenSomeNumbersToRangeShouldReturnThreeRanges() {
+    void givenSomeNumbersToRangeShouldReturnThreeRanges() {
         List<MessageRange> ranges = MessageRange.toRanges(
                 Arrays.asList(
                         MessageUid.of(1L),
@@ -46,34 +45,34 @@ public class MessageRangeTest {
     }
     
     @Test
-    public void givenASingleNumberToRangeShouldReturnOneRange() {
+    void givenASingleNumberToRangeShouldReturnOneRange() {
         List<MessageRange> ranges = MessageRange.toRanges(Arrays.asList(MessageUid.of(1L)));
         assertThat(ranges).containsExactly(MessageUid.of(1).toRange());
     }
     
     // Test for MAILBOX-56
     @Test
-    public void testTwoSeqUidToRange() {
+    void testTwoSeqUidToRange() {
         List<MessageRange> ranges = MessageRange.toRanges(Arrays.asList(MessageUid.of(1L), MessageUid.of(2L)));
         assertThat(ranges).containsExactly(MessageRange.range(MessageUid.of(1), MessageUid.of(2)));
     }
     
     @Test
-    public void splitASingletonRangeShouldReturnASingleRange() {
+    void splitASingletonRangeShouldReturnASingleRange() {
         MessageRange one = MessageUid.of(1).toRange();
         List<MessageRange> ranges = one.split(2);
         assertThat(ranges).containsExactly(MessageUid.of(1).toRange());
     }
 
     @Test
-    public void splitUnboundedRangeShouldReturnTheSameRange() {
+    void splitUnboundedRangeShouldReturnTheSameRange() {
         MessageRange from = MessageRange.from(MessageUid.of(1));
         List<MessageRange> ranges = from.split(2);
         assertThat(ranges).containsExactly(MessageRange.from(MessageUid.of(1)));
     }
     
     @Test
-    public void splitTenElementsRangeShouldReturn4Ranges() {
+    void splitTenElementsRangeShouldReturn4Ranges() {
         MessageRange range = MessageRange.range(MessageUid.of(1),MessageUid.of(10));
         List<MessageRange> ranges = range.split(3);
         assertThat(ranges).containsExactly(
@@ -84,70 +83,70 @@ public class MessageRangeTest {
     }
 
     @Test
-    public void includeShouldBeTrueWhenAfterFrom() {
+    void includeShouldBeTrueWhenAfterFrom() {
         MessageRange range = MessageRange.from(MessageUid.of(3));
         boolean actual = range.includes(MessageUid.of(5));
         assertThat(actual).isTrue();
     }
 
     @Test
-    public void includeShouldBeFalseWhenBeforeFrom() {
+    void includeShouldBeFalseWhenBeforeFrom() {
         MessageRange range = MessageRange.from(MessageUid.of(3));
         boolean actual = range.includes(MessageUid.of(1));
         assertThat(actual).isFalse();
     }
 
     @Test
-    public void includeShouldBeTrueWhenEqualsFrom() {
+    void includeShouldBeTrueWhenEqualsFrom() {
         MessageRange range = MessageRange.from(MessageUid.of(3));
         boolean actual = range.includes(MessageUid.of(3));
         assertThat(actual).isTrue();
     }
 
     @Test
-    public void includeShouldBeFalseWhenDifferentOne() {
+    void includeShouldBeFalseWhenDifferentOne() {
         MessageRange range = MessageUid.of(3).toRange();
         boolean actual = range.includes(MessageUid.of(1));
         assertThat(actual).isFalse();
     }
 
     @Test
-    public void includeShouldBeTrueWhenEqualsOne() {
+    void includeShouldBeTrueWhenEqualsOne() {
         MessageRange range = MessageUid.of(3).toRange();
         boolean actual = range.includes(MessageUid.of(3));
         assertThat(actual).isTrue();
     }
 
     @Test
-    public void includeShouldBeFalseWhenBeforeRange() {
+    void includeShouldBeFalseWhenBeforeRange() {
         MessageRange range = MessageRange.range(MessageUid.of(3), MessageUid.of(6));
         boolean actual = range.includes(MessageUid.of(1));
         assertThat(actual).isFalse();
     }
 
     @Test
-    public void includeShouldBeTrueWhenEqualsFromRange() {
+    void includeShouldBeTrueWhenEqualsFromRange() {
         MessageRange range = MessageRange.range(MessageUid.of(3), MessageUid.of(6));
         boolean actual = range.includes(MessageUid.of(3));
         assertThat(actual).isTrue();
     }
 
     @Test
-    public void includeShouldBeTrueWhenInRange() {
+    void includeShouldBeTrueWhenInRange() {
         MessageRange range = MessageRange.range(MessageUid.of(3), MessageUid.of(6));
         boolean actual = range.includes(MessageUid.of(4));
         assertThat(actual).isTrue();
     }
 
     @Test
-    public void includeShouldBeTrueWhenEqualsToRange() {
+    void includeShouldBeTrueWhenEqualsToRange() {
         MessageRange range = MessageRange.range(MessageUid.of(3), MessageUid.of(6));
         boolean actual = range.includes(MessageUid.of(6));
         assertThat(actual).isTrue();
     }
 
     @Test
-    public void includeShouldBeFalseWhenAfterRange() {
+    void includeShouldBeFalseWhenAfterRange() {
         MessageRange range = MessageRange.range(MessageUid.of(3), MessageUid.of(6));
         boolean actual = range.includes(MessageUid.of(7));
         assertThat(actual).isFalse();

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MultimailboxesSearchQueryTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MultimailboxesSearchQueryTest.java
@@ -19,76 +19,84 @@
 package org.apache.james.mailbox.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableSet;
 
-public class MultimailboxesSearchQueryTest {
+class MultimailboxesSearchQueryTest {
 
     private static final SearchQuery EMPTY_QUERY = new SearchQuery();
     private static final TestId.Factory FACTORY = new TestId.Factory();
     private static final MailboxId ID_1 = FACTORY.fromString("1");
     private static final MailboxId ID_2 = FACTORY.fromString("2");
 
-    @Test(expected = NullPointerException.class)
-    public void buildShouldThrowWhenQueryIsNull() {
-        MultimailboxesSearchQuery.from(null);
+    @Test
+    void buildShouldThrowWhenQueryIsNull() {
+        assertThatThrownBy(() -> MultimailboxesSearchQuery.from(null))
+            .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void buildShouldBuildWheninMailboxes() {
+    void buildShouldBuildWheninMailboxes() {
         ImmutableSet<MailboxId> inMailboxes = ImmutableSet.of();
         ImmutableSet<MailboxId> notInMailboxes = ImmutableSet.of();
         MultimailboxesSearchQuery expected = new MultimailboxesSearchQuery(EMPTY_QUERY, inMailboxes, notInMailboxes);
         MultimailboxesSearchQuery actual = MultimailboxesSearchQuery.from(EMPTY_QUERY).build();
+
         assertThat(actual).isEqualToComparingFieldByField(expected);
     }
 
     @Test
-    public void buildShouldBuildWhenEmptyMailboxes() {
+    void buildShouldBuildWhenEmptyMailboxes() {
         ImmutableSet<MailboxId> inMailboxes = ImmutableSet.of();
         ImmutableSet<MailboxId> notInMailboxes = ImmutableSet.of();
         MultimailboxesSearchQuery expected = new MultimailboxesSearchQuery(EMPTY_QUERY, inMailboxes, notInMailboxes);
         MultimailboxesSearchQuery actual = MultimailboxesSearchQuery.from(EMPTY_QUERY).inMailboxes().build();
+
         assertThat(actual).isEqualToComparingFieldByField(expected);
     }
 
     @Test
-    public void buildShouldBuildWhenEmptyNotInMailboxes() {
+    void buildShouldBuildWhenEmptyNotInMailboxes() {
         ImmutableSet<MailboxId> inMailboxes = ImmutableSet.of();
         ImmutableSet<MailboxId> notInMailboxes = ImmutableSet.of();
         MultimailboxesSearchQuery expected = new MultimailboxesSearchQuery(EMPTY_QUERY, inMailboxes, notInMailboxes);
         MultimailboxesSearchQuery actual = MultimailboxesSearchQuery.from(EMPTY_QUERY).notInMailboxes().build();
+
         assertThat(actual).isEqualToComparingFieldByField(expected);
     }
 
     
     @Test
-    public void buildShouldBuildWhenOneMailbox() {
+    void buildShouldBuildWhenOneMailbox() {
         ImmutableSet<MailboxId> inMailboxes = ImmutableSet.of(ID_1);
         ImmutableSet<MailboxId> notInMailboxes = ImmutableSet.of();
         MultimailboxesSearchQuery expected = new MultimailboxesSearchQuery(EMPTY_QUERY, inMailboxes, notInMailboxes);
         MultimailboxesSearchQuery actual = MultimailboxesSearchQuery.from(EMPTY_QUERY).inMailboxes(ID_1).build();
+
         assertThat(actual).isEqualToComparingFieldByField(expected);
     }
 
     @Test
-    public void buildShouldBuildWhenOneNotInMailbox() {
+    void buildShouldBuildWhenOneNotInMailbox() {
         ImmutableSet<MailboxId> inMailboxes = ImmutableSet.of();
         ImmutableSet<MailboxId> notInMailboxes = ImmutableSet.of(ID_1);
         MultimailboxesSearchQuery expected = new MultimailboxesSearchQuery(EMPTY_QUERY, inMailboxes, notInMailboxes);
         MultimailboxesSearchQuery actual = MultimailboxesSearchQuery.from(EMPTY_QUERY).notInMailboxes(ID_1).build();
+
         assertThat(actual).isEqualToComparingFieldByField(expected);
     }
 
     
     @Test
-    public void buildShouldBuildWhenAllDefined() {
+    void buildShouldBuildWhenAllDefined() {
         ImmutableSet<MailboxId> inMailboxes = ImmutableSet.of(ID_1);
         ImmutableSet<MailboxId> notInMailboxes = ImmutableSet.of(ID_2);
         MultimailboxesSearchQuery expected = new MultimailboxesSearchQuery(EMPTY_QUERY, inMailboxes, notInMailboxes);
         MultimailboxesSearchQuery actual = MultimailboxesSearchQuery.from(EMPTY_QUERY).inMailboxes(ID_1).notInMailboxes(ID_2).build();
+        
         assertThat(actual).isEqualToComparingFieldByField(expected);
     }
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/QuotaTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/QuotaTest.java
@@ -24,69 +24,69 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.james.core.quota.QuotaCount;
 import org.apache.james.core.quota.QuotaSize;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class QuotaTest {
+class QuotaTest {
 
 
     @Test
-    public void isOverQuotaShouldReturnFalseWhenQuotaIsNotExceeded() {
+    void isOverQuotaShouldReturnFalseWhenQuotaIsNotExceeded() {
         Quota<QuotaCount> quota = Quota.<QuotaCount>builder().used(QuotaCount.count(36)).computedLimit(QuotaCount.count(360)).build();
         assertThat(quota.isOverQuota()).isFalse();
     }
 
     @Test
-    public void isOverQuotaShouldReturnFalseWhenMaxValueIsUnlimited() {
+    void isOverQuotaShouldReturnFalseWhenMaxValueIsUnlimited() {
         Quota<QuotaCount> quota = Quota.<QuotaCount>builder().used(QuotaCount.count(36)).computedLimit(QuotaCount.unlimited()).build();
         assertThat(quota.isOverQuota()).isFalse();
     }
 
     @Test
-    public void isOverQuotaShouldReturnTrueWhenQuotaIsExceeded() {
+    void isOverQuotaShouldReturnTrueWhenQuotaIsExceeded() {
         Quota<QuotaCount> quota = Quota.<QuotaCount>builder().used(QuotaCount.count(360)).computedLimit(QuotaCount.count(36)).build();
         assertThat(quota.isOverQuota()).isTrue();
     }
 
     @Test
-    public void isOverQuotaWithAdditionalValueShouldReturnTrueWhenOverLimit() {
+    void isOverQuotaWithAdditionalValueShouldReturnTrueWhenOverLimit() {
         Quota<QuotaCount> quota = Quota.<QuotaCount>builder().used(QuotaCount.count(36)).computedLimit(QuotaCount.count(36)).build();
         assertThat(quota.isOverQuotaWithAdditionalValue(1)).isTrue();
     }
 
     @Test
-    public void isOverQuotaWithAdditionalValueShouldReturnTrueWhenUnderLimit() {
+    void isOverQuotaWithAdditionalValueShouldReturnTrueWhenUnderLimit() {
         Quota<QuotaCount> quota = Quota.<QuotaCount>builder().used(QuotaCount.count(34)).computedLimit(QuotaCount.count(36)).build();
         assertThat(quota.isOverQuotaWithAdditionalValue(1)).isFalse();
     }
 
     @Test
-    public void isOverQuotaWithAdditionalValueShouldReturnFalseWhenAtLimit() {
+    void isOverQuotaWithAdditionalValueShouldReturnFalseWhenAtLimit() {
         Quota<QuotaCount> quota = Quota.<QuotaCount>builder().used(QuotaCount.count(36)).computedLimit(QuotaCount.count(36)).build();
         assertThat(quota.isOverQuotaWithAdditionalValue(0)).isFalse();
     }
 
     @Test
-    public void isOverQuotaWithAdditionalValueShouldThrowOnNegativeValue() {
+    void isOverQuotaWithAdditionalValueShouldThrowOnNegativeValue() {
         Quota<QuotaCount> quota = Quota.<QuotaCount>builder().used(QuotaCount.count(25)).computedLimit(QuotaCount.count(36)).build();
         assertThatThrownBy(() -> quota.isOverQuotaWithAdditionalValue(-1)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void buildShouldThrowOnMissingUsedValue() {
+    void buildShouldThrowOnMissingUsedValue() {
         assertThatThrownBy(
             () -> Quota.<QuotaCount>builder().computedLimit(QuotaCount.count(1)).build())
             .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void buildShouldThrowOnMissingComputedLimitValue() {
+    void buildShouldThrowOnMissingComputedLimitValue() {
         assertThatThrownBy(
             () -> Quota.<QuotaCount>builder().used(QuotaCount.count(1)).build())
             .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void buildShouldCreateValidObjectGivenMandatoryFields() {
+    void buildShouldCreateValidObjectGivenMandatoryFields() {
         Quota<QuotaCount> actual = Quota.<QuotaCount>builder()
             .used(QuotaCount.count(1))
             .computedLimit(QuotaCount.count(2))
@@ -95,7 +95,7 @@ public class QuotaTest {
     }
 
     @Test
-    public void getRatioShouldReturnUsedDividedByLimit() {
+    void getRatioShouldReturnUsedDividedByLimit() {
         assertThat(
             Quota.<QuotaSize>builder()
                 .used(QuotaSize.size(15))
@@ -106,7 +106,7 @@ public class QuotaTest {
     }
 
     @Test
-    public void getRatioShouldReturnZeroWhenUnlimited() {
+    void getRatioShouldReturnZeroWhenUnlimited() {
         assertThat(
             Quota.<QuotaSize>builder()
                 .used(QuotaSize.size(15))

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/Rfc4314RightsTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/Rfc4314RightsTest.java
@@ -36,10 +36,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.james.mailbox.exception.UnsupportedRightException;
 import org.apache.james.mailbox.model.MailboxACL.Rfc4314Rights;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class Rfc4314RightsTest {
+class Rfc4314RightsTest {
     
     private Rfc4314Rights aeik;
     private Rfc4314Rights lprs;
@@ -47,8 +47,8 @@ public class Rfc4314RightsTest {
     private Rfc4314Rights full;
     private Rfc4314Rights none;
     
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         aeik = Rfc4314Rights.fromSerializedRfc4314Rights("aeik");
         lprs = Rfc4314Rights.fromSerializedRfc4314Rights("lprs");
         twx = Rfc4314Rights.fromSerializedRfc4314Rights("twx");
@@ -56,55 +56,56 @@ public class Rfc4314RightsTest {
         none = MailboxACL.NO_RIGHTS;
     }
     
-    @Test(expected = NullPointerException.class)
-    public void newInstanceShouldThrowWhenNullString() throws UnsupportedRightException {
-        Rfc4314Rights.fromSerializedRfc4314Rights((String) null);
+    @Test
+    void newInstanceShouldThrowWhenNullString() throws UnsupportedRightException {
+        assertThatThrownBy(() -> Rfc4314Rights.fromSerializedRfc4314Rights((String) null))
+            .isInstanceOf(NullPointerException.class);
     }
     
     @Test
-    public void newInstanceShouldHaveNoRightsWhenEmptyString() throws UnsupportedRightException {
+    void newInstanceShouldHaveNoRightsWhenEmptyString() throws UnsupportedRightException {
         Rfc4314Rights rights = Rfc4314Rights.fromSerializedRfc4314Rights("");
         assertThat(rights.list()).isEmpty();
     }
     
     @Test
-    public void containsShouldReturnFalseWhenNotMatching() throws UnsupportedRightException {
+    void containsShouldReturnFalseWhenNotMatching() throws UnsupportedRightException {
         assertThat(aeik.contains('x')).isFalse();
     }
     
     @Test
-    public void containsShouldReturnTrueWhenMatching() throws UnsupportedRightException {
+    void containsShouldReturnTrueWhenMatching() throws UnsupportedRightException {
         assertThat(aeik.contains('e')).isTrue();
     }
     
     @Test
-    public void exceptShouldRemoveAllWhenChaining() throws UnsupportedRightException {
+    void exceptShouldRemoveAllWhenChaining() throws UnsupportedRightException {
         assertThat(full.except(aeik).except(lprs).except(twx)).isEqualTo(none);
     }
     
     @Test
-    public void exceptShouldReturnOriginWhenExceptingNull() throws UnsupportedRightException {
+    void exceptShouldReturnOriginWhenExceptingNull() throws UnsupportedRightException {
         assertThat(aeik.except(null)).isEqualTo(aeik);
     }
     
     @Test
-    public void exceptShouldReturnOriginWhenExceptingNonExistent() throws UnsupportedRightException {
+    void exceptShouldReturnOriginWhenExceptingNonExistent() throws UnsupportedRightException {
         assertThat(aeik.except(lprs)).isEqualTo(aeik);
     }
 
     @Test
-    public void rfc4314RightsShouldThrowWhenUnknownFlag() throws UnsupportedRightException {
+    void rfc4314RightsShouldThrowWhenUnknownFlag() {
         assertThatThrownBy(() -> Rfc4314Rights.fromSerializedRfc4314Rights("z"))
             .isInstanceOf(UnsupportedRightException.class);
     }
     
     @Test
-    public void exceptShouldReturnOriginWhenExceptingEmpty() throws UnsupportedRightException {
+    void exceptShouldReturnOriginWhenExceptingEmpty() throws UnsupportedRightException {
         assertThat(aeik.except(none)).isEqualTo(aeik);
     }
     
     @Test
-    public void fullRightsShouldContainsAllRights() {
+    void fullRightsShouldContainsAllRights() {
         assertThat(full.list()).containsOnly(
             Administer,
             PerformExpunge,
@@ -120,12 +121,12 @@ public class Rfc4314RightsTest {
     }
     
     @Test
-    public void noneRightsShouldContainsNoRights() {
+    void noneRightsShouldContainsNoRights() {
         assertThat(none.list()).isEmpty();
     }
     
     @Test
-    public void rightsShouldContainsSpecificRightsWhenAEIK() {
+    void rightsShouldContainsSpecificRightsWhenAEIK() {
         assertThat(aeik.list()).containsOnly(
             Administer,
             PerformExpunge,
@@ -134,7 +135,7 @@ public class Rfc4314RightsTest {
     }
     
     @Test
-    public void rightsShouldContainsSpecificRightsWhenLPRS() {
+    void rightsShouldContainsSpecificRightsWhenLPRS() {
         assertThat(lprs.list()).containsOnly(
             Lookup,
             Post,
@@ -143,7 +144,7 @@ public class Rfc4314RightsTest {
     }
     
     @Test
-    public void rightsShouldContainsSpecificRightsWhenTWX() {
+    void rightsShouldContainsSpecificRightsWhenTWX() {
         assertThat(twx.list()).containsOnly(
             DeleteMessages,
             Write,
@@ -151,92 +152,92 @@ public class Rfc4314RightsTest {
     }
 
     @Test
-    public void getValueShouldReturnSigmaWhenAeik() throws UnsupportedRightException {
+    void getValueShouldReturnSigmaWhenAeik() {
         assertThat(aeik.list()).containsExactly(Administer, PerformExpunge, Insert, CreateMailbox);
     }
 
     @Test
-    public void getValueShouldReturnSigmaWhenLprs() throws UnsupportedRightException {
+    void getValueShouldReturnSigmaWhenLprs() {
         assertThat(lprs.list()).containsExactly(Lookup, Post, Read, WriteSeenFlag);
     }
 
     @Test
-    public void getValueShouldReturnSigmaWhenTwx() throws UnsupportedRightException {
+    void getValueShouldReturnSigmaWhenTwx() {
         assertThat(twx.list()).containsExactly(DeleteMessages, Write, DeleteMailbox);
     }
 
     @Test
-    public void getValueShouldReturnEmptyWhenNone() throws UnsupportedRightException {
+    void getValueShouldReturnEmptyWhenNone() throws UnsupportedRightException {
         assertThat(Rfc4314Rights.fromSerializedRfc4314Rights("").list()).isEmpty();
     }
 
     @Test
-    public void serializeShouldReturnStringWhenAeik() throws UnsupportedRightException {
+    void serializeShouldReturnStringWhenAeik() {
         assertThat(aeik.serialize()).isEqualTo("aeik");
     }
 
     @Test
-    public void serializeShouldReturnStringWhenLprs() throws UnsupportedRightException {
+    void serializeShouldReturnStringWhenLprs() {
         assertThat(lprs.serialize()).isEqualTo("lprs");
     }
 
     @Test
-    public void serializeShouldReturnStringWhenTwx() throws UnsupportedRightException {
+    void serializeShouldReturnStringWhenTwx() {
         assertThat(twx.serialize()).isEqualTo("twx");
     }
     
     @Test
-    public void serializeShouldReturnStringWhenAeiklprstwx() throws UnsupportedRightException {
+    void serializeShouldReturnStringWhenAeiklprstwx() {
         assertThat(full.serialize()).isEqualTo("aeiklprstwx");
     }
 
     @Test
-    public void serializeShouldReturnEmptyStringWhenEmpty() throws UnsupportedRightException {
+    void serializeShouldReturnEmptyStringWhenEmpty() {
         assertThat(none.serialize()).isEmpty();
     }
     
     @Test
-    public void unionShouldReturnFullWhenChaining() throws UnsupportedRightException {
+    void unionShouldReturnFullWhenChaining() throws UnsupportedRightException {
         assertThat(aeik.union(lprs).union(twx)).isEqualTo(full);
     }
     
     @Test
-    public void unionShouldReturnOriginWhenAppliedWithEmpty() throws UnsupportedRightException {
+    void unionShouldReturnOriginWhenAppliedWithEmpty() throws UnsupportedRightException {
         assertThat(lprs.union(none)).isEqualTo(lprs);
     }
     
     @Test
-    public void unionShouldThrowWhenAppliedWithNull() throws UnsupportedRightException {
+    void unionShouldThrowWhenAppliedWithNull() {
         assertThatThrownBy(() -> lprs.union(null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void containsShouldReturnFalseWhenRightNotPresent() throws UnsupportedRightException {
+    void containsShouldReturnFalseWhenRightNotPresent() {
         assertThat(lprs.contains(Write)).isFalse();
     }
 
     @Test
-    public void containsShouldReturnFalseWhenAtLeastOneRightNotPresent() throws UnsupportedRightException {
+    void containsShouldReturnFalseWhenAtLeastOneRightNotPresent() {
         assertThat(lprs.contains(Lookup, Write)).isFalse();
     }
 
     @Test
-    public void containsShouldReturnTrueWhenAllRightsPresent() throws UnsupportedRightException {
+    void containsShouldReturnTrueWhenAllRightsPresent() {
         assertThat(lprs.contains(Lookup, Post)).isTrue();
     }
 
     @Test
-    public void containsShouldReturnTrueWhenNonRightsPresent() throws UnsupportedRightException {
+    void containsShouldReturnTrueWhenNonRightsPresent() {
         assertThat(lprs.contains()).isTrue();
     }
 
     @Test
-    public void allExceptShouldReturnFullWhenProvidedEmpty() throws UnsupportedRightException {
+    void allExceptShouldReturnFullWhenProvidedEmpty() throws UnsupportedRightException {
         assertThat(Rfc4314Rights.allExcept()).isEqualTo(MailboxACL.FULL_RIGHTS);
     }
 
     @Test
-    public void allExceptShouldReturnAllButProvidedRight() throws UnsupportedRightException {
+    void allExceptShouldReturnAllButProvidedRight() throws UnsupportedRightException {
         assertThat(Rfc4314Rights.allExcept(Lookup))
             .isEqualTo(new Rfc4314Rights(
                 DeleteMessages,
@@ -252,7 +253,7 @@ public class Rfc4314RightsTest {
     }
 
     @Test
-    public void allExceptShouldReturnAllButProvidedRights() throws UnsupportedRightException {
+    void allExceptShouldReturnAllButProvidedRights() throws UnsupportedRightException {
         assertThat(Rfc4314Rights.allExcept(Lookup, Read))
             .isEqualTo(new Rfc4314Rights(
                 DeleteMessages,
@@ -267,7 +268,7 @@ public class Rfc4314RightsTest {
     }
 
     @Test
-    public void allExceptShouldReturnEmptyWhenProvidedAllRights() throws UnsupportedRightException {
+    void allExceptShouldReturnEmptyWhenProvidedAllRights() throws UnsupportedRightException {
         assertThat(
             Rfc4314Rights.allExcept(
                 Lookup,

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/SearchQueryTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/SearchQueryTest.java
@@ -22,21 +22,21 @@ package org.apache.james.mailbox.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class SearchQueryTest {
+class SearchQueryTest {
 
     @Test
-    public void searchQueryShouldRespectBeanContract() {
+    void searchQueryShouldRespectBeanContract() {
         EqualsVerifier.forClass(SearchQuery.class)
             .withOnlyTheseFields("criterias")
             .verify();
     }
 
     @Test
-    public void equalsShouldCompareCriteria() {
+    void equalsShouldCompareCriteria() {
         SearchQuery searchQuery1 = new SearchQuery();
         SearchQuery searchQuery2 = new SearchQuery();
         searchQuery1.andCriteria(SearchQuery.all());

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/UpdatedFlagsTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/UpdatedFlagsTest.java
@@ -24,24 +24,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 import javax.mail.Flags;
 
 import org.apache.james.mailbox.MessageUid;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class UpdatedFlagsTest {
+class UpdatedFlagsTest {
 
     public static final MessageUid UID = MessageUid.of(45L);
     public static final long MOD_SEQ = 47L;
 
     @Test
-    public void shouldMatchBeanContract() {
+    void shouldMatchBeanContract() {
         EqualsVerifier.forClass(UpdatedFlags.class)
             .withIgnoredFields("modifiedFlags")
             .verify();
     }
 
     @Test
-    public void isModifiedToSetShouldReturnTrueWhenFlagOnlyInNewFlag() {
+    void isModifiedToSetShouldReturnTrueWhenFlagOnlyInNewFlag() {
         UpdatedFlags updatedFlags = UpdatedFlags.builder()
             .newFlags(new Flags(Flags.Flag.RECENT))
             .oldFlags(new Flags())
@@ -53,7 +53,7 @@ public class UpdatedFlagsTest {
     }
 
     @Test
-    public void isModifiedToSetShouldReturnFalseWhenFlagOnlyInOldFlag() {
+    void isModifiedToSetShouldReturnFalseWhenFlagOnlyInOldFlag() {
         UpdatedFlags updatedFlags = UpdatedFlags.builder()
             .newFlags(new Flags())
             .oldFlags(new Flags(Flags.Flag.RECENT))
@@ -65,7 +65,7 @@ public class UpdatedFlagsTest {
     }
 
     @Test
-    public void isModifiedToSetShouldReturnFalseWhenFlagIsOnNone() {
+    void isModifiedToSetShouldReturnFalseWhenFlagIsOnNone() {
         UpdatedFlags updatedFlags = UpdatedFlags.builder()
             .newFlags(new Flags())
             .oldFlags(new Flags())
@@ -77,7 +77,7 @@ public class UpdatedFlagsTest {
     }
 
     @Test
-    public void isModifiedToSetShouldReturnFalseWhenFlagIsOnBoth() {
+    void isModifiedToSetShouldReturnFalseWhenFlagIsOnBoth() {
         UpdatedFlags updatedFlags = UpdatedFlags.builder()
             .newFlags(new Flags(Flags.Flag.RECENT))
             .oldFlags(new Flags(Flags.Flag.RECENT))
@@ -89,7 +89,7 @@ public class UpdatedFlagsTest {
     }
 
     @Test
-    public void isModifiedToUnsetShouldReturnFalseWhenFlagOnlyInNewFlag() {
+    void isModifiedToUnsetShouldReturnFalseWhenFlagOnlyInNewFlag() {
         UpdatedFlags updatedFlags = UpdatedFlags.builder()
             .newFlags(new Flags(Flags.Flag.RECENT))
             .oldFlags(new Flags())
@@ -101,7 +101,7 @@ public class UpdatedFlagsTest {
     }
 
     @Test
-    public void isModifiedToUnsetShouldReturnTrueWhenFlagOnlyInOldFlag() {
+    void isModifiedToUnsetShouldReturnTrueWhenFlagOnlyInOldFlag() {
         UpdatedFlags updatedFlags = UpdatedFlags.builder()
             .newFlags(new Flags())
             .oldFlags(new Flags(Flags.Flag.RECENT))
@@ -113,7 +113,7 @@ public class UpdatedFlagsTest {
     }
 
     @Test
-    public void isModifiedToUnsetShouldReturnFalseWhenFlagIsOnNone() {
+    void isModifiedToUnsetShouldReturnFalseWhenFlagIsOnNone() {
         UpdatedFlags updatedFlags = UpdatedFlags.builder()
             .newFlags(new Flags())
             .oldFlags(new Flags())
@@ -125,7 +125,7 @@ public class UpdatedFlagsTest {
     }
 
     @Test
-    public void isModifiedToUnsetShouldReturnFalseWhenFlagIsOnBoth() {
+    void isModifiedToUnsetShouldReturnFalseWhenFlagIsOnBoth() {
         UpdatedFlags updatedFlags = UpdatedFlags.builder()
             .newFlags(new Flags(Flags.Flag.RECENT))
             .oldFlags(new Flags(Flags.Flag.RECENT))
@@ -137,7 +137,7 @@ public class UpdatedFlagsTest {
     }
 
     @Test
-    public void isUnchangedShouldReturnFalseWhenFlagOnlyInNewFlag() {
+    void isUnchangedShouldReturnFalseWhenFlagOnlyInNewFlag() {
         UpdatedFlags updatedFlags = UpdatedFlags.builder()
             .newFlags(new Flags(Flags.Flag.RECENT))
             .oldFlags(new Flags())
@@ -149,7 +149,7 @@ public class UpdatedFlagsTest {
     }
 
     @Test
-    public void isUnchangedShouldReturnFalseWhenFlagOnlyInOldFlag() {
+    void isUnchangedShouldReturnFalseWhenFlagOnlyInOldFlag() {
         UpdatedFlags updatedFlags = UpdatedFlags.builder()
             .newFlags(new Flags())
             .oldFlags(new Flags(Flags.Flag.RECENT))
@@ -161,7 +161,7 @@ public class UpdatedFlagsTest {
     }
 
     @Test
-    public void isUnchangedShouldReturnTrueWhenFlagIsOnNone() {
+    void isUnchangedShouldReturnTrueWhenFlagIsOnNone() {
         UpdatedFlags updatedFlags = UpdatedFlags.builder()
             .newFlags(new Flags())
             .oldFlags(new Flags())
@@ -173,7 +173,7 @@ public class UpdatedFlagsTest {
     }
 
     @Test
-    public void isUnchangedShouldReturnTrueWhenFlagIsOnBoth() {
+    void isUnchangedShouldReturnTrueWhenFlagIsOnBoth() {
         UpdatedFlags updatedFlags = UpdatedFlags.builder()
             .newFlags(new Flags(Flags.Flag.RECENT))
             .oldFlags(new Flags(Flags.Flag.RECENT))

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/ExactNameTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/ExactNameTest.java
@@ -22,7 +22,7 @@ package org.apache.james.mailbox.model.search;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -30,43 +30,43 @@ public class ExactNameTest {
     public static final String NAME = "toto";
 
     @Test
-    public void shouldMatchBeanContract() {
+    void shouldMatchBeanContract() {
         EqualsVerifier.forClass(ExactName.class)
             .verify();
     }
 
     @Test
-    public void constructorShouldThrowOnNullName() {
+    void constructorShouldThrowOnNullName() {
         assertThatThrownBy(() -> new ExactName(null))
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void isWildShouldReturnFalse() {
+    void isWildShouldReturnFalse() {
         assertThat(new ExactName(NAME).isWild())
             .isFalse();
     }
 
     @Test
-    public void getCombinedNameShouldReturnName() {
+    void getCombinedNameShouldReturnName() {
         assertThat(new ExactName(NAME).getCombinedName())
             .isEqualTo(NAME);
     }
 
     @Test
-    public void isExpressionMatchShouldReturnTrueWhenName() {
+    void isExpressionMatchShouldReturnTrueWhenName() {
         assertThat(new ExactName(NAME).isExpressionMatch(NAME))
             .isTrue();
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenOtherValue() {
+    void isExpressionMatchShouldReturnFalseWhenOtherValue() {
         assertThat(new ExactName(NAME).isExpressionMatch("other"))
             .isFalse();
     }
 
     @Test
-    public void isExpressionMatchShouldThrowOnNullValue() {
+    void isExpressionMatchShouldThrowOnNullValue() {
         assertThatThrownBy(() -> new ExactName(NAME).isExpressionMatch(null))
             .isInstanceOf(NullPointerException.class);
     }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/MailboxQueryTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/MailboxQueryTest.java
@@ -21,33 +21,34 @@
 package org.apache.james.mailbox.model.search;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.search.MailboxQuery.Builder;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class MailboxQueryTest {
+class MailboxQueryTest {
     private static final String CURRENT_USER = "user";
 
     private MailboxPath mailboxPath;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         mailboxPath = new MailboxPath("namespace", "user", "name");
     }
 
     @Test
-    public void shouldMatchBeanContract() {
+    void shouldMatchBeanContract() {
         EqualsVerifier.forClass(MailboxQuery.class)
             .verify();
     }
 
     @Test
-    public void buildShouldMatchAllValuesWhenMatchesAll() throws Exception {
-
+    void buildShouldMatchAllValuesWhenMatchesAll() {
         MailboxQuery actual = MailboxQuery.builder()
                 .userAndNamespaceFrom(mailboxPath)
                 .matchesAllMailboxNames()
@@ -57,7 +58,7 @@ public class MailboxQueryTest {
     }
 
     @Test
-    public void buildShouldConstructMailboxPathWhenPrivateUserMailboxes() throws Exception {
+    void buildShouldConstructMailboxPathWhenPrivateUserMailboxes() {
         MailboxPath expected = MailboxPath.forUser("user", "");
 
         MailboxQuery actual = MailboxQuery.builder()
@@ -71,7 +72,7 @@ public class MailboxQueryTest {
     }
 
     @Test
-    public void buildShouldMatchAllValuesWhenPrivateUserMailboxes() throws Exception {
+    void buildShouldMatchAllValuesWhenPrivateUserMailboxes() {
         Builder testee = MailboxQuery.builder()
                 .username("user")
                 .privateNamespace();
@@ -82,42 +83,41 @@ public class MailboxQueryTest {
     }
 
     @Test
-    public void builderShouldNotThrowWhenNoBaseDefined() throws Exception {
+    void builderShouldNotThrowWhenNoBaseDefined() {
         Builder testee = MailboxQuery.builder()
                 .expression(new ExactName("abc"));
 
-        testee.build();
+        assertThatCode(testee::build)
+            .doesNotThrowAnyException();
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void builderShouldThrowWhenBaseAndUsernameGiven() throws Exception {
-        Builder testee = MailboxQuery.builder()
+    @Test
+    void builderShouldThrowWhenBaseAndUsernameGiven() {
+        assertThatThrownBy(() -> MailboxQuery.builder()
                 .userAndNamespaceFrom(mailboxPath)
-                .username("user");
-
-        testee.build();
+                .username("user"))
+            .isInstanceOf(IllegalStateException.class);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void builderShouldThrowWhenBaseGiven() throws Exception {
-        Builder testee = MailboxQuery.builder()
+    @Test
+    void builderShouldThrowWhenBaseGiven() {
+        assertThatThrownBy(() -> MailboxQuery.builder()
                 .userAndNamespaceFrom(mailboxPath)
-                .privateNamespace();
-
-        testee.build();
+                .privateNamespace())
+            .isInstanceOf(IllegalStateException.class);
     } 
 
     @Test
-    public void builderShouldNotThrowWhenMissingUsername() throws Exception {
+    void builderShouldNotThrowWhenMissingUsername() {
         Builder testee = MailboxQuery.builder()
                 .privateNamespace();
 
-        testee.build();
+        assertThatCode(testee::build)
+            .doesNotThrowAnyException();
     }
 
     @Test
-    public void builderShouldUseBaseWhenGiven() throws Exception {
-
+    void builderShouldUseBaseWhenGiven() {
         MailboxQuery actual = MailboxQuery.builder()
                 .userAndNamespaceFrom(mailboxPath)
                 .build();
@@ -128,7 +128,7 @@ public class MailboxQueryTest {
     }
 
     @Test
-    public void belongsToNamespaceAndUserShouldReturnTrueWithIdenticalMailboxes() {
+    void belongsToNamespaceAndUserShouldReturnTrueWithIdenticalMailboxes() {
         MailboxQuery mailboxQuery = MailboxQuery.builder()
             .userAndNamespaceFrom(mailboxPath)
             .build();
@@ -138,7 +138,7 @@ public class MailboxQueryTest {
     }
 
     @Test
-    public void belongsToNamespaceAndUserShouldReturnTrueWithIdenticalMailboxesWithNullNamespace() {
+    void belongsToNamespaceAndUserShouldReturnTrueWithIdenticalMailboxesWithNullNamespace() {
         MailboxPath mailboxPath = new MailboxPath(null, "user", "name");
 
         MailboxQuery mailboxQuery = MailboxQuery.builder()
@@ -150,7 +150,7 @@ public class MailboxQueryTest {
     }
 
     @Test
-    public void belongsToNamespaceAndUserShouldReturnTrueWithMailboxWithSameNamespaceAndUser() {
+    void belongsToNamespaceAndUserShouldReturnTrueWithMailboxWithSameNamespaceAndUser() {
         MailboxQuery mailboxQuery = MailboxQuery.builder()
             .userAndNamespaceFrom(new MailboxPath("namespace", CURRENT_USER, "name"))
             .build();
@@ -160,7 +160,7 @@ public class MailboxQueryTest {
     }
 
     @Test
-    public void belongsToNamespaceAndUserShouldReturnFalseWithDifferentNamespace() {
+    void belongsToNamespaceAndUserShouldReturnFalseWithDifferentNamespace() {
         MailboxQuery mailboxQuery = MailboxQuery.builder()
             .userAndNamespaceFrom(new MailboxPath("namespace", CURRENT_USER, "name"))
             .build();
@@ -170,7 +170,7 @@ public class MailboxQueryTest {
     }
 
     @Test
-    public void belongsToNamespaceAndUserShouldReturnFalseWithDifferentUser() {
+    void belongsToNamespaceAndUserShouldReturnFalseWithDifferentUser() {
         MailboxQuery mailboxQuery = MailboxQuery.builder()
             .userAndNamespaceFrom(new MailboxPath("namespace", CURRENT_USER, "name"))
             .build();
@@ -178,9 +178,9 @@ public class MailboxQueryTest {
         assertThat(mailboxQuery.belongsToRequestedNamespaceAndUser(new MailboxPath("namespace", CURRENT_USER + "2", "name")))
             .isFalse();
     }
-    
+
     @Test
-    public void belongsToNamespaceAndUserShouldReturnFalseWhenDifferentUser() {
+    void belongsToNamespaceAndUserShouldReturnFalseWhenDifferentUser() {
         MailboxQuery mailboxQuery = MailboxQuery.builder()
             .userAndNamespaceFrom(new MailboxPath("namespace", CURRENT_USER, "name"))
             .build();

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/PrefixedRegexTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/PrefixedRegexTest.java
@@ -21,11 +21,11 @@ package org.apache.james.mailbox.model.search;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class PrefixedRegexTest {
+class PrefixedRegexTest {
     private static final char PATH_DELIMITER = '.';
     private static final String PREFIX = "name";
     private static final String EMPTY_PREFIX = "";
@@ -38,7 +38,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isWildShouldReturnTrueWhenOnlyFreeWildcard() throws Exception {
+    void isWildShouldReturnTrueWhenOnlyFreeWildcard() {
         PrefixedRegex prefixedRegex = new PrefixedRegex(PREFIX, "*", PATH_DELIMITER);
 
         boolean actual = prefixedRegex.isWild();
@@ -47,7 +47,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isWildShouldReturnTrueWhenOnlyLocalWildcard() throws Exception {
+    void isWildShouldReturnTrueWhenOnlyLocalWildcard() {
         PrefixedRegex prefixedRegex = new PrefixedRegex(PREFIX, "%", PATH_DELIMITER);
 
         boolean actual = prefixedRegex.isWild();
@@ -56,7 +56,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isWildShouldReturnTrueWhenFreeWildcardAtBeginning() throws Exception {
+    void isWildShouldReturnTrueWhenFreeWildcardAtBeginning() {
         PrefixedRegex prefixedRegex = new PrefixedRegex(PREFIX, "*One", PATH_DELIMITER);
 
         boolean actual = prefixedRegex.isWild();
@@ -65,7 +65,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isWildShouldReturnTrueWhenLocalWildcardAtBeginning() throws Exception {
+    void isWildShouldReturnTrueWhenLocalWildcardAtBeginning() {
         PrefixedRegex prefixedRegex = new PrefixedRegex(PREFIX, "%One", PATH_DELIMITER);
 
         boolean actual = prefixedRegex.isWild();
@@ -74,7 +74,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isWildShouldReturnTrueWhenFreeWildcardInMiddle() throws Exception {
+    void isWildShouldReturnTrueWhenFreeWildcardInMiddle() {
         PrefixedRegex prefixedRegex = new PrefixedRegex(PREFIX, "A*A", PATH_DELIMITER);
 
         boolean actual = prefixedRegex.isWild();
@@ -83,7 +83,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isWildShouldReturnTrueWhenLocalWildcardInMiddle() throws Exception {
+    void isWildShouldReturnTrueWhenLocalWildcardInMiddle() {
         PrefixedRegex prefixedRegex = new PrefixedRegex(PREFIX, "A%A", PATH_DELIMITER);
 
         boolean actual = prefixedRegex.isWild();
@@ -92,7 +92,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isWildShouldReturnTrueWhenFreeWildcardAtEnd() throws Exception {
+    void isWildShouldReturnTrueWhenFreeWildcardAtEnd() {
         PrefixedRegex prefixedRegex = new PrefixedRegex(PREFIX, "One*", PATH_DELIMITER);
 
         boolean actual = prefixedRegex.isWild();
@@ -101,7 +101,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isWildShouldReturnTrueWhenLocalWildcardAtEnd() throws Exception {
+    void isWildShouldReturnTrueWhenLocalWildcardAtEnd() {
         PrefixedRegex prefixedRegex = new PrefixedRegex(PREFIX, "One%", PATH_DELIMITER);
 
         boolean actual = prefixedRegex.isWild();
@@ -110,7 +110,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isWildShouldReturnFalseWhenEmptyExpression() throws Exception {
+    void isWildShouldReturnFalseWhenEmptyExpression() {
         PrefixedRegex prefixedRegex = new PrefixedRegex(PREFIX, "", PATH_DELIMITER);
 
         boolean actual = prefixedRegex.isWild();
@@ -119,7 +119,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isWildShouldReturnFalseWhenNullExpression() throws Exception {
+    void isWildShouldReturnFalseWhenNullExpression() {
         PrefixedRegex prefixedRegex = new PrefixedRegex(PREFIX, null, PATH_DELIMITER);
 
         boolean actual = prefixedRegex.isWild();
@@ -128,7 +128,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isWildShouldReturnFalseWhenNoWildcard() throws Exception {
+    void isWildShouldReturnFalseWhenNoWildcard() {
         PrefixedRegex prefixedRegex = new PrefixedRegex(PREFIX, "ONE", PATH_DELIMITER);
 
         boolean actual = prefixedRegex.isWild();
@@ -137,7 +137,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void getCombinedNameShouldWork() throws Exception {
+    void getCombinedNameShouldWork() {
         PrefixedRegex prefixedRegex = new PrefixedRegex(PREFIX, "mailbox", PATH_DELIMITER);
 
         String actual = prefixedRegex.getCombinedName();
@@ -146,7 +146,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void getCombinedNameShouldWorkWhenEmptyExpression() throws Exception {
+    void getCombinedNameShouldWorkWhenEmptyExpression() {
         PrefixedRegex prefixedRegex = new PrefixedRegex(PREFIX, "", PATH_DELIMITER);
 
         String actual = prefixedRegex.getCombinedName();
@@ -155,7 +155,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void getCombinedNameShouldReturnEmptyStringWhenNullMailboxPathAndExpression() throws Exception {
+    void getCombinedNameShouldReturnEmptyStringWhenNullMailboxPathAndExpression() {
         String prefix = null;
         String regex = null;
         PrefixedRegex prefixedRegex = new PrefixedRegex(prefix, regex, PATH_DELIMITER);
@@ -166,7 +166,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void getCombinedNameShouldIgnoreDelimiterWhenPresentAtBeginningOfExpression() throws Exception {
+    void getCombinedNameShouldIgnoreDelimiterWhenPresentAtBeginningOfExpression() {
         PrefixedRegex prefixedRegex = new PrefixedRegex(PREFIX, ".mailbox", PATH_DELIMITER);
 
         String actual = prefixedRegex.getCombinedName();
@@ -175,7 +175,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void getCombinedNameShouldIgnoreDelimiterWhenPresentAtEndOfMailboxName() throws Exception {
+    void getCombinedNameShouldIgnoreDelimiterWhenPresentAtEndOfMailboxName() {
         PrefixedRegex prefixedRegex = new PrefixedRegex(PREFIX + ".", ".mailbox", PATH_DELIMITER);
 
         String actual = prefixedRegex.getCombinedName();
@@ -184,7 +184,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenNullExpression() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenNullExpression() {
         PrefixedRegex testee = new PrefixedRegex(PREFIX, null, PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("folder");
@@ -193,7 +193,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchFolderWhenMatching() throws Exception {
+    void isExpressionMatchShouldMatchFolderWhenMatching() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox");
@@ -202,7 +202,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenNameBeginsWithDelimiter() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenNameBeginsWithDelimiter() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch(".mailbox");
@@ -211,7 +211,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenNameEndsWithDelimiter() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenNameEndsWithDelimiter() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox.");
@@ -220,7 +220,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchFolderWhenNoMatching() throws Exception {
+    void isExpressionMatchShouldNotMatchFolderWhenNoMatching() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub");
@@ -229,7 +229,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchFolderWithExpandedEndName() throws Exception {
+    void isExpressionMatchShouldNotMatchFolderWithExpandedEndName() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox123");
@@ -238,7 +238,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchSubFolder() throws Exception {
+    void isExpressionMatchShouldNotMatchSubFolder() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox.123");
@@ -247,7 +247,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnTrueWhenEmptyNameAndExpression() throws Exception {
+    void isExpressionMatchShouldReturnTrueWhenEmptyNameAndExpression() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("");
@@ -256,7 +256,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenEmptyExpressionAndNameBeginsWithDelimiter() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenEmptyExpressionAndNameBeginsWithDelimiter() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch(".123");
@@ -265,7 +265,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchFolderWhenEmptyExpression() throws Exception {
+    void isExpressionMatchShouldNotMatchFolderWhenEmptyExpression() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("folder");
@@ -274,7 +274,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnTrueWhenEmptyNameAndOnlyLocalWildcard() throws Exception {
+    void isExpressionMatchShouldReturnTrueWhenEmptyNameAndOnlyLocalWildcard() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "%", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("");
@@ -283,7 +283,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnTrueWhenOnlyLocalWildcard() throws Exception {
+    void isExpressionMatchShouldReturnTrueWhenOnlyLocalWildcard() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "%", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("folder");
@@ -292,7 +292,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchSubFolderWhenOnlyLocalWildcard() throws Exception {
+    void isExpressionMatchShouldNotMatchSubFolderWhenOnlyLocalWildcard() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "%", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox.sub");
@@ -301,7 +301,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnTrueWhenEmptyNameAndOnlyFreeWildcard() throws Exception {
+    void isExpressionMatchShouldReturnTrueWhenEmptyNameAndOnlyFreeWildcard() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "*", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("");
@@ -310,7 +310,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchFolderWhenOnlyFreeWildcard() throws Exception {
+    void isExpressionMatchShouldMatchFolderWhenOnlyFreeWildcard() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "*", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub");
@@ -319,7 +319,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchSubFolderWhenOnlyFreeWildcard() throws Exception {
+    void isExpressionMatchShouldMatchSubFolderWhenOnlyFreeWildcard() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "*", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox.sub");
@@ -328,7 +328,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenEmptyNameAndLocalWildcardAtEnd() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenEmptyNameAndLocalWildcardAtEnd() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "mailbox%", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("");
@@ -337,7 +337,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenLocalWildcardAtEndAndNoMatching() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenLocalWildcardAtEndAndNoMatching() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "mailbox%", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub");
@@ -346,7 +346,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchFolderWhenLocalWildcardAtEndNotUsed() throws Exception {
+    void isExpressionMatchShouldMatchFolderWhenLocalWildcardAtEndNotUsed() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "mailbox%", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox");
@@ -355,7 +355,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnTrueWhenLocalWildcardAtEndUsed() throws Exception {
+    void isExpressionMatchShouldReturnTrueWhenLocalWildcardAtEndUsed() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "mailbox%", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailboxsub");
@@ -364,7 +364,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchSubFolderWhenLocalWildcardAtEnd() throws Exception {
+    void isExpressionMatchShouldNotMatchSubFolderWhenLocalWildcardAtEnd() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "mailbox%", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox.sub");
@@ -373,7 +373,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenEmptyNameAndLocalWildcardAtBeginning() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenEmptyNameAndLocalWildcardAtBeginning() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("");
@@ -382,7 +382,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchFolderWhenLocalWildcardAtBeginningAndNoMatching() throws Exception {
+    void isExpressionMatchShouldNotMatchFolderWhenLocalWildcardAtBeginningAndNoMatching() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub");
@@ -391,7 +391,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchFolderWhenLocalWildcardAtBeginningNotUsed() throws Exception {
+    void isExpressionMatchShouldMatchFolderWhenLocalWildcardAtBeginningNotUsed() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox");
@@ -400,7 +400,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchFolderWhenLocalWildcardAtBeginningUsed() throws Exception {
+    void isExpressionMatchShouldMatchFolderWhenLocalWildcardAtBeginningUsed() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("submailbox");
@@ -409,7 +409,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchSubFolderWhenLocalWildcardAtBeginning() throws Exception {
+    void isExpressionMatchShouldNotMatchSubFolderWhenLocalWildcardAtBeginning() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub.mailbox");
@@ -418,7 +418,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchDeeplyNestedFolderWhenLocalWildcardAtBeginning() throws Exception {
+    void isExpressionMatchShouldNotMatchDeeplyNestedFolderWhenLocalWildcardAtBeginning() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub.mailbox.sub");
@@ -427,7 +427,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenEmptyNameAndLocalWildcardInMiddle() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenEmptyNameAndLocalWildcardInMiddle() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("");
@@ -436,7 +436,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenLocalWildcardInMiddleAndMissingEndName() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenLocalWildcardInMiddleAndMissingEndName() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub");
@@ -445,7 +445,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchFolderWhenLocalWildcardInMiddleAndMatching() throws Exception {
+    void isExpressionMatchShouldMatchFolderWhenLocalWildcardInMiddleAndMatching() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("submailbox");
@@ -454,7 +454,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchFolderWhenLocalWildcardInMiddle() throws Exception {
+    void isExpressionMatchShouldMatchFolderWhenLocalWildcardInMiddle() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub123mailbox");
@@ -463,7 +463,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchSubFolderWhenLocalWildcardInMiddle() throws Exception {
+    void isExpressionMatchShouldNotMatchSubFolderWhenLocalWildcardInMiddle() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub.mailbox");
@@ -472,7 +472,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchSubFolderWhenLocalWildcardInMiddleAndExpandedMiddleName() throws Exception {
+    void isExpressionMatchShouldNotMatchSubFolderWhenLocalWildcardInMiddleAndExpandedMiddleName() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub.123mailbox");
@@ -481,7 +481,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenLocalWildcardInMiddleAndMissingBeginningName() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenLocalWildcardInMiddleAndMissingBeginningName() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox");
@@ -490,7 +490,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchDeeplyNestedFolderWhenLocalWildcardInMiddle() throws Exception {
+    void isExpressionMatchShouldNotMatchDeeplyNestedFolderWhenLocalWildcardInMiddle() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("subw.hat.eve.rmailbox");
@@ -499,7 +499,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchSubFolderWhenFreeWildcardAtEnd() throws Exception {
+    void isExpressionMatchShouldMatchSubFolderWhenFreeWildcardAtEnd() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "mailbox*", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox.sub");
@@ -508,7 +508,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenEmptyNameAndFreeWildcardAtEnd() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenEmptyNameAndFreeWildcardAtEnd() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "mailbox*", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("");
@@ -517,7 +517,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchFolderWhenFreeWildcardAtEndAndNoMatching() throws Exception {
+    void isExpressionMatchShouldNotMatchFolderWhenFreeWildcardAtEndAndNoMatching() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "mailbox*", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub");
@@ -526,7 +526,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchFolderWhenFreeWildcardAtEndNotUsed() throws Exception {
+    void isExpressionMatchShouldMatchFolderWhenFreeWildcardAtEndNotUsed() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "mailbox*", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox");
@@ -535,7 +535,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchFolderWhenFreeWildcardAtEndUsed() throws Exception {
+    void isExpressionMatchShouldMatchFolderWhenFreeWildcardAtEndUsed() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "mailbox*", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox123");
@@ -544,7 +544,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenEmptyNameAndFreeWildcardAtBeginning() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenEmptyNameAndFreeWildcardAtBeginning() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "*mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("");
@@ -553,7 +553,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchFolderWhenFreeWildcardAtBeginningAndNoMatching() throws Exception {
+    void isExpressionMatchShouldNotMatchFolderWhenFreeWildcardAtBeginningAndNoMatching() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "*mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub");
@@ -562,7 +562,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchFolderWhenFreeWildcardAtBeginningNotUsed() throws Exception {
+    void isExpressionMatchShouldMatchFolderWhenFreeWildcardAtBeginningNotUsed() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "*mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox");
@@ -571,7 +571,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchFolderWhenFreeWildcardAtBeginningUsed() throws Exception {
+    void isExpressionMatchShouldMatchFolderWhenFreeWildcardAtBeginningUsed() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "*mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("submailbox");
@@ -580,7 +580,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchSubFolderWhenFreeWildcardAtBeginning() throws Exception {
+    void isExpressionMatchShouldMatchSubFolderWhenFreeWildcardAtBeginning() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "*mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub.mailbox");
@@ -589,7 +589,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenEmptyNameAndFreeWildcardInMiddle() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenEmptyNameAndFreeWildcardInMiddle() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("");
@@ -598,7 +598,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchFolderWhenFreeWildcardInMiddleAndMissingEndName() throws Exception {
+    void isExpressionMatchShouldNotMatchFolderWhenFreeWildcardInMiddleAndMissingEndName() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub");
@@ -607,7 +607,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchFolderWhenFreeWildcardInMiddleNotUsed() throws Exception {
+    void isExpressionMatchShouldMatchFolderWhenFreeWildcardInMiddleNotUsed() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("submailbox");
@@ -616,7 +616,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchSubFolderWhenFreeWildcardInMiddle() throws Exception {
+    void isExpressionMatchShouldMatchSubFolderWhenFreeWildcardInMiddle() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub.mailbox");
@@ -625,7 +625,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenFreeWildcardInMiddleNotUsedAndMissingBeginningName() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenFreeWildcardInMiddleNotUsedAndMissingBeginningName() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox");
@@ -634,7 +634,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchDeeplyNestedFolderWhenFreeWildcardInMiddle() throws Exception {
+    void isExpressionMatchShouldMatchDeeplyNestedFolderWhenFreeWildcardInMiddle() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("subw.hat.eve.rmailbox");
@@ -643,7 +643,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenEmptyNameAndDoubleFreeWildcardInMiddle() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenEmptyNameAndDoubleFreeWildcardInMiddle() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub**mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("");
@@ -652,7 +652,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenDoubleFreeWildcardInMiddleAndMissingEndName() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenDoubleFreeWildcardInMiddleAndMissingEndName() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub**mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub");
@@ -661,7 +661,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnTrueWhenDoubleFreeWildcardInMiddleNotUsed() throws Exception {
+    void isExpressionMatchShouldReturnTrueWhenDoubleFreeWildcardInMiddleNotUsed() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub**mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("submailbox");
@@ -670,7 +670,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchSubFolderWhenDoubleFreeWildcardInMiddle() throws Exception {
+    void isExpressionMatchShouldMatchSubFolderWhenDoubleFreeWildcardInMiddle() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub**mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub.mailbox");
@@ -679,7 +679,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenDoubleFreeWildcardInMiddleAndMissingBeginningName() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenDoubleFreeWildcardInMiddleAndMissingBeginningName() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub**mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox");
@@ -688,7 +688,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchDeeplyNestedFolderWhenDoubleFreeWildcardInMiddle() throws Exception {
+    void isExpressionMatchShouldMatchDeeplyNestedFolderWhenDoubleFreeWildcardInMiddle() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub**mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("subw.hat.eve.rmailbox");
@@ -697,7 +697,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenEmptyNameAndFreeLocalWildcardInMiddle() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenEmptyNameAndFreeLocalWildcardInMiddle() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("");
@@ -706,7 +706,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenFreeLocalWildcardInMiddleAndMissingEndName() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenFreeLocalWildcardInMiddleAndMissingEndName() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub");
@@ -715,7 +715,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchFolderWhenFreeLocalWildcardInMiddleNotUsed() throws Exception {
+    void isExpressionMatchShouldMatchFolderWhenFreeLocalWildcardInMiddleNotUsed() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("submailbox");
@@ -724,7 +724,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchSubFolderWhenFreeLocalWildcardInMiddle() throws Exception {
+    void isExpressionMatchShouldMatchSubFolderWhenFreeLocalWildcardInMiddle() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub.mailbox");
@@ -733,7 +733,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenFreeLocalWildcardInMiddleAndMissingBeginningName() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenFreeLocalWildcardInMiddleAndMissingBeginningName() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox");
@@ -742,7 +742,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchDeeplyNestedFolderWhenFreeLocalWildcardInMiddle() throws Exception {
+    void isExpressionMatchShouldMatchDeeplyNestedFolderWhenFreeLocalWildcardInMiddle() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*%mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("subw.hat.eve.rmailbox");
@@ -751,7 +751,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenEmptyNameAndLocalFreeWildcardInMiddle() throws Exception {
+    void isExpressionMatchShouldReturnFalseWhenEmptyNameAndLocalFreeWildcardInMiddle() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub%*mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("");
@@ -760,7 +760,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchFolderWhenLocalFreeWildcardInMiddleAndMissingEndName() throws Exception {
+    void isExpressionMatchShouldNotMatchFolderWhenLocalFreeWildcardInMiddleAndMissingEndName() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub%*mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub");
@@ -769,7 +769,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchFolderWhenLocalFreewildcardInMiddleNotUsed() throws Exception {
+    void isExpressionMatchShouldMatchFolderWhenLocalFreewildcardInMiddleNotUsed() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub%*mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("submailbox");
@@ -778,7 +778,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchSubFolderWhenLocalFreeWildcardInMiddle() throws Exception {
+    void isExpressionMatchShouldMatchSubFolderWhenLocalFreeWildcardInMiddle() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub%*mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub.mailbox");
@@ -787,7 +787,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchFolderWhenLocalFreeWildcardInMiddleAndMissingBeginningName() throws Exception {
+    void isExpressionMatchShouldNotMatchFolderWhenLocalFreeWildcardInMiddleAndMissingBeginningName() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub%*mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox");
@@ -796,7 +796,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchDeeplyNestedFolderWhenLocalFreeWildcardInMiddle() throws Exception {
+    void isExpressionMatchShouldMatchDeeplyNestedFolderWhenLocalFreeWildcardInMiddle() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub%*mailbox", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("subw.hat.eve.rmailbox");
@@ -805,7 +805,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchFolderWhenMultipleFreeWildcards() throws Exception {
+    void isExpressionMatchShouldMatchFolderWhenMultipleFreeWildcards() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox*sub**", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("submailboxsub");
@@ -814,7 +814,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchDeeplyNestedFolderWhenMultipleFreeWildcardsNotUsed() throws Exception {
+    void isExpressionMatchShouldMatchDeeplyNestedFolderWhenMultipleFreeWildcardsNotUsed() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox*sub**", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub.mailbox.sub");
@@ -823,7 +823,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchDeeplyNestedFolderWhenMultipleFreeWildcardsUsed() throws Exception {
+    void isExpressionMatchShouldMatchDeeplyNestedFolderWhenMultipleFreeWildcardsUsed() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox*sub**", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("subtosh.boshmailboxtosh.boshsubboshtosh");
@@ -832,7 +832,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchDeeplyNestedFolderWhenMultipleFreeWildcardsAndMissingMiddleName() throws Exception {
+    void isExpressionMatchShouldNotMatchDeeplyNestedFolderWhenMultipleFreeWildcardsAndMissingMiddleName() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox*sub**", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub.a.sub");
@@ -841,7 +841,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchDeeplyNestedFolderWhenMultipleFreeWildcardsAndMissingEndName() throws Exception {
+    void isExpressionMatchShouldNotMatchDeeplyNestedFolderWhenMultipleFreeWildcardsAndMissingEndName() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox*sub**", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub.a.submailbox.u");
@@ -850,7 +850,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchDeeplyNestedFolderWhenMultipleFreeWildcardsAndMissingBeginningdName() throws Exception {
+    void isExpressionMatchShouldNotMatchDeeplyNestedFolderWhenMultipleFreeWildcardsAndMissingBeginningdName() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox*sub**", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("utosh.boshmailboxtosh.boshsubasubboshtoshmailboxu");
@@ -859,7 +859,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchFolderWhenMixedLocalFreeWildcardsNotUsed() throws Exception {
+    void isExpressionMatchShouldMatchFolderWhenMixedLocalFreeWildcardsNotUsed() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub%mailbox*sub", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("submailboxsub");
@@ -868,7 +868,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchSubFolderWhenMixedLocalFreeWildcards() throws Exception {
+    void isExpressionMatchShouldNotMatchSubFolderWhenMixedLocalFreeWildcards() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub%mailbox*sub", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub.mailboxsub");
@@ -877,7 +877,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchFolderWhenMixedFreeLocalWildcardsNotUsed() throws Exception {
+    void isExpressionMatchShouldMatchFolderWhenMixedFreeLocalWildcardsNotUsed() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox%sub", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("submailboxsub");
@@ -886,7 +886,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchSubFolderWhenMixedFreeLocalWildcards() throws Exception {
+    void isExpressionMatchShouldMatchSubFolderWhenMixedFreeLocalWildcards() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox%sub", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub.mailboxsub");
@@ -895,7 +895,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchSubFolderWhenMixedFreeLocalWildcards() throws Exception {
+    void isExpressionMatchShouldNotMatchSubFolderWhenMixedFreeLocalWildcards() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox%sub", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("submailbox.sub");
@@ -904,7 +904,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchFolderWhenMixedFreeLocalWildcards() throws Exception {
+    void isExpressionMatchShouldMatchFolderWhenMixedFreeLocalWildcards() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox%sub", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("submailboxwhateversub");
@@ -913,7 +913,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchSubFolderEndingWithDelimiterWhenMixedFreeLocalWildcards() throws Exception {
+    void isExpressionMatchShouldNotMatchSubFolderEndingWithDelimiterWhenMixedFreeLocalWildcards() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox%sub", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("submailboxsub.Whatever.");
@@ -922,7 +922,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchDeeplyNestedFolderWhenMixedFreeLocalWildcards() throws Exception {
+    void isExpressionMatchShouldNotMatchDeeplyNestedFolderWhenMixedFreeLocalWildcards() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox%sub", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub.mailboxsub.sub");
@@ -931,7 +931,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchSubFoldeWhenMixedFreeLocalWildcards() throws Exception {
+    void isExpressionMatchShouldMatchSubFoldeWhenMixedFreeLocalWildcards() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox%sub", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub.mailboxsub");
@@ -940,7 +940,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchDeeplyNestedFoldeWhenMixedFreeLocalWildcards() throws Exception {
+    void isExpressionMatchShouldMatchDeeplyNestedFoldeWhenMixedFreeLocalWildcards() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "sub*mailbox%sub", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("sub.whatever.mailbox123sub");
@@ -949,7 +949,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchFolderWhenTwoLocalPathDelimitedWildcards() throws Exception {
+    void isExpressionMatchShouldNotMatchFolderWhenTwoLocalPathDelimitedWildcards() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "%.%", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox");
@@ -958,7 +958,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchDeeplyNestedFolderWhenTwoLocalPathDelimitedWildcards() throws Exception {
+    void isExpressionMatchShouldNotMatchDeeplyNestedFolderWhenTwoLocalPathDelimitedWildcards() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "%.%", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox.sub.sub");
@@ -967,7 +967,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchSubFolderWhenTwoLocalPathDelimitedWildcards() throws Exception {
+    void isExpressionMatchShouldMatchSubFolderWhenTwoLocalPathDelimitedWildcards() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "%.%", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("mailbox.sub");
@@ -976,7 +976,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldMatchSubFolderWhenFreeWildcardAndPathDelimiterAtBeginning() throws Exception {
+    void isExpressionMatchShouldMatchSubFolderWhenFreeWildcardAndPathDelimiterAtBeginning() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "*.test", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("blah.test");
@@ -985,7 +985,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchSubFolderWhenWhenFreeWildcardAndPathDelimiterAtBeginning() throws Exception {
+    void isExpressionMatchShouldNotMatchSubFolderWhenWhenFreeWildcardAndPathDelimiterAtBeginning() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "*.test", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("blah.test3");
@@ -994,7 +994,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotMatchDeeplyNestedFolderWhenFreeWildcardAndPathDelimiterAtBeginning() throws Exception {
+    void isExpressionMatchShouldNotMatchDeeplyNestedFolderWhenFreeWildcardAndPathDelimiterAtBeginning() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "*.test", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("blah.test.go");
@@ -1003,7 +1003,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldIgnoreRegexInjection() throws Exception {
+    void isExpressionMatchShouldIgnoreRegexInjection() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "folder^$!)(%3", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("folder^$!)(123");
@@ -1012,7 +1012,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldIgnoreRegexInjectionWhenUsingEndOfQuoteAndNoMatching() throws Exception {
+    void isExpressionMatchShouldIgnoreRegexInjectionWhenUsingEndOfQuoteAndNoMatching() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "\\Efo.", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("\\Efol");
@@ -1021,7 +1021,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldIgnoreRegexInjectionWhenUsingEndOfQuoteAndMatching() throws Exception {
+    void isExpressionMatchShouldIgnoreRegexInjectionWhenUsingEndOfQuoteAndMatching() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "\\Efo.", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("\\Efo.");
@@ -1030,7 +1030,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldIgnoreRegexInjectionWhenUsingBeginOfQuoteAndNoMatching() throws Exception {
+    void isExpressionMatchShouldIgnoreRegexInjectionWhenUsingBeginOfQuoteAndNoMatching() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "\\Qfo?", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("\\Qfol");
@@ -1039,7 +1039,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldIgnoreRegexInjectionWhenUsingBeginOfQuoteAndMatching() throws Exception {
+    void isExpressionMatchShouldIgnoreRegexInjectionWhenUsingBeginOfQuoteAndMatching() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "\\Qfo?", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("\\Qfo?");
@@ -1048,7 +1048,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotEscapeFreeWildcard() throws Exception {
+    void isExpressionMatchShouldNotEscapeFreeWildcard() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "folder\\*", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("folder\\123");
@@ -1057,7 +1057,7 @@ public class PrefixedRegexTest {
     }
 
     @Test
-    public void isExpressionMatchShouldNotEscapeLocalWildcard() throws Exception {
+    void isExpressionMatchShouldNotEscapeLocalWildcard() {
         PrefixedRegex testee = new PrefixedRegex(EMPTY_PREFIX, "folder\\%", PATH_DELIMITER);
 
         boolean actual = testee.isExpressionMatch("folder\\123");

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/PrefixedWildcardTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/PrefixedWildcardTest.java
@@ -22,7 +22,7 @@ package org.apache.james.mailbox.model.search;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -30,49 +30,49 @@ public class PrefixedWildcardTest {
     public static final String NAME = "toto";
 
     @Test
-    public void shouldMatchBeanContract() {
+    void shouldMatchBeanContract() {
         EqualsVerifier.forClass(PrefixedWildcard.class)
             .verify();
     }
 
     @Test
-    public void constructorShouldThrowOnNullName() {
+    void constructorShouldThrowOnNullName() {
         assertThatThrownBy(() -> new PrefixedWildcard(null))
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void isWildShouldReturnTrue() {
+    void isWildShouldReturnTrue() {
         assertThat(new PrefixedWildcard(NAME).isWild())
             .isTrue();
     }
 
     @Test
-    public void getCombinedNameShouldReturnName() {
+    void getCombinedNameShouldReturnName() {
         assertThat(new PrefixedWildcard(NAME).getCombinedName())
             .isEqualTo(NAME + MailboxNameExpression.FREEWILDCARD);
     }
 
     @Test
-    public void isExpressionMatchShouldReturnTrueWhenName() {
+    void isExpressionMatchShouldReturnTrueWhenName() {
         assertThat(new PrefixedWildcard(NAME).isExpressionMatch(NAME))
             .isTrue();
     }
 
     @Test
-    public void isExpressionMatchShouldReturnTrueWhenNameAndPostfix() {
+    void isExpressionMatchShouldReturnTrueWhenNameAndPostfix() {
         assertThat(new PrefixedWildcard(NAME).isExpressionMatch(NAME + "any"))
             .isTrue();
     }
 
     @Test
-    public void isExpressionMatchShouldReturnFalseWhenOtherValue() {
+    void isExpressionMatchShouldReturnFalseWhenOtherValue() {
         assertThat(new PrefixedWildcard(NAME).isExpressionMatch("other"))
             .isFalse();
     }
 
     @Test
-    public void isExpressionMatchShouldThrowOnNullValue() {
+    void isExpressionMatchShouldThrowOnNullValue() {
         assertThatThrownBy(() -> new PrefixedWildcard(NAME).isExpressionMatch(null))
             .isInstanceOf(NullPointerException.class);
     }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/WildcardTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/WildcardTest.java
@@ -22,36 +22,36 @@ package org.apache.james.mailbox.model.search;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class WildcardTest {
+class WildcardTest {
 
     @Test
-    public void isWildShouldBeTrue() {
+    void isWildShouldBeTrue() {
         assertThat(Wildcard.INSTANCE.isWild())
             .isTrue();
     }
 
     @Test
-    public void getCombinedNameShouldReturnWildcard() {
+    void getCombinedNameShouldReturnWildcard() {
         assertThat(Wildcard.INSTANCE.getCombinedName())
             .isEqualTo(String.valueOf(MailboxNameExpression.FREEWILDCARD));
     }
 
     @Test
-    public void isExpressionMatchShouldMatchAnyValue() {
+    void isExpressionMatchShouldMatchAnyValue() {
         assertThat(Wildcard.INSTANCE.isExpressionMatch("any"))
             .isTrue();
     }
 
     @Test
-    public void isExpressionMatchShouldMatchEmptyValue() {
+    void isExpressionMatchShouldMatchEmptyValue() {
         assertThat(Wildcard.INSTANCE.isExpressionMatch(""))
             .isTrue();
     }
 
     @Test
-    public void isExpressionMatchShouldThrowOnNullValue() {
+    void isExpressionMatchShouldThrowOnNullValue() {
         assertThatThrownBy(() -> Wildcard.INSTANCE.isExpressionMatch(null))
             .isInstanceOf(NullPointerException.class);
     }


### PR DESCRIPTION
Except for `AbstractSubscriptionManagerTest` and `MailboxManagerStressTest`.
Those are trickier and require quite some work with the implementation classes depending on it.
Will try moving them in an other PR, an other time.