### PR TITLE
JAMES-2988 Restrict MessageView to the minimal one in GetResponse

### DIFF
--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMessagesMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMessagesMethod.java
@@ -39,7 +39,6 @@ import org.apache.james.jmap.draft.model.message.view.MetaMessageViewFactory;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.exception.MailboxException;
-import org.apache.james.mailbox.model.FetchGroupImpl;
 import org.apache.james.mailbox.model.MessageResult;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.util.MDCBuilder;
@@ -128,7 +127,7 @@ public class GetMessagesMethod implements Method {
 
             return GetMessagesResponse.builder()
                 .messages(
-                    messageIdManager.getMessages(getMessagesRequest.getIds(), FetchGroupImpl.FULL_CONTENT, mailboxSession)
+                    messageIdManager.getMessages(getMessagesRequest.getIds(), readProfile.getFetchGroup(), mailboxSession)
                         .stream()
                         .collect(Guavate.toImmutableListMultimap(MessageResult::getMessageId))
                         .asMap()

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMessagesMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMessagesMethod.java
@@ -33,8 +33,9 @@ import org.apache.james.jmap.draft.model.GetMessagesResponse;
 import org.apache.james.jmap.draft.model.MessageProperties;
 import org.apache.james.jmap.draft.model.MessageProperties.HeaderProperty;
 import org.apache.james.jmap.draft.model.MethodCallId;
-import org.apache.james.jmap.draft.model.message.view.MessageFullView;
-import org.apache.james.jmap.draft.model.message.view.MessageFullViewFactory;
+import org.apache.james.jmap.draft.model.message.view.MessageView;
+import org.apache.james.jmap.draft.model.message.view.MessageViewFactory;
+import org.apache.james.jmap.draft.model.message.view.MetaMessageViewFactory;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -59,16 +60,16 @@ public class GetMessagesMethod implements Method {
     private static final Logger LOGGER = LoggerFactory.getLogger(GetMessagesMethod.class);
     private static final Method.Request.Name METHOD_NAME = Method.Request.name("getMessages");
     private static final Method.Response.Name RESPONSE_NAME = Method.Response.name("messages");
-    private final MessageFullViewFactory messageFullViewFactory;
+    private final MetaMessageViewFactory messageViewFactory;
     private final MessageIdManager messageIdManager;
     private final MetricFactory metricFactory;
 
     @Inject
     @VisibleForTesting GetMessagesMethod(
-            MessageFullViewFactory messageFullViewFactory,
+            MetaMessageViewFactory messageViewFactory,
             MessageIdManager messageIdManager,
             MetricFactory metricFactory) {
-        this.messageFullViewFactory = messageFullViewFactory;
+        this.messageViewFactory = messageViewFactory;
         this.messageIdManager = messageIdManager;
         this.metricFactory = metricFactory;
     }
@@ -123,6 +124,8 @@ public class GetMessagesMethod implements Method {
 
         try {
             MessageProperties.ReadProfile readProfile = getMessagesRequest.getProperties().computeReadLevel();
+            MessageViewFactory<? extends MessageView> factory = messageViewFactory.getFactory(readProfile.getAssociatedView());
+
             return GetMessagesResponse.builder()
                 .messages(
                     messageIdManager.getMessages(getMessagesRequest.getIds(), FetchGroupImpl.FULL_CONTENT, mailboxSession)
@@ -132,7 +135,7 @@ public class GetMessagesMethod implements Method {
                         .values()
                         .stream()
                         .filter(collection -> !collection.isEmpty())
-                        .flatMap(toMessageViews())
+                        .flatMap(toMessageViews(factory))
                         .collect(Guavate.toImmutableList()))
                 .expectedMessageIds(getMessagesRequest.getIds())
                 .build();
@@ -141,10 +144,10 @@ public class GetMessagesMethod implements Method {
         }
     }
 
-    private Function<Collection<MessageResult>, Stream<MessageFullView>> toMessageViews() {
+    private Function<Collection<MessageResult>, Stream<? extends MessageView>> toMessageViews(MessageViewFactory<? extends MessageView> factory) {
         return messageResults -> {
             try {
-                return Stream.of(messageFullViewFactory.fromMessageResults(messageResults));
+                return Stream.of(factory.fromMessageResults(messageResults));
             } catch (Exception e) {
                 LOGGER.error("Can not convert MessageResults to Message for {}", messageResults.iterator().next().getMessageId().serialize(), e);
                 return Stream.of();

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMessagesMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMessagesMethod.java
@@ -124,7 +124,7 @@ public class GetMessagesMethod implements Method {
 
         try {
             MessageProperties.ReadProfile readProfile = getMessagesRequest.getProperties().computeReadLevel();
-            MessageViewFactory<? extends MessageView> factory = messageViewFactory.getFactory(readProfile.getAssociatedView());
+            MessageViewFactory factory = messageViewFactory.getFactory(readProfile);
 
             return GetMessagesResponse.builder()
                 .messages(
@@ -144,7 +144,7 @@ public class GetMessagesMethod implements Method {
         }
     }
 
-    private Function<Collection<MessageResult>, Stream<? extends MessageView>> toMessageViews(MessageViewFactory<? extends MessageView> factory) {
+    private Function<Collection<MessageResult>, Stream<MessageView>> toMessageViews(MessageViewFactory factory) {
         return messageResults -> {
             try {
                 return Stream.of(factory.fromMessageResults(messageResults));

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/MessageProperties.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/MessageProperties.java
@@ -24,6 +24,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.apache.james.mailbox.model.FetchGroupImpl;
+import org.apache.james.mailbox.model.MessageResult;
+
 import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
@@ -213,9 +216,9 @@ public class MessageProperties {
     }
 
     public enum ReadProfile {
-        Metadata(0),
-        Header(1),
-        Full(2);
+        Metadata(0, FetchGroupImpl.MINIMAL),
+        Header(1, FetchGroupImpl.HEADERS),
+        Full(2, FetchGroupImpl.FULL_CONTENT);
 
         static ReadProfile combine(ReadProfile readProfile1, ReadProfile readProfile2) {
             if (readProfile1.priority > readProfile2.priority) {
@@ -225,9 +228,15 @@ public class MessageProperties {
         }
 
         private final int priority;
+        private final MessageResult.FetchGroup fetchGroup;
 
-        ReadProfile(int priority) {
+        ReadProfile(int priority, MessageResult.FetchGroup fetchGroup) {
             this.priority = priority;
+            this.fetchGroup = fetchGroup;
+        }
+
+        public MessageResult.FetchGroup getFetchGroup() {
+            return fetchGroup;
         }
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/MessageProperties.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/MessageProperties.java
@@ -24,11 +24,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.apache.james.jmap.draft.model.message.view.MessageFullView;
-import org.apache.james.jmap.draft.model.message.view.MessageHeaderView;
-import org.apache.james.jmap.draft.model.message.view.MessageMetadataView;
-import org.apache.james.jmap.draft.model.message.view.MessageView;
-
 import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/MessageProperties.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/MessageProperties.java
@@ -24,6 +24,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.apache.james.jmap.draft.model.message.view.MessageFullView;
+import org.apache.james.jmap.draft.model.message.view.MessageHeaderView;
+import org.apache.james.jmap.draft.model.message.view.MessageMetadataView;
+import org.apache.james.jmap.draft.model.message.view.MessageView;
+
 import com.github.steveash.guavate.Guavate;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
@@ -213,9 +218,9 @@ public class MessageProperties {
     }
 
     public enum ReadProfile {
-        Metadata(0),
-        Header(1),
-        Full(2);
+        Metadata(0, MessageMetadataView.class),
+        Header(1, MessageHeaderView.class),
+        Full(2, MessageFullView.class);
 
         static ReadProfile combine(ReadProfile readProfile1, ReadProfile readProfile2) {
             if (readProfile1.priority > readProfile2.priority) {
@@ -225,9 +230,15 @@ public class MessageProperties {
         }
 
         private final int priority;
+        private final Class<? extends MessageView> associatedView;
 
-        ReadProfile(int priority) {
+        ReadProfile(int priority, Class<? extends MessageView> associatedView) {
             this.priority = priority;
+            this.associatedView = associatedView;
+        }
+
+        public Class<? extends MessageView> getAssociatedView() {
+            return associatedView;
         }
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/MessageProperties.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/MessageProperties.java
@@ -218,9 +218,9 @@ public class MessageProperties {
     }
 
     public enum ReadProfile {
-        Metadata(0, MessageMetadataView.class),
-        Header(1, MessageHeaderView.class),
-        Full(2, MessageFullView.class);
+        Metadata(0),
+        Header(1),
+        Full(2);
 
         static ReadProfile combine(ReadProfile readProfile1, ReadProfile readProfile2) {
             if (readProfile1.priority > readProfile2.priority) {
@@ -230,15 +230,9 @@ public class MessageProperties {
         }
 
         private final int priority;
-        private final Class<? extends MessageView> associatedView;
 
-        ReadProfile(int priority, Class<? extends MessageView> associatedView) {
+        ReadProfile(int priority) {
             this.priority = priority;
-            this.associatedView = associatedView;
-        }
-
-        public Class<? extends MessageView> getAssociatedView() {
-            return associatedView;
         }
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MessageHeaderViewFactory.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MessageHeaderViewFactory.java
@@ -36,13 +36,15 @@ import org.apache.james.mailbox.model.MessageResult;
 import org.apache.james.mime4j.dom.Message;
 import org.apache.james.mime4j.stream.MimeConfig;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 
 public class MessageHeaderViewFactory implements MessageViewFactory<MessageHeaderView> {
     private final BlobManager blobManager;
 
     @Inject
-    MessageHeaderViewFactory(BlobManager blobManager) {
+    @VisibleForTesting
+    public MessageHeaderViewFactory(BlobManager blobManager) {
         this.blobManager = blobManager;
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MessageMetadataViewFactory.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MessageMetadataViewFactory.java
@@ -30,11 +30,14 @@ import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageResult;
 
+import com.google.common.annotations.VisibleForTesting;
+
 public class MessageMetadataViewFactory implements MessageViewFactory<MessageMetadataView> {
     private final BlobManager blobManager;
 
     @Inject
-    MessageMetadataViewFactory(BlobManager blobManager) {
+    @VisibleForTesting
+    public MessageMetadataViewFactory(BlobManager blobManager) {
         this.blobManager = blobManager;
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MetaMessageViewFactory.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MetaMessageViewFactory.java
@@ -21,6 +21,8 @@ package org.apache.james.jmap.draft.model.message.view;
 
 import javax.inject.Inject;
 
+import org.apache.james.jmap.draft.model.MessageProperties;
+
 public class MetaMessageViewFactory {
     private final MessageFullViewFactory messageFullViewFactory;
     private final MessageHeaderViewFactory messageHeaderViewFactory;
@@ -33,16 +35,16 @@ public class MetaMessageViewFactory {
         this.messageMetadataViewFactory = messageMetadataViewFactory;
     }
 
-    public <T extends MessageView> MessageViewFactory<T> getFactory(Class<T> expectedClass) {
-        if (expectedClass.equals(MessageFullView.class)) {
-            return (MessageViewFactory<T>) messageFullViewFactory;
+    public MessageViewFactory getFactory(MessageProperties.ReadProfile readProfile) {
+        switch (readProfile) {
+            case Full:
+                return messageFullViewFactory;
+            case Header:
+                return messageHeaderViewFactory;
+            case Metadata:
+                return messageMetadataViewFactory;
+            default:
+                throw new IllegalArgumentException(readProfile + " is not a James JMAP draft supported view");
         }
-        if (expectedClass.equals(MessageHeaderView.class)) {
-            return (MessageViewFactory<T>) messageHeaderViewFactory;
-        }
-        if (expectedClass.equals(MessageMetadataView.class)) {
-            return (MessageViewFactory<T>) messageMetadataViewFactory;
-        }
-        throw new IllegalArgumentException(expectedClass + " is not a James JMAP draft supported view");
     }
 }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MetaMessageViewFactory.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MetaMessageViewFactory.java
@@ -1,0 +1,48 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.draft.model.message.view;
+
+import javax.inject.Inject;
+
+public class MetaMessageViewFactory {
+    private final MessageFullViewFactory messageFullViewFactory;
+    private final MessageHeaderViewFactory messageHeaderViewFactory;
+    private final MessageMetadataViewFactory messageMetadataViewFactory;
+
+    @Inject
+    public MetaMessageViewFactory(MessageFullViewFactory messageFullViewFactory, MessageHeaderViewFactory messageHeaderViewFactory, MessageMetadataViewFactory messageMetadataViewFactory) {
+        this.messageFullViewFactory = messageFullViewFactory;
+        this.messageHeaderViewFactory = messageHeaderViewFactory;
+        this.messageMetadataViewFactory = messageMetadataViewFactory;
+    }
+
+    public <T extends MessageView> MessageViewFactory<T> getFactory(Class<T> expectedClass) {
+        if (expectedClass.equals(MessageFullView.class)) {
+            return (MessageViewFactory<T>) messageFullViewFactory;
+        }
+        if (expectedClass.equals(MessageHeaderView.class)) {
+            return (MessageViewFactory<T>) messageHeaderViewFactory;
+        }
+        if (expectedClass.equals(MessageMetadataView.class)) {
+            return (MessageViewFactory<T>) messageMetadataViewFactory;
+        }
+        throw new IllegalArgumentException(expectedClass + " is not a James JMAP draft supported view");
+    }
+}


### PR DESCRIPTION
Work remaining:

 - Considering `hasAttachment` as metadata
 - Using the FetchGroup corresponding to the readProfile.

Will be contributed in separated PRs.