### PR TITLE
[Refactoring] Slightly improve IMAP range commands handling

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/api/message/IdRange.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/message/IdRange.java
@@ -37,7 +37,7 @@ public final class IdRange implements Iterable<Long>, Comparable<IdRange> {
     /**
      * {@link Iterator} of a range of msn/uid
      */
-    private final class RangeIterator implements Iterator<Long> {
+    private static final class RangeIterator implements Iterator<Long> {
 
         private final long to;
         private long current;

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/message/IdRange.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/message/IdRange.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
+import org.apache.james.mailbox.model.MessageRange;
+
 import com.google.common.collect.ImmutableList;
 
 /**
@@ -37,6 +39,12 @@ public final class IdRange implements Iterable<Long>, Comparable<IdRange> {
         return Optional.ofNullable(ranges)
             .map(ImmutableList::copyOf)
             .toString();
+    }
+
+    public static IdRange from(MessageRange messageRange) {
+        return new IdRange(
+            messageRange.getUidFrom().asLong(),
+            messageRange.getUidTo().asLong());
     }
 
     private long lowVal;

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/message/IdRange.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/message/IdRange.java
@@ -47,8 +47,7 @@ public final class IdRange implements Iterable<Long>, Comparable<IdRange> {
             messageRange.getUidTo().asLong());
     }
 
-    private long lowVal;
-
+    private final long lowVal;
     private long highVal;
 
     public IdRange(long singleVal) {
@@ -70,13 +69,6 @@ public final class IdRange implements Iterable<Long>, Comparable<IdRange> {
 
     public long getHighVal() {
         return highVal;
-    }
-
-    public void setLowVal(long lowVal) {
-        if (lowVal > highVal) {
-            throw new IllegalArgumentException("LowVal must be <= HighVal");
-        }
-        this.lowVal = lowVal;
     }
 
     public void setHighVal(long highVal) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/message/IdRange.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/message/IdRange.java
@@ -78,14 +78,6 @@ public final class IdRange implements Iterable<Long>, Comparable<IdRange> {
         this.highVal = highVal;
     }
 
-    /**
-     * Return true if the {@link IdRange} includes the given value
-     *
-     */
-    public boolean includes(long value) {
-        return lowVal <= value && value <= highVal;
-    }
-
     @Override
     public int hashCode() {
         final int PRIME = 31;

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/message/IdRange.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/message/IdRange.java
@@ -42,7 +42,7 @@ public final class IdRange implements Iterable<Long>, Comparable<IdRange> {
         private final long to;
         private long current;
 
-        public RangeIterator(long from, long to) {
+        RangeIterator(long from, long to) {
             this.to = to;
             this.current = from;
         }
@@ -143,7 +143,7 @@ public final class IdRange implements Iterable<Long>, Comparable<IdRange> {
         return highVal;
     }
 
-    public void setHighVal(long highVal) {
+    private void setHighVal(long highVal) {
         if (lowVal > highVal) {
             throw new IllegalArgumentException("HighVal must be >= LowVal");
         }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMessageRangeProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMessageRangeProcessor.java
@@ -105,7 +105,7 @@ public abstract class AbstractMessageRangeProcessor<R extends AbstractMessageRan
             .toArray(new IdRange[0]);
 
         // get folder UIDVALIDITY
-        Long uidValidity = mailbox.getMetaData(false, mailboxSession, MessageManager.MetaData.FetchGroup.NO_UNSEEN).getUidValidity();
+        Long uidValidity = mailbox.getMailboxEntity().getUidValidity();
 
         return StatusResponse.ResponseCode.copyUid(uidValidity, request.getIdSet(), resultUids);
     }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMessageRangeProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMessageRangeProcessor.java
@@ -51,19 +51,19 @@ public abstract class AbstractMessageRangeProcessor<R extends AbstractMessageRan
         super(acceptableClass, next, mailboxManager, factory, metricFactory);
     }
 
-    protected abstract List<MessageRange> process(final MailboxPath targetMailbox,
-                                                  final SelectedMailbox currentMailbox,
-                                                  final MailboxSession mailboxSession,
+    protected abstract List<MessageRange> process(MailboxPath targetMailbox,
+                                                  SelectedMailbox currentMailbox,
+                                                  MailboxSession mailboxSession,
                                                   MessageRange messageSet) throws MailboxException;
 
     protected abstract String getOperationName();
 
     @Override
     protected void processRequest(R request, ImapSession session, Responder responder) {
-        final MailboxPath targetMailbox = PathConverter.forSession(session).buildFullPath(request.getMailboxName());
+        MailboxPath targetMailbox = PathConverter.forSession(session).buildFullPath(request.getMailboxName());
 
         try {
-            final MailboxSession mailboxSession = ImapSessionUtils.getMailboxSession(session);
+            MailboxSession mailboxSession = ImapSessionUtils.getMailboxSession(session);
 
             if (!getMailboxManager().mailboxExists(targetMailbox, mailboxSession)) {
                 no(request, responder, HumanReadableText.FAILURE_NO_SUCH_MAILBOX, StatusResponse.ResponseCode.tryCreate());
@@ -84,7 +84,7 @@ public abstract class AbstractMessageRangeProcessor<R extends AbstractMessageRan
     }
 
     private StatusResponse.ResponseCode handleRanges(R request, ImapSession session, MailboxPath targetMailbox, MailboxSession mailboxSession) throws MailboxException {
-        final MessageManager mailbox = getMailboxManager().getMailbox(targetMailbox, mailboxSession);
+        MessageManager mailbox = getMailboxManager().getMailbox(targetMailbox, mailboxSession);
 
         List<IdRange> resultRanges = new ArrayList<>();
         for (IdRange range : request.getIdSet()) {

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMessageRangeProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMessageRangeProcessor.java
@@ -54,7 +54,6 @@ public abstract class AbstractMessageRangeProcessor<R extends AbstractMessageRan
     protected abstract List<MessageRange> process(final MailboxPath targetMailbox,
                                                   final SelectedMailbox currentMailbox,
                                                   final MailboxSession mailboxSession,
-                                                  final MailboxManager mailboxManager,
                                                   MessageRange messageSet) throws MailboxException;
 
     protected abstract String getOperationName();
@@ -91,9 +90,7 @@ public abstract class AbstractMessageRangeProcessor<R extends AbstractMessageRan
         for (IdRange range : request.getIdSet()) {
             MessageRange messageSet = messageRange(session.getSelected(), range, request.isUseUids());
             if (messageSet != null) {
-                List<MessageRange> processedUids = process(
-                    targetMailbox, session.getSelected(), mailboxSession,
-                    getMailboxManager(), messageSet);
+                List<MessageRange> processedUids = process(targetMailbox, session.getSelected(), mailboxSession, messageSet);
                 for (MessageRange mr : processedUids) {
                     // Set recent flag on copied message as this SHOULD be
                     // done.

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AppendProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AppendProcessor.java
@@ -43,7 +43,6 @@ import org.apache.james.imap.message.request.AppendRequest;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageManager;
-import org.apache.james.mailbox.MessageManager.MetaData.FetchGroup;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.MailboxNotFoundException;
 import org.apache.james.mailbox.model.ComposedMessageId;
@@ -135,7 +134,9 @@ public class AppendProcessor extends AbstractMailboxProcessor<AppendRequest> {
             }
 
             // get folder UIDVALIDITY
-            Long uidValidity = mailboxManager.getMailbox(mailboxPath, mailboxSession).getMetaData(false, mailboxSession, FetchGroup.NO_COUNT).getUidValidity();
+            Long uidValidity = mailboxManager.getMailbox(mailboxPath, mailboxSession)
+                .getMailboxEntity()
+                .getUidValidity();
 
             unsolicitedResponses(session, responder, false);
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/CopyProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/CopyProcessor.java
@@ -51,8 +51,8 @@ public class CopyProcessor extends AbstractMessageRangeProcessor<CopyRequest> {
     protected List<MessageRange> process(MailboxPath targetMailbox,
                                          SelectedMailbox currentMailbox,
                                          MailboxSession mailboxSession,
-                                         MailboxManager mailboxManager, MessageRange messageSet) throws MailboxException {
-        return mailboxManager.copyMessages(messageSet, currentMailbox.getPath(), targetMailbox, mailboxSession);
+                                         MessageRange messageSet) throws MailboxException {
+        return getMailboxManager().copyMessages(messageSet, currentMailbox.getPath(), targetMailbox, mailboxSession);
     }
 
     @Override

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/MoveProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/MoveProcessor.java
@@ -51,9 +51,8 @@ public class MoveProcessor extends AbstractMessageRangeProcessor<MoveRequest> im
 
     @Override
     protected List<MessageRange> process(MailboxPath targetMailbox, SelectedMailbox currentMailbox,
-                                         MailboxSession mailboxSession,
-                                         MailboxManager mailboxManager, MessageRange messageSet) throws MailboxException {
-        return mailboxManager.moveMessages(messageSet, currentMailbox.getPath(), targetMailbox, mailboxSession);
+                                         MailboxSession mailboxSession, MessageRange messageSet) throws MailboxException {
+        return getMailboxManager().moveMessages(messageSet, currentMailbox.getPath(), targetMailbox, mailboxSession);
     }
 
     @Override

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/CopyProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/CopyProcessorTest.java
@@ -49,9 +49,9 @@ import org.apache.james.mailbox.MailboxSessionUtil;
 import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageRange;
-import org.apache.james.mailbox.store.MailboxMetaData;
 import org.apache.james.metrics.api.NoopMetricFactory;
 import org.junit.Before;
 import org.junit.Test;
@@ -97,7 +97,9 @@ public class CopyProcessorTest {
         when(mockMailboxManager.mailboxExists(inbox, mailboxSession)).thenReturn(true);
         MessageManager targetMessageManager = mock(MessageManager.class);
         when(mockMailboxManager.getMailbox(inbox, mailboxSession)).thenReturn(targetMessageManager);
-        when(targetMessageManager.getMetaData(false, mailboxSession, MessageManager.MetaData.FetchGroup.NO_UNSEEN)).thenReturn(new MailboxMetaData(null, null, 58L, MessageUid.of(18), 8L, 8L, 8L, MessageUid.of(8), true, true, null));
+        Mailbox mailbox = mock(Mailbox.class);
+        when(mailbox.getUidValidity()).thenReturn(58L);
+        when(targetMessageManager.getMailboxEntity()).thenReturn(mailbox);
         StatusResponse okResponse = mock(StatusResponse.class);
         when(mockStatusResponseFactory.taggedOk(any(Tag.class), any(ImapCommand.class), any(HumanReadableText.class), any(StatusResponse.ResponseCode.class))).thenReturn(okResponse);
         when(mockMailboxManager.moveMessages(MessageRange.range(MessageUid.of(4), MessageUid.of(6)), selected, inbox, mailboxSession)).thenReturn(Lists.<MessageRange>newArrayList(MessageRange.range(MessageUid.of(4), MessageUid.of(6))));
@@ -109,7 +111,7 @@ public class CopyProcessorTest {
         verify(mockMailboxManager).mailboxExists(inbox, mailboxSession);
         verify(mockMailboxManager).getMailbox(inbox, mailboxSession);
         verify(mockMailboxManager).copyMessages(MessageRange.range(MessageUid.of(4), MessageUid.of(6)), selected, inbox, mailboxSession);
-        verify(targetMessageManager).getMetaData(false, mailboxSession, MessageManager.MetaData.FetchGroup.NO_UNSEEN);
+        verify(targetMessageManager).getMailboxEntity();
         verify(mockResponder).respond(okResponse);
         verifyNoMoreInteractions(mockMailboxManager, targetMessageManager, mockResponder, mockNextProcessor);
     }
@@ -131,7 +133,9 @@ public class CopyProcessorTest {
         when(mockMailboxManager.mailboxExists(inbox, mailboxSession)).thenReturn(true);
         MessageManager targetMessageManager = mock(MessageManager.class);
         when(mockMailboxManager.getMailbox(inbox, mailboxSession)).thenReturn(targetMessageManager);
-        when(targetMessageManager.getMetaData(false, mailboxSession, MessageManager.MetaData.FetchGroup.NO_UNSEEN)).thenReturn(new MailboxMetaData(null, null, 58L, MessageUid.of(18), 8L, 8L, 8L, MessageUid.of(8), true, true, null));
+        Mailbox mailbox = mock(Mailbox.class);
+        when(mailbox.getUidValidity()).thenReturn(58L);
+        when(targetMessageManager.getMailboxEntity()).thenReturn(mailbox);
         StatusResponse okResponse = mock(StatusResponse.class);
         when(mockStatusResponseFactory.taggedOk(any(Tag.class), any(ImapCommand.class), any(HumanReadableText.class), any(StatusResponse.ResponseCode.class))).thenReturn(okResponse);
 
@@ -143,7 +147,7 @@ public class CopyProcessorTest {
         verify(mockMailboxManager).getMailbox(inbox, mailboxSession);
         verify(mockMailboxManager).copyMessages(MessageRange.range(MessageUid.of(5), MessageUid.of(6)), selected, inbox, mailboxSession);
         verify(mockMailboxManager).copyMessages(MessageRange.range(MessageUid.of(1), MessageUid.of(3)), selected, inbox, mailboxSession);
-        verify(targetMessageManager).getMetaData(false, mailboxSession, MessageManager.MetaData.FetchGroup.NO_UNSEEN);
+        verify(targetMessageManager).getMailboxEntity();
         verify(mockResponder).respond(okResponse);
         verifyNoMoreInteractions(mockMailboxManager, targetMessageManager, mockResponder, mockNextProcessor);
     }

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/MoveProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/MoveProcessorTest.java
@@ -52,6 +52,7 @@ import org.apache.james.mailbox.MailboxSessionUtil;
 import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.store.MailboxMetaData;
@@ -114,8 +115,9 @@ public class MoveProcessorTest {
         when(mockMailboxManager.mailboxExists(inbox, mailboxSession)).thenReturn(true);
         MessageManager targetMessageManager = mock(MessageManager.class);
         when(mockMailboxManager.getMailbox(inbox, mailboxSession)).thenReturn(targetMessageManager);
-        when(targetMessageManager.getMetaData(false, mailboxSession, MessageManager.MetaData.FetchGroup.NO_UNSEEN))
-            .thenReturn(new MailboxMetaData(null, null, 58L, MessageUid.of(18), 8L, 8L, 8L, MessageUid.of(8), true, true, null));
+        Mailbox mailbox = mock(Mailbox.class);
+        when(mailbox.getUidValidity()).thenReturn(58L);
+        when(targetMessageManager.getMailboxEntity()).thenReturn(mailbox);
         StatusResponse okResponse = mock(StatusResponse.class);
         when(mockStatusResponseFactory.taggedOk(any(Tag.class), any(ImapCommand.class), any(HumanReadableText.class), any(StatusResponse.ResponseCode.class))).thenReturn(okResponse);
         when(mockMailboxManager.moveMessages(MessageRange.range(MessageUid.of(4), MessageUid.of(6)), selected, inbox, mailboxSession))
@@ -128,7 +130,7 @@ public class MoveProcessorTest {
         verify(mockMailboxManager).mailboxExists(inbox, mailboxSession);
         verify(mockMailboxManager).getMailbox(inbox, mailboxSession);
         verify(mockMailboxManager).moveMessages(MessageRange.range(MessageUid.of(4), MessageUid.of(6)), selected, inbox, mailboxSession);
-        verify(targetMessageManager).getMetaData(false, mailboxSession, MessageManager.MetaData.FetchGroup.NO_UNSEEN);
+        verify(targetMessageManager).getMailboxEntity();
         verify(mockResponder).respond(okResponse);
         verifyNoMoreInteractions(mockMailboxManager, targetMessageManager, mockResponder, mockNextProcessor);
     }
@@ -150,8 +152,9 @@ public class MoveProcessorTest {
         when(mockMailboxManager.mailboxExists(inbox, mailboxSession)).thenReturn(true);
         MessageManager targetMessageManager = mock(MessageManager.class);
         when(mockMailboxManager.getMailbox(inbox, mailboxSession)).thenReturn(targetMessageManager);
-        when(targetMessageManager.getMetaData(false, mailboxSession, MessageManager.MetaData.FetchGroup.NO_UNSEEN))
-            .thenReturn(new MailboxMetaData(null, null, 58L, MessageUid.of(18), 8L, 8L, 8L, MessageUid.of(8), true, true, null));
+        Mailbox mailbox = mock(Mailbox.class);
+        when(mailbox.getUidValidity()).thenReturn(58L);
+        when(targetMessageManager.getMailboxEntity()).thenReturn(mailbox);
         StatusResponse okResponse = mock(StatusResponse.class);
         when(mockStatusResponseFactory.taggedOk(any(Tag.class), any(ImapCommand.class), any(HumanReadableText.class), any(StatusResponse.ResponseCode.class))).thenReturn(okResponse);
 
@@ -163,7 +166,7 @@ public class MoveProcessorTest {
         verify(mockMailboxManager).getMailbox(inbox, mailboxSession);
         verify(mockMailboxManager).moveMessages(MessageRange.range(MessageUid.of(5), MessageUid.of(6)), selected, inbox, mailboxSession);
         verify(mockMailboxManager).moveMessages(MessageRange.range(MessageUid.of(1), MessageUid.of(3)), selected, inbox, mailboxSession);
-        verify(targetMessageManager).getMetaData(false, mailboxSession, MessageManager.MetaData.FetchGroup.NO_UNSEEN);
+        verify(targetMessageManager).getMailboxEntity();
         verify(mockResponder).respond(okResponse);
         verifyNoMoreInteractions(mockMailboxManager, targetMessageManager, mockResponder, mockNextProcessor);
     }

--- a/server/protocols/protocols-pop3/src/main/java/org/apache/james/pop3server/mailbox/MailboxAdapter.java
+++ b/server/protocols/protocols-pop3/src/main/java/org/apache/james/pop3server/mailbox/MailboxAdapter.java
@@ -192,7 +192,7 @@ public class MailboxAdapter implements Mailbox {
     public String getIdentifier() throws IOException {
         try {
             mailboxManager.startProcessingRequest(session);
-            long validity = manager.getMetaData(false, session, MessageManager.MetaData.FetchGroup.NO_COUNT)
+            long validity = manager.getMailboxEntity()
                     .getUidValidity();
             return Long.toString(validity);
         } catch (MailboxException e) {


### PR DESCRIPTION
Don't ask for `IdRange::merge` rewritting, I already lost too much time trying to write it in a clean way.

Finding of the day: `COPY, MOVE & APPEND` read waaaaaaaay too much metadata upon UIDVALIDITY retrieval...