### PR TITLE
JAMES-2919 Validate JMAP partial read ADR after performance tests

### DIFF
--- a/src/adr/0012-jmap-partial-reads.md
+++ b/src/adr/0012-jmap-partial-reads.md
@@ -34,13 +34,13 @@ Given the following scenario played by 5000 users per hour (constant rate)
  - Authenticate
  - List mailboxes
  - List messages in one of their mailboxes
- - Get 10 time the properties expected to be fast to fetch with JMAP
+ - Get 10 time the mailboxIds and keywords of the given messages
 
 We went from:
  - A 20% failure rate before this change to no failure
  - Mean time for GetMessages went from 27 159 ms to 27 ms (1000 time improvment), for all operation from
  27 591 ms to 60 ms (460 time improvment)
- - P99 is a metic thatdid not make sense because the initial simulation exceeded Gatling (the performance measuring tool 
+ - P99 is a metric that did not make sense because the initial simulation exceeded Gatling (the performance measuring tool 
  we use) timeout (60s) at the p50 percentile. After this proposal p99 for the entire scenario is of 1 383 ms
 
 ## References

--- a/src/adr/0012-jmap-partial-reads.md
+++ b/src/adr/0012-jmap-partial-reads.md
@@ -4,9 +4,7 @@ Date: 2019-10-09
 
 ## Status
 
-Proposed
-
-Adoption needs to be backed by some performance tests.
+Accepted
 
 ## Context
 
@@ -29,10 +27,21 @@ Some performance tests will be run in order to evaluate the improvements.
 
 ## Consequences
 
-GetMessages with a limited set of requested properties will no longer result necessarily in full database message read. We
-thus expect a significant improvement, for instance when only metadata are requested.
+GetMessages with a limited set of requested properties no longer result necessarily in full database message read. We
+thus have a significant improvement, for instance when only metadata are requested.
 
-In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'rejected'.
+Given the following scenario played by 5000 users per hour (constant rate)
+ - Authenticate
+ - List mailboxes
+ - List messages in one of their mailboxes
+ - Get 10 time the properties expected to be fast to fetch with JMAP
+
+We went from:
+ - A 20% failure rate before this change to no failure
+ - Mean time for GetMessages went from 27 159 ms to 27 ms (1000 time improvment), for all operation from
+ 27 591 ms to 60 ms (460 time improvment)
+ - P99 is a metic thatdid not make sense because the initial simulation exceeded Gatling (the performance measuring tool 
+ we use) timeout (60s) at the p50 percentile. After this proposal p99 for the entire scenario is of 1 383 ms
 
 ## References
 

--- a/src/adr/0012-jmap-partial-reads.md
+++ b/src/adr/0012-jmap-partial-reads.md
@@ -34,7 +34,7 @@ Given the following scenario played by 5000 users per hour (constant rate)
  - Authenticate
  - List mailboxes
  - List messages in one of their mailboxes
- - Get 10 time the mailboxIds and keywords of the given messages
+ - Get 10 times the mailboxIds and keywords of the given messages
 
 We went from:
  - A 20% failure rate before this change to no failure

--- a/src/adr/0012-jmap-partial-reads.md
+++ b/src/adr/0012-jmap-partial-reads.md
@@ -37,7 +37,7 @@ Given the following scenario played by 5000 users per hour (constant rate)
  - Get 10 times the mailboxIds and keywords of the given messages
 
 We went from:
- - A 20% failure rate before this change to no failure
+ - A 20% failure and timeout rate before this change to no failure
  - Mean time for GetMessages went from 27 159 ms to 27 ms (1000 time improvment), for all operation from
  27 591 ms to 60 ms (460 time improvment)
  - P99 is a metric that did not make sense because the initial simulation exceeded Gatling (the performance measuring tool 

--- a/src/adr/0013-precompute-jmap-preview.md
+++ b/src/adr/0013-precompute-jmap-preview.md
@@ -40,7 +40,7 @@ Given the following scenario played by 2500 users per hour (constant rate)
  - Get 8 times the properties expected to be fast to fetch with JMAP
 
 We went from:
- - A 7% failure rate before this change to almost no failure
+ - A 7% failure and timeout rate before this change to almost no failure
  - Mean time for GetMessages went from 9 710 ms to 434 ms (22 time improvment), for all operation from
  12 802 ms to 407 ms (31 time improvment)
  - P99 is a metric that did not make sense because the initial simulation exceeded Gatling (the performance measuring tool 

--- a/src/adr/0013-precompute-jmap-preview.md
+++ b/src/adr/0013-precompute-jmap-preview.md
@@ -33,20 +33,20 @@ Some performance tests will be run in order to evaluate the improvements.
 
 ## Consequences
 
-Given the following scenario played by 5000 users per hour (constant rate)
+Given the following scenario played by 2500 users per hour (constant rate)
  - Authenticate
  - List mailboxes
  - List messages in one of their mailboxes
- - Get 10 time the properties expected to be fast to fetch with JMAP
+ - Get 8 time the properties expected to be fast to fetch with JMAP
 
 We went from:
- - A 20% failure rate before this change to no failure
- - Mean time for GetMessages went from 27 159 ms to 27 ms (1000 time improvment), for all operation from
- 27 591 ms to 60 ms (460 time improvment)
- - P99 is a metic thatdid not make sense because the initial simulation exceeded Gatling (the performance measuring tool 
- we use) timeout (60s) at the p50 percentile. After this proposal p99 for the entire scenario is of 1 383 ms
+ - A 7% failure rate before this change to almost no failure
+ - Mean time for GetMessages went from 9 710 ms to 434 ms (22 time improvment), for all operation from
+ 12 802 ms to 407 ms (31 time improvment)
+ - P99 is a metric that did not make sense because the initial simulation exceeded Gatling (the performance measuring tool 
+ we use) timeout (60s) at the p95 percentile. After this proposal p99 for the entire scenario is of 1 747 ms
 
-As such, this changeset significantly increase the JMAP performance.
+As such, this changeset significantly increases the JMAP performance.
 
 ## References
 

--- a/src/adr/0013-precompute-jmap-preview.md
+++ b/src/adr/0013-precompute-jmap-preview.md
@@ -4,9 +4,7 @@ Date: 2019-10-09
 
 ## Status
 
-Proposed
-
-Adoption needs to be backed by some performance tests.
+Accepted
 
 ## Context
 
@@ -35,9 +33,20 @@ Some performance tests will be run in order to evaluate the improvements.
 
 ## Consequences
 
-We expect a huge performance enhancement for JMAP clients relying on preview for listing mails.
+Given the following scenario played by 5000 users per hour (constant rate)
+ - Authenticate
+ - List mailboxes
+ - List messages in one of their mailboxes
+ - Get 10 time the properties expected to be fast to fetch with JMAP
 
-In case of a less than 5% improvement, the code will not be added to the codebase and the proposal will get the status 'rejected'.
+We went from:
+ - A 20% failure rate before this change to no failure
+ - Mean time for GetMessages went from 27 159 ms to 27 ms (1000 time improvment), for all operation from
+ 27 591 ms to 60 ms (460 time improvment)
+ - P99 is a metic thatdid not make sense because the initial simulation exceeded Gatling (the performance measuring tool 
+ we use) timeout (60s) at the p50 percentile. After this proposal p99 for the entire scenario is of 1 383 ms
+
+As such, this changeset significantly increase the JMAP performance.
 
 ## References
 

--- a/src/adr/0013-precompute-jmap-preview.md
+++ b/src/adr/0013-precompute-jmap-preview.md
@@ -37,7 +37,7 @@ Given the following scenario played by 2500 users per hour (constant rate)
  - Authenticate
  - List mailboxes
  - List messages in one of their mailboxes
- - Get 8 time the properties expected to be fast to fetch with JMAP
+ - Get 8 times the properties expected to be fast to fetch with JMAP
 
 We went from:
  - A 7% failure rate before this change to almost no failure


### PR DESCRIPTION
# Performance results

## Metadata

`Metadata read`: only mailboxIds + flags

 - GetMailboxes
 - GetMessageMist
 - 10x GetMessages 

With 5000 users per hour...

### Before:

![Capture d’écran de 2019-12-04 17-38-10](https://user-images.githubusercontent.com/6928740/70138771-8e4bfd80-16c3-11ea-854c-3eb26d1fb586.png)

### After:

![Capture d’écran de 2019-12-04 17-38-14](https://user-images.githubusercontent.com/6928740/70138758-8a1fe000-16c3-11ea-8fee-20e0b78d9794.png)

However all the slow results (and few errors) occured upon projection population as this graphic shows:

![Capture d’écran de 2019-12-04 17-38-17](https://user-images.githubusercontent.com/6928740/70138776-9310b180-16c3-11ea-9712-0d6e59821b92.png)

A second run (on populated projection) means consistant, quick results:

![Capture d’écran de 2019-12-04 17-38-20](https://user-images.githubusercontent.com/6928740/70138795-9f950a00-16c3-11ea-8228-9e3c2134e28e.png)

Key metrics given 14 GetMessages request per second:

 - From 19% failure rate to 0
 - From 27.159 ms for succeding requests to 27 ms (x1000 inprovment of GetMessage command mean time)
 - At a global level, from 27.591 ms mean time (all requests) to 60 ms (x460 mean time improvment)

--------------------------------------------------

## Home loading

`FastView read`

 - GetMailboxes
 - GetMessageMist
 - 8x GetMessages 

2500 concurrent users

### Before:

![Capture d’écran de 2019-12-05 09-47-37](https://user-images.githubusercontent.com/6928740/70199990-c562f300-1745-11ea-99a5-77a3b7062574.png)


### After:

![Capture d’écran de 2019-12-05 09-47-39](https://user-images.githubusercontent.com/6928740/70199996-cac03d80-1745-11ea-88f6-d10ed74ead41.png)


Key metric:

 - From 7% errors to almost 0%
 - Mean time: From 12 802 ms to 407 ms (x14 improvment)
 - P99: From 60s (exceeding gatling time out at p95) to 1742 ms