### PR TITLE
JAMES-2993 session refactoring

### DIFF
--- a/examples/custom-listeners/src/test/java/org/apache/james/examples/custom/listeners/SetCustomFlagOnBigMessagesTest.java
+++ b/examples/custom-listeners/src/test/java/org/apache/james/examples/custom/listeners/SetCustomFlagOnBigMessagesTest.java
@@ -67,7 +67,7 @@ class SetCustomFlagOnBigMessagesTest {
     void beforeEach() throws Exception {
         InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultResources();
         mailboxManager = resources.getMailboxManager();
-        mailboxSession = MailboxSessionUtil.create(USER);
+        mailboxSession = MailboxSessionUtil.createUserSession(USER);
         inboxId = mailboxManager.createMailbox(INBOX_PATH, mailboxSession).get();
         inboxMessageManager = mailboxManager.getMailbox(inboxId, mailboxSession);
 

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/SessionProvider.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/SessionProvider.java
@@ -32,7 +32,11 @@ public interface SessionProvider {
 
     /**
      * Creates a new system session.<br>
-     * A system session is intended to be used for programmatic access.<br>
+     * A system session is intended to be used for programmatic access, for technical
+     * purposes that do not require right validation.<br>
+     *
+     * User {@link #createUserSession(Username)} for programatic access that requires right validation.
+     *
      * Use {@link #login(Username, String)} when accessing this API from a
      * protocol.
      *
@@ -41,6 +45,18 @@ public interface SessionProvider {
      * @return <code>MailboxSession</code>, not null
      */
     MailboxSession createSystemSession(Username userName);
+
+    /**
+     * Creates a new user session, by-passing authentication.<br>
+     * An user session is intended to be used for programmatic access.<br>
+     * Use {@link #login(Username, String)} when accessing this API from a
+     * protocol.
+     *
+     * @param userName
+     *            the name of the user whose session is being created
+     * @return <code>MailboxSession</code>, not null
+     */
+    MailboxSession createUserSession(Username userName);
 
     /**
      * Autenticates the given user against the given password.<br>

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/SystemMailboxesProvider.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/SystemMailboxesProvider.java
@@ -28,6 +28,8 @@ import org.apache.james.mailbox.exception.MailboxRoleNotFoundException;
 public interface SystemMailboxesProvider {
     Stream<MessageManager> getMailboxByRole(Role aRole, Username username) throws MailboxException;
 
+    Stream<MessageManager> getMailboxByRole(Role aRole, MailboxSession session) throws MailboxException;
+
     default MessageManager findMailbox(Role role, Username username) throws MailboxException {
         return getMailboxByRole(role, username).findAny()
             .orElseThrow(() -> new MailboxRoleNotFoundException(role));

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerStressContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerStressContract.java
@@ -61,7 +61,7 @@ public interface MailboxManagerStressContract<T extends MailboxManager> {
         ExecutorService pool = Executors.newFixedThreadPool(APPEND_OPERATIONS / 20, threadFactory);
         Collection<MessageUid> uList = new ConcurrentLinkedDeque<>();
         Username username = Username.of("username");
-        MailboxSession session = getManager().createSystemSession(username);
+        MailboxSession session = getManager().createUserSession(username);
         getManager().startProcessingRequest(session);
         MailboxPath path = MailboxPath.forUser(username, "INBOX");
         MailboxId mailboxId = getManager().createMailbox(path, session).get();
@@ -85,7 +85,7 @@ public interface MailboxManagerStressContract<T extends MailboxManager> {
                 }
 
                 try {
-                    MailboxSession mailboxSession = getManager().createSystemSession(username);
+                    MailboxSession mailboxSession = getManager().createUserSession(username);
 
                     getManager().startProcessingRequest(mailboxSession);
                     MessageManager m = getManager().getMailbox(path, mailboxSession);

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -153,7 +153,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
     @Test
     protected void creatingConcurrentlyMailboxesWithSameParentShouldNotFail() throws Exception {
-        MailboxSession session = mailboxManager.createSystemSession(USER_1);
+        MailboxSession session = mailboxManager.createUserSession(USER_1);
         String mailboxName = "a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z";
 
         ConcurrentTestRunner.builder()
@@ -164,7 +164,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
     @Test
     void createMailboxShouldReturnRightId() throws Exception {
-        session = mailboxManager.createSystemSession(USER_1);
+        session = mailboxManager.createUserSession(USER_1);
         mailboxManager.startProcessingRequest(session);
 
         MailboxPath mailboxPath = MailboxPath.forUser(USER_1, "name.subfolder");
@@ -179,7 +179,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
     class MailboxCreationTests {
         @Test
         void hasInboxShouldBeFalseWhenINBOXIsNotCreated() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             mailboxManager.startProcessingRequest(session);
 
             assertThat(mailboxManager.hasInbox(session)).isFalse();
@@ -187,7 +187,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void hasInboxShouldBeTrueWhenINBOXIsCreated() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             mailboxManager.startProcessingRequest(session);
 
             MailboxPath mailboxPath = MailboxPath.inbox(session);
@@ -200,7 +200,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void creatingMixedCaseINBOXShouldCreateItAsINBOX() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             mailboxManager.startProcessingRequest(session);
 
             Optional<MailboxId> mailboxId = mailboxManager.createMailbox(MailboxPath.forUser(USER_1, "iNbOx"), session);
@@ -212,7 +212,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void creatingMixedCaseINBOXShouldNotBeRetrievableAsIt() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             mailboxManager.startProcessingRequest(session);
 
             MailboxPath mailboxPath = MailboxPath.forUser(USER_1, "iNbOx");
@@ -225,7 +225,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void creatingMixedCaseINBOXWhenItHasAlreadyBeenCreatedShouldThrow() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             mailboxManager.startProcessingRequest(session);
 
             mailboxManager.createMailbox(MailboxPath.inbox(session), session);
@@ -236,7 +236,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void creatingMixedCaseINBOXShouldCreateItAsINBOXUponChildMailboxCreation() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             mailboxManager.startProcessingRequest(session);
 
             Optional<MailboxId> mailboxId = mailboxManager.createMailbox(MailboxPath.forUser(USER_1, "iNbOx.submailbox"), session);
@@ -247,7 +247,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void creatingMixedCaseINBOXChildShouldNormalizeChildPath() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             mailboxManager.startProcessingRequest(session);
 
             MailboxPath childPath = MailboxPath.forUser(USER_1, "iNbOx.submailbox");
@@ -263,7 +263,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
     public class MailboxNameLimitTests {
         @Test
         void creatingMailboxShouldNotFailWhenLimitNameLength() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName = Strings.repeat("a", MailboxManager.MAX_MAILBOX_NAME_LENGTH);
 
@@ -273,7 +273,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void renamingMailboxShouldNotFailWhenLimitNameLength() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName = Strings.repeat("a", MailboxManager.MAX_MAILBOX_NAME_LENGTH);
 
@@ -286,7 +286,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         protected void renamingMailboxByIdShouldNotFailWhenLimitNameLength() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName = Strings.repeat("a", MailboxManager.MAX_MAILBOX_NAME_LENGTH);
 
@@ -299,7 +299,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void creatingMailboxShouldThrowWhenOverLimitNameLength() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName = Strings.repeat("a", MailboxManager.MAX_MAILBOX_NAME_LENGTH + 1);
 
@@ -309,7 +309,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void renamingMailboxShouldThrowWhenOverLimitNameLength() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName = Strings.repeat("a", MailboxManager.MAX_MAILBOX_NAME_LENGTH + 1);
 
@@ -322,7 +322,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void renamingMailboxByIdShouldThrowWhenOverLimitNameLength() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName = Strings.repeat("a", MailboxManager.MAX_MAILBOX_NAME_LENGTH + 1);
 
@@ -335,7 +335,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void creatingMailboxShouldNotThrowWhenNameWithoutEmptyHierarchicalLevel() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName =  "a.b.c";
 
@@ -344,7 +344,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void creatingMailboxShouldNotThrowWhenNameWithASingleToBeNormalizedTrailingDelimiter() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName =  "a.b.";
 
@@ -354,7 +354,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void creatingMailboxShouldThrowWhenNameWithMoreThanOneTrailingDelimiter() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName =  "a..";
 
@@ -364,7 +364,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void creatingMailboxShouldThrowWhenNameWithHeadingDelimiter() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName =  ".a";
 
@@ -374,7 +374,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void creatingMailboxShouldThrowWhenNameWithEmptyHierarchicalLevel() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName =  "a..b";
 
@@ -384,7 +384,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void renamingMailboxShouldNotThrowWhenNameWithoutEmptyHierarchicalLevel() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName =  "a.b.c";
 
@@ -396,7 +396,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         protected void renamingMailboxByIdShouldNotThrowWhenNameWithoutEmptyHierarchicalLevel() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName =  "a.b.c";
 
@@ -408,7 +408,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void renamingMailboxShouldNotThrowWhenNameWithASingleToBeNormalizedTrailingDelimiter() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName =  "a.b.";
 
@@ -420,7 +420,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         protected void renamingMailboxByIdShouldNotThrowWhenNameWithASingleToBeNormalizedTrailingDelimiter() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName =  "a.b.";
 
@@ -432,7 +432,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void renamingMailboxShouldThrowWhenNameWithMoreThanOneTrailingDelimiter() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName =  "a..";
 
@@ -445,7 +445,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void renamingMailboxByIdShouldThrowWhenNameWithMoreThanOneTrailingDelimiter() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName =  "a..";
 
@@ -458,7 +458,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void renamingMailboxShouldThrowWhenNameWithHeadingDelimiter() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName =  ".a";
 
@@ -471,7 +471,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void renamingMailboxByIdShouldThrowWhenNameWithHeadingDelimiter() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName =  ".a";
 
@@ -484,7 +484,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void renamingMailboxShouldThrowWhenNameWithEmptyHierarchicalLevel() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName =  "a..b";
 
@@ -497,7 +497,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void renamingMailboxByIdShouldThrowWhenNameWithEmptyHierarchicalLevel() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             String mailboxName =  "a..b";
 
@@ -527,7 +527,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void updateAnnotationsShouldUpdateStoredAnnotation() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Annotation));
-            session = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
 
@@ -540,7 +540,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void updateAnnotationsShouldDeleteAnnotationWithNilValue() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Annotation));
-            session = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
 
@@ -553,7 +553,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void updateAnnotationsShouldThrowExceptionIfMailboxDoesNotExist() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Annotation));
-            session = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox = MailboxPath.inbox(session);
 
             assertThatThrownBy(() -> mailboxManager.updateAnnotations(inbox, session, ImmutableList.of(privateAnnotation)))
@@ -563,7 +563,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void getAnnotationsShouldReturnEmptyForNonStoredAnnotation() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Annotation));
-            session = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
 
@@ -573,7 +573,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void getAllAnnotationsShouldRetrieveStoredAnnotations() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Annotation));
-            session = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
 
@@ -585,7 +585,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void getAllAnnotationsShouldThrowExceptionIfMailboxDoesNotExist() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Annotation));
-            session = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox = MailboxPath.inbox(session);
 
             assertThatThrownBy(() -> mailboxManager.getAllAnnotations(inbox, session))
@@ -595,7 +595,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void getAnnotationsByKeysShouldRetrieveStoresAnnotationsByKeys() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Annotation));
-            session = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
 
@@ -608,7 +608,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void getAnnotationsByKeysShouldThrowExceptionIfMailboxDoesNotExist() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Annotation));
-            session = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox = MailboxPath.inbox(session);
 
             assertThatThrownBy(() -> mailboxManager.getAnnotationsByKeys(inbox, session, ImmutableSet.of(privateKey)))
@@ -618,7 +618,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void getAnnotationsByKeysWithOneDepthShouldRetriveAnnotationsWithOneDepth() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Annotation));
-            session = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
 
@@ -631,7 +631,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void getAnnotationsByKeysWithAllDepthShouldThrowExceptionWhenMailboxDoesNotExist() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Annotation));
-            session = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox = MailboxPath.inbox(session);
 
             assertThatThrownBy(() -> mailboxManager.getAnnotationsByKeysWithAllDepth(inbox, session, ImmutableSet.of(privateKey)))
@@ -641,7 +641,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void getAnnotationsByKeysWithAllDepthShouldRetriveAnnotationsWithAllDepth() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Annotation));
-            session = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
 
@@ -654,7 +654,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void updateAnnotationsShouldThrowExceptionIfAnnotationDataIsOverLimitation() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Annotation));
-            session = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
 
@@ -665,7 +665,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void shouldUpdateAnnotationWhenRequestCreatesNewAndMailboxIsNotOverLimit() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Annotation));
-            session = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
 
@@ -680,7 +680,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void updateAnnotationsShouldThrowExceptionIfRequestCreateNewButMailboxIsOverLimit() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Annotation));
-            session = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
 
@@ -706,7 +706,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @BeforeEach
         void setUp() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             inbox = MailboxPath.inbox(session);
             newPath = MailboxPath.forUser(USER_1, "specialMailbox");
 
@@ -995,7 +995,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void searchShouldNotReturnResultsFromOtherNamespaces() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Namespace));
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             mailboxManager.createMailbox(new MailboxPath("other_namespace", USER_1, "Other"), session);
             mailboxManager.createMailbox(MailboxPath.inbox(session), session);
             List<MailboxMetaData> metaDatas = mailboxManager.search(
@@ -1011,7 +1011,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         void searchShouldReturnACL() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Namespace));
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             Optional<MailboxId> inboxId = mailboxManager.createMailbox(MailboxPath.inbox(session), session);
 
             MailboxACL acl = MailboxACL.EMPTY.apply(MailboxACL.command()
@@ -1037,8 +1037,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void searchShouldNotReturnResultsFromOtherUsers() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
-            MailboxSession session2 = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_1);
+            MailboxSession session2 = mailboxManager.createUserSession(USER_2);
             mailboxManager.createMailbox(MailboxPath.forUser(USER_2, "Other"), session2);
             mailboxManager.createMailbox(MailboxPath.inbox(session), session);
             List<MailboxMetaData> metaDatas = mailboxManager.search(
@@ -1053,7 +1053,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void searchShouldNotDuplicateMailboxWhenReportedAsUserMailboxesAndUserHasRightOnMailboxes() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
-            MailboxSession session1 = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session1 = mailboxManager.createUserSession(USER_1);
             MailboxPath inbox1 = MailboxPath.inbox(session1);
             mailboxManager.createMailbox(inbox1, session1);
             mailboxManager.setRights(inbox1,
@@ -1076,8 +1076,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void searchShouldIncludeDelegatedMailboxes() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
-            MailboxSession session1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession session2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession session1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession session2 = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox1 = MailboxPath.inbox(session1);
             Optional<MailboxId> mailboxIdInbox1 = mailboxManager.createMailbox(inbox1, session1);
             mailboxManager.setRights(inbox1,
@@ -1099,8 +1099,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void searchShouldCombinePrivateAndDelegatedMailboxes() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
-            MailboxSession session1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession session2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession session1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession session2 = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox1 = MailboxPath.inbox(session1);
             MailboxPath inbox2 = MailboxPath.inbox(session2);
             mailboxManager.createMailbox(inbox1, session1);
@@ -1124,8 +1124,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void searchShouldAllowUserFiltering() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
-            MailboxSession session1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession session2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession session1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession session2 = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox1 = MailboxPath.inbox(session1);
             MailboxPath inbox2 = MailboxPath.inbox(session2);
             mailboxManager.createMailbox(inbox1, session1);
@@ -1150,8 +1150,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void searchShouldAllowNamespaceFiltering() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
-            MailboxSession session1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession session2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession session1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession session2 = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox1 = MailboxPath.inbox(session1);
             String specificNamespace = "specificNamespace";
             MailboxPath mailboxPath1 = new MailboxPath(specificNamespace, USER_1, "mailbox");
@@ -1186,7 +1186,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
                 .getSupportedMessageCapabilities()
                 .contains(MailboxManager.MessageCapabilities.UniqueID));
 
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
 
             MailboxPath cacahueteFolder = MailboxPath.forUser(USER_1, "CACAHUETE");
             MailboxId cacahueteMailboxId = mailboxManager.createMailbox(cacahueteFolder, session).get();
@@ -1216,8 +1216,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         void searchForMessageShouldReturnMessagesFromMyDelegatedMailboxes() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
 
-            session = mailboxManager.createSystemSession(USER_1);
-            MailboxSession sessionFromDelegater = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_1);
+            MailboxSession sessionFromDelegater = mailboxManager.createUserSession(USER_2);
             MailboxPath delegatedMailboxPath = MailboxPath.forUser(USER_2, "SHARED");
             MailboxId delegatedMailboxId = mailboxManager.createMailbox(delegatedMailboxPath, sessionFromDelegater).get();
             MessageManager delegatedMessageManager = mailboxManager.getMailbox(delegatedMailboxId, sessionFromDelegater);
@@ -1245,8 +1245,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         void searchForMessageShouldNotReturnMessagesFromMyDelegatedMailboxesICanNotRead() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
 
-            session = mailboxManager.createSystemSession(USER_1);
-            MailboxSession sessionFromDelegater = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_1);
+            MailboxSession sessionFromDelegater = mailboxManager.createUserSession(USER_2);
             MailboxPath delegatedMailboxPath = MailboxPath.forUser(USER_2, "SHARED");
             MailboxId delegatedMailboxId = mailboxManager.createMailbox(delegatedMailboxPath, sessionFromDelegater).get();
             MessageManager delegatedMessageManager = mailboxManager.getMailbox(delegatedMailboxId, sessionFromDelegater);
@@ -1272,8 +1272,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         void searchForMessageShouldOnlySearchInMailboxICanRead() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
 
-            session = mailboxManager.createSystemSession(USER_1);
-            MailboxSession sessionFromDelegater = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_1);
+            MailboxSession sessionFromDelegater = mailboxManager.createUserSession(USER_2);
             MailboxPath otherMailboxPath = MailboxPath.forUser(USER_2, "OTHER_MAILBOX");
             MailboxId otherMailboxId = mailboxManager.createMailbox(otherMailboxPath, sessionFromDelegater).get();
             MessageManager otherMailboxManager = mailboxManager.getMailbox(otherMailboxId, sessionFromDelegater);
@@ -1292,8 +1292,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         void searchForMessageShouldIgnoreMailboxThatICanNotRead() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
 
-            session = mailboxManager.createSystemSession(USER_1);
-            MailboxSession sessionFromDelegater = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_1);
+            MailboxSession sessionFromDelegater = mailboxManager.createUserSession(USER_2);
             MailboxPath otherMailboxPath = MailboxPath.forUser(USER_2, "SHARED");
             MailboxId otherMailboxId = mailboxManager.createMailbox(otherMailboxPath, sessionFromDelegater).get();
             MessageManager otherMessageManager = mailboxManager.getMailbox(otherMailboxId, sessionFromDelegater);
@@ -1313,7 +1313,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         void searchForMessageShouldCorrectlyExcludeMailbox() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
 
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             MailboxPath otherMailboxPath = MailboxPath.forUser(USER_1, "SHARED");
             MailboxId otherMailboxId = mailboxManager.createMailbox(otherMailboxPath, session).get();
             MessageManager otherMessageManager = mailboxManager.getMailbox(otherMailboxId, session);
@@ -1333,7 +1333,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         void searchForMessageShouldPriorizeExclusionFromInclusion() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
 
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             MailboxPath otherMailboxPath = MailboxPath.forUser(USER_1, "SHARED");
             MailboxId otherMailboxId = mailboxManager.createMailbox(otherMailboxPath, session).get();
             MessageManager otherMessageManager = mailboxManager.getMailbox(otherMailboxId, session);
@@ -1354,7 +1354,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         void searchForMessageShouldOnlySearchInGivenMailbox() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
 
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
 
             MailboxPath searchedMailboxPath = MailboxPath.forUser(USER_1, "WANTED");
             MailboxId searchedMailboxId = mailboxManager.createMailbox(searchedMailboxPath, session).get();
@@ -1382,8 +1382,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void searchShouldNotReturnNoMoreDelegatedMailboxes() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
-            MailboxSession session1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession session2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession session1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession session2 = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox1 = MailboxPath.inbox(session1);
             Optional<MailboxId> mailboxIdInbox1 = mailboxManager.createMailbox(inbox1, session1);
             mailboxManager.setRights(inbox1,
@@ -1414,8 +1414,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void getMailboxCountersShouldReturnDefaultValueWhenNoReadRight() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
-            MailboxSession session1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession session2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession session1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession session2 = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox1 = MailboxPath.inbox(session1);
             Optional<MailboxId> mailboxIdInbox1 = mailboxManager.createMailbox(inbox1, session1);
             mailboxManager.setRights(inbox1,
@@ -1441,8 +1441,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void getMailboxCountersShouldReturnStoredValueWhenReadRight() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
-            MailboxSession session1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession session2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession session1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession session2 = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox1 = MailboxPath.inbox(session1);
             Optional<MailboxId> mailboxIdInbox1 = mailboxManager.createMailbox(inbox1, session1);
             mailboxManager.setRights(inbox1,
@@ -1472,8 +1472,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @SuppressWarnings("unchecked")
         void getMetaDataShouldReturnDefaultValueWhenNoReadRight() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
-            MailboxSession session1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession session2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession session1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession session2 = mailboxManager.createUserSession(USER_2);
             MailboxPath inbox1 = MailboxPath.inbox(session1);
             mailboxManager.createMailbox(inbox1, session1);
             mailboxManager.setRights(inbox1,
@@ -1520,7 +1520,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
     public class BasicFeaturesTests {
         @Test
         void user1ShouldNotHaveAnInbox() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             mailboxManager.startProcessingRequest(session);
 
             MailboxPath inbox = MailboxPath.inbox(session);
@@ -1529,7 +1529,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void user1ShouldBeAbleToCreateInbox() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             mailboxManager.startProcessingRequest(session);
 
             MailboxPath inbox = MailboxPath.inbox(session);
@@ -1540,7 +1540,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         protected void renameMailboxShouldChangeTheMailboxPathOfAMailbox() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             MailboxPath mailboxPath1 = MailboxPath.forUser(USER_1, "mbx1");
             MailboxPath mailboxPath2 = MailboxPath.forUser(USER_1, "mbx2");
@@ -1554,7 +1554,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         protected void renameMailboxByIdShouldChangeTheMailboxPathOfAMailbox() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USER_1);
+            MailboxSession session = mailboxManager.createUserSession(USER_1);
 
             MailboxPath mailboxPath1 = MailboxPath.forUser(USER_1, "mbx1");
             MailboxPath mailboxPath2 = MailboxPath.forUser(USER_1, "mbx2");
@@ -1568,8 +1568,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void renameMailboxShouldThrowWhenMailboxPathsDoNotBelongToUser() throws Exception {
-            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession sessionUser1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createUserSession(USER_2);
 
             MailboxPath mailboxPath1 = MailboxPath.forUser(USER_1, "mbx1");
             MailboxPath mailboxPath2 = MailboxPath.forUser(USER_1, "mbx2");
@@ -1581,8 +1581,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void renameMailboxByIdShouldThrowWhenMailboxPathsDoNotBelongToUser() throws Exception {
-            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession sessionUser1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createUserSession(USER_2);
 
             MailboxPath mailboxPath1 = MailboxPath.forUser(USER_1, "mbx1");
             MailboxPath mailboxPath2 = MailboxPath.forUser(USER_1, "mbx2");
@@ -1594,8 +1594,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void renameMailboxShouldThrowWhenFromMailboxPathDoesNotBelongToUser() throws Exception {
-            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession sessionUser1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createUserSession(USER_2);
 
             MailboxPath mailboxPath1 = MailboxPath.forUser(USER_1, "mbx1");
             MailboxPath mailboxPath2 = MailboxPath.forUser(USER_2, "mbx2");
@@ -1607,8 +1607,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void renameMailboxByIdShouldThrowWhenFromMailboxPathDoesNotBelongToUser() throws Exception {
-            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession sessionUser1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createUserSession(USER_2);
 
             MailboxPath mailboxPath1 = MailboxPath.forUser(USER_1, "mbx1");
             MailboxPath mailboxPath2 = MailboxPath.forUser(USER_2, "mbx2");
@@ -1620,7 +1620,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void renameMailboxShouldThrowWhenToMailboxPathDoesNotBelongToUser() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
 
             MailboxPath mailboxPath1 = MailboxPath.forUser(USER_1, "mbx1");
             MailboxPath mailboxPath2 = MailboxPath.forUser(USER_2, "mbx2");
@@ -1632,7 +1632,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void renameMailboxByIdShouldThrowWhenToMailboxPathDoesNotBelongToUser() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
 
             MailboxPath mailboxPath1 = MailboxPath.forUser(USER_1, "mbx1");
             MailboxPath mailboxPath2 = MailboxPath.forUser(USER_2, "mbx2");
@@ -1644,7 +1644,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void user1ShouldNotBeAbleToCreateInboxTwice() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             mailboxManager.startProcessingRequest(session);
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
@@ -1655,7 +1655,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void user1ShouldNotHaveTestSubmailbox() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             mailboxManager.startProcessingRequest(session);
 
             MailboxPath inbox = MailboxPath.inbox(session);
@@ -1666,7 +1666,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void user1ShouldBeAbleToCreateTestSubmailbox() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             mailboxManager.startProcessingRequest(session);
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
@@ -1679,7 +1679,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void user1ShouldBeAbleToDeleteInbox() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             mailboxManager.startProcessingRequest(session);
 
             MailboxPath inbox = MailboxPath.inbox(session);
@@ -1696,7 +1696,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         protected void user1ShouldBeAbleToDeleteInboxById() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             mailboxManager.startProcessingRequest(session);
 
             MailboxPath inbox = MailboxPath.inbox(session);
@@ -1712,8 +1712,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void user2ShouldNotBeAbleToDeleteUser1Mailbox() throws Exception {
-            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession sessionUser1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createUserSession(USER_2);
 
             MailboxPath inbox = MailboxPath.inbox(sessionUser1);
             mailboxManager.createMailbox(inbox, sessionUser1);
@@ -1725,8 +1725,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void user2ShouldNotBeAbleToDeleteUser1MailboxById() throws Exception {
-            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession sessionUser1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createUserSession(USER_2);
 
             MailboxPath inbox = MailboxPath.inbox(sessionUser1);
             MailboxId inboxId = mailboxManager.createMailbox(inbox, sessionUser1).get();
@@ -1737,7 +1737,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void user1ShouldBeAbleToDeleteSubmailbox() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             mailboxManager.startProcessingRequest(session);
 
             MailboxPath inbox = MailboxPath.inbox(session);
@@ -1753,7 +1753,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         protected void user1ShouldBeAbleToDeleteSubmailboxByid() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             mailboxManager.startProcessingRequest(session);
 
             MailboxPath inbox = MailboxPath.inbox(session);
@@ -1769,7 +1769,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void listShouldReturnMailboxes() throws Exception {
-            session = mailboxManager.createSystemSession(Username.of("manager"));
+            session = mailboxManager.createUserSession(Username.of("manager"));
             mailboxManager.startProcessingRequest(session);
 
             DataProvisioner.feedMailboxManager(mailboxManager);
@@ -1779,7 +1779,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void listShouldReturnEmptyListWhenNoMailboxes() throws Exception {
-            session = mailboxManager.createSystemSession(Username.of("manager"));
+            session = mailboxManager.createUserSession(Username.of("manager"));
 
             assertThat(mailboxManager.list(session))
                 .isEmpty();
@@ -1787,7 +1787,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void user2ShouldBeAbleToCreateRootlessFolder() throws MailboxException {
-            session = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_2);
             MailboxPath trash = MailboxPath.forUser(USER_2, "Trash");
             mailboxManager.createMailbox(trash, session);
 
@@ -1796,7 +1796,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void user2ShouldBeAbleToCreateNestedFoldersWithoutTheirParents() throws Exception {
-            session = mailboxManager.createSystemSession(USER_2);
+            session = mailboxManager.createUserSession(USER_2);
             MailboxPath nestedFolder = MailboxPath.forUser(USER_2, "INBOX.testfolder");
             mailboxManager.createMailbox(nestedFolder, session);
 
@@ -1807,7 +1807,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void moveMessagesShouldNotThrowWhenMovingAllMessagesOfAnEmptyMailbox() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
 
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
@@ -1821,7 +1821,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Move));
 
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
 
             MailboxPath inbox = MailboxPath.inbox(session);
             MailboxId inboxId = mailboxManager.createMailbox(inbox, session).get();
@@ -1861,7 +1861,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Move));
 
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
 
             MailboxPath inbox = MailboxPath.inbox(session);
             MailboxId inboxId = mailboxManager.createMailbox(inbox, session).get();
@@ -1897,8 +1897,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void moveMessagesShouldThrowWhenMovingMessageFromMailboxNotBelongingToSameUser() throws Exception {
-            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession sessionUser1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createUserSession(USER_2);
 
             MailboxPath inbox1 = MailboxPath.inbox(sessionUser1);
             mailboxManager.createMailbox(inbox1, sessionUser1);
@@ -1917,8 +1917,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void moveMessagesShouldThrowWhenMovingMessageToMailboxNotBelongingToSameUser() throws Exception {
-            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession sessionUser1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createUserSession(USER_2);
 
             MailboxPath inbox1 = MailboxPath.inbox(sessionUser1);
             mailboxManager.createMailbox(inbox1, sessionUser1);
@@ -1937,7 +1937,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void copyMessagesShouldNotThrowWhenMovingAllMessagesOfAnEmptyMailbox() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
 
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session);
@@ -1950,7 +1950,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         void copyMessagesShouldCopyAllMessagesFromOneMailboxToAnOtherOfASameUser() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
 
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
 
             MailboxPath inbox = MailboxPath.inbox(session);
             MailboxId inboxId = mailboxManager.createMailbox(inbox, session).get();
@@ -1989,7 +1989,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         void copyMessagesShouldCopyOnlyOneMessageFromOneMailboxToAnOtherOfASameUser() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
 
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
 
             MailboxPath inbox = MailboxPath.inbox(session);
             MailboxId inboxId = mailboxManager.createMailbox(inbox, session).get();
@@ -2027,8 +2027,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void copyMessagesShouldThrowWhenCopyingMessageFromMailboxNotBelongingToSameUser() throws Exception {
-            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession sessionUser1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createUserSession(USER_2);
 
             MailboxPath inbox1 = MailboxPath.inbox(sessionUser1);
             mailboxManager.createMailbox(inbox1, sessionUser1);
@@ -2047,8 +2047,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void copyMessagesShouldThrowWhenCopyingMessageToMailboxNotBelongingToSameUser() throws Exception {
-            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession sessionUser1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createUserSession(USER_2);
 
             MailboxPath inbox1 = MailboxPath.inbox(sessionUser1);
             mailboxManager.createMailbox(inbox1, sessionUser1);
@@ -2067,7 +2067,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void createMailboxShouldNotThrowWhenMailboxPathBelongsToUser() throws MailboxException {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             Optional<MailboxId> mailboxId = mailboxManager
                 .createMailbox(MailboxPath.forUser(USER_1, "mailboxName"), session);
 
@@ -2076,7 +2076,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void createMailboxShouldThrowWhenMailboxPathBelongsToAnotherUser() {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
 
             assertThatThrownBy(() -> mailboxManager
                     .createMailbox(MailboxPath.forUser(USER_2, "mailboxName"), session))
@@ -2085,7 +2085,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void getMailboxShouldThrowWhenMailboxDoesNotExist() {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
 
             assertThatThrownBy(() -> mailboxManager.getMailbox(MailboxPath.forUser(USER_1, "mailboxName"), session))
                 .isInstanceOf(MailboxNotFoundException.class);
@@ -2093,7 +2093,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void getMailboxByPathShouldReturnMailboxWhenBelongingToUser() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
 
             MailboxPath mailboxPath = MailboxPath.forUser(USER_1, "mailboxName");
             Optional<MailboxId> mailboxId = mailboxManager.createMailbox(mailboxPath, session);
@@ -2104,7 +2104,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         protected void getMailboxByIdShouldReturnMailboxWhenBelongingToUser() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
 
             MailboxPath mailboxPath = MailboxPath.forUser(USER_1, "mailboxName");
             Optional<MailboxId> mailboxId = mailboxManager.createMailbox(mailboxPath, session);
@@ -2115,8 +2115,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void getMailboxByPathShouldThrowWhenMailboxNotBelongingToUser() throws Exception {
-            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession sessionUser1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createUserSession(USER_2);
 
             MailboxPath mailboxPath = MailboxPath.forUser(USER_1, "mailboxName");
             mailboxManager.createMailbox(mailboxPath, sessionUser1);
@@ -2127,8 +2127,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void getMailboxByIdShouldThrowWhenMailboxNotBelongingToUser() throws Exception {
-            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
-            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+            MailboxSession sessionUser1 = mailboxManager.createUserSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createUserSession(USER_2);
 
             MailboxPath mailboxPath = MailboxPath.forUser(USER_1, "mailboxName");
             Optional<MailboxId> mailboxId = mailboxManager.createMailbox(mailboxPath, sessionUser1);
@@ -2142,14 +2142,14 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
     class SessionTests {
         @Test
         void createUser1SystemSessionShouldReturnValidSession() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
 
             assertThat(session.getUser()).isEqualTo(USER_1);
         }
 
         @Test
         void closingSessionShouldWork() {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             mailboxManager.startProcessingRequest(session);
 
             mailboxManager.logout(session);
@@ -2173,7 +2173,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
             @BeforeEach
             void setUp() throws Exception {
-                session = mailboxManager.createSystemSession(USER_1);
+                session = mailboxManager.createUserSession(USER_1);
                 inbox = MailboxPath.inbox(session);
 
                 MailboxPath anotherMailboxPath = MailboxPath.forUser(USER_1, "anotherMailbox");
@@ -2393,7 +2393,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @BeforeEach
         void setUp() throws Exception {
-            session = mailboxManager.createSystemSession(USER_1);
+            session = mailboxManager.createUserSession(USER_1);
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session).get();
             inboxManager = mailboxManager.getMailbox(inbox, session);

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -2302,7 +2302,6 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        @Disabled("JAMES-2993 createMailbox asserts that the mailbox path belongs to user, disregarding the type of session")
         void createMailboxShouldNotThrowWhenMailboxPathBelongsToAnotherUserAndSystemSession() throws MailboxException {
             session = mailboxManager.createSystemSession(USER_2);
             MailboxPath mailboxPath = MailboxPath.forUser(USER_1, "mailboxName");

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -86,7 +86,6 @@ import org.apache.james.util.concurrency.ConcurrentTestRunner;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -2312,7 +2311,6 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        @Disabled("JAMES-2993 renameMailbox asserts that the user of the session owns the mailbox, disregarding the session type")
         protected void renameMailboxShouldChangeMailboxPathOfMailboxOfAnOtherUserWhenSystemSession() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
 
@@ -2330,7 +2328,6 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        @Disabled("JAMES-2993 renameMailbox asserts that the user of the session owns the mailbox, disregarding the session type")
         protected void renameMailboxByIdShouldChangeMailboxPathOfMailboxOfAnOtherUserWhenSystemSession() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
 
@@ -2348,7 +2345,6 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        @Disabled("JAMES-2993 deleteMailbox asserts that the user of the session owns the mailbox, disregarding the session type")
         void deleteMailboxShouldDeleteOtherUserMailboxWhenSystemSession() throws Exception {
             MailboxSession sessionUser = mailboxManager.createUserSession(USER_1);
             MailboxSession sessionSystem = mailboxManager.createSystemSession(USER_2);
@@ -2362,7 +2358,6 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        @Disabled("JAMES-2993 deleteMailbox asserts that the user of the session owns the mailbox, disregarding the session type")
         protected void deleteMailboxByIdShouldDeleteOtherUserMailboxWhenSystemSession() throws Exception {
             MailboxSession sessionUser = mailboxManager.createUserSession(USER_1);
             MailboxSession sessionSystem = mailboxManager.createSystemSession(USER_2);

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxSessionUtil.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxSessionUtil.java
@@ -26,15 +26,16 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.model.MailboxConstants;
 
-import com.google.common.annotations.VisibleForTesting;
-
 public class MailboxSessionUtil {
-    public static MailboxSession create(Username username) {
-        return create(username, MailboxSession.SessionId.of(ThreadLocalRandom.current().nextLong()));
+    public static MailboxSession createUserSession(Username username) {
+        return createSession(username, MailboxSession.SessionId.of(ThreadLocalRandom.current().nextLong()), MailboxSession.SessionType.User);
     }
 
-    @VisibleForTesting
-    public static MailboxSession create(Username username, MailboxSession.SessionId sessionId) {
+    public static MailboxSession createSystemSession(Username username) {
+        return createSession(username, MailboxSession.SessionId.of(ThreadLocalRandom.current().nextLong()), MailboxSession.SessionType.System);
+    }
+
+    private static MailboxSession createSession(Username username, MailboxSession.SessionId sessionId, MailboxSession.SessionType sessionType) {
         ArrayList<Locale> locales = new ArrayList<>();
 
         return new MailboxSession(
@@ -42,6 +43,6 @@ public class MailboxSessionUtil {
             username,
             locales,
             MailboxConstants.DEFAULT_DELIMITER,
-            MailboxSession.SessionType.User);
+            sessionType);
     }
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MessageMoveEventTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MessageMoveEventTest.java
@@ -49,7 +49,7 @@ class MessageMoveEventTest {
     @Test
     void builderShouldThrowWhenMessageMovesIsNull() {
         assertThatThrownBy(() -> MessageMoveEvent.builder()
-                .session(MailboxSessionUtil.create(USER))
+                .session(MailboxSessionUtil.createUserSession(USER))
                 .build())
             .isInstanceOf(NullPointerException.class);
     }
@@ -57,7 +57,7 @@ class MessageMoveEventTest {
     @Test
     void builderShouldReturnNoopWhenMessagesIsEmpty() {
         assertThat(MessageMoveEvent.builder()
-                .session(MailboxSessionUtil.create(USER))
+                .session(MailboxSessionUtil.createUserSession(USER))
                 .messageMoves(MessageMoves.builder()
                     .previousMailboxIds(TestId.of(1))
                     .targetMailboxIds(TestId.of(2))
@@ -68,7 +68,7 @@ class MessageMoveEventTest {
 
     @Test
     void builderShouldNotBeNoopWhenFieldsAreGiven() {
-        MailboxSession session = MailboxSessionUtil.create(USER);
+        MailboxSession session = MailboxSessionUtil.createUserSession(USER);
         MessageMoves messageMoves = MessageMoves.builder()
             .targetMailboxIds(TestId.of(2))
             .previousMailboxIds(TestId.of(1))
@@ -85,7 +85,7 @@ class MessageMoveEventTest {
 
     @Test
     void builderShouldBuildWhenFieldsAreGiven() {
-        MailboxSession session = MailboxSessionUtil.create(USER);
+        MailboxSession session = MailboxSessionUtil.createUserSession(USER);
         MessageMoves messageMoves = MessageMoves.builder()
             .targetMailboxIds(TestId.of(2))
             .previousMailboxIds(TestId.of(1))
@@ -108,7 +108,7 @@ class MessageMoveEventTest {
     @Test
     void isMoveToShouldReturnFalseWhenMailboxIdIsNotInAddedMailboxIds() {
         MessageMoveEvent event = MessageMoveEvent.builder()
-            .session(MailboxSessionUtil.create(USER))
+            .session(MailboxSessionUtil.createUserSession(USER))
             .messageMoves(MessageMoves.builder()
                     .previousMailboxIds(TestId.of(1))
                     .targetMailboxIds(TestId.of(2))
@@ -122,7 +122,7 @@ class MessageMoveEventTest {
     void isMoveToShouldReturnTrueWhenMailboxIdIsInAddedMailboxIds() {
         TestId mailboxId = TestId.of(123);
         MessageMoveEvent event = MessageMoveEvent.builder()
-            .session(MailboxSessionUtil.create(USER))
+            .session(MailboxSessionUtil.createUserSession(USER))
             .messageMoves(MessageMoves.builder()
                 .previousMailboxIds(TestId.of(1))
                 .targetMailboxIds(TestId.of(2), mailboxId)
@@ -135,7 +135,7 @@ class MessageMoveEventTest {
     @Test
     void isMoveFromShouldReturnFalseWhenMailboxIdIsNotInRemovedMailboxIds() {
         MessageMoveEvent event = MessageMoveEvent.builder()
-            .session(MailboxSessionUtil.create(USER))
+            .session(MailboxSessionUtil.createUserSession(USER))
             .messageMoves(MessageMoves.builder()
                     .previousMailboxIds(TestId.of(1))
                     .targetMailboxIds(TestId.of(2))
@@ -149,7 +149,7 @@ class MessageMoveEventTest {
     void isMoveFromShouldReturnTrueWhenMailboxIdIsInRemovedMailboxIds() {
         TestId mailboxId = TestId.of(123);
         MessageMoveEvent event = MessageMoveEvent.builder()
-            .session(MailboxSessionUtil.create(USER))
+            .session(MailboxSessionUtil.createUserSession(USER))
             .messageMoves(MessageMoves.builder()
                 .previousMailboxIds(TestId.of(1), mailboxId)
                 .targetMailboxIds(TestId.of(2))

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/SubscriptionManagerContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/SubscriptionManagerContract.java
@@ -29,7 +29,7 @@ public interface SubscriptionManagerContract {
     Username USER1 = Username.of("test");
     String MAILBOX1 = "test1";
     String MAILBOX2 = "test2";
-    MailboxSession SESSION = MailboxSessionUtil.create(USER1);
+    MailboxSession SESSION = MailboxSessionUtil.createUserSession(USER1);
 
     SubscriptionManager getSubscriptionManager();
     

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/mock/DataProvisioner.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/mock/DataProvisioner.java
@@ -83,7 +83,7 @@ public class DataProvisioner {
     }
 
     private static void provisionUser(MailboxManager mailboxManager, Username user) {
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(user);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(user);
         mailboxManager.startProcessingRequest(mailboxSession);
 
         createMailbox(mailboxManager, mailboxSession, MailboxPath.inbox(mailboxSession));

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/DefaultMailboxBackupTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/DefaultMailboxBackupTest.java
@@ -63,8 +63,8 @@ class DefaultMailboxBackupTest implements MailboxMessageFixture {
         mailboxManager = InMemoryIntegrationResources.defaultResources().getMailboxManager();
         archiveRestorer = new ZipMailArchiveRestorer(mailboxManager, archiveLoader);
         backup = new DefaultMailboxBackup(mailboxManager, archiveService, archiveRestorer);
-        sessionUser = mailboxManager.createSystemSession(USER);
-        sessionOtherUser = mailboxManager.createSystemSession(OTHER_USER);
+        sessionUser = mailboxManager.createUserSession(USER);
+        sessionOtherUser = mailboxManager.createUserSession(OTHER_USER);
     }
 
     private void createMailboxWithMessages(MailboxSession session, MailboxPath mailboxPath, MessageManager.AppendCommand... messages) throws Exception {

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxMessageFixture.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxMessageFixture.java
@@ -89,7 +89,7 @@ public interface MailboxMessageFixture {
 
     Flags flags1 = new Flags("myFlags");
 
-    MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(USER);
+    MailboxSession MAILBOX_SESSION = MailboxSessionUtil.createUserSession(USER);
 
     String MAILBOX_1_NAME = "mailbox1";
     String MAILBOX_2_NAME = "mailbox2";

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipArchivesLoaderTest.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/ZipArchivesLoaderTest.java
@@ -59,7 +59,7 @@ class ZipArchivesLoaderTest implements MailboxMessageFixture {
     }
 
     private void createMailBoxWithMessage(MailboxPath mailboxPath, MailboxMessage... messages) throws Exception {
-        MailboxSession session = mailboxManager.createSystemSession(mailboxPath.getUser());
+        MailboxSession session = mailboxManager.createUserSession(mailboxPath.getUser());
         MailboxId mailboxId = mailboxManager.createMailbox(mailboxPath, session).get();
         Arrays.stream(messages).forEach(Throwing.consumer(message ->
             {

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMapperProvider.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMapperProvider.java
@@ -51,7 +51,7 @@ public class CassandraMapperProvider implements MapperProvider {
     private final CassandraCluster cassandra;
     private final MessageUidProvider messageUidProvider;
     private final CassandraModSeqProvider cassandraModSeqProvider;
-    private final MailboxSession mailboxSession = MailboxSessionUtil.create(Username.of("benwa"));
+    private final MailboxSession mailboxSession = MailboxSessionUtil.createUserSession(Username.of("benwa"));
     private CassandraMailboxSessionMapperFactory mapperFactory;
 
     public CassandraMapperProvider(CassandraCluster cassandra) {

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapperTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.google.common.collect.ImmutableList;
 
 class CassandraMessageIdMapperTest extends MessageIdMapperTest {
-    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("benwa"));
+    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.createUserSession(Username.of("benwa"));
 
     @RegisterExtension
     static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(MailboxAggregateModule.MODULE);

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/ElasticSearchIntegrationTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/ElasticSearchIntegrationTest.java
@@ -123,7 +123,7 @@ class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest {
     @Test
     void termsBetweenElasticSearchAndLuceneLimitDueTuNonAsciiCharsShouldBeTruncated() throws Exception {
         MailboxPath mailboxPath = MailboxPath.forUser(USERNAME, INBOX);
-        MailboxSession session = MailboxSessionUtil.create(USERNAME);
+        MailboxSession session = MailboxSessionUtil.createUserSession(USERNAME);
         MessageManager messageManager = storeMailboxManager.getMailbox(mailboxPath, session);
 
         String recipient = "benwa@linagora.com";
@@ -142,7 +142,7 @@ class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest {
     @Test
     void tooLongTermsShouldNotMakeIndexingFail() throws Exception {
         MailboxPath mailboxPath = MailboxPath.forUser(USERNAME, INBOX);
-        MailboxSession session = MailboxSessionUtil.create(USERNAME);
+        MailboxSession session = MailboxSessionUtil.createUserSession(USERNAME);
         MessageManager messageManager = storeMailboxManager.getMailbox(mailboxPath, session);
 
         String recipient = "benwa@linagora.com";
@@ -161,7 +161,7 @@ class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest {
     @Test
     void fieldsExceedingLuceneLimitShouldNotBeIgnored() throws Exception {
         MailboxPath mailboxPath = MailboxPath.forUser(USERNAME, INBOX);
-        MailboxSession session = MailboxSessionUtil.create(USERNAME);
+        MailboxSession session = MailboxSessionUtil.createUserSession(USERNAME);
         MessageManager messageManager = storeMailboxManager.getMailbox(mailboxPath, session);
 
         String recipient = "benwa@linagora.com";
@@ -180,7 +180,7 @@ class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest {
     @Test
     void fieldsWithTooLongTermShouldStillBeIndexed() throws Exception {
         MailboxPath mailboxPath = MailboxPath.forUser(USERNAME, INBOX);
-        MailboxSession session = MailboxSessionUtil.create(USERNAME);
+        MailboxSession session = MailboxSessionUtil.createUserSession(USERNAME);
         MessageManager messageManager = storeMailboxManager.getMailbox(mailboxPath, session);
 
         String recipient = "benwa@linagora.com";
@@ -199,7 +199,7 @@ class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest {
     @Test
     void reasonableLongTermShouldNotBeIgnored() throws Exception {
         MailboxPath mailboxPath = MailboxPath.forUser(USERNAME, INBOX);
-        MailboxSession session = MailboxSessionUtil.create(USERNAME);
+        MailboxSession session = MailboxSessionUtil.createUserSession(USERNAME);
         MessageManager messageManager = storeMailboxManager.getMailbox(mailboxPath, session);
 
         String recipient = "benwa@linagora.com";
@@ -219,7 +219,7 @@ class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest {
     @Test
     void headerSearchShouldIncludeMessageWhenDifferentTypesOnAnIndexedField() throws Exception {
         MailboxPath mailboxPath = MailboxPath.forUser(USERNAME, INBOX);
-        MailboxSession session = MailboxSessionUtil.create(USERNAME);
+        MailboxSession session = MailboxSessionUtil.createUserSession(USERNAME);
         MessageManager messageManager = storeMailboxManager.getMailbox(mailboxPath, session);
 
         ComposedMessageId customDateHeaderMessageId = messageManager.appendMessage(
@@ -243,7 +243,7 @@ class ElasticSearchIntegrationTest extends AbstractMessageSearchIndexTest {
     @Test
     void messageShouldStillBeIndexedEvenAfterOneFieldFailsIndexation() throws Exception {
         MailboxPath mailboxPath = MailboxPath.forUser(USERNAME, INBOX);
-        MailboxSession session = MailboxSessionUtil.create(USERNAME);
+        MailboxSession session = MailboxSessionUtil.createUserSession(USERNAME);
         MessageManager messageManager = storeMailboxManager.getMailbox(mailboxPath, session);
 
         messageManager.appendMessage(

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndexTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndexTest.java
@@ -175,7 +175,7 @@ class ElasticSearchListeningMessageSearchIndexTest {
         
         testee = new ElasticSearchListeningMessageSearchIndex(mapperFactory, elasticSearchIndexer, elasticSearchSearcher,
             messageToElasticSearchJson, sessionProvider, new MailboxIdRoutingKeyFactory());
-        session = sessionProvider.createSystemSession(USERNAME);
+        session = sessionProvider.createUserSession(USERNAME);
 
         mailbox = new Mailbox(MailboxPath.forUser(USERNAME, DefaultMailboxes.INBOX), MAILBOX_ID.id);
         mapperFactory.getMailboxMapper(session).save(mailbox);

--- a/mailbox/lucene/src/test/java/org/apache/james/mailbox/lucene/search/LuceneMailboxMessageSearchIndexTest.java
+++ b/mailbox/lucene/src/test/java/org/apache/james/mailbox/lucene/search/LuceneMailboxMessageSearchIndexTest.java
@@ -96,7 +96,7 @@ class LuceneMailboxMessageSearchIndexTest {
     
     @BeforeEach
     void setUp() throws Exception {
-        session = MailboxSessionUtil.create(Username.of("username"));
+        session = MailboxSessionUtil.createUserSession(Username.of("username"));
         TestMessageId.Factory factory = new TestMessageId.Factory();
         id1 = factory.generate();
         id2 = factory.generate();

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/DomainUserMaildirMailboxManagerTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/DomainUserMaildirMailboxManagerTest.java
@@ -61,6 +61,26 @@ class DomainUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreMailbo
         @Test
         protected void getMailboxByIdShouldReturnMailboxWhenBelongingToUser() {
         }
+
+        @Disabled("JAMES-2993 mailboxId support for Maildir is partial")
+        @Test
+        protected void renameMailboxShouldChangeMailboxPathOfMailboxOfAnOtherUserWhenSystemSession() {
+        }
+
+        @Disabled("JAMES-2993 mailboxId support for Maildir is partial")
+        @Test
+        protected void renameMailboxByIdShouldChangeMailboxPathOfMailboxOfAnOtherUserWhenSystemSession() {
+        }
+
+        @Disabled("JAMES-2993 mailboxId support for Maildir is partial")
+        @Test
+        protected void deleteMailboxByIdShouldDeleteOtherUserMailboxWhenSystemSession() {
+        }
+
+        @Disabled("JAMES-2993 mailboxId support for Maildir is partial")
+        @Test
+        protected void getMailboxByIdShouldReturnOtherUserMailboxWhenSystemSession() {
+        }
     }
 
     @Nested

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerTest.java
@@ -61,6 +61,26 @@ class FullUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreMailboxM
         @Test
         protected void getMailboxByIdShouldReturnMailboxWhenBelongingToUser() {
         }
+
+        @Disabled("JAMES-2993 mailboxId support for Maildir is partial")
+        @Test
+        protected void renameMailboxShouldChangeMailboxPathOfMailboxOfAnOtherUserWhenSystemSession() {
+        }
+
+        @Disabled("JAMES-2993 mailboxId support for Maildir is partial")
+        @Test
+        protected void renameMailboxByIdShouldChangeMailboxPathOfMailboxOfAnOtherUserWhenSystemSession() {
+        }
+
+        @Disabled("JAMES-2993 mailboxId support for Maildir is partial")
+        @Test
+        protected void deleteMailboxByIdShouldDeleteOtherUserMailboxWhenSystemSession() {
+        }
+
+        @Disabled("JAMES-2993 mailboxId support for Maildir is partial")
+        @Test
+        protected void getMailboxByIdShouldReturnOtherUserMailboxWhenSystemSession() {
+        }
     }
 
     @Nested

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/mail/InMemoryMapperProvider.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/mail/InMemoryMapperProvider.java
@@ -45,7 +45,7 @@ import com.google.common.collect.ImmutableList;
 public class InMemoryMapperProvider implements MapperProvider {
 
     private static final Username USER = Username.of("user");
-    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(USER);
+    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.createUserSession(USER);
 
     private final MessageId.Factory messageIdFactory;
     private final MessageUidProvider messageUidProvider;
@@ -65,7 +65,7 @@ public class InMemoryMapperProvider implements MapperProvider {
 
     @Override
     public MessageMapper createMessageMapper() throws MailboxException {
-        return inMemoryMailboxSessionMapperFactory.createMessageMapper(MailboxSessionUtil.create(USER));
+        return inMemoryMailboxSessionMapperFactory.createMessageMapper(MailboxSessionUtil.createUserSession(USER));
     }
 
     @Override

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageVaultHookTest.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageVaultHookTest.java
@@ -139,8 +139,8 @@ class DeletedMessageVaultHookTest {
         searchQuery = new SearchQuery();
         searchQuery.andCriteria(SearchQuery.internalDateOn(INTERNAL_DATE, SearchQuery.DateResolution.Second));
 
-        aliceSession = mailboxManager.createSystemSession(ALICE);
-        bobSession = mailboxManager.createSystemSession(BOB);
+        aliceSession = mailboxManager.createUserSession(ALICE);
+        bobSession = mailboxManager.createUserSession(BOB);
     }
 
     @Test

--- a/mailbox/plugin/quota-search/src/test/java/org/apache/james/quota/search/QuotaSearcherContract.java
+++ b/mailbox/plugin/quota-search/src/test/java/org/apache/james/quota/search/QuotaSearcherContract.java
@@ -266,7 +266,7 @@ public interface QuotaSearcherContract {
 
     default void appendMessage(QuotaSearchTestSystem testSystem, Username username, MessageManager.AppendCommand appendCommand) throws MailboxException, UsersRepositoryException, DomainListException {
         MailboxManager mailboxManager = testSystem.getMailboxManager();
-        MailboxSession session = mailboxManager.createSystemSession(username);
+        MailboxSession session = mailboxManager.createUserSession(username);
 
         MailboxPath mailboxPath = MailboxPath.inbox(session);
         mailboxManager.createMailbox(mailboxPath, session);

--- a/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
+++ b/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
@@ -79,7 +79,7 @@ class SpamAssassinListenerTest {
     void setup() throws Exception {
         StoreMailboxManager mailboxManager = spy(InMemoryIntegrationResources.defaultResources().getMailboxManager());
         SystemMailboxesProviderImpl systemMailboxesProvider = new SystemMailboxesProviderImpl(mailboxManager);
-        when(mailboxManager.createSystemSession(USER))
+        when(mailboxManager.createUserSession(USER))
             .thenReturn(MAILBOX_SESSION);
 
         spamAssassin = mock(SpamAssassin.class);

--- a/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
+++ b/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
@@ -59,7 +59,7 @@ import org.junit.jupiter.api.Test;
 
 class SpamAssassinListenerTest {
     static final Username USER = Username.of("user");
-    static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(USER);
+    static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.createUserSession(USER);
     static final int UID_VALIDITY = 43;
     static final TestMessageId MESSAGE_ID = TestMessageId.of(45);
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/SessionProviderImpl.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/SessionProviderImpl.java
@@ -56,6 +56,11 @@ public class SessionProviderImpl implements SessionProvider {
     }
 
     @Override
+    public MailboxSession createUserSession(Username userName) {
+        return createSystemSession(userName);
+    }
+
+    @Override
     public MailboxSession login(Username userid, String passwd) throws MailboxException {
         if (isValidLogin(userid, passwd)) {
             return createSession(userid, MailboxSession.SessionType.User);

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/SessionProviderImpl.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/SessionProviderImpl.java
@@ -78,7 +78,7 @@ public class SessionProviderImpl implements SessionProvider {
         Authorizator.AuthorizationState authorizationState = authorizator.canLoginAsOtherUser(adminUserid, otherUserId);
         switch (authorizationState) {
             case ALLOWED:
-                return createSystemSession(otherUserId);
+                return createSession(otherUserId, MailboxSession.SessionType.User);
             case NOT_ADMIN:
                 throw new NotAdminException();
             case UNKNOWN_USER:

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/SessionProviderImpl.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/SessionProviderImpl.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MailboxSession.SessionType;
 import org.apache.james.mailbox.MailboxSessionIdGenerator;
 import org.apache.james.mailbox.SessionProvider;
 import org.apache.james.mailbox.exception.BadCredentialsException;
@@ -52,18 +53,18 @@ public class SessionProviderImpl implements SessionProvider {
 
     @Override
     public MailboxSession createSystemSession(Username userName) {
-        return createSession(userName, MailboxSession.SessionType.System);
+        return createSession(userName, SessionType.System);
     }
 
     @Override
     public MailboxSession createUserSession(Username userName) {
-        return createSystemSession(userName);
+        return createSession(userName, SessionType.User);
     }
 
     @Override
     public MailboxSession login(Username userid, String passwd) throws MailboxException {
         if (isValidLogin(userid, passwd)) {
-            return createSession(userid, MailboxSession.SessionType.User);
+            return createUserSession(userid);
         } else {
             throw new BadCredentialsException();
         }
@@ -94,7 +95,7 @@ public class SessionProviderImpl implements SessionProvider {
         }
     }
 
-    private MailboxSession createSession(Username userName, MailboxSession.SessionType type) {
+    private MailboxSession createSession(Username userName, SessionType type) {
         return new MailboxSession(newSessionId(), userName, new ArrayList<>(), getDelimiter(), type);
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -242,6 +242,11 @@ public class StoreMailboxManager implements MailboxManager {
     }
 
     @Override
+    public MailboxSession createUserSession(Username userName) {
+        return sessionProvider.createUserSession(userName);
+    }
+
+    @Override
     public void logout(MailboxSession session) {
         sessionProvider.logout(session);
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -522,7 +522,7 @@ public class StoreMailboxManager implements MailboxManager {
     }
 
     private void assertIsOwner(MailboxSession mailboxSession, MailboxPath mailboxPath) throws MailboxNotFoundException {
-        if (!mailboxPath.belongsTo(mailboxSession)) {
+        if (mailboxSession.getType() != MailboxSession.SessionType.System && !mailboxPath.belongsTo(mailboxSession)) {
             LOGGER.info("Mailbox {} does not belong to {}", mailboxPath.asString(), mailboxSession.getUser().asString());
             throw new MailboxNotFoundException(mailboxPath.asString());
         }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -701,9 +701,15 @@ public class StoreMailboxManager implements MailboxManager {
     }
 
     private Stream<MailboxId> getInMailboxes(ImmutableSet<MailboxId> inMailboxes, MailboxSession session) throws MailboxException {
-       if (inMailboxes.isEmpty()) {
+        if (inMailboxes.isEmpty()) {
+            if (session.getType() == MailboxSession.SessionType.System) {
+                throw new IllegalArgumentException("'inMailboxes' can't be empty with a system session");
+            }
             return getAllReadableMailbox(session);
         } else {
+            if (session.getType() == MailboxSession.SessionType.System) {
+                return inMailboxes.stream();
+            }
             return getAllReadableMailbox(session).filter(inMailboxes::contains);
         }
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -411,7 +411,7 @@ public class StoreMailboxManager implements MailboxManager {
     }
 
     private void assertMailboxPathBelongToUser(MailboxSession mailboxSession, MailboxPath mailboxPath) throws MailboxException {
-        if (!mailboxPath.belongsTo(mailboxSession)) {
+        if (mailboxSession.getType() != MailboxSession.SessionType.System && !mailboxPath.belongsTo(mailboxSession)) {
             throw new InsufficientRightsException("mailboxPath '" + mailboxPath.asString() + "'"
                 + " does not belong to user '" + mailboxSession.getUser().asString() + "'");
         }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreRightManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreRightManager.java
@@ -103,6 +103,10 @@ public class StoreRightManager implements RightManager {
     public Rfc4314Rights myRights(Mailbox mailbox, MailboxSession session) throws UnsupportedRightException {
         Username username = session.getUser();
 
+        if (session.getType() == MailboxSession.SessionType.System) {
+            return MailboxACL.FULL_RIGHTS;
+        }
+
         return Optional.ofNullable(username)
             .map(Throwing.function(value ->
                 aclResolver.resolveRights(
@@ -156,6 +160,10 @@ public class StoreRightManager implements RightManager {
 
     public boolean isReadWrite(MailboxSession session, Mailbox mailbox, Flags sharedPermanentFlags) throws UnsupportedRightException {
         Rfc4314Rights rights = myRights(mailbox, session);
+
+        if (session.getType() == MailboxSession.SessionType.System) {
+            return true;
+        }
 
         /*
          * then go through shared flags. RFC 4314 section 4:
@@ -245,6 +253,12 @@ public class StoreRightManager implements RightManager {
         MailboxACL acl = aclResolver.applyGlobalACL(
             mailbox.getACL(),
             !GROUP_FOLDER);
+
+        if (mailboxSession.getType() == MailboxSession.SessionType.System) {
+            return acl.apply(MailboxACL.command().rights(MailboxACL.FULL_RIGHTS)
+                .forUser(mailboxSession.getUser())
+                .asAddition());
+        }
 
         return filteredForSession(mailbox, acl, mailboxSession);
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/SystemMailboxesProviderImpl.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/SystemMailboxesProviderImpl.java
@@ -53,11 +53,16 @@ public class SystemMailboxesProviderImpl implements SystemMailboxesProvider {
     @Override
     public Stream<MessageManager> getMailboxByRole(Role aRole, Username username) throws MailboxException {
         MailboxSession session = mailboxManager.createSystemSession(username);
-        MailboxPath mailboxPath = MailboxPath.forUser(username, aRole.getDefaultMailbox());
+        return getMailboxByRole(aRole, session);
+    }
+
+    @Override
+    public Stream<MessageManager> getMailboxByRole(Role aRole, MailboxSession session) throws MailboxException {
+        MailboxPath mailboxPath = MailboxPath.forUser(session.getUser(), aRole.getDefaultMailbox());
         try {
             return Stream.of(mailboxManager.getMailbox(mailboxPath, session));
         } catch (MailboxNotFoundException e) {
-            return searchMessageManagerByMailboxRole(aRole, username);
+            return searchMessageManagerByMailboxRole(aRole, session.getUser());
         }
     }
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractCombinationManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractCombinationManagerTest.java
@@ -75,7 +75,7 @@ public abstract class AbstractCombinationManagerTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        session = MailboxSessionUtil.create(MailboxFixture.ALICE);
+        session = MailboxSessionUtil.createUserSession(MailboxFixture.ALICE);
         testingData = createTestingData();
 
         mailbox1 = testingData.createMailbox(MailboxFixture.INBOX_ALICE, session);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMailboxManagerAttachmentTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMailboxManagerAttachmentTest.java
@@ -71,7 +71,7 @@ public abstract class AbstractMailboxManagerAttachmentTest {
     protected abstract AttachmentMapperFactory getAttachmentMapperFactory();
 
     protected void setUp() throws Exception {
-        mailboxSession = MailboxSessionUtil.create(USERNAME);
+        mailboxSession = MailboxSessionUtil.createUserSession(USERNAME);
         messageMapper = getMailboxSessionMapperFactory().getMessageMapper(mailboxSession);
         mailboxMapper = getMailboxSessionMapperFactory().getMailboxMapper(mailboxSession);
         inboxPath = MailboxPath.forUser(USERNAME, "INBOX");

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerQuotaTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerQuotaTest.java
@@ -69,7 +69,7 @@ public abstract class AbstractMessageIdManagerQuotaTest {
         CurrentQuotaManager currentQuotaManager = createCurrentQuotaManager();
         QuotaManager quotaManager = createQuotaManager(maxQuotaManager, currentQuotaManager);
 
-        session = MailboxSessionUtil.create(ALICE);
+        session = MailboxSessionUtil.createUserSession(ALICE);
         testingData = createTestSystem(quotaManager, currentQuotaManager);
         messageIdManager = testingData.getMessageIdManager();
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerSideEffectTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerSideEffectTest.java
@@ -109,7 +109,7 @@ public abstract class AbstractMessageIdManagerSideEffectTest {
         eventCollector = new EventCollector();
         quotaManager = mock(QuotaManager.class);
 
-        session = MailboxSessionUtil.create(ALICE);
+        session = MailboxSessionUtil.createUserSession(ALICE);
         setupMockForPreDeletionHooks();
         testingData = createTestSystem(quotaManager, eventBus, ImmutableSet.of(preDeletionHook1, preDeletionHook2));
         messageIdManager = testingData.getMessageIdManager();

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerStorageTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerStorageTest.java
@@ -76,9 +76,9 @@ public abstract class AbstractMessageIdManagerStorageTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        aliceSession = MailboxSessionUtil.create(MailboxFixture.ALICE);
-        bobSession = MailboxSessionUtil.create(MailboxFixture.BOB);
-        systemSession = MailboxSessionUtil.create(Username.of("systemuser"));
+        aliceSession = MailboxSessionUtil.createUserSession(MailboxFixture.ALICE);
+        bobSession = MailboxSessionUtil.createUserSession(MailboxFixture.BOB);
+        systemSession = MailboxSessionUtil.createUserSession(Username.of("systemuser"));
         testingData = createTestingData();
         messageIdManager = testingData.getMessageIdManager();
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageManagerTest.java
@@ -25,6 +25,7 @@ import static org.apache.james.mailbox.fixture.MailboxFixture.CEDRIC;
 import static org.apache.james.mailbox.fixture.MailboxFixture.INBOX_ALICE;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.james.core.Username;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MailboxSessionUtil;
@@ -70,6 +71,18 @@ public abstract class AbstractMessageManagerTest {
 
         MessageManager.MetaData actual = messageManager.getMetaData(NO_RESET_RECENT, bobSession, MessageManager.MetaData.FetchGroup.NO_COUNT);
         assertThat(actual.getACL().getEntries()).containsOnlyKeys(MailboxACL.EntryKey.createUserEntryKey(BOB));
+    }
+
+    @Test
+    void getMetadataShouldExposeAllUsersWhenSystemSession() throws Exception {
+        MailboxSession systemSession = MailboxSessionUtil.createSystemSession(Username.of("systemuser"));
+
+        mailboxManager.applyRightsCommand(INBOX_ALICE, MailboxACL.command().forUser(BOB).rights(MailboxACL.Right.Read).asAddition(), aliceSession);
+        mailboxManager.applyRightsCommand(INBOX_ALICE, MailboxACL.command().forUser(CEDRIC).rights(MailboxACL.Right.Read).asAddition(), aliceSession);
+        MessageManager messageManager = mailboxManager.getMailbox(INBOX_ALICE, aliceSession);
+
+        MessageManager.MetaData actual = messageManager.getMetaData(NO_RESET_RECENT, systemSession, MessageManager.MetaData.FetchGroup.NO_COUNT);
+        assertThat(actual.getACL().getEntries()).containsKeys(MailboxACL.EntryKey.createUserEntryKey(BOB), MailboxACL.EntryKey.createUserEntryKey(CEDRIC));
     }
 
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageManagerTest.java
@@ -42,8 +42,8 @@ public abstract class AbstractMessageManagerTest {
     MailboxSession bobSession;
 
     protected void setup(MessageManagerTestSystem testSystem) throws Exception {
-        aliceSession = MailboxSessionUtil.create(ALICE);
-        bobSession = MailboxSessionUtil.create(BOB);
+        aliceSession = MailboxSessionUtil.createUserSession(ALICE);
+        bobSession = MailboxSessionUtil.createUserSession(BOB);
         mailboxManager = testSystem.getMailboxManager();
 
         testSystem.createMailbox(INBOX_ALICE, aliceSession);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreBlobManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreBlobManagerTest.java
@@ -68,7 +68,7 @@ class StoreBlobManagerTest {
     void setUp() {
         attachmentManager = mock(AttachmentManager.class);
         messageIdManager = mock(MessageIdManager.class);
-        session = MailboxSessionUtil.create(Username.of("user"));
+        session = MailboxSessionUtil.createUserSession(Username.of("user"));
 
         blobManager = new StoreBlobManager(attachmentManager, messageIdManager, new TestMessageId.Factory());
     }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxManagerAnnotationTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxManagerAnnotationTest.java
@@ -81,7 +81,7 @@ class StoreMailboxManagerAnnotationTest {
     void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        session = MailboxSessionUtil.create(Username.of("userName"));
+        session = MailboxSessionUtil.createUserSession(Username.of("userName"));
 
         when(mailboxSessionMapperFactory.getMailboxMapper(eq(session))).thenReturn(mailboxMapper);
         when(mailboxSessionMapperFactory.getAnnotationMapper(eq(session))).thenReturn(annotationMapper);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxManagerTest.java
@@ -75,7 +75,7 @@ class StoreMailboxManagerTest {
     @BeforeEach
     void setUp() throws MailboxException {
         MailboxSessionMapperFactory mockedMapperFactory = mock(MailboxSessionMapperFactory.class);
-        mockedMailboxSession = MailboxSessionUtil.create(CURRENT_USER);
+        mockedMailboxSession = MailboxSessionUtil.createUserSession(CURRENT_USER);
         mockedMailboxMapper = mock(MailboxMapper.class);
         when(mockedMapperFactory.getMailboxMapper(mockedMailboxSession))
             .thenReturn(mockedMailboxMapper);
@@ -209,7 +209,7 @@ class StoreMailboxManagerTest {
     @Test
     void getPathLikeShouldReturnUserPathLikeWhenNoPrefixDefined() {
         //Given
-        MailboxSession session = MailboxSessionUtil.create(CURRENT_USER);
+        MailboxSession session = MailboxSessionUtil.createUserSession(CURRENT_USER);
         MailboxQuery.Builder testee = MailboxQuery.builder()
             .expression(new PrefixedRegex(EMPTY_PREFIX, "abc", session.getPathDelimiter()));
         //When
@@ -227,7 +227,7 @@ class StoreMailboxManagerTest {
     @Test
     void getPathLikeShouldReturnUserPathLikeWhenPrefixDefined() {
         //Given
-        MailboxSession session = MailboxSessionUtil.create(CURRENT_USER);
+        MailboxSession session = MailboxSessionUtil.createUserSession(CURRENT_USER);
         MailboxQuery.Builder testee = MailboxQuery.builder()
             .expression(new PrefixedRegex("prefix.", "abc", session.getPathDelimiter()));
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxManagerTest.java
@@ -55,6 +55,7 @@ import org.apache.james.mailbox.store.quota.QuotaComponents;
 import org.apache.james.mailbox.store.search.MessageSearchIndex;
 import org.apache.james.mailbox.store.search.SimpleMessageSearchIndex;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -203,7 +204,10 @@ class StoreMailboxManagerTest {
     void loginAsOtherUserShouldCreateUserSessionWhenAdminWithGoodPassword() throws Exception {
         MailboxSession expected = storeMailboxManager.loginAsOtherUser(ADMIN, ADMIN_PASSWORD, CURRENT_USER);
 
-        assertThat(expected.getUser()).isEqualTo(CURRENT_USER);
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(expected.getUser()).isEqualTo(CURRENT_USER);
+            softly.assertThat(expected.getType()).isEqualTo(MailboxSession.SessionType.User);
+        });
     }
 
     @Test

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreRightManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreRightManagerTest.java
@@ -64,7 +64,7 @@ class StoreRightManagerTest {
 
     @BeforeEach
     void setup() throws MailboxException {
-        aliceSession = MailboxSessionUtil.create(MailboxFixture.ALICE);
+        aliceSession = MailboxSessionUtil.createUserSession(MailboxFixture.ALICE);
         MailboxSessionMapperFactory mockedMapperFactory = mock(MailboxSessionMapperFactory.class);
         mockedMailboxMapper = mock(MailboxMapper.class);
         mailboxAclResolver = new UnionMailboxACLResolver();
@@ -216,7 +216,7 @@ class StoreRightManagerTest {
             .apply(MailboxACL.command().rights(Right.Read, Right.Write).forUser(BOB).asAddition())
             .apply(MailboxACL.command().rights(Right.Read, Right.Write, Right.Administer).forUser(CEDRIC).asAddition());
         MailboxACL actual = StoreRightManager.filteredForSession(
-            new Mailbox(INBOX_ALICE, UID_VALIDITY), acl, MailboxSessionUtil.create(CEDRIC));
+            new Mailbox(INBOX_ALICE, UID_VALIDITY), acl, MailboxSessionUtil.createUserSession(CEDRIC));
         assertThat(actual).isEqualTo(acl);
     }
 
@@ -226,7 +226,7 @@ class StoreRightManagerTest {
             .apply(MailboxACL.command().rights(Right.Read, Right.Write).forUser(BOB).asAddition())
             .apply(MailboxACL.command().rights(Right.Read, Right.Write, Right.Administer).forUser(CEDRIC).asAddition());
         MailboxACL actual = StoreRightManager.filteredForSession(
-            new Mailbox(INBOX_ALICE, UID_VALIDITY), acl, MailboxSessionUtil.create(BOB));
+            new Mailbox(INBOX_ALICE, UID_VALIDITY), acl, MailboxSessionUtil.createUserSession(BOB));
         assertThat(actual.getEntries()).containsKey(MailboxACL.EntryKey.createUserEntryKey(BOB));
     }
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/SystemMailboxesProviderImplTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/SystemMailboxesProviderImplTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 
 class SystemMailboxesProviderImplTest {
 
-    MailboxSession mailboxSession = MailboxSessionUtil.create(MailboxFixture.ALICE);
+    MailboxSession mailboxSession = MailboxSessionUtil.createUserSession(MailboxFixture.ALICE);
     SystemMailboxesProviderImpl systemMailboxProvider;
 
     MailboxManager mailboxManager;

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/event/MailboxAnnotationListenerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/event/MailboxAnnotationListenerTest.java
@@ -79,7 +79,7 @@ class MailboxAnnotationListenerTest {
     @BeforeEach
     void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        mailboxSession = MailboxSessionUtil.create(Username.of("test"));
+        mailboxSession = MailboxSessionUtil.createUserSession(Username.of("test"));
         listener = new MailboxAnnotationListener(mailboxSessionMapperFactory, sessionProvider);
 
         deleteEvent = EventFactory.mailboxDeleted()

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/AbstractMessageSearchIndexTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/AbstractMessageSearchIndexTest.java
@@ -109,8 +109,8 @@ public abstract class AbstractMessageSearchIndexTest {
     protected void setUp() throws Exception {
         initializeMailboxManager();
 
-        session = storeMailboxManager.createSystemSession(USERNAME);
-        otherSession = storeMailboxManager.createSystemSession(OTHERUSER);
+        session = storeMailboxManager.createUserSession(USERNAME);
+        otherSession = storeMailboxManager.createUserSession(OTHERUSER);
 
         inboxPath = MailboxPath.inbox(USERNAME);
         otherInboxPath = MailboxPath.inbox(OTHERUSER);

--- a/mailbox/tools/copier/src/test/java/org/apache/james/mailbox/tools/copier/MailboxCopierTest.java
+++ b/mailbox/tools/copier/src/test/java/org/apache/james/mailbox/tools/copier/MailboxCopierTest.java
@@ -111,7 +111,7 @@ public class MailboxCopierTest {
      * @throws BadCredentialsException
      */
     private void assertMailboxManagerSize(MailboxManager mailboxManager, int multiplicationFactor) throws BadCredentialsException, MailboxException {
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(Username.of("manager"));
+        MailboxSession mailboxSession = mailboxManager.createUserSession(Username.of("manager"));
         mailboxManager.startProcessingRequest(mailboxSession);
 
         List<MailboxPath> mailboxPathList = mailboxManager.list(mailboxSession);
@@ -119,7 +119,7 @@ public class MailboxCopierTest {
         assertThat(mailboxPathList).hasSize(DataProvisioner.EXPECTED_MAILBOXES_COUNT);
 
         for (MailboxPath mailboxPath: mailboxPathList) {
-            MailboxSession userSession = mailboxManager.createSystemSession(mailboxPath.getUser());
+            MailboxSession userSession = mailboxManager.createUserSession(mailboxPath.getUser());
             mailboxManager.startProcessingRequest(mailboxSession);
             MessageManager messageManager = mailboxManager.getMailbox(mailboxPath, userSession);
             assertThat(messageManager.getMetaData(false, userSession, FetchGroup.NO_UNSEEN).getMessageCount()).isEqualTo(DataProvisioner.MESSAGE_PER_MAILBOX_COUNT * multiplicationFactor);

--- a/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/CassandraReIndexerImplTest.java
+++ b/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/CassandraReIndexerImplTest.java
@@ -75,7 +75,7 @@ public class CassandraReIndexerImplTest {
     @Test
     void reIndexShouldBeWellPerformed() throws Exception {
         // Given a mailbox with 1000 messages * 150 KB
-        MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
         mailboxManager.createMailbox(INBOX, systemSession);
 
         byte[] bigBody = (Strings.repeat("header: value\r\n", 10000) + "\r\nbody").getBytes(StandardCharsets.UTF_8);

--- a/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/MessageIdReIndexerImplTest.java
+++ b/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/MessageIdReIndexerImplTest.java
@@ -62,7 +62,7 @@ public class MessageIdReIndexerImplTest {
 
     @Test
     void reIndexShouldBeWellPerformed() throws Exception {
-        MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
         MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
         ComposedMessageId createdMessage = mailboxManager.getMailbox(INBOX, systemSession)
             .appendMessage(

--- a/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/ReIndexerImplTest.java
+++ b/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/ReIndexerImplTest.java
@@ -66,7 +66,7 @@ public class ReIndexerImplTest {
 
     @Test
     void reIndexAllShouldCallMessageSearchIndex() throws Exception {
-        MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
         MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
         ComposedMessageId createdMessage = mailboxManager.getMailbox(INBOX, systemSession)
             .appendMessage(
@@ -93,7 +93,7 @@ public class ReIndexerImplTest {
 
     @Test
     void reIndexMailboxPathShouldCallMessageSearchIndex() throws Exception {
-        MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
         MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
         ComposedMessageId createdMessage = mailboxManager.getMailbox(INBOX, systemSession)
             .appendMessage(
@@ -119,7 +119,7 @@ public class ReIndexerImplTest {
 
     @Test
     void userReIndexShouldCallMessageSearchIndex() throws Exception {
-        MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
         MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
         ComposedMessageId createdMessage = mailboxManager.getMailbox(INBOX, systemSession)
             .appendMessage(
@@ -145,7 +145,7 @@ public class ReIndexerImplTest {
 
     @Test
     void messageReIndexShouldCallMessageSearchIndex() throws Exception {
-        MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
         MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
         ComposedMessageId createdMessage = mailboxManager.getMailbox(INBOX, systemSession)
             .appendMessage(
@@ -168,7 +168,7 @@ public class ReIndexerImplTest {
 
     @Test
     void messageReIndexUsingMailboxIdShouldCallMessageSearchIndex() throws Exception {
-        MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
         MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
         ComposedMessageId createdMessage = mailboxManager.getMailbox(INBOX, systemSession)
             .appendMessage(
@@ -191,7 +191,7 @@ public class ReIndexerImplTest {
 
     @Test
     void messageReIndexUsingMailboxIdShouldDoNothingWhenUidNotFound() throws Exception {
-        MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
         MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
         MessageUid uid = MessageUid.of(36);
 
@@ -211,7 +211,7 @@ public class ReIndexerImplTest {
 
     @Test
     void mailboxIdReIndexShouldCallMessageSearchIndex() throws Exception {
-        MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
         MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
         ComposedMessageId createdMessage = mailboxManager.getMailbox(INBOX, systemSession)
             .appendMessage(
@@ -237,7 +237,7 @@ public class ReIndexerImplTest {
 
     @Test
     void mailboxIdReIndexShouldOnlyDropSearchIndexWhenEmptyMailbox() throws Exception {
-        MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
         MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
 
         reIndexer.reIndex(mailboxId).run();

--- a/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/host/JamesImapHostSystem.java
+++ b/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/host/JamesImapHostSystem.java
@@ -101,7 +101,7 @@ public abstract class JamesImapHostSystem implements ImapHostSystem, GrantRights
     @Override
     public void createMailbox(MailboxPath mailboxPath) throws Exception {
         MailboxManager mailboxManager = getMailboxManager();
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(mailboxPath.getUser());
+        MailboxSession mailboxSession = mailboxManager.createUserSession(mailboxPath.getUser());
         mailboxManager.startProcessingRequest(mailboxSession);
         mailboxManager.createMailbox(mailboxPath, mailboxSession);
         mailboxManager.logout(mailboxSession);
@@ -111,14 +111,14 @@ public abstract class JamesImapHostSystem implements ImapHostSystem, GrantRights
     @Override
     public void grantRights(MailboxPath mailboxPath, Username username, MailboxACL.Rfc4314Rights rights) throws Exception {
         MailboxManager mailboxManager = getMailboxManager();
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(mailboxPath.getUser());
+        MailboxSession mailboxSession = mailboxManager.createUserSession(mailboxPath.getUser());
         mailboxManager.startProcessingRequest(mailboxSession);
         mailboxManager.setRights(mailboxPath,
             MailboxACL.EMPTY.apply(MailboxACL.command()
                 .forUser(username)
                 .rights(rights)
                 .asAddition()),
-            mailboxManager.createSystemSession(username));
+            mailboxManager.createUserSession(username));
         mailboxManager.logout(mailboxSession);
         mailboxManager.endProcessingRequest(mailboxSession);
     }

--- a/protocols/imap/src/test/java/org/apache/james/imap/api/ImapSessionTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/api/ImapSessionTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 
 public class ImapSessionTest {
     private static final Username USERNAME = Username.of("username");
-    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(USERNAME);
+    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.createUserSession(USERNAME);
     private FakeImapSession fakeImapSession;
 
     @Before

--- a/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/CreateCommandParserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/decode/parser/CreateCommandParserTest.java
@@ -48,7 +48,7 @@ public class CreateCommandParserTest {
 
     @Before
     public void setUp() throws Exception {
-        MailboxSession mailboxSession = MailboxSessionUtil.create(Username.of("userName"));
+        MailboxSession mailboxSession = MailboxSessionUtil.createUserSession(Username.of("userName"));
         imapSession = new FakeImapSession();
         imapSession.setMailboxSession(mailboxSession);
 

--- a/protocols/imap/src/test/java/org/apache/james/imap/main/PathConverterTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/main/PathConverterTest.java
@@ -45,7 +45,7 @@ public class PathConverterTest {
     @Before
     public void setUp() {
         imapSession = new FakeImapSession();
-        mailboxSession = MailboxSessionUtil.create(USERNAME);
+        mailboxSession = MailboxSessionUtil.createUserSession(USERNAME);
         pathConverter = PathConverter.forSession(imapSession);
         imapSession.setMailboxSession(mailboxSession);
     }

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/CopyProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/CopyProcessorTest.java
@@ -75,7 +75,7 @@ public class CopyProcessorTest {
         mockStatusResponseFactory = mock(StatusResponseFactory.class);
         mockResponder = mock(ImapProcessor.Responder.class);
         imapSession = new FakeImapSession();
-        mailboxSession = MailboxSessionUtil.create(USERNAME);
+        mailboxSession = MailboxSessionUtil.createUserSession(USERNAME);
 
         testee = new CopyProcessor(mockNextProcessor, mockMailboxManager, mockStatusResponseFactory, new RecordingMetricFactory());
 

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/DeleteACLProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/DeleteACLProcessorTest.java
@@ -79,7 +79,7 @@ public class DeleteACLProcessorTest {
         mailboxManager = mock(MailboxManager.class);
         subject = new DeleteACLProcessor(mock(ImapProcessor.class), mailboxManager, statusResponseFactory, new RecordingMetricFactory());
         imapSession = new FakeImapSession();
-        mailboxSession = MailboxSessionUtil.create(USER_1);
+        mailboxSession = MailboxSessionUtil.createUserSession(USER_1);
 
         MessageManager messageManager = mock(MessageManager.class);
         metaData = mock(MetaData.class);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/GetACLProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/GetACLProcessorTest.java
@@ -78,7 +78,7 @@ public class GetACLProcessorTest {
         mailboxManager = mock(MailboxManager.class);
         subject = new GetACLProcessor(mock(ImapProcessor.class), mailboxManager, statusResponseFactory, new RecordingMetricFactory());
         imapSession = new FakeImapSession();
-        mailboxSession = MailboxSessionUtil.create(USER_1);
+        mailboxSession = MailboxSessionUtil.createUserSession(USER_1);
         MessageManager messageManager = mock(MessageManager.class);
         metaData = mock(MetaData.class);
         responder = mock(Responder.class);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/GetAnnotationProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/GetAnnotationProcessorTest.java
@@ -103,7 +103,7 @@ public class GetAnnotationProcessorTest {
         imapSession = new FakeImapSession();
 
         Username username = Username.of("username");
-        mailboxSession = MailboxSessionUtil.create(username);
+        mailboxSession = MailboxSessionUtil.createUserSession(username);
         inbox = MailboxPath.inbox(username);
         keys = ImmutableSet.of(PRIVATE_KEY);
         annotationRequestBuilder = GetAnnotationRequest.builder()

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/GetQuotaProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/GetQuotaProcessorTest.java
@@ -81,7 +81,7 @@ public class GetQuotaProcessorTest {
 
     @Before
     public void setUp() throws Exception {
-        mailboxSession = MailboxSessionUtil.create(PLOP);
+        mailboxSession = MailboxSessionUtil.createUserSession(PLOP);
         UnpooledStatusResponseFactory statusResponseFactory = new UnpooledStatusResponseFactory();
         imapSession = new FakeImapSession();
         mockedQuotaManager = mock(QuotaManager.class);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/GetQuotaRootProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/GetQuotaRootProcessorTest.java
@@ -79,7 +79,7 @@ public class GetQuotaRootProcessorTest {
 
     @Before
     public void setUp() {
-        mailboxSession = MailboxSessionUtil.create(PLOP);
+        mailboxSession = MailboxSessionUtil.createUserSession(PLOP);
         UnpooledStatusResponseFactory statusResponseFactory = new UnpooledStatusResponseFactory();
         imapSession = new FakeImapSession();
         mockedQuotaManager = mock(QuotaManager.class);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/LSubProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/LSubProcessorTest.java
@@ -94,7 +94,7 @@ public class LSubProcessorTest {
         statusResponse = mock(StatusResponse.class);
         responderImpl = responder;
         manager =  mock(SubscriptionManager.class);
-        mailboxSession = MailboxSessionUtil.create(USER);
+        mailboxSession = MailboxSessionUtil.createUserSession(USER);
         processor = new LSubProcessor(next, mock(MailboxManager.class), manager, serverResponseFactory, new RecordingMetricFactory());
         session.setMailboxSession(mailboxSession);
     }

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/ListRightsProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/ListRightsProcessorTest.java
@@ -81,7 +81,7 @@ public class ListRightsProcessorTest {
         mailboxManager = mock(MailboxManager.class);
         subject = new ListRightsProcessor(mock(ImapProcessor.class), mailboxManager, statusResponseFactory, new RecordingMetricFactory());
         imapSession = new FakeImapSession();
-        mailboxSession = MailboxSessionUtil.create(USER_1);
+        mailboxSession = MailboxSessionUtil.createUserSession(USER_1);
         MessageManager messageManager = mock(MessageManager.class);
         metaData = mock(MetaData.class);
         responder = mock(Responder.class);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/MoveProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/MoveProcessorTest.java
@@ -78,7 +78,7 @@ public class MoveProcessorTest {
         mockStatusResponseFactory = mock(StatusResponseFactory.class);
         mockResponder = mock(ImapProcessor.Responder.class);
         imapSession = new FakeImapSession();
-        mailboxSession = MailboxSessionUtil.create(USERNAME);
+        mailboxSession = MailboxSessionUtil.createUserSession(USERNAME);
 
         when(mockMailboxManager.hasCapability(eq(MailboxCapabilities.Move))).thenReturn(true);
         testee = new MoveProcessor(mockNextProcessor, mockMailboxManager, mockStatusResponseFactory, new RecordingMetricFactory());

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/SearchProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/SearchProcessorTest.java
@@ -124,7 +124,7 @@ public class SearchProcessorTest {
         statusResponse = mock(StatusResponse.class);
         mailbox = mock(MessageManager.class);
         mailboxManager = mock(MailboxManager.class);
-        mailboxSession = MailboxSessionUtil.create(USER);
+        mailboxSession = MailboxSessionUtil.createUserSession(USER);
         selectedMailbox = mock(SelectedMailbox.class);
         when(selectedMailbox.getMailboxId()).thenReturn(mailboxId);
         

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/SetACLProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/SetACLProcessorTest.java
@@ -83,7 +83,7 @@ public class SetACLProcessorTest {
         mailboxManager = mock(MailboxManager.class);
         subject = new SetACLProcessor(mock(ImapProcessor.class), mailboxManager, statusResponseFactory, new RecordingMetricFactory());
         imapSession = new FakeImapSession();
-        mailboxSession = MailboxSessionUtil.create(USER_1);
+        mailboxSession = MailboxSessionUtil.createUserSession(USER_1);
         MessageManager messageManager = mock(MessageManager.class);
         MetaData metaData = mock(MetaData.class);
         responder = mock(Responder.class);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/SetAnnotationProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/SetAnnotationProcessorTest.java
@@ -90,7 +90,7 @@ public class SetAnnotationProcessorTest {
         imapSession = new FakeImapSession();
 
         Username username = Username.of("username");
-        mockMailboxSession = MailboxSessionUtil.create(username);
+        mockMailboxSession = MailboxSessionUtil.createUserSession(username);
         inbox = MailboxPath.inbox(username);
         mailboxAnnotations = ImmutableList.of(MailboxAnnotation.newInstance(new MailboxAnnotationKey("/private/key"), "anyValue"));
         request = new SetAnnotationRequest(TAG, ImapConstants.INBOX_NAME, mailboxAnnotations);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/SetQuotaProcessorTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/SetQuotaProcessorTest.java
@@ -46,7 +46,7 @@ public class SetQuotaProcessorTest {
 
     @Before
     public void setUp() {
-        MailboxSession mailboxSession = MailboxSessionUtil.create(Username.of("plop"));
+        MailboxSession mailboxSession = MailboxSessionUtil.createUserSession(Username.of("plop"));
         UnpooledStatusResponseFactory statusResponseFactory = new UnpooledStatusResponseFactory();
         imapSession = new FakeImapSession();
         mockedResponder = mock(ImapProcessor.Responder.class);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/MailboxEventAnalyserTest.java
@@ -111,8 +111,8 @@ public class MailboxEventAnalyserTest {
 
     private static final MessageUid MESSAGE_UID = MessageUid.of(1);
     private static final Username USER = Username.of("user");
-    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(USER);
-    private static final MailboxSession OTHER_MAILBOX_SESSION = MailboxSessionUtil.create(USER);
+    private static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.createUserSession(USER);
+    private static final MailboxSession OTHER_MAILBOX_SESSION = MailboxSessionUtil.createUserSession(USER);
     private static final char PATH_DELIMITER = '.';
     private static final MailboxPath MAILBOX_PATH = new MailboxPath("namespace", USER, "name");
     private static final TestId MAILBOX_ID = TestId.of(36);

--- a/protocols/imap/src/test/java/org/apache/james/imap/processor/base/SelectedMailboxImplTest.java
+++ b/protocols/imap/src/test/java/org/apache/james/imap/processor/base/SelectedMailboxImplTest.java
@@ -171,7 +171,7 @@ public class SelectedMailboxImplTest {
     private void emitEvent(MailboxListener mailboxListener) throws Exception {
         mailboxListener.event(EventFactory.added()
             .randomEventId()
-            .mailboxSession(MailboxSessionUtil.create(Username.of("user")))
+            .mailboxSession(MailboxSessionUtil.createUserSession(Username.of("user")))
             .mailbox(mailbox)
             .addMetaData(new MessageMetaData(EMITTED_EVENT_UID, MOD_SEQ, new Flags(), SIZE, new Date(), new DefaultMessageId()))
             .build());

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/ACLProbeImpl.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/ACLProbeImpl.java
@@ -60,7 +60,7 @@ public class ACLProbeImpl implements GuiceProbe, ACLProbe {
 
     @Override
     public MailboxACL retrieveRights(MailboxPath mailboxPath) throws MailboxException {
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(mailboxPath.getUser());
+        MailboxSession mailboxSession = mailboxManager.createUserSession(mailboxPath.getUser());
 
         return mailboxManager.getMailbox(mailboxPath, mailboxSession)
             .getMetaData(RESET_RECENT, mailboxSession, MessageManager.MetaData.FetchGroup.NO_COUNT)

--- a/server/container/mailbox-jmx/src/test/java/org/apache/james/adapter/mailbox/MailboxManagementTest.java
+++ b/server/container/mailbox-jmx/src/test/java/org/apache/james/adapter/mailbox/MailboxManagementTest.java
@@ -60,7 +60,7 @@ public class MailboxManagementTest {
 
         mailboxManagerManagement = new MailboxManagerManagement();
         mailboxManagerManagement.setMailboxManager(mailboxManager);
-        session = mailboxManager.createSystemSession(Username.of("TEST"));
+        session = mailboxManager.createUserSession(Username.of("TEST"));
     }
 
     @Test

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/MailboxAppenderTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/delivery/MailboxAppenderTest.java
@@ -63,7 +63,7 @@ public class MailboxAppenderTest {
         mailboxManager = InMemoryIntegrationResources.defaultResources().getMailboxManager();
         testee = new MailboxAppender(mailboxManager);
 
-        session = mailboxManager.createSystemSession(USER);
+        session = mailboxManager.createUserSession(USER);
     }
 
     @Test

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/AccessTokenAuthenticationStrategy.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/AccessTokenAuthenticationStrategy.java
@@ -57,7 +57,7 @@ public class AccessTokenAuthenticationStrategy implements AuthenticationStrategy
             .findFirst();
 
         if (username.isPresent()) {
-            return mailboxManager.createSystemSession(username.get());
+            return mailboxManager.createUserSession(username.get());
         }
         throw new NoValidAuthHeaderException();
     }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/DefaultMailboxesProvisioningFilter.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/DefaultMailboxesProvisioningFilter.java
@@ -88,7 +88,7 @@ public class DefaultMailboxesProvisioningFilter implements Filter {
     }
 
     private void createDefaultMailboxes(Username username) throws MailboxException {
-        MailboxSession session = mailboxManager.createSystemSession(username);
+        MailboxSession session = mailboxManager.createUserSession(username);
         DefaultMailboxes.DEFAULT_MAILBOXES.stream()
             .map(toMailboxPath(session))
             .filter(mailboxPath -> mailboxDoesntExist(mailboxPath, session))

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/JWTAuthenticationStrategy.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/JWTAuthenticationStrategy.java
@@ -68,7 +68,7 @@ public class JWTAuthenticationStrategy implements AuthenticationStrategy {
             });
 
         Stream<MailboxSession> mailboxSessionStream = userLoginStream
-                .map(mailboxManager::createSystemSession);
+                .map(mailboxManager::createUserSession);
 
         return mailboxSessionStream
                 .findFirst()

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/QueryParameterAccessTokenAuthenticationStrategy.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/QueryParameterAccessTokenAuthenticationStrategy.java
@@ -53,7 +53,7 @@ public class QueryParameterAccessTokenAuthenticationStrategy implements Authenti
             .filter(tokenManager::isValid)
             .map(AttachmentAccessToken::getUsername)
             .map(Username::of)
-            .map(mailboxManager::createSystemSession)
+            .map(mailboxManager::createUserSession)
             .orElseThrow(UnauthorizedException::new);
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SendMDNProcessor.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SendMDNProcessor.java
@@ -185,9 +185,8 @@ public class SendMDNProcessor implements SetMessagesProcessor {
             .build();
     }
 
-
     private MessageManager getOutbox(MailboxSession mailboxSession) throws MailboxException {
-        return systemMailboxesProvider.getMailboxByRole(Role.OUTBOX, mailboxSession.getUser())
+        return systemMailboxesProvider.getMailboxByRole(Role.OUTBOX, mailboxSession)
             .findAny()
             .orElseThrow(() -> new IllegalStateException("User don't have an Outbox"));
     }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesCreationProcessor.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesCreationProcessor.java
@@ -318,7 +318,7 @@ public class SetMessagesCreationProcessor implements SetMessagesProcessor {
     }
 
     private Optional<MessageManager> getMailboxWithRole(MailboxSession mailboxSession, Role role) throws MailboxException {
-        return systemMailboxesProvider.getMailboxByRole(role, mailboxSession.getUser()).findFirst();
+        return systemMailboxesProvider.getMailboxByRole(role, mailboxSession).findFirst();
     }
     
     private SetError buildSetErrorFromValidationResult(List<ValidationResult> validationErrors) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesUpdateProcessor.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesUpdateProcessor.java
@@ -245,7 +245,7 @@ public class SetMessagesUpdateProcessor implements SetMessagesProcessor {
     }
 
     private List<MailboxId> mailboxIdFor(Role role, MailboxSession session) throws MailboxException {
-        return systemMailboxesProvider.getMailboxByRole(role, session.getUser())
+        return systemMailboxesProvider.getMailboxByRole(role, session)
             .map(MessageManager::getId)
             .collect(Guavate.toImmutableList());
     }
@@ -273,7 +273,7 @@ public class SetMessagesUpdateProcessor implements SetMessagesProcessor {
     }
 
     private Set<MailboxId> listMailboxIdsForRole(MailboxSession session, Role role) throws MailboxException {
-        return systemMailboxesProvider.getMailboxByRole(role, session.getUser())
+        return systemMailboxesProvider.getMailboxByRole(role, session)
             .map(MessageManager::getId)
             .collect(Guavate.toImmutableSet());
     }

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/MessageFastViewProjectionItemFactoryTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/MessageFastViewProjectionItemFactoryTest.java
@@ -52,7 +52,7 @@ class MessageFastViewProjectionItemFactoryTest {
         testee = new MessageFastViewPrecomputedProperties.Factory(
             new Preview.Factory(new MessageContentExtractor(), new JsoupHtmlTextExtractor()));
         mailboxManager = InMemoryIntegrationResources.defaultResources().getMailboxManager();
-        session = mailboxManager.createSystemSession(BOB);
+        session = mailboxManager.createUserSession(BOB);
         MailboxId mailboxId = mailboxManager.createMailbox(MailboxPath.inbox(BOB), session).get();
         mailbox = mailboxManager.getMailbox(mailboxId, session);
     }

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/AccessTokenAuthenticationStrategyTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/AccessTokenAuthenticationStrategyTest.java
@@ -81,7 +81,7 @@ public class AccessTokenAuthenticationStrategyTest {
         Username username = Username.of("123456789");
         MailboxSession fakeMailboxSession = mock(MailboxSession.class);
 
-        when(mockedMailboxManager.createSystemSession(eq(username)))
+        when(mockedMailboxManager.createUserSession(eq(username)))
                 .thenReturn(fakeMailboxSession);
 
         UUID authHeader = UUID.randomUUID();
@@ -100,7 +100,7 @@ public class AccessTokenAuthenticationStrategyTest {
         Username username = Username.of("123456789");
         MailboxSession fakeMailboxSession = mock(MailboxSession.class);
 
-        when(mockedMailboxManager.createSystemSession(eq(username)))
+        when(mockedMailboxManager.createUserSession(eq(username)))
                 .thenReturn(fakeMailboxSession);
 
         UUID authHeader = UUID.randomUUID();

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/DefaultMailboxesProvisioningFilterTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/DefaultMailboxesProvisioningFilterTest.java
@@ -48,7 +48,7 @@ public class DefaultMailboxesProvisioningFilterTest {
 
     @Before
     public void before() throws Exception {
-        session = MailboxSessionUtil.create(USERNAME);
+        session = MailboxSessionUtil.createUserSession(USERNAME);
 
         mailboxManager = InMemoryIntegrationResources.defaultResources().getMailboxManager();
         subscriptionManager = new StoreSubscriptionManager(mailboxManager.getMapperFactory());

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/DefaultMailboxesProvisioningFilterThreadTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/DefaultMailboxesProvisioningFilterThreadTest.java
@@ -51,7 +51,7 @@ public class DefaultMailboxesProvisioningFilterThreadTest {
 
     @Before
     public void before() {
-        session = MailboxSessionUtil.create(USERNAME);
+        session = MailboxSessionUtil.createUserSession(USERNAME);
         mailboxManager = mock(MailboxManager.class);
         subscriptionManager = mock(SubscriptionManager.class);
         sut = new DefaultMailboxesProvisioningFilter(mailboxManager, subscriptionManager, new RecordingMetricFactory());

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/DefaultMailboxesProvisioningFilterThreadTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/DefaultMailboxesProvisioningFilterThreadTest.java
@@ -63,7 +63,7 @@ public class DefaultMailboxesProvisioningFilterThreadTest {
 
         when(mailboxManager.createMailbox(any(MailboxPath.class), eq(session))).thenReturn(Optional.of(TestId.of(18L)));
         when(mailboxManager.mailboxExists(any(MailboxPath.class), eq(session))).thenReturn(false);
-        when(mailboxManager.createSystemSession(USERNAME)).thenReturn(session);
+        when(mailboxManager.createUserSession(USERNAME)).thenReturn(session);
 
         ConcurrentTestRunner
             .builder()

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/DownloadServletTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/DownloadServletTest.java
@@ -41,7 +41,7 @@ public class DownloadServletTest {
 
     @Test
     public void downloadMayFailWhenUnknownErrorOnAttachmentManager() throws Exception {
-        MailboxSession mailboxSession = MailboxSessionUtil.create(Username.of("User"));
+        MailboxSession mailboxSession = MailboxSessionUtil.createUserSession(Username.of("User"));
         BlobManager mockedBlobManager = mock(BlobManager.class);
         when(mockedBlobManager.retrieve(any(), eq(mailboxSession)))
             .thenThrow(new MailboxException());

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/JWTAuthenticationStrategyTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/JWTAuthenticationStrategyTest.java
@@ -79,7 +79,7 @@ public class JWTAuthenticationStrategyTest {
 
         when(stubTokenVerifier.verify(validAuthHeader)).thenReturn(false);
         when(stubTokenVerifier.extractLogin(validAuthHeader)).thenReturn(username);
-        when(mockedMailboxManager.createSystemSession(eq(Username.of(username))))
+        when(mockedMailboxManager.createUserSession(eq(Username.of(username))))
                 .thenReturn(fakeMailboxSession);
         when(mockAuthenticationExtractor.authHeaders(request))
             .thenReturn(Stream.of(fakeAuthHeaderWithPrefix));
@@ -107,7 +107,7 @@ public class JWTAuthenticationStrategyTest {
 
         when(stubTokenVerifier.verify(validAuthHeader)).thenReturn(true);
         when(stubTokenVerifier.extractLogin(validAuthHeader)).thenReturn(username);
-        when(mockedMailboxManager.createSystemSession(eq(Username.of(username))))
+        when(mockedMailboxManager.createUserSession(eq(Username.of(username))))
                 .thenReturn(fakeMailboxSession);
         when(mockAuthenticationExtractor.authHeaders(request))
             .thenReturn(Stream.of(fakeAuthHeaderWithPrefix));
@@ -126,7 +126,7 @@ public class JWTAuthenticationStrategyTest {
 
         when(stubTokenVerifier.verify(validAuthHeader)).thenReturn(true);
         when(stubTokenVerifier.extractLogin(validAuthHeader)).thenReturn(username);
-        when(mockedMailboxManager.createSystemSession(eq(Username.of(username))))
+        when(mockedMailboxManager.createUserSession(eq(Username.of(username))))
                 .thenReturn(fakeMailboxSession);
         when(mockAuthenticationExtractor.authHeaders(request))
             .thenReturn(Stream.of(fakeAuthHeaderWithPrefix));

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/UserProvisioningFilterTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/UserProvisioningFilterTest.java
@@ -77,7 +77,7 @@ public class UserProvisioningFilterTest {
     @Test
     public void filterShouldAddUsernameWhenNoVirtualHostingAndMailboxSessionContainsUsername() throws Exception {
         usersRepository.setEnableVirtualHosting(false);
-        MailboxSession mailboxSession = MailboxSessionUtil.create(USERNAME);
+        MailboxSession mailboxSession = MailboxSessionUtil.createUserSession(USERNAME);
         when(request.getAttribute(AuthenticationFilter.MAILBOX_SESSION))
             .thenReturn(mailboxSession);
 
@@ -91,7 +91,7 @@ public class UserProvisioningFilterTest {
     @Test
     public void filterShouldFailOnInvalidVirtualHosting() {
         usersRepository.setEnableVirtualHosting(false);
-        MailboxSession mailboxSession = MailboxSessionUtil.create(USERNAME_WITH_DOMAIN);
+        MailboxSession mailboxSession = MailboxSessionUtil.createUserSession(USERNAME_WITH_DOMAIN);
         when(request.getAttribute(AuthenticationFilter.MAILBOX_SESSION))
             .thenReturn(mailboxSession);
 
@@ -105,7 +105,7 @@ public class UserProvisioningFilterTest {
         when(usersRepository.isReadOnly()).thenReturn(true);
         sut = new UserProvisioningFilter(usersRepository, new RecordingMetricFactory());
 
-        MailboxSession mailboxSession = MailboxSessionUtil.create(USERNAME_WITH_DOMAIN);
+        MailboxSession mailboxSession = MailboxSessionUtil.createUserSession(USERNAME_WITH_DOMAIN);
         when(request.getAttribute(AuthenticationFilter.MAILBOX_SESSION))
             .thenReturn(mailboxSession);
 
@@ -121,7 +121,7 @@ public class UserProvisioningFilterTest {
         when(usersRepository.isReadOnly()).thenReturn(true);
         sut = new UserProvisioningFilter(usersRepository, new RecordingMetricFactory());
 
-        MailboxSession mailboxSession = MailboxSessionUtil.create(USERNAME_WITH_DOMAIN);
+        MailboxSession mailboxSession = MailboxSessionUtil.createUserSession(USERNAME_WITH_DOMAIN);
         when(request.getAttribute(AuthenticationFilter.MAILBOX_SESSION))
             .thenReturn(mailboxSession);
 

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/UserProvisioningFilterThreadTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/UserProvisioningFilterThreadTest.java
@@ -41,7 +41,7 @@ public class UserProvisioningFilterThreadTest {
     @Before
     public void before() {
         usersRepository = MemoryUsersRepository.withoutVirtualHosting(NO_DOMAIN_LIST);
-        session = MailboxSessionUtil.create(Username.of("username"));
+        session = MailboxSessionUtil.createUserSession(Username.of("username"));
         sut = new UserProvisioningFilter(usersRepository, new RecordingMetricFactory());
     }
 

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/AttachmentCheckerTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/AttachmentCheckerTest.java
@@ -56,7 +56,7 @@ public class AttachmentCheckerTest {
 
     @Before
     public void setUp() {
-        session = MailboxSessionUtil.create(Username.of("Jonhy"));
+        session = MailboxSessionUtil.createUserSession(Username.of("Jonhy"));
         attachmentManager = mock(AttachmentManager.class);
 
         sut = new AttachmentChecker(attachmentManager);

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/GetMailboxesMethodTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/GetMailboxesMethodTest.java
@@ -86,7 +86,7 @@ public class GetMailboxesMethodTest {
         GetMailboxesRequest getMailboxesRequest = GetMailboxesRequest.builder()
                 .build();
 
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
 
         List<JmapResponse> getMailboxesResponse = getMailboxesMethod.process(getMailboxesRequest, methodCallId, mailboxSession).collect(Collectors.toList());
 
@@ -127,7 +127,7 @@ public class GetMailboxesMethodTest {
     @SuppressWarnings("unchecked")
     public void getMailboxesShouldReturnMailboxesWhenAvailable() throws Exception {
         MailboxPath mailboxPath = MailboxPath.forUser(USERNAME, "name");
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         mailboxManager.createMailbox(mailboxPath, mailboxSession);
         MessageManager messageManager = mailboxManager.getMailbox(mailboxPath, mailboxSession);
         messageManager.appendMessage(MessageManager.AppendCommand.from(
@@ -159,8 +159,8 @@ public class GetMailboxesMethodTest {
     public void getMailboxesShouldReturnOnlyMailboxesOfCurrentUserWhenAvailable() throws Exception {
         MailboxPath mailboxPathToReturn = MailboxPath.forUser(USERNAME, "mailboxToReturn");
         MailboxPath mailboxPathtoSkip = MailboxPath.forUser(USERNAME2, "mailboxToSkip");
-        MailboxSession userSession = mailboxManager.createSystemSession(USERNAME);
-        MailboxSession user2Session = mailboxManager.createSystemSession(USERNAME2);
+        MailboxSession userSession = mailboxManager.createUserSession(USERNAME);
+        MailboxSession user2Session = mailboxManager.createUserSession(USERNAME2);
         mailboxManager.createMailbox(mailboxPathToReturn, userSession);
         mailboxManager.createMailbox(mailboxPathtoSkip, user2Session);
 
@@ -181,7 +181,7 @@ public class GetMailboxesMethodTest {
 
     @Test
     public void getMailboxesShouldReturnInboxWithSortOrder10() throws Exception {
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         MailboxPath mailboxPath = MailboxPath.forUser(USERNAME, "INBOX");
         mailboxManager.createMailbox(mailboxPath, mailboxSession);
 
@@ -202,7 +202,7 @@ public class GetMailboxesMethodTest {
 
     @Test
     public void getMailboxesShouldReturnSortOrder1000OnUnknownFolder() throws Exception {
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         MailboxPath mailboxPath = MailboxPath.forUser(USERNAME, "unknown");
         mailboxManager.createMailbox(mailboxPath, mailboxSession);
 
@@ -223,7 +223,7 @@ public class GetMailboxesMethodTest {
 
     @Test
     public void getMailboxesShouldReturnInboxWithSortOrder10OnDifferenceCase() throws Exception {
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         MailboxPath mailboxPath = MailboxPath.forUser(USERNAME, "InBoX");
         mailboxManager.createMailbox(mailboxPath, mailboxSession);
 
@@ -245,7 +245,7 @@ public class GetMailboxesMethodTest {
     @Test
     @SuppressWarnings("unchecked")
     public void getMailboxesShouldReturnMailboxesWithSortOrder() throws Exception {
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         mailboxManager.createMailbox(MailboxPath.inbox(USERNAME), mailboxSession);
         mailboxManager.createMailbox(MailboxPath.forUser(USERNAME, "Archive"), mailboxSession);
         mailboxManager.createMailbox(MailboxPath.forUser(USERNAME, "Drafts"), mailboxSession);
@@ -282,7 +282,7 @@ public class GetMailboxesMethodTest {
     @SuppressWarnings("unchecked")
     public void getMailboxesShouldReturnEmptyMailboxByDefault() throws MailboxException {
         MailboxPath mailboxPath = MailboxPath.forUser(USERNAME, "name");
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         mailboxManager.createMailbox(mailboxPath, mailboxSession);
 
         GetMailboxesRequest getMailboxesRequest = GetMailboxesRequest.builder()
@@ -303,7 +303,7 @@ public class GetMailboxesMethodTest {
     @Test
     public void getMailboxesShouldReturnCorrectTotalMessagesCount() throws Exception {
         MailboxPath mailboxPath = MailboxPath.forUser(USERNAME, "name");
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         mailboxManager.createMailbox(mailboxPath, mailboxSession);
         MessageManager messageManager = mailboxManager.getMailbox(mailboxPath, mailboxSession);
         messageManager.appendMessage(MessageManager.AppendCommand.from(
@@ -333,7 +333,7 @@ public class GetMailboxesMethodTest {
     @Test
     public void getMailboxesShouldReturnCorrectUnreadMessagesCount() throws Exception {
         MailboxPath mailboxPath = MailboxPath.forUser(USERNAME, "name");
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         mailboxManager.createMailbox(mailboxPath, mailboxSession);
         MessageManager messageManager = mailboxManager.getMailbox(mailboxPath, mailboxSession);
         Flags defaultUnseenFlag = new Flags();
@@ -372,7 +372,7 @@ public class GetMailboxesMethodTest {
     @Test
     @SuppressWarnings("unchecked")
     public void getMailboxesShouldReturnMailboxesWithRoles() throws Exception {
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         mailboxManager.createMailbox(MailboxPath.forUser(USERNAME, "INBOX"), mailboxSession);
         mailboxManager.createMailbox(MailboxPath.forUser(USERNAME, "Archive"), mailboxSession);
         mailboxManager.createMailbox(MailboxPath.forUser(USERNAME, "Drafts"), mailboxSession);

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/GetMailboxesMethodTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/GetMailboxesMethodTest.java
@@ -110,7 +110,7 @@ public class GetMailboxesMethodTest {
 
         GetMailboxesRequest getMailboxesRequest = GetMailboxesRequest.builder()
                 .build();
-        MailboxSession session = MailboxSessionUtil.create(USERNAME);
+        MailboxSession session = MailboxSessionUtil.createUserSession(USERNAME);
 
         List<JmapResponse> getMailboxesResponse = testee.process(getMailboxesRequest, methodCallId, session).collect(Collectors.toList());
 

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/GetMessagesMethodTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/GetMessagesMethodTest.java
@@ -115,7 +115,7 @@ public class GetMessagesMethodTest {
         InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultResources();
         mailboxManager = resources.getMailboxManager();
 
-        session = MailboxSessionUtil.create(ROBERT);
+        session = MailboxSessionUtil.createUserSession(ROBERT);
         inboxPath = MailboxPath.inbox(session);
         customMailboxPath = new MailboxPath(inboxPath, "custom");
         mailboxManager.createMailbox(inboxPath, session);

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/SetMessagesCreationProcessorTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/SetMessagesCreationProcessorTest.java
@@ -383,6 +383,11 @@ public class SetMessagesCreationProcessorTest {
         }
 
         @Override
+        public Stream<MessageManager> getMailboxByRole(Role aRole, MailboxSession session) {
+            return getMailboxByRole(aRole, session.getUser());
+        }
+
+        @Override
         public Stream<MessageManager> getMailboxByRole(Role aRole, Username username) {
             if (aRole.equals(Role.OUTBOX)) {
                 return OptionalUtils.toStream(outboxSupplier.get());

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/SetMessagesCreationProcessorTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/SetMessagesCreationProcessorTest.java
@@ -137,7 +137,7 @@ public class SetMessagesCreationProcessorTest {
         MessageIdManager mockMessageIdManager = mock(MessageIdManager.class);
         
         fakeSystemMailboxesProvider = new TestSystemMailboxesProvider(() -> optionalOutbox, () -> optionalDrafts);
-        session = MailboxSessionUtil.create(USER);
+        session = MailboxSessionUtil.createUserSession(USER);
         MIMEMessageConverter mimeMessageConverter = new MIMEMessageConverter();
         messageAppender = new MessageAppender(mockedMailboxManager, mockMessageIdManager, mockedAttachmentManager, mimeMessageConverter);
         messageSender = new MessageSender(mockedMailSpool);

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/JmapMDNTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/JmapMDNTest.java
@@ -57,7 +57,7 @@ public class JmapMDNTest {
         .subject(SUBJECT)
         .textBody(TEXT_BODY)
         .build();
-    public static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.create(Username.of("user@localhost.com"));
+    public static final MailboxSession MAILBOX_SESSION = MailboxSessionUtil.createUserSession(Username.of("user@localhost.com"));
 
     @Test
     public void shouldMatchBeanContract() {

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/message/view/MessageFastViewFactoryTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/message/view/MessageFastViewFactoryTest.java
@@ -113,7 +113,7 @@ class MessageFastViewFactoryTest {
         messageIdManager = spy(resources.getMessageIdManager());
         InMemoryMailboxManager mailboxManager = resources.getMailboxManager();
 
-        session = mailboxManager.createSystemSession(BOB);
+        session = mailboxManager.createUserSession(BOB);
         MailboxId bobInboxId = mailboxManager.createMailbox(MailboxPath.inbox(session), session).get();
 
         bobInbox = mailboxManager.getMailbox(bobInboxId, session);

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/message/view/MessageFullViewFactoryTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/message/view/MessageFullViewFactoryTest.java
@@ -106,7 +106,7 @@ class MessageFullViewFactoryTest {
         messageIdManager = resources.getMessageIdManager();
         InMemoryMailboxManager mailboxManager = resources.getMailboxManager();
 
-        session = mailboxManager.createSystemSession(BOB);
+        session = mailboxManager.createUserSession(BOB);
         MailboxId bobInboxId = mailboxManager.createMailbox(MailboxPath.inbox(session), session).get();
         MailboxId bobMailboxId = mailboxManager.createMailbox(MailboxPath.forUser(BOB, "anotherMailbox"), session).get();
 

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/message/view/MessageHeaderViewFactoryTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/message/view/MessageHeaderViewFactoryTest.java
@@ -64,7 +64,7 @@ class MessageHeaderViewFactoryTest {
         messageIdManager = resources.getMessageIdManager();
         InMemoryMailboxManager mailboxManager = resources.getMailboxManager();
 
-        session = mailboxManager.createSystemSession(BOB);
+        session = mailboxManager.createUserSession(BOB);
         MailboxId bobInboxId = mailboxManager.createMailbox(MailboxPath.inbox(session), session).get();
         MailboxId bobMailboxId = mailboxManager.createMailbox(MailboxPath.forUser(BOB, "anotherMailbox"), session).get();
 

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/message/view/MessageMetadataViewFactoryTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/message/view/MessageMetadataViewFactoryTest.java
@@ -56,7 +56,7 @@ class MessageMetadataViewFactoryTest {
         messageIdManager = resources.getMessageIdManager();
         InMemoryMailboxManager mailboxManager = resources.getMailboxManager();
 
-        session = mailboxManager.createSystemSession(BOB);
+        session = mailboxManager.createUserSession(BOB);
         MailboxId bobInboxId = mailboxManager.createMailbox(MailboxPath.inbox(session), session).get();
         MailboxId bobMailboxId = mailboxManager.createMailbox(MailboxPath.forUser(BOB, "anotherMailbox"), session).get();
 

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/send/PostDequeueDecoratorTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/send/PostDequeueDecoratorTest.java
@@ -110,7 +110,7 @@ public class PostDequeueDecoratorTest {
     
     @Test
     public void doneShouldNotThrowWhenMessageIsNotInOutbox() throws Exception {
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         mailboxManager.createMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
         mailboxManager.createMailbox(SENT_MAILBOX_PATH, mailboxSession);
         MessageManager messageManager = mailboxManager.getMailbox(SENT_MAILBOX_PATH, mailboxSession);
@@ -123,7 +123,7 @@ public class PostDequeueDecoratorTest {
     
     @Test(expected = MailboxRoleNotFoundException.class)
     public void doneShouldThrowWhenSentDoesNotExist() throws Exception {
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         mailboxManager.createMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
         MessageManager messageManager = mailboxManager.getMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
         ComposedMessageId messageId = messageManager.appendMessage(AppendCommand.from(message), mailboxSession);
@@ -135,7 +135,7 @@ public class PostDequeueDecoratorTest {
     
     @Test
     public void doneShouldCopyMailFromOutboxToSentWhenSuccess() throws Exception {
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         mailboxManager.createMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
         mailboxManager.createMailbox(SENT_MAILBOX_PATH, mailboxSession);
         MessageManager messageManager = mailboxManager.getMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
@@ -153,7 +153,7 @@ public class PostDequeueDecoratorTest {
     
     @Test
     public void doneShouldDeleteMailFromOutboxWhenSuccess() throws Exception {
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         mailboxManager.createMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
         mailboxManager.createMailbox(SENT_MAILBOX_PATH, mailboxSession);
         MessageManager messageManager = mailboxManager.getMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
@@ -171,7 +171,7 @@ public class PostDequeueDecoratorTest {
     
     @Test
     public void doneShouldNotMoveMailFromOutboxToSentWhenSuccessIsFalse() throws Exception {
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         mailboxManager.createMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
         mailboxManager.createMailbox(SENT_MAILBOX_PATH, mailboxSession);
         MessageManager messageManager = mailboxManager.getMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
@@ -189,7 +189,7 @@ public class PostDequeueDecoratorTest {
     
     @Test
     public void doneShouldNotMoveMailFromOutboxToSentWhenNoMetadataProvided() throws Exception {
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         mailboxManager.createMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
         mailboxManager.createMailbox(SENT_MAILBOX_PATH, mailboxSession);
         MessageManager messageManager = mailboxManager.getMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
@@ -205,7 +205,7 @@ public class PostDequeueDecoratorTest {
     
     @Test
     public void doneShouldNotMoveMailFromOutboxToSentWhenUsernameNotProvided() throws Exception {
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         mailboxManager.createMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
         mailboxManager.createMailbox(SENT_MAILBOX_PATH, mailboxSession);
         MessageManager messageManager = mailboxManager.getMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
@@ -222,7 +222,7 @@ public class PostDequeueDecoratorTest {
     
     @Test
     public void doneShouldNotMoveMailFromOutboxToSentWhenMessageIdNotProvided() throws Exception {
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         mailboxManager.createMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
         mailboxManager.createMailbox(SENT_MAILBOX_PATH, mailboxSession);
         MessageManager messageManager = mailboxManager.getMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
@@ -239,7 +239,7 @@ public class PostDequeueDecoratorTest {
     
     @Test
     public void doneShouldNotMoveMailFromOutboxToSentWhenInvalidMessageIdProvided() throws Exception {
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         mailboxManager.createMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
         mailboxManager.createMailbox(SENT_MAILBOX_PATH, mailboxSession);
         MessageManager messageManager = mailboxManager.getMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
@@ -261,7 +261,7 @@ public class PostDequeueDecoratorTest {
         testee = new PostDequeueDecorator(mockedMailQueueItem, mailboxManager, new InMemoryMessageId.Factory(),
                 messageIdManager, new SystemMailboxesProviderImpl(mailboxManager));
 
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         mailboxManager.createMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
         MailboxId sentMailboxId = mailboxManager.createMailbox(SENT_MAILBOX_PATH, mailboxSession).get();
         MessageManager messageManager = mailboxManager.getMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
@@ -289,7 +289,7 @@ public class PostDequeueDecoratorTest {
         testee = new PostDequeueDecorator(mockedMailQueueItem, mailboxManager, new InMemoryMessageId.Factory(),
                 messageIdManager, new SystemMailboxesProviderImpl(mailboxManager));
 
-        MailboxSession mailboxSession = mailboxManager.createSystemSession(USERNAME);
+        MailboxSession mailboxSession = mailboxManager.createUserSession(USERNAME);
         mailboxManager.createMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);
         mailboxManager.createMailbox(SENT_MAILBOX_PATH, mailboxSession).get();
         MessageManager messageManager = mailboxManager.getMailbox(OUTBOX_MAILBOX_PATH, mailboxSession);

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/utils/MailboxUtilsTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/utils/MailboxUtilsTest.java
@@ -42,7 +42,7 @@ public class MailboxUtilsTest {
     public void setup() throws Exception {
         mailboxManager = InMemoryIntegrationResources.defaultResources().getMailboxManager();
         user = Username.of("user@domain.org");
-        mailboxSession = mailboxManager.createSystemSession(user);
+        mailboxSession = mailboxManager.createUserSession(user);
         sut = new MailboxUtils(mailboxManager);
     }
     

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/event/ComputeMessageFastViewProjectionListenerTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/event/ComputeMessageFastViewProjectionListenerTest.java
@@ -134,7 +134,7 @@ class ComputeMessageFastViewProjectionListenerTest {
 
         resources.getEventBus().register(listener);
 
-        mailboxSession = MailboxSessionUtil.create(BOB);
+        mailboxSession = MailboxSessionUtil.createUserSession(BOB);
 
         MailboxId inboxId = mailboxManager.createMailbox(BOB_INBOX_PATH, mailboxSession).get();
         inboxMessageManager = mailboxManager.getMailbox(inboxId, mailboxSession);

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/event/PropagateLookupRightListenerTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/event/PropagateLookupRightListenerTest.java
@@ -60,7 +60,7 @@ public class PropagateLookupRightListenerTest {
     private StoreMailboxManager storeMailboxManager;
     private PropagateLookupRightListener testee;
 
-    private MailboxSession mailboxSession = MailboxSessionUtil.create(OWNER_USER);
+    private MailboxSession mailboxSession = MailboxSessionUtil.createUserSession(OWNER_USER);
 
     private MailboxId parentMailboxId;
     private MailboxId parentMailboxId1;

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/mailet/filter/JMAPFilteringExtension.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/mailet/filter/JMAPFilteringExtension.java
@@ -92,7 +92,7 @@ public class JMAPFilteringExtension implements BeforeEachCallback, ParameterReso
         }
 
         public MailboxId createMailbox(Username username, String mailboxName) throws Exception {
-            MailboxSession mailboxSession = mailboxManager.createSystemSession(username);
+            MailboxSession mailboxSession = mailboxManager.createUserSession(username);
             return mailboxManager
                 .createMailbox(MailboxPath.forUser(username, mailboxName), mailboxSession)
                 .orElseThrow(() -> new RuntimeException("Missing mailboxId when creating mailbox"));

--- a/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/RecomputeAllFastViewProjectionItemsRequestToTaskTest.java
+++ b/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/RecomputeAllFastViewProjectionItemsRequestToTaskTest.java
@@ -240,7 +240,7 @@ class RecomputeAllFastViewProjectionItemsRequestToTaskTest {
     @Test
     void recomputeAllShouldCompleteWhenUserWithNoMessage() throws Exception {
         usersRepository.addUser(BOB, "pass");
-        mailboxManager.createMailbox(MailboxPath.inbox(BOB), mailboxManager.createSystemSession(BOB));
+        mailboxManager.createMailbox(MailboxPath.inbox(BOB), mailboxManager.createUserSession(BOB));
 
         String taskId = with()
             .queryParam("action", "recomputeFastViewProjectionItems")
@@ -268,7 +268,7 @@ class RecomputeAllFastViewProjectionItemsRequestToTaskTest {
     @Test
     void recomputeAllShouldCompleteWhenOneMessage() throws Exception {
         usersRepository.addUser(BOB, "pass");
-        MailboxSession session = mailboxManager.createSystemSession(BOB);
+        MailboxSession session = mailboxManager.createUserSession(BOB);
         Optional<MailboxId> mailboxId = mailboxManager.createMailbox(MailboxPath.inbox(BOB), session);
         mailboxManager.getMailbox(mailboxId.get(), session).appendMessage(
             MessageManager.AppendCommand.builder().build("header: value\r\n\r\nbody"),
@@ -300,7 +300,7 @@ class RecomputeAllFastViewProjectionItemsRequestToTaskTest {
     @Test
     void recomputeAllShouldUpdateProjection() throws Exception {
         usersRepository.addUser(BOB, "pass");
-        MailboxSession session = mailboxManager.createSystemSession(BOB);
+        MailboxSession session = mailboxManager.createUserSession(BOB);
         Optional<MailboxId> mailboxId = mailboxManager.createMailbox(MailboxPath.inbox(BOB), session);
         ComposedMessageId messageId = mailboxManager.getMailbox(mailboxId.get(), session).appendMessage(
             MessageManager.AppendCommand.builder().build("header: value\r\n\r\nbody"),
@@ -323,7 +323,7 @@ class RecomputeAllFastViewProjectionItemsRequestToTaskTest {
     @Test
     void recomputeAllShouldBeIdempotent() throws Exception {
         usersRepository.addUser(BOB, "pass");
-        MailboxSession session = mailboxManager.createSystemSession(BOB);
+        MailboxSession session = mailboxManager.createUserSession(BOB);
         Optional<MailboxId> mailboxId = mailboxManager.createMailbox(MailboxPath.inbox(BOB), session);
         ComposedMessageId messageId = mailboxManager.getMailbox(mailboxId.get(), session).appendMessage(
             MessageManager.AppendCommand.builder().build("header: value\r\n\r\nbody"),

--- a/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/RecomputeUserFastViewProjectionItemsRequestToTaskTest.java
+++ b/server/protocols/webadmin/webadmin-jmap/src/test/java/org/apache/james/webadmin/data/jmap/RecomputeUserFastViewProjectionItemsRequestToTaskTest.java
@@ -124,7 +124,7 @@ class RecomputeUserFastViewProjectionItemsRequestToTaskTest {
         mailboxManager = InMemoryIntegrationResources.defaultResources().getMailboxManager();
         usersRepository = MemoryUsersRepository.withoutVirtualHosting(NO_DOMAIN_LIST);
         usersRepository.addUser(BOB, "pass");
-        bobSession = mailboxManager.createSystemSession(BOB);
+        bobSession = mailboxManager.createUserSession(BOB);
         bobInboxboxId = mailboxManager.createMailbox(MailboxPath.inbox(BOB), bobSession)
             .get();
 
@@ -340,7 +340,7 @@ class RecomputeUserFastViewProjectionItemsRequestToTaskTest {
             bobSession);
 
         usersRepository.addUser(CEDRIC, "pass");
-        MailboxSession cedricSession = mailboxManager.createSystemSession(CEDRIC);
+        MailboxSession cedricSession = mailboxManager.createUserSession(CEDRIC);
         Optional<MailboxId> mailboxIdCedric = mailboxManager.createMailbox(MailboxPath.inbox(CEDRIC), cedricSession);
         mailboxManager.getMailbox(mailboxIdCedric.get(), cedricSession).appendMessage(
             MessageManager.AppendCommand.builder().build("header: value\r\n\r\nbody"),

--- a/server/protocols/webadmin/webadmin-mailbox-deleted-message-vault/src/test/java/org/apache/james/webadmin/vault/routes/DeletedMessagesVaultRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox-deleted-message-vault/src/test/java/org/apache/james/webadmin/vault/routes/DeletedMessagesVaultRoutesTest.java
@@ -1696,7 +1696,7 @@ class DeletedMessagesVaultRoutesTest {
 
         @Test
         void restoreShouldNotDeleteExistingMessagesInTheUserMailbox() throws Exception {
-            MailboxSession session = mailboxManager.createSystemSession(USERNAME);
+            MailboxSession session = mailboxManager.createUserSession(USERNAME);
             MailboxPath restoreMailboxPath = MailboxPath.forUser(USERNAME, DefaultMailboxes.RESTORED_MESSAGES);
             mailboxManager.createMailbox(restoreMailboxPath, session);
             MessageManager messageManager = mailboxManager.getMailbox(restoreMailboxPath, session);
@@ -2260,7 +2260,7 @@ class DeletedMessagesVaultRoutesTest {
     }
 
     private boolean hasAnyMail(Username username) throws MailboxException {
-        MailboxSession session = mailboxManager.createSystemSession(username);
+        MailboxSession session = mailboxManager.createUserSession(username);
         int limitToOneMessage = 1;
 
         return !mailboxManager.search(MultimailboxesSearchQuery.from(new SearchQuery()).build(), session, limitToOneMessage)
@@ -2281,7 +2281,7 @@ class DeletedMessagesVaultRoutesTest {
     }
 
     private List<MessageResult> restoreMailboxMessages(Username username) throws Exception {
-        MailboxSession session = mailboxManager.createSystemSession(username);
+        MailboxSession session = mailboxManager.createUserSession(username);
         MessageManager messageManager = mailboxManager.getMailbox(MailboxPath.forUser(username, DefaultMailboxes.RESTORED_MESSAGES), session);
         return ImmutableList.copyOf(messageManager.getMessages(MessageRange.all(), FetchGroup.MINIMAL, session));
     }

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MailboxesRoutesTest.java
@@ -173,7 +173,7 @@ class MailboxesRoutesTest {
 
             @Test
             void fullReprocessingShouldReturnTaskDetailsWhenMail() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 mailboxManager.createMailbox(INBOX, systemSession).get();
                 mailboxManager.getMailbox(INBOX, systemSession)
                     .appendMessage(
@@ -202,7 +202,7 @@ class MailboxesRoutesTest {
 
             @Test
             void fullReprocessingShouldReturnTaskDetailsWhenFailing() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
                 ComposedMessageId composedMessageId = mailboxManager.getMailbox(INBOX, systemSession)
                     .appendMessage(
@@ -239,7 +239,7 @@ class MailboxesRoutesTest {
         class SideEffects {
             @Test
             void fullReprocessingShouldPerformReprocessingWhenMail() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
                 ComposedMessageId createdMessage = mailboxManager.getMailbox(INBOX, systemSession)
                     .appendMessage(
@@ -280,7 +280,7 @@ class MailboxesRoutesTest {
         class Validation {
             @Test
             void mailboxReprocessingShouldFailWithNoTask() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
 
                 when()
@@ -295,7 +295,7 @@ class MailboxesRoutesTest {
 
             @Test
             void mailboxReprocessingShouldFailWithBadTask() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
 
                 when()
@@ -335,7 +335,7 @@ class MailboxesRoutesTest {
         class TaskDetails {
             @Test
             void mailboxReprocessingShouldNotFailWhenNoMail() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
 
                 String taskId = when()
@@ -361,7 +361,7 @@ class MailboxesRoutesTest {
 
             @Test
             void mailboxReprocessingShouldReturnTaskDetailsWhenMail() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
                 mailboxManager.getMailbox(INBOX, systemSession)
                     .appendMessage(
@@ -390,7 +390,7 @@ class MailboxesRoutesTest {
 
             @Test
             void mailboxReprocessingShouldReturnTaskDetailsWhenFailing() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
                 ComposedMessageId composedMessageId = mailboxManager.getMailbox(INBOX, systemSession)
                     .appendMessage(
@@ -428,7 +428,7 @@ class MailboxesRoutesTest {
         class SideEffects {
             @Test
             void mailboxReprocessingShouldPerformReprocessingWhenMail() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
                 ComposedMessageId createdMessage = mailboxManager.getMailbox(INBOX, systemSession)
                     .appendMessage(
@@ -470,7 +470,7 @@ class MailboxesRoutesTest {
         class Validation {
             @Test
             void messageReprocessingShouldFailWithNoTask() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
 
                 when()
@@ -485,7 +485,7 @@ class MailboxesRoutesTest {
 
             @Test
             void messageReprocessingShouldFailWithBadTask() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
 
                 when()
@@ -536,7 +536,7 @@ class MailboxesRoutesTest {
         class TaskDetails {
             @Test
             void messageReprocessingShouldNotFailWhenUidNotFound() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
 
                 String taskId = when()
@@ -561,7 +561,7 @@ class MailboxesRoutesTest {
 
             @Test
             void messageReprocessingShouldReturnTaskDetailsWhenMail() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
                 ComposedMessageId composedMessageId = mailboxManager.getMailbox(INBOX, systemSession)
                     .appendMessage(
@@ -594,7 +594,7 @@ class MailboxesRoutesTest {
         class SideEffects {
             @Test
             void mailboxReprocessingShouldPerformReprocessingWhenMail() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
                 ComposedMessageId createdMessage = mailboxManager.getMailbox(INBOX, systemSession)
                     .appendMessage(
@@ -732,7 +732,7 @@ class MailboxesRoutesTest {
 
             @Test
             void fixingReIndexingShouldReturnTaskDetailsWhenMail() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 mailboxManager.createMailbox(INBOX, systemSession).get();
                 mailboxManager.getMailbox(INBOX, systemSession)
                     .appendMessage(
@@ -776,7 +776,7 @@ class MailboxesRoutesTest {
 
             @Test
             void mailboxReprocessingShouldReturnTaskDetailsWhenFailing() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
                 ComposedMessageId composedMessageId = mailboxManager.getMailbox(INBOX, systemSession)
                     .appendMessage(
@@ -824,7 +824,7 @@ class MailboxesRoutesTest {
         class SideEffects {
             @Test
             void fixingReprocessingShouldPerformReprocessingWhenMail() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
                 ComposedMessageId createdMessage = mailboxManager.getMailbox(INBOX, systemSession)
                     .appendMessage(

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MessageRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MessageRoutesTest.java
@@ -161,7 +161,7 @@ class MessageRoutesTest {
 
             @Test
             void messageIdReprocessingShouldReturnTaskDetailsWhenMail() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 mailboxManager.createMailbox(INBOX, systemSession).get();
                 ComposedMessageId composedMessageId = mailboxManager.getMailbox(INBOX, systemSession)
                     .appendMessage(
@@ -192,7 +192,7 @@ class MessageRoutesTest {
         class SideEffects {
             @Test
             void messageIdReprocessingShouldPerformReprocessingWhenMail() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 mailboxManager.createMailbox(INBOX, systemSession).get();
                 ComposedMessageId composedMessageId = mailboxManager.getMailbox(INBOX, systemSession)
                     .appendMessage(

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -780,7 +780,7 @@ class UserMailboxesRoutesTest {
         @BeforeEach
         void setUp() throws Exception {
             mailboxManager = mock(MailboxManager.class);
-            when(mailboxManager.createUserSession(any())).thenReturn(MailboxSessionUtil.create(USERNAME));
+            when(mailboxManager.createSystemSession(any())).thenReturn(MailboxSessionUtil.createUserSession(USERNAME));
 
             createServer(mailboxManager, mock(MailboxSessionMapperFactory.class));
         }

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -780,7 +780,7 @@ class UserMailboxesRoutesTest {
         @BeforeEach
         void setUp() throws Exception {
             mailboxManager = mock(MailboxManager.class);
-            when(mailboxManager.createSystemSession(any())).thenReturn(MailboxSessionUtil.create(USERNAME));
+            when(mailboxManager.createUserSession(any())).thenReturn(MailboxSessionUtil.create(USERNAME));
 
             createServer(mailboxManager, mock(MailboxSessionMapperFactory.class));
         }
@@ -1120,7 +1120,7 @@ class UserMailboxesRoutesTest {
 
             @Test
             void userReprocessingShouldReturnTaskDetailsWhenMail() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 mailboxManager.createMailbox(INBOX, systemSession).get();
                 mailboxManager.getMailbox(INBOX, systemSession)
                     .appendMessage(
@@ -1152,7 +1152,7 @@ class UserMailboxesRoutesTest {
 
             @Test
             void userReprocessingShouldReturnTaskDetailsWhenFailing() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
                 ComposedMessageId composedMessageId = mailboxManager.getMailbox(INBOX, systemSession)
                     .appendMessage(
@@ -1190,7 +1190,7 @@ class UserMailboxesRoutesTest {
         class SideEffects {
             @Test
             void userReprocessingShouldPerformReprocessingWhenMail() throws Exception {
-                MailboxSession systemSession = mailboxManager.createSystemSession(USERNAME);
+                MailboxSession systemSession = mailboxManager.createUserSession(USERNAME);
                 MailboxId mailboxId = mailboxManager.createMailbox(INBOX, systemSession).get();
                 ComposedMessageId createdMessage = mailboxManager.getMailbox(INBOX, systemSession)
                     .appendMessage(

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserQuotaRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserQuotaRoutesTest.java
@@ -436,7 +436,7 @@ class UserQuotaRoutesTest {
 
         default void appendMessage(QuotaSearchTestSystem testSystem, Username username, MessageManager.AppendCommand appendCommand) throws MailboxException {
             MailboxManager mailboxManager = testSystem.getMailboxManager();
-            MailboxSession session = mailboxManager.createSystemSession(username);
+            MailboxSession session = mailboxManager.createUserSession(username);
 
             MailboxPath mailboxPath = MailboxPath.inbox(username);
             mailboxManager.createMailbox(mailboxPath, session);


### PR DESCRIPTION
A refactoring of the session usage, regarding the discussion in https://github.com/linagora/james-project/pull/3035#discussion_r363684700

Note: At the end, I did an attempt to refactor the `ReIndexerPerformer` to not use the `Mapper`, but didn't succeed. The problem being that the `ListeningMessageSearchIndex` is expecting `MailboxMessage` , returned by the `Mapper`, while a `MessageManager` returns a `MessageResult`. Starting to dig into this for a change sounds too time consuming and painful.

However, we agreed with @chibenwa that it was ok to let it like this for now, as `ReIndexerPerformer` is part of the `mailbox-tools-indexer` module, which makes it then a mailbox module?

But this change should allow us to not use the mapper in `MessageFastViewProjectionCorrector`, so it's still a necessary one.