### PR TITLE
[Refactoring] Improve IMAP Search command parser code quality

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/SearchCommandParser.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/decode/parser/SearchCommandParser.java
@@ -24,6 +24,7 @@ import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.james.imap.api.ImapCommand;
 import org.apache.james.imap.api.ImapConstants;
@@ -74,68 +75,97 @@ public class SearchCommandParser extends AbstractUidCommandParser {
         } else if (next == '(') {
             return paren(session, request, charset);
         } else {
-            final int cap = consumeAndCap(request);
-            switch (cap) {
-            
-            case 'A':
-                return a(request);
-            case 'B':
-                return b(request, charset);
-            case 'C':
-                return c(session, request, isFirstToken, charset);
-            case 'D':
-                return d(request);
-            case 'E':
-                throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-            case 'F':
-                return f(request, charset);
-            case 'G':
-                throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-            case 'H':
-                return header(request, charset);
-            case 'I':
-                throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-            case 'J':
-                throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-            case 'K':
-                return keyword(request);
-            case 'L':
-                return larger(request);
-            case 'M':
-                return modseq(request);
-            case 'N':
-                return n(session, request, charset);
-            case 'O':
-                return o(session, request, charset);
-            case 'P':
-                throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-            case 'Q':
-                throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-            case 'R':
-                nextIsE(request);
-                nextIsC(request);
-                return recent(request);
-            case 'S':
-                return s(request, charset);
-            case 'T':
-                return t(request, charset);
-            case 'U':
-                return u(request);
-            case 'Y':
-                return younger(request);
-            default:
-                throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-            }
+            return parseSearchKey(session, request, charset, isFirstToken);
         }
     }
 
-    private SearchKey modseq(ImapRequestLineReader request) throws DecodingException {        
-        nextIsO(request);
-        nextIsD(request);
-        nextIsS(request);
-        nextIsE(request);
-        nextIsQ(request);
-        
+    private SearchKey parseSearchKey(ImapSession session, ImapRequestLineReader request, Charset charset, boolean isFirstToken) throws DecodingException {
+        String searchKey = request.atom().toUpperCase(Locale.US);
+        switch (searchKey) {
+            case "ANSWERED":
+                return SearchKey.buildAnswered();
+            case "ALL":
+                return SearchKey.buildAll();
+            case "BCC":
+                return bcc(request, charset);
+            case "BEFORE":
+                return before(request);
+            case "BODY":
+                return body(request, charset);
+            case "CC":
+                return cc(request, charset);
+            case "CHARSET":
+                return charset(session, request, isFirstToken);
+            case "DELETED":
+                return SearchKey.buildDeleted();
+            case "DRAFT":
+                return SearchKey.buildDraft();
+            case "FLAGGED":
+                return SearchKey.buildFlagged();
+            case "FROM":
+                return from(request, charset);
+            case "HEADER":
+                return header(request, charset);
+            case "KEYWORD":
+                return keyword(request);
+            case "LARGER":
+                return larger(request);
+            case "MODSEQ":
+                return modseq(request);
+            case "NEW":
+                return SearchKey.buildNew();
+            case "NOT":
+                return not(session, request, charset);
+            case "OLD":
+                return SearchKey.buildOld();
+            case "OLDER":
+                return older(request);
+            case "ON":
+                return on(request);
+            case "OR":
+                return or(session, request, charset);
+            case "RECENT":
+                return SearchKey.buildRecent();
+            case "SEEN":
+                return SearchKey.buildSeen();
+            case "SENTBEFORE":
+                return sentBefore(request);
+            case "SENTON":
+                return sentOn(request);
+            case "SENTSINCE":
+                return sentSince(request);
+            case "SINCE":
+                return since(request);
+            case "SMALLER":
+                return smaller(request);
+            case "SUBJECT":
+                return subject(request, charset);
+            case "TEXT":
+                return text(request, charset);
+            case "TO":
+                return to(request, charset);
+            case "UID":
+                return uid(request);
+            case "UNANSWERED":
+                return SearchKey.buildUnanswered();
+            case "UNDELETED":
+                return SearchKey.buildUndeleted();
+            case "UNDRAFT":
+                return SearchKey.buildUndraft();
+            case "UNFLAGGED":
+                return SearchKey.buildUnflagged();
+            case "UNKEYWORD":
+                return unkeyword(request);
+            case "UNSEEN":
+                return SearchKey.buildUnseen();
+            case "YOUNGER":
+                return younger(request);
+            default:
+                throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
+        }
+    }
+
+    private SearchKey modseq(ImapRequestLineReader request) throws DecodingException {
         try {
             return SearchKey.buildModSeq(request.number());
         } catch (DecodingException e) {
@@ -171,32 +201,12 @@ public class SearchCommandParser extends AbstractUidCommandParser {
     }
     
     private SearchKey cc(ImapRequestLineReader request, Charset charset) throws DecodingException {
-        final SearchKey result;
         nextIsSpace(request);
-        final String value = request.astring(charset);
-        result = SearchKey.buildCc(value);
-        return result;
-    }
-
-    private SearchKey c(ImapSession session, ImapRequestLineReader request, boolean isFirstToken, Charset charset) throws DecodingException, IllegalCharsetNameException, UnsupportedCharsetException {
-        final int next = consumeAndCap(request);
-        switch (next) {
-        case 'C':
-            return cc(request, charset);
-        case 'H':
-            return charset(session, request, isFirstToken);
-        default:
-            throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-        }
+        String value = request.astring(charset);
+        return SearchKey.buildCc(value);
     }
 
     private SearchKey charset(ImapSession session, ImapRequestLineReader request, boolean isFirstToken) throws DecodingException, IllegalCharsetNameException, UnsupportedCharsetException {
-        final SearchKey result;
-        nextIsA(request);
-        nextIsR(request);
-        nextIsS(request);
-        nextIsE(request);
-        nextIsT(request);
         nextIsSpace(request);
         if (!isFirstToken) {
             throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
@@ -204,341 +214,55 @@ public class SearchCommandParser extends AbstractUidCommandParser {
         final String value = request.astring();
         final Charset charset = Charset.forName(value);
         request.nextWordChar();
-        result = searchKey(session, request, charset, false);
-        return result;
-    }
-
-    private SearchKey u(ImapRequestLineReader request) throws DecodingException {
-        final int next = consumeAndCap(request);
-        switch (next) {
-        case 'I':
-            return uid(request);
-        case 'N':
-            return un(request);
-        default:
-            throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-        }
-    }
-
-    private SearchKey un(ImapRequestLineReader request) throws DecodingException {
-        final int next = consumeAndCap(request);
-        switch (next) {
-        case 'A':
-            return unanswered(request);
-        case 'D':
-            return und(request);
-        case 'F':
-            return unflagged(request);
-        case 'K':
-            return unkeyword(request);
-        case 'S':
-            return unseen(request);
-        default:
-            throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-        }
-    }
-
-    private SearchKey und(ImapRequestLineReader request) throws DecodingException {
-        final int next = consumeAndCap(request);
-        switch (next) {
-        case 'E':
-            return undeleted(request);
-        case 'R':
-            return undraft(request);
-        default:
-            throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-        }
-    }
-
-    private SearchKey t(ImapRequestLineReader request, Charset charset) throws DecodingException {
-        final int next = consumeAndCap(request);
-        switch (next) {
-        case 'E':
-            return text(request, charset);
-        case 'O':
-            return to(request, charset);
-        default:
-            throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-        }
-    }
-
-    private SearchKey s(ImapRequestLineReader request, Charset charset) throws DecodingException {
-        final int next = consumeAndCap(request);
-        switch (next) {
-        case 'E':
-            return se(request);
-        case 'I':
-            return since(request);
-        case 'M':
-            return smaller(request);
-        case 'U':
-            return subject(request, charset);
-        default:
-            throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-        }
-    }
-
-    private SearchKey se(ImapRequestLineReader request) throws DecodingException {
-        final int next = consumeAndCap(request);
-        switch (next) {
-        case 'E':
-            return seen(request);
-        case 'N':
-            return sen(request);
-        default:
-            throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-        }
-    }
-
-    private SearchKey sen(ImapRequestLineReader request) throws DecodingException {
-        final int next = consumeAndCap(request);
-        switch (next) {
-        case 'T':
-            return sent(request);
-        default:
-            throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-        }
-    }
-
-    private SearchKey sent(ImapRequestLineReader request) throws DecodingException {
-        final int next = consumeAndCap(request);
-        switch (next) {
-        case 'B':
-            return sentBefore(request);
-        case 'O':
-            return sentOn(request);
-        case 'S':
-            return sentSince(request);
-        default:
-            throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-        }
-    }
-
-    private SearchKey o(ImapSession session, ImapRequestLineReader request, Charset charset) throws DecodingException {
-        final int next = consumeAndCap(request);
-        switch (next) {
-        case 'L':
-            return old(request);
-        case 'N':
-            return on(request);
-        case 'R':
-            return or(session, request, charset);
-        default:
-            throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-        }
-    }
-    
-    private SearchKey old(ImapRequestLineReader request) throws DecodingException {
-        nextIsD(request);
-        try {
-            // Check if its OLDER keyword
-            nextIsE(request);
-            return older(request);
-        } catch (DecodingException e) {
-            return SearchKey.buildOld();
-        }
-    }
-    
-    private SearchKey n(ImapSession session, ImapRequestLineReader request, Charset charset) throws DecodingException {
-        final int next = consumeAndCap(request);
-        switch (next) {
-        case 'E':
-            return newOperator(request);
-        case 'O':
-            return not(session, request, charset);
-        default:
-            throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-        }
-    }
-
-    private SearchKey f(ImapRequestLineReader request, Charset charset) throws DecodingException {
-        final int next = consumeAndCap(request);
-        switch (next) {
-        case 'L':
-            return flagged(request);
-        case 'R':
-            return from(request, charset);
-        default:
-            throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-        }
-    }
-
-    private SearchKey d(ImapRequestLineReader request) throws DecodingException {
-        final int next = consumeAndCap(request);
-        switch (next) {
-        case 'E':
-            return deleted(request);
-        case 'R':
-            return draft(request);
-        default:
-            throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-        }
+        return searchKey(session, request, charset, false);
     }
 
     private SearchKey keyword(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsE(request);
-        nextIsY(request);
-        nextIsW(request);
-        nextIsO(request);
-        nextIsR(request);
-        nextIsD(request);
         nextIsSpace(request);
-        final String value = request.atom();
-        result = SearchKey.buildKeyword(value);
-        return result;
+        String value = request.atom();
+        return SearchKey.buildKeyword(value);
     }
 
     private SearchKey unkeyword(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsE(request);
-        nextIsY(request);
-        nextIsW(request);
-        nextIsO(request);
-        nextIsR(request);
-        nextIsD(request);
         nextIsSpace(request);
-        final String value = request.atom();
-        result = SearchKey.buildUnkeyword(value);
-        return result;
+        String value = request.atom();
+        return SearchKey.buildUnkeyword(value);
     }
 
     private SearchKey header(ImapRequestLineReader request, Charset charset) throws DecodingException {
-        final SearchKey result;
-        nextIsE(request);
-        nextIsA(request);
-        nextIsD(request);
-        nextIsE(request);
-        nextIsR(request);
         nextIsSpace(request);
-        final String field = request.astring(charset);
+        String field = request.astring(charset);
         nextIsSpace(request);
-        final String value = request.astring(charset);
-        result = SearchKey.buildHeader(field, value);
-        return result;
+        String value = request.astring(charset);
+        return SearchKey.buildHeader(field, value);
     }
 
     private SearchKey larger(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsA(request);
-        nextIsR(request);
-        nextIsG(request);
-        nextIsE(request);
-        nextIsR(request);
         nextIsSpace(request);
-        final long value = request.number();
-        result = SearchKey.buildLarger(value);
-        return result;
+        long value = request.number();
+        return SearchKey.buildLarger(value);
     }
 
     private SearchKey smaller(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsA(request);
-        nextIsL(request);
-        nextIsL(request);
-        nextIsE(request);
-        nextIsR(request);
         nextIsSpace(request);
-        final long value = request.number();
-        result = SearchKey.buildSmaller(value);
-        return result;
+        long value = request.number();
+        return SearchKey.buildSmaller(value);
     }
 
     private SearchKey from(ImapRequestLineReader request, Charset charset) throws DecodingException {
-        final SearchKey result;
-        nextIsO(request);
-        nextIsM(request);
         nextIsSpace(request);
-        final String value = request.astring(charset);
-        result = SearchKey.buildFrom(value);
-        return result;
-    }
-
-    private SearchKey flagged(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsA(request);
-        nextIsG(request);
-        nextIsG(request);
-        nextIsE(request);
-        nextIsD(request);
-        result = SearchKey.buildFlagged();
-        return result;
-    }
-
-    private SearchKey unseen(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsE(request);
-        nextIsE(request);
-        nextIsN(request);
-        result = SearchKey.buildUnseen();
-        return result;
-    }
-
-    private SearchKey undraft(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsA(request);
-        nextIsF(request);
-        nextIsT(request);
-        result = SearchKey.buildUndraft();
-        return result;
-    }
-
-    private SearchKey undeleted(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsL(request);
-        nextIsE(request);
-        nextIsT(request);
-        nextIsE(request);
-        nextIsD(request);
-        result = SearchKey.buildUndeleted();
-        return result;
-    }
-
-    private SearchKey unflagged(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsL(request);
-        nextIsA(request);
-        nextIsG(request);
-        nextIsG(request);
-        nextIsE(request);
-        nextIsD(request);
-        result = SearchKey.buildUnflagged();
-        return result;
-    }
-
-    private SearchKey unanswered(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsN(request);
-        nextIsS(request);
-        nextIsW(request);
-        nextIsE(request);
-        nextIsR(request);
-        nextIsE(request);
-        nextIsD(request);
-        result = SearchKey.buildUnanswered();
-        return result;
+        String value = request.astring(charset);
+        return SearchKey.buildFrom(value);
     }
     
     private SearchKey younger(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsO(request);
-        nextIsU(request);
-        nextIsN(request);
-        nextIsG(request);
-        nextIsE(request);
-        nextIsR(request);
         nextIsSpace(request);
-        result = SearchKey.buildYounger(request.nzNumber());
-        return result;
+        return SearchKey.buildYounger(request.nzNumber());
     }
     
     private SearchKey older(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsR(request);
-        
         nextIsSpace(request);
-        result = SearchKey.buildOlder(request.nzNumber());
-        return result;
+        return SearchKey.buildOlder(request.nzNumber());
     }
 
     private SearchKey or(ImapSession session, ImapRequestLineReader request, Charset charset) throws DecodingException {
@@ -552,174 +276,69 @@ public class SearchCommandParser extends AbstractUidCommandParser {
     }
 
     private SearchKey not(ImapSession session, ImapRequestLineReader request, Charset charset) throws DecodingException {
-        final SearchKey result;
-        nextIsT(request);
         nextIsSpace(request);
-        final SearchKey nextKey = searchKey(session, request, charset, false);
-        result = SearchKey.buildNot(nextKey);
-        return result;
-    }
-
-    private SearchKey newOperator(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsW(request);
-        result = SearchKey.buildNew();
-        return result;
-    }
-
-    private SearchKey recent(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        //nextIsE(request);
-        //nextIsC(request);
-        nextIsE(request);
-        nextIsN(request);
-        nextIsT(request);
-        result = SearchKey.buildRecent();
-        return result;
-    }
-
-    private SearchKey seen(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsN(request);
-        result = SearchKey.buildSeen();
-        return result;
-    }
-
-    private SearchKey draft(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsA(request);
-        nextIsF(request);
-        nextIsT(request);
-        result = SearchKey.buildDraft();
-        return result;
-    }
-
-    private SearchKey deleted(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsL(request);
-        nextIsE(request);
-        nextIsT(request);
-        nextIsE(request);
-        nextIsD(request);
-        result = SearchKey.buildDeleted();
-        return result;
-    }
-
-    private SearchKey b(ImapRequestLineReader request, Charset charset) throws DecodingException {
-        final int next = consumeAndCap(request);
-        switch (next) {
-        case 'C':
-            return bcc(request, charset);
-        case 'E':
-            return before(request);
-        case 'O':
-            return body(request, charset);
-        default:
-            throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-        }
+        SearchKey nextKey = searchKey(session, request, charset, false);
+        return SearchKey.buildNot(nextKey);
     }
 
     private SearchKey body(ImapRequestLineReader request, Charset charset) throws DecodingException {
-        final SearchKey result;
-        nextIsD(request);
-        nextIsY(request);
         nextIsSpace(request);
-        final String value = request.astring(charset);
-        result = SearchKey.buildBody(value);
-        return result;
+        String value = request.astring(charset);
+        return SearchKey.buildBody(value);
     }
 
     private SearchKey on(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
         nextIsSpace(request);
-        final DayMonthYear value = request.date();
-        result = SearchKey.buildOn(value);
-        return result;
+        DayMonthYear value = request.date();
+        return SearchKey.buildOn(value);
     }
 
     private SearchKey sentBefore(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsE(request);
-        nextIsF(request);
-        nextIsO(request);
-        nextIsR(request);
-        nextIsE(request);
         nextIsSpace(request);
-        final DayMonthYear value = request.date();
-        result = SearchKey.buildSentBefore(value);
-        return result;
+        DayMonthYear value = request.date();
+        return SearchKey.buildSentBefore(value);
     }
 
     private SearchKey sentSince(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsI(request);
-        nextIsN(request);
-        nextIsC(request);
-        nextIsE(request);
         nextIsSpace(request);
-        final DayMonthYear value = request.date();
-        result = SearchKey.buildSentSince(value);
-        return result;
+        DayMonthYear value = request.date();
+        return SearchKey.buildSentSince(value);
     }
 
     private SearchKey since(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsN(request);
-        nextIsC(request);
-        nextIsE(request);
         nextIsSpace(request);
-        final DayMonthYear value = request.date();
-        result = SearchKey.buildSince(value);
-        return result;
+        DayMonthYear value = request.date();
+        return SearchKey.buildSince(value);
     }
 
     private SearchKey sentOn(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsN(request);
         nextIsSpace(request);
-        final DayMonthYear value = request.date();
-        result = SearchKey.buildSentOn(value);
-        return result;
+        DayMonthYear value = request.date();
+        return SearchKey.buildSentOn(value);
     }
 
     private SearchKey before(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsF(request);
-        nextIsO(request);
-        nextIsR(request);
-        nextIsE(request);
         nextIsSpace(request);
-        final DayMonthYear value = request.date();
-        result = SearchKey.buildBefore(value);
-        return result;
+        DayMonthYear value = request.date();
+        return SearchKey.buildBefore(value);
     }
 
     private SearchKey bcc(ImapRequestLineReader request, Charset charset) throws DecodingException {
-        final SearchKey result;
-        nextIsC(request);
         nextIsSpace(request);
-        final String value = request.astring(charset);
-        result = SearchKey.buildBcc(value);
-        return result;
+        String value = request.astring(charset);
+        return SearchKey.buildBcc(value);
     }
 
     private SearchKey text(ImapRequestLineReader request, Charset charset) throws DecodingException {
-        final SearchKey result;
-        nextIsX(request);
-        nextIsT(request);
         nextIsSpace(request);
-        final String value = request.astring(charset);
-        result = SearchKey.buildText(value);
-        return result;
+        String value = request.astring(charset);
+        return SearchKey.buildText(value);
     }
 
     private SearchKey uid(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsD(request);
         nextIsSpace(request);
-        final UidRange[] range = request.parseUidRange();
-        result = SearchKey.buildUidSet(range);
-        return result;
+        UidRange[] range = request.parseUidRange();
+        return SearchKey.buildUidSet(range);
     }
 
     private SearchKey sequenceSet(ImapSession session, ImapRequestLineReader request) throws DecodingException {
@@ -728,156 +347,20 @@ public class SearchCommandParser extends AbstractUidCommandParser {
     }
 
     private SearchKey to(ImapRequestLineReader request, Charset charset) throws DecodingException {
-        final SearchKey result;
         nextIsSpace(request);
-        final String value = request.astring(charset);
-        result = SearchKey.buildTo(value);
-        return result;
+        String value = request.astring(charset);
+        return SearchKey.buildTo(value);
     }
 
     private SearchKey subject(ImapRequestLineReader request, Charset charset) throws DecodingException {
-        final SearchKey result;
-        nextIsB(request);
-        nextIsJ(request);
-        nextIsE(request);
-        nextIsC(request);
-        nextIsT(request);
         nextIsSpace(request);
         final String value = request.astring(charset);
-        result = SearchKey.buildSubject(value);
-        return result;
-    }
-
-    private SearchKey a(ImapRequestLineReader request) throws DecodingException {
-        final int next = consumeAndCap(request);
-        switch (next) {
-        case 'L':
-            return all(request);
-        case 'N':
-            return answered(request);
-        default:
-            throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-        }
-    }
-
-    private SearchKey answered(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsS(request);
-        nextIsW(request);
-        nextIsE(request);
-        nextIsR(request);
-        nextIsE(request);
-        nextIsD(request);
-        result = SearchKey.buildAnswered();
-        return result;
-    }
-
-    private SearchKey all(ImapRequestLineReader request) throws DecodingException {
-        final SearchKey result;
-        nextIsL(request);
-        result = SearchKey.buildAll();
-        return result;
+        return SearchKey.buildSubject(value);
     }
 
     private void nextIsSpace(ImapRequestLineReader request) throws DecodingException {
         final char next = request.consume();
         if (next != ' ') {
-            throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-        }
-    }
-
-    private void nextIsG(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'G', 'g');
-    }
-
-    private void nextIsM(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'M', 'm');
-    }
-
-    private void nextIsI(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'I', 'i');
-    }
-
-    private void nextIsN(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'N', 'n');
-    }
-
-    private void nextIsA(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'A', 'a');
-    }
-
-    private void nextIsT(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'T', 't');
-    }
-
-    private void nextIsY(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'Y', 'y');
-    }
-
-    private void nextIsX(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'X', 'x');
-    }
-    
-    private void nextIsU(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'U', 'u');
-    }
-    
-    private void nextIsO(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'O', 'o');
-    }
-
-    private void nextIsQ(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'Q', 'q');
-    }
-
-    private void nextIsF(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'F', 'f');
-    }
-
-    private void nextIsJ(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'J', 'j');
-    }
-
-    private void nextIsC(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'C', 'c');
-    }
-
-    private void nextIsD(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'D', 'd');
-    }
-
-    private void nextIsB(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'B', 'b');
-    }
-
-    private void nextIsR(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'R', 'r');
-    }
-
-    private void nextIsE(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'E', 'e');
-    }
-
-    private void nextIsW(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'W', 'w');
-    }
-
-    private void nextIsS(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'S', 's');
-    }
-
-    private void nextIsL(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'L', 'l');
-    }
-
-
-    private void nextIsV(ImapRequestLineReader request) throws DecodingException {
-        nextIs(request, 'V', 'v');
-    }
-
-    private void nextIs(ImapRequestLineReader request, char upper, char lower) throws DecodingException {
-        final char next = request.consume();
-        if (next != upper && next != lower) {
             throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
         }
     }
@@ -914,50 +397,30 @@ public class SearchCommandParser extends AbstractUidCommandParser {
         List<SearchResultOption> options = new ArrayList<>();
         reader.consumeChar('(');
         reader.nextWordChar();
-        
-        int cap = consumeAndCap(reader);
 
-        while (cap != ')') {
-            switch (cap) {
-            case 'A':
-                nextIsL(reader);
-                nextIsL(reader);
-                options.add(SearchResultOption.ALL);
-                break;
-            case 'C':
-                nextIsO(reader);
-                nextIsU(reader);
-                nextIsN(reader);
-                nextIsT(reader);
-                options.add(SearchResultOption.COUNT);
-                break;
-            case 'M':
-                final int c = consumeAndCap(reader);
-                switch (c) {
-                case 'A':
-                    nextIsX(reader);
+        while (reader.nextChar() != ')') {
+            String option = reader.atom();
+            switch (option) {
+                case "ALL":
+                    options.add(SearchResultOption.ALL);
+                    break;
+                case "COUNT":
+                    options.add(SearchResultOption.COUNT);
+                    break;
+                case "MAX":
                     options.add(SearchResultOption.MAX);
                     break;
-                case 'I':
-                    nextIsN(reader);
+                case "MIN":
                     options.add(SearchResultOption.MIN);
+                    break;
+                // Check for SAVE options which is part of the SEARCHRES extension
+                case "SAVE":
+                    options.add(SearchResultOption.SAVE);
                     break;
                 default:
                     throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
-                }
-                break;
-            // Check for SAVE options which is part of the SEARCHRES extension
-            case 'S':
-                nextIsA(reader);
-                nextIsV(reader);
-                nextIsE(reader);
-                options.add(SearchResultOption.SAVE);
-                break;
-            default:
-                throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
             }
             reader.nextWordChar();
-            cap = consumeAndCap(reader);
         }
         // if the options are empty then we parsed RETURN () which is a shortcut for ALL.
         // See http://www.faqs.org/rfcs/rfc4731.html 3.1
@@ -975,25 +438,18 @@ public class SearchCommandParser extends AbstractUidCommandParser {
             int c = ImapRequestLineReader.cap(request.nextWordChar());
             if (c == 'R') {
                 // if we found a R its either RECENT or RETURN so consume it
-                request.consume();
-                
-                nextIsE(request);
-                c = consumeAndCap(request);
+                String atom = request.atom().toUpperCase(Locale.US);
 
-                switch (c) {
-                case 'C':
-                    recent = recent(request);
-                    break;
-                case 'T': 
-                    nextIsU(request);
-                    nextIsR(request);
-                    nextIsN(request);
-                    request.nextWordChar();
-                    options = parseOptions(request);
-                    break;
-
-                default:
-                    throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
+                switch (atom) {
+                    case "RECENT":
+                        recent = SearchKey.buildRecent();
+                        break;
+                    case "RETURN":
+                        request.nextWordChar();
+                        options = parseOptions(request);
+                        break;
+                    default:
+                        throw new DecodingException(HumanReadableText.ILLEGAL_ARGUMENTS, "Unknown search key");
                 }
             }
             final SearchKey finalKey;
@@ -1011,8 +467,6 @@ public class SearchCommandParser extends AbstractUidCommandParser {
                 // Parse the search term from the request
                 finalKey = decode(session, request);
             }
-           
-            
             
             if (options == null) {
                 options = new ArrayList<>();


### PR DESCRIPTION
Rely on String switch case to greatly improve readability.

This changeset is unit tested (I know, that's unexpected).