### PR TITLE
JAMES-2981 Keyspace creation should be optional

### DIFF
--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/KeyspaceFactory.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/KeyspaceFactory.java
@@ -26,7 +26,7 @@ import com.datastax.driver.core.Session;
 
 public class KeyspaceFactory {
     public static void createKeyspace(ClusterConfiguration clusterConfiguration, Cluster cluster) {
-        if (clusterConfiguration.isCreateKeyspace()) {
+        if (clusterConfiguration.shouldCreateKeyspace()) {
             try (Session session = cluster.connect()) {
                 session.execute("CREATE KEYSPACE IF NOT EXISTS " + clusterConfiguration.getKeyspace()
                     + " WITH replication = {'class':'SimpleStrategy', 'replication_factor':" + clusterConfiguration.getReplicationFactor() + "}"

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/KeyspaceFactory.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/KeyspaceFactory.java
@@ -27,12 +27,16 @@ import com.datastax.driver.core.Session;
 public class KeyspaceFactory {
     public static void createKeyspace(ClusterConfiguration clusterConfiguration, Cluster cluster) {
         if (clusterConfiguration.shouldCreateKeyspace()) {
-            try (Session session = cluster.connect()) {
-                session.execute("CREATE KEYSPACE IF NOT EXISTS " + clusterConfiguration.getKeyspace()
-                    + " WITH replication = {'class':'SimpleStrategy', 'replication_factor':" + clusterConfiguration.getReplicationFactor() + "}"
-                    + " AND durable_writes = " + clusterConfiguration.isDurableWrites()
-                    + ";");
-            }
+            doCreateKeyspace(clusterConfiguration, cluster);
+        }
+    }
+
+    private static void doCreateKeyspace(ClusterConfiguration clusterConfiguration, Cluster cluster) {
+        try (Session session = cluster.connect()) {
+            session.execute("CREATE KEYSPACE IF NOT EXISTS " + clusterConfiguration.getKeyspace()
+                + " WITH replication = {'class':'SimpleStrategy', 'replication_factor':" + clusterConfiguration.getReplicationFactor() + "}"
+                + " AND durable_writes = " + clusterConfiguration.isDurableWrites()
+                + ";");
         }
     }
 }

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/KeyspaceFactory.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/KeyspaceFactory.java
@@ -26,11 +26,13 @@ import com.datastax.driver.core.Session;
 
 public class KeyspaceFactory {
     public static void createKeyspace(ClusterConfiguration clusterConfiguration, Cluster cluster) {
-        try (Session session = cluster.connect()) {
-            session.execute("CREATE KEYSPACE IF NOT EXISTS " + clusterConfiguration.getKeyspace()
-                + " WITH replication = {'class':'SimpleStrategy', 'replication_factor':" + clusterConfiguration.getReplicationFactor() + "}"
-                + " AND durable_writes = " + clusterConfiguration.isDurableWrites()
-                + ";");
+        if (clusterConfiguration.isCreateKeyspace()) {
+            try (Session session = cluster.connect()) {
+                session.execute("CREATE KEYSPACE IF NOT EXISTS " + clusterConfiguration.getKeyspace()
+                    + " WITH replication = {'class':'SimpleStrategy', 'replication_factor':" + clusterConfiguration.getReplicationFactor() + "}"
+                    + " AND durable_writes = " + clusterConfiguration.isDurableWrites()
+                    + ";");
+            }
         }
     }
 }

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/configuration/ClusterConfiguration.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/configuration/ClusterConfiguration.java
@@ -37,6 +37,7 @@ public class ClusterConfiguration {
 
     public static class Builder {
         private ImmutableList.Builder<Host> hosts;
+        private boolean createKeyspace;
         private Optional<String> keyspace;
         private Optional<Integer> replicationFactor;
         private Optional<Integer> minDelay;
@@ -52,6 +53,7 @@ public class ClusterConfiguration {
 
         public Builder() {
             hosts = ImmutableList.builder();
+            createKeyspace = true;
             keyspace = Optional.empty();
             replicationFactor = Optional.empty();
             minDelay = Optional.empty();
@@ -78,6 +80,11 @@ public class ClusterConfiguration {
 
         public Builder hosts(Host... hosts) {
             this.hosts.addAll(Arrays.asList(hosts));
+            return this;
+        }
+
+        public Builder createKeyspace(boolean createKeyspace) {
+            this.createKeyspace = createKeyspace;
             return this;
         }
 
@@ -189,6 +196,7 @@ public class ClusterConfiguration {
         public ClusterConfiguration build() {
             return new ClusterConfiguration(
                 hosts.build(),
+                createKeyspace,
                 keyspace.orElse(DEFAULT_KEYSPACE),
                 replicationFactor.orElse(DEFAULT_REPLICATION_FACTOR),
                 minDelay.orElse(DEFAULT_CONNECTION_MIN_DELAY),
@@ -205,6 +213,7 @@ public class ClusterConfiguration {
     }
 
     private static final String CASSANDRA_NODES = "cassandra.nodes";
+    public static final String CASSANDRA_CREATE_KEYSPACE = "cassandra.create.keyspace";
     public static final String CASSANDRA_KEYSPACE = "cassandra.keyspace";
     public static final String CASSANDRA_USER = "cassandra.user";
     public static final String CASSANDRA_PASSWORD = "cassandra.password";
@@ -232,6 +241,7 @@ public class ClusterConfiguration {
     public static ClusterConfiguration from(Configuration configuration) {
         return ClusterConfiguration.builder()
             .hosts(listCassandraServers(configuration))
+            .createKeyspace(configuration.getBoolean(CASSANDRA_CREATE_KEYSPACE, true))
             .keyspace(Optional.ofNullable(configuration.getString(CASSANDRA_KEYSPACE, null)))
             .replicationFactor(Optional.ofNullable(configuration.getInteger(REPLICATION_FACTOR, null)))
             .minDelay(Optional.ofNullable(configuration.getInteger(CONNECTION_RETRY_MIN_DELAY, null)))
@@ -286,6 +296,7 @@ public class ClusterConfiguration {
     }
 
     private final List<Host> hosts;
+    private final boolean createKeyspace;
     private final String keyspace;
     private final int replicationFactor;
     private final int minDelay;
@@ -299,11 +310,12 @@ public class ClusterConfiguration {
     private final Optional<String> password;
     private final boolean durableWrites;
 
-    public ClusterConfiguration(List<Host> hosts, String keyspace, int replicationFactor, int minDelay, int maxRetry,
+    public ClusterConfiguration(List<Host> hosts, boolean createKeyspace, String keyspace, int replicationFactor, int minDelay, int maxRetry,
                                 Optional<QueryLoggerConfiguration> queryLoggerConfiguration, Optional<PoolingOptions> poolingOptions,
                                 int readTimeoutMillis, int connectTimeoutMillis, boolean useSsl, Optional<String> username,
                                 Optional<String> password, boolean durableWrites) {
         this.hosts = hosts;
+        this.createKeyspace = createKeyspace;
         this.keyspace = keyspace;
         this.replicationFactor = replicationFactor;
         this.minDelay = minDelay;
@@ -324,6 +336,10 @@ public class ClusterConfiguration {
 
     public List<Host> getHosts() {
         return hosts;
+    }
+
+    public boolean isCreateKeyspace() {
+        return createKeyspace;
     }
 
     public String getKeyspace() {
@@ -378,6 +394,7 @@ public class ClusterConfiguration {
             return Objects.equals(this.minDelay, that.minDelay)
                 && Objects.equals(this.maxRetry, that.maxRetry)
                 && Objects.equals(this.hosts, that.hosts)
+                && Objects.equals(this.createKeyspace, that.createKeyspace)
                 && Objects.equals(this.keyspace, that.keyspace)
                 && Objects.equals(this.replicationFactor, that.replicationFactor)
                 && Objects.equals(this.queryLoggerConfiguration, that.queryLoggerConfiguration)
@@ -393,7 +410,7 @@ public class ClusterConfiguration {
 
     @Override
     public final int hashCode() {
-        return Objects.hash(hosts, keyspace, replicationFactor, minDelay, maxRetry, queryLoggerConfiguration, poolingOptions,
+        return Objects.hash(hosts, createKeyspace, keyspace, replicationFactor, minDelay, maxRetry, queryLoggerConfiguration, poolingOptions,
             readTimeoutMillis, connectTimeoutMillis, username, useSsl, password);
     }
 }

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/CassandraCluster.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/CassandraCluster.java
@@ -60,6 +60,7 @@ public final class CassandraCluster implements AutoCloseable {
             ClusterConfiguration clusterConfiguration = ClusterConfiguration.builder()
                 .host(host)
                 .keyspace(KEYSPACE)
+                .createKeyspace()
                 .disableDurableWrites()
                 .build();
             cluster = ClusterFactory.create(clusterConfiguration);

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/init/SessionWithInitializedTablesFactoryTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/init/SessionWithInitializedTablesFactoryTest.java
@@ -123,6 +123,7 @@ class SessionWithInitializedTablesFactoryTest {
         ClusterConfiguration clusterConfiguration = ClusterConfiguration.builder()
             .host(cassandraServer.getHost())
             .keyspace(KEYSPACE)
+            .createKeyspace()
             .replicationFactor(1)
             .disableDurableWrites()
             .build();

--- a/dockerfiles/run/guice/cassandra-ldap/destination/conf/cassandra.properties
+++ b/dockerfiles/run/guice/cassandra-ldap/destination/conf/cassandra.properties
@@ -2,6 +2,7 @@
 # Read https://james.apache.org/server/config-cassandra.html for further details
 
 cassandra.nodes=cassandra
+cassandra.keyspace.create=true
 cassandra.keyspace=apache_james
 #cassandra.user=cassandra
 #cassandra.password=cassandra

--- a/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/cassandra.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/cassandra.properties
@@ -2,6 +2,7 @@
 # Read https://james.apache.org/server/config-cassandra.html for further details
 
 cassandra.nodes=cassandra
+cassandra.keyspace.create=true
 cassandra.keyspace=apache_james
 #cassandra.user=cassandra
 #cassandra.password=cassandra

--- a/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/cassandra.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/cassandra.properties
@@ -2,6 +2,7 @@
 # Read https://james.apache.org/server/config-cassandra.html for further details
 
 cassandra.nodes=cassandra
+cassandra.keyspace.create=true
 cassandra.keyspace=apache_james
 #cassandra.user=cassandra
 #cassandra.password=cassandra

--- a/dockerfiles/run/guice/cassandra/destination/conf/cassandra.properties
+++ b/dockerfiles/run/guice/cassandra/destination/conf/cassandra.properties
@@ -2,6 +2,7 @@
 # Read https://james.apache.org/server/config-cassandra.html for further details
 
 cassandra.nodes=cassandra
+cassandra.create.keyspace=true
 cassandra.keyspace=apache_james
 #cassandra.user=cassandra
 #cassandra.password=cassandra

--- a/dockerfiles/run/guice/cassandra/destination/conf/cassandra.properties
+++ b/dockerfiles/run/guice/cassandra/destination/conf/cassandra.properties
@@ -2,7 +2,7 @@
 # Read https://james.apache.org/server/config-cassandra.html for further details
 
 cassandra.nodes=cassandra
-cassandra.create.keyspace=true
+cassandra.keyspace.create=true
 cassandra.keyspace=apache_james
 #cassandra.user=cassandra
 #cassandra.password=cassandra

--- a/mpt/impl/smtp/cassandra-rabbitmq-object-storage/src/test/java/org/apache/james/mpt/smtp/CassandraRabbitMQAwsS3SmtpTestRuleFactory.java
+++ b/mpt/impl/smtp/cassandra-rabbitmq-object-storage/src/test/java/org/apache/james/mpt/smtp/CassandraRabbitMQAwsS3SmtpTestRuleFactory.java
@@ -67,6 +67,7 @@ public final class CassandraRabbitMQAwsS3SmtpTestRuleFactory {
                     ClusterConfiguration.builder()
                         .host(cassandraHost)
                         .keyspace("testing")
+                        .createKeyspace()
                         .replicationFactor(1)
                         .build()),
                 binder -> binder.bind(DNSService.class).toInstance(dnsService),

--- a/mpt/impl/smtp/cassandra/src/test/java/org/apache/james/mpt/smtp/CassandraSmtpTestRuleFactory.java
+++ b/mpt/impl/smtp/cassandra/src/test/java/org/apache/james/mpt/smtp/CassandraSmtpTestRuleFactory.java
@@ -55,6 +55,7 @@ public final class CassandraSmtpTestRuleFactory {
                     ClusterConfiguration.builder()
                         .host(cassandraHost)
                         .keyspace("testing")
+                        .createKeyspace()
                         .replicationFactor(1)
                         .build()),
                 binder -> binder.bind(DNSService.class).toInstance(dnsService));

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/AuthenticatedCassandraJamesServerTest.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/AuthenticatedCassandraJamesServerTest.java
@@ -68,6 +68,7 @@ class AuthenticatedCassandraJamesServerTest {
                 .toInstance(ClusterConfiguration.builder()
                     .host(cassandraExtension.getCassandra().getHost())
                     .keyspace("testing")
+                    .createKeyspace()
                     .replicationFactor(1)
                     .maxRetry(1)
                     .minDelay(100)

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraAuthenticationExtension.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraAuthenticationExtension.java
@@ -64,6 +64,7 @@ public class CassandraAuthenticationExtension implements GuiceModuleTestExtensio
                 .toInstance(configurationBuilder
                     .host(authenticatedCassandra.getHost())
                     .keyspace("testing")
+                    .createKeyspace()
                     .username("cassandra")
                     .replicationFactor(1)
                     .build()),

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraNodeConfTest.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraNodeConfTest.java
@@ -128,6 +128,7 @@ class CassandraNodeConfTest {
         return ClusterConfiguration.builder()
             .hosts(hosts)
             .keyspace("apache_james")
+            .createKeyspace()
             .replicationFactor(1)
             .maxRetry(10)
             .minDelay(5000)

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/DockerCassandraRule.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/DockerCassandraRule.java
@@ -49,6 +49,7 @@ public class DockerCassandraRule implements GuiceModuleTestRule {
             .toInstance(ClusterConfiguration.builder()
                 .host(cassandraContainer.getHost())
                 .keyspace("testing")
+                .createKeyspace()
                 .replicationFactor(1)
                 .maxRetry(20)
                 .minDelay(5000)

--- a/src/site/xdoc/server/config-cassandra.xml
+++ b/src/site/xdoc/server/config-cassandra.xml
@@ -35,6 +35,11 @@
         <dt><strong>cassandra.nodes</strong></dt>
         <dd>List of some nodes of the cassandra's cluster in following format host:port or host, if the port is not specified we use 9042</dd>
 
+        <dt><strong>cassandra.keyspace.create</strong></dt>
+        <dd>Indicate if the keyspace should be created by James. Optional, default value: <b>false</b><br />
+            If set to true James will attempt to create the keyspace when starting up.<br />
+        </dd>
+
         <dt><strong>cassandra.keyspace</strong></dt>
         <dd>Is the name of the keyspace used by James. Optional, default value: <b>apache_james</b></dd>
 


### PR DESCRIPTION
Hi,

This PR needs to be adapted to our latest coding style.

The cassandra user may not have all authorization on the Cassandra cluster (may be he can't create keyspace).

The underlying explanation is that a Cassandra cluster may be used to serve multiple instances of James.
We have to ensure that one James instance can't see data of another.