### PR TITLE
MAILBOX-391 MailboxMapper::findMailboxWithPathLike should use MailboxQuery

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxPath.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxPath.java
@@ -76,8 +76,7 @@ public class MailboxPath {
     }
 
     /**
-     * Get the name of the user who owns the mailbox. This can be null e.g. for
-     * shared mailboxes.
+     * Get the name of the user who owns the mailbox.
      */
     public String getUser() {
         return user;

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/ExactName.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/ExactName.java
@@ -49,6 +49,11 @@ public class ExactName implements MailboxNameExpression {
     }
 
     @Override
+    public MailboxNameExpression includeChildren() {
+        return new PrefixedWildcard(name);
+    }
+
+    @Override
     public final boolean equals(Object o) {
         if (o instanceof ExactName) {
             ExactName exactName = (ExactName) o;

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/ExactName.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/ExactName.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mailbox.model.search;
 
+import java.util.Objects;
+
 import com.google.common.base.Preconditions;
 
 public class ExactName implements MailboxNameExpression {
@@ -44,5 +46,20 @@ public class ExactName implements MailboxNameExpression {
     @Override
     public boolean isWild() {
         return false;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof ExactName) {
+            ExactName exactName = (ExactName) o;
+
+            return Objects.equals(this.name, exactName.name);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(name);
     }
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/MailboxNameExpression.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/MailboxNameExpression.java
@@ -53,6 +53,8 @@ public interface MailboxNameExpression {
      */
     boolean isWild();
 
+    MailboxNameExpression includeChildren();
+
     /**
      * Gets wildcard character that matches any series of characters.
      *

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/MailboxQuery.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/MailboxQuery.java
@@ -117,7 +117,7 @@ public final class MailboxQuery {
     /**
      * Constructs an expression determining a set of mailbox names.
      */
-    @VisibleForTesting MailboxQuery(Optional<String> namespace, Optional<String> user, MailboxNameExpression mailboxNameExpression) {
+    private MailboxQuery(Optional<String> namespace, Optional<String> user, MailboxNameExpression mailboxNameExpression) {
         this.namespace = namespace;
         this.user = user;
         this.mailboxNameExpression = mailboxNameExpression;

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/MailboxQuery.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/MailboxQuery.java
@@ -34,7 +34,7 @@ import com.google.common.base.Preconditions;
 /**
  * Expresses select criteria for mailboxes.
  */
-public final class MailboxQuery {
+public class MailboxQuery {
 
     public static Builder builder() {
         return new Builder();
@@ -110,8 +110,24 @@ public final class MailboxQuery {
         }
     }
 
-    private final Optional<String> namespace;
-    private final Optional<String> user;
+    public static class UserBound extends MailboxQuery {
+        private UserBound(Optional<String> namespace, Optional<String> user, MailboxNameExpression mailboxNameExpression) {
+            super(namespace, user, mailboxNameExpression);
+            Preconditions.checkArgument(namespace.isPresent());
+            Preconditions.checkArgument(user.isPresent());
+        }
+
+        public String getFixedNamespace() {
+            return namespace.get();
+        }
+
+        public String getFixedUser() {
+            return user.get();
+        }
+    }
+
+    protected final Optional<String> namespace;
+    protected final Optional<String> user;
     private final MailboxNameExpression mailboxNameExpression;
 
     /**
@@ -160,6 +176,10 @@ public final class MailboxQuery {
     public boolean isPathMatch(MailboxPath mailboxPath) {
         return belongsToRequestedNamespaceAndUser(mailboxPath)
             && isExpressionMatch(mailboxPath.getName());
+    }
+
+    public UserBound asUserBound() {
+        return new UserBound(namespace, user, mailboxNameExpression);
     }
 
     public String toString() {

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/MailboxQuery.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/MailboxQuery.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mailbox.model.search;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.james.core.Username;
@@ -180,6 +181,23 @@ public class MailboxQuery {
 
     public UserBound asUserBound() {
         return new UserBound(namespace, user, mailboxNameExpression);
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof MailboxQuery) {
+            MailboxQuery that = (MailboxQuery) o;
+
+            return Objects.equals(this.namespace, that.namespace)
+                && Objects.equals(this.user, that.user)
+                && Objects.equals(this.mailboxNameExpression, that.mailboxNameExpression);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(namespace, user, mailboxNameExpression);
     }
 
     public String toString() {

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/MailboxQuery.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/MailboxQuery.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxConstants;
 import org.apache.james.mailbox.model.MailboxPath;
 
@@ -177,6 +178,10 @@ public class MailboxQuery {
     public boolean isPathMatch(MailboxPath mailboxPath) {
         return belongsToRequestedNamespaceAndUser(mailboxPath)
             && isExpressionMatch(mailboxPath.getName());
+    }
+
+    public boolean matches(Mailbox mailbox) {
+        return isPathMatch(mailbox.generateAssociatedPath());
     }
 
     public UserBound asUserBound() {

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/MailboxQuery.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/MailboxQuery.java
@@ -113,10 +113,10 @@ public class MailboxQuery {
     }
 
     public static class UserBound extends MailboxQuery {
-        private UserBound(Optional<String> namespace, Optional<String> user, MailboxNameExpression mailboxNameExpression) {
-            super(namespace, user, mailboxNameExpression);
-            Preconditions.checkArgument(namespace.isPresent());
-            Preconditions.checkArgument(user.isPresent());
+        private UserBound(String namespace, String user, MailboxNameExpression mailboxNameExpression) {
+            super(Optional.of(namespace), Optional.of(user), mailboxNameExpression);
+            Preconditions.checkNotNull(namespace);
+            Preconditions.checkNotNull(user);
         }
 
         public String getFixedNamespace() {
@@ -185,7 +185,9 @@ public class MailboxQuery {
     }
 
     public UserBound asUserBound() {
-        return new UserBound(namespace, user, mailboxNameExpression);
+        Preconditions.checkState(namespace.isPresent(), "This MailboxQuery is not user bound as namespace is missing");
+        Preconditions.checkState(user.isPresent(), "This MailboxQuery is not user bound as user is missing");
+        return new UserBound(namespace.get(), user.get(), mailboxNameExpression);
     }
 
     @Override

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/PrefixedRegex.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/PrefixedRegex.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mailbox.model.search;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.StringTokenizer;
 import java.util.regex.Pattern;
@@ -108,5 +109,22 @@ public class PrefixedRegex implements MailboxNameExpression {
         } else {
             return Pattern.quote(token);
         }
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof PrefixedRegex) {
+            PrefixedRegex that = (PrefixedRegex) o;
+
+            return Objects.equals(this.pathDelimiter, that.pathDelimiter)
+                && Objects.equals(this.prefix, that.prefix)
+                && Objects.equals(this.regex, that.regex);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(prefix, regex, pathDelimiter);
     }
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/PrefixedRegex.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/PrefixedRegex.java
@@ -54,6 +54,11 @@ public class PrefixedRegex implements MailboxNameExpression {
     }
 
     @Override
+    public MailboxNameExpression includeChildren() {
+        return new PrefixedRegex(prefix, regex + "*", pathDelimiter);
+    }
+
+    @Override
     public String getCombinedName() {
         if (prefix != null && prefix.length() > 0) {
             final int baseLength = prefix.length();

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/PrefixedWildcard.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/PrefixedWildcard.java
@@ -48,6 +48,11 @@ public class PrefixedWildcard implements MailboxNameExpression {
     }
 
     @Override
+    public MailboxNameExpression includeChildren() {
+        return this;
+    }
+
+    @Override
     public final boolean equals(Object o) {
         if (o instanceof PrefixedWildcard) {
             PrefixedWildcard that = (PrefixedWildcard) o;

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/PrefixedWildcard.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/PrefixedWildcard.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mailbox.model.search;
 
+import java.util.Objects;
+
 import com.google.common.base.Preconditions;
 
 public class PrefixedWildcard implements MailboxNameExpression {
@@ -43,5 +45,20 @@ public class PrefixedWildcard implements MailboxNameExpression {
     @Override
     public boolean isWild() {
         return true;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof PrefixedWildcard) {
+            PrefixedWildcard that = (PrefixedWildcard) o;
+
+            return Objects.equals(this.prefix, that.prefix);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(prefix);
     }
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/Wildcard.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/search/Wildcard.java
@@ -47,6 +47,11 @@ public class Wildcard implements MailboxNameExpression {
     }
 
     @Override
+    public MailboxNameExpression includeChildren() {
+        return this;
+    }
+
+    @Override
     public final boolean equals(Object o) {
         return o instanceof Wildcard;
     }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/quota/QuotaRootResolver.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/quota/QuotaRootResolver.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.QuotaRoot;
@@ -39,5 +40,5 @@ public interface QuotaRootResolver extends QuotaRootDeserializer {
 
     QuotaRoot getQuotaRoot(MailboxId mailboxId) throws MailboxException;
 
-    List<MailboxPath> retrieveAssociatedMailboxes(QuotaRoot quotaRoot, MailboxSession mailboxSession) throws MailboxException;
+    List<Mailbox> retrieveAssociatedMailboxes(QuotaRoot quotaRoot, MailboxSession mailboxSession) throws MailboxException;
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/ExactNameTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/ExactNameTest.java
@@ -24,9 +24,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
-public class ExactNameTest {
+import nl.jqno.equalsverifier.EqualsVerifier;
 
+public class ExactNameTest {
     public static final String NAME = "toto";
+
+    @Test
+    public void shouldMatchBeanContract() {
+        EqualsVerifier.forClass(ExactName.class)
+            .verify();
+    }
 
     @Test
     public void constructorShouldThrowOnNullName() {

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/MailboxQueryTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/MailboxQueryTest.java
@@ -27,6 +27,8 @@ import org.apache.james.mailbox.model.search.MailboxQuery.Builder;
 import org.junit.Before;
 import org.junit.Test;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+
 public class MailboxQueryTest {
     private static final String CURRENT_USER = "user";
 
@@ -35,6 +37,12 @@ public class MailboxQueryTest {
     @Before
     public void setUp() {
         mailboxPath = new MailboxPath("namespace", "user", "name");
+    }
+
+    @Test
+    public void shouldMatchBeanContract() {
+        EqualsVerifier.forClass(MailboxQuery.class)
+            .verify();
     }
 
     @Test

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/MailboxQueryTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/MailboxQueryTest.java
@@ -130,18 +130,6 @@ public class MailboxQueryTest {
     }
 
     @Test
-    public void belongsToNamespaceAndUserShouldReturnTrueWithIdenticalMailboxesWithNullUser() {
-        MailboxPath base = new MailboxPath("namespace", null, "name");
-
-        MailboxQuery mailboxQuery = MailboxQuery.builder()
-            .userAndNamespaceFrom(base)
-            .build();
-
-        assertThat(mailboxQuery.belongsToRequestedNamespaceAndUser(mailboxPath))
-            .isTrue();
-    }
-
-    @Test
     public void belongsToNamespaceAndUserShouldReturnTrueWithIdenticalMailboxesWithNullNamespace() {
         MailboxPath mailboxPath = new MailboxPath(null, "user", "name");
 
@@ -150,16 +138,6 @@ public class MailboxQueryTest {
             .build();
 
         assertThat(mailboxQuery.belongsToRequestedNamespaceAndUser(mailboxPath))
-            .isTrue();
-    }
-
-    @Test
-    public void belongsToNamespaceAndUserShouldReturnTrueWithMailboxWithSameNamespaceAndUserWithNullUser() {
-        MailboxQuery mailboxQuery = MailboxQuery.builder()
-            .userAndNamespaceFrom(new MailboxPath("namespace", null, "name"))
-            .build();
-
-        assertThat(mailboxQuery.belongsToRequestedNamespaceAndUser(new MailboxPath("namespace", null, "name")))
             .isTrue();
     }
 
@@ -194,32 +172,12 @@ public class MailboxQueryTest {
     }
     
     @Test
-    public void belongsToNamespaceAndUserShouldReturnFalseWithOneOfTheUserNull() {
-        MailboxQuery mailboxQuery = MailboxQuery.builder()
-            .userAndNamespaceFrom(new MailboxPath("namespace", CURRENT_USER, "name"))
-            .build();
-
-        assertThat(mailboxQuery.belongsToRequestedNamespaceAndUser(new MailboxPath("namespace", null, "name")))
-            .isFalse();
-    }
-
-    @Test
     public void belongsToNamespaceAndUserShouldReturnFalseWhenDifferentUser() {
         MailboxQuery mailboxQuery = MailboxQuery.builder()
             .userAndNamespaceFrom(new MailboxPath("namespace", CURRENT_USER, "name"))
             .build();
 
         assertThat(mailboxQuery.belongsToRequestedNamespaceAndUser(new MailboxPath("namespace", "other", "name")))
-            .isFalse();
-    }
-
-    @Test
-    public void belongsToNamespaceAndUserShouldReturnFalseIfNamespaceAreDifferentWithNullUser() {
-        MailboxQuery mailboxQuery = MailboxQuery.builder()
-            .userAndNamespaceFrom(new MailboxPath("namespace", null, "name"))
-            .build();
-
-        assertThat(mailboxQuery.belongsToRequestedNamespaceAndUser(new MailboxPath("namespace2", null, "name")))
             .isFalse();
     }
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/PrefixedRegexTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/PrefixedRegexTest.java
@@ -23,10 +23,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+
 public class PrefixedRegexTest {
     private static final char PATH_DELIMITER = '.';
     private static final String PREFIX = "name";
     private static final String EMPTY_PREFIX = "";
+
+    @Test
+    public void shouldMatchBeanContract() {
+        EqualsVerifier.forClass(PrefixedRegex.class)
+            .withIgnoredFields("pattern")
+            .verify();
+    }
 
     @Test
     public void isWildShouldReturnTrueWhenOnlyFreeWildcard() throws Exception {

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/PrefixedWildcardTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/search/PrefixedWildcardTest.java
@@ -24,8 +24,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+
 public class PrefixedWildcardTest {
     public static final String NAME = "toto";
+
+    @Test
+    public void shouldMatchBeanContract() {
+        EqualsVerifier.forClass(PrefixedWildcard.class)
+            .verify();
+    }
 
     @Test
     public void constructorShouldThrowOnNullName() {

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/DefaultMailboxBackup.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/DefaultMailboxBackup.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import com.github.fge.lambdas.Throwing;
 import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
+
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
@@ -138,6 +139,7 @@ public class DefaultMailboxBackup implements MailboxBackup {
     @VisibleForTesting
     List<MailAccountContent> getAccountContentForUser(MailboxSession session) throws MailboxException {
         MailboxQuery queryUser = MailboxQuery.builder()
+            .privateNamespace()
             .user(session.getUser())
             .build();
         Stream<MailboxPath> paths = mailboxManager.search(queryUser, session)

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperTest.java
@@ -37,8 +37,9 @@ import org.apache.james.mailbox.cassandra.modules.CassandraMailboxModule;
 import org.apache.james.mailbox.exception.MailboxNotFoundException;
 import org.apache.james.mailbox.exception.TooLongMailboxNameException;
 import org.apache.james.mailbox.model.Mailbox;
-import org.apache.james.mailbox.model.MailboxConstants;
 import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.search.MailboxQuery;
+import org.apache.james.mailbox.model.search.Wildcard;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -55,9 +56,7 @@ public class CassandraMailboxMapperTest {
 
     private static final CassandraId MAILBOX_ID_2 = CassandraId.timeBased();
 
-
     private static final Mailbox MAILBOX_BIS = new Mailbox(MAILBOX_PATH, UID_VALIDITY, MAILBOX_ID_2);
-    private static final String WILDCARD = "%";
 
     private static final CassandraModule MODULES = CassandraModule.aggregateModules(
         CassandraMailboxModule.MODULE,
@@ -236,7 +235,12 @@ public class CassandraMailboxMapperTest {
         mailboxPathDAO.save(MAILBOX_PATH, MAILBOX_ID)
             .block();
     
-        List<Mailbox> mailboxes = testee.findMailboxWithPathLike(new MailboxPath(MailboxConstants.USER_NAMESPACE, USER, WILDCARD));
+        List<Mailbox> mailboxes = testee.findMailboxWithPathLike(MailboxQuery.builder()
+            .privateNamespace()
+            .username(USER)
+            .expression(Wildcard.INSTANCE)
+            .build()
+            .asUserBound());
 
         assertThat(mailboxes).containsOnly(MAILBOX);
     }
@@ -250,7 +254,12 @@ public class CassandraMailboxMapperTest {
         mailboxPathV2DAO.save(MAILBOX_PATH, MAILBOX_ID)
             .block();
 
-        List<Mailbox> mailboxes = testee.findMailboxWithPathLike(new MailboxPath(MailboxConstants.USER_NAMESPACE, USER, WILDCARD));
+        List<Mailbox> mailboxes = testee.findMailboxWithPathLike(MailboxQuery.builder()
+            .privateNamespace()
+            .username(USER)
+            .expression(Wildcard.INSTANCE)
+            .build()
+            .asUserBound());
 
         assertThat(mailboxes).containsOnly(MAILBOX);
     }
@@ -262,7 +271,12 @@ public class CassandraMailboxMapperTest {
         mailboxPathV2DAO.save(MAILBOX_PATH, MAILBOX_ID)
             .block();
     
-        List<Mailbox> mailboxes = testee.findMailboxWithPathLike(new MailboxPath(MailboxConstants.USER_NAMESPACE, USER, WILDCARD));
+        List<Mailbox> mailboxes = testee.findMailboxWithPathLike(MailboxQuery.builder()
+            .privateNamespace()
+            .username(USER)
+            .expression(Wildcard.INSTANCE)
+            .build()
+            .asUserBound());
 
         assertThat(mailboxes).containsOnly(MAILBOX);
     }
@@ -335,7 +349,12 @@ public class CassandraMailboxMapperTest {
         mailboxPathDAO.save(MAILBOX_PATH, MAILBOX_ID_2).block();
 
         assertThat(testee.findMailboxWithPathLike(
-            new MailboxPath(MailboxConstants.USER_NAMESPACE, USER, WILDCARD)))
+            MailboxQuery.builder()
+                .privateNamespace()
+                .username(USER)
+                .expression(Wildcard.INSTANCE)
+                .build()
+                .asUserBound()))
             .containsOnly(MAILBOX);
     }
 }

--- a/mailbox/event/json/src/test/java/org/apache/james/event/json/dtos/MailboxPathTest.java
+++ b/mailbox/event/json/src/test/java/org/apache/james/event/json/dtos/MailboxPathTest.java
@@ -47,17 +47,6 @@ class MailboxPathTest {
     }
 
     @Test
-    void mailboxPathWithNullUserShouldBeWellSerialized() {
-        assertThatJson(DTO_JSON_SERIALIZE.mailboxPathWrites().writes(DTOs.MailboxPath$.MODULE$.fromJava(
-            new MailboxPath(MailboxConstants.USER_NAMESPACE, null, MAILBOX_NAME))).toString())
-            .isEqualTo(
-                "{" +
-                "  \"namespace\":\"#private\"," +
-                "  \"name\":\"mailboxName\"" +
-                "}");
-    }
-
-    @Test
     void mailboxPathWithEmptyNamespaceShouldBeWellSerialized() {
         assertThatJson(DTO_JSON_SERIALIZE.mailboxPathWrites().writes(DTOs.MailboxPath$.MODULE$.fromJava(
             new MailboxPath("", "user", MAILBOX_NAME))).toString())
@@ -78,27 +67,6 @@ class MailboxPathTest {
             "}")).get())
             .isEqualTo(DTOs.MailboxPath$.MODULE$.fromJava(
                 new MailboxPath(MailboxConstants.USER_NAMESPACE, "user", MAILBOX_NAME)));
-    }
-
-    @Test
-    void mailboxPathWithNullUserShouldBeWellDeSerialized() {
-        assertThat(DTO_JSON_SERIALIZE.mailboxPathReads().reads(Json.parse("{" +
-            "  \"namespace\":\"#private\"," +
-            "  \"user\":null," +
-            "  \"name\":\"mailboxName\"" +
-            "}")).get())
-            .isEqualTo(DTOs.MailboxPath$.MODULE$.fromJava(
-                new MailboxPath(MailboxConstants.USER_NAMESPACE, null, MAILBOX_NAME)));
-    }
-
-    @Test
-    void mailboxPathWithNoUserShouldBeWellDeSerialized() {
-        assertThat(DTO_JSON_SERIALIZE.mailboxPathReads().reads(Json.parse("{" +
-            "  \"namespace\":\"#private\"," +
-            "  \"name\":\"mailboxName\"" +
-            "}")).get())
-            .isEqualTo(DTOs.MailboxPath$.MODULE$.fromJava(
-                new MailboxPath(MailboxConstants.USER_NAMESPACE, null, MAILBOX_NAME)));
     }
 
     @Test

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMailboxMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMailboxMapper.java
@@ -198,7 +198,7 @@ public class JPAMailboxMapper extends JPATransactionalMapper implements MailboxM
                 .getResultList()
                 .stream()
                 .map(JPAMailbox::toMailbox)
-                .filter(mailbox -> query.isPathMatch(mailbox.generateAssociatedPath()))
+                .filter(query::matches)
                 .collect(Guavate.toImmutableList());
         } catch (PersistenceException e) {
             throw new MailboxException("Search of mailbox " + query + " failed", e);

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMailboxMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMailboxMapper.java
@@ -202,16 +202,10 @@ public class JPAMailboxMapper extends JPATransactionalMapper implements MailboxM
     }
 
     private TypedQuery<JPAMailbox> findMailboxWithPathLikeTypedQuery(MailboxPath path) {
-        if (path.getUser() == null) {
-            return getEntityManager().createNamedQuery("findMailboxWithNameLike", JPAMailbox.class)
-                .setParameter("nameParam", path.getName())
-                .setParameter("namespaceParam", path.getNamespace());
-        } else {
-            return getEntityManager().createNamedQuery("findMailboxWithNameLikeWithUser", JPAMailbox.class)
-                .setParameter("nameParam", path.getName())
-                .setParameter("namespaceParam", path.getNamespace())
-                .setParameter("userParam", path.getUser());
-        }
+        return getEntityManager().createNamedQuery("findMailboxWithNameLikeWithUser", JPAMailbox.class)
+            .setParameter("nameParam", path.getName())
+            .setParameter("namespaceParam", path.getNamespace())
+            .setParameter("userParam", path.getUser().asId());
     }
 
     public void deleteAllMemberships() throws MailboxException {
@@ -234,11 +228,7 @@ public class JPAMailboxMapper extends JPATransactionalMapper implements MailboxM
     public boolean hasChildren(Mailbox mailbox, char delimiter) throws MailboxException, MailboxNotFoundException {
         final String name = mailbox.getName() + delimiter + SQL_WILDCARD_CHAR; 
         final Long numberOfChildMailboxes;
-        if (mailbox.getUser() == null) {
-            numberOfChildMailboxes = (Long) getEntityManager().createNamedQuery("countMailboxesWithNameLike").setParameter("nameParam", name).setParameter("namespaceParam", mailbox.getNamespace()).getSingleResult();
-        } else {
-            numberOfChildMailboxes = (Long) getEntityManager().createNamedQuery("countMailboxesWithNameLikeWithUser").setParameter("nameParam", name).setParameter("namespaceParam", mailbox.getNamespace()).setParameter("userParam", mailbox.getUser()).getSingleResult();
-        }
+        numberOfChildMailboxes = (Long) getEntityManager().createNamedQuery("countMailboxesWithNameLikeWithUser").setParameter("nameParam", name).setParameter("namespaceParam", mailbox.getNamespace()).setParameter("userParam", mailbox.getUser()).getSingleResult();
         return numberOfChildMailboxes != null && numberOfChildMailboxes > 0;
     }
 

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMailboxMapper.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMailboxMapper.java
@@ -30,6 +30,7 @@ import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxACL.Right;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.search.MailboxQuery;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.apache.james.mailbox.store.transaction.Mapper;
 
@@ -71,8 +72,8 @@ public class TransactionalMailboxMapper implements MailboxMapper {
     }
 
     @Override
-    public List<Mailbox> findMailboxWithPathLike(MailboxPath mailboxPath) throws MailboxException {
-        return wrapped.findMailboxWithPathLike(mailboxPath);
+    public List<Mailbox> findMailboxWithPathLike(MailboxQuery.UserBound query) throws MailboxException {
+        return wrapped.findMailboxWithPathLike(query);
     }
 
     @Override

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMailboxMapper.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMailboxMapper.java
@@ -143,7 +143,7 @@ public class MaildirMailboxMapper extends NonTransactionalMapper implements Mail
             mailboxList.add(0, mailbox);
         }
         return mailboxList.stream()
-            .filter(mailbox -> query.isPathMatch(mailbox.generateAssociatedPath()))
+            .filter(query::matches)
             .collect(Guavate.toImmutableList());
     }
 

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMailboxMapper.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMailboxMapper.java
@@ -82,10 +82,10 @@ public class InMemoryMailboxMapper implements MailboxMapper {
     }
 
     @Override
-    public List<Mailbox> findMailboxWithPathLike(MailboxQuery.UserBound query) throws MailboxException {
+    public List<Mailbox> findMailboxWithPathLike(MailboxQuery.UserBound query) {
         return mailboxesByPath.values()
             .stream()
-            .filter(mailbox -> query.isPathMatch(mailbox.generateAssociatedPath()))
+            .filter(query::matches)
             .map(Mailbox::new)
             .collect(Guavate.toImmutableList());
     }

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMailboxMapper.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMailboxMapper.java
@@ -35,6 +35,7 @@ import org.apache.james.mailbox.model.MailboxACL.NameType;
 import org.apache.james.mailbox.model.MailboxACL.Right;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.search.MailboxQuery;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 
 import com.github.steveash.guavate.Guavate;
@@ -81,19 +82,12 @@ public class InMemoryMailboxMapper implements MailboxMapper {
     }
 
     @Override
-    public List<Mailbox> findMailboxWithPathLike(MailboxPath path) throws MailboxException {
-        final String regex = path.getName().replace("%", ".*");
+    public List<Mailbox> findMailboxWithPathLike(MailboxQuery.UserBound query) throws MailboxException {
         return mailboxesByPath.values()
             .stream()
-            .filter(mailbox -> mailboxMatchesRegex(mailbox, path, regex))
+            .filter(mailbox -> query.isPathMatch(mailbox.generateAssociatedPath()))
             .map(Mailbox::new)
             .collect(Guavate.toImmutableList());
-    }
-
-    private boolean mailboxMatchesRegex(Mailbox mailbox, MailboxPath path, String regex) {
-        return Objects.equal(mailbox.getNamespace(), path.getNamespace())
-            && Objects.equal(mailbox.getUser(), path.getUser())
-            && mailbox.getName().matches(regex);
     }
 
     @Override

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/MailboxExpressionBackwardCompatibility.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/MailboxExpressionBackwardCompatibility.java
@@ -1,0 +1,35 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.store;
+
+import static org.apache.james.mailbox.store.StoreMailboxManager.SQL_WILDCARD_CHAR;
+
+import org.apache.james.mailbox.model.search.MailboxNameExpression;
+import org.apache.james.mailbox.model.search.MailboxQuery;
+
+public class MailboxExpressionBackwardCompatibility {
+    public static String getPathLike(MailboxQuery mailboxQuery) {
+        MailboxNameExpression nameExpression = mailboxQuery.getMailboxNameExpression();
+        return nameExpression.getCombinedName()
+            .replace(nameExpression.getFreeWildcard(), SQL_WILDCARD_CHAR)
+            .replace(nameExpression.getLocalWildcard(), SQL_WILDCARD_CHAR)
+            + SQL_WILDCARD_CHAR;
+    }
+}

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MailboxMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MailboxMapper.java
@@ -28,6 +28,7 @@ import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxACL.Right;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.search.MailboxQuery;
 import org.apache.james.mailbox.store.transaction.Mapper;
 
 /**
@@ -68,7 +69,7 @@ public interface MailboxMapper extends Mapper {
     /**
      * Return a List of {@link Mailbox} which name is like the given name
      */
-    List<Mailbox> findMailboxWithPathLike(MailboxPath mailboxPath)
+    List<Mailbox> findMailboxWithPathLike(MailboxQuery.UserBound query)
             throws MailboxException;
 
     /**

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/CurrentQuotaCalculator.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/CurrentQuotaCalculator.java
@@ -29,16 +29,12 @@ import javax.inject.Inject;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Mailbox;
-import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.mailbox.quota.QuotaRootResolver;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
-import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
-
-import com.google.common.collect.Lists;
 
 public class CurrentQuotaCalculator {
 
@@ -53,7 +49,7 @@ public class CurrentQuotaCalculator {
     }
 
     public CurrentQuotas recalculateCurrentQuotas(QuotaRoot quotaRoot, MailboxSession session) throws MailboxException {
-        List<Mailbox> mailboxes = retrieveMailboxes(quotaRoot, session);
+        List<Mailbox> mailboxes = quotaRootResolver.retrieveAssociatedMailboxes(quotaRoot, session);
         MessageMapper mapper = factory.getMessageMapper(session);
         long messagesSizes = 0;
         long messageCount = 0;
@@ -65,18 +61,6 @@ public class CurrentQuotaCalculator {
             }
         }
         return new CurrentQuotas(messageCount, messagesSizes);
-    }
-
-    private List<Mailbox> retrieveMailboxes(QuotaRoot quotaRoot, MailboxSession session) throws MailboxException {
-        List<MailboxPath> paths = quotaRootResolver.retrieveAssociatedMailboxes(quotaRoot, session);
-        final MailboxMapper mapper = factory.getMailboxMapper(session);
-        return Lists.transform(paths, mailboxPath -> {
-            try {
-                return mapper.findMailboxByPath(mailboxPath);
-            } catch (MailboxException e) {
-                throw new RuntimeException(e);
-            }
-        });
     }
 
     public static class CurrentQuotas {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/DefaultUserQuotaRootResolver.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/DefaultUserQuotaRootResolver.java
@@ -39,7 +39,6 @@ import org.apache.james.mailbox.store.SessionProvider;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
-import com.google.common.collect.Lists;
 
 public class DefaultUserQuotaRootResolver implements UserQuotaRootResolver {
 
@@ -109,12 +108,11 @@ public class DefaultUserQuotaRootResolver implements UserQuotaRootResolver {
     }
 
     @Override
-    public List<MailboxPath> retrieveAssociatedMailboxes(QuotaRoot quotaRoot, MailboxSession mailboxSession) throws MailboxException {
+    public List<Mailbox> retrieveAssociatedMailboxes(QuotaRoot quotaRoot, MailboxSession mailboxSession) throws MailboxException {
         List<String> parts = QUOTA_ROOT_DESERIALIZER.toParts(quotaRoot.getValue());
         String namespace = parts.get(0);
         String user = parts.get(1);
-        return Lists.transform(factory.getMailboxMapper(mailboxSession)
-            .findMailboxWithPathLike(new MailboxPath(namespace, user, "%")),
-            Mailbox::generateAssociatedPath);
+        return factory.getMailboxMapper(mailboxSession)
+            .findMailboxWithPathLike(new MailboxPath(namespace, user, "%"));
     }
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/DefaultUserQuotaRootResolver.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/DefaultUserQuotaRootResolver.java
@@ -32,6 +32,7 @@ import org.apache.james.mailbox.model.MailboxConstants;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.QuotaRoot;
+import org.apache.james.mailbox.model.search.MailboxQuery;
 import org.apache.james.mailbox.quota.QuotaRootDeserializer;
 import org.apache.james.mailbox.quota.UserQuotaRootResolver;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
@@ -113,6 +114,11 @@ public class DefaultUserQuotaRootResolver implements UserQuotaRootResolver {
         String namespace = parts.get(0);
         String user = parts.get(1);
         return factory.getMailboxMapper(mailboxSession)
-            .findMailboxWithPathLike(new MailboxPath(namespace, user, "%"));
+            .findMailboxWithPathLike(MailboxQuery.builder()
+                .namespace(namespace)
+                .user(Username.of(user))
+                .matchesAllMailboxNames()
+                .build()
+                .asUserBound());
     }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxManagerTest.java
@@ -38,6 +38,7 @@ import org.apache.james.mailbox.exception.NotAdminException;
 import org.apache.james.mailbox.exception.UserDoesNotExistException;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxACL;
+import org.apache.james.mailbox.model.MailboxConstants;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageId;
@@ -195,7 +196,7 @@ public class StoreMailboxManagerTest {
     }
 
     @Test
-    public void getPathLikeShouldReturnUserPathLikeWhenNoPrefixDefined() throws Exception {
+    public void getPathLikeShouldReturnUserPathLikeWhenNoPrefixDefined() {
         //Given
         MailboxSession session = MailboxSessionUtil.create("user");
         MailboxQuery.Builder testee = MailboxQuery.builder()
@@ -203,12 +204,17 @@ public class StoreMailboxManagerTest {
         //When
         MailboxQuery mailboxQuery = testee.build();
 
-        assertThat(StoreMailboxManager.getPathLike(mailboxQuery, session))
-            .isEqualTo(MailboxPath.forUser("user", "abc%"));
+        assertThat(StoreMailboxManager.toSingleUserQuery(mailboxQuery, session))
+            .isEqualTo(MailboxQuery.builder()
+                .namespace(MailboxConstants.USER_NAMESPACE)
+                .username("user")
+                .expression(new PrefixedRegex(EMPTY_PREFIX, "abc", session.getPathDelimiter()))
+                .build()
+                .asUserBound());
     }
 
     @Test
-    public void getPathLikeShouldReturnUserPathLikeWhenPrefixDefined() throws Exception {
+    public void getPathLikeShouldReturnUserPathLikeWhenPrefixDefined() {
         //Given
         MailboxSession session = MailboxSessionUtil.create("user");
         MailboxQuery.Builder testee = MailboxQuery.builder()
@@ -217,8 +223,13 @@ public class StoreMailboxManagerTest {
         //When
         MailboxQuery mailboxQuery = testee.build();
 
-        assertThat(StoreMailboxManager.getPathLike(mailboxQuery, session))
-            .isEqualTo(MailboxPath.forUser("user", "prefix.abc%"));
+        assertThat(StoreMailboxManager.toSingleUserQuery(mailboxQuery, session))
+            .isEqualTo(MailboxQuery.builder()
+                .namespace(MailboxConstants.USER_NAMESPACE)
+                .username("user")
+                .expression(new PrefixedRegex("prefix.", "abc", session.getPathDelimiter()))
+                .build()
+                .asUserBound());
     }
 }
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxManagerTest.java
@@ -208,7 +208,7 @@ public class StoreMailboxManagerTest {
             .isEqualTo(MailboxQuery.builder()
                 .namespace(MailboxConstants.USER_NAMESPACE)
                 .username("user")
-                .expression(new PrefixedRegex(EMPTY_PREFIX, "abc.*", session.getPathDelimiter()))
+                .expression(new PrefixedRegex(EMPTY_PREFIX, "abc*", session.getPathDelimiter()))
                 .build()
                 .asUserBound());
     }
@@ -227,7 +227,7 @@ public class StoreMailboxManagerTest {
             .isEqualTo(MailboxQuery.builder()
                 .namespace(MailboxConstants.USER_NAMESPACE)
                 .username("user")
-                .expression(new PrefixedRegex("prefix.", "abc.*", session.getPathDelimiter()))
+                .expression(new PrefixedRegex("prefix.", "abc*", session.getPathDelimiter()))
                 .build()
                 .asUserBound());
     }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxManagerTest.java
@@ -208,7 +208,7 @@ public class StoreMailboxManagerTest {
             .isEqualTo(MailboxQuery.builder()
                 .namespace(MailboxConstants.USER_NAMESPACE)
                 .username("user")
-                .expression(new PrefixedRegex(EMPTY_PREFIX, "abc", session.getPathDelimiter()))
+                .expression(new PrefixedRegex(EMPTY_PREFIX, "abc.*", session.getPathDelimiter()))
                 .build()
                 .asUserBound());
     }
@@ -227,7 +227,7 @@ public class StoreMailboxManagerTest {
             .isEqualTo(MailboxQuery.builder()
                 .namespace(MailboxConstants.USER_NAMESPACE)
                 .username("user")
-                .expression(new PrefixedRegex("prefix.", "abc", session.getPathDelimiter()))
+                .expression(new PrefixedRegex("prefix.", "abc.*", session.getPathDelimiter()))
                 .build()
                 .asUserBound());
     }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMapperTest.java
@@ -60,18 +60,6 @@ public abstract class MailboxMapperTest {
     private Mailbox bobyMailbox;
     private MailboxPath bobyMailboxPath;
     private Mailbox bobInboxMailbox;
-    private MailboxPath esnDevGroupInboxPath;
-    private Mailbox esnDevGroupInboxMailbox;
-    private MailboxPath esnDevGroupHublinPath;
-    private Mailbox esnDevGroupHublinMailbox;
-    private MailboxPath esnDevGroupJamesPath;
-    private Mailbox esnDevGroupJamesMailbox;
-    private MailboxPath obmTeamGroupInboxPath;
-    private Mailbox obmTeamGroupInboxMailbox;
-    private MailboxPath obmTeamGroupOPushPath;
-    private Mailbox obmTeamGroupOPushMailbox;
-    private MailboxPath obmTeamGroupRoundCubePath;
-    private Mailbox obmTeamGroupRoundCubeMailbox;
     private MailboxPath bobDifferentNamespacePath;
     private Mailbox bobDifferentNamespaceMailbox;
 
@@ -111,20 +99,12 @@ public abstract class MailboxMapperTest {
     }
 
     @Test
-    public void saveWithNullUserShouldPersistTheMailbox() throws MailboxException {
-        mailboxMapper.save(esnDevGroupInboxMailbox);
-        MailboxAssert.assertThat(mailboxMapper.findMailboxByPath(esnDevGroupInboxPath)).isEqualTo(esnDevGroupInboxMailbox);
-    }
-
-    @Test
     public void listShouldRetrieveAllMailbox() throws MailboxException {
         saveAll();
         List<Mailbox> mailboxes = mailboxMapper.list();
 
         assertMailboxes(mailboxes)
             .containOnly(benwaInboxMailbox, benwaWorkMailbox, benwaWorkTodoMailbox, benwaPersoMailbox, benwaWorkDoneMailbox, 
-                esnDevGroupInboxMailbox, esnDevGroupHublinMailbox, esnDevGroupJamesMailbox, 
-                obmTeamGroupInboxMailbox, obmTeamGroupOPushMailbox, obmTeamGroupRoundCubeMailbox, 
                 bobyMailbox, bobDifferentNamespaceMailbox, bobInboxMailbox);
     }
     
@@ -138,18 +118,6 @@ public abstract class MailboxMapperTest {
     public void hasChildrenShouldReturnTrueWhenChildrenExists() throws MailboxException {
         saveAll();
         assertThat(mailboxMapper.hasChildren(benwaInboxMailbox, DELIMITER)).isTrue();
-    }
-
-    @Test
-    public void hasChildrenWithNullUserShouldReturnFalseWhenNoChildrenExists() throws MailboxException {
-        saveAll();
-        assertThat(mailboxMapper.hasChildren(esnDevGroupHublinMailbox, DELIMITER)).isFalse();
-    }
-
-    @Test
-    public void hasChildrenWithNullUserShouldReturnTrueWhenChildrenExists() throws MailboxException {
-        saveAll();
-        assertThat(mailboxMapper.hasChildren(esnDevGroupInboxMailbox, DELIMITER)).isTrue();
     }
 
     @Test
@@ -177,15 +145,6 @@ public abstract class MailboxMapperTest {
     }
 
     @Test
-    public void deleteWithNullUserShouldEraseTheGivenMailbox() throws MailboxException {
-        saveAll();
-        mailboxMapper.delete(esnDevGroupJamesMailbox);
-
-        assertThatThrownBy(() -> mailboxMapper.findMailboxByPath(esnDevGroupJamesPath))
-            .isInstanceOf(MailboxNotFoundException.class);
-    }
-
-    @Test
     public void findMailboxWithPathLikeWithChildRegexShouldRetrieveChildren() throws MailboxException {
         saveAll();
         MailboxPath regexPath = new MailboxPath(benwaWorkPath.getNamespace(), benwaWorkPath.getUser(), benwaWorkPath.getName() + WILDCARD);
@@ -195,33 +154,17 @@ public abstract class MailboxMapperTest {
     }
 
     @Test
-    public void findMailboxWithPathLikeWithNullUserWithChildRegexShouldRetrieveChildren() throws MailboxException {
-        saveAll();
-        MailboxPath regexPath = new MailboxPath(obmTeamGroupInboxPath.getNamespace(), obmTeamGroupInboxPath.getUser(), obmTeamGroupInboxPath.getName() + WILDCARD);
-
-        List<Mailbox> mailboxes = mailboxMapper.findMailboxWithPathLike(regexPath);
-
-        assertMailboxes(mailboxes).containOnly(obmTeamGroupInboxMailbox, obmTeamGroupOPushMailbox, obmTeamGroupRoundCubeMailbox);
-    }
-    
-    @Test
     public void findMailboxWithPathLikeWithRegexShouldRetrieveCorrespondingMailbox() throws MailboxException {
         saveAll();
-        MailboxPath regexPath = new MailboxPath(benwaInboxPath.getNamespace(), benwaInboxPath.getUser(), WILDCARD + "X");
+        MailboxQuery.UserBound mailboxQuery = MailboxQuery.builder()
+            .userAndNamespaceFrom(benwaWorkPath)
+            .expression(new ExactName("INBOX"))
+            .build()
+            .asUserBound();
 
-        List<Mailbox> mailboxes = mailboxMapper.findMailboxWithPathLike(regexPath);
+        List<Mailbox> mailboxes = mailboxMapper.findMailboxWithPathLike(mailboxQuery);
 
         assertMailboxes(mailboxes).containOnly(benwaInboxMailbox);
-    }
-
-    @Test
-    public void findMailboxWithPathLikeWithNullUserWithRegexShouldRetrieveCorrespondingMailbox() throws MailboxException {
-        saveAll();
-        MailboxPath regexPath = new MailboxPath(esnDevGroupInboxPath.getNamespace(), esnDevGroupInboxPath.getUser(), WILDCARD + "X");
-
-        List<Mailbox> mailboxes = mailboxMapper.findMailboxWithPathLike(regexPath);
-
-        assertMailboxes(mailboxes).containOnly(esnDevGroupInboxMailbox);
     }
 
     @Test
@@ -256,12 +199,6 @@ public abstract class MailboxMapperTest {
         bobInboxPath = MailboxPath.forUser("bob", "INBOX");
         bobyMailboxPath = MailboxPath.forUser("boby", "INBOX.that.is.a.trick");
         bobDifferentNamespacePath = new MailboxPath("#private_bob", "bob", "INBOX.bob");
-        esnDevGroupInboxPath = new MailboxPath("#community_ESN_DEV", null, "INBOX");
-        esnDevGroupHublinPath = new MailboxPath("#community_ESN_DEV", null, "INBOX" + DELIMITER + "hublin");
-        esnDevGroupJamesPath = new MailboxPath("#community_ESN_DEV", null, "INBOX" + DELIMITER + "james");
-        obmTeamGroupInboxPath = new MailboxPath("#community_OBM_Core_Team", null, "INBOX");
-        obmTeamGroupOPushPath = new MailboxPath("#community_OBM_Core_Team", null, "INBOX" + DELIMITER + "OPush");
-        obmTeamGroupRoundCubePath = new MailboxPath("#community_OBM_Core_Team", null, "INBOX" + DELIMITER + "roundCube");
 
         benwaInboxMailbox = createMailbox(benwaInboxPath);
         benwaWorkMailbox = createMailbox(benwaWorkPath);
@@ -269,12 +206,6 @@ public abstract class MailboxMapperTest {
         benwaPersoMailbox = createMailbox(benwaPersoPath);
         benwaWorkDoneMailbox = createMailbox(benwaWorkDonePath);
         bobInboxMailbox = createMailbox(bobInboxPath);
-        esnDevGroupInboxMailbox = createMailbox(esnDevGroupInboxPath);
-        esnDevGroupHublinMailbox = createMailbox(esnDevGroupHublinPath);
-        esnDevGroupJamesMailbox = createMailbox(esnDevGroupJamesPath);
-        obmTeamGroupInboxMailbox = createMailbox(obmTeamGroupInboxPath);
-        obmTeamGroupOPushMailbox = createMailbox(obmTeamGroupOPushPath);
-        obmTeamGroupRoundCubeMailbox = createMailbox(obmTeamGroupRoundCubePath);
         bobyMailbox = createMailbox(bobyMailboxPath);
         bobDifferentNamespaceMailbox = createMailbox(bobDifferentNamespacePath);
     }
@@ -285,12 +216,6 @@ public abstract class MailboxMapperTest {
         mailboxMapper.save(benwaWorkTodoMailbox);
         mailboxMapper.save(benwaPersoMailbox);
         mailboxMapper.save(benwaWorkDoneMailbox);
-        mailboxMapper.save(esnDevGroupInboxMailbox);
-        mailboxMapper.save(esnDevGroupHublinMailbox);
-        mailboxMapper.save(esnDevGroupJamesMailbox);
-        mailboxMapper.save(obmTeamGroupInboxMailbox);
-        mailboxMapper.save(obmTeamGroupOPushMailbox);
-        mailboxMapper.save(obmTeamGroupRoundCubeMailbox);
         mailboxMapper.save(bobyMailbox);
         mailboxMapper.save(bobDifferentNamespaceMailbox);
         mailboxMapper.save(bobInboxMailbox);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMapperTest.java
@@ -32,6 +32,9 @@ import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxAssert;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.search.ExactName;
+import org.apache.james.mailbox.model.search.MailboxQuery;
+import org.apache.james.mailbox.model.search.PrefixedWildcard;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.junit.Test;
 
@@ -129,8 +132,13 @@ public abstract class MailboxMapperTest {
     @Test
     public void findMailboxWithPathLikeShouldBeLimitedToUserAndNamespace() throws MailboxException {
         saveAll();
-        MailboxPath mailboxPathQuery = new MailboxPath(bobInboxMailbox.getNamespace(), bobInboxMailbox.getUser(), "IN" + WILDCARD);
-        List<Mailbox> mailboxes = mailboxMapper.findMailboxWithPathLike(mailboxPathQuery);
+        MailboxQuery.UserBound mailboxQuery = MailboxQuery.builder()
+            .userAndNamespaceFrom(bobInboxPath)
+            .expression(new PrefixedWildcard("IN"))
+            .build()
+            .asUserBound();
+
+        List<Mailbox> mailboxes = mailboxMapper.findMailboxWithPathLike(mailboxQuery);
 
         assertMailboxes(mailboxes).containOnly(bobInboxMailbox);
     }
@@ -147,8 +155,13 @@ public abstract class MailboxMapperTest {
     @Test
     public void findMailboxWithPathLikeWithChildRegexShouldRetrieveChildren() throws MailboxException {
         saveAll();
-        MailboxPath regexPath = new MailboxPath(benwaWorkPath.getNamespace(), benwaWorkPath.getUser(), benwaWorkPath.getName() + WILDCARD);
-        List<Mailbox> mailboxes = mailboxMapper.findMailboxWithPathLike(regexPath);
+        MailboxQuery.UserBound mailboxQuery = MailboxQuery.builder()
+            .userAndNamespaceFrom(benwaWorkPath)
+            .expression(new PrefixedWildcard(benwaWorkPath.getName()))
+            .build()
+            .asUserBound();
+
+        List<Mailbox> mailboxes = mailboxMapper.findMailboxWithPathLike(mailboxQuery);
 
         assertMailboxes(mailboxes).containOnly(benwaWorkMailbox, benwaWorkDoneMailbox, benwaWorkTodoMailbox);
     }
@@ -170,8 +183,13 @@ public abstract class MailboxMapperTest {
     @Test
     public void findMailboxWithPathLikeShouldEscapeMailboxName() throws MailboxException {
         saveAll();
-        MailboxPath regexPath = new MailboxPath(benwaInboxPath.getNamespace(), benwaInboxPath.getUser(), "INB?X");
-        assertThat(mailboxMapper.findMailboxWithPathLike(regexPath)).isEmpty();
+        MailboxQuery.UserBound mailboxQuery = MailboxQuery.builder()
+            .userAndNamespaceFrom(benwaInboxPath)
+            .expression(new ExactName("INB?X"))
+            .build()
+            .asUserBound();
+
+        assertThat(mailboxMapper.findMailboxWithPathLike(mailboxQuery)).isEmpty();
     }
 
     @Test

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/quota/DefaultUserQuotaRootResolverTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/quota/DefaultUserQuotaRootResolverTest.java
@@ -89,7 +89,7 @@ public class DefaultUserQuotaRootResolverTest {
         when(mockedFactory.getMailboxMapper(MAILBOX_SESSION)).thenReturn(mockedMapper);
         when(mockedMapper.findMailboxWithPathLike(PATH_LIKE)).thenReturn(Lists.newArrayList(MAILBOX, MAILBOX_2));
 
-        assertThat(testee.retrieveAssociatedMailboxes(QUOTA_ROOT, MAILBOX_SESSION)).containsOnly(MAILBOX_PATH, MAILBOX_PATH_2);
+        assertThat(testee.retrieveAssociatedMailboxes(QUOTA_ROOT, MAILBOX_SESSION)).containsOnly(MAILBOX, MAILBOX_2);
     }
 
     @Test(expected = MailboxException.class)

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/quota/DefaultUserQuotaRootResolverTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/quota/DefaultUserQuotaRootResolverTest.java
@@ -87,7 +87,7 @@ public class DefaultUserQuotaRootResolverTest {
     public void retrieveAssociatedMailboxesShouldWork() throws Exception {
         MailboxMapper mockedMapper = mock(MailboxMapper.class);
         when(mockedFactory.getMailboxMapper(MAILBOX_SESSION)).thenReturn(mockedMapper);
-        when(mockedMapper.findMailboxWithPathLike(PATH_LIKE)).thenReturn(Lists.newArrayList(MAILBOX, MAILBOX_2));
+        when(mockedMapper.findMailboxWithPathLike(any())).thenReturn(Lists.newArrayList(MAILBOX, MAILBOX_2));
 
         assertThat(testee.retrieveAssociatedMailboxes(QUOTA_ROOT, MAILBOX_SESSION)).containsOnly(MAILBOX, MAILBOX_2);
     }

--- a/protocols/imap/src/main/java/org/apache/james/imap/main/PathConverter.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/main/PathConverter.java
@@ -48,17 +48,13 @@ public class PathConverter {
 
     public MailboxPath buildFullPath(String mailboxName) {
         if (Strings.isNullOrEmpty(mailboxName)) {
-            return buildDefaultPath();
+            return buildRelativePath("");
         }
         if (isAbsolute(mailboxName)) {
             return buildAbsolutePath(mailboxName);
         } else {
             return buildRelativePath(mailboxName);
         }
-    }
-
-    private MailboxPath buildDefaultPath() {
-        return new MailboxPath("", "", "");
     }
 
     private boolean isAbsolute(String mailboxName) {
@@ -82,7 +78,7 @@ public class PathConverter {
         if (namespace.equals(MailboxConstants.USER_NAMESPACE)) {
             return ImapSessionUtils.getUserName(session);
         }
-        return null;
+        throw new DeniedAccessOnSharedMailboxException();
     }
 
     private MailboxPath buildMailboxPath(String namespace, String user, String mailboxName) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/GetQuotaProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/GetQuotaProcessor.java
@@ -36,8 +36,8 @@ import org.apache.james.imap.message.response.QuotaResponse;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxACL;
-import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.Quota;
 import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.mailbox.quota.QuotaManager;
@@ -100,9 +100,9 @@ public class GetQuotaProcessor extends AbstractMailboxProcessor<GetQuotaRequest>
     private boolean hasRight(QuotaRoot quotaRoot, ImapSession session) throws MailboxException {
         // If any of the mailboxes owned by quotaRoot user can be read by the current user, then we should respond to him.
         final MailboxSession mailboxSession = ImapSessionUtils.getMailboxSession(session);
-        List<MailboxPath> mailboxList = quotaRootResolver.retrieveAssociatedMailboxes(quotaRoot, mailboxSession);
-        for (MailboxPath mailboxPath : mailboxList) {
-            if (getMailboxManager().hasRight(mailboxPath, MailboxACL.Right.Read, mailboxSession)) {
+        List<Mailbox> mailboxList = quotaRootResolver.retrieveAssociatedMailboxes(quotaRoot, mailboxSession);
+        for (Mailbox mailbox : mailboxList) {
+            if (getMailboxManager().hasRight(mailbox.generateAssociatedPath(), MailboxACL.Right.Read, mailboxSession)) {
                 return true;
             }
         }

--- a/protocols/imap/src/test/java/org/apache/james/imap/main/PathConverterTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/main/PathConverterTest.java
@@ -30,7 +30,6 @@ import org.apache.james.mailbox.MailboxSessionUtil;
 import org.apache.james.mailbox.model.MailboxConstants;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -56,13 +55,13 @@ public class PathConverterTest {
     @Test
     public void buildFullPathShouldAcceptNull() {
         assertThat(pathConverter.buildFullPath(null))
-            .isEqualTo(new MailboxPath("", "", ""));
+            .isEqualTo(new MailboxPath("", USERNAME, ""));
     }
 
     @Test
     public void buildPathShouldAcceptEmpty() {
         assertThat(pathConverter.buildFullPath(""))
-            .isEqualTo(new MailboxPath("", "", ""));
+            .isEqualTo(new MailboxPath("", USERNAME, ""));
     }
 
     @Test
@@ -72,25 +71,10 @@ public class PathConverterTest {
             .isEqualTo(MailboxPath.forUser(USERNAME, mailboxName));
     }
 
-    @Ignore("Shared mailbox is not supported yet")
-    @Test
-    public void buildFullPathShouldAcceptNamespacePrefix() {
-        assertThat(pathConverter.buildFullPath("#"))
-            .isEqualTo(new MailboxPath("#", null, ""));
-    }
-
     @Test
     public void buildFullPathShouldAcceptUserNamespace() {
         assertThat(pathConverter.buildFullPath(MailboxConstants.USER_NAMESPACE))
             .isEqualTo(MailboxPath.forUser(USERNAME, ""));
-    }
-
-    @Ignore("Shared mailbox is not supported yet")
-    @Test
-    public void buildFullPathShouldAcceptNamespaceAlone() {
-        String namespace = "#any";
-        assertThat(pathConverter.buildFullPath(namespace))
-            .isEqualTo(new MailboxPath(namespace, null, ""));
     }
 
     @Test
@@ -99,28 +83,11 @@ public class PathConverterTest {
             .isEqualTo(MailboxPath.forUser(USERNAME, ""));
     }
 
-    @Ignore("Shared mailbox is not supported yet")
-    @Test
-    public void buildFullPathShouldAcceptNamespaceAndDelimiter() {
-        String namespace = "#any";
-        assertThat(pathConverter.buildFullPath(namespace + PATH_DELIMITER))
-            .isEqualTo(new MailboxPath(namespace, null, ""));
-    }
-
     @Test
     public void buildFullPathShouldAcceptFullAbsoluteUserPath() {
         String mailboxName = "mailboxName";
         assertThat(pathConverter.buildFullPath(MailboxConstants.USER_NAMESPACE + PATH_DELIMITER + mailboxName))
             .isEqualTo(MailboxPath.forUser(USERNAME, mailboxName));
-    }
-
-    @Ignore("Shared mailbox is not supported yet")
-    @Test
-    public void buildFullPathShouldAcceptFullAbsolutePath() {
-        String namespace = "#any";
-        String mailboxName = "mailboxName";
-        assertThat(pathConverter.buildFullPath(namespace + PATH_DELIMITER + mailboxName))
-            .isEqualTo(new MailboxPath(namespace, null, mailboxName));
     }
 
     @Test
@@ -135,15 +102,6 @@ public class PathConverterTest {
         String mailboxName = "mailboxName.subFolder";
         assertThat(pathConverter.buildFullPath(MailboxConstants.USER_NAMESPACE + PATH_DELIMITER + mailboxName))
             .isEqualTo(MailboxPath.forUser(USERNAME, mailboxName));
-    }
-
-    @Ignore("Shared mailbox is not supported yet")
-    @Test
-    public void buildFullPathShouldAcceptAbsolutePathWithSubFolder() {
-        String namespace = "#any";
-        String mailboxName = "mailboxName.subFolder";
-        assertThat(pathConverter.buildFullPath(namespace + PATH_DELIMITER + mailboxName))
-            .isEqualTo(new MailboxPath(namespace, null, mailboxName));
     }
 
     @Test

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/GetQuotaProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/GetQuotaProcessorTest.java
@@ -44,6 +44,7 @@ import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MailboxSessionUtil;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.Quota;
@@ -73,6 +74,7 @@ public class GetQuotaProcessorTest {
     private QuotaRootResolver mockedQuotaRootResolver;
     private MailboxManager mockedMailboxManager;
     private MailboxSession mailboxSession;
+    private Mailbox mailbox;
 
     @Before
     public void setUp() throws Exception {
@@ -86,6 +88,8 @@ public class GetQuotaProcessorTest {
         mockedMailboxManager = mock(MailboxManager.class);
         testee = new GetQuotaProcessor(mock(ImapProcessor.class), mockedMailboxManager,
             statusResponseFactory, mockedQuotaManager, mockedQuotaRootResolver, new NoopMetricFactory());
+        mailbox = mock(Mailbox.class);
+        when(mailbox.generateAssociatedPath()).thenReturn(MAILBOX_PATH);
     }
 
     @Test
@@ -96,7 +100,7 @@ public class GetQuotaProcessorTest {
         when(mockedImapSession.getAttribute(ImapSessionUtils.MAILBOX_SESSION_ATTRIBUTE_SESSION_KEY))
             .thenReturn(mailboxSession);
         when(mockedQuotaRootResolver.retrieveAssociatedMailboxes(QUOTA_ROOT, mailboxSession))
-            .thenReturn(ImmutableList.of(MAILBOX_PATH));
+            .thenReturn(ImmutableList.of(mailbox));
         when(mockedMailboxManager.hasRight(MAILBOX_PATH, MailboxACL.Right.Read, mailboxSession))
             .thenReturn(true);
         when(mockedQuotaManager.getMessageQuota(QUOTA_ROOT)).thenReturn(MESSAGE_QUOTA);
@@ -126,7 +130,7 @@ public class GetQuotaProcessorTest {
         when(mockedImapSession.getAttribute(ImapSessionUtils.MAILBOX_SESSION_ATTRIBUTE_SESSION_KEY))
             .thenReturn(mailboxSession);
         when(mockedQuotaRootResolver.retrieveAssociatedMailboxes(QUOTA_ROOT, mailboxSession))
-            .thenReturn(ImmutableList.of(MAILBOX_PATH));
+            .thenReturn(ImmutableList.of(mailbox));
         when(mockedMailboxManager.hasRight(MAILBOX_PATH, MailboxACL.Right.Read, mailboxSession))
             .thenReturn(true);
         when(mockedQuotaManager.getMessageQuota(QUOTA_ROOT)).thenThrow(new MailboxException());
@@ -151,7 +155,7 @@ public class GetQuotaProcessorTest {
         when(mockedImapSession.getAttribute(ImapSessionUtils.MAILBOX_SESSION_ATTRIBUTE_SESSION_KEY))
             .thenReturn(mailboxSession);
         when(mockedQuotaRootResolver.retrieveAssociatedMailboxes(QUOTA_ROOT, mailboxSession))
-            .thenReturn(ImmutableList.of(MAILBOX_PATH));
+            .thenReturn(ImmutableList.of(mailbox));
         when(mockedMailboxManager.hasRight(MAILBOX_PATH, MailboxACL.Right.Read, mailboxSession))
             .thenReturn(false);
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/mailbox/MailboxNamespace.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/mailbox/MailboxNamespace.java
@@ -42,6 +42,7 @@ public class MailboxNamespace {
     }
 
     public static MailboxNamespace delegated(String owner) {
+        Preconditions.checkArgument(owner != null);
         Preconditions.checkArgument(!StringUtils.isBlank(owner));
         return new MailboxNamespace(Type.Delegated, Optional.of(owner));
     }


### PR DESCRIPTION
This is a mandatory step to restrict use of `*` and `%` which usage is discouraged in RFC-3501.