### PR TITLE
[Refactoring] Remove MailboxManager::logout(session, force)

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
@@ -251,34 +251,6 @@ public interface MailboxManager extends RequestAware, RightManager, MailboxAnnot
     }
 
     /**
-     * <p>
-     * Logs the session out, freeing any resources. Clients who open session
-     * should make best efforts to call this when the session is closed.
-     * </p>
-     * <p>
-     * Note that clients may not always be able to call logout (whether forced
-     * or not). Mailboxes that create sessions which are expensive to maintain
-     * <code>MUST</code> retain a reference and periodically check
-     * {@link MailboxSession#isOpen()}.
-     * </p>
-     * <p>
-     * Note that implementations much be aware that it is possible that this
-     * method may be called more than once with the same session.
-     * </p>
-     * 
-     * @param session
-     *            not null
-     * @param force
-     *            true when the session logout is forced by premature connection
-     *            termination
-     * @throws MailboxException
-     *             when logout fails
-     */
-    default void logout(MailboxSession session, boolean force) throws MailboxException {
-        logout(session);
-    }
-
-    /**
      * Return a unmodifiable {@link List} of {@link MailboxPath} objects
      */
     List<MailboxPath> list(MailboxSession session) throws MailboxException;

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerStressContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerStressContract.java
@@ -71,7 +71,7 @@ public interface MailboxManagerStressContract<T extends MailboxManager> {
                 uList.add(u);
             }, new MailboxIdRegistrationKey(mailboxId));
         getManager().endProcessingRequest(session);
-        getManager().logout(session, false);
+        getManager().logout(session);
 
         final AtomicBoolean fail = new AtomicBoolean(false);
         final ConcurrentHashMap<MessageUid, Object> uids = new ConcurrentHashMap<>();
@@ -100,7 +100,7 @@ public interface MailboxManagerStressContract<T extends MailboxManager> {
                         fail.set(true);
                     }
                     getManager().endProcessingRequest(mailboxSession);
-                    getManager().logout(mailboxSession, false);
+                    getManager().logout(mailboxSession);
                 } catch (Exception e) {
                     e.printStackTrace();
                     fail.set(true);

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -144,8 +144,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
     }
 
     @AfterEach
-    void tearDown() throws Exception {
-        mailboxManager.logout(session, false);
+    void tearDown() {
+        mailboxManager.logout(session);
         mailboxManager.endProcessingRequest(session);
     }
 
@@ -1591,11 +1591,11 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        void closingSessionShouldWork() throws Exception {
+        void closingSessionShouldWork() {
             session = mailboxManager.createSystemSession(USER_1);
             mailboxManager.startProcessingRequest(session);
 
-            mailboxManager.logout(session, false);
+            mailboxManager.logout(session);
             mailboxManager.endProcessingRequest(session);
 
             assertThat(session.isOpen()).isFalse();

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/mock/DataProvisioner.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/mock/DataProvisioner.java
@@ -30,8 +30,6 @@ import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.MailboxConstants;
 import org.apache.james.mailbox.model.MailboxPath;
 
-import com.github.fge.lambdas.Throwing;
-
 public class DataProvisioner {
     
     /**
@@ -81,10 +79,10 @@ public class DataProvisioner {
         IntStream.range(0, USER_COUNT)
             .mapToObj(i -> "user" + i + "@" + domain)
             .map(Username::of)
-            .forEach(Throwing.consumer(user -> provisionUser(mailboxManager, user)));
+            .forEach(user -> provisionUser(mailboxManager, user));
     }
 
-    private static void provisionUser(MailboxManager mailboxManager, Username user) throws MailboxException {
+    private static void provisionUser(MailboxManager mailboxManager, Username user) {
         MailboxSession mailboxSession = mailboxManager.createSystemSession(user);
         mailboxManager.startProcessingRequest(mailboxSession);
 
@@ -96,7 +94,7 @@ public class DataProvisioner {
             .forEach(name ->  createSubSubMailboxes(mailboxManager, mailboxSession, name));
 
         mailboxManager.endProcessingRequest(mailboxSession);
-        mailboxManager.logout(mailboxSession, true);
+        mailboxManager.logout(mailboxSession);
     }
 
     private static void createSubSubMailboxes(MailboxManager mailboxManager,MailboxSession mailboxSession, String subFolderName) {

--- a/mailbox/tools/copier/src/test/java/org/apache/james/mailbox/tools/copier/MailboxCopierTest.java
+++ b/mailbox/tools/copier/src/test/java/org/apache/james/mailbox/tools/copier/MailboxCopierTest.java
@@ -126,8 +126,7 @@ public class MailboxCopierTest {
         }
 
         mailboxManager.endProcessingRequest(mailboxSession);
-        mailboxManager.logout(mailboxSession, true);
-
+        mailboxManager.logout(mailboxSession);
     }
 
     /**

--- a/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/host/JamesImapHostSystem.java
+++ b/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/host/JamesImapHostSystem.java
@@ -104,7 +104,7 @@ public abstract class JamesImapHostSystem implements ImapHostSystem, GrantRights
         MailboxSession mailboxSession = mailboxManager.createSystemSession(mailboxPath.getUser());
         mailboxManager.startProcessingRequest(mailboxSession);
         mailboxManager.createMailbox(mailboxPath, mailboxSession);
-        mailboxManager.logout(mailboxSession, true);
+        mailboxManager.logout(mailboxSession);
         mailboxManager.endProcessingRequest(mailboxSession);
     }
 
@@ -119,7 +119,7 @@ public abstract class JamesImapHostSystem implements ImapHostSystem, GrantRights
                 .rights(rights)
                 .asAddition()),
             mailboxManager.createSystemSession(username));
-        mailboxManager.logout(mailboxSession, true);
+        mailboxManager.logout(mailboxSession);
         mailboxManager.endProcessingRequest(mailboxSession);
     }
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/LogoutProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/LogoutProcessor.java
@@ -22,14 +22,12 @@ package org.apache.james.imap.processor;
 import java.io.Closeable;
 
 import org.apache.james.imap.api.ImapSessionUtils;
-import org.apache.james.imap.api.display.HumanReadableText;
 import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.api.process.ImapSession;
 import org.apache.james.imap.message.request.LogoutRequest;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
-import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.util.MDCBuilder;
 import org.slf4j.Logger;
@@ -45,16 +43,11 @@ public class LogoutProcessor extends AbstractMailboxProcessor<LogoutRequest> {
 
     @Override
     protected void processRequest(LogoutRequest request, ImapSession session, Responder responder) {
-        final MailboxSession mailboxSession = ImapSessionUtils.getMailboxSession(session);
-        try {
-            getMailboxManager().logout(mailboxSession, false);
-            session.logout();
-            bye(responder);
-            okComplete(request, responder);
-        } catch (MailboxException e) {
-            LOGGER.error("Logout failed for user {}", mailboxSession.getUser().asString(), e);
-            no(request, responder, HumanReadableText.GENERIC_FAILURE_DURING_PROCESSING);
-        }
+        MailboxSession mailboxSession = ImapSessionUtils.getMailboxSession(session);
+        getMailboxManager().logout(mailboxSession);
+        session.logout();
+        bye(responder);
+        okComplete(request, responder);
     }
 
     @Override

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SystemMessageProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SystemMessageProcessor.java
@@ -28,7 +28,6 @@ import org.apache.james.imap.message.request.SystemMessage;
 import org.apache.james.imap.processor.base.AbstractChainedProcessor;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
-import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.util.MDCBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,17 +47,13 @@ public class SystemMessageProcessor extends AbstractChainedProcessor<SystemMessa
 
     @Override
     protected void doProcess(SystemMessage message, Responder responder, ImapSession session) {
-        try {
-            switch (message) {
+        switch (message) {
             case FORCE_LOGOUT:
                 forceLogout(session);
                 break;
             default:
                 LOGGER.info("Unknown system message {}", message);
                 break;
-            }
-        } catch (MailboxException e) {
-            LOGGER.error("Cannot force logout", e);
         }
     }
 
@@ -67,16 +62,14 @@ public class SystemMessageProcessor extends AbstractChainedProcessor<SystemMessa
      * 
      * @param imapSession
      *            not null
-     * @throws MailboxException
-     *             when forced logout fails
      */
-    private void forceLogout(ImapSession imapSession) throws MailboxException {
+    private void forceLogout(ImapSession imapSession) {
         final MailboxSession session = ImapSessionUtils.getMailboxSession(imapSession);
         if (session == null) {
             LOGGER.trace("No mailbox session so no force logout needed");
         } else {
             session.close();
-            mailboxManager.logout(session, true);
+            mailboxManager.logout(session);
         }
     }
 

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/MailboxProbeImpl.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/MailboxProbeImpl.java
@@ -97,11 +97,7 @@ public class MailboxProbeImpl implements GuiceProbe, MailboxProbe {
     private void closeSession(MailboxSession session) {
         if (session != null) {
             mailboxManager.endProcessingRequest(session);
-            try {
-                mailboxManager.logout(session, true);
-            } catch (MailboxException e) {
-                throw new RuntimeException(e);
-            }
+            mailboxManager.logout(session);
         }
     }
 

--- a/server/container/mailbox-jmx/src/main/java/org/apache/james/adapter/mailbox/MailboxManagerManagement.java
+++ b/server/container/mailbox-jmx/src/main/java/org/apache/james/adapter/mailbox/MailboxManagerManagement.java
@@ -196,11 +196,7 @@ public class MailboxManagerManagement extends StandardMBean implements MailboxMa
     private void closeSession(MailboxSession session) {
         if (session != null) {
             mailboxManager.endProcessingRequest(session);
-            try {
-                mailboxManager.logout(session, true);
-            } catch (MailboxException e) {
-                LOGGER.error("Can not log session out", e);
-            }
+            mailboxManager.logout(session);
         }
     }
 

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/MailboxAppender.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/delivery/MailboxAppender.java
@@ -102,11 +102,7 @@ public class MailboxAppender {
     private void closeProcessing(MailboxSession session) throws MessagingException {
         session.close();
         try {
-            try {
-                mailboxManager.logout(session, true);
-            } catch (MailboxException e) {
-                throw new MessagingException("Can logout from mailbox", e);
-            }
+            mailboxManager.logout(session);
         } finally {
             mailboxManager.endProcessingRequest(session);
         }

--- a/server/protocols/protocols-pop3/src/main/java/org/apache/james/pop3server/mailbox/MailboxAdapter.java
+++ b/server/protocols/protocols-pop3/src/main/java/org/apache/james/pop3server/mailbox/MailboxAdapter.java
@@ -166,9 +166,7 @@ public class MailboxAdapter implements Mailbox {
     @Override
     public void close() throws IOException {
         try {
-            mailboxManager.logout(session, true);
-        } catch (MailboxException e) {
-            throw new IOException("Unable to close mailbox", e);
+            mailboxManager.logout(session);
         } finally {
             mailboxManager.endProcessingRequest(session);
         }


### PR DESCRIPTION
No implementation currently uses the force parameter, making it useless.

MailboxManager::logout(session) should be used instead