### PR TITLE
JAMES-2666 Fix EventDeadLetters unstable test

### DIFF
--- a/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/EventDeadLettersIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/EventDeadLettersIntegrationTest.java
@@ -24,8 +24,10 @@ import static io.restassured.RestAssured.when;
 import static io.restassured.RestAssured.with;
 import static org.awaitility.Duration.ONE_HUNDRED_MILLISECONDS;
 import static org.awaitility.Duration.ONE_MINUTE;
+import static org.awaitility.Duration.TEN_SECONDS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 
 import java.util.ArrayList;
@@ -189,12 +191,14 @@ public class EventDeadLettersIntegrationTest {
     }
 
     private String retrieveFirstFailedInsertionId() {
-        List<String> response = with()
-            .get(EventDeadLettersRoutes.BASE_PATH + "/groups/" + GROUP_ID)
-            .jsonPath()
-            .getList(".");
+        List<String> insertionIds = calmlyAwait.atMost(TEN_SECONDS)
+            .until(() -> with()
+                    .get(EventDeadLettersRoutes.BASE_PATH + "/groups/" + GROUP_ID)
+                    .jsonPath()
+                    .getList("."),
+                hasSize(greaterThanOrEqualTo(1)));
 
-        return response.get(0);
+        return insertionIds.get(0);
     }
 
     @Test

--- a/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/EventDeadLettersIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/EventDeadLettersIntegrationTest.java
@@ -191,14 +191,18 @@ public class EventDeadLettersIntegrationTest {
     }
 
     private String retrieveFirstFailedInsertionId() {
-        List<String> insertionIds = calmlyAwait.atMost(TEN_SECONDS)
-            .until(() -> with()
+        calmlyAwait.atMost(TEN_SECONDS)
+            .untilAsserted(() ->
+                when()
                     .get(EventDeadLettersRoutes.BASE_PATH + "/groups/" + GROUP_ID)
-                    .jsonPath()
-                    .getList("."),
-                hasSize(greaterThanOrEqualTo(1)));
+                .then()
+                    .body(".", hasSize(1)));
 
-        return insertionIds.get(0);
+        return (String) with()
+            .get(EventDeadLettersRoutes.BASE_PATH + "/groups/" + GROUP_ID)
+            .jsonPath()
+            .getList(".")
+            .get(0);
     }
 
     @Test


### PR DESCRIPTION
From:
```
EventDeadLettersIntegrationTest.failedEventShouldNotBeInDeadLettersAfterSuccessfulRedelivery:334->retrieveFirstFailedInsertionId:197 » IndexOutOfBounds
```


There is a time window after the listener has been failed to process an
event and storing that event into deadletter. If webadmin is requested
during that time window, there is no event returned from the deadletter
and consequently, IndexOutboundException at `response.get(0)`