### PR TITLE
make Reactor toInputStream 50 times faster

### DIFF
--- a/server/container/util/src/main/java/org/apache/james/util/ReactorUtils.java
+++ b/server/container/util/src/main/java/org/apache/james/util/ReactorUtils.java
@@ -21,9 +21,8 @@ package org.apache.james.util;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.Iterator;
 import java.util.Optional;
-import java.util.Spliterator;
-import java.util.stream.Stream;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -33,66 +32,56 @@ public class ReactorUtils {
         return Mono.fromRunnable(runnable).then(Mono.empty());
     }
 
+
     public static InputStream toInputStream(Flux<ByteBuffer> byteArrays) {
-        return new StreamInputStream(byteArrays.toStream(1));
+        return new StreamInputStream(byteArrays.toIterable(1).iterator());
     }
 
-    private static  class StreamInputStream extends InputStream {
+    private static class StreamInputStream extends InputStream {
         private static final int NO_MORE_DATA = -1;
 
-        private final Stream<ByteBuffer> source;
-        private final Spliterator<ByteBuffer> spliterator;
+        private final Iterator<ByteBuffer> source;
         private Optional<ByteBuffer> currentItemByteStream;
 
-        StreamInputStream(Stream<ByteBuffer> source) {
+        StreamInputStream(Iterator<ByteBuffer> source) {
             this.source = source;
-            this.spliterator = source.spliterator();
             this.currentItemByteStream = Optional.empty();
         }
 
         @Override
-        public int read() {
-            try {
-                if (!dataAvailableToRead()) {
-                    switchToNextChunk();
-                }
-
-                if (!dataAvailableToRead()) {
-                    source.close();
-                    return NO_MORE_DATA;
-                }
-
-                return currentItemByteStream
-                    .filter(ByteBuffer::hasRemaining)
-                    .map(buffer -> buffer.get() & 0xFF)
-                    .orElseGet(this::readNextChunk);
-            } catch (Throwable t) {
-                source.close();
-                throw t;
-            }
-        }
-
-        private boolean dataAvailableToRead() {
-            return currentItemByteStream.isPresent();
-        }
-
-        private void switchToNextChunk() {
-            spliterator.tryAdvance(bytes ->
-                currentItemByteStream = Optional.of(bytes));
-        }
-
-        private Integer readNextChunk() {
-            currentItemByteStream = Optional.empty();
-            return read();
+        public int read(byte[] b, int off, int len) throws IOException {
+            return nextNonEmptyBuffer()
+                .map(buffer -> {
+                    int toRead = Math.min(len, buffer.remaining());
+                    buffer.get(b, off, toRead);
+                    return toRead;
+                })
+                .orElse(NO_MORE_DATA);
         }
 
         @Override
-        public void close() throws IOException {
-            try {
-                source.close();
-            } finally {
-                super.close();
-            }
+        public int read() {
+            return nextNonEmptyBuffer()
+                .map(ReactorUtils::byteToInt)
+                .orElse(NO_MORE_DATA);
         }
+
+        private Optional<ByteBuffer> nextNonEmptyBuffer() {
+            Boolean needsNewBuffer = currentItemByteStream.map(buffer -> !buffer.hasRemaining()).orElse(true);
+            if (needsNewBuffer) {
+                if (source.hasNext()) {
+                    currentItemByteStream = Optional.of(source.next());
+                    return nextNonEmptyBuffer();
+                } else {
+                    return Optional.empty();
+                }
+            }
+            return currentItemByteStream;
+        }
+
+    }
+
+    private static int byteToInt(ByteBuffer buffer) {
+        return buffer.get() & 0xff;
     }
 }


### PR DESCRIPTION
	From 500 MiB/s to 10 GiB/s on my workstation

	It's due to the implementation of read(byte[], int off, int len)
	and some minor optimizations