### PR TITLE
[Refactoring] Move remaining test classes in mailbox-lucene to JUnit 5

### DIFF
--- a/mailbox/lucene/src/test/java/org/apache/james/mailbox/lucene/search/LuceneMailboxMessageSearchIndexTest.java
+++ b/mailbox/lucene/src/test/java/org/apache/james/mailbox/lucene/search/LuceneMailboxMessageSearchIndexTest.java
@@ -49,53 +49,53 @@ import org.apache.james.mailbox.model.TestId;
 import org.apache.james.mailbox.model.TestMessageId;
 import org.apache.james.mailbox.store.MessageBuilder;
 import org.apache.lucene.store.RAMDirectory;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
 
-public class LuceneMailboxMessageSearchIndexTest {
-    private static final long LIMIT = 100L;
-    private static final TestId TEST_ID_1 = TestId.of(0);
-    private static final TestId TEST_ID_2 = TestId.of(1);
-    private static final TestId TEST_ID_3 = TestId.of(2);
+class LuceneMailboxMessageSearchIndexTest {
+    static final long LIMIT = 100L;
+    static final TestId TEST_ID_1 = TestId.of(0);
+    static final TestId TEST_ID_2 = TestId.of(1);
+    static final TestId TEST_ID_3 = TestId.of(2);
 
-    private static final Username BOB = Username.of("bob");
-    private Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, "box"), 18, TEST_ID_1);
-    private Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(BOB, "box"), 19, TEST_ID_2);
-    private Mailbox mailbox3 = new Mailbox(MailboxPath.forUser(BOB, "box"), 12, TEST_ID_3);
-    private LuceneMessageSearchIndex index;
-    private MailboxSession session;
+    static final Username BOB = Username.of("bob");
+    Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, "box"), 18, TEST_ID_1);
+    Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(BOB, "box"), 19, TEST_ID_2);
+    Mailbox mailbox3 = new Mailbox(MailboxPath.forUser(BOB, "box"), 12, TEST_ID_3);
+    LuceneMessageSearchIndex index;
+    MailboxSession session;
 
-    private static final String FROM_ADDRESS = "Harry <harry@example.org>";
+    static final String FROM_ADDRESS = "Harry <harry@example.org>";
 
-    private static final String SUBJECT_PART = "Mixed";
+    static final String SUBJECT_PART = "Mixed";
 
-    private static final String CUSTARD = "CUSTARD";
+    static final String CUSTARD = "CUSTARD";
 
-    private static final String RHUBARD = "Rhubard";
+    static final String RHUBARD = "Rhubard";
 
-    private static final String BODY = "This is a simple email\r\n "
+    static final String BODY = "This is a simple email\r\n "
             + "It has " + RHUBARD + ".\r\n" + "It has " + CUSTARD + ".\r\n"
             + "It needs naught else.\r\n";
 
-    private MessageUid uid1;
-    private MessageUid uid2;
-    private MessageUid uid3;
-    private MessageUid uid4;
-    private MessageUid uid5;
-    private MessageId id1;
-    private MessageId id2;
-    private MessageId id3;
-    private MessageId id4;
-    private MessageId id5;
+    MessageUid uid1;
+    MessageUid uid2;
+    MessageUid uid3;
+    MessageUid uid4;
+    MessageUid uid5;
+    MessageId id1;
+    MessageId id2;
+    MessageId id3;
+    MessageId id4;
+    MessageId id5;
 
     protected boolean useLenient() {
         return true;
     }
     
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         session = MailboxSessionUtil.create(Username.of("username"));
         TestMessageId.Factory factory = new TestMessageId.Factory();
         id1 = factory.generate();
@@ -183,11 +183,9 @@ public class LuceneMailboxMessageSearchIndexTest {
         index.add(session, mailbox3, builder.build(id5));
 
     }
-    
-
 
     @Test
-    public void bodySearchShouldMatchPhraseInBody() throws Exception {
+    void bodySearchShouldMatchPhraseInBody() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.bodyContains(CUSTARD));
         Stream<MessageUid> result = index.search(session, mailbox3, query);
@@ -195,7 +193,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
 
     @Test
-    public void bodySearchShouldNotMatchAbsentPhraseInBody() throws Exception {
+    void bodySearchShouldNotMatchAbsentPhraseInBody() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.bodyContains(CUSTARD + CUSTARD));
         Stream<MessageUid> result = index.search(session, mailbox3, query);
@@ -203,7 +201,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void bodySearchShouldBeCaseInsensitive() throws Exception {
+    void bodySearchShouldBeCaseInsensitive() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.bodyContains(RHUBARD));
         Stream<MessageUid> result = index.search(session, mailbox3, query);
@@ -211,7 +209,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
 
     @Test
-    public void bodySearchNotMatchPhraseOnlyInFrom() throws Exception {
+    void bodySearchNotMatchPhraseOnlyInFrom() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.bodyContains(FROM_ADDRESS));
         Stream<MessageUid> result = index.search(session, mailbox3, query);
@@ -219,7 +217,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
 
     @Test
-    public void bodySearchShouldNotMatchPhraseOnlyInSubject() throws Exception {
+    void bodySearchShouldNotMatchPhraseOnlyInSubject() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.bodyContains(SUBJECT_PART));
         Stream<MessageUid> result = index.search(session, mailbox3, query);
@@ -227,7 +225,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
 
     @Test
-    public void textSearchShouldMatchPhraseInBody() throws Exception {
+    void textSearchShouldMatchPhraseInBody() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.mailContains(CUSTARD));
         Stream<MessageUid> result = index.search(session, mailbox3, query);
@@ -235,7 +233,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
 
     @Test
-    public void textSearchShouldNotAbsentMatchPhraseInBody() throws Exception {
+    void textSearchShouldNotAbsentMatchPhraseInBody() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.mailContains(CUSTARD + CUSTARD));
         Stream<MessageUid> result = index.search(session, mailbox3, query);
@@ -243,7 +241,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
 
     @Test
-    public void textSearchMatchShouldBeCaseInsensitive() throws Exception {
+    void textSearchMatchShouldBeCaseInsensitive() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.mailContains(RHUBARD.toLowerCase(Locale.US)));
         Stream<MessageUid> result = index.search(session, mailbox3, query);
@@ -251,7 +249,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
 
     @Test
-    public void addressSearchShouldMatchToFullAddress() throws Exception {
+    void addressSearchShouldMatchToFullAddress() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.address(AddressType.To,FROM_ADDRESS));
         Stream<MessageUid> result = index.search(session, mailbox3, query);
@@ -259,7 +257,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
 
     @Test
-    public void addressSearchShouldMatchToDisplayName() throws Exception {
+    void addressSearchShouldMatchToDisplayName() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.address(AddressType.To,"Harry"));
         Stream<MessageUid> result = index.search(session, mailbox3, query);
@@ -267,7 +265,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void addressSearchShouldMatchToEmail() throws Exception {
+    void addressSearchShouldMatchToEmail() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.address(AddressType.To,"Harry@example.org"));
         Stream<MessageUid> result = index.search(session, mailbox3, query);
@@ -275,7 +273,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void addressSearchShouldMatchFrom() throws Exception {
+    void addressSearchShouldMatchFrom() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.address(AddressType.From,"ser-from@domain.or"));
         Stream<MessageUid> result = index.search(session, mailbox3, query);
@@ -283,7 +281,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
 
     @Test
-    public void textSearchShouldMatchPhraseOnlyInToHeader() throws Exception {
+    void textSearchShouldMatchPhraseOnlyInToHeader() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.mailContains(FROM_ADDRESS));
         Stream<MessageUid> result = index.search(session, mailbox3, query);
@@ -291,7 +289,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void textSearchShouldMatchPhraseOnlyInSubjectHeader() throws Exception {
+    void textSearchShouldMatchPhraseOnlyInSubjectHeader() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.mailContains(SUBJECT_PART));
         Stream<MessageUid> result = index.search(session, mailbox3, query);
@@ -299,7 +297,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void searchAllShouldMatchAllMailboxEmails() throws Exception {
+    void searchAllShouldMatchAllMailboxEmails() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.all());
         Stream<MessageUid> result = index.search(session, mailbox2, query);
@@ -307,7 +305,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
 
     @Test
-    public void searchBodyInAllMailboxesShouldMatch() throws Exception {
+    void searchBodyInAllMailboxesShouldMatch() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.bodyContains("My Body"));
 
@@ -317,7 +315,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
 
     @Test
-    public void searchBodyInSpecificMailboxesShouldMatch() throws Exception {
+    void searchBodyInSpecificMailboxesShouldMatch() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.bodyContains("My Body"));
 
@@ -330,7 +328,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
 
     @Test
-    public void searchAllShouldMatchAllUserEmails() throws Exception {
+    void searchAllShouldMatchAllUserEmails() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.all());
 
@@ -341,7 +339,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
 
     @Test
-    public void searchAllShouldLimitTheSize() throws Exception {
+    void searchAllShouldLimitTheSize() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.all());
 
@@ -352,7 +350,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void flagSearchShouldMatch() throws Exception {
+    void flagSearchShouldMatch() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.flagIsSet(Flag.DELETED));
         Stream<MessageUid> result = index.search(session, mailbox, query);
@@ -360,7 +358,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void bodySearchShouldMatchSeveralEmails() throws Exception {    
+    void bodySearchShouldMatchSeveralEmails() throws Exception {    
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.bodyContains("body"));
         Stream<MessageUid> result = index.search(session, mailbox, query);
@@ -368,7 +366,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void textSearchShouldMatchSeveralEmails() throws Exception {    
+    void textSearchShouldMatchSeveralEmails() throws Exception {    
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.mailContains("body"));
         Stream<MessageUid> result = index.search(session, mailbox, query);
@@ -376,7 +374,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void headerSearchShouldMatch() throws Exception {
+    void headerSearchShouldMatch() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.headerContains("Subject", "test"));
         Stream<MessageUid> result = index.search(session, mailbox, query);
@@ -384,7 +382,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void headerExistsShouldMatch() throws Exception {
+    void headerExistsShouldMatch() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.headerExists("Subject"));
         Stream<MessageUid> result = index.search(session, mailbox, query);
@@ -392,7 +390,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void flagUnsetShouldMatch() throws Exception {
+    void flagUnsetShouldMatch() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.flagIsUnSet(Flag.DRAFT));
         Stream<MessageUid> result = index.search(session, mailbox, query);
@@ -400,7 +398,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void internalDateBeforeShouldMatch() throws Exception {
+    void internalDateBeforeShouldMatch() throws Exception {
         SearchQuery query = new SearchQuery();
         Calendar cal = Calendar.getInstance();
         cal.setTime(new Date());
@@ -412,7 +410,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     
     
     @Test
-    public void internalDateAfterShouldMatch() throws Exception {
+    void internalDateAfterShouldMatch() throws Exception {
         SearchQuery query = new SearchQuery();
         Calendar cal = Calendar.getInstance();
         cal.setTime(new Date());
@@ -424,7 +422,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     
     
     @Test
-    public void internalDateOnShouldMatch() throws Exception {
+    void internalDateOnShouldMatch() throws Exception {
         SearchQuery query = new SearchQuery();
         Calendar cal = Calendar.getInstance();
         cal.setTime(new Date());
@@ -434,7 +432,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void uidSearchShouldMatch() throws Exception {
+    void uidSearchShouldMatch() throws Exception {
         SearchQuery query = new SearchQuery();
         Calendar cal = Calendar.getInstance();
         cal.setTime(new Date());
@@ -444,7 +442,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void uidRangeSearchShouldMatch() throws Exception {
+    void uidRangeSearchShouldMatch() throws Exception {
         SearchQuery query = new SearchQuery();
         Calendar cal = Calendar.getInstance();
         cal.setTime(new Date());
@@ -454,7 +452,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void sizeEqualsShouldMatch() throws Exception {
+    void sizeEqualsShouldMatch() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.sizeEquals(200));
         Stream<MessageUid> result = index.search(session, mailbox, query);
@@ -462,7 +460,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void sizeLessThanShouldMatch() throws Exception {
+    void sizeLessThanShouldMatch() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.sizeLessThan(200));
         Stream<MessageUid> result = index.search(session, mailbox, query);
@@ -470,7 +468,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void sizeGreaterThanShouldMatch() throws Exception {
+    void sizeGreaterThanShouldMatch() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.sizeGreaterThan(6));
         Stream<MessageUid> result = index.search(session, mailbox, query);
@@ -478,7 +476,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void uidShouldBeSorted() throws Exception {
+    void uidShouldBeSorted() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.all());
         Stream<MessageUid> result = index.search(session, mailbox, query);
@@ -486,7 +484,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void uidReverseSortShouldReturnWellOrderedResults() throws Exception {
+    void uidReverseSortShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.Uid, Order.REVERSE)));
 
@@ -495,7 +493,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void sortOnSentDateShouldReturnWellOrderedResults() throws Exception {
+    void sortOnSentDateShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.SentDate, Order.NATURAL)));
 
@@ -504,7 +502,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void reverseSortOnSentDateShouldReturnWellOrderedResults() throws Exception {
+    void reverseSortOnSentDateShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.SentDate, Order.REVERSE)));
 
@@ -513,7 +511,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
 
     @Test
-    public void sortOnSubjectShouldReturnWellOrderedResults() throws Exception {
+    void sortOnSubjectShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.BaseSubject, Order.NATURAL)));
 
@@ -522,7 +520,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void reverseSortOnSubjectShouldReturnWellOrderedResults() throws Exception {
+    void reverseSortOnSubjectShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.BaseSubject, Order.REVERSE)));
 
@@ -531,7 +529,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void sortOnMailboxFromShouldReturnWellOrderedResults() throws Exception {
+    void sortOnMailboxFromShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.MailboxFrom, Order.NATURAL)));
 
@@ -540,7 +538,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void reverseSortOnMailboxFromShouldReturnWellOrderedResults() throws Exception {
+    void reverseSortOnMailboxFromShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.MailboxFrom, Order.REVERSE)));
 
@@ -549,7 +547,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void sortOnMailboxCCShouldReturnWellOrderedResults() throws Exception {
+    void sortOnMailboxCCShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.MailboxCc, Order.NATURAL)));
 
@@ -558,7 +556,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void reverseSortOnMailboxCCShouldReturnWellOrderedResults() throws Exception {
+    void reverseSortOnMailboxCCShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.MailboxCc, Order.REVERSE)));
 
@@ -567,7 +565,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void sortOnMailboxToShouldReturnWellOrderedResults() throws Exception {
+    void sortOnMailboxToShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.MailboxTo, Order.NATURAL)));
 
@@ -576,7 +574,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void reverseSortOnMailboxToShouldReturnWellOrderedResults() throws Exception {
+    void reverseSortOnMailboxToShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.MailboxTo, Order.REVERSE)));
 
@@ -585,7 +583,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void sortOnDisplayToShouldReturnWellOrderedResults() throws Exception {
+    void sortOnDisplayToShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.DisplayTo, Order.NATURAL)));
 
@@ -594,7 +592,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void reverseSortOnDisplayToShouldReturnWellOrderedResults() throws Exception {
+    void reverseSortOnDisplayToShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.DisplayTo, Order.REVERSE)));
 
@@ -603,7 +601,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void sortOnDisplayFromShouldReturnWellOrderedResults() throws Exception {
+    void sortOnDisplayFromShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.DisplayFrom, Order.NATURAL)));
 
@@ -612,7 +610,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void reverseSortOnDisplayFromShouldReturnWellOrderedResults() throws Exception {
+    void reverseSortOnDisplayFromShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.DisplayFrom, Order.REVERSE)));
 
@@ -621,7 +619,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void sortOnArrivalDateShouldReturnWellOrderedResults() throws Exception {
+    void sortOnArrivalDateShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.Arrival, Order.NATURAL)));
 
@@ -630,7 +628,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void reverseSortOnArrivalDateShouldReturnWellOrderedResults() throws Exception {
+    void reverseSortOnArrivalDateShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.Arrival, Order.REVERSE)));
 
@@ -639,7 +637,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void sortOnSizeShouldReturnWellOrderedResults() throws Exception {
+    void sortOnSizeShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.Size, Order.NATURAL)));
 
@@ -648,7 +646,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void reverseSortOnSizeShouldReturnWellOrderedResults() throws Exception {
+    void reverseSortOnSizeShouldReturnWellOrderedResults() throws Exception {
         SearchQuery query = new SearchQuery(SearchQuery.all());
         query.setSorts(ImmutableList.of(new Sort(SortClause.Size, Order.REVERSE)));
 
@@ -657,7 +655,7 @@ public class LuceneMailboxMessageSearchIndexTest {
     }
     
     @Test
-    public void notOperatorShouldReverseMatching() throws Exception {
+    void notOperatorShouldReverseMatching() throws Exception {
         SearchQuery query = new SearchQuery();
         query.andCriteria(SearchQuery.not(SearchQuery.uid(new SearchQuery.UidRange[] { new SearchQuery.UidRange(uid1)})));
 

--- a/mailbox/lucene/src/test/java/org/apache/james/mailbox/lucene/search/StrictLuceneMessageSearchIndexText.java
+++ b/mailbox/lucene/src/test/java/org/apache/james/mailbox/lucene/search/StrictLuceneMessageSearchIndexText.java
@@ -18,7 +18,7 @@
  ****************************************************************/
 package org.apache.james.mailbox.lucene.search;
 
-public class StrictLuceneMessageSearchIndexText extends LuceneMailboxMessageSearchIndexTest {
+class StrictLuceneMessageSearchIndexText extends LuceneMailboxMessageSearchIndexTest {
 
     @Override
     protected boolean useLenient() {


### PR DESCRIPTION
Note: `LuceneMessageSearchIndexTest` is being moved to JUnit 5 in #2976 