### PR TITLE
JAMES-2642 Add alias mapping integration test to show that alias deli…

### DIFF
--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/AliasMappingTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/AliasMappingTest.java
@@ -60,12 +60,11 @@ public class AliasMappingTest {
     private static final String DOMAIN = "domain.tld";
 
     private static final String BOB_USER = "bob";
-    private static final String UPPER_CASE_USER = "USER";
     private static final String ALICE_USER = "alice";
     private static final String CEDRIC_USER = "cedric";
 
     private static final String BOB_ADDRESS = BOB_USER + "@" + DOMAIN;
-    private static final String UPPER_CASE_ADDRESS = UPPER_CASE_USER + "@" + DOMAIN;
+    private static final String UPPER_BOB_ADDRESS = BOB_USER.toUpperCase() + "@" + DOMAIN;
     private static final String ALICE_ADDRESS = ALICE_USER + "@" + DOMAIN;
     private static final String CEDRIC_ADDRESS = CEDRIC_USER + "@" + DOMAIN;
 
@@ -74,7 +73,7 @@ public class AliasMappingTest {
 
     private static final String BOB_ALIAS = BOB_USER + "-alias@" + DOMAIN;
     private static final String BOB_ALIAS_2 = BOB_USER + "-alias2@" + DOMAIN;
-    private static final String UPPER_CASE_ALIAS = UPPER_CASE_USER + "-ALIAS@" + DOMAIN;
+    private static final String UPPER_BOB_ALIAS = BOB_USER.toUpperCase() + "-ALIAS@" + DOMAIN;
     private static final String GROUP_ALIAS = GROUP + "-alias@" + DOMAIN;
 
     private static final String MESSAGE_CONTENT = "any text";
@@ -106,12 +105,10 @@ public class AliasMappingTest {
         dataProbe.addDomain(DOMAIN);
 
         dataProbe.addUser(BOB_ADDRESS, PASSWORD);
-        dataProbe.addUser(UPPER_CASE_ADDRESS, PASSWORD);
         dataProbe.addUser(ALICE_ADDRESS, PASSWORD);
         dataProbe.addUser(CEDRIC_ADDRESS, PASSWORD);
 
         jamesServer.getProbe(MailboxProbeImpl.class).createMailbox(MailboxPath.inbox(Username.of(BOB_ADDRESS)));
-        jamesServer.getProbe(MailboxProbeImpl.class).createMailbox(MailboxPath.inbox(Username.of(UPPER_CASE_ADDRESS)));
         jamesServer.getProbe(MailboxProbeImpl.class).createMailbox(MailboxPath.inbox(Username.of(ALICE_ADDRESS)));
         jamesServer.getProbe(MailboxProbeImpl.class).createMailbox(MailboxPath.inbox(Username.of(CEDRIC_ADDRESS)));
 
@@ -148,14 +145,14 @@ public class AliasMappingTest {
 
     @Test
     public void messageShouldRedirectToUserWhenSentToHisUpperCaseAlias() throws Exception {
-        webAdminApi.put(AliasRoutes.ROOT_PATH + "/" + BOB_ADDRESS + "/sources/" + UPPER_CASE_ALIAS.toLowerCase());
+        webAdminApi.put(AliasRoutes.ROOT_PATH + "/" + BOB_ADDRESS + "/sources/" + BOB_ALIAS);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
                 .sender(ALICE_ADDRESS)
-                .recipient(UPPER_CASE_ALIAS));
+                .recipient(UPPER_BOB_ALIAS));
 
         imapMessageReader.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
             .login(BOB_ADDRESS, PASSWORD)
@@ -165,8 +162,8 @@ public class AliasMappingTest {
     }
 
     @Test
-    public void messageShouldRedirectToUpperCaseDefinedUserWhenSentToHisLowerCaseAlias() throws Exception {
-        webAdminApi.put(AliasRoutes.ROOT_PATH + "/" + UPPER_CASE_ADDRESS + "/sources/" + BOB_ALIAS);
+    public void messageShouldRedirectToUserWhenLowerCaseAliasMappedToUpperCaseUser() throws Exception {
+        webAdminApi.put(AliasRoutes.ROOT_PATH + "/" + UPPER_BOB_ADDRESS + "/sources/" + BOB_ALIAS);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
             .sendMessage(FakeMail.builder()
@@ -176,7 +173,7 @@ public class AliasMappingTest {
                 .recipient(BOB_ALIAS));
 
         imapMessageReader.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
-            .login(UPPER_CASE_ADDRESS, PASSWORD)
+            .login(BOB_ADDRESS, PASSWORD)
             .select(IMAPMessageReader.INBOX)
             .awaitMessage(awaitAtMostOneMinute);
         assertThat(imapMessageReader.readFirstMessage()).contains(MESSAGE_CONTENT);
@@ -184,14 +181,14 @@ public class AliasMappingTest {
 
     @Test
     public void messageShouldRedirectToUserWithUpperCaseDefinedAliasWhenSentToHisLowerCaseAlias() throws Exception {
-        webAdminApi.put(AliasRoutes.ROOT_PATH + "/" + BOB_ADDRESS + "/sources/" + UPPER_CASE_ALIAS);
+        webAdminApi.put(AliasRoutes.ROOT_PATH + "/" + BOB_ADDRESS + "/sources/" + UPPER_BOB_ALIAS);
 
         messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
             .sendMessage(FakeMail.builder()
                 .name("name")
                 .mimeMessage(message)
                 .sender(ALICE_ADDRESS)
-                .recipient(UPPER_CASE_ALIAS.toLowerCase()));
+                .recipient(BOB_ALIAS));
 
         imapMessageReader.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
             .login(BOB_ADDRESS, PASSWORD)

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/AliasMappingTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/AliasMappingTest.java
@@ -142,6 +142,24 @@ public class AliasMappingTest {
     }
 
     @Test
+    public void messageShouldRedirectToUserWhenSentToHisAliasWithUpperCase() throws Exception {
+        webAdminApi.put(AliasRoutes.ROOT_PATH + "/" + BOB_ADDRESS + "/sources/" + BOB_ALIAS);
+
+        messageSender.connect(LOCALHOST_IP, jamesServer.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .sendMessage(FakeMail.builder()
+                .name("name")
+                .mimeMessage(message)
+                .sender(ALICE_ADDRESS)
+                .recipient("BOB-ALIAS@domain.tld"));
+
+        imapMessageReader.connect(LOCALHOST_IP, jamesServer.getProbe(ImapGuiceProbe.class).getImapPort())
+            .login(BOB_ADDRESS, PASSWORD)
+            .select(IMAPMessageReader.INBOX)
+            .awaitMessage(awaitAtMostOneMinute);
+        assertThat(imapMessageReader.readFirstMessage()).contains(MESSAGE_CONTENT);
+    }
+
+    @Test
     public void messageShouldRedirectToForwardOfUserWhenSentToHisAlias() throws Exception {
         webAdminApi.put(AliasRoutes.ROOT_PATH + "/" + BOB_ADDRESS + "/sources/" + BOB_ALIAS);
         webAdminApi.put(ForwardRoutes.ROOT_PATH + "/" + BOB_ADDRESS + "/targets/" + CEDRIC_ADDRESS);


### PR DESCRIPTION
…very is case-insensitive

The question was raised on Gitter by jtconsol that aliases were case sensitive and if he was sending a mail to an alias with the local-part in the address to upper-case, while the alias was registered in lower case, then the mail was not delivered.

I believed with the work done recently on case sensitivity that we don't have this issue anymore, it's just that it has not been released yet. However, the test is missing and this PR is to demonstrate that aliases are case-insensitive now.