### PR TITLE
JAMES-2997 Split byte array away from Attachment

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/AttachmentManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/AttachmentManager.java
@@ -34,7 +34,7 @@ public interface AttachmentManager {
 
     List<Attachment> getAttachments(List<AttachmentId> attachmentIds, MailboxSession mailboxSession) throws MailboxException;
 
-    void storeAttachment(Attachment.WithBytes attachment, MailboxSession mailboxSession) throws MailboxException;
+    void storeAttachment(Attachment attachment, byte[] bytes, MailboxSession mailboxSession) throws MailboxException;
 
     InputStream retrieveContent(AttachmentId id, MailboxSession session) throws MailboxException, AttachmentNotFoundException;
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/AttachmentManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/AttachmentManager.java
@@ -19,17 +19,14 @@
 
 package org.apache.james.mailbox;
 
-import java.util.Collection;
 import java.util.List;
 
 import org.apache.james.mailbox.exception.AttachmentNotFoundException;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Attachment;
 import org.apache.james.mailbox.model.AttachmentId;
-import org.apache.james.mailbox.model.MessageId;
 
 public interface AttachmentManager {
-
     boolean exists(AttachmentId attachmentId, MailboxSession session) throws MailboxException;
 
     Attachment getAttachment(AttachmentId attachmentId, MailboxSession mailboxSession) throws MailboxException, AttachmentNotFoundException;
@@ -37,6 +34,4 @@ public interface AttachmentManager {
     List<Attachment> getAttachments(List<AttachmentId> attachmentIds, MailboxSession mailboxSession) throws MailboxException;
 
     void storeAttachment(Attachment attachment, MailboxSession mailboxSession) throws MailboxException;
-
-    void storeAttachmentsForMessage(Collection<Attachment> attachments, MessageId ownerMessageId, MailboxSession mailboxSession) throws MailboxException;
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/AttachmentManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/AttachmentManager.java
@@ -33,5 +33,7 @@ public interface AttachmentManager {
 
     List<Attachment> getAttachments(List<AttachmentId> attachmentIds, MailboxSession mailboxSession) throws MailboxException;
 
-    void storeAttachment(Attachment attachment, MailboxSession mailboxSession) throws MailboxException;
+    void storeAttachment(Attachment.WithBytes attachment, MailboxSession mailboxSession) throws MailboxException;
+
+    Attachment.WithBytes retrieveContent(AttachmentId id, MailboxSession session) throws MailboxException, AttachmentNotFoundException;
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/AttachmentManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/AttachmentManager.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mailbox;
 
+import java.io.InputStream;
 import java.util.List;
 
 import org.apache.james.mailbox.exception.AttachmentNotFoundException;
@@ -35,5 +36,5 @@ public interface AttachmentManager {
 
     void storeAttachment(Attachment.WithBytes attachment, MailboxSession mailboxSession) throws MailboxException;
 
-    Attachment.WithBytes retrieveContent(AttachmentId id, MailboxSession session) throws MailboxException, AttachmentNotFoundException;
+    InputStream retrieveContent(AttachmentId id, MailboxSession session) throws MailboxException, AttachmentNotFoundException;
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/Attachment.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/Attachment.java
@@ -20,7 +20,6 @@
 package org.apache.james.mailbox.model;
 
 import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -94,7 +93,7 @@ public class Attachment {
             return metadata;
         }
 
-        public InputStream getStream() {
+        public ByteArrayInputStream getStream() {
             return new ByteArrayInputStream(bytes);
         }
 

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/Attachment.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/Attachment.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.mailbox.model;
 
-import java.io.ByteArrayInputStream;
-import java.util.Arrays;
 import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
@@ -65,61 +63,11 @@ public class Attachment {
             return new Attachment(builtAttachmentId, type, size);
         }
 
-        public Attachment.WithBytes buildWithBytes(byte[] bytes) {
-            return size(bytes.length)
-                .build()
-                .withBytes(bytes);
-        }
-
         private AttachmentId attachmentId() {
             if (attachmentId != null) {
                 return attachmentId;
             }
             return AttachmentId.random();
-        }
-    }
-
-    public static class WithBytes {
-        private final byte[] bytes;
-        private final Attachment metadata;
-
-        public WithBytes(byte[] bytes, Attachment metadata) {
-            Preconditions.checkArgument(bytes != null);
-            this.bytes = bytes;
-            this.metadata = metadata;
-        }
-
-        public Attachment getMetadata() {
-            return metadata;
-        }
-
-        public ByteArrayInputStream getStream() {
-            return new ByteArrayInputStream(bytes);
-        }
-
-        /**
-         * Be careful the returned array is not a copy of the attachment byte array.
-         * Mutating it will mutate the attachment!
-         * @return the attachment content
-         */
-        public byte[] getBytes() {
-            return bytes;
-        }
-
-        @Override
-        public final boolean equals(Object o) {
-            if (o instanceof WithBytes) {
-                WithBytes withBytes = (WithBytes) o;
-
-                return Arrays.equals(this.bytes, withBytes.bytes)
-                    && Objects.equals(this.metadata, withBytes.metadata);
-            }
-            return false;
-        }
-
-        @Override
-        public final int hashCode() {
-            return Objects.hash(bytes, metadata);
         }
     }
 
@@ -143,12 +91,6 @@ public class Attachment {
 
     public long getSize() {
         return size;
-    }
-
-    public Attachment.WithBytes withBytes(byte[] bytes) {
-        Preconditions.checkNotNull(bytes);
-        Preconditions.checkArgument(bytes.length == size, "Provided content do not match attachment size");
-        return new WithBytes(bytes, this);
     }
 
     @Override

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/Attachment.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/Attachment.java
@@ -23,9 +23,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
@@ -128,17 +128,17 @@ public class Attachment {
     public boolean equals(Object obj) {
         if (obj instanceof Attachment) {
             Attachment other = (Attachment) obj;
-            return Objects.equal(attachmentId, other.attachmentId)
+            return Objects.equals(attachmentId, other.attachmentId)
                 && Arrays.equals(bytes, other.bytes)
-                && Objects.equal(type, other.type)
-                && Objects.equal(size, other.size);
+                && Objects.equals(type, other.type)
+                && Objects.equals(size, other.size);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(attachmentId, bytes, type, size);
+        return Objects.hash(attachmentId, bytes, type, size);
     }
 
     @Override

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/Attachment.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/Attachment.java
@@ -20,7 +20,6 @@
 package org.apache.james.mailbox.model;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Objects;
@@ -95,7 +94,7 @@ public class Attachment {
             return metadata;
         }
 
-        public InputStream getStream() throws IOException {
+        public InputStream getStream() {
             return new ByteArrayInputStream(bytes);
         }
 
@@ -106,14 +105,6 @@ public class Attachment {
          */
         public byte[] getBytes() {
             return bytes;
-        }
-
-        public Blob toBlob() {
-            return Blob.builder()
-                .id(BlobId.fromBytes(bytes))
-                .payload(bytes)
-                .contentType(metadata.type)
-                .build();
         }
 
         @Override

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/Blob.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/Blob.java
@@ -44,6 +44,11 @@ public class Blob {
             return this;
         }
 
+        /**
+         * Be careful the returned array is not a copy of the attachment byte array.
+         * Mutating it will mutate the blob!
+         * @return the attachment content
+         */
         public Builder payload(byte[] payload) {
             this.payload = () -> new ByteArrayInputStream(payload);
             this.size = Long.valueOf(payload.length);

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/Blob.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/Blob.java
@@ -83,10 +83,6 @@ public class Blob {
         return blobId;
     }
 
-    public byte[] getPayload() {
-        return payload;
-    }
-
     public InputStream getStream() throws IOException {
         return new ByteArrayInputStream(payload);
     }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/Blob.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/Blob.java
@@ -20,7 +20,6 @@
 package org.apache.james.mailbox.model;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -98,7 +97,12 @@ public class Blob {
         return blobId;
     }
 
-    public InputStream getStream() throws IOException {
+    /**
+     * Needs to be closed by the caller
+     *
+     * @return An InputStream containing the data of this Blob
+     */
+    public InputStream createStream() {
         return payload.get();
     }
 

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MessageAttachment.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MessageAttachment.java
@@ -26,6 +26,32 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
 public class MessageAttachment {
+    public static class WithBytes {
+        private final byte[] bytes;
+        private final MessageAttachment metadata;
+
+        public WithBytes(byte[] bytes, MessageAttachment metadata) {
+            Preconditions.checkArgument(bytes != null);
+            this.bytes = bytes;
+            this.metadata = metadata;
+        }
+
+        public MessageAttachment getMetadata() {
+            return metadata;
+        }
+
+        public Attachment getAttachment() {
+            return metadata.attachment;
+        }
+
+        public Attachment.WithBytes getAttachmentWithBytes() {
+            return metadata.attachment.withBytes(bytes);
+        }
+
+        public byte[] getBytes() {
+            return bytes;
+        }
+    }
 
     public static Builder builder() {
         return new Builder();
@@ -111,6 +137,12 @@ public class MessageAttachment {
 
     public boolean isInlinedWithCid() {
         return isInline && cid.isPresent();
+    }
+
+    public MessageAttachment.WithBytes withBytes(byte[] bytes) {
+        Preconditions.checkNotNull(bytes);
+        Preconditions.checkArgument(bytes.length == attachment.getSize(), "Provided content do not match attachment size");
+        return new WithBytes(bytes, this);
     }
 
     @Override

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MessageAttachment.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MessageAttachment.java
@@ -26,33 +26,6 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
 public class MessageAttachment {
-    public static class WithBytes {
-        private final byte[] bytes;
-        private final MessageAttachment metadata;
-
-        public WithBytes(byte[] bytes, MessageAttachment metadata) {
-            Preconditions.checkArgument(bytes != null);
-            this.bytes = bytes;
-            this.metadata = metadata;
-        }
-
-        public MessageAttachment getMetadata() {
-            return metadata;
-        }
-
-        public Attachment getAttachment() {
-            return metadata.attachment;
-        }
-
-        public Attachment.WithBytes getAttachmentWithBytes() {
-            return metadata.attachment.withBytes(bytes);
-        }
-
-        public byte[] getBytes() {
-            return bytes;
-        }
-    }
-
     public static Builder builder() {
         return new Builder();
     }
@@ -137,12 +110,6 @@ public class MessageAttachment {
 
     public boolean isInlinedWithCid() {
         return isInline && cid.isPresent();
-    }
-
-    public MessageAttachment.WithBytes withBytes(byte[] bytes) {
-        Preconditions.checkNotNull(bytes);
-        Preconditions.checkArgument(bytes.length == attachment.getSize(), "Provided content do not match attachment size");
-        return new WithBytes(bytes, this);
     }
 
     @Override

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/AttachmentTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/AttachmentTest.java
@@ -20,58 +20,16 @@
 
 package org.apache.james.mailbox.model;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
-import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 
 class AttachmentTest {
 
     private static Charset CHARSET = StandardCharsets.UTF_8;
-
-    @Test
-    void streamShouldBeConsumedOneTime() throws Exception {
-        String input = "mystream";
-        byte[] bytes = input.getBytes(CHARSET);
-        Attachment.WithBytes attachment = Attachment.builder()
-                .type("content")
-                .buildWithBytes(bytes);
-
-        InputStream stream = attachment.getStream();
-        assertThat(stream).isNotNull();
-        assertThat(IOUtils.toString(stream, CHARSET)).isEqualTo(input);
-    }
-
-    @Test
-    void getByteShouldReturnByteArrayRepresentingTheAttachment() {
-        String input = "mystream";
-        byte[] inputBytes = input.getBytes(CHARSET);
-        Attachment.WithBytes attachment = Attachment.builder()
-            .type("content")
-            .buildWithBytes(inputBytes);
-
-        byte[] bytes = attachment.getBytes();
-        assertThat(new String(bytes, CHARSET)).isEqualTo(input);
-    }
-
-    @Test
-    void streamShouldBeConsumedMoreThanOneTime() throws Exception {
-        String input = "mystream";
-        byte[] inputBytes = input.getBytes(CHARSET);
-        Attachment.WithBytes attachment = Attachment.builder()
-            .type("content")
-            .buildWithBytes(inputBytes);
-
-        attachment.getStream();
-        InputStream stream = attachment.getStream();
-        assertThat(stream).isNotNull();
-        assertThat(IOUtils.toString(stream, CHARSET)).isEqualTo(input);
-    }
 
     @Test
     void builderShouldThrowWhenAttachmentIdIsNull() {
@@ -85,20 +43,6 @@ class AttachmentTest {
         assertThatThrownBy(() -> Attachment.builder()
                 .size(-1))
             .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void withBytesShouldThrowWhenNull() {
-        String input = "mystream";
-        byte[] inputBytes = input.getBytes(CHARSET);
-
-        Attachment attachment = Attachment.builder()
-            .size(inputBytes.length)
-            .type("content")
-            .build();
-
-        assertThatThrownBy(() -> attachment.withBytes(null))
-            .isInstanceOf(NullPointerException.class);
     }
 
     @Test
@@ -123,7 +67,7 @@ class AttachmentTest {
     }
 
     @Test
-    void buildShouldThrowWhenBytesIsNotProvided() {
+    void buildShouldThrowWhenSizeIsNotProvided() {
         assertThatThrownBy(() -> Attachment.builder()
                 .attachmentId(AttachmentId.random())
                 .type("image/png")
@@ -138,16 +82,5 @@ class AttachmentTest {
                 .size(36)
                 .build())
             .isInstanceOf(IllegalStateException.class);
-    }
-
-    @Test
-    void buildShouldSetTheSize() {
-        String input = "mystream";
-        byte[] inputBytes = input.getBytes(CHARSET);
-        Attachment.WithBytes attachment = Attachment.builder()
-            .type("content")
-            .buildWithBytes(inputBytes);
-
-        assertThat(attachment.getMetadata().getSize()).isEqualTo(input.getBytes(CHARSET).length);
     }
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/AttachmentTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/AttachmentTest.java
@@ -150,23 +150,4 @@ class AttachmentTest {
 
         assertThat(attachment.getMetadata().getSize()).isEqualTo(input.getBytes(CHARSET).length);
     }
-
-    @Test
-    void toBlobShouldGenerateTheAttachmentBlob() {
-        byte[] bytes = "mystream".getBytes(CHARSET);
-        String content = "content";
-        String input = "mystream";
-        byte[] inputBytes = input.getBytes(CHARSET);
-        Attachment.WithBytes attachment = Attachment.builder()
-            .type(content)
-            .buildWithBytes(inputBytes);
-
-        Blob expected = Blob.builder()
-            .id(BlobId.fromBytes(bytes))
-            .contentType(content)
-            .payload(bytes)
-            .build();
-
-        assertThat(attachment.toBlob()).isEqualTo(expected);
-    }
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/BlobTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/BlobTest.java
@@ -22,17 +22,20 @@ package org.apache.james.mailbox.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 class BlobTest {
-
-    public static final BlobId ID = BlobId.fromString("123");
-    public static final String CONTENT_TYPE = "text/plain";
-    public static final byte[] PAYLOAD = "abc".getBytes(StandardCharsets.UTF_8);
+    private static final BlobId ID = BlobId.fromString("123");
+    private static final String CONTENT_TYPE = "text/plain";
+    private static final byte[] PAYLOAD = "abc".getBytes(StandardCharsets.UTF_8);
+    private static final Supplier<InputStream> PAYLOAD_SUPPLIER = () -> new ByteArrayInputStream(PAYLOAD);
 
     @Test
     void shouldMatchBeanContract() {
@@ -50,7 +53,7 @@ class BlobTest {
                 .payload(PAYLOAD)
                 .build())
             .isEqualTo(
-                new Blob(ID, PAYLOAD, CONTENT_TYPE));
+                new Blob(ID, PAYLOAD_SUPPLIER, CONTENT_TYPE, Long.valueOf(PAYLOAD.length)));
     }
 
     @Test
@@ -79,6 +82,18 @@ class BlobTest {
             Blob.builder()
                 .id(ID)
                 .contentType(CONTENT_TYPE)
+                .size(36)
+                .build())
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void buildShouldThrowOnMissingSize() {
+        assertThatThrownBy(() ->
+            Blob.builder()
+                .id(ID)
+                .contentType(CONTENT_TYPE)
+                .payload(PAYLOAD_SUPPLIER)
                 .build())
             .isInstanceOf(IllegalStateException.class);
     }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MessageAttachmentTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MessageAttachmentTest.java
@@ -49,10 +49,9 @@ class MessageAttachmentTest {
     @Test
     void buildShouldWorkWhenMandatoryAttributesAreGiven() {
         Attachment attachment = Attachment.builder()
-                .type("type")
-
-
-    .size(36)        .build();
+            .type("type")
+            .size(36)
+            .build();
         MessageAttachment expectedMessageAttachment = new MessageAttachment(attachment, Optional.empty(), Optional.empty(), false);
 
         MessageAttachment messageAttachment = MessageAttachment.builder()
@@ -65,10 +64,9 @@ class MessageAttachmentTest {
     @Test
     void buildShouldAcceptIsInlineAndNoCid() {
         Attachment attachment = Attachment.builder()
-                .type("type")
-
-
-    .size(36)        .build();
+            .type("type")
+            .size(36)
+            .build();
 
         MessageAttachment messageAttachment = MessageAttachment.builder()
             .attachment(attachment)
@@ -81,10 +79,9 @@ class MessageAttachmentTest {
     @Test
     void buildShouldSetAttributesWhenAllAreGiven() {
         Attachment attachment = Attachment.builder()
-                .type("type")
-
-
-    .size(36)        .build();
+            .type("type")
+            .size(36)
+            .build();
         MessageAttachment expectedMessageAttachment = new MessageAttachment(attachment, Optional.of("name"), Optional.of(Cid.from("cid")), true);
 
         MessageAttachment messageAttachment = MessageAttachment.builder()

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MessageAttachmentTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MessageAttachmentTest.java
@@ -22,16 +22,20 @@ package org.apache.james.mailbox.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
 class MessageAttachmentTest {
 
+    public static final byte[] BYTES = "content".getBytes(StandardCharsets.UTF_8);
+
     @Test
     void buildShouldThrowWhenAttachmentIsNotGiven() {
         assertThatThrownBy(() -> MessageAttachment.builder()
-                .build())
+
+            .build())
             .isInstanceOf(IllegalStateException.class);
     }
 
@@ -45,9 +49,10 @@ class MessageAttachmentTest {
     @Test
     void buildShouldWorkWhenMandatoryAttributesAreGiven() {
         Attachment attachment = Attachment.builder()
-                .bytes("content".getBytes())
                 .type("type")
-                .build();
+
+
+    .size(36)        .build();
         MessageAttachment expectedMessageAttachment = new MessageAttachment(attachment, Optional.empty(), Optional.empty(), false);
 
         MessageAttachment messageAttachment = MessageAttachment.builder()
@@ -60,9 +65,10 @@ class MessageAttachmentTest {
     @Test
     void buildShouldAcceptIsInlineAndNoCid() {
         Attachment attachment = Attachment.builder()
-                .bytes("content".getBytes())
                 .type("type")
-                .build();
+
+
+    .size(36)        .build();
 
         MessageAttachment messageAttachment = MessageAttachment.builder()
             .attachment(attachment)
@@ -75,9 +81,10 @@ class MessageAttachmentTest {
     @Test
     void buildShouldSetAttributesWhenAllAreGiven() {
         Attachment attachment = Attachment.builder()
-                .bytes("content".getBytes())
                 .type("type")
-                .build();
+
+
+    .size(36)        .build();
         MessageAttachment expectedMessageAttachment = new MessageAttachment(attachment, Optional.of("name"), Optional.of(Cid.from("cid")), true);
 
         MessageAttachment messageAttachment = MessageAttachment.builder()
@@ -93,8 +100,8 @@ class MessageAttachmentTest {
     @Test
     void isInlinedWithCidShouldReturnTrueWhenIsInlineAndHasCid() throws Exception {
         Attachment attachment = Attachment.builder()
-            .bytes("content".getBytes())
             .type("type")
+            .size(36)
             .build();
 
         MessageAttachment messageAttachment = MessageAttachment.builder()
@@ -110,8 +117,8 @@ class MessageAttachmentTest {
     @Test
     void isInlinedWithCidShouldReturnFalseWhenIsNotInline() throws Exception {
         Attachment attachment = Attachment.builder()
-            .bytes("content".getBytes())
             .type("type")
+            .size(36)
             .build();
 
         MessageAttachment messageAttachment = MessageAttachment.builder()
@@ -127,8 +134,8 @@ class MessageAttachmentTest {
     @Test
     void isInlinedWithCidShouldReturnFalseWhenIsInlineButNoCid() throws Exception {
         Attachment attachment = Attachment.builder()
-            .bytes("content".getBytes())
             .type("type")
+            .size(36)
             .build();
 
         MessageAttachment messageAttachment = MessageAttachment.builder()

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MessageAttachmentTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MessageAttachmentTest.java
@@ -34,7 +34,6 @@ class MessageAttachmentTest {
     @Test
     void buildShouldThrowWhenAttachmentIsNotGiven() {
         assertThatThrownBy(() -> MessageAttachment.builder()
-
             .build())
             .isInstanceOf(IllegalStateException.class);
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMessageManager.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMessageManager.java
@@ -19,7 +19,7 @@
 
 package org.apache.james.mailbox.cassandra;
 
-import java.util.List;
+import java.util.Map;
 
 import javax.mail.Flags;
 
@@ -72,7 +72,7 @@ public class CassandraMessageManager extends StoreMessageManager {
     }
 
     @Override
-    protected void storeAttachment(MailboxMessage message, List<Attachment.WithBytes> attachments, MailboxSession session) throws MailboxException {
+    protected void storeAttachment(MailboxMessage message, Map<Attachment, byte[]> attachments, MailboxSession session) throws MailboxException {
         mapperFactory.getAttachmentMapper(session)
             .storeAttachmentsForMessage(
                 attachments,

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMessageManager.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMessageManager.java
@@ -27,8 +27,8 @@ import org.apache.james.mailbox.MailboxPathLocker;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.events.EventBus;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.Attachment;
 import org.apache.james.mailbox.model.Mailbox;
-import org.apache.james.mailbox.model.MessageAttachment;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.quota.QuotaManager;
 import org.apache.james.mailbox.quota.QuotaRootResolver;
@@ -39,8 +39,6 @@ import org.apache.james.mailbox.store.StoreRightManager;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.impl.MessageParser;
 import org.apache.james.mailbox.store.search.MessageSearchIndex;
-
-import com.github.steveash.guavate.Guavate;
 
 /**
  * Cassandra implementation of {@link StoreMessageManager}
@@ -74,12 +72,10 @@ public class CassandraMessageManager extends StoreMessageManager {
     }
 
     @Override
-    protected void storeAttachment(MailboxMessage message, List<MessageAttachment> messageAttachments, MailboxSession session) throws MailboxException {
+    protected void storeAttachment(MailboxMessage message, List<Attachment.WithBytes> attachments, MailboxSession session) throws MailboxException {
         mapperFactory.getAttachmentMapper(session)
             .storeAttachmentsForMessage(
-                messageAttachments.stream()
-                    .map(MessageAttachment::getAttachment)
-                    .collect(Guavate.toImmutableList()),
+                attachments,
                 message.getMessageId());
     }
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAO.java
@@ -52,7 +52,7 @@ import reactor.core.publisher.Mono;
 public class CassandraAttachmentDAO {
 
     private final CassandraAsyncExecutor cassandraAsyncExecutor;
-    private CassandraConfiguration configuration;
+    private final CassandraConfiguration configuration;
     private final PreparedStatement insertStatement;
     private final PreparedStatement deleteStatement;
     private final PreparedStatement selectStatement;

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2.java
@@ -44,6 +44,7 @@ import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.google.common.base.Preconditions;
+
 import reactor.core.publisher.Mono;
 
 public class CassandraAttachmentDAOV2 {
@@ -76,11 +77,11 @@ public class CassandraAttachmentDAOV2 {
             return size;
         }
 
-        public Attachment toAttachment(byte[] data) {
+        public Attachment toAttachment() {
             return Attachment.builder()
                 .attachmentId(attachmentId)
                 .type(type)
-                .bytes(data)
+                .size(size)
                 .build();
         }
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
@@ -101,7 +101,7 @@ public class CassandraAttachmentMapper implements AttachmentMapper {
 
     private Mono<Attachment> fallbackToV1(AttachmentId attachmentId) {
         return attachmentDAO.getAttachment(attachmentId)
-            .map(Attachment.WithBytes::getMetadata);
+            .map(CassandraAttachmentDAO.DAOAttachmentV1::getMetadata);
     }
 
     @Override
@@ -142,10 +142,10 @@ public class CassandraAttachmentMapper implements AttachmentMapper {
     private Mono<InputStream> retrieveContentAsync(AttachmentId attachmentId) {
         return attachmentDAOV2.getAttachment(attachmentId)
             .map(dao -> blobStore.read(blobStore.getDefaultBucketName(), dao.getBlobId()))
-            .switchIfEmpty(fallbackToV1WithBytes(attachmentId).map(Attachment.WithBytes::getStream));
+            .switchIfEmpty(fallbackToV1WithBytes(attachmentId).map(CassandraAttachmentDAO.DAOAttachmentV1::getStream));
     }
 
-    private Mono<Attachment.WithBytes> fallbackToV1WithBytes(AttachmentId attachmentId) {
+    private Mono<CassandraAttachmentDAO.DAOAttachmentV1> fallbackToV1WithBytes(AttachmentId attachmentId) {
         return attachmentDAO.getAttachment(attachmentId);
     }
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentV2Migration.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentV2Migration.java
@@ -24,8 +24,8 @@ import javax.inject.Inject;
 import org.apache.james.backends.cassandra.migration.Migration;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAO.DAOAttachmentV1;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
-import org.apache.james.mailbox.model.Attachment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +54,7 @@ public class AttachmentV2Migration implements Migration {
             .blockLast();
     }
 
-    private Mono<Void> migrateAttachment(Attachment.WithBytes attachment) {
+    private Mono<Void> migrateAttachment(DAOAttachmentV1 attachment) {
         return blobStore.save(blobStore.getDefaultBucketName(), attachment.getBytes())
             .map(blobId -> CassandraAttachmentDAOV2.from(attachment.getMetadata(), blobId))
             .flatMap(attachmentDAOV2::storeAttachment)

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentV2Migration.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentV2Migration.java
@@ -54,10 +54,10 @@ public class AttachmentV2Migration implements Migration {
             .blockLast();
     }
 
-    private Mono<Void> migrateAttachment(Attachment attachment) {
+    private Mono<Void> migrateAttachment(Attachment.WithBytes attachment) {
         return blobStore.save(blobStore.getDefaultBucketName(), attachment.getBytes())
-            .map(blobId -> CassandraAttachmentDAOV2.from(attachment, blobId))
+            .map(blobId -> CassandraAttachmentDAOV2.from(attachment.getMetadata(), blobId))
             .flatMap(attachmentDAOV2::storeAttachment)
-            .then(attachmentDAOV1.deleteAttachment(attachment.getAttachmentId()));
+            .then(attachmentDAOV1.deleteAttachment(attachment.getMetadata().getAttachmentId()));
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/AttachmentLoaderTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/AttachmentLoaderTest.java
@@ -53,7 +53,7 @@ class AttachmentLoaderTest {
 
         Attachment attachment = Attachment.builder()
             .attachmentId(attachmentId)
-            .bytes("attachment".getBytes())
+            .size(10)
             .type("type")
             .build();
 
@@ -79,7 +79,7 @@ class AttachmentLoaderTest {
 
         Attachment attachment = Attachment.builder()
             .attachmentId(attachmentId)
-            .bytes("attachment".getBytes())
+            .size(10)
             .type("type")
             .build();
 
@@ -108,12 +108,12 @@ class AttachmentLoaderTest {
 
         Attachment attachment1 = Attachment.builder()
             .attachmentId(attachmentId1)
-            .bytes("attachment1".getBytes())
+            .size(11)
             .type("type")
             .build();
         Attachment attachment2 = Attachment.builder()
             .attachmentId(attachmentId2)
-            .bytes("attachment2".getBytes())
+            .size(11)
             .type("type")
             .build();
 
@@ -143,7 +143,7 @@ class AttachmentLoaderTest {
 
         Attachment attachment = Attachment.builder()
             .attachmentId(attachmentId)
-            .bytes("attachment".getBytes())
+            .size(10)
             .type("type")
             .build();
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2Test.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2Test.java
@@ -21,7 +21,6 @@ package org.apache.james.mailbox.cassandra.mail;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import org.apache.james.backends.cassandra.CassandraCluster;
@@ -65,7 +64,7 @@ class CassandraAttachmentDAOV2Test {
         Attachment attachment = Attachment.builder()
             .attachmentId(ATTACHMENT_ID)
             .type("application/json")
-            .bytes("{\"property\":`\"value\"}".getBytes(StandardCharsets.UTF_8))
+            .size(28)
             .build();
         BlobId blobId = BLOB_ID_FACTORY.from("blobId");
         DAOAttachment daoAttachment = CassandraAttachmentDAOV2.from(attachment, blobId);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOTest.java
@@ -213,7 +213,7 @@ class CassandraMessageDAOTest {
         //Given
         MessageAttachment attachment = MessageAttachment.builder()
             .attachment(Attachment.builder()
-                .bytes("content".getBytes(StandardCharsets.UTF_8))
+                .size(7)
                 .type("type")
                 .build())
             .build();
@@ -233,13 +233,13 @@ class CassandraMessageDAOTest {
         //Given
         MessageAttachment attachment1 = MessageAttachment.builder()
             .attachment(Attachment.builder()
-                .bytes("content".getBytes(StandardCharsets.UTF_8))
+                .size(7)
                 .type("type")
                 .build())
             .build();
         MessageAttachment attachment2 = MessageAttachment.builder()
             .attachment(Attachment.builder()
-                .bytes("other content".getBytes(StandardCharsets.UTF_8))
+                .size(13)
                 .type("type")
                 .build())
             .build();
@@ -261,13 +261,13 @@ class CassandraMessageDAOTest {
         MessageId messageId2 = messageIdFactory.generate();
         MessageAttachment attachment1 = MessageAttachment.builder()
             .attachment(Attachment.builder()
-                .bytes("content".getBytes(StandardCharsets.UTF_8))
+                .size(7)
                 .type("type")
                 .build())
             .build();
         MessageAttachment attachment2 = MessageAttachment.builder()
             .attachment(Attachment.builder()
-                .bytes("other content".getBytes(StandardCharsets.UTF_8))
+                .size(13)
                 .type("type")
                 .build())
             .build();
@@ -306,13 +306,13 @@ class CassandraMessageDAOTest {
         MessageId messageId3 = messageIdFactory.generate();
         MessageAttachment attachmentFor1 = MessageAttachment.builder()
             .attachment(Attachment.builder()
-                .bytes("content".getBytes(StandardCharsets.UTF_8))
+                .size(7)
                 .type("type")
                 .build())
             .build();
         MessageAttachment attachmentFor3 = MessageAttachment.builder()
             .attachment(Attachment.builder()
-                .bytes("other content".getBytes(StandardCharsets.UTF_8))
+                .size(13)
                 .type("type")
                 .build())
             .build();

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentMessageIdCreationTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentMessageIdCreationTest.java
@@ -61,6 +61,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+
 import reactor.core.publisher.Flux;
 
 @ExtendWith(CassandraRestartExtension.class)
@@ -192,7 +193,7 @@ class AttachmentMessageIdCreationTest {
     private MessageAttachment createAttachment() {
         return MessageAttachment.builder()
             .attachment(Attachment.builder()
-                .bytes("content".getBytes(StandardCharsets.UTF_8))
+                .size(10)
                 .type("type")
                 .build())
             .build();

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentV2MigrationTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/AttachmentV2MigrationTest.java
@@ -36,6 +36,7 @@ import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.cassandra.CassandraBlobModule;
 import org.apache.james.blob.cassandra.CassandraBlobStore;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAO.DAOAttachmentV1;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
 import org.apache.james.mailbox.cassandra.modules.CassandraAttachmentModule;
 import org.apache.james.mailbox.model.Attachment;
@@ -65,8 +66,8 @@ class AttachmentV2MigrationTest {
     private CassandraAttachmentDAOV2 attachmentDAOV2;
     private CassandraBlobStore blobsStore;
     private AttachmentV2Migration migration;
-    private Attachment.WithBytes attachment1;
-    private Attachment.WithBytes attachment2;
+    private DAOAttachmentV1 attachment1;
+    private DAOAttachmentV1 attachment2;
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
@@ -77,15 +78,17 @@ class AttachmentV2MigrationTest {
         migration = new AttachmentV2Migration(attachmentDAO, attachmentDAOV2, blobsStore);
 
         byte[] bytes1 = "{\"property\":`\"value1\"}".getBytes(StandardCharsets.UTF_8);
-        attachment1 = Attachment.builder()
+        attachment1 = new DAOAttachmentV1(bytes1, Attachment.builder()
             .attachmentId(ATTACHMENT_ID)
             .type("application/json")
-            .buildWithBytes(bytes1);
+            .size(bytes1.length)
+            .build());
         byte[] bytes2 = "{\"property\":`\"value2\"}".getBytes(StandardCharsets.UTF_8);
-        attachment2 = Attachment.builder()
+        attachment2 = new DAOAttachmentV1(bytes2, Attachment.builder()
             .attachmentId(ATTACHMENT_ID_2)
             .type("application/json")
-            .buildWithBytes(bytes2);
+            .size(bytes2.length)
+            .build());
     }
 
     @Test

--- a/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndex.java
+++ b/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndex.java
@@ -149,7 +149,7 @@ public class ElasticSearchListeningMessageSearchIndex extends ListeningMessageSe
 
     private String generateIndexedJson(Mailbox mailbox, MailboxMessage message, MailboxSession session) throws JsonProcessingException {
         try {
-            return messageToElasticSearchJson.convertToJson(message, ImmutableList.of(session.getUser()));
+            return messageToElasticSearchJson.convertToJson(message);
         } catch (Exception e) {
             LOGGER.warn("Indexing mailbox {}-{} of user {} on message {} without attachments ",
                 mailbox.getName(),
@@ -157,7 +157,7 @@ public class ElasticSearchListeningMessageSearchIndex extends ListeningMessageSe
                 session.getUser().asString(),
                 message.getUid(),
                 e);
-            return messageToElasticSearchJson.convertToJsonWithoutAttachment(message, ImmutableList.of(session.getUser()));
+            return messageToElasticSearchJson.convertToJsonWithoutAttachment(message);
         }
     }
 

--- a/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/json/MessageToElasticSearchJson.java
+++ b/mailbox/elasticsearch/src/main/java/org/apache/james/mailbox/elasticsearch/json/MessageToElasticSearchJson.java
@@ -20,12 +20,10 @@
 package org.apache.james.mailbox.elasticsearch.json;
 
 import java.time.ZoneId;
-import java.util.List;
 
 import javax.inject.Inject;
 import javax.mail.Flags;
 
-import org.apache.james.core.Username;
 import org.apache.james.mailbox.ModSeq;
 import org.apache.james.mailbox.elasticsearch.IndexAttachments;
 import org.apache.james.mailbox.extractor.TextExtractor;
@@ -58,7 +56,7 @@ public class MessageToElasticSearchJson {
         this(textExtractor, ZoneId.systemDefault(), indexAttachments);
     }
 
-    public String convertToJson(MailboxMessage message, List<Username> usernames) throws JsonProcessingException {
+    public String convertToJson(MailboxMessage message) throws JsonProcessingException {
         Preconditions.checkNotNull(message);
 
         return mapper.writeValueAsString(IndexableMessage.builder()
@@ -69,7 +67,7 @@ public class MessageToElasticSearchJson {
                 .build());
     }
 
-    public String convertToJsonWithoutAttachment(MailboxMessage message, List<Username> usernames) throws JsonProcessingException {
+    public String convertToJsonWithoutAttachment(MailboxMessage message) throws JsonProcessingException {
         return mapper.writeValueAsString(IndexableMessage.builder()
                 .message(message)
                 .extractor(textExtractor)

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndexTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndexTest.java
@@ -113,7 +113,7 @@ public class ElasticSearchListeningMessageSearchIndexTest {
 
     private static final MessageAttachment MESSAGE_ATTACHMENT = MessageAttachment.builder()
         .attachment(Attachment.builder()
-            .bytes("".getBytes(StandardCharsets.UTF_8))
+            .size(0)
             .type("type")
             .build())
         .name("name")

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/MessageToElasticSearchJsonTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/MessageToElasticSearchJsonTest.java
@@ -31,7 +31,6 @@ import java.util.Date;
 
 import javax.mail.Flags;
 
-import org.apache.james.core.Username;
 import org.apache.james.mailbox.FlagsBuilder;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.ModSeq;
@@ -55,8 +54,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
-
 public class MessageToElasticSearchJsonTest {
     private static final int SIZE = 25;
     private static final int BODY_START_OCTET = 100;
@@ -64,7 +61,6 @@ public class MessageToElasticSearchJsonTest {
     private static final MessageId MESSAGE_ID = TestMessageId.of(184L);
     private static final ModSeq MOD_SEQ = ModSeq.of(42L);
     private static final MessageUid UID = MessageUid.of(25);
-    private static final Username USERNAME = Username.of("username");
 
     private TextExtractor textExtractor;
 
@@ -105,7 +101,7 @@ public class MessageToElasticSearchJsonTest {
                 MAILBOX_ID);
         spamMail.setUid(UID);
         spamMail.setModSeq(MOD_SEQ);
-        assertThatJson(messageToElasticSearchJson.convertToJson(spamMail, ImmutableList.of(USERNAME)))
+        assertThatJson(messageToElasticSearchJson.convertToJson(spamMail))
             .when(IGNORING_ARRAY_ORDER)
             .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/spamMail.json"));
     }
@@ -125,7 +121,7 @@ public class MessageToElasticSearchJsonTest {
                 MAILBOX_ID);
         htmlMail.setModSeq(MOD_SEQ);
         htmlMail.setUid(UID);
-        assertThatJson(messageToElasticSearchJson.convertToJson(htmlMail, ImmutableList.of(USERNAME)))
+        assertThatJson(messageToElasticSearchJson.convertToJson(htmlMail))
             .when(IGNORING_ARRAY_ORDER)
             .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/htmlMail.json"));
     }
@@ -145,7 +141,7 @@ public class MessageToElasticSearchJsonTest {
                 MAILBOX_ID);
         pgpSignedMail.setModSeq(MOD_SEQ);
         pgpSignedMail.setUid(UID);
-        assertThatJson(messageToElasticSearchJson.convertToJson(pgpSignedMail, ImmutableList.of(USERNAME)))
+        assertThatJson(messageToElasticSearchJson.convertToJson(pgpSignedMail))
             .when(IGNORING_ARRAY_ORDER)
             .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/pgpSignedMail.json"));
     }
@@ -165,8 +161,7 @@ public class MessageToElasticSearchJsonTest {
                 MAILBOX_ID);
         mail.setModSeq(MOD_SEQ);
         mail.setUid(UID);
-        assertThatJson(messageToElasticSearchJson.convertToJson(mail,
-                ImmutableList.of(Username.of("user1"), Username.of("user2"))))
+        assertThatJson(messageToElasticSearchJson.convertToJson(mail))
             .when(IGNORING_ARRAY_ORDER).when(IGNORING_VALUES)
             .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/mail.json"));
     }
@@ -186,7 +181,7 @@ public class MessageToElasticSearchJsonTest {
                 MAILBOX_ID);
         recursiveMail.setModSeq(MOD_SEQ);
         recursiveMail.setUid(UID);
-        assertThatJson(messageToElasticSearchJson.convertToJson(recursiveMail, ImmutableList.of(USERNAME)))
+        assertThatJson(messageToElasticSearchJson.convertToJson(recursiveMail))
             .when(IGNORING_ARRAY_ORDER).when(IGNORING_VALUES)
             .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/recursiveMail.json"));
     }
@@ -206,7 +201,7 @@ public class MessageToElasticSearchJsonTest {
                 MAILBOX_ID);
         mailWithNoInternalDate.setModSeq(MOD_SEQ);
         mailWithNoInternalDate.setUid(UID);
-        assertThatJson(messageToElasticSearchJson.convertToJson(mailWithNoInternalDate, ImmutableList.of(USERNAME)))
+        assertThatJson(messageToElasticSearchJson.convertToJson(mailWithNoInternalDate))
             .when(IGNORING_ARRAY_ORDER)
             .when(IGNORING_VALUES)
             .isEqualTo(ClassLoaderUtils.getSystemResourceAsString("eml/recursiveMail.json"));
@@ -231,7 +226,7 @@ public class MessageToElasticSearchJsonTest {
             new DefaultTextExtractor(),
             ZoneId.of("Europe/Paris"),
             IndexAttachments.YES);
-        String convertToJson = messageToElasticSearchJson.convertToJson(mailWithNoInternalDate, ImmutableList.of(USERNAME));
+        String convertToJson = messageToElasticSearchJson.convertToJson(mailWithNoInternalDate);
 
         // Then
         assertThatJson(convertToJson)
@@ -259,7 +254,7 @@ public class MessageToElasticSearchJsonTest {
             new DefaultTextExtractor(),
             ZoneId.of("Europe/Paris"),
             IndexAttachments.NO);
-        String convertToJson = messageToElasticSearchJson.convertToJson(mailWithNoInternalDate, ImmutableList.of(USERNAME));
+        String convertToJson = messageToElasticSearchJson.convertToJson(mailWithNoInternalDate);
 
         // Then
         assertThatJson(convertToJson)
@@ -284,7 +279,7 @@ public class MessageToElasticSearchJsonTest {
         mailWithNoMailboxId.setUid(UID);
 
         assertThatThrownBy(() ->
-            messageToElasticSearchJson.convertToJson(mailWithNoMailboxId, ImmutableList.of(USERNAME)))
+            messageToElasticSearchJson.convertToJson(mailWithNoMailboxId))
             .isInstanceOf(NullPointerException.class);
     }
 
@@ -333,7 +328,7 @@ public class MessageToElasticSearchJsonTest {
         spamMail.setUid(UID);
         spamMail.setModSeq(MOD_SEQ);
 
-        assertThatJson(messageToElasticSearchJson.convertToJson(spamMail, ImmutableList.of(USERNAME)))
+        assertThatJson(messageToElasticSearchJson.convertToJson(spamMail))
             .when(IGNORING_ARRAY_ORDER)
             .isEqualTo(
                 ClassLoaderUtils.getSystemResourceAsString("eml/nonTextual.json", StandardCharsets.UTF_8));
@@ -358,7 +353,7 @@ public class MessageToElasticSearchJsonTest {
                 new DefaultTextExtractor(),
                 ZoneId.of("Europe/Paris"),
                 IndexAttachments.NO);
-        String convertToJsonWithoutAttachment = messageToElasticSearchJson.convertToJsonWithoutAttachment(message, ImmutableList.of(USERNAME));
+        String convertToJsonWithoutAttachment = messageToElasticSearchJson.convertToJsonWithoutAttachment(message);
 
         // Then
         assertThatJson(convertToJsonWithoutAttachment)
@@ -386,7 +381,7 @@ public class MessageToElasticSearchJsonTest {
                 new JsoupTextExtractor(),
                 ZoneId.of("Europe/Paris"),
                 IndexAttachments.NO);
-        String convertToJsonWithoutAttachment = messageToElasticSearchJson.convertToJsonWithoutAttachment(message, ImmutableList.of(USERNAME));
+        String convertToJsonWithoutAttachment = messageToElasticSearchJson.convertToJsonWithoutAttachment(message);
 
         System.out.println(convertToJsonWithoutAttachment);
 

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/AbstractJPAMailboxMessage.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/AbstractJPAMailboxMessage.java
@@ -505,7 +505,10 @@ public abstract class AbstractJPAMailboxMessage implements MailboxMessage {
     @Override
     public List<MessageAttachment> getAttachments() {
         try {
-            return new MessageParser().retrieveAttachments(getFullContent());
+            return new MessageParser().retrieveAttachments(getFullContent())
+                .stream()
+                .map(MessageAttachment.WithBytes::getMetadata)
+                .collect(Guavate.toImmutableList());
         } catch (MimeException | IOException e) {
             throw new RuntimeException(e);
         }

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/AbstractJPAMailboxMessage.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/AbstractJPAMailboxMessage.java
@@ -507,7 +507,7 @@ public abstract class AbstractJPAMailboxMessage implements MailboxMessage {
         try {
             return new MessageParser().retrieveAttachments(getFullContent())
                 .stream()
-                .map(MessageAttachment.WithBytes::getMetadata)
+                .map(MessageParser.MessageAttachmentWithBytes::getMetadata)
                 .collect(Guavate.toImmutableList());
         } catch (MimeException | IOException e) {
             throw new RuntimeException(e);

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/model/MaildirMessage.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/model/MaildirMessage.java
@@ -47,6 +47,8 @@ import org.apache.james.mime4j.stream.MimeConfig;
 import org.apache.james.mime4j.stream.MimeTokenStream;
 import org.apache.james.mime4j.stream.RecursionMode;
 
+import com.github.steveash.guavate.Guavate;
+
 public class MaildirMessage implements Message {
 
     private final MaildirMessageName messageName;
@@ -269,7 +271,10 @@ public class MaildirMessage implements Message {
     @Override
     public List<MessageAttachment> getAttachments() {
         try {
-            return new MessageParser().retrieveAttachments(getFullContent());
+            return new MessageParser().retrieveAttachments(getFullContent())
+                .stream()
+                .map(MessageAttachment.WithBytes::getMetadata)
+                .collect(Guavate.toImmutableList());
         } catch (MimeException | IOException e) {
             throw new RuntimeException(e);
         }

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/model/MaildirMessage.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/model/MaildirMessage.java
@@ -273,7 +273,7 @@ public class MaildirMessage implements Message {
         try {
             return new MessageParser().retrieveAttachments(getFullContent())
                 .stream()
-                .map(MessageAttachment.WithBytes::getMetadata)
+                .map(MessageParser.MessageAttachmentWithBytes::getMetadata)
                 .collect(Guavate.toImmutableList());
         } catch (MimeException | IOException e) {
             throw new RuntimeException(e);

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/InMemoryMessageManager.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/InMemoryMessageManager.java
@@ -8,8 +8,8 @@ import org.apache.james.mailbox.MailboxPathLocker;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.events.EventBus;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.Attachment;
 import org.apache.james.mailbox.model.Mailbox;
-import org.apache.james.mailbox.model.MessageAttachment;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.quota.QuotaManager;
 import org.apache.james.mailbox.quota.QuotaRootResolver;
@@ -21,8 +21,6 @@ import org.apache.james.mailbox.store.StoreRightManager;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.impl.MessageParser;
 import org.apache.james.mailbox.store.search.MessageSearchIndex;
-
-import com.github.steveash.guavate.Guavate;
 
 public class InMemoryMessageManager extends StoreMessageManager {
 
@@ -54,12 +52,10 @@ public class InMemoryMessageManager extends StoreMessageManager {
     }
 
     @Override
-    protected void storeAttachment(final MailboxMessage message, final List<MessageAttachment> messageAttachments, final MailboxSession session) throws MailboxException {
+    protected void storeAttachment(final MailboxMessage message, final List<Attachment.WithBytes> messageAttachments, final MailboxSession session) throws MailboxException {
         mapperFactory.getAttachmentMapper(session)
             .storeAttachmentsForMessage(
-                messageAttachments.stream()
-                    .map(MessageAttachment::getAttachment)
-                    .collect(Guavate.toImmutableList()),
+                messageAttachments,
                 message.getMessageId());
     }
 }

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/InMemoryMessageManager.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/InMemoryMessageManager.java
@@ -1,6 +1,6 @@
 package org.apache.james.mailbox.inmemory;
 
-import java.util.List;
+import java.util.Map;
 
 import javax.mail.Flags;
 
@@ -52,7 +52,7 @@ public class InMemoryMessageManager extends StoreMessageManager {
     }
 
     @Override
-    protected void storeAttachment(final MailboxMessage message, final List<Attachment.WithBytes> messageAttachments, final MailboxSession session) throws MailboxException {
+    protected void storeAttachment(final MailboxMessage message, final Map<Attachment, byte[]> messageAttachments, final MailboxSession session) throws MailboxException {
         mapperFactory.getAttachmentMapper(session)
             .storeAttachmentsForMessage(
                 messageAttachments,

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryAttachmentMapper.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryAttachmentMapper.java
@@ -114,9 +114,9 @@ public class InMemoryAttachmentMapper implements AttachmentMapper {
     }
 
     @Override
-    public void storeAttachmentForOwner(Attachment.WithBytes attachment, Username owner) throws MailboxException {
-        attachmentsById.put(attachment.getMetadata().getAttachmentId(), new AttachmentWithBytes(attachment.getBytes(), attachment.getMetadata()));
-        ownersByAttachmentId.put(attachment.getMetadata().getAttachmentId(), owner);
+    public void storeAttachmentForOwner(Attachment attachment, byte[] bytes, Username owner) throws MailboxException {
+        attachmentsById.put(attachment.getAttachmentId(), new AttachmentWithBytes(bytes, attachment));
+        ownersByAttachmentId.put(attachment.getAttachmentId(), owner);
     }
 
     @Override

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryAttachmentMapper.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryAttachmentMapper.java
@@ -18,7 +18,7 @@
  ****************************************************************/
 package org.apache.james.mailbox.inmemory.mail;
 
-import java.io.InputStream;
+import java.io.ByteArrayInputStream;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -104,7 +104,7 @@ public class InMemoryAttachmentMapper implements AttachmentMapper {
     }
 
     @Override
-    public InputStream retrieveContent(AttachmentId attachmentId) throws MailboxException {
+    public ByteArrayInputStream retrieveContent(AttachmentId attachmentId) throws MailboxException {
         return retrieveContentWithBytes(attachmentId).getStream();
     }
 

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageConverterTest.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageConverterTest.java
@@ -35,7 +35,6 @@ import static org.apache.mailet.base.MailAddressFixture.SENDER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -73,7 +72,7 @@ class DeletedMessageConverterTest {
     private static final Collection<MessageAttachment> NO_ATTACHMENT = ImmutableList.of();
     private static final Collection<MessageAttachment> ATTACHMENTS = ImmutableList.of(MessageAttachment.builder()
         .attachment(Attachment.builder()
-            .bytes("content".getBytes(StandardCharsets.UTF_8))
+            .size(7)
             .type("type")
             .build())
         .build());

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreAttachmentManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreAttachmentManager.java
@@ -81,6 +81,9 @@ public class StoreAttachmentManager implements AttachmentManager {
 
     @Override
     public Attachment.WithBytes retrieveContent(AttachmentId id, MailboxSession session) throws MailboxException, AttachmentNotFoundException {
+        if (!userHasAccessToAttachment(id, session)) {
+            throw new AttachmentNotFoundException(id.getId());
+        }
         return attachmentMapperFactory.getAttachmentMapper(session)
             .retrieveContent(id);
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreAttachmentManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreAttachmentManager.java
@@ -75,9 +75,9 @@ public class StoreAttachmentManager implements AttachmentManager {
     }
 
     @Override
-    public void storeAttachment(Attachment.WithBytes attachment, MailboxSession mailboxSession) throws MailboxException {
+    public void storeAttachment(Attachment attachment, byte[] bytes, MailboxSession mailboxSession) throws MailboxException {
         attachmentMapperFactory.getAttachmentMapper(mailboxSession)
-            .storeAttachmentForOwner(attachment.getMetadata(), attachment.getBytes(), mailboxSession.getUser());
+            .storeAttachmentForOwner(attachment, bytes, mailboxSession.getUser());
     }
 
     @Override

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreAttachmentManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreAttachmentManager.java
@@ -77,7 +77,7 @@ public class StoreAttachmentManager implements AttachmentManager {
     @Override
     public void storeAttachment(Attachment.WithBytes attachment, MailboxSession mailboxSession) throws MailboxException {
         attachmentMapperFactory.getAttachmentMapper(mailboxSession)
-            .storeAttachmentForOwner(attachment, mailboxSession.getUser());
+            .storeAttachmentForOwner(attachment.getMetadata(), attachment.getBytes(), mailboxSession.getUser());
     }
 
     @Override

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreAttachmentManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreAttachmentManager.java
@@ -74,9 +74,15 @@ public class StoreAttachmentManager implements AttachmentManager {
     }
 
     @Override
-    public void storeAttachment(Attachment attachment, MailboxSession mailboxSession) throws MailboxException {
+    public void storeAttachment(Attachment.WithBytes attachment, MailboxSession mailboxSession) throws MailboxException {
         attachmentMapperFactory.getAttachmentMapper(mailboxSession)
             .storeAttachmentForOwner(attachment, mailboxSession.getUser());
+    }
+
+    @Override
+    public Attachment.WithBytes retrieveContent(AttachmentId id, MailboxSession session) throws MailboxException, AttachmentNotFoundException {
+        return attachmentMapperFactory.getAttachmentMapper(session)
+            .retrieveContent(id);
     }
 
     private boolean userHasAccessToAttachment(AttachmentId attachmentId, MailboxSession mailboxSession) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreAttachmentManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreAttachmentManager.java
@@ -34,7 +34,6 @@ import org.apache.james.mailbox.model.Attachment;
 import org.apache.james.mailbox.model.AttachmentId;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.store.mail.AttachmentMapperFactory;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,11 +77,6 @@ public class StoreAttachmentManager implements AttachmentManager {
     public void storeAttachment(Attachment attachment, MailboxSession mailboxSession) throws MailboxException {
         attachmentMapperFactory.getAttachmentMapper(mailboxSession)
             .storeAttachmentForOwner(attachment, mailboxSession.getUser());
-    }
-
-    @Override
-    public void storeAttachmentsForMessage(Collection<Attachment> attachments, MessageId ownerMessageId, MailboxSession mailboxSession) throws MailboxException {
-        attachmentMapperFactory.getAttachmentMapper(mailboxSession).storeAttachmentsForMessage(attachments, ownerMessageId);
     }
 
     private boolean userHasAccessToAttachment(AttachmentId attachmentId, MailboxSession mailboxSession) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreAttachmentManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreAttachmentManager.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mailbox.store;
 
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
 
@@ -80,7 +81,7 @@ public class StoreAttachmentManager implements AttachmentManager {
     }
 
     @Override
-    public Attachment.WithBytes retrieveContent(AttachmentId id, MailboxSession session) throws MailboxException, AttachmentNotFoundException {
+    public InputStream retrieveContent(AttachmentId id, MailboxSession session) throws MailboxException, AttachmentNotFoundException {
         if (!userHasAccessToAttachment(id, session)) {
             throw new AttachmentNotFoundException(id.getId());
         }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreBlobManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreBlobManager.java
@@ -70,7 +70,7 @@ public class StoreBlobManager implements BlobManager {
     private Optional<Blob> getBlobFromAttachment(BlobId blobId, MailboxSession mailboxSession) throws MailboxException {
         try {
             AttachmentId attachmentId = AttachmentId.from(blobId);
-            return Optional.of(attachmentManager.getAttachment(attachmentId, mailboxSession).toBlob());
+            return Optional.of(attachmentManager.retrieveContent(attachmentId, mailboxSession).toBlob());
         } catch (AttachmentNotFoundException e) {
             return Optional.empty();
         }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -681,10 +681,11 @@ public class StoreMessageManager implements MessageManager {
     }
 
     private MessageMetaData appendMessageToStore(final MailboxMessage message, final List<MessageParser.MessageAttachmentWithBytes> messageAttachments, MailboxSession session) throws MailboxException {
-        final MessageMapper messageMapper = mapperFactory.getMessageMapper(session);
-        final List<Attachment.WithBytes> attachmentsWithByte = messageAttachments.stream()
-            .map(MessageParser.MessageAttachmentWithBytes::getAttachmentWithBytes)
-            .collect(Guavate.toImmutableList());
+        MessageMapper messageMapper = mapperFactory.getMessageMapper(session);
+        Map<Attachment, byte[]> attachmentsWithByte = messageAttachments.stream()
+            .collect(Guavate.toImmutableMap(
+                MessageParser.MessageAttachmentWithBytes::getAttachment,
+                MessageParser.MessageAttachmentWithBytes::getBytes));
 
         return mapperFactory.getMessageMapper(session).execute(() -> {
             storeAttachment(message, attachmentsWithByte, session);
@@ -692,7 +693,7 @@ public class StoreMessageManager implements MessageManager {
         });
     }
 
-    protected void storeAttachment(final MailboxMessage message, final List<Attachment.WithBytes> messageAttachments, final MailboxSession session) throws MailboxException {
+    protected void storeAttachment(final MailboxMessage message, final Map<Attachment, byte[]> messageAttachments, final MailboxSession session) throws MailboxException {
 
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -446,9 +446,9 @@ public class StoreMessageManager implements MessageManager {
         try (SharedFileInputStream contentIn = new SharedFileInputStream(file)) {
             final int size = (int) file.length();
 
-            final List<MessageAttachment.WithBytes> attachments = extractAttachments(contentIn);
+            final List<MessageParser.MessageAttachmentWithBytes> attachments = extractAttachments(contentIn);
             final List<MessageAttachment> attachmentsMetadata = attachments.stream()
-                .map(MessageAttachment.WithBytes::getMetadata)
+                .map(MessageParser.MessageAttachmentWithBytes::getMetadata)
                 .collect(Guavate.toImmutableList());
             propertyBuilder.setHasAttachment(hasNonInlinedAttachment(attachments));
 
@@ -503,13 +503,13 @@ public class StoreMessageManager implements MessageManager {
         return propertyBuilder;
     }
 
-    private boolean hasNonInlinedAttachment(List<MessageAttachment.WithBytes> attachments) {
+    private boolean hasNonInlinedAttachment(List<MessageParser.MessageAttachmentWithBytes> attachments) {
         return attachments.stream()
-            .map(MessageAttachment.WithBytes::getMetadata)
+            .map(MessageParser.MessageAttachmentWithBytes::getMetadata)
             .anyMatch(messageAttachment -> !messageAttachment.isInlinedWithCid());
     }
 
-    private List<MessageAttachment.WithBytes> extractAttachments(SharedFileInputStream contentIn) {
+    private List<MessageParser.MessageAttachmentWithBytes> extractAttachments(SharedFileInputStream contentIn) {
         try {
             return messageParser.retrieveAttachments(contentIn);
         } catch (Exception e) {
@@ -680,10 +680,10 @@ public class StoreMessageManager implements MessageManager {
         }, MailboxPathLocker.LockType.Write);
     }
 
-    protected MessageMetaData appendMessageToStore(final MailboxMessage message, final List<MessageAttachment.WithBytes> messageAttachments, MailboxSession session) throws MailboxException {
+    private MessageMetaData appendMessageToStore(final MailboxMessage message, final List<MessageParser.MessageAttachmentWithBytes> messageAttachments, MailboxSession session) throws MailboxException {
         final MessageMapper messageMapper = mapperFactory.getMessageMapper(session);
         final List<Attachment.WithBytes> attachmentsWithByte = messageAttachments.stream()
-            .map(MessageAttachment.WithBytes::getAttachmentWithBytes)
+            .map(MessageParser.MessageAttachmentWithBytes::getAttachmentWithBytes)
             .collect(Guavate.toImmutableList());
 
         return mapperFactory.getMessageMapper(session).execute(() -> {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AttachmentMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AttachmentMapper.java
@@ -21,6 +21,7 @@ package org.apache.james.mailbox.store.mail;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.exception.AttachmentNotFoundException;
@@ -38,9 +39,9 @@ public interface AttachmentMapper extends Mapper {
 
     InputStream retrieveContent(AttachmentId attachmentId) throws MailboxException, AttachmentNotFoundException;
 
-    void storeAttachmentForOwner(Attachment.WithBytes attachment, Username owner) throws MailboxException;
+    void storeAttachmentForOwner(Attachment attachment, byte[] bytes, Username owner) throws MailboxException;
 
-    void storeAttachmentsForMessage(Collection<Attachment.WithBytes> attachments, MessageId ownerMessageId) throws MailboxException;
+    void storeAttachmentsForMessage(Map<Attachment, byte[]> attachments, MessageId ownerMessageId) throws MailboxException;
 
     Collection<MessageId> getRelatedMessageIds(AttachmentId attachmentId) throws MailboxException;
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AttachmentMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AttachmentMapper.java
@@ -18,6 +18,7 @@
  ****************************************************************/
 package org.apache.james.mailbox.store.mail;
 
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
 
@@ -35,9 +36,7 @@ public interface AttachmentMapper extends Mapper {
 
     List<Attachment> getAttachments(Collection<AttachmentId> attachmentIds);
 
-    Attachment.WithBytes retrieveContent(AttachmentId attachmentId) throws AttachmentNotFoundException;
-
-    List<Attachment.WithBytes> retrieveContents(Collection<AttachmentId> attachmentIds);
+    InputStream retrieveContent(AttachmentId attachmentId) throws MailboxException, AttachmentNotFoundException;
 
     void storeAttachmentForOwner(Attachment.WithBytes attachment, Username owner) throws MailboxException;
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AttachmentMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AttachmentMapper.java
@@ -35,9 +35,13 @@ public interface AttachmentMapper extends Mapper {
 
     List<Attachment> getAttachments(Collection<AttachmentId> attachmentIds);
 
-    void storeAttachmentForOwner(Attachment attachment, Username owner) throws MailboxException;
+    Attachment.WithBytes retrieveContent(AttachmentId attachmentId) throws AttachmentNotFoundException;
 
-    void storeAttachmentsForMessage(Collection<Attachment> attachments, MessageId ownerMessageId) throws MailboxException;
+    List<Attachment.WithBytes> retrieveContents(Collection<AttachmentId> attachmentIds);
+
+    void storeAttachmentForOwner(Attachment.WithBytes attachment, Username owner) throws MailboxException;
+
+    void storeAttachmentsForMessage(Collection<Attachment.WithBytes> attachments, MessageId ownerMessageId) throws MailboxException;
 
     Collection<MessageId> getRelatedMessageIds(AttachmentId attachmentId) throws MailboxException;
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/MessageParser.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/MessageParser.java
@@ -72,10 +72,6 @@ public class MessageParser {
             return metadata.getAttachment();
         }
 
-        public Attachment.WithBytes getAttachmentWithBytes() {
-            return metadata.getAttachment().withBytes(bytes);
-        }
-
         public byte[] getBytes() {
             return bytes;
         }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/MessageSearches.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/MessageSearches.java
@@ -240,7 +240,7 @@ public class MessageSearches implements Iterable<SimpleMessageSearchIndex.Search
     }
 
     private boolean attachmentsContain(String value, MailboxMessage message) throws IOException, MimeException {
-        List<MessageAttachment.WithBytes> attachments = new MessageParser().retrieveAttachments(message.getFullContent());
+        List<MessageParser.MessageAttachmentWithBytes> attachments = new MessageParser().retrieveAttachments(message.getFullContent());
         return isInAttachments(value, attachments);
     }
 
@@ -251,18 +251,18 @@ public class MessageSearches implements Iterable<SimpleMessageSearchIndex.Search
             .anyMatch(nameOptional -> nameOptional.map(value::equals).orElse(false));
     }
 
-    private boolean isInAttachments(String value, List<MessageAttachment.WithBytes> attachments) {
+    private boolean isInAttachments(String value, List<MessageParser.MessageAttachmentWithBytes> attachments) {
         return attachments.stream()
             .flatMap(this::toAttachmentContent)
             .anyMatch(string -> string.contains(value));
     }
 
-    private Stream<String> toAttachmentContent(MessageAttachment.WithBytes attachment) {
+    private Stream<String> toAttachmentContent(MessageParser.MessageAttachmentWithBytes attachment) {
         try {
             return OptionalUtils.toStream(
                     textExtractor
                          .extractContent(
-                             attachment.getAttachmentWithBytes().getStream(),
+                             new ByteArrayInputStream(attachment.getBytes()),
                              attachment.getAttachment().getType())
                         .getTextualContent());
         } catch (Exception e) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/MessageSearches.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/MessageSearches.java
@@ -265,7 +265,7 @@ public class MessageSearches implements Iterable<SimpleMessageSearchIndex.Search
                              attachment.getAttachmentWithBytes().getStream(),
                              attachment.getAttachment().getType())
                         .getTextualContent());
-            } catch (Exception e) {
+        } catch (Exception e) {
             LOGGER.error("Error while parsing attachment content", e);
             return Stream.of();
         }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMailboxManagerAttachmentTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMailboxManagerAttachmentTest.java
@@ -123,7 +123,7 @@ public abstract class AbstractMailboxManagerAttachmentTest {
         assertThat(messages.hasNext()).isTrue();
         List<MessageAttachment> attachments = messages.next().getAttachments();
         assertThat(attachments).hasSize(1);
-        assertThat(attachmentMapper.retrieveContent(attachments.get(0).getAttachmentId()).getStream())
+        assertThat(attachmentMapper.retrieveContent(attachments.get(0).getAttachmentId()))
             .hasSameContentAs(ClassLoader.getSystemResourceAsStream("eml/gimp.png"));
     }
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreAttachmentManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreAttachmentManagerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.james.mailbox.MailboxSession;
@@ -81,7 +82,7 @@ public class StoreAttachmentManagerTest {
     @Test
     public void retrieveContentShouldThrowWhenAttachmentDoesNotBelongToUser() throws Exception {
         MailboxSession mailboxSession = mock(MailboxSession.class);
-        when(attachmentMapper.retrieveContent(ATTACHMENT_ID)).thenReturn(ATTACHMENT.withBytes("abc".getBytes(StandardCharsets.UTF_8)));
+        when(attachmentMapper.retrieveContent(ATTACHMENT_ID)).thenReturn(new ByteArrayInputStream("abc".getBytes(StandardCharsets.UTF_8)));
         when(attachmentMapper.getRelatedMessageIds(ATTACHMENT_ID)).thenReturn(MESSAGE_IDS);
         when(attachmentMapper.getOwners(ATTACHMENT_ID)).thenReturn(ImmutableList.of());
         when(messageIdManager.accessibleMessages(MESSAGE_IDS, mailboxSession)).thenReturn(ImmutableSet.of());

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreAttachmentManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreAttachmentManagerTest.java
@@ -24,6 +24,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.exception.AttachmentNotFoundException;
@@ -73,6 +75,18 @@ public class StoreAttachmentManagerTest {
         when(messageIdManager.accessibleMessages(MESSAGE_IDS, mailboxSession)).thenReturn(ImmutableSet.of());
 
         assertThatThrownBy(() -> testee.getAttachment(ATTACHMENT_ID, mailboxSession))
+            .isInstanceOf(AttachmentNotFoundException.class);
+    }
+
+    @Test
+    public void retrieveContentShouldThrowWhenAttachmentDoesNotBelongToUser() throws Exception {
+        MailboxSession mailboxSession = mock(MailboxSession.class);
+        when(attachmentMapper.retrieveContent(ATTACHMENT_ID)).thenReturn(ATTACHMENT.withBytes("abc".getBytes(StandardCharsets.UTF_8)));
+        when(attachmentMapper.getRelatedMessageIds(ATTACHMENT_ID)).thenReturn(MESSAGE_IDS);
+        when(attachmentMapper.getOwners(ATTACHMENT_ID)).thenReturn(ImmutableList.of());
+        when(messageIdManager.accessibleMessages(MESSAGE_IDS, mailboxSession)).thenReturn(ImmutableSet.of());
+
+        assertThatThrownBy(() -> testee.retrieveContent(ATTACHMENT_ID, mailboxSession))
             .isInstanceOf(AttachmentNotFoundException.class);
     }
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreAttachmentManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreAttachmentManagerTest.java
@@ -24,8 +24,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.nio.charset.StandardCharsets;
-
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.exception.AttachmentNotFoundException;
@@ -48,7 +46,7 @@ public class StoreAttachmentManagerTest {
     private static final Attachment ATTACHMENT = Attachment.builder()
         .attachmentId(ATTACHMENT_ID)
         .type("type")
-        .bytes("Any".getBytes(StandardCharsets.UTF_8))
+        .size(3)
         .build();
 
     private StoreAttachmentManager testee;

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreBlobManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreBlobManagerTest.java
@@ -75,15 +75,18 @@ public class StoreBlobManagerTest {
 
     @Test
     public void retrieveShouldReturnBlobWhenAttachment() throws Exception {
-        when(attachmentManager.retrieveContent(ATTACHMENT_ID, session))
+        when(attachmentManager.getAttachment(ATTACHMENT_ID, session))
             .thenReturn(Attachment.builder()
                 .attachmentId(ATTACHMENT_ID)
                 .type(CONTENT_TYPE)
-                .buildWithBytes(BYTES));
+                .size(BYTES.length)
+                .build());
+        when(attachmentManager.retrieveContent(ATTACHMENT_ID, session))
+            .thenReturn(new ByteArrayInputStream(BYTES));
 
         assertThat(blobManager.retrieve(BLOB_ID_ATTACHMENT, session))
             .isEqualTo(Blob.builder()
-                .id(BlobId.fromString("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"))
+                .id(BLOB_ID_ATTACHMENT)
                 .contentType(CONTENT_TYPE)
                 .payload(BYTES)
                 .build());
@@ -91,7 +94,7 @@ public class StoreBlobManagerTest {
 
     @Test
     public void retrieveShouldThrowWhenNotFound() throws Exception {
-        when(attachmentManager.retrieveContent(ATTACHMENT_ID, session))
+        when(attachmentManager.getAttachment(ATTACHMENT_ID, session))
             .thenThrow(new AttachmentNotFoundException(ID));
         when(messageIdManager.getMessages(ImmutableList.of(MESSAGE_ID), FetchGroup.FULL_CONTENT, session))
             .thenReturn(ImmutableList.of());
@@ -102,7 +105,7 @@ public class StoreBlobManagerTest {
 
     @Test
     public void retrieveShouldReturnBlobWhenMessage() throws Exception {
-        when(attachmentManager.retrieveContent(any(), any()))
+        when(attachmentManager.getAttachment(any(), any()))
             .thenThrow(new AttachmentNotFoundException(ID));
 
         MessageResult messageResult = mock(MessageResult.class);
@@ -122,7 +125,7 @@ public class StoreBlobManagerTest {
 
     @Test
     public void retrieveShouldThrowOnMailboxExceptionWhenRetrievingAttachment() throws Exception {
-        when(attachmentManager.retrieveContent(any(), any()))
+        when(attachmentManager.getAttachment(any(), any()))
             .thenThrow(new MailboxException());
 
         assertThatThrownBy(() -> blobManager.retrieve(BLOB_ID_MESSAGE, session))

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreBlobManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreBlobManagerTest.java
@@ -75,12 +75,11 @@ public class StoreBlobManagerTest {
 
     @Test
     public void retrieveShouldReturnBlobWhenAttachment() throws Exception {
-        when(attachmentManager.getAttachment(ATTACHMENT_ID, session))
+        when(attachmentManager.retrieveContent(ATTACHMENT_ID, session))
             .thenReturn(Attachment.builder()
                 .attachmentId(ATTACHMENT_ID)
-                .bytes(BYTES)
                 .type(CONTENT_TYPE)
-                .build());
+                .buildWithBytes(BYTES));
 
         assertThat(blobManager.retrieve(BLOB_ID_ATTACHMENT, session))
             .isEqualTo(Blob.builder()
@@ -92,7 +91,7 @@ public class StoreBlobManagerTest {
 
     @Test
     public void retrieveShouldThrowWhenNotFound() throws Exception {
-        when(attachmentManager.getAttachment(ATTACHMENT_ID, session))
+        when(attachmentManager.retrieveContent(ATTACHMENT_ID, session))
             .thenThrow(new AttachmentNotFoundException(ID));
         when(messageIdManager.getMessages(ImmutableList.of(MESSAGE_ID), FetchGroup.FULL_CONTENT, session))
             .thenReturn(ImmutableList.of());
@@ -103,7 +102,7 @@ public class StoreBlobManagerTest {
 
     @Test
     public void retrieveShouldReturnBlobWhenMessage() throws Exception {
-        when(attachmentManager.getAttachment(any(), any()))
+        when(attachmentManager.retrieveContent(any(), any()))
             .thenThrow(new AttachmentNotFoundException(ID));
 
         MessageResult messageResult = mock(MessageResult.class);
@@ -123,7 +122,7 @@ public class StoreBlobManagerTest {
 
     @Test
     public void retrieveShouldThrowOnMailboxExceptionWhenRetrievingAttachment() throws Exception {
-        when(attachmentManager.getAttachment(any(), any()))
+        when(attachmentManager.retrieveContent(any(), any()))
             .thenThrow(new MailboxException());
 
         assertThatThrownBy(() -> blobManager.retrieve(BLOB_ID_MESSAGE, session))

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/AttachmentMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/AttachmentMapperTest.java
@@ -22,6 +22,7 @@ package org.apache.james.mailbox.store.mail.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
@@ -96,9 +97,9 @@ public abstract class AttachmentMapperTest {
         AttachmentId attachmentId = ATTACHMENT.getMetadata().getAttachmentId();
         attachmentMapper.storeAttachmentForOwner(ATTACHMENT, OWNER);
         //When
-        Attachment.WithBytes attachment = attachmentMapper.retrieveContent(attachmentId);
+        InputStream attachment = attachmentMapper.retrieveContent(attachmentId);
         //Then
-        assertThat(attachment).isEqualTo(ATTACHMENT);
+        assertThat(attachment).hasSameContentAs(ATTACHMENT.getStream());
     }
 
     @Test

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageWithAttachmentMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageWithAttachmentMapperTest.java
@@ -51,6 +51,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 public abstract class MessageWithAttachmentMapperTest {
 
@@ -83,38 +84,40 @@ public abstract class MessageWithAttachmentMapperTest {
         attachmentsMailbox = createMailbox(MailboxPath.forUser(Username.of("benwa"), "Attachments"));
 
         byte[] bytes = "attachment".getBytes(StandardCharsets.UTF_8);
-        Attachment.WithBytes attachment = Attachment.builder()
+        Attachment attachment = Attachment.builder()
                 .attachmentId(AttachmentId.from("123"))
                 .type("content")
-                .buildWithBytes(bytes);
+                .size(bytes.length)
+                .build();
         byte[] bytes2 = "attachment2".getBytes(StandardCharsets.UTF_8);
-        Attachment.WithBytes attachment2 = Attachment.builder()
+        Attachment attachment2 = Attachment.builder()
                 .attachmentId(AttachmentId.from("456"))
                 .type("content")
-                .buildWithBytes(bytes2);
+                .size(bytes2.length)
+                .build();
         messageWith1Attachment = createMessage(attachmentsMailbox, mapperProvider.generateMessageId(), "Subject: Test7 \n\nBody7\n.\n", BODY_START, new PropertyBuilder(), 
                 ImmutableList.of(MessageAttachment.builder()
-                        .attachment(attachment.getMetadata())
+                        .attachment(attachment)
                         .cid(Cid.from("cid"))
                         .isInline(true)
                         .build()));
         messageWith2Attachments = createMessage(attachmentsMailbox, mapperProvider.generateMessageId(), "Subject: Test8 \n\nBody8\n.\n", BODY_START, new PropertyBuilder(),
                 ImmutableList.of(
                         MessageAttachment.builder()
-                            .attachment(attachment.getMetadata())
+                            .attachment(attachment)
                             .cid(Cid.from("cid"))
                             .isInline(true)
                             .build(),
                         MessageAttachment.builder()
-                            .attachment(attachment2.getMetadata())
+                            .attachment(attachment2)
                             .cid(Cid.from("cid2"))
                             .isInline(false)
                             .build()));
         messageWithoutAttachment = createMessage(attachmentsMailbox, mapperProvider.generateMessageId(), "Subject: Test1 \n\nBody1\n.\n", BODY_START, new PropertyBuilder());
 
-        attachmentMapper.storeAttachmentsForMessage(ImmutableList.of(attachment), messageWith1Attachment.getMessageId());
-        attachmentMapper.storeAttachmentsForMessage(ImmutableList.of(attachment), messageWith2Attachments.getMessageId());
-        attachmentMapper.storeAttachmentsForMessage(ImmutableList.of(attachment2), messageWith2Attachments.getMessageId());
+        attachmentMapper.storeAttachmentsForMessage(ImmutableMap.of(attachment, bytes), messageWith1Attachment.getMessageId());
+        attachmentMapper.storeAttachmentsForMessage(ImmutableMap.of(attachment, bytes), messageWith2Attachments.getMessageId());
+        attachmentMapper.storeAttachmentsForMessage(ImmutableMap.of(attachment2, bytes2), messageWith2Attachments.getMessageId());
     }
 
     @Test

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageWithAttachmentMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageWithAttachmentMapperTest.java
@@ -23,6 +23,7 @@ import static org.apache.james.mailbox.store.mail.model.MessageAssert.assertThat
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -81,31 +82,31 @@ public abstract class MessageWithAttachmentMapperTest {
 
         attachmentsMailbox = createMailbox(MailboxPath.forUser(Username.of("benwa"), "Attachments"));
 
-        Attachment attachment = Attachment.builder()
+        byte[] bytes = "attachment".getBytes(StandardCharsets.UTF_8);
+        Attachment.WithBytes attachment = Attachment.builder()
                 .attachmentId(AttachmentId.from("123"))
-                .bytes("attachment".getBytes())
                 .type("content")
-                .build();
-        Attachment attachment2 = Attachment.builder()
+                .buildWithBytes(bytes);
+        byte[] bytes2 = "attachment2".getBytes(StandardCharsets.UTF_8);
+        Attachment.WithBytes attachment2 = Attachment.builder()
                 .attachmentId(AttachmentId.from("456"))
-                .bytes("attachment2".getBytes())
                 .type("content")
-                .build();
+                .buildWithBytes(bytes2);
         messageWith1Attachment = createMessage(attachmentsMailbox, mapperProvider.generateMessageId(), "Subject: Test7 \n\nBody7\n.\n", BODY_START, new PropertyBuilder(), 
                 ImmutableList.of(MessageAttachment.builder()
-                        .attachment(attachment)
+                        .attachment(attachment.getMetadata())
                         .cid(Cid.from("cid"))
                         .isInline(true)
                         .build()));
         messageWith2Attachments = createMessage(attachmentsMailbox, mapperProvider.generateMessageId(), "Subject: Test8 \n\nBody8\n.\n", BODY_START, new PropertyBuilder(),
                 ImmutableList.of(
                         MessageAttachment.builder()
-                            .attachment(attachment)
+                            .attachment(attachment.getMetadata())
                             .cid(Cid.from("cid"))
                             .isInline(true)
                             .build(),
                         MessageAttachment.builder()
-                            .attachment(attachment2)
+                            .attachment(attachment2.getMetadata())
                             .cid(Cid.from("cid2"))
                             .isInline(false)
                             .build()));

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/MessageParserTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/MessageParserTest.java
@@ -25,7 +25,6 @@ import java.io.ByteArrayInputStream;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.james.mailbox.model.Attachment;
 import org.apache.james.mailbox.model.Cid;
 import org.apache.james.mailbox.model.MessageAttachment;
 import org.apache.james.mdn.MDN;
@@ -51,45 +50,45 @@ public class MessageParserTest {
 
     @Test
     public void getAttachmentsShouldBeEmptyWhenNoAttachment() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/noAttachment.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/noAttachment.eml"));
 
         assertThat(attachments).isEmpty();
     }
 
     @Test
     public void getAttachmentsShouldRetrieveAttachmentsWhenOneAttachment() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
 
         assertThat(attachments).hasSize(1);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveAttachmentNameWhenOne() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
 
         assertThat(attachments).hasSize(1);
         Optional<String> expectedName = Optional.of("exploits_of_a_mom.png");
-        assertThat(attachments.get(0).getName()).isEqualTo(expectedName);
+        assertThat(attachments.get(0).getMetadata().getName()).isEqualTo(expectedName);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveAttachmentNameWhenOneContainingNonASCIICharacters() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/messageWithNonASCIIFilenameAttachment.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/messageWithNonASCIIFilenameAttachment.eml"));
         assertThat(attachments).hasSize(1);
-        assertThat(attachments.get(0).getName()).contains("ديناصور.odt");
+        assertThat(attachments.get(0).getMetadata().getName()).contains("ديناصور.odt");
     }
 
     @Test
     public void getAttachmentsShouldRetrieveEmptyNameWhenNone() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentWithoutName.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentWithoutName.eml"));
 
         assertThat(attachments).hasSize(1);
-        assertThat(attachments.get(0).getName()).isEqualTo(Optional.empty());
+        assertThat(attachments.get(0).getMetadata().getName()).isEqualTo(Optional.empty());
     }
 
     @Test
     public void getAttachmentsShouldNotFailWhenContentTypeIsNotHere() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentWithoutContentType.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentWithoutContentType.eml"));
 
         assertThat(attachments).hasSize(1);
         assertThat(attachments.get(0).getAttachment().getType()).isEqualTo("application/octet-stream");
@@ -97,7 +96,7 @@ public class MessageParserTest {
 
     @Test
     public void getAttachmentsShouldNotFailWhenContentTypeIsEmpty() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentWithEmptyContentType.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentWithEmptyContentType.eml"));
 
         assertThat(attachments).hasSize(1);
         assertThat(attachments.get(0).getAttachment().getType()).isEqualTo("application/octet-stream");
@@ -105,7 +104,7 @@ public class MessageParserTest {
 
     @Test
     public void getAttachmentsShouldRetrieveTheAttachmentContentTypeWhenOneAttachment() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
 
         assertThat(attachments).hasSize(1);
         assertThat(attachments.get(0).getAttachment().getType()).isEqualTo("application/octet-stream");
@@ -113,21 +112,21 @@ public class MessageParserTest {
 
     @Test
     public void retrieveAttachmentsShouldNotFailOnMessagesWithManyHeaders() throws Exception {
-        List<MessageAttachment> messageAttachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/mailWithManyHeaders.eml"));
+        List<MessageAttachment.WithBytes> messageAttachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/mailWithManyHeaders.eml"));
 
         assertThat(messageAttachments).hasSize(1);
     }
 
     @Test
     public void retrieveAttachmentsShouldNotFailOnMessagesWithLongHeaders() throws Exception {
-        List<MessageAttachment> messageAttachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/mailWithLongHeaders.eml"));
+        List<MessageAttachment.WithBytes> messageAttachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/mailWithLongHeaders.eml"));
 
         assertThat(messageAttachments).hasSize(1);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveTheAttachmentContentTypeWhenOneAttachmentWithSimpleContentType() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentWithSimpleContentType.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentWithSimpleContentType.eml"));
 
         assertThat(attachments).hasSize(1);
         assertThat(attachments.get(0).getAttachment().getType()).isEqualTo("application/octet-stream");
@@ -135,7 +134,7 @@ public class MessageParserTest {
 
     @Test
     public void getAttachmentsShouldRetrieveTheAttachmentSizeWhenOneAttachment() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
 
         assertThat(attachments).hasSize(1);
         assertThat(attachments.get(0).getAttachment().getSize()).isEqualTo(3071);
@@ -143,24 +142,26 @@ public class MessageParserTest {
 
     @Test
     public void getAttachmentsShouldReturnTheExpectedAttachment() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
 
-        Attachment attachment = attachments.get(0).getAttachment();
-        assertThat(attachment.getStream()).hasSameContentAs(ClassLoader.getSystemResourceAsStream("eml/gimp.png"));
+        MessageAttachment.WithBytes attachment = attachments.get(0);
+        assertThat(new ByteArrayInputStream(attachment.getBytes()))
+            .hasSameContentAs(ClassLoader.getSystemResourceAsStream("eml/gimp.png"));
     }
 
     @Test
     public void getAttachmentsShouldRetrieveAttachmentsWhenTwo() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/twoAttachments.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/twoAttachments.eml"));
 
         assertThat(attachments).hasSize(2);
     }
 
     @Test
     public void retrieveAttachmentShouldUseFilenameAsNameWhenNoName() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/filenameOnly.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/filenameOnly.eml"));
 
         assertThat(attachments).hasSize(1)
+            .extracting(MessageAttachment.WithBytes::getMetadata)
             .extracting(MessageAttachment::getName)
             .allMatch(Optional::isPresent)
             .extracting(Optional::get)
@@ -169,9 +170,10 @@ public class MessageParserTest {
 
     @Test
     public void retrieveAttachmentShouldUseNameWhenBothNameAndFilename() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/filenameAndName.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/filenameAndName.eml"));
 
         assertThat(attachments).hasSize(1)
+            .extracting(MessageAttachment.WithBytes::getMetadata)
             .extracting(MessageAttachment::getName)
             .allMatch(Optional::isPresent)
             .extracting(Optional::get)
@@ -180,93 +182,93 @@ public class MessageParserTest {
 
     @Test
     public void getAttachmentsShouldRetrieveEmbeddedAttachmentsWhenSome() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/embeddedAttachmentWithInline.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/embeddedAttachmentWithInline.eml"));
 
         assertThat(attachments).hasSize(1);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveInlineAttachmentsWhenSome() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/embeddedAttachmentWithAttachment.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/embeddedAttachmentWithAttachment.eml"));
 
         assertThat(attachments).hasSize(1);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveTheAttachmentCIDWhenOne() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachment.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachment.eml"));
 
         assertThat(attachments).hasSize(1);
-        assertThat(attachments.get(0).getCid()).isEqualTo(Optional.of(Cid.from("part1.37A15C92.A7C3488D@linagora.com")));
+        assertThat(attachments.get(0).getMetadata().getCid()).isEqualTo(Optional.of(Cid.from("part1.37A15C92.A7C3488D@linagora.com")));
     }
 
     @Test
     public void getAttachmentsShouldSetInlineWhenOneInlinedAttachment() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachment.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachment.eml"));
 
         assertThat(attachments).hasSize(1);
-        assertThat(attachments.get(0).isInline()).isTrue();
+        assertThat(attachments.get(0).getMetadata().isInline()).isTrue();
     }
 
     @Test
     public void getAttachementsShouldRetrieveHtmlAttachementsWhenSome() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneHtmlAttachmentAndSomeTextInlined.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneHtmlAttachmentAndSomeTextInlined.eml"));
 
         assertThat(attachments).hasSize(1);
     }
 
     @Test
     public void getAttachementsShouldRetrieveAttachmentsWhenSomeAreInTheMultipartAlternative() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/invitationEmailFromOP.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/invitationEmailFromOP.eml"));
         
         assertThat(attachments).hasSize(7);
     }
 
     @Test
     public void getAttachmentsShouldNotConsiderUnknownContentDispositionAsAttachments() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/unknownDisposition.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/unknownDisposition.eml"));
 
         assertThat(attachments).hasSize(0);
     }
 
     @Test
     public void getAttachmentsShouldConsiderNoContentDispositionAsAttachmentsWhenCID() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/noContentDispositionWithCID.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/noContentDispositionWithCID.eml"));
 
         assertThat(attachments).hasSize(1);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveAttachmentsWhenNoCidForInlined() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachmentWithNoCid.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachmentWithNoCid.eml"));
 
         assertThat(attachments).hasSize(1);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveAttachmentsWhenEmptyCidForInlined() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachmentWithEmptyCid.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachmentWithEmptyCid.eml"));
 
         assertThat(attachments).hasSize(1);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveAttachmentsWhenBlankCidForInlined() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachmentWithBlankCid.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachmentWithBlankCid.eml"));
 
         assertThat(attachments).hasSize(1);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveAttachmentsWhenOneFailOnWrongContentDisposition() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/multiAttachmentsWithOneWrongContentDisposition.eml"));
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/multiAttachmentsWithOneWrongContentDisposition.eml"));
 
         assertThat(attachments).hasSize(2);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveOneAttachmentWhenMessageWithAttachmentContentDisposition() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(
             ClassLoader.getSystemResourceAsStream("eml/emailWithOnlyAttachment.eml"));
 
         assertThat(attachments).hasSize(1);
@@ -274,7 +276,7 @@ public class MessageParserTest {
 
     @Test
     public void getAttachmentsShouldConsiderICSAsAttachments() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(
             ClassLoader.getSystemResourceAsStream("eml/calendar.eml"));
 
         assertThat(attachments)
@@ -284,10 +286,11 @@ public class MessageParserTest {
 
     @Test
     public void gpgSignatureShouldBeConsideredAsAnAttachment() throws Exception {
-        List<MessageAttachment> attachments = testee.retrieveAttachments(
+        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(
             ClassLoader.getSystemResourceAsStream("eml/signedMessage.eml"));
 
         assertThat(attachments).hasSize(2)
+            .extracting(MessageAttachment.WithBytes::getMetadata)
             .extracting(MessageAttachment::getName)
             .allMatch(Optional::isPresent)
             .extracting(Optional::get)
@@ -313,7 +316,7 @@ public class MessageParserTest {
             .asMime4JMessageBuilder()
             .build();
 
-        List<MessageAttachment> result = testee.retrieveAttachments(new ByteArrayInputStream(DefaultMessageWriter.asBytes(message)));
+        List<MessageAttachment.WithBytes> result = testee.retrieveAttachments(new ByteArrayInputStream(DefaultMessageWriter.asBytes(message)));
         assertThat(result).hasSize(1)
             .allMatch(attachment -> attachment.getAttachment().getType().equals(MDN.DISPOSITION_CONTENT_TYPE));
     }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/MessageParserTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/MessageParserTest.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 
 import org.apache.james.mailbox.model.Cid;
 import org.apache.james.mailbox.model.MessageAttachment;
+import org.apache.james.mailbox.store.mail.model.impl.MessageParser.MessageAttachmentWithBytes;
 import org.apache.james.mdn.MDN;
 import org.apache.james.mdn.MDNReport;
 import org.apache.james.mdn.action.mode.DispositionActionMode;
@@ -50,21 +51,21 @@ public class MessageParserTest {
 
     @Test
     public void getAttachmentsShouldBeEmptyWhenNoAttachment() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/noAttachment.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/noAttachment.eml"));
 
         assertThat(attachments).isEmpty();
     }
 
     @Test
     public void getAttachmentsShouldRetrieveAttachmentsWhenOneAttachment() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
 
         assertThat(attachments).hasSize(1);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveAttachmentNameWhenOne() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
 
         assertThat(attachments).hasSize(1);
         Optional<String> expectedName = Optional.of("exploits_of_a_mom.png");
@@ -73,14 +74,14 @@ public class MessageParserTest {
 
     @Test
     public void getAttachmentsShouldRetrieveAttachmentNameWhenOneContainingNonASCIICharacters() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/messageWithNonASCIIFilenameAttachment.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/messageWithNonASCIIFilenameAttachment.eml"));
         assertThat(attachments).hasSize(1);
         assertThat(attachments.get(0).getMetadata().getName()).contains("ديناصور.odt");
     }
 
     @Test
     public void getAttachmentsShouldRetrieveEmptyNameWhenNone() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentWithoutName.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentWithoutName.eml"));
 
         assertThat(attachments).hasSize(1);
         assertThat(attachments.get(0).getMetadata().getName()).isEqualTo(Optional.empty());
@@ -88,7 +89,7 @@ public class MessageParserTest {
 
     @Test
     public void getAttachmentsShouldNotFailWhenContentTypeIsNotHere() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentWithoutContentType.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentWithoutContentType.eml"));
 
         assertThat(attachments).hasSize(1);
         assertThat(attachments.get(0).getAttachment().getType()).isEqualTo("application/octet-stream");
@@ -96,7 +97,7 @@ public class MessageParserTest {
 
     @Test
     public void getAttachmentsShouldNotFailWhenContentTypeIsEmpty() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentWithEmptyContentType.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentWithEmptyContentType.eml"));
 
         assertThat(attachments).hasSize(1);
         assertThat(attachments.get(0).getAttachment().getType()).isEqualTo("application/octet-stream");
@@ -104,7 +105,7 @@ public class MessageParserTest {
 
     @Test
     public void getAttachmentsShouldRetrieveTheAttachmentContentTypeWhenOneAttachment() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
 
         assertThat(attachments).hasSize(1);
         assertThat(attachments.get(0).getAttachment().getType()).isEqualTo("application/octet-stream");
@@ -112,21 +113,21 @@ public class MessageParserTest {
 
     @Test
     public void retrieveAttachmentsShouldNotFailOnMessagesWithManyHeaders() throws Exception {
-        List<MessageAttachment.WithBytes> messageAttachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/mailWithManyHeaders.eml"));
+        List<MessageAttachmentWithBytes> messageAttachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/mailWithManyHeaders.eml"));
 
         assertThat(messageAttachments).hasSize(1);
     }
 
     @Test
     public void retrieveAttachmentsShouldNotFailOnMessagesWithLongHeaders() throws Exception {
-        List<MessageAttachment.WithBytes> messageAttachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/mailWithLongHeaders.eml"));
+        List<MessageAttachmentWithBytes> messageAttachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/mailWithLongHeaders.eml"));
 
         assertThat(messageAttachments).hasSize(1);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveTheAttachmentContentTypeWhenOneAttachmentWithSimpleContentType() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentWithSimpleContentType.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentWithSimpleContentType.eml"));
 
         assertThat(attachments).hasSize(1);
         assertThat(attachments.get(0).getAttachment().getType()).isEqualTo("application/octet-stream");
@@ -134,7 +135,7 @@ public class MessageParserTest {
 
     @Test
     public void getAttachmentsShouldRetrieveTheAttachmentSizeWhenOneAttachment() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
 
         assertThat(attachments).hasSize(1);
         assertThat(attachments.get(0).getAttachment().getSize()).isEqualTo(3071);
@@ -142,26 +143,26 @@ public class MessageParserTest {
 
     @Test
     public void getAttachmentsShouldReturnTheExpectedAttachment() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneAttachmentAndSomeTextInlined.eml"));
 
-        MessageAttachment.WithBytes attachment = attachments.get(0);
+        MessageAttachmentWithBytes attachment = attachments.get(0);
         assertThat(new ByteArrayInputStream(attachment.getBytes()))
             .hasSameContentAs(ClassLoader.getSystemResourceAsStream("eml/gimp.png"));
     }
 
     @Test
     public void getAttachmentsShouldRetrieveAttachmentsWhenTwo() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/twoAttachments.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/twoAttachments.eml"));
 
         assertThat(attachments).hasSize(2);
     }
 
     @Test
     public void retrieveAttachmentShouldUseFilenameAsNameWhenNoName() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/filenameOnly.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/filenameOnly.eml"));
 
         assertThat(attachments).hasSize(1)
-            .extracting(MessageAttachment.WithBytes::getMetadata)
+            .extracting(MessageAttachmentWithBytes::getMetadata)
             .extracting(MessageAttachment::getName)
             .allMatch(Optional::isPresent)
             .extracting(Optional::get)
@@ -170,10 +171,10 @@ public class MessageParserTest {
 
     @Test
     public void retrieveAttachmentShouldUseNameWhenBothNameAndFilename() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/filenameAndName.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/filenameAndName.eml"));
 
         assertThat(attachments).hasSize(1)
-            .extracting(MessageAttachment.WithBytes::getMetadata)
+            .extracting(MessageAttachmentWithBytes::getMetadata)
             .extracting(MessageAttachment::getName)
             .allMatch(Optional::isPresent)
             .extracting(Optional::get)
@@ -182,21 +183,21 @@ public class MessageParserTest {
 
     @Test
     public void getAttachmentsShouldRetrieveEmbeddedAttachmentsWhenSome() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/embeddedAttachmentWithInline.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/embeddedAttachmentWithInline.eml"));
 
         assertThat(attachments).hasSize(1);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveInlineAttachmentsWhenSome() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/embeddedAttachmentWithAttachment.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/embeddedAttachmentWithAttachment.eml"));
 
         assertThat(attachments).hasSize(1);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveTheAttachmentCIDWhenOne() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachment.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachment.eml"));
 
         assertThat(attachments).hasSize(1);
         assertThat(attachments.get(0).getMetadata().getCid()).isEqualTo(Optional.of(Cid.from("part1.37A15C92.A7C3488D@linagora.com")));
@@ -204,7 +205,7 @@ public class MessageParserTest {
 
     @Test
     public void getAttachmentsShouldSetInlineWhenOneInlinedAttachment() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachment.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachment.eml"));
 
         assertThat(attachments).hasSize(1);
         assertThat(attachments.get(0).getMetadata().isInline()).isTrue();
@@ -212,63 +213,63 @@ public class MessageParserTest {
 
     @Test
     public void getAttachementsShouldRetrieveHtmlAttachementsWhenSome() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneHtmlAttachmentAndSomeTextInlined.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneHtmlAttachmentAndSomeTextInlined.eml"));
 
         assertThat(attachments).hasSize(1);
     }
 
     @Test
     public void getAttachementsShouldRetrieveAttachmentsWhenSomeAreInTheMultipartAlternative() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/invitationEmailFromOP.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/invitationEmailFromOP.eml"));
         
         assertThat(attachments).hasSize(7);
     }
 
     @Test
     public void getAttachmentsShouldNotConsiderUnknownContentDispositionAsAttachments() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/unknownDisposition.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/unknownDisposition.eml"));
 
         assertThat(attachments).hasSize(0);
     }
 
     @Test
     public void getAttachmentsShouldConsiderNoContentDispositionAsAttachmentsWhenCID() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/noContentDispositionWithCID.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/noContentDispositionWithCID.eml"));
 
         assertThat(attachments).hasSize(1);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveAttachmentsWhenNoCidForInlined() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachmentWithNoCid.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachmentWithNoCid.eml"));
 
         assertThat(attachments).hasSize(1);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveAttachmentsWhenEmptyCidForInlined() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachmentWithEmptyCid.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachmentWithEmptyCid.eml"));
 
         assertThat(attachments).hasSize(1);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveAttachmentsWhenBlankCidForInlined() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachmentWithBlankCid.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/oneInlinedAttachmentWithBlankCid.eml"));
 
         assertThat(attachments).hasSize(1);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveAttachmentsWhenOneFailOnWrongContentDisposition() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/multiAttachmentsWithOneWrongContentDisposition.eml"));
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(ClassLoader.getSystemResourceAsStream("eml/multiAttachmentsWithOneWrongContentDisposition.eml"));
 
         assertThat(attachments).hasSize(2);
     }
 
     @Test
     public void getAttachmentsShouldRetrieveOneAttachmentWhenMessageWithAttachmentContentDisposition() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(
             ClassLoader.getSystemResourceAsStream("eml/emailWithOnlyAttachment.eml"));
 
         assertThat(attachments).hasSize(1);
@@ -276,7 +277,7 @@ public class MessageParserTest {
 
     @Test
     public void getAttachmentsShouldConsiderICSAsAttachments() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(
             ClassLoader.getSystemResourceAsStream("eml/calendar.eml"));
 
         assertThat(attachments)
@@ -286,11 +287,11 @@ public class MessageParserTest {
 
     @Test
     public void gpgSignatureShouldBeConsideredAsAnAttachment() throws Exception {
-        List<MessageAttachment.WithBytes> attachments = testee.retrieveAttachments(
+        List<MessageAttachmentWithBytes> attachments = testee.retrieveAttachments(
             ClassLoader.getSystemResourceAsStream("eml/signedMessage.eml"));
 
         assertThat(attachments).hasSize(2)
-            .extracting(MessageAttachment.WithBytes::getMetadata)
+            .extracting(MessageAttachmentWithBytes::getMetadata)
             .extracting(MessageAttachment::getName)
             .allMatch(Optional::isPresent)
             .extracting(Optional::get)
@@ -316,7 +317,7 @@ public class MessageParserTest {
             .asMime4JMessageBuilder()
             .build();
 
-        List<MessageAttachment.WithBytes> result = testee.retrieveAttachments(new ByteArrayInputStream(DefaultMessageWriter.asBytes(message)));
+        List<MessageAttachmentWithBytes> result = testee.retrieveAttachments(new ByteArrayInputStream(DefaultMessageWriter.asBytes(message)));
         assertThat(result).hasSize(1)
             .allMatch(attachment -> attachment.getAttachment().getType().equals(MDN.DISPOSITION_CONTENT_TYPE));
     }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailboxMessageTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailboxMessageTest.java
@@ -185,7 +185,7 @@ public class SimpleMailboxMessageTest {
         MessageUid uid = MessageUid.of(45);
         MessageAttachment messageAttachment = MessageAttachment.builder()
             .attachment(Attachment.builder()
-                .bytes("".getBytes(StandardCharsets.UTF_8))
+                .size(0)
                 .type("type")
                 .build())
             .name("name")

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMessagesMethodTest.java
@@ -3943,7 +3943,7 @@ public abstract class SetMessagesMethodTest {
             .body(thirdAttachment + ".name", equalTo("进化还是不.png"));
     }
 
-    private String uploadAttachment(Attachment.WithBytes attachment) throws IOException {
+    private String uploadAttachment(Attachment.WithBytes attachment) {
         return with()
             .header("Authorization", accessToken.serialize())
             .contentType(attachment.getMetadata().getType())

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMessagesMethodTest.java
@@ -1991,10 +1991,10 @@ public abstract class SetMessagesMethodTest {
     public void setMessagesShouldAcceptAttachmentsWhenDraft() throws Exception {
         String messageCreationId = "creationId1337";
         String fromAddress = USERNAME.asString();
-        Attachment attachment = Attachment.builder()
-            .bytes("attachment".getBytes(StandardCharsets.UTF_8))
+        byte[] bytes = "attachment".getBytes(StandardCharsets.UTF_8);
+        Attachment.WithBytes attachment = Attachment.builder()
             .type("application/octet-stream")
-            .build();
+            .buildWithBytes(bytes);
         String uploadedBlobId = uploadAttachment(attachment);
         String requestBody = "[" +
             "  [" +
@@ -2007,8 +2007,8 @@ public abstract class SetMessagesMethodTest {
             "        \"keywords\": {\"$Draft\": true}," +
             "        \"attachments\": [" +
             "                {\"blobId\" : \"" + uploadedBlobId + "\", " +
-            "                 \"type\" : \"" + attachment.getType() + "\"," +
-            "                 \"size\" : " + attachment.getSize() + "}" +
+            "                 \"type\" : \"" + attachment.getMetadata().getType() + "\"," +
+            "                 \"size\" : " + attachment.getMetadata().getSize() + "}" +
             "             ]," +
             "        \"mailboxIds\": [\"" + getDraftId(accessToken) + "\"]" +
             "      }}" +
@@ -3684,15 +3684,15 @@ public abstract class SetMessagesMethodTest {
 
     @Test
     public void setMessagesShouldReturnAttachmentsWhenMessageHasAttachment() throws Exception {
-        Attachment attachment = Attachment.builder()
-            .bytes("attachment".getBytes(StandardCharsets.UTF_8))
+        byte[] bytes = "attachment".getBytes(StandardCharsets.UTF_8);
+        Attachment.WithBytes attachment = Attachment.builder()
             .type("application/octet-stream")
-            .build();
+            .buildWithBytes(bytes);
         String uploadedAttachment1 = uploadAttachment(attachment);
-        Attachment attachment2 = Attachment.builder()
-            .bytes("attachment2".getBytes(StandardCharsets.UTF_8))
+        byte[] bytes2 = "attachment2".getBytes(StandardCharsets.UTF_8);
+        Attachment.WithBytes attachment2 = Attachment.builder()
             .type("application/octet-stream")
-            .build();
+            .buildWithBytes(bytes2);
         String uploadedAttachment2 = uploadAttachment(attachment2);
 
         String messageCreationId = "creationId";
@@ -3710,11 +3710,11 @@ public abstract class SetMessagesMethodTest {
             "        \"mailboxIds\": [\"" + outboxId + "\"], " +
             "        \"attachments\": [" +
             "               {\"blobId\" : \"" + uploadedAttachment1 + "\", " +
-            "               \"type\" : \"" + attachment.getType() + "\", " +
-            "               \"size\" : " + attachment.getSize() + "}," +
+            "               \"type\" : \"" + attachment.getMetadata().getType() + "\", " +
+            "               \"size\" : " + attachment.getMetadata().getSize() + "}," +
             "               {\"blobId\" : \"" + uploadedAttachment2 + "\", " +
-            "               \"type\" : \"" + attachment2.getType() + "\", " +
-            "               \"size\" : " + attachment2.getSize() + ", " +
+            "               \"type\" : \"" + attachment2.getMetadata().getType() + "\", " +
+            "               \"size\" : " + attachment2.getMetadata().getSize() + ", " +
             "               \"cid\" : \"123456789\", " +
             "               \"isInline\" : true }" +
             "           ]" +
@@ -3741,32 +3741,32 @@ public abstract class SetMessagesMethodTest {
             .body(createdPath + ".attachments", hasSize(2))
             .body(firstAttachment + ".blobId", equalTo(uploadedAttachment1))
             .body(firstAttachment + ".type", equalTo("application/octet-stream; charset=UTF-8"))
-            .body(firstAttachment + ".size", equalTo((int) attachment.getSize()))
+            .body(firstAttachment + ".size", equalTo((int) attachment.getMetadata().getSize()))
             .body(firstAttachment + ".cid", nullValue())
             .body(firstAttachment + ".isInline", equalTo(false))
             .body(secondAttachment + ".blobId", equalTo(uploadedAttachment2))
             .body(secondAttachment + ".type", equalTo("application/octet-stream; charset=UTF-8"))
-            .body(secondAttachment + ".size", equalTo((int) attachment2.getSize()))
+            .body(secondAttachment + ".size", equalTo((int) attachment2.getMetadata().getSize()))
             .body(secondAttachment + ".cid", equalTo("123456789"))
             .body(secondAttachment + ".isInline", equalTo(true));
     }
 
     @Test
     public void setMessagesShouldReturnAttachmentsWithNonASCIINames() throws Exception {
-        Attachment attachment = Attachment.builder()
-            .bytes("attachment".getBytes(StandardCharsets.UTF_8))
+        byte[] bytes1 = "attachment".getBytes(StandardCharsets.UTF_8);
+        Attachment.WithBytes attachment = Attachment.builder()
             .type("application/octet-stream")
-            .build();
+            .buildWithBytes(bytes1);
         String uploadedAttachment1 = uploadAttachment(attachment);
-        Attachment attachment2 = Attachment.builder()
-            .bytes("attachment2".getBytes(StandardCharsets.UTF_8))
+        byte[] bytes2 = "attachment2".getBytes(StandardCharsets.UTF_8);
+        Attachment.WithBytes attachment2 = Attachment.builder()
             .type("application/octet-stream")
-            .build();
+            .buildWithBytes(bytes2);
         String uploadedAttachment2 = uploadAttachment(attachment2);
-        Attachment attachment3 = Attachment.builder()
-            .bytes("attachment3".getBytes(StandardCharsets.UTF_8))
+        byte[] bytes3 = "attachment3".getBytes(StandardCharsets.UTF_8);
+        Attachment.WithBytes attachment3 = Attachment.builder()
             .type("application/octet-stream")
-            .build();
+            .buildWithBytes(bytes3);
         String uploadedAttachment3 = uploadAttachment(attachment3);
 
         String messageCreationId = "creationId";
@@ -3789,22 +3789,22 @@ public abstract class SetMessagesMethodTest {
             "          [" +
             "            {" +
             "              \"blobId\" : \"" + uploadedAttachment1 + "\", " +
-            "              \"type\" : \"" + attachment.getType() + "\", " +
-            "              \"size\" : " + attachment.getSize() + "," +
+            "              \"type\" : \"" + attachment.getMetadata().getType() + "\", " +
+            "              \"size\" : " + attachment.getMetadata().getSize() + "," +
             "              \"name\" : \"ديناصور.png\", " +
             "              \"isInline\" : false" +
             "            }," +
             "            {" +
             "              \"blobId\" : \"" + uploadedAttachment2 + "\", " +
-            "              \"type\" : \"" + attachment2.getType() + "\", " +
-            "              \"size\" : " + attachment2.getSize() + "," +
+            "              \"type\" : \"" + attachment2.getMetadata().getType() + "\", " +
+            "              \"size\" : " + attachment2.getMetadata().getSize() + "," +
             "              \"name\" : \"эволюционировать.png\", " +
             "              \"isInline\" : false" +
             "            }," +
             "            {" +
             "              \"blobId\" : \"" + uploadedAttachment3 + "\", " +
-            "              \"type\" : \"" + attachment3.getType() + "\", " +
-            "              \"size\" : " + attachment3.getSize() + "," +
+            "              \"type\" : \"" + attachment3.getMetadata().getType() + "\", " +
+            "              \"size\" : " + attachment3.getMetadata().getSize() + "," +
             "              \"name\" : \"进化还是不.png\"," +
             "              \"isInline\" : false" +
             "            }" +
@@ -3839,22 +3839,22 @@ public abstract class SetMessagesMethodTest {
 
     @Test
     public void filenamesAttachmentsWithNonASCIICharactersShouldBeRetrievedWhenChainingSetMessagesAndGetMessages() throws Exception {
-        Attachment attachment = Attachment.builder()
-            .bytes("attachment".getBytes(StandardCharsets.UTF_8))
+        byte[] bytes1 = "attachment".getBytes(StandardCharsets.UTF_8);
+        Attachment.WithBytes attachment = Attachment.builder()
             .type("application/octet-stream")
-            .build();
+            .buildWithBytes(bytes1);
         String uploadedAttachment1 = uploadAttachment(attachment);
 
-        Attachment attachment2 = Attachment.builder()
-            .bytes("attachment2".getBytes(StandardCharsets.UTF_8))
+        byte[] bytes2 = "attachment2".getBytes(StandardCharsets.UTF_8);
+        Attachment.WithBytes attachment2 = Attachment.builder()
             .type("application/octet-stream")
-            .build();
+            .buildWithBytes(bytes2);
         String uploadedAttachment2 = uploadAttachment(attachment2);
 
-        Attachment attachment3 = Attachment.builder()
-            .bytes("attachment3".getBytes(StandardCharsets.UTF_8))
+        byte[] bytes3 = "attachment3".getBytes(StandardCharsets.UTF_8);
+        Attachment.WithBytes attachment3 = Attachment.builder()
             .type("application/octet-stream")
-            .build();
+            .buildWithBytes(bytes3);
         String uploadedAttachment3 = uploadAttachment(attachment3);
 
         String messageCreationId = "creationId";
@@ -3877,22 +3877,22 @@ public abstract class SetMessagesMethodTest {
             "          [" +
             "            {" +
             "              \"blobId\" : \"" + uploadedAttachment1 + "\", " +
-            "              \"type\" : \"" + attachment.getType() + "\", " +
-            "              \"size\" : " + attachment.getSize() + "," +
+            "              \"type\" : \"" + attachment.getMetadata().getType() + "\", " +
+            "              \"size\" : " + attachment.getMetadata().getSize() + "," +
             "              \"name\" : \"ديناصور.png\", " +
             "              \"isInline\" : false" +
             "            }," +
             "            {" +
             "              \"blobId\" : \"" + uploadedAttachment2 + "\", " +
-            "              \"type\" : \"" + attachment2.getType() + "\", " +
-            "              \"size\" : " + attachment2.getSize() + "," +
+            "              \"type\" : \"" + attachment2.getMetadata().getType() + "\", " +
+            "              \"size\" : " + attachment2.getMetadata().getSize() + "," +
             "              \"name\" : \"эволюционировать.png\", " +
             "              \"isInline\" : false" +
             "            }," +
             "            {" +
             "              \"blobId\" : \"" + uploadedAttachment3 + "\", " +
-            "              \"type\" : \"" + attachment3.getType() + "\", " +
-            "              \"size\" : " + attachment3.getSize() + "," +
+            "              \"type\" : \"" + attachment3.getMetadata().getType() + "\", " +
+            "              \"size\" : " + attachment3.getMetadata().getSize() + "," +
             "              \"name\" : \"进化还是不.png\"," +
             "              \"isInline\" : false" +
             "            }" +
@@ -3943,10 +3943,10 @@ public abstract class SetMessagesMethodTest {
             .body(thirdAttachment + ".name", equalTo("进化还是不.png"));
     }
 
-    private String uploadAttachment(Attachment attachment) throws IOException {
+    private String uploadAttachment(Attachment.WithBytes attachment) throws IOException {
         return with()
             .header("Authorization", accessToken.serialize())
-            .contentType(attachment.getType())
+            .contentType(attachment.getMetadata().getType())
             .body(attachment.getStream())
             .post("/upload")
         .then()
@@ -3956,10 +3956,10 @@ public abstract class SetMessagesMethodTest {
             .getString("blobId");
     }
 
-    private String uploadTextAttachment(Attachment attachment) throws IOException {
+    private String uploadTextAttachment(Attachment.WithBytes attachment) throws IOException {
         return with()
             .header("Authorization", accessToken.serialize())
-            .contentType(attachment.getType())
+            .contentType(attachment.getMetadata().getType())
             .body(new String(IOUtils.toByteArray(attachment.getStream()), StandardCharsets.UTF_8))
             .post("/upload")
         .then()
@@ -3978,10 +3978,9 @@ public abstract class SetMessagesMethodTest {
             50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,
             100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127};
 
-        Attachment attachment = Attachment.builder()
-            .bytes(rawBytes)
+        Attachment.WithBytes attachment = Attachment.builder()
             .type("application/octet-stream")
-            .build();
+            .buildWithBytes(rawBytes);
         String uploadedAttachment = uploadAttachment(attachment);
 
         String messageCreationId = "creationId";
@@ -3999,8 +3998,8 @@ public abstract class SetMessagesMethodTest {
             "        \"mailboxIds\": [\"" + outboxId + "\"], " +
             "        \"attachments\": [" +
             "               {\"blobId\" : \"" + uploadedAttachment + "\", " +
-            "               \"type\" : \"" + attachment.getType() + "\", " +
-            "               \"size\" : " + attachment.getSize() + ", " +
+            "               \"type\" : \"" + attachment.getMetadata().getType() + "\", " +
+            "               \"size\" : " + attachment.getMetadata().getSize() + ", " +
             "               \"cid\" : \"123456789\", " +
             "               \"isInline\" : true }" +
             "           ]" +
@@ -4040,7 +4039,7 @@ public abstract class SetMessagesMethodTest {
             .body(ARGUMENTS + ".list", hasSize(1))
             .body(firstMessage + ".attachments", hasSize(1))
             .body(firstAttachment + ".type", equalTo("application/octet-stream"))
-            .body(firstAttachment + ".size", equalTo((int) attachment.getSize()))
+            .body(firstAttachment + ".size", equalTo((int) attachment.getMetadata().getSize()))
             .body(firstAttachment + ".cid", equalTo("123456789"))
             .body(firstAttachment + ".isInline", equalTo(true))
             .extract()
@@ -4054,10 +4053,9 @@ public abstract class SetMessagesMethodTest {
     @Test
     public void attachmentsShouldBeRetrievedWhenChainingSetMessagesAndGetMessagesTextAttachment() throws Exception {
         byte[] rawBytes = ByteStreams.toByteArray(new ZeroedInputStream(_1MB));
-        Attachment attachment = Attachment.builder()
-            .bytes(rawBytes)
+        Attachment.WithBytes attachment = Attachment.builder()
             .type("application/octet-stream")
-            .build();
+            .buildWithBytes(rawBytes);
         String uploadedAttachment = uploadAttachment(attachment);
 
         String messageCreationId = "creationId";
@@ -4075,8 +4073,8 @@ public abstract class SetMessagesMethodTest {
             "        \"mailboxIds\": [\"" + outboxId + "\"], " +
             "        \"attachments\": [" +
             "               {\"blobId\" : \"" + uploadedAttachment + "\", " +
-            "               \"type\" : \"" + attachment.getType() + "\", " +
-            "               \"size\" : " + attachment.getSize() + ", " +
+            "               \"type\" : \"" + attachment.getMetadata().getType() + "\", " +
+            "               \"size\" : " + attachment.getMetadata().getSize() + ", " +
             "               \"cid\" : \"123456789\", " +
             "               \"isInline\" : true }" +
             "           ]" +
@@ -4117,7 +4115,7 @@ public abstract class SetMessagesMethodTest {
             .body(ARGUMENTS + ".list", hasSize(1))
             .body(firstMessage + ".attachments", hasSize(1))
             .body(firstAttachment + ".type", equalTo("application/octet-stream"))
-            .body(firstAttachment + ".size", equalTo((int) attachment.getSize()))
+            .body(firstAttachment + ".size", equalTo((int) attachment.getMetadata().getSize()))
             .body(firstAttachment + ".cid", equalTo("123456789"))
             .body(firstAttachment + ".isInline", equalTo(true))
             .extract()
@@ -4151,10 +4149,9 @@ public abstract class SetMessagesMethodTest {
         byte[] rawBytes = ("<html>\n" +
             "  <body>attachment</body>\n" + // needed indentation, else restassured is adding some
             "</html>").getBytes(StandardCharsets.UTF_8);
-        Attachment attachment = Attachment.builder()
-            .bytes(rawBytes)
+        Attachment.WithBytes attachment = Attachment.builder()
             .type("text/html; charset=UTF-8")
-            .build();
+            .buildWithBytes(rawBytes);
         String uploadedBlobId = uploadTextAttachment(attachment);
 
         String messageCreationId = "creationId";
@@ -4173,8 +4170,8 @@ public abstract class SetMessagesMethodTest {
             "        \"mailboxIds\": [\"" + outboxId + "\"], " +
             "        \"attachments\": [" +
             "               {\"blobId\" : \"" + uploadedBlobId + "\", " +
-            "               \"type\" : \"" + attachment.getType() + "\", " +
-            "               \"size\" : " + attachment.getSize() + ", " +
+            "               \"type\" : \"" + attachment.getMetadata().getType() + "\", " +
+            "               \"size\" : " + attachment.getMetadata().getSize() + ", " +
             "               \"isInline\" : false }" +
             "           ]" +
             "      }}" +
@@ -4217,7 +4214,7 @@ public abstract class SetMessagesMethodTest {
             .body(firstMessage + ".htmlBody", equalTo("Test <b>body</b>, HTML version"))
             .body(firstMessage + ".attachments", hasSize(1))
             .body(firstAttachment + ".type", equalTo("text/html"))
-            .body(firstAttachment + ".size", equalTo((int) attachment.getSize()))
+            .body(firstAttachment + ".size", equalTo((int) attachment.getMetadata().getSize()))
             .extract()
             .jsonPath()
             .getString(firstAttachment + ".blobId");
@@ -4230,10 +4227,9 @@ public abstract class SetMessagesMethodTest {
         byte[] rawBytes = ("<html>\n" +
             "  <body>attachment</body>\n" + // needed indentation, else restassured is adding some
             "</html>").getBytes(StandardCharsets.UTF_8);
-        Attachment attachment = Attachment.builder()
-            .bytes(rawBytes)
+        Attachment.WithBytes attachment = Attachment.builder()
             .type("text/html; charset=UTF-8")
-            .build();
+            .buildWithBytes(rawBytes);
         String uploadedBlobId = uploadTextAttachment(attachment);
 
         String messageCreationId = "creationId";
@@ -4251,8 +4247,8 @@ public abstract class SetMessagesMethodTest {
             "        \"mailboxIds\": [\"" + outboxId + "\"], " +
             "        \"attachments\": [" +
             "               {\"blobId\" : \"" + uploadedBlobId + "\", " +
-            "               \"type\" : \"" + attachment.getType() + "\", " +
-            "               \"size\" : " + attachment.getSize() + ", " +
+            "               \"type\" : \"" + attachment.getMetadata().getType() + "\", " +
+            "               \"size\" : " + attachment.getMetadata().getSize() + ", " +
             "               \"isInline\" : false }" +
             "           ]" +
             "      }}" +
@@ -4295,7 +4291,7 @@ public abstract class SetMessagesMethodTest {
             .body(firstMessage + ".htmlBody", isEmptyOrNullString())
             .body(firstMessage + ".attachments", hasSize(1))
             .body(firstAttachment + ".type", equalTo("text/html"))
-            .body(firstAttachment + ".size", equalTo((int) attachment.getSize()))
+            .body(firstAttachment + ".size", equalTo((int) attachment.getMetadata().getSize()))
             .extract()
             .jsonPath()
             .getString(firstAttachment + ".blobId");
@@ -4318,10 +4314,9 @@ public abstract class SetMessagesMethodTest {
     @Test
     public void attachmentAndEmptyBodyShouldBeRetrievedWhenChainingSetMessagesAndGetMessagesWithTextAttachmentWithoutMailBody() throws Exception {
         byte[] rawBytes = ("some text").getBytes(StandardCharsets.UTF_8);
-        Attachment attachment = Attachment.builder()
-            .bytes(rawBytes)
+        Attachment.WithBytes attachment = Attachment.builder()
             .type("text/plain; charset=UTF-8")
-            .build();
+            .buildWithBytes(rawBytes);
         String uploadedBlobId = uploadTextAttachment(attachment);
 
         String messageCreationId = "creationId";
@@ -4338,8 +4333,8 @@ public abstract class SetMessagesMethodTest {
             "        \"mailboxIds\": [\"" + outboxId + "\"], " +
             "        \"attachments\": [" +
             "               {\"blobId\" : \"" + uploadedBlobId + "\", " +
-            "               \"type\" : \"" + attachment.getType() + "\", " +
-            "               \"size\" : " + attachment.getSize() + ", " +
+            "               \"type\" : \"" + attachment.getMetadata().getType() + "\", " +
+            "               \"size\" : " + attachment.getMetadata().getSize() + ", " +
             "               \"isInline\" : false }" +
             "           ]" +
             "      }}" +
@@ -4382,7 +4377,7 @@ public abstract class SetMessagesMethodTest {
             .body(firstMessage + ".htmlBody", isEmptyOrNullString())
             .body(firstMessage + ".attachments", hasSize(1))
             .body(firstAttachment + ".type", equalTo("text/plain"))
-            .body(firstAttachment + ".size", equalTo((int) attachment.getSize()))
+            .body(firstAttachment + ".size", equalTo((int) attachment.getMetadata().getSize()))
             .extract()
             .jsonPath()
             .getString(firstAttachment + ".blobId");
@@ -5080,10 +5075,10 @@ public abstract class SetMessagesMethodTest {
 
     @Test
     public void setMessagesShouldCreateMessageWhenSendingMessageWithNonIndexableAttachment() throws Exception {
-        Attachment nonIndexableAttachment = Attachment.builder()
-                .bytes(ClassLoaderUtils.getSystemResourceAsByteArray("attachment/nonIndexableAttachment.html"))
+        byte[] bytes = ClassLoaderUtils.getSystemResourceAsByteArray("attachment/nonIndexableAttachment.html");
+        Attachment.WithBytes nonIndexableAttachment = Attachment.builder()
                 .type("text/html")
-                .build();
+                .buildWithBytes(bytes);
         String uploadedBlobId = uploadTextAttachment(nonIndexableAttachment);
 
         String messageCreationId = "creationId";
@@ -5101,9 +5096,9 @@ public abstract class SetMessagesMethodTest {
                 "        \"mailboxIds\": [\"" + outboxId + "\"], " +
                 "        \"attachments\": [" +
                 "               {\"blobId\" : \"" + uploadedBlobId + "\", " +
-                "               \"type\" : \"" + nonIndexableAttachment.getType() + "\", " +
+                "               \"type\" : \"" + nonIndexableAttachment.getMetadata().getType() + "\", " +
                 "               \"name\" : \"nonIndexableAttachment.html\", " +
-                "               \"size\" : " + nonIndexableAttachment.getSize() + "}" +
+                "               \"size\" : " + nonIndexableAttachment.getMetadata().getSize() + "}" +
                 "           ]" +
                 "      }}" +
                 "    }," +
@@ -5127,15 +5122,15 @@ public abstract class SetMessagesMethodTest {
             .body(createdPath + ".attachments", hasSize(1))
             .body(singleAttachment + ".blobId", equalTo(uploadedBlobId))
             .body(singleAttachment + ".type", equalTo("text/html; charset=UTF-8"))
-            .body(singleAttachment + ".size", equalTo((int) nonIndexableAttachment.getSize()));
+            .body(singleAttachment + ".size", equalTo((int) nonIndexableAttachment.getMetadata().getSize()));
     }
 
     @Test
     public void messageWithNonIndexableAttachmentShouldBeRetrievedWhenChainingSetMessagesAndGetMessages() throws Exception {
-        Attachment nonIndexableAttachment = Attachment.builder()
-                .bytes(ClassLoaderUtils.getSystemResourceAsByteArray("attachment/nonIndexableAttachment.html"))
+        byte[] bytes = ClassLoaderUtils.getSystemResourceAsByteArray("attachment/nonIndexableAttachment.html");
+        Attachment.WithBytes nonIndexableAttachment = Attachment.builder()
                 .type("text/html")
-                .build();
+                .buildWithBytes(bytes);
         String uploadedBlobId = uploadTextAttachment(nonIndexableAttachment);
 
         String messageCreationId = "creationId";
@@ -5153,9 +5148,9 @@ public abstract class SetMessagesMethodTest {
                 "        \"mailboxIds\": [\"" + outboxId + "\"], " +
                 "        \"attachments\": [" +
                 "               {\"blobId\" : \"" + uploadedBlobId + "\", " +
-                "               \"type\" : \"" + nonIndexableAttachment.getType() + "\", " +
+                "               \"type\" : \"" + nonIndexableAttachment.getMetadata().getType() + "\", " +
                 "               \"name\" : \"nonIndexableAttachment.html\", " +
-                "               \"size\" : " + nonIndexableAttachment.getSize() + "}" +
+                "               \"size\" : " + nonIndexableAttachment.getMetadata().getSize() + "}" +
                 "           ]" +
                 "      }}" +
                 "    }," +
@@ -5192,10 +5187,10 @@ public abstract class SetMessagesMethodTest {
 
     @Test
     public void messageWithNonIndexableAttachmentShouldHaveItsEmailBodyIndexed() throws Exception {
-        Attachment nonIndexableAttachment = Attachment.builder()
-                .bytes(ClassLoaderUtils.getSystemResourceAsByteArray("attachment/nonIndexableAttachment.html"))
+        byte[] bytes = ClassLoaderUtils.getSystemResourceAsByteArray("attachment/nonIndexableAttachment.html");
+        Attachment.WithBytes nonIndexableAttachment = Attachment.builder()
                 .type("text/html")
-                .build();
+                .buildWithBytes(bytes);
         String uploadedBlobId = uploadTextAttachment(nonIndexableAttachment);
 
         String messageCreationId = "creationId";
@@ -5214,9 +5209,9 @@ public abstract class SetMessagesMethodTest {
                 "        \"mailboxIds\": [\"" + outboxId + "\"], " +
                 "        \"attachments\": [" +
                 "               {\"blobId\" : \"" + uploadedBlobId + "\", " +
-                "               \"type\" : \"" + nonIndexableAttachment.getType() + "\", " +
+                "               \"type\" : \"" + nonIndexableAttachment.getMetadata().getType() + "\", " +
                 "               \"name\" : \"nonIndexableAttachment.html\", " +
-                "               \"size\" : " + nonIndexableAttachment.getSize() + "}" +
+                "               \"size\" : " + nonIndexableAttachment.getMetadata().getSize() + "}" +
                 "           ]" +
                 "      }}" +
                 "    }," +
@@ -5248,15 +5243,15 @@ public abstract class SetMessagesMethodTest {
 
     @Test
     public void setMessagesShouldReturnAttachmentsWhenMessageHasInlinedAttachmentButNoCid() throws Exception {
-        Attachment attachment = Attachment.builder()
-            .bytes("attachment".getBytes(StandardCharsets.UTF_8))
+        byte[] bytes1 = "attachment".getBytes(StandardCharsets.UTF_8);
+        Attachment.WithBytes attachment = Attachment.builder()
             .type("application/octet-stream")
-            .build();
+            .buildWithBytes(bytes1);
         String uploadedAttachment1 = uploadAttachment(attachment);
-        Attachment attachment2 = Attachment.builder()
-            .bytes("attachment2".getBytes(StandardCharsets.UTF_8))
+        byte[] bytes2 = "attachment2".getBytes(StandardCharsets.UTF_8);
+        Attachment.WithBytes attachment2 = Attachment.builder()
             .type("application/octet-stream")
-            .build();
+            .buildWithBytes(bytes2);
         String uploadedAttachment2 = uploadAttachment(attachment2);
 
         String messageCreationId = "creationId";
@@ -5274,11 +5269,11 @@ public abstract class SetMessagesMethodTest {
             "        \"mailboxIds\": [\"" + outboxId + "\"], " +
             "        \"attachments\": [" +
             "               {\"blobId\" : \"" + uploadedAttachment1 + "\", " +
-            "               \"type\" : \"" + attachment.getType() + "\", " +
-            "               \"size\" : " + attachment.getSize() + "}," +
+            "               \"type\" : \"" + attachment.getMetadata().getType() + "\", " +
+            "               \"size\" : " + attachment.getMetadata().getSize() + "}," +
             "               {\"blobId\" : \"" + uploadedAttachment2 + "\", " +
-            "               \"type\" : \"" + attachment2.getType() + "\", " +
-            "               \"size\" : " + attachment2.getSize() + ", " +
+            "               \"type\" : \"" + attachment2.getMetadata().getType() + "\", " +
+            "               \"size\" : " + attachment2.getMetadata().getSize() + ", " +
             "               \"isInline\" : true }" +
             "           ]" +
             "      }}" +
@@ -5304,12 +5299,12 @@ public abstract class SetMessagesMethodTest {
             .body(createdPath + ".attachments", hasSize(2))
             .body(firstAttachment + ".blobId", equalTo(uploadedAttachment1))
             .body(firstAttachment + ".type", equalTo("application/octet-stream; charset=UTF-8"))
-            .body(firstAttachment + ".size", equalTo((int) attachment.getSize()))
+            .body(firstAttachment + ".size", equalTo((int) attachment.getMetadata().getSize()))
             .body(firstAttachment + ".cid", nullValue())
             .body(firstAttachment + ".isInline", equalTo(false))
             .body(secondAttachment + ".blobId", equalTo(uploadedAttachment2))
             .body(secondAttachment + ".type", equalTo("application/octet-stream; charset=UTF-8"))
-            .body(secondAttachment + ".size", equalTo((int) attachment2.getSize()))
+            .body(secondAttachment + ".size", equalTo((int) attachment2.getMetadata().getSize()))
             .body(secondAttachment + ".cid", nullValue())
             .body(secondAttachment + ".isInline", equalTo(true));
     }

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMessagesMethodTest.java
@@ -71,7 +71,6 @@ import javax.mail.Flags;
 import javax.mail.Flags.Flag;
 import javax.mail.internet.MimeMessage;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.james.GuiceJamesServer;
 import org.apache.james.core.Username;
 import org.apache.james.core.quota.QuotaSizeLimit;
@@ -3960,7 +3959,7 @@ public abstract class SetMessagesMethodTest {
         return with()
             .header("Authorization", accessToken.serialize())
             .contentType(attachment.getMetadata().getType())
-            .body(new String(IOUtils.toByteArray(attachment.getStream()), StandardCharsets.UTF_8))
+            .body(new String(attachment.getBytes(), StandardCharsets.UTF_8))
             .post("/upload")
         .then()
             .extract()

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/DownloadServlet.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/DownloadServlet.java
@@ -24,6 +24,7 @@ import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Optional;
 
 import javax.inject.Inject;
@@ -129,7 +130,9 @@ public class DownloadServlet extends HttpServlet {
             resp.setHeader("Content-Length", String.valueOf(blob.getSize()));
             resp.setHeader("Content-Type", blob.getContentType());
             resp.setStatus(SC_OK);
-            IOUtils.copy(blob.getStream(), resp.getOutputStream());
+            try (InputStream stream = blob.createStream()) {
+                IOUtils.copy(stream, resp.getOutputStream());
+            }
         } catch (BlobNotFoundException e) {
             LOGGER.info("Attachment '{}' not found", blobId, e);
             resp.setStatus(SC_NOT_FOUND);

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/UploadHandler.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/UploadHandler.java
@@ -53,14 +53,15 @@ public class UploadHandler {
 
     private UploadResponse uploadContent(String contentType, InputStream inputStream, MailboxSession session) throws IOException, MailboxException {
         byte[] bytes = ByteStreams.toByteArray(inputStream);
-        Attachment.WithBytes attachment = Attachment.builder()
+        Attachment attachment = Attachment.builder()
                 .type(contentType)
-                .buildWithBytes(bytes);
-        attachmentManager.storeAttachment(attachment, session);
+                .size(bytes.length)
+                .build();
+        attachmentManager.storeAttachment(attachment, bytes, session);
         return UploadResponse.builder()
-                .blobId(attachment.getMetadata().getAttachmentId().getId())
-                .type(attachment.getMetadata().getType())
-                .size(attachment.getMetadata().getSize())
+                .blobId(attachment.getAttachmentId().getId())
+                .type(attachment.getType())
+                .size(attachment.getSize())
                 .build();
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/UploadHandler.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/UploadHandler.java
@@ -52,15 +52,15 @@ public class UploadHandler {
     }
 
     private UploadResponse uploadContent(String contentType, InputStream inputStream, MailboxSession session) throws IOException, MailboxException {
-        Attachment attachment = Attachment.builder()
-                .bytes(ByteStreams.toByteArray(inputStream))
+        byte[] bytes = ByteStreams.toByteArray(inputStream);
+        Attachment.WithBytes attachment = Attachment.builder()
                 .type(contentType)
-                .build();
+                .buildWithBytes(bytes);
         attachmentManager.storeAttachment(attachment, session);
         return UploadResponse.builder()
-                .blobId(attachment.getAttachmentId().getId())
-                .type(attachment.getType())
-                .size(attachment.getSize())
+                .blobId(attachment.getMetadata().getAttachmentId().getId())
+                .type(attachment.getMetadata().getType())
+                .size(attachment.getMetadata().getSize())
                 .build();
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/MIMEMessageConverter.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/MIMEMessageConverter.java
@@ -70,18 +70,18 @@ public class MIMEMessageConverter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MIMEMessageConverter.class);
 
-    public static class MessageAttachmentWithBytes {
+    static class MessageAttachmentWithBytes {
         private final MessageAttachment messageAttachment;
         private final byte[] content;
 
-        public MessageAttachmentWithBytes(MessageAttachment messageAttachment, byte[] content) {
+        MessageAttachmentWithBytes(MessageAttachment messageAttachment, byte[] content) {
             Preconditions.checkArgument(messageAttachment.getAttachment().getSize() == content.length);
 
             this.messageAttachment = messageAttachment;
             this.content = content;
         }
 
-        public MessageAttachment getMessageAttachment() {
+        MessageAttachment getMessageAttachment() {
             return messageAttachment;
         }
     }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/MIMEMessageConverter.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/MIMEMessageConverter.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.TimeZone;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.apache.james.jmap.draft.model.CreationMessage;
@@ -246,7 +245,7 @@ public class MIMEMessageConverter {
 
     private MultipartBuilder addAttachments(List<MessageAttachment.WithBytes> messageAttachments,
                                             MultipartBuilder multipartBuilder) {
-        messageAttachments.forEach(addAttachment(multipartBuilder));
+        messageAttachments.forEach(att -> multipartBuilder.addBodyPart(attachmentBodyPart(att)));
 
         return multipartBuilder;
     }
@@ -288,18 +287,7 @@ public class MIMEMessageConverter {
         }
     }
 
-    private Consumer<MessageAttachment.WithBytes> addAttachment(MultipartBuilder builder) {
-        return att -> { 
-            try {
-                builder.addBodyPart(attachmentBodyPart(att));
-            } catch (IOException e) {
-                LOGGER.error("Error while creating attachment", e);
-                throw new RuntimeException(e);
-            }
-        };
-    }
-
-    private BodyPart attachmentBodyPart(MessageAttachment.WithBytes att) throws IOException {
+    private BodyPart attachmentBodyPart(MessageAttachment.WithBytes att) {
         BodyPartBuilder builder = BodyPartBuilder.create()
             .use(bodyFactory)
             .setBody(new BasicBodyFactory().binaryBody(att.getBytes()))

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/MIMEMessageConverter.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/MIMEMessageConverter.java
@@ -64,7 +64,6 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
-import com.google.common.io.ByteStreams;
 import com.google.common.net.MediaType;
 
 public class MIMEMessageConverter {
@@ -303,7 +302,7 @@ public class MIMEMessageConverter {
     private BodyPart attachmentBodyPart(MessageAttachment.WithBytes att) throws IOException {
         BodyPartBuilder builder = BodyPartBuilder.create()
             .use(bodyFactory)
-            .setBody(new BasicBodyFactory().binaryBody(ByteStreams.toByteArray(att.getAttachmentWithBytes().getStream())))
+            .setBody(new BasicBodyFactory().binaryBody(att.getBytes()))
             .setField(contentTypeField(att.getMetadata()))
             .setField(contentDispositionField(att.getMetadata().isInline()))
             .setContentTransferEncoding(BASE64);

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SendMDNProcessor.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SendMDNProcessor.java
@@ -176,8 +176,9 @@ public class SendMDNProcessor implements SetMessagesProcessor {
     }
 
     private MessageAttachment convertReportToAttachment(MDNReport mdnReport) {
+        byte[] bytes = mdnReport.formattedValue().getBytes(StandardCharsets.UTF_8);
         Attachment attachment = Attachment.builder()
-            .bytes(mdnReport.formattedValue().getBytes(StandardCharsets.UTF_8))
+            .size(bytes.length)
             .type(MDN.DISPOSITION_CONTENT_TYPE)
             .build();
 

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/MIMEMessageConverterTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/MIMEMessageConverterTest.java
@@ -53,7 +53,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 class MIMEMessageConverterTest {
-    
+
     @Test
     void convertToMimeShouldAddInReplyToHeaderWhenProvided() {
         // Given
@@ -597,15 +597,16 @@ class MIMEMessageConverterTest {
             String expectedMimeType = "image/png";
             String text = "123456";
             TextBody expectedBody = new BasicBodyFactory().textBody(text.getBytes(), StandardCharsets.UTF_8);
-            MessageAttachment attachment = MessageAttachment.builder()
+            MessageAttachment.WithBytes attachment = MessageAttachment.builder()
                 .attachment(org.apache.james.mailbox.model.Attachment.builder()
                     .attachmentId(AttachmentId.from("blodId"))
-                    .bytes(text.getBytes())
+                    .size(text.getBytes(StandardCharsets.UTF_8).length)
                     .type(expectedMimeType)
                     .build())
                 .cid(Cid.from(expectedCID))
                 .isInline(true)
-                .build();
+                .build()
+                .withBytes(text.getBytes(StandardCharsets.UTF_8));
 
             // When
             Message result = sut.convertToMime(new ValueWithId.CreationMessageEntry(
@@ -644,15 +645,16 @@ class MIMEMessageConverterTest {
             String expectedMimeType = "image/png";
             String text = "123456";
             TextBody expectedAttachmentBody = new BasicBodyFactory().textBody(text.getBytes(), StandardCharsets.UTF_8);
-            MessageAttachment attachment = MessageAttachment.builder()
+            MessageAttachment.WithBytes attachment = MessageAttachment.builder()
                 .attachment(org.apache.james.mailbox.model.Attachment.builder()
                     .attachmentId(AttachmentId.from("blodId"))
-                    .bytes(text.getBytes())
+                    .size(text.getBytes(StandardCharsets.UTF_8).length)
                     .type(expectedMimeType)
                     .build())
                 .cid(Cid.from(expectedCID))
                 .isInline(true)
-                .build();
+                .build()
+                .withBytes(text.getBytes(StandardCharsets.UTF_8));
 
             // When
             Message result = sut.convertToMime(new ValueWithId.CreationMessageEntry(
@@ -694,7 +696,7 @@ class MIMEMessageConverterTest {
                     .build();
 
             // When
-            ImmutableList<MessageAttachment> attachments = ImmutableList.of();
+            ImmutableList<MessageAttachment.WithBytes> attachments = ImmutableList.of();
             byte[] convert = sut.convert(new ValueWithId.CreationMessageEntry(
                     CreationMessageId.of("user|mailbox|1"), testMessage), attachments);
 
@@ -722,16 +724,17 @@ class MIMEMessageConverterTest {
             String text = "123456";
             String name = "ديناصور.png";
             String expectedName = EncoderUtil.encodeEncodedWord(name, Usage.TEXT_TOKEN);
-            MessageAttachment attachment = MessageAttachment.builder()
+            MessageAttachment.WithBytes attachment = MessageAttachment.builder()
                 .name(name)
                 .attachment(org.apache.james.mailbox.model.Attachment.builder()
                     .attachmentId(AttachmentId.from("blodId"))
-                    .bytes(text.getBytes())
+                    .size(text.getBytes(StandardCharsets.UTF_8).length)
                     .type(expectedMimeType)
                     .build())
                 .cid(Cid.from(expectedCID))
                 .isInline(true)
-                .build();
+                .build()
+                .withBytes(text.getBytes(StandardCharsets.UTF_8));
 
             // When
             Message result = sut.convertToMime(new ValueWithId.CreationMessageEntry(
@@ -757,16 +760,18 @@ class MIMEMessageConverterTest {
                 .htmlBody("Hello <b>all<b>!")
                 .build();
 
-            MessageAttachment attachment = MessageAttachment.builder()
+            byte[] bytes = "123456".getBytes(StandardCharsets.UTF_8);
+            MessageAttachment.WithBytes attachment = MessageAttachment.builder()
                 .name("ديناصور.png")
                 .attachment(org.apache.james.mailbox.model.Attachment.builder()
                     .attachmentId(AttachmentId.from("blodId"))
-                    .bytes("123456".getBytes())
+                    .size(bytes.length)
                     .type("image/png")
                     .build())
                 .cid(Cid.from("cid"))
                 .isInline(false)
-                .build();
+                .build()
+                .withBytes(bytes);
 
             Message result = sut.convertToMime(new ValueWithId.CreationMessageEntry(
                 CreationMessageId.of("user|mailbox|1"), testMessage), ImmutableList.of(attachment));
@@ -787,16 +792,18 @@ class MIMEMessageConverterTest {
                 .htmlBody("Hello <b>all<b>!")
                 .build();
 
-            MessageAttachment attachment = MessageAttachment.builder()
+            byte[] bytes = "123456".getBytes(StandardCharsets.UTF_8);
+            MessageAttachment.WithBytes attachment = MessageAttachment.builder()
                 .name("ديناصور.png")
                 .attachment(org.apache.james.mailbox.model.Attachment.builder()
                     .attachmentId(AttachmentId.from("blodId"))
-                    .bytes("123456".getBytes())
+                    .size(bytes.length)
                     .type("image/png")
                     .build())
                 .cid(Cid.from("cid"))
                 .isInline(false)
-                .build();
+                .build()
+                .withBytes(bytes);
 
             Message result = sut.convertToMime(new ValueWithId.CreationMessageEntry(
                 CreationMessageId.of("user|mailbox|1"), testMessage), ImmutableList.of(attachment));
@@ -817,16 +824,18 @@ class MIMEMessageConverterTest {
                 .htmlBody("Hello <b>all<b>!")
                 .build();
 
-            MessageAttachment attachment = MessageAttachment.builder()
+            byte[] bytes = "123456".getBytes(StandardCharsets.UTF_8);
+            MessageAttachment.WithBytes attachment = MessageAttachment.builder()
                 .name("ديناصور.png")
                 .attachment(org.apache.james.mailbox.model.Attachment.builder()
                     .attachmentId(AttachmentId.from("blodId"))
-                    .bytes("123456".getBytes())
+                    .size(bytes.length)
                     .type("image/png")
                     .build())
                 .cid(Cid.from("cid"))
                 .isInline(false)
-                .build();
+                .build()
+                .withBytes(bytes);
 
             Message result = sut.convertToMime(new ValueWithId.CreationMessageEntry(
                 CreationMessageId.of("user|mailbox|1"), testMessage), ImmutableList.of(attachment));
@@ -848,17 +857,19 @@ class MIMEMessageConverterTest {
                 .htmlBody("Hello <b>all<b>!")
                 .build();
 
+            byte[] bytes = "123456".getBytes(StandardCharsets.UTF_8);
             String name = "ديناصور.png";
-            MessageAttachment attachment = MessageAttachment.builder()
+            MessageAttachment.WithBytes attachment = MessageAttachment.builder()
                 .name(name)
                 .attachment(org.apache.james.mailbox.model.Attachment.builder()
                     .attachmentId(AttachmentId.from("blodId"))
-                    .bytes("123456".getBytes())
+                    .size(bytes.length)
                     .type("image/png")
                     .build())
                 .cid(Cid.from("cid"))
                 .isInline(true)
-                .build();
+                .build()
+                .withBytes(bytes);
 
             Message result = sut.convertToMime(new ValueWithId.CreationMessageEntry(
                     CreationMessageId.of("user|mailbox|1"), testMessage), ImmutableList.of(attachment));
@@ -883,27 +894,30 @@ class MIMEMessageConverterTest {
                 .htmlBody("Hello <b>all<b>!")
                 .build();
 
-            MessageAttachment inline = MessageAttachment.builder()
+            byte[] bytes = "inline data".getBytes(StandardCharsets.UTF_8);
+            MessageAttachment.WithBytes inline = MessageAttachment.builder()
                 .name("ديناصور.png")
                 .attachment(org.apache.james.mailbox.model.Attachment.builder()
                     .attachmentId(AttachmentId.from("blodId"))
-                    .bytes("inline data".getBytes())
+                    .size(bytes.length)
                     .type("image/png")
                     .build())
                 .cid(Cid.from("cid"))
                 .isInline(true)
-                .build();
+                .build()
+                .withBytes(bytes);
 
-            MessageAttachment attachment = MessageAttachment.builder()
+            MessageAttachment.WithBytes attachment = MessageAttachment.builder()
                 .name("att.pdf")
                 .attachment(org.apache.james.mailbox.model.Attachment.builder()
                     .attachmentId(AttachmentId.from("blodId2"))
-                    .bytes("attachment data".getBytes())
+                    .size(bytes.length)
                     .type("image/png")
                     .build())
                 .cid(Cid.from("cid2"))
                 .isInline(false)
-                .build();
+                .build()
+                .withBytes(bytes);
 
             Message result = sut.convertToMime(new ValueWithId.CreationMessageEntry(
                     CreationMessageId.of("user|mailbox|1"), testMessage), ImmutableList.of(inline, attachment));

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/MIMEMessageConverterTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/MIMEMessageConverterTest.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
+import org.apache.james.jmap.draft.methods.MIMEMessageConverter.MessageAttachmentWithBytes;
 import org.apache.james.jmap.draft.methods.ValueWithId.MessageWithId;
 import org.apache.james.jmap.draft.model.CreationMessage;
 import org.apache.james.jmap.draft.model.CreationMessage.DraftEmailer;
@@ -597,7 +598,7 @@ class MIMEMessageConverterTest {
             String expectedMimeType = "image/png";
             String text = "123456";
             TextBody expectedBody = new BasicBodyFactory().textBody(text.getBytes(), StandardCharsets.UTF_8);
-            MessageAttachment.WithBytes attachment = MessageAttachment.builder()
+            MessageAttachmentWithBytes attachment = new MessageAttachmentWithBytes(MessageAttachment.builder()
                 .attachment(org.apache.james.mailbox.model.Attachment.builder()
                     .attachmentId(AttachmentId.from("blodId"))
                     .size(text.getBytes(StandardCharsets.UTF_8).length)
@@ -605,8 +606,8 @@ class MIMEMessageConverterTest {
                     .build())
                 .cid(Cid.from(expectedCID))
                 .isInline(true)
-                .build()
-                .withBytes(text.getBytes(StandardCharsets.UTF_8));
+                .build(),
+                text.getBytes(StandardCharsets.UTF_8));
 
             // When
             Message result = sut.convertToMime(new ValueWithId.CreationMessageEntry(
@@ -645,7 +646,7 @@ class MIMEMessageConverterTest {
             String expectedMimeType = "image/png";
             String text = "123456";
             TextBody expectedAttachmentBody = new BasicBodyFactory().textBody(text.getBytes(), StandardCharsets.UTF_8);
-            MessageAttachment.WithBytes attachment = MessageAttachment.builder()
+            MessageAttachmentWithBytes attachment = new MessageAttachmentWithBytes(MessageAttachment.builder()
                 .attachment(org.apache.james.mailbox.model.Attachment.builder()
                     .attachmentId(AttachmentId.from("blodId"))
                     .size(text.getBytes(StandardCharsets.UTF_8).length)
@@ -653,8 +654,8 @@ class MIMEMessageConverterTest {
                     .build())
                 .cid(Cid.from(expectedCID))
                 .isInline(true)
-                .build()
-                .withBytes(text.getBytes(StandardCharsets.UTF_8));
+                .build(),
+                text.getBytes(StandardCharsets.UTF_8));
 
             // When
             Message result = sut.convertToMime(new ValueWithId.CreationMessageEntry(
@@ -696,7 +697,7 @@ class MIMEMessageConverterTest {
                     .build();
 
             // When
-            ImmutableList<MessageAttachment.WithBytes> attachments = ImmutableList.of();
+            ImmutableList<MessageAttachmentWithBytes> attachments = ImmutableList.of();
             byte[] convert = sut.convert(new ValueWithId.CreationMessageEntry(
                     CreationMessageId.of("user|mailbox|1"), testMessage), attachments);
 
@@ -724,7 +725,7 @@ class MIMEMessageConverterTest {
             String text = "123456";
             String name = "ديناصور.png";
             String expectedName = EncoderUtil.encodeEncodedWord(name, Usage.TEXT_TOKEN);
-            MessageAttachment.WithBytes attachment = MessageAttachment.builder()
+            MessageAttachmentWithBytes attachment = new MessageAttachmentWithBytes(MessageAttachment.builder()
                 .name(name)
                 .attachment(org.apache.james.mailbox.model.Attachment.builder()
                     .attachmentId(AttachmentId.from("blodId"))
@@ -733,8 +734,8 @@ class MIMEMessageConverterTest {
                     .build())
                 .cid(Cid.from(expectedCID))
                 .isInline(true)
-                .build()
-                .withBytes(text.getBytes(StandardCharsets.UTF_8));
+                .build(),
+                text.getBytes(StandardCharsets.UTF_8));
 
             // When
             Message result = sut.convertToMime(new ValueWithId.CreationMessageEntry(
@@ -761,7 +762,7 @@ class MIMEMessageConverterTest {
                 .build();
 
             byte[] bytes = "123456".getBytes(StandardCharsets.UTF_8);
-            MessageAttachment.WithBytes attachment = MessageAttachment.builder()
+            MessageAttachmentWithBytes attachment = new MessageAttachmentWithBytes(MessageAttachment.builder()
                 .name("ديناصور.png")
                 .attachment(org.apache.james.mailbox.model.Attachment.builder()
                     .attachmentId(AttachmentId.from("blodId"))
@@ -770,8 +771,8 @@ class MIMEMessageConverterTest {
                     .build())
                 .cid(Cid.from("cid"))
                 .isInline(false)
-                .build()
-                .withBytes(bytes);
+                .build(),
+                bytes);
 
             Message result = sut.convertToMime(new ValueWithId.CreationMessageEntry(
                 CreationMessageId.of("user|mailbox|1"), testMessage), ImmutableList.of(attachment));
@@ -793,7 +794,7 @@ class MIMEMessageConverterTest {
                 .build();
 
             byte[] bytes = "123456".getBytes(StandardCharsets.UTF_8);
-            MessageAttachment.WithBytes attachment = MessageAttachment.builder()
+            MessageAttachmentWithBytes attachment = new MessageAttachmentWithBytes(MessageAttachment.builder()
                 .name("ديناصور.png")
                 .attachment(org.apache.james.mailbox.model.Attachment.builder()
                     .attachmentId(AttachmentId.from("blodId"))
@@ -802,8 +803,8 @@ class MIMEMessageConverterTest {
                     .build())
                 .cid(Cid.from("cid"))
                 .isInline(false)
-                .build()
-                .withBytes(bytes);
+                .build(),
+                bytes);
 
             Message result = sut.convertToMime(new ValueWithId.CreationMessageEntry(
                 CreationMessageId.of("user|mailbox|1"), testMessage), ImmutableList.of(attachment));
@@ -825,7 +826,7 @@ class MIMEMessageConverterTest {
                 .build();
 
             byte[] bytes = "123456".getBytes(StandardCharsets.UTF_8);
-            MessageAttachment.WithBytes attachment = MessageAttachment.builder()
+            MessageAttachmentWithBytes attachment = new MessageAttachmentWithBytes(MessageAttachment.builder()
                 .name("ديناصور.png")
                 .attachment(org.apache.james.mailbox.model.Attachment.builder()
                     .attachmentId(AttachmentId.from("blodId"))
@@ -834,8 +835,8 @@ class MIMEMessageConverterTest {
                     .build())
                 .cid(Cid.from("cid"))
                 .isInline(false)
-                .build()
-                .withBytes(bytes);
+                .build(),
+                bytes);
 
             Message result = sut.convertToMime(new ValueWithId.CreationMessageEntry(
                 CreationMessageId.of("user|mailbox|1"), testMessage), ImmutableList.of(attachment));
@@ -859,7 +860,7 @@ class MIMEMessageConverterTest {
 
             byte[] bytes = "123456".getBytes(StandardCharsets.UTF_8);
             String name = "ديناصور.png";
-            MessageAttachment.WithBytes attachment = MessageAttachment.builder()
+            MessageAttachmentWithBytes attachment = new MessageAttachmentWithBytes(MessageAttachment.builder()
                 .name(name)
                 .attachment(org.apache.james.mailbox.model.Attachment.builder()
                     .attachmentId(AttachmentId.from("blodId"))
@@ -868,8 +869,8 @@ class MIMEMessageConverterTest {
                     .build())
                 .cid(Cid.from("cid"))
                 .isInline(true)
-                .build()
-                .withBytes(bytes);
+                .build(),
+                bytes);
 
             Message result = sut.convertToMime(new ValueWithId.CreationMessageEntry(
                     CreationMessageId.of("user|mailbox|1"), testMessage), ImmutableList.of(attachment));
@@ -895,7 +896,7 @@ class MIMEMessageConverterTest {
                 .build();
 
             byte[] bytes = "inline data".getBytes(StandardCharsets.UTF_8);
-            MessageAttachment.WithBytes inline = MessageAttachment.builder()
+            MessageAttachmentWithBytes inline = new MessageAttachmentWithBytes(MessageAttachment.builder()
                 .name("ديناصور.png")
                 .attachment(org.apache.james.mailbox.model.Attachment.builder()
                     .attachmentId(AttachmentId.from("blodId"))
@@ -904,10 +905,10 @@ class MIMEMessageConverterTest {
                     .build())
                 .cid(Cid.from("cid"))
                 .isInline(true)
-                .build()
-                .withBytes(bytes);
+                .build(),
+                bytes);
 
-            MessageAttachment.WithBytes attachment = MessageAttachment.builder()
+            MessageAttachmentWithBytes attachment = new MessageAttachmentWithBytes(MessageAttachment.builder()
                 .name("att.pdf")
                 .attachment(org.apache.james.mailbox.model.Attachment.builder()
                     .attachmentId(AttachmentId.from("blodId2"))
@@ -916,8 +917,8 @@ class MIMEMessageConverterTest {
                     .build())
                 .cid(Cid.from("cid2"))
                 .isInline(false)
-                .build()
-                .withBytes(bytes);
+                .build(),
+                bytes);
 
             Message result = sut.convertToMime(new ValueWithId.CreationMessageEntry(
                     CreationMessageId.of("user|mailbox|1"), testMessage), ImmutableList.of(inline, attachment));

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/message/view/MessageFullViewFactoryTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/message/view/MessageFullViewFactoryTest.java
@@ -478,7 +478,7 @@ class MessageFullViewFactoryTest {
                 .attachments(ImmutableList.of(MessageAttachment.builder()
                         .attachment(org.apache.james.mailbox.model.Attachment.builder()
                                 .attachmentId(AttachmentId.from(blodId.getRawValue()))
-                                .bytes(payload.getBytes())
+                                .size(payload.getBytes(StandardCharsets.UTF_8).length)
                                 .type(type)
                                 .build())
                         .cid(Cid.from("cid"))


### PR DESCRIPTION
 - Defines a Attachment.WithBytes POJO (&MessageAttachment equivalent) to 
 be used on the write path, or explicilty read.
 - Remove byte[] field from Attachment & MessageAttachment. This POJO now
 become cheap to return.
 - Add read methods to retrieve Attachment.WithBytes where needed

This proposal avoids loading (unused) attachment content upon GetMessages call,
IMAP FETCH call, and some smaller other places.
