### PR TITLE
JAMES-2937 Calling several time the RabbitMQ endpoint should not fail

### DIFF
--- a/backends-common/rabbitmq/src/test/java/org/apache/james/backends/rabbitmq/RabbitMQHealthCheckTest.java
+++ b/backends-common/rabbitmq/src/test/java/org/apache/james/backends/rabbitmq/RabbitMQHealthCheckTest.java
@@ -52,6 +52,20 @@ class RabbitMQHealthCheckTest {
     }
 
     @Test
+    void checkShouldReturnHealthyWhenCalledSeveralTime() {
+        healthCheck.check();
+        healthCheck.check();
+        healthCheck.check();
+        healthCheck.check();
+        healthCheck.check();
+        healthCheck.check();
+        healthCheck.check();
+        Result check = healthCheck.check();
+
+        assertThat(check.isHealthy()).isTrue();
+    }
+
+    @Test
     void checkShouldReturnUnhealthyWhenRabbitMQIsNotRunning(DockerRabbitMQ rabbitMQ) throws Exception {
         rabbitMQ.stopApp();
 

--- a/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/WebAdminServerIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/WebAdminServerIntegrationTest.java
@@ -126,6 +126,20 @@ public class WebAdminServerIntegrationTest {
     }
 
     @Test
+    public void healthCheckShouldReturn200WhenCalledRepeatedly() {
+        given().get(HealthCheckRoutes.HEALTHCHECK);
+        given().get(HealthCheckRoutes.HEALTHCHECK);
+        given().get(HealthCheckRoutes.HEALTHCHECK);
+        given().get(HealthCheckRoutes.HEALTHCHECK);
+        given().get(HealthCheckRoutes.HEALTHCHECK);
+
+        when()
+            .get(HealthCheckRoutes.HEALTHCHECK)
+        .then()
+            .statusCode(HttpStatus.OK_200);
+    }
+
+    @Test
     public void mailRepositoriesRoutesShouldBeExposed() {
         when()
             .get(MailRepositoriesRoutes.MAIL_REPOSITORIES)


### PR DESCRIPTION
Channel was not given back to the pool, causing repeated calling of this
endpoint to fail