### PR TITLE
Revert "[Refactoring] Port FixingGhostMailboxTest to use distributed …

### DIFF
--- a/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraExtension.java
+++ b/server/container/guice/cassandra-guice/src/test/java/org/apache/james/CassandraExtension.java
@@ -19,10 +19,7 @@
 
 package org.apache.james;
 
-import org.apache.james.util.Host;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.ParameterContext;
-import org.junit.jupiter.api.extension.ParameterResolutionException;
 
 import com.google.inject.Module;
 
@@ -58,15 +55,5 @@ public class CassandraExtension implements GuiceModuleTestExtension {
 
     public void unpause() {
         cassandra.unpause();
-    }
-
-    @Override
-    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
-        return parameterContext.getParameter().getType() == Host.class;
-    }
-
-    @Override
-    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
-        return cassandra.getHost();
     }
 }


### PR DESCRIPTION
…product"

Unfortunately, this commit made the build very unstable. I could reproduce it locally on master, by repeating the test `ghostMailboxBugShouldDiscardOldContent` in `FixingGhostMailboxTest` 50 times... Then it was breaking a lot of times. After reverting this commit, the 50 times test was green locally.

I'm not sure about the reason why it's so unstable yet, but I think it's better to revert this for now asap, as it disturbs the other builds too much.