### PR TITLE
JAMES-2993 missing tests in MailboxManager and fix access issue in getMailbox by path 

### DIFF
--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -85,6 +85,7 @@ import org.apache.james.util.concurrency.ConcurrentTestRunner;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -1567,7 +1568,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        void renameMailboxShouldThrowWhenMailboxPathDoesNotBelongToUser() throws Exception {
+        void renameMailboxShouldThrowWhenMailboxPathsDoNotBelongToUser() throws Exception {
             MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
             MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
 
@@ -1580,7 +1581,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        void renameMailboxByIdShouldThrowWhenMailboxPathDoesNotBelongToUser() throws Exception {
+        void renameMailboxByIdShouldThrowWhenMailboxPathsDoNotBelongToUser() throws Exception {
             MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
             MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
 
@@ -1589,6 +1590,58 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             Optional<MailboxId> mailboxId = mailboxManager.createMailbox(mailboxPath1, sessionUser1);
 
             assertThatThrownBy(() -> mailboxManager.renameMailbox(mailboxId.get(), mailboxPath2, sessionUser2))
+                .isInstanceOf(MailboxNotFoundException.class);
+        }
+
+        @Test
+        void renameMailboxShouldThrowWhenFromMailboxPathDoesNotBelongToUser() throws Exception {
+            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+
+            MailboxPath mailboxPath1 = MailboxPath.forUser(USER_1, "mbx1");
+            MailboxPath mailboxPath2 = MailboxPath.forUser(USER_2, "mbx2");
+            mailboxManager.createMailbox(mailboxPath1, sessionUser1);
+
+            assertThatThrownBy(() -> mailboxManager.renameMailbox(mailboxPath1, mailboxPath2, sessionUser2))
+                .isInstanceOf(MailboxNotFoundException.class);
+        }
+
+        @Test
+        void renameMailboxByIdShouldThrowWhenFromMailboxPathDoesNotBelongToUser() throws Exception {
+            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+
+            MailboxPath mailboxPath1 = MailboxPath.forUser(USER_1, "mbx1");
+            MailboxPath mailboxPath2 = MailboxPath.forUser(USER_2, "mbx2");
+            Optional<MailboxId> mailboxId = mailboxManager.createMailbox(mailboxPath1, sessionUser1);
+
+            assertThatThrownBy(() -> mailboxManager.renameMailbox(mailboxId.get(), mailboxPath2, sessionUser2))
+                .isInstanceOf(MailboxNotFoundException.class);
+        }
+
+        @Test
+        @Disabled("JAMES-2933 renameMailbox does not assert that user is the owner of destination mailbox")
+        void renameMailboxShouldThrowWhenToMailboxPathDoesNotBelongToUser() throws Exception {
+            session = mailboxManager.createSystemSession(USER_1);
+
+            MailboxPath mailboxPath1 = MailboxPath.forUser(USER_1, "mbx1");
+            MailboxPath mailboxPath2 = MailboxPath.forUser(USER_2, "mbx2");
+            mailboxManager.createMailbox(mailboxPath1, session);
+
+            assertThatThrownBy(() -> mailboxManager.renameMailbox(mailboxPath1, mailboxPath2, session))
+                .isInstanceOf(MailboxNotFoundException.class);
+        }
+
+        @Test
+        @Disabled("JAMES-2933 renameMailbox does not assert that user is the owner of destination mailbox")
+        void renameMailboxByIdShouldThrowWhenToMailboxPathDoesNotBelongToUser() throws Exception {
+            session = mailboxManager.createSystemSession(USER_1);
+
+            MailboxPath mailboxPath1 = MailboxPath.forUser(USER_1, "mbx1");
+            MailboxPath mailboxPath2 = MailboxPath.forUser(USER_2, "mbx2");
+            Optional<MailboxId> mailboxId = mailboxManager.createMailbox(mailboxPath1, session);
+
+            assertThatThrownBy(() -> mailboxManager.renameMailbox(mailboxId.get(), mailboxPath2, session))
                 .isInstanceOf(MailboxNotFoundException.class);
         }
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -85,7 +85,6 @@ import org.apache.james.util.concurrency.ConcurrentTestRunner;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -1620,7 +1619,6 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        @Disabled("JAMES-2933 renameMailbox does not assert that user is the owner of destination mailbox")
         void renameMailboxShouldThrowWhenToMailboxPathDoesNotBelongToUser() throws Exception {
             session = mailboxManager.createSystemSession(USER_1);
 
@@ -1633,7 +1631,6 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        @Disabled("JAMES-2933 renameMailbox does not assert that user is the owner of destination mailbox")
         void renameMailboxByIdShouldThrowWhenToMailboxPathDoesNotBelongToUser() throws Exception {
             session = mailboxManager.createSystemSession(USER_1);
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -83,6 +83,7 @@ import org.apache.james.util.concurrency.ConcurrentTestRunner;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -1565,6 +1566,32 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
+        void renameMailboxShouldThrowWhenMailboxPathDoesNotBelongToUser() throws Exception {
+            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+
+            MailboxPath mailboxPath1 = MailboxPath.forUser(USER_1, "mbx1");
+            MailboxPath mailboxPath2 = MailboxPath.forUser(USER_1, "mbx2");
+            mailboxManager.createMailbox(mailboxPath1, sessionUser1);
+
+            assertThatThrownBy(() -> mailboxManager.renameMailbox(mailboxPath1, mailboxPath2, sessionUser2))
+                .isInstanceOf(MailboxException.class);
+        }
+
+        @Test
+        void renameMailboxByIdShouldThrowWhenMailboxPathDoesNotBelongToUser() throws Exception {
+            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+
+            MailboxPath mailboxPath1 = MailboxPath.forUser(USER_1, "mbx1");
+            MailboxPath mailboxPath2 = MailboxPath.forUser(USER_1, "mbx2");
+            Optional<MailboxId> mailboxId = mailboxManager.createMailbox(mailboxPath1, sessionUser1);
+
+            assertThatThrownBy(() -> mailboxManager.renameMailbox(mailboxId.get(), mailboxPath2, sessionUser2))
+                .isInstanceOf(MailboxException.class);
+        }
+
+        @Test
         void user1ShouldNotBeAbleToCreateInboxTwice() throws Exception {
             session = mailboxManager.createSystemSession(USER_1);
             mailboxManager.startProcessingRequest(session);
@@ -1633,6 +1660,31 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
+        void user2ShouldNotBeAbleToDeleteUser1Mailbox() throws Exception {
+            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+
+            MailboxPath inbox = MailboxPath.inbox(sessionUser1);
+            mailboxManager.createMailbox(inbox, sessionUser1);
+
+            assertThatThrownBy(() -> mailboxManager.deleteMailbox(inbox, sessionUser2))
+                .isInstanceOf(MailboxException.class);
+        }
+
+
+        @Test
+        void user2ShouldNotBeAbleToDeleteUser1MailboxById() throws Exception {
+            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+
+            MailboxPath inbox = MailboxPath.inbox(sessionUser1);
+            MailboxId inboxId = mailboxManager.createMailbox(inbox, sessionUser1).get();
+
+            assertThatThrownBy(() -> mailboxManager.deleteMailbox(inboxId, sessionUser2))
+                .isInstanceOf(MailboxException.class);
+        }
+
+        @Test
         void user1ShouldBeAbleToDeleteSubmailbox() throws Exception {
             session = mailboxManager.createSystemSession(USER_1);
             mailboxManager.startProcessingRequest(session);
@@ -1675,6 +1727,14 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
+        void listShouldReturnEmptyListWhenNoMailboxes() throws Exception {
+            session = mailboxManager.createSystemSession(Username.of("manager"));
+
+            assertThat(mailboxManager.list(session))
+                .isEmpty();
+        }
+
+        @Test
         void user2ShouldBeAbleToCreateRootlessFolder() throws MailboxException {
             session = mailboxManager.createSystemSession(USER_2);
             MailboxPath trash = MailboxPath.forUser(USER_2, "Trash");
@@ -1706,6 +1766,119 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
+        void moveMessagesShouldMoveAllMessagesFromOneMailboxToAnOtherOfASameUser() throws Exception {
+            session = mailboxManager.createSystemSession(USER_1);
+
+            MailboxPath inbox = MailboxPath.inbox(session);
+            MailboxId inboxId = mailboxManager.createMailbox(inbox, session).get();
+
+            MailboxPath otherMailbox = MailboxPath.forUser(USER_1, "otherMailbox");
+            MailboxId otherMailboxId = mailboxManager.createMailbox(otherMailbox, session).get();
+
+            MessageManager inboxMessageManager = mailboxManager.getMailbox(inboxId, session);
+
+            MessageId messageId1 = inboxMessageManager
+                .appendMessage(AppendCommand.from(message), session)
+                .getMessageId();
+            MessageId messageId2 = inboxMessageManager
+                .appendMessage(AppendCommand.from(message), session)
+                .getMessageId();
+
+            mailboxManager.moveMessages(MessageRange.all(), inbox, otherMailbox, session);
+
+            MultimailboxesSearchQuery inboxQuery = MultimailboxesSearchQuery
+                .from(new SearchQuery())
+                .inMailboxes(inboxId)
+                .build();
+
+            MultimailboxesSearchQuery otherMailboxQuery = MultimailboxesSearchQuery
+                .from(new SearchQuery())
+                .inMailboxes(otherMailboxId)
+                .build();
+
+            assertThat(mailboxManager.search(inboxQuery, session, DEFAULT_MAXIMUM_LIMIT))
+                .isEmpty();
+            assertThat(mailboxManager.search(otherMailboxQuery, session, DEFAULT_MAXIMUM_LIMIT))
+                .containsExactly(messageId1, messageId2);
+        }
+
+        @Test
+        void moveMessagesShouldMoveOnlyOneMessageFromOneMailboxToAnOtherOfASameUser() throws Exception {
+            session = mailboxManager.createSystemSession(USER_1);
+
+            MailboxPath inbox = MailboxPath.inbox(session);
+            MailboxId inboxId = mailboxManager.createMailbox(inbox, session).get();
+
+            MailboxPath otherMailbox = MailboxPath.forUser(USER_1, "otherMailbox");
+            MailboxId otherMailboxId = mailboxManager.createMailbox(otherMailbox, session).get();
+
+            MessageManager inboxMessageManager = mailboxManager.getMailbox(inboxId, session);
+
+            ComposedMessageId composedMessageId1 = inboxMessageManager
+                .appendMessage(AppendCommand.from(message), session);
+            MessageId messageId2 = inboxMessageManager
+                .appendMessage(AppendCommand.from(message), session)
+                .getMessageId();
+
+            mailboxManager.moveMessages(MessageRange.one(composedMessageId1.getUid()), inbox, otherMailbox, session);
+
+            MultimailboxesSearchQuery inboxQuery = MultimailboxesSearchQuery
+                .from(new SearchQuery())
+                .inMailboxes(inboxId)
+                .build();
+
+            MultimailboxesSearchQuery otherMailboxQuery = MultimailboxesSearchQuery
+                .from(new SearchQuery())
+                .inMailboxes(otherMailboxId)
+                .build();
+
+            assertThat(mailboxManager.search(inboxQuery, session, DEFAULT_MAXIMUM_LIMIT))
+                .containsExactly(messageId2);
+            assertThat(mailboxManager.search(otherMailboxQuery, session, DEFAULT_MAXIMUM_LIMIT))
+                .containsExactly(composedMessageId1.getMessageId());
+        }
+
+        @Test
+        void moveMessagesShouldThrowWhenMovingMessageFromMailboxNotBelongingToSameUser() throws Exception {
+            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+
+            MailboxPath inbox1 = MailboxPath.inbox(sessionUser1);
+            mailboxManager.createMailbox(inbox1, sessionUser1);
+
+            MailboxPath inbox2 = MailboxPath.inbox(sessionUser2);
+            mailboxManager.createMailbox(inbox2, sessionUser2);
+
+            MessageManager inboxMessageManager = mailboxManager.getMailbox(inbox1, sessionUser1);
+
+            inboxMessageManager
+                .appendMessage(AppendCommand.from(message), sessionUser1);
+
+            assertThatThrownBy(() -> mailboxManager.moveMessages(MessageRange.all(), inbox1, inbox2, sessionUser2))
+                .isInstanceOf(MailboxException.class);
+        }
+
+        @Test
+        void moveMessagesShouldThrowWhenMovingMessageToMailboxNotBelongingToSameUser() throws Exception {
+            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+
+            MailboxPath inbox1 = MailboxPath.inbox(sessionUser1);
+            mailboxManager.createMailbox(inbox1, sessionUser1);
+
+            MailboxPath inbox2 = MailboxPath.inbox(sessionUser2);
+            mailboxManager.createMailbox(inbox2, sessionUser2);
+
+            MessageManager inboxMessageManager = mailboxManager.getMailbox(inbox1, sessionUser1);
+
+            inboxMessageManager
+                .appendMessage(AppendCommand.from(message), sessionUser1);
+
+            assertThatThrownBy(() -> mailboxManager.moveMessages(MessageRange.all(), inbox1, inbox2, sessionUser1))
+                .isInstanceOf(MailboxException.class);
+        }
+
+        @Test
         void copyMessagesShouldNotThrowWhenMovingAllMessagesOfAnEmptyMailbox() throws Exception {
             session = mailboxManager.createSystemSession(USER_1);
 
@@ -1714,6 +1887,123 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
             assertThatCode(() -> mailboxManager.copyMessages(MessageRange.all(), inbox, inbox, session))
                 .doesNotThrowAnyException();
+        }
+
+        @Test
+        void copyMessagesShouldCopyAllMessagesFromOneMailboxToAnOtherOfASameUser() throws Exception {
+            session = mailboxManager.createSystemSession(USER_1);
+
+            MailboxPath inbox = MailboxPath.inbox(session);
+            MailboxId inboxId = mailboxManager.createMailbox(inbox, session).get();
+
+            MailboxPath otherMailbox = MailboxPath.forUser(USER_1, "otherMailbox");
+            MailboxId otherMailboxId = mailboxManager.createMailbox(otherMailbox, session).get();
+
+            MessageManager inboxMessageManager = mailboxManager.getMailbox(inboxId, session);
+
+            MessageId messageId1 = inboxMessageManager
+                .appendMessage(AppendCommand.from(message), session)
+                .getMessageId();
+            MessageId messageId2 = inboxMessageManager
+                .appendMessage(AppendCommand.from(message), session)
+                .getMessageId();
+
+            mailboxManager.copyMessages(MessageRange.all(), inbox, otherMailbox, session);
+
+            MultimailboxesSearchQuery inboxQuery = MultimailboxesSearchQuery
+                .from(new SearchQuery())
+                .inMailboxes(inboxId)
+                .build();
+
+            MultimailboxesSearchQuery otherMailboxQuery = MultimailboxesSearchQuery
+                .from(new SearchQuery())
+                .inMailboxes(otherMailboxId)
+                .build();
+
+            assertThat(mailboxManager.search(inboxQuery, session, DEFAULT_MAXIMUM_LIMIT))
+                .containsExactly(messageId1, messageId2);
+            assertThat(mailboxManager.search(otherMailboxQuery, session, DEFAULT_MAXIMUM_LIMIT))
+                .containsExactly(messageId1, messageId2);
+        }
+
+        @Test
+        void copyMessagesShouldCopyOnlyOneMessageFromOneMailboxToAnOtherOfASameUser() throws Exception {
+            session = mailboxManager.createSystemSession(USER_1);
+
+            MailboxPath inbox = MailboxPath.inbox(session);
+            MailboxId inboxId = mailboxManager.createMailbox(inbox, session).get();
+
+            MailboxPath otherMailbox = MailboxPath.forUser(USER_1, "otherMailbox");
+            MailboxId otherMailboxId = mailboxManager.createMailbox(otherMailbox, session).get();
+
+            MessageManager inboxMessageManager = mailboxManager.getMailbox(inboxId, session);
+
+            ComposedMessageId composedMessageId1 = inboxMessageManager
+                .appendMessage(AppendCommand.from(message), session);
+            MessageId messageId2 = inboxMessageManager
+                .appendMessage(AppendCommand.from(message), session)
+                .getMessageId();
+
+            MessageId messageId1 = composedMessageId1.getMessageId();
+
+            mailboxManager.copyMessages(MessageRange.one(composedMessageId1.getUid()), inbox, otherMailbox, session);
+
+            MultimailboxesSearchQuery inboxQuery = MultimailboxesSearchQuery
+                .from(new SearchQuery())
+                .inMailboxes(inboxId)
+                .build();
+
+            MultimailboxesSearchQuery otherMailboxQuery = MultimailboxesSearchQuery
+                .from(new SearchQuery())
+                .inMailboxes(otherMailboxId)
+                .build();
+
+            assertThat(mailboxManager.search(inboxQuery, session, DEFAULT_MAXIMUM_LIMIT))
+                .containsExactly(messageId1, messageId2);
+            assertThat(mailboxManager.search(otherMailboxQuery, session, DEFAULT_MAXIMUM_LIMIT))
+                .containsExactly(messageId1);
+        }
+
+        @Test
+        @Disabled("JAMES-2993 It seems that getMailbox by path in MailboxManager does not check that the mailbox belongs to user, "
+                + "compared to getMailbox by id that actually does assert it")
+        void copyMessagesShouldThrowWhenCopyingMessageFromMailboxNotBelongingToSameUser() throws Exception {
+            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+
+            MailboxPath inbox1 = MailboxPath.inbox(sessionUser1);
+            mailboxManager.createMailbox(inbox1, sessionUser1);
+
+            MailboxPath inbox2 = MailboxPath.inbox(sessionUser2);
+            mailboxManager.createMailbox(inbox2, sessionUser2);
+
+            MessageManager inboxMessageManager = mailboxManager.getMailbox(inbox1, sessionUser1);
+
+            inboxMessageManager
+                .appendMessage(AppendCommand.from(message), sessionUser1);
+
+            assertThatThrownBy(() -> mailboxManager.copyMessages(MessageRange.all(), inbox1, inbox2, sessionUser2))
+                .isInstanceOf(MailboxException.class);
+        }
+
+        @Test
+        void copyMessagesShouldThrowWhenCopyingMessageToMailboxNotBelongingToSameUser() throws Exception {
+            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+
+            MailboxPath inbox1 = MailboxPath.inbox(sessionUser1);
+            mailboxManager.createMailbox(inbox1, sessionUser1);
+
+            MailboxPath inbox2 = MailboxPath.inbox(sessionUser2);
+            mailboxManager.createMailbox(inbox2, sessionUser2);
+
+            MessageManager inboxMessageManager = mailboxManager.getMailbox(inbox1, sessionUser1);
+
+            inboxMessageManager
+                .appendMessage(AppendCommand.from(message), sessionUser1);
+
+            assertThatThrownBy(() -> mailboxManager.copyMessages(MessageRange.all(), inbox1, inbox2, sessionUser1))
+                .isInstanceOf(MailboxException.class);
         }
 
         @Test
@@ -1726,11 +2016,67 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        void createMailboxShouldThrowWhenMailboxPathBelongsToAnotherUser() throws MailboxException {
+        void createMailboxShouldThrowWhenMailboxPathBelongsToAnotherUser() {
             session = mailboxManager.createSystemSession(USER_1);
 
             assertThatThrownBy(() -> mailboxManager
                     .createMailbox(MailboxPath.forUser(USER_2, "mailboxName"), session))
+                .isInstanceOf(MailboxException.class);
+        }
+
+        @Test
+        void getMailboxShouldThrowWhenMailboxDoesNotExist() {
+            session = mailboxManager.createSystemSession(USER_1);
+
+            assertThatThrownBy(() -> mailboxManager.getMailbox(MailboxPath.forUser(USER_1, "mailboxName"), session))
+                .isInstanceOf(MailboxException.class);
+        }
+
+        @Test
+        void getMailboxByPathShouldReturnMailboxWhenBelongingToUser() throws Exception {
+            session = mailboxManager.createSystemSession(USER_1);
+
+            MailboxPath mailboxPath = MailboxPath.forUser(USER_1, "mailboxName");
+            Optional<MailboxId> mailboxId = mailboxManager.createMailbox(mailboxPath, session);
+
+            assertThat(mailboxManager.getMailbox(mailboxPath, session).getId())
+                .isEqualTo(mailboxId.get());
+        }
+
+        @Test
+        void getMailboxByIdShouldReturnMailboxWhenBelongingToUser() throws Exception {
+            session = mailboxManager.createSystemSession(USER_1);
+
+            MailboxPath mailboxPath = MailboxPath.forUser(USER_1, "mailboxName");
+            Optional<MailboxId> mailboxId = mailboxManager.createMailbox(mailboxPath, session);
+
+            assertThat(mailboxManager.getMailbox(mailboxId.get(), session).getId())
+                .isEqualTo(mailboxId.get());
+        }
+
+        @Test
+        @Disabled("JAMES-2993 It seems that getMailbox by path in MailboxManager does not check that the mailbox belongs to user, "
+            + "compared to getMailbox by id that actually does assert it")
+        void getMailboxByPathShouldThrowWhenMailboxNotBelongingToUser() throws Exception {
+            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+
+            MailboxPath mailboxPath = MailboxPath.forUser(USER_1, "mailboxName");
+            mailboxManager.createMailbox(mailboxPath, sessionUser1);
+
+            assertThatThrownBy(() -> mailboxManager.getMailbox(mailboxPath, sessionUser2))
+                .isInstanceOf(MailboxException.class);
+        }
+
+        @Test
+        void getMailboxByIdShouldThrowWhenMailboxNotBelongingToUser() throws Exception {
+            MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
+            MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
+
+            MailboxPath mailboxPath = MailboxPath.forUser(USER_1, "mailboxName");
+            Optional<MailboxId> mailboxId = mailboxManager.createMailbox(mailboxPath, sessionUser1);
+
+            assertThatThrownBy(() -> mailboxManager.getMailbox(mailboxId.get(), sessionUser2))
                 .isInstanceOf(MailboxException.class);
         }
     }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -1765,7 +1765,9 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        void moveMessagesShouldMoveAllMessagesFromOneMailboxToAnOtherOfASameUser() throws Exception {
+        protected void moveMessagesShouldMoveAllMessagesFromOneMailboxToAnOtherOfASameUser() throws Exception {
+            assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
+
             session = mailboxManager.createSystemSession(USER_1);
 
             MailboxPath inbox = MailboxPath.inbox(session);
@@ -1774,7 +1776,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             MailboxPath otherMailbox = MailboxPath.forUser(USER_1, "otherMailbox");
             MailboxId otherMailboxId = mailboxManager.createMailbox(otherMailbox, session).get();
 
-            MessageManager inboxMessageManager = mailboxManager.getMailbox(inboxId, session);
+            MessageManager inboxMessageManager = mailboxManager.getMailbox(inbox, session);
 
             MessageId messageId1 = inboxMessageManager
                 .appendMessage(AppendCommand.from(message), session)
@@ -1802,7 +1804,9 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        void moveMessagesShouldMoveOnlyOneMessageFromOneMailboxToAnOtherOfASameUser() throws Exception {
+        protected void moveMessagesShouldMoveOnlyOneMessageFromOneMailboxToAnOtherOfASameUser() throws Exception {
+            assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
+
             session = mailboxManager.createSystemSession(USER_1);
 
             MailboxPath inbox = MailboxPath.inbox(session);
@@ -1811,7 +1815,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             MailboxPath otherMailbox = MailboxPath.forUser(USER_1, "otherMailbox");
             MailboxId otherMailboxId = mailboxManager.createMailbox(otherMailbox, session).get();
 
-            MessageManager inboxMessageManager = mailboxManager.getMailbox(inboxId, session);
+            MessageManager inboxMessageManager = mailboxManager.getMailbox(inbox, session);
 
             ComposedMessageId composedMessageId1 = inboxMessageManager
                 .appendMessage(AppendCommand.from(message), session);
@@ -1890,6 +1894,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void copyMessagesShouldCopyAllMessagesFromOneMailboxToAnOtherOfASameUser() throws Exception {
+            assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
+
             session = mailboxManager.createSystemSession(USER_1);
 
             MailboxPath inbox = MailboxPath.inbox(session);
@@ -1898,7 +1904,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             MailboxPath otherMailbox = MailboxPath.forUser(USER_1, "otherMailbox");
             MailboxId otherMailboxId = mailboxManager.createMailbox(otherMailbox, session).get();
 
-            MessageManager inboxMessageManager = mailboxManager.getMailbox(inboxId, session);
+            MessageManager inboxMessageManager = mailboxManager.getMailbox(inbox, session);
 
             MessageId messageId1 = inboxMessageManager
                 .appendMessage(AppendCommand.from(message), session)
@@ -1927,6 +1933,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void copyMessagesShouldCopyOnlyOneMessageFromOneMailboxToAnOtherOfASameUser() throws Exception {
+            assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
+
             session = mailboxManager.createSystemSession(USER_1);
 
             MailboxPath inbox = MailboxPath.inbox(session);
@@ -1935,7 +1943,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             MailboxPath otherMailbox = MailboxPath.forUser(USER_1, "otherMailbox");
             MailboxId otherMailboxId = mailboxManager.createMailbox(otherMailbox, session).get();
 
-            MessageManager inboxMessageManager = mailboxManager.getMailbox(inboxId, session);
+            MessageManager inboxMessageManager = mailboxManager.getMailbox(inbox, session);
 
             ComposedMessageId composedMessageId1 = inboxMessageManager
                 .appendMessage(AppendCommand.from(message), session);
@@ -2041,7 +2049,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        void getMailboxByIdShouldReturnMailboxWhenBelongingToUser() throws Exception {
+        protected void getMailboxByIdShouldReturnMailboxWhenBelongingToUser() throws Exception {
             session = mailboxManager.createSystemSession(USER_1);
 
             MailboxPath mailboxPath = MailboxPath.forUser(USER_1, "mailboxName");

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -53,7 +53,9 @@ import org.apache.james.mailbox.events.MessageMoveEvent;
 import org.apache.james.mailbox.exception.AnnotationException;
 import org.apache.james.mailbox.exception.HasEmptyMailboxNameInHierarchyException;
 import org.apache.james.mailbox.exception.InboxAlreadyCreated;
+import org.apache.james.mailbox.exception.InsufficientRightsException;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.exception.MailboxExistsException;
 import org.apache.james.mailbox.exception.MailboxNotFoundException;
 import org.apache.james.mailbox.exception.TooLongMailboxNameException;
 import org.apache.james.mailbox.extension.PreDeletionHook;
@@ -555,7 +557,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             MailboxPath inbox = MailboxPath.inbox(session);
 
             assertThatThrownBy(() -> mailboxManager.updateAnnotations(inbox, session, ImmutableList.of(privateAnnotation)))
-                .isInstanceOf(MailboxException.class);
+                .isInstanceOf(MailboxNotFoundException.class);
         }
 
         @Test
@@ -587,7 +589,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             MailboxPath inbox = MailboxPath.inbox(session);
 
             assertThatThrownBy(() -> mailboxManager.getAllAnnotations(inbox, session))
-                .isInstanceOf(MailboxException.class);
+                .isInstanceOf(MailboxNotFoundException.class);
         }
 
         @Test
@@ -610,7 +612,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             MailboxPath inbox = MailboxPath.inbox(session);
 
             assertThatThrownBy(() -> mailboxManager.getAnnotationsByKeys(inbox, session, ImmutableSet.of(privateKey)))
-                .isInstanceOf(MailboxException.class);
+                .isInstanceOf(MailboxNotFoundException.class);
         }
 
         @Test
@@ -633,7 +635,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             MailboxPath inbox = MailboxPath.inbox(session);
 
             assertThatThrownBy(() -> mailboxManager.getAnnotationsByKeysWithAllDepth(inbox, session, ImmutableSet.of(privateKey)))
-                .isInstanceOf(MailboxException.class);
+                .isInstanceOf(MailboxNotFoundException.class);
         }
 
         @Test
@@ -1574,7 +1576,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             mailboxManager.createMailbox(mailboxPath1, sessionUser1);
 
             assertThatThrownBy(() -> mailboxManager.renameMailbox(mailboxPath1, mailboxPath2, sessionUser2))
-                .isInstanceOf(MailboxException.class);
+                .isInstanceOf(MailboxNotFoundException.class);
         }
 
         @Test
@@ -1587,7 +1589,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             Optional<MailboxId> mailboxId = mailboxManager.createMailbox(mailboxPath1, sessionUser1);
 
             assertThatThrownBy(() -> mailboxManager.renameMailbox(mailboxId.get(), mailboxPath2, sessionUser2))
-                .isInstanceOf(MailboxException.class);
+                .isInstanceOf(MailboxNotFoundException.class);
         }
 
         @Test
@@ -1598,7 +1600,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             mailboxManager.createMailbox(inbox, session);
 
             assertThatThrownBy(() -> mailboxManager.createMailbox(inbox, session))
-                .isInstanceOf(MailboxException.class);
+                .isInstanceOf(MailboxExistsException.class);
         }
 
         @Test
@@ -1667,7 +1669,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             mailboxManager.createMailbox(inbox, sessionUser1);
 
             assertThatThrownBy(() -> mailboxManager.deleteMailbox(inbox, sessionUser2))
-                .isInstanceOf(MailboxException.class);
+                .isInstanceOf(MailboxNotFoundException.class);
         }
 
 
@@ -1680,7 +1682,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             MailboxId inboxId = mailboxManager.createMailbox(inbox, sessionUser1).get();
 
             assertThatThrownBy(() -> mailboxManager.deleteMailbox(inboxId, sessionUser2))
-                .isInstanceOf(MailboxException.class);
+                .isInstanceOf(MailboxNotFoundException.class);
         }
 
         @Test
@@ -1860,7 +1862,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
                 .appendMessage(AppendCommand.from(message), sessionUser1);
 
             assertThatThrownBy(() -> mailboxManager.moveMessages(MessageRange.all(), inbox1, inbox2, sessionUser2))
-                .isInstanceOf(MailboxException.class);
+                .isInstanceOf(MailboxNotFoundException.class);
         }
 
         @Test
@@ -1880,7 +1882,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
                 .appendMessage(AppendCommand.from(message), sessionUser1);
 
             assertThatThrownBy(() -> mailboxManager.moveMessages(MessageRange.all(), inbox1, inbox2, sessionUser1))
-                .isInstanceOf(MailboxException.class);
+                .isInstanceOf(MailboxNotFoundException.class);
         }
 
         @Test
@@ -1990,7 +1992,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
                 .appendMessage(AppendCommand.from(message), sessionUser1);
 
             assertThatThrownBy(() -> mailboxManager.copyMessages(MessageRange.all(), inbox1, inbox2, sessionUser2))
-                .isInstanceOf(MailboxException.class);
+                .isInstanceOf(MailboxNotFoundException.class);
         }
 
         @Test
@@ -2010,7 +2012,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
                 .appendMessage(AppendCommand.from(message), sessionUser1);
 
             assertThatThrownBy(() -> mailboxManager.copyMessages(MessageRange.all(), inbox1, inbox2, sessionUser1))
-                .isInstanceOf(MailboxException.class);
+                .isInstanceOf(MailboxNotFoundException.class);
         }
 
         @Test
@@ -2028,7 +2030,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
             assertThatThrownBy(() -> mailboxManager
                     .createMailbox(MailboxPath.forUser(USER_2, "mailboxName"), session))
-                .isInstanceOf(MailboxException.class);
+                .isInstanceOf(InsufficientRightsException.class);
         }
 
         @Test
@@ -2036,7 +2038,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             session = mailboxManager.createSystemSession(USER_1);
 
             assertThatThrownBy(() -> mailboxManager.getMailbox(MailboxPath.forUser(USER_1, "mailboxName"), session))
-                .isInstanceOf(MailboxException.class);
+                .isInstanceOf(MailboxNotFoundException.class);
         }
 
         @Test
@@ -2070,7 +2072,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             mailboxManager.createMailbox(mailboxPath, sessionUser1);
 
             assertThatThrownBy(() -> mailboxManager.getMailbox(mailboxPath, sessionUser2))
-                .isInstanceOf(MailboxException.class);
+                .isInstanceOf(MailboxNotFoundException.class);
         }
 
         @Test
@@ -2082,7 +2084,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             Optional<MailboxId> mailboxId = mailboxManager.createMailbox(mailboxPath, sessionUser1);
 
             assertThatThrownBy(() -> mailboxManager.getMailbox(mailboxId.get(), sessionUser2))
-                .isInstanceOf(MailboxException.class);
+                .isInstanceOf(MailboxNotFoundException.class);
         }
     }
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -83,7 +83,6 @@ import org.apache.james.util.concurrency.ConcurrentTestRunner;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -1965,8 +1964,6 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        @Disabled("JAMES-2993 It seems that getMailbox by path in MailboxManager does not check that the mailbox belongs to user, "
-                + "compared to getMailbox by id that actually does assert it")
         void copyMessagesShouldThrowWhenCopyingMessageFromMailboxNotBelongingToSameUser() throws Exception {
             MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
             MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);
@@ -2055,8 +2052,6 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        @Disabled("JAMES-2993 It seems that getMailbox by path in MailboxManager does not check that the mailbox belongs to user, "
-            + "compared to getMailbox by id that actually does assert it")
         void getMailboxByPathShouldThrowWhenMailboxNotBelongingToUser() throws Exception {
             MailboxSession sessionUser1 = mailboxManager.createSystemSession(USER_1);
             MailboxSession sessionUser2 = mailboxManager.createSystemSession(USER_2);

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -1765,8 +1765,9 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        protected void moveMessagesShouldMoveAllMessagesFromOneMailboxToAnOtherOfASameUser() throws Exception {
+        void moveMessagesShouldMoveAllMessagesFromOneMailboxToAnOtherOfASameUser() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
+            assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Move));
 
             session = mailboxManager.createSystemSession(USER_1);
 
@@ -1804,8 +1805,9 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         }
 
         @Test
-        protected void moveMessagesShouldMoveOnlyOneMessageFromOneMailboxToAnOtherOfASameUser() throws Exception {
+        void moveMessagesShouldMoveOnlyOneMessageFromOneMailboxToAnOtherOfASameUser() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.ACL));
+            assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Move));
 
             session = mailboxManager.createSystemSession(USER_1);
 

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/DomainUserMaildirMailboxManagerTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/DomainUserMaildirMailboxManagerTest.java
@@ -57,16 +57,6 @@ class DomainUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreMailbo
         protected void user1ShouldBeAbleToDeleteInboxById() {
         }
 
-        @Disabled("JAMES-2993 Mailbox move is not supported by Maildir")
-        @Test
-        protected void moveMessagesShouldMoveOnlyOneMessageFromOneMailboxToAnOtherOfASameUser() {
-        }
-
-        @Disabled("JAMES-2993 Mailbox move is not supported by Maildir")
-        @Test
-        protected void moveMessagesShouldMoveAllMessagesFromOneMailboxToAnOtherOfASameUser() {
-        }
-
         @Disabled("JAMES-2993 mailboxId support for Maildir is partial")
         @Test
         protected void getMailboxByIdShouldReturnMailboxWhenBelongingToUser() {

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/DomainUserMaildirMailboxManagerTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/DomainUserMaildirMailboxManagerTest.java
@@ -56,6 +56,21 @@ class DomainUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreMailbo
         @Test
         protected void user1ShouldBeAbleToDeleteInboxById() {
         }
+
+        @Disabled("JAMES-2993 Mailbox move is not supported by Maildir")
+        @Test
+        protected void moveMessagesShouldMoveOnlyOneMessageFromOneMailboxToAnOtherOfASameUser() {
+        }
+
+        @Disabled("JAMES-2993 Mailbox move is not supported by Maildir")
+        @Test
+        protected void moveMessagesShouldMoveAllMessagesFromOneMailboxToAnOtherOfASameUser() {
+        }
+
+        @Disabled("JAMES-2993 mailboxId support for Maildir is partial")
+        @Test
+        protected void getMailboxByIdShouldReturnMailboxWhenBelongingToUser() {
+        }
     }
 
     @Nested

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerTest.java
@@ -56,6 +56,21 @@ class FullUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreMailboxM
         @Test
         protected void user1ShouldBeAbleToDeleteInboxById() {
         }
+
+        @Disabled("JAMES-2993 Mailbox move is not supported by Maildir")
+        @Test
+        protected void moveMessagesShouldMoveOnlyOneMessageFromOneMailboxToAnOtherOfASameUser() {
+        }
+
+        @Disabled("JAMES-2993 Mailbox move is not supported by Maildir")
+        @Test
+        protected void moveMessagesShouldMoveAllMessagesFromOneMailboxToAnOtherOfASameUser() {
+        }
+
+        @Disabled("JAMES-2993 mailboxId support for Maildir is partial")
+        @Test
+        protected void getMailboxByIdShouldReturnMailboxWhenBelongingToUser() {
+        }
     }
 
     @Nested

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerTest.java
@@ -57,16 +57,6 @@ class FullUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreMailboxM
         protected void user1ShouldBeAbleToDeleteInboxById() {
         }
 
-        @Disabled("JAMES-2993 Mailbox move is not supported by Maildir")
-        @Test
-        protected void moveMessagesShouldMoveOnlyOneMessageFromOneMailboxToAnOtherOfASameUser() {
-        }
-
-        @Disabled("JAMES-2993 Mailbox move is not supported by Maildir")
-        @Test
-        protected void moveMessagesShouldMoveAllMessagesFromOneMailboxToAnOtherOfASameUser() {
-        }
-
         @Disabled("JAMES-2993 mailboxId support for Maildir is partial")
         @Test
         protected void getMailboxByIdShouldReturnMailboxWhenBelongingToUser() {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -512,6 +512,7 @@ public class StoreMailboxManager implements MailboxManager {
         if (mailboxExists(newMailboxPath, session)) {
             throw new MailboxExistsException(newMailboxPath.toString());
         }
+        assertIsOwner(session, newMailboxPath);
         newMailboxPath.assertAcceptable(session.getPathDelimiter());
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -273,11 +273,16 @@ public class StoreMailboxManager implements MailboxManager {
             LOGGER.info("Mailbox '{}' not found.", mailboxPath);
             throw new MailboxNotFoundException(mailboxPath);
 
-        } else {
-            LOGGER.debug("Loaded mailbox {}", mailboxPath);
-
-            return createMessageManager(mailboxRow, session);
         }
+
+        if (!assertUserHasAccessTo(mailboxRow, session)) {
+            LOGGER.info("Mailbox '{}' does not belong to user '{}' but to '{}'", mailboxPath, session.getUser(), mailboxRow.getUser());
+            throw new MailboxNotFoundException(mailboxPath);
+        }
+
+        LOGGER.debug("Loaded mailbox {}", mailboxPath);
+
+        return createMessageManager(mailboxRow, session);
     }
 
     @Override
@@ -291,7 +296,7 @@ public class StoreMailboxManager implements MailboxManager {
             throw new MailboxNotFoundException(mailboxId);
         }
 
-        if (! assertUserHasAccessTo(mailboxRow, session)) {
+        if (!assertUserHasAccessTo(mailboxRow, session)) {
             LOGGER.info("Mailbox '{}' does not belong to user '{}' but to '{}'", mailboxId.serialize(), session.getUser(), mailboxRow.getUser());
             throw new MailboxNotFoundException(mailboxId);
         }


### PR DESCRIPTION
While working on #3038 , I noticed those following things regarding `MailboxManager` :
* the class `MailboxManagerTest` is definitely missing some important tests in its suite
* we don't check if the mailbox belongs to the user before returning it in getMailbox by path in `MailboxManager`, while we do in getMailbox by id. There was clearly a miss there. That created an issue with a test I added on copyMessages, where  a user2 can copy mails from user1 mailbox to one of his mailboxes, which I believe shouldn't be allowed.

This PR intends to address and fix those issues. It's possible that we need to test more cases as well that I missed, please don't hesitate to comment if you think we need more. Thanks !