### PR TITLE
JAMES-2996 Guice should not end up in zombie state when start fail

### DIFF
--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/CassandraJamesServerMain.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/CassandraJamesServerMain.java
@@ -155,7 +155,7 @@ public class CassandraJamesServerMain {
         CASSANDRA_EVENT_STORE_JSON_SERIALIZATION_DEFAULT_MODULE
     );
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         Configuration configuration = Configuration.builder()
             .useWorkingDirectoryEnvProperty()
             .build();

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/AuthenticatedCassandraJamesServerTest.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/AuthenticatedCassandraJamesServerTest.java
@@ -21,6 +21,7 @@ package org.apache.james;
 
 import static org.apache.james.CassandraJamesServerMain.ALL_BUT_JMX_CASSANDRA_MODULE;
 import static org.apache.james.JamesServerContract.DOMAIN_LIST_CONFIGURATION_MODULE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.james.backends.cassandra.init.configuration.ClusterConfiguration;
@@ -78,9 +79,9 @@ class AuthenticatedCassandraJamesServerTest {
 
         @Test
         void startShouldFailWhenSslUsedAndNotSupportedByServer(GuiceJamesServer jamesServer) {
-            assertThatThrownBy(jamesServer::start)
-                .isInstanceOf(CreationException.class)
-                .hasStackTraceContaining("Caused by: com.datastax.driver.core.exceptions.NoHostAvailableException: All host(s) tried for query failed");
+            jamesServer.start();
+
+            assertThat(jamesServer.isStarted()).isFalse();
         }
     }
 
@@ -100,9 +101,9 @@ class AuthenticatedCassandraJamesServerTest {
 
         @Test
         void startShouldFailOnBadPassword(GuiceJamesServer jamesServer) {
-            assertThatThrownBy(jamesServer::start)
-                .isInstanceOf(CreationException.class)
-                .hasStackTraceContaining("Caused by: com.datastax.driver.core.exceptions.AuthenticationException: Authentication error");
+            jamesServer.start();
+
+            assertThat(jamesServer.isStarted()).isFalse();
         }
     }
 }

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/JamesCapabilitiesServerTest.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/JamesCapabilitiesServerTest.java
@@ -60,12 +60,10 @@ class JamesCapabilitiesServerTest {
             .thenReturn(EnumSet.allOf(MailboxManager.MessageCapabilities.class));
         when(mailboxManager.getSupportedSearchCapabilities())
             .thenReturn(EnumSet.allOf(MailboxManager.SearchCapabilities.class));
-        
-        assertThatThrownBy(server::start)
-            .isInstanceOfSatisfying(
-                StartUpChecksPerformer.StartUpChecksException.class,
-                exception -> assertThat(exception.badCheckNames())
-                    .containsOnly(JMAPModule.RequiredCapabilitiesStartUpCheck.CHECK_NAME));
+
+        server.start();
+
+        assertThat(server.isStarted()).isFalse();
     }
     
     @Test
@@ -76,12 +74,10 @@ class JamesCapabilitiesServerTest {
             .thenReturn(EnumSet.allOf(MailboxManager.MessageCapabilities.class));
         when(mailboxManager.getSupportedSearchCapabilities())
             .thenReturn(EnumSet.allOf(MailboxManager.SearchCapabilities.class));
-        
-        assertThatThrownBy(server::start)
-            .isInstanceOfSatisfying(
-                StartUpChecksPerformer.StartUpChecksException.class,
-                exception -> assertThat(exception.badCheckNames())
-                    .containsOnly(JMAPModule.RequiredCapabilitiesStartUpCheck.CHECK_NAME));
+
+        server.start();
+
+        assertThat(server.isStarted()).isFalse();
     }
     
     @Test
@@ -93,11 +89,9 @@ class JamesCapabilitiesServerTest {
         when(mailboxManager.getSupportedSearchCapabilities())
             .thenReturn(EnumSet.complementOf(EnumSet.of(MailboxManager.SearchCapabilities.Attachment)));
 
-        assertThatThrownBy(server::start)
-            .isInstanceOfSatisfying(
-                StartUpChecksPerformer.StartUpChecksException.class,
-                exception -> assertThat(exception.badCheckNames())
-                    .containsOnly(JMAPModule.RequiredCapabilitiesStartUpCheck.CHECK_NAME));
+        server.start();
+
+        assertThat(server.isStarted()).isFalse();
     }
 
     @Test
@@ -109,11 +103,9 @@ class JamesCapabilitiesServerTest {
         when(mailboxManager.getSupportedSearchCapabilities())
             .thenReturn(EnumSet.complementOf(EnumSet.of(MailboxManager.SearchCapabilities.AttachmentFileName)));
 
-        assertThatThrownBy(server::start)
-            .isInstanceOfSatisfying(
-                StartUpChecksPerformer.StartUpChecksException.class,
-                exception -> assertThat(exception.badCheckNames())
-                    .containsOnly(JMAPModule.RequiredCapabilitiesStartUpCheck.CHECK_NAME));
+        server.start();
+
+        assertThat(server.isStarted()).isFalse();
     }
     
     @Test
@@ -125,11 +117,9 @@ class JamesCapabilitiesServerTest {
         when(mailboxManager.getSupportedSearchCapabilities())
             .thenReturn(EnumSet.complementOf(EnumSet.of(MailboxManager.SearchCapabilities.MultimailboxSearch)));
 
-        assertThatThrownBy(server::start)
-            .isInstanceOfSatisfying(
-                StartUpChecksPerformer.StartUpChecksException.class,
-                exception -> assertThat(exception.badCheckNames())
-                    .containsOnly(JMAPModule.RequiredCapabilitiesStartUpCheck.CHECK_NAME));
+        server.start();
+
+        assertThat(server.isStarted()).isFalse();
     }
 
     @Test
@@ -141,15 +131,13 @@ class JamesCapabilitiesServerTest {
         when(mailboxManager.getSupportedSearchCapabilities())
             .thenReturn(EnumSet.allOf(MailboxManager.SearchCapabilities.class));
 
-        assertThatThrownBy(server::start)
-            .isInstanceOfSatisfying(
-                StartUpChecksPerformer.StartUpChecksException.class,
-                exception -> assertThat(exception.badCheckNames())
-                    .containsOnly(JMAPModule.RequiredCapabilitiesStartUpCheck.CHECK_NAME));
+        server.start();
+
+        assertThat(server.isStarted()).isFalse();
     }
 
     @Test
-    void startShouldSucceedWhenRequiredCapabilities(GuiceJamesServer server) throws Exception {
+    void startShouldSucceedWhenRequiredCapabilities(GuiceJamesServer server) {
         when(mailboxManager.hasCapability(MailboxManager.MailboxCapabilities.Move)).thenReturn(true);
         when(mailboxManager.hasCapability(MailboxManager.MailboxCapabilities.ACL)).thenReturn(true);
         when(mailboxManager.getSupportedMessageCapabilities())

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/JamesWithNonCompatibleElasticSearchServerTest.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/JamesWithNonCompatibleElasticSearchServerTest.java
@@ -58,18 +58,9 @@ class JamesWithNonCompatibleElasticSearchServerTest {
     }
 
     @Test
-    void jamesShouldStopWhenStartingWithANonCompatibleElasticSearchServer(GuiceJamesServer server) throws Exception {
-        assertThatThrownBy(server::start)
-            .isInstanceOfSatisfying(
-                StartUpChecksPerformer.StartUpChecksException.class,
-                ex -> assertThat(ex.getBadChecks())
-                    .containsOnly(CheckResult.builder()
-                        .checkName(ElasticSearchStartUpCheck.CHECK_NAME)
-                        .resultType(StartUpCheck.ResultType.BAD)
-                        .description("ES version(2.4.6) is not compatible with the recommendation(6.3.2)")
-                        .build()));
+    void jamesShouldStopWhenStartingWithANonCompatibleElasticSearchServer(GuiceJamesServer server) {
+        server.start();
 
-        assertThat(server.isStarted())
-            .isFalse();
+        assertThat(server.isStarted()).isFalse();
     }
 }

--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/modules/mailbox/CassandraSchemaVersionStartUpCheckTest.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/modules/mailbox/CassandraSchemaVersionStartUpCheckTest.java
@@ -29,6 +29,7 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import org.apache.james.CassandraExtension;
@@ -122,11 +123,9 @@ class CassandraSchemaVersionStartUpCheckTest {
         when(versionDAO.getCurrentSchemaVersion())
             .thenReturn(Mono.just(Optional.of(MIN_VERSION.previous())));
 
-        assertThatThrownBy(server::start)
-            .isInstanceOfSatisfying(
-                StartUpChecksException.class,
-                exception -> assertThat(exception.badCheckNames())
-                    .containsOnly(CassandraSchemaVersionStartUpCheck.CHECK_NAME));
+        server.start();
+
+        assertThat(server.isStarted()).isFalse();
     }
 
     @Test
@@ -134,11 +133,9 @@ class CassandraSchemaVersionStartUpCheckTest {
         when(versionDAO.getCurrentSchemaVersion())
             .thenReturn(Mono.just(Optional.of(MAX_VERSION.next())));
 
-        assertThatThrownBy(server::start)
-            .isInstanceOfSatisfying(
-                StartUpChecksException.class,
-                exception -> assertThat(exception.badCheckNames())
-                    .containsOnly(CassandraSchemaVersionStartUpCheck.CHECK_NAME));
+        server.start();
+
+        assertThat(server.isStarted()).isFalse();
     }
 
     private String responseAfterConnectTo(GuiceJamesServer server) throws IOException {
@@ -148,6 +145,6 @@ class CassandraSchemaVersionStartUpCheckTest {
         socketChannel.read(byteBuffer);
         byte[] bytes = byteBuffer.array();
 
-        return new String(bytes, Charset.forName("UTF-8"));
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 }

--- a/server/container/guice/cassandra-ldap-guice/src/main/java/org/apache/james/CassandraLdapJamesServerMain.java
+++ b/server/container/guice/cassandra-ldap-guice/src/main/java/org/apache/james/CassandraLdapJamesServerMain.java
@@ -33,7 +33,7 @@ public class CassandraLdapJamesServerMain {
     public static final Module MODULES = Modules.override(ALL_BUT_JMX_CASSANDRA_MODULE)
         .with(new LdapUsersRepositoryModule());
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         Configuration configuration = Configuration.builder()
             .useWorkingDirectoryEnvProperty()
             .build();

--- a/server/container/guice/cassandra-rabbitmq-ldap-guice/src/main/java/org/apache/james/CassandraRabbitMQLdapJamesServerMain.java
+++ b/server/container/guice/cassandra-rabbitmq-ldap-guice/src/main/java/org/apache/james/CassandraRabbitMQLdapJamesServerMain.java
@@ -31,7 +31,7 @@ public class CassandraRabbitMQLdapJamesServerMain {
         .override(CassandraRabbitMQJamesServerMain.MODULES)
         .with(new LdapUsersRepositoryModule());
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         Configuration configuration = Configuration.builder()
             .useWorkingDirectoryEnvProperty()
             .build();

--- a/server/container/guice/jpa-guice/src/main/java/org/apache/james/JPAJamesServerMain.java
+++ b/server/container/guice/jpa-guice/src/main/java/org/apache/james/JPAJamesServerMain.java
@@ -93,7 +93,7 @@ public class JPAJamesServerMain {
 
     public static final Module JPA_MODULE_AGGREGATE = Modules.combine(JPA_SERVER_MODULE, PROTOCOLS);
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         Configuration configuration = Configuration.builder()
             .useWorkingDirectoryEnvProperty()
             .build();

--- a/server/container/guice/jpa-smtp-common/src/main/java/org/apache/james/JPAJamesServerMain.java
+++ b/server/container/guice/jpa-smtp-common/src/main/java/org/apache/james/JPAJamesServerMain.java
@@ -59,7 +59,7 @@ public class JPAJamesServerMain {
         new RawPostDequeueDecoratorModule(),
         new ElasticSearchMetricReporterModule());
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         Configuration configuration = Configuration.builder()
             .useWorkingDirectoryEnvProperty()
             .build();

--- a/server/container/guice/memory-guice/src/test/java/org/apache/james/GuiceJamesServerStartUpCheckTest.java
+++ b/server/container/guice/memory-guice/src/test/java/org/apache/james/GuiceJamesServerStartUpCheckTest.java
@@ -163,18 +163,8 @@ class GuiceJamesServerStartUpCheckTest {
             .build();
 
         @Test
-        void startUpCheckFailsShouldThrowAnExceptionCarryingOnlyBadChecks(GuiceJamesServer server) {
-            assertThatThrownBy(server::start)
-                .isInstanceOfSatisfying(
-                    StartUpChecksPerformer.StartUpChecksException.class,
-                    exception -> assertThat(nameOfStartUpChecks(exception.getBadChecks()))
-                        .containsOnly(FailingStartUpCheck.CHECK_NAME));
-        }
-
-        @Test
         void serverShouldNotStartWhenAStartUpCheckFails(GuiceJamesServer server) {
-            assertThatThrownBy(server::start)
-                .isInstanceOf(StartUpChecksPerformer.StartUpChecksException.class);
+            server.start();
 
             assertThat(server.isStarted())
                 .isFalse();

--- a/server/container/guice/memory-guice/src/test/java/org/apache/james/GuiceJamesServerStartUpCheckTest.java
+++ b/server/container/guice/memory-guice/src/test/java/org/apache/james/GuiceJamesServerStartUpCheckTest.java
@@ -106,7 +106,7 @@ class GuiceJamesServerStartUpCheckTest {
     interface StartUpCheckSuccessContract {
 
         @Test
-        default void serverShouldStartSuccessfully(GuiceJamesServer server) throws Exception {
+        default void serverShouldStartSuccessfully(GuiceJamesServer server) {
             server.start();
 
             assertThat(server.isStarted()).isTrue();
@@ -163,7 +163,7 @@ class GuiceJamesServerStartUpCheckTest {
             .build();
 
         @Test
-        void startUpCheckFailsShouldThrowAnExceptionCarryingOnlyBadChecks(GuiceJamesServer server) throws Exception {
+        void startUpCheckFailsShouldThrowAnExceptionCarryingOnlyBadChecks(GuiceJamesServer server) {
             assertThatThrownBy(server::start)
                 .isInstanceOfSatisfying(
                     StartUpChecksPerformer.StartUpChecksException.class,
@@ -172,7 +172,7 @@ class GuiceJamesServerStartUpCheckTest {
         }
 
         @Test
-        void serverShouldNotStartWhenAStartUpCheckFails(GuiceJamesServer server) throws Exception {
+        void serverShouldNotStartWhenAStartUpCheckFails(GuiceJamesServer server) {
             assertThatThrownBy(server::start)
                 .isInstanceOf(StartUpChecksPerformer.StartUpChecksException.class);
 

--- a/server/container/guice/memory-guice/src/test/java/org/apache/james/GuiceJamesServerTest.java
+++ b/server/container/guice/memory-guice/src/test/java/org/apache/james/GuiceJamesServerTest.java
@@ -1,7 +1,30 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
 package org.apache.james;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.annotation.PreDestroy;
 
 import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.modules.TestJMAPServerModule;
@@ -12,6 +35,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.inject.Inject;
 import com.google.inject.multibindings.Multibinder;
 
 class GuiceJamesServerTest {
@@ -33,14 +57,14 @@ class GuiceJamesServerTest {
         JamesServerExtension jamesServerExtension = extensionBuilder().build();
 
         @Test
-        void serverShouldBeStartedAfterCallingStart(GuiceJamesServer server) throws Exception {
+        void serverShouldBeStartedAfterCallingStart(GuiceJamesServer server) {
             server.start();
 
             assertThat(server.isStarted()).isTrue();
         }
 
         @Test
-        void serverShouldNotBeStartedAfterCallingStop(GuiceJamesServer server) throws Exception {
+        void serverShouldNotBeStartedAfterCallingStop(GuiceJamesServer server) {
             server.start();
 
             server.stop();
@@ -54,8 +78,43 @@ class GuiceJamesServerTest {
         }
     }
 
+    static class Stoppable {
+        private final AtomicBoolean stopped;
+
+        Stoppable(AtomicBoolean stopped) {
+            this.stopped = stopped;
+        }
+
+        @PreDestroy
+        public void dispose() {
+            stopped.set(true);
+        }
+    }
+
+    static class ThrowingInitializationOperation implements InitializationOperation {
+        private final Stoppable stoppable;
+
+        @Inject
+        ThrowingInitializationOperation(Stoppable stoppable) {
+            this.stoppable = stoppable;
+        }
+
+        @Override
+        public void initModule() {
+            throw new RuntimeException();
+        }
+
+        @Override
+        public Class<? extends Startable> forClass() {
+            return Startable.class;
+        }
+
+    }
+
     @Nested
     class InitFailed {
+        AtomicBoolean stopped = new AtomicBoolean(false);
+
         private final InitializationOperation throwingInitializationOperation = new InitializationOperation() {
             @Override
             public void initModule() {
@@ -70,19 +129,27 @@ class GuiceJamesServerTest {
 
         @RegisterExtension
         JamesServerExtension jamesServerExtension = extensionBuilder()
+            .overrideServerModule(binder -> binder.bind(Stoppable.class).toInstance(new Stoppable(stopped)))
             .overrideServerModule(binder -> Multibinder.newSetBinder(binder, InitializationOperation.class)
                 .addBinding()
-                .toInstance(throwingInitializationOperation))
+                .to(ThrowingInitializationOperation.class))
             .build();
 
         @Test
-        void serverShouldPropagateUncaughtConfigurationException(GuiceJamesServer server) {
-            assertThatThrownBy(server::start)
-                .isInstanceOf(RuntimeException.class);
+        void serverShouldNotPropagateUncaughtConfigurationException(GuiceJamesServer server) {
+            assertThatCode(server::start)
+                .doesNotThrowAnyException();
         }
 
         @Test
-        void serverShouldNotBeStartedOnUncaughtException(GuiceJamesServer server) throws Exception {
+        void serverShouldStopWhenStartFail(GuiceJamesServer server) {
+            server.start();
+
+            assertThat(stopped.get()).isTrue();
+        }
+
+        @Test
+        void serverShouldNotBeStartedOnUncaughtException(GuiceJamesServer server) {
             try {
                 server.start();
             } catch (RuntimeException e) {

--- a/server/container/guice/memory-guice/src/test/java/org/apache/james/MemoryJmapJamesServerTest.java
+++ b/server/container/guice/memory-guice/src/test/java/org/apache/james/MemoryJmapJamesServerTest.java
@@ -68,12 +68,9 @@ class MemoryJmapJamesServerTest {
 
             @Test
             void jamesShouldNotStartWhenBadAliasKeyStore(GuiceJamesServer server) {
-                assertThatThrownBy(server::start)
-                    .isInstanceOfSatisfying(
-                        StartUpChecksPerformer.StartUpChecksException.class,
-                        ex -> assertThat(ex.badCheckNames())
-                            .containsOnly(JMAPConfigurationStartUpCheck.CHECK_NAME))
-                    .hasMessageContaining("Alias 'james' keystore can't be found");
+                server.start();
+
+                assertThat(server.isStarted()).isFalse();
             }
         }
 
@@ -92,12 +89,9 @@ class MemoryJmapJamesServerTest {
 
             @Test
             void jamesShouldNotStartWhenBadSecret(GuiceJamesServer server) {
-                assertThatThrownBy(server::start)
-                    .isInstanceOfSatisfying(
-                        StartUpChecksPerformer.StartUpChecksException.class,
-                        ex -> assertThat(ex.badCheckNames())
-                            .containsOnly(JMAPConfigurationStartUpCheck.CHECK_NAME))
-                    .hasMessageContaining("Keystore was tampered with, or password was incorrect");
+                server.start();
+
+                assertThat(server.isStarted()).isFalse();
             }
         }
     }


### PR DESCRIPTION
Currently when an error arise:
 - the exception is not catched and logged in stderr
 - James is started despite some failed components, and the initialization is not completed

I would expect:
 - that an error upon start leave the app in a clean stopped state
 - that the error is logged using slf4j in order to be caught by proper monitoring tools