### PR TITLE
JAMES-2983 Add MailboxId as part of MailboxResponse

### DIFF
--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/dto/MailboxResponse.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/dto/MailboxResponse.java
@@ -19,15 +19,23 @@
 
 package org.apache.james.webadmin.dto;
 
+import org.apache.james.mailbox.model.MailboxId;
+
 public class MailboxResponse {
 
     private final String mailboxName;
+    private final MailboxId mailboxId;
 
-    public MailboxResponse(String mailboxName) {
+    public MailboxResponse(String mailboxName, MailboxId mailboxId) {
         this.mailboxName = mailboxName;
+        this.mailboxId = mailboxId;
     }
 
     public String getMailboxName() {
         return mailboxName;
+    }
+
+    public String getMailboxId() {
+        return mailboxId.serialize();
     }
 }

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/UserMailboxesService.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/UserMailboxesService.java
@@ -82,7 +82,7 @@ public class UserMailboxesService {
         usernamePreconditions(username);
         MailboxSession mailboxSession = mailboxManager.createSystemSession(username);
         return listUserMailboxes(mailboxSession)
-            .map(mailboxMetaData -> new MailboxResponse(mailboxMetaData.getPath().getName()))
+            .map(mailboxMetaData -> new MailboxResponse(mailboxMetaData.getPath().getName(), mailboxMetaData.getId().serialize()))
             .collect(Guavate.toImmutableList());
     }
 

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/UserMailboxesService.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/UserMailboxesService.java
@@ -82,7 +82,7 @@ public class UserMailboxesService {
         usernamePreconditions(username);
         MailboxSession mailboxSession = mailboxManager.createSystemSession(username);
         return listUserMailboxes(mailboxSession)
-            .map(mailboxMetaData -> new MailboxResponse(mailboxMetaData.getPath().getName(), mailboxMetaData.getId().serialize()))
+            .map(mailboxMetaData -> new MailboxResponse(mailboxMetaData.getPath().getName(), mailboxMetaData.getId()))
             .collect(Guavate.toImmutableList());
     }
 

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -679,8 +679,12 @@ class UserMailboxesRoutesTest {
                     .jsonPath()
                     .getList(".");
 
-            assertThat(list).containsExactly(ImmutableMap.of("mailboxName", mailboxName,
-                "mailboxId", "1"));
+            assertThat(list)
+                .hasSize(1)
+                .first()
+                .satisfies(map -> assertThat(map).hasSize(2)
+                    .containsKeys("mailboxId")
+                    .containsEntry("mailboxName", mailboxName));
         }
 
         @Test
@@ -719,8 +723,12 @@ class UserMailboxesRoutesTest {
                     .jsonPath()
                     .getList(".");
 
-            assertThat(list).containsExactly(ImmutableMap.of("mailboxName", MAILBOX_NAME,
-                "mailboxId", "1"));
+            assertThat(list)
+                .hasSize(1)
+                .first()
+                .satisfies(map -> assertThat(map).hasSize(2)
+                    .containsKeys("mailboxId")
+                    .containsEntry("mailboxName", MAILBOX_NAME));
         }
     }
 

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -25,6 +25,7 @@ import static org.apache.james.webadmin.Constants.SEPARATOR;
 import static org.apache.james.webadmin.routes.UserMailboxesRoutes.USERS_BASE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -495,7 +496,9 @@ class UserMailboxesRoutesTest {
                 .get()
             .then()
                 .statusCode(HttpStatus.OK_200)
-                .body(is("[{\"mailboxName\":\"myMailboxName\"}]"));
+                .body(".", hasSize(1))
+                .body("[0].mailboxName", is("myMailboxName"))
+                .body("[0].mailboxId", is("1"));
         }
 
         @Test
@@ -676,7 +679,8 @@ class UserMailboxesRoutesTest {
                     .jsonPath()
                     .getList(".");
 
-            assertThat(list).containsExactly(ImmutableMap.of("mailboxName", mailboxName));
+            assertThat(list).containsExactly(ImmutableMap.of("mailboxName", mailboxName,
+                "mailboxId", "1"));
         }
 
         @Test
@@ -715,7 +719,8 @@ class UserMailboxesRoutesTest {
                     .jsonPath()
                     .getList(".");
 
-            assertThat(list).containsExactly(ImmutableMap.of("mailboxName", MAILBOX_NAME));
+            assertThat(list).containsExactly(ImmutableMap.of("mailboxName", MAILBOX_NAME,
+                "mailboxId", "1"));
         }
     }
 


### PR DESCRIPTION
Currently, several webAdmin APIs relies on mailboxId in their endpoints.

That is a good choice, as mailboxId is immutable and thus more predictable than mailboxPath.

However, mailboxId is not directly exposed to the end user, who can get confused.

Currently, using webadmin, I have no way of linking mailboxPath and mailboxId

Proposal is to add mailboxId as part of the MailboxResponse object.