### PR TITLE
Fix grafana boards

### DIFF
--- a/grafana-reporting/Cassandra_driver-1504068385404-dashboard.json
+++ b/grafana-reporting/Cassandra_driver-1504068385404-dashboard.json
@@ -110,7 +110,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:requests",
+              "query": "name:\"requests\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -223,7 +223,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:requests",
+              "query": "name:\"requests\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -341,7 +341,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:executor-queue-depth",
+              "query": "name:\"executor-queue-depth\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -447,7 +447,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:task-scheduler-task-count",
+              "query": "name:\"task-scheduler-task-count\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -553,7 +553,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:blocking-executor-queue-depth",
+              "query": "name:\"blocking-executor-queue-depth\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -659,7 +659,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:open-connections",
+              "query": "name:\"open-connections\"",
               "refId": "A",
               "timeField": "@timestamp"
             }

--- a/grafana-reporting/IMAP_board-1488774825351-dashboard.json
+++ b/grafana-reporting/IMAP_board-1488774825351-dashboard.json
@@ -1836,7 +1836,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "IMAP_LIST",
+          "title": "IMAP-LIST",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1953,7 +1953,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:\"IMAP_CREATE\"",
+              "query": "name:\"IMAP-CREATE\"",
               "refId": "A",
               "timeField": "@timestamp"
             }

--- a/grafana-reporting/IMAP_board-1488774825351-dashboard.json
+++ b/grafana-reporting/IMAP_board-1488774825351-dashboard.json
@@ -97,7 +97,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:imapConnections",
+              "query": "name:\"imapConnections\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -210,7 +210,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:IMAP-LOGIN",
+              "query": "name:\"IMAP-LOGIN\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -323,7 +323,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:IMAP-CAPABILITY",
+              "query": "name:\"IMAP-CAPABILITY\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -436,7 +436,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:IMAP-AUTHENTICATE",
+              "query": "name:\"IMAP-AUTHENTICATE\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -561,7 +561,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:IMAP-SELECT",
+              "query": "name:\"IMAP-SELECT\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -674,7 +674,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:IMAP-GETQUOTAROOT",
+              "query": "name:\"IMAP-GETQUOTAROOT\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -787,7 +787,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:IMAP-FETCH",
+              "query": "name:\"IMAP-FETCH\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -900,7 +900,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:IMAP-APPEND",
+              "query": "name:\"IMAP-APPEND\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1025,7 +1025,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:IMAP-IDLE",
+              "query": "name:\"IMAP-IDLE\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1138,7 +1138,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:IMAP-NOOP",
+              "query": "name:\"IMAP-NOOP\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1251,7 +1251,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:IMAP-STORE",
+              "query": "name:\"IMAP-STORE\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1364,7 +1364,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:IMAP-LSUB",
+              "query": "name:\"IMAP-LSUB\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1489,7 +1489,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:IMAP-NAMESPACE",
+              "query": "name:\"IMAP-NAMESPACE\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1602,7 +1602,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:IMAP-CLOSE",
+              "query": "name:\"IMAP-CLOSE\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1715,7 +1715,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:IMAP-LOGOUT",
+              "query": "name:\"IMAP-LOGOUT\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1828,7 +1828,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:IMAP-LIST",
+              "query": "name:\"IMAP-LIST\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1953,7 +1953,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:IMAP_CREATE",
+              "query": "name:\"IMAP_CREATE\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -2066,7 +2066,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:IMAP-COPY",
+              "query": "name:\"IMAP-COPY\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -2179,7 +2179,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:IMAP-MOVE",
+              "query": "name:\"IMAP-MOVE\"",
               "refId": "A",
               "timeField": "@timestamp"
             }

--- a/grafana-reporting/IMAP_count_board-1488774815587-dashboard.json
+++ b/grafana-reporting/IMAP_count_board-1488774815587-dashboard.json
@@ -97,7 +97,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:imapConnections",
+              "query": "name:\"imapConnections\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -202,7 +202,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:IMAP-LOGIN",
+              "query": "name:\"IMAP-LOGIN\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -307,7 +307,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:IMAP-CAPABILITY",
+              "query": "name:\"IMAP-CAPABILITY\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -412,7 +412,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:IMAP-AUTHENTICATE",
+              "query": "name:\"IMAP-AUTHENTICATE\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -529,7 +529,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:IMAP-SELECT",
+              "query": "name:\"IMAP-SELECT\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -634,7 +634,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:IMAP-GETQUOTAROOT",
+              "query": "name:\"IMAP-GETQUOTAROOT\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -739,7 +739,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:IMAP-FETCH",
+              "query": "name:\"IMAP-FETCH\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -844,7 +844,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:IMAP-APPEND",
+              "query": "name:\"IMAP-APPEND\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -961,7 +961,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:IMAP-IDLE",
+              "query": "name:\"IMAP-IDLE\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1066,7 +1066,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:IMAP-NOOP",
+              "query": "name:\"IMAP-NOOP\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1171,7 +1171,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:IMAP-STORE",
+              "query": "name:\"IMAP-STORE\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1276,7 +1276,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:IMAP-LSUB",
+              "query": "name:\"IMAP-LSUB\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1393,7 +1393,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:IMAP-NAMESPACE",
+              "query": "name:\"IMAP-NAMESPACE\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1498,7 +1498,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:IMAP-CLOSE",
+              "query": "name:\"IMAP-CLOSE\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1603,7 +1603,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:IMAP-LOGOUT",
+              "query": "name:\"IMAP-LOGOUT\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1708,7 +1708,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:IMAP-LIST",
+              "query": "name:\"IMAP-LIST\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1825,7 +1825,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:IMAP-CREATE",
+              "query": "name:\"IMAP-CREATE\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1930,7 +1930,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:IMAP-COPY",
+              "query": "name:\"IMAP-COPY\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -2035,7 +2035,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:IMAP-MOVE",
+              "query": "name:\"IMAP-MOVE\"",
               "refId": "A",
               "timeField": "@timestamp"
             }

--- a/grafana-reporting/JAMES_DNS_dashboard-1491268903944-dashboard.json
+++ b/grafana-reporting/JAMES_DNS_dashboard-1491268903944-dashboard.json
@@ -117,7 +117,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:findMXRecords",
+              "query": "name:\"findMXRecords\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -230,7 +230,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:getByName",
+              "query": "name:\"getByName\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -343,7 +343,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:getAllByName",
+              "query": "name:\"getAllByName\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -468,7 +468,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:getHostName",
+              "query": "name:\"getHostName\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -581,7 +581,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:findTXTRecords",
+              "query": "name:\"findTXTRecords\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -706,7 +706,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:getHostName",
+              "query": "name:\"getHostName\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -819,7 +819,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:findMXRecords",
+              "query": "name:\"findMXRecords\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -932,7 +932,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:findTXTRecords",
+              "query": "name:\"findTXTRecords\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1049,7 +1049,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:getByName",
+              "query": "name:\"getByName\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1154,7 +1154,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:getAllByName",
+              "query": "name:\"getAllByName\"",
               "refId": "A",
               "timeField": "@timestamp"
             }

--- a/grafana-reporting/JMAP_board-1488774804236-dashboard.json
+++ b/grafana-reporting/JMAP_board-1488774804236-dashboard.json
@@ -117,7 +117,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-request",
+              "query": "name:\"JMAP-request\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -230,7 +230,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-getMailboxes",
+              "query": "name:\"JMAP-getMailboxes\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -343,7 +343,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-getMessageList",
+              "query": "name:\"JMAP-getMessageList\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -456,7 +456,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-getMessages",
+              "query": "name:\"JMAP-getMessages\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -581,7 +581,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-SetMessageDestructionProcessor",
+              "query": "name:\"JMAP-SetMessageDestructionProcessor\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -694,7 +694,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-SetMessagesUpdateProcessor",
+              "query": "name:\"JMAP-SetMessagesUpdateProcessor\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -807,7 +807,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-SetMessageCreationProcessor",
+              "query": "name:\"JMAP-SetMessageCreationProcessor\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -920,7 +920,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-setMessages",
+              "query": "name:\"JMAP-setMessages\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1045,7 +1045,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-SetMailboxesDestructionProcessor",
+              "query": "name:\"JMAP-SetMailboxesDestructionProcessor\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1158,7 +1158,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-SetMailboxesCreationProcessor",
+              "query": "name:\"JMAP-SetMailboxesCreationProcessor\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1271,7 +1271,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-mailboxUpdateProcessor",
+              "query": "name:\"JMAP-mailboxUpdateProcessor\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1384,7 +1384,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-setMailboxes",
+              "query": "name:\"JMAP-setMailboxes\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1509,7 +1509,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-getVacationResponse",
+              "query": "name:\"JMAP-getVacationResponse\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1622,7 +1622,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-setVacationResponse",
+              "query": "name:\"JMAP-setVacationResponse\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1735,7 +1735,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-mailboxes-provisioning",
+              "query": "name:\"JMAP-mailboxes-provisioning\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1848,7 +1848,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-user-provisioning",
+              "query": "name:\"JMAP-user-provisioning\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1973,7 +1973,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-upload-post",
+              "query": "name:\"JMAP-upload-post\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -2086,7 +2086,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-download-post",
+              "query": "name:\"JMAP-download-post\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -2199,7 +2199,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-download-get",
+              "query": "name:\"JMAP-download-get\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -2312,7 +2312,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-authentication-post",
+              "query": "name:\"JMAP-authentication-post\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -2437,7 +2437,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:JMAP-authentication-filter",
+              "query": "name:\"JMAP-authentication-filter\"",
               "refId": "A",
               "timeField": "@timestamp"
             }

--- a/grafana-reporting/JMAP_count_board-1488774795514-dashboard.json
+++ b/grafana-reporting/JMAP_count_board-1488774795514-dashboard.json
@@ -114,7 +114,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:JMAP-request",
+              "query": "name:\"JMAP-request\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -224,7 +224,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:JMAP-getMailboxes",
+              "query": "name:\"JMAP-getMailboxes\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -334,7 +334,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:JMAP-getMessageList",
+              "query": "name:\"JMAP-getMessageList\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -444,7 +444,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:JMAP-getMessages",
+              "query": "name:\"JMAP-getMessages\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -566,7 +566,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:JMAP-setMessages",
+              "query": "name:\"JMAP-setMessages\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -676,7 +676,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:JMAP-setMailboxes",
+              "query": "name:\"JMAP-setMailboxes\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -786,7 +786,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:JMAP-getVacationResponse",
+              "query": "name:\"JMAP-getVacationResponse\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -896,7 +896,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:JMAP-setVacationResponse",
+              "query": "name:\"JMAP-setVacationResponse\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1018,7 +1018,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:JMAP-upload-post",
+              "query": "name:\"JMAP-upload-post\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1128,7 +1128,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:JMAP-download-post",
+              "query": "name:\"JMAP-download-post\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1238,7 +1238,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:JMAP-download-get",
+              "query": "name:\"JMAP-download-get\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1348,7 +1348,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:JMAP-authentication-post",
+              "query": "name:\"JMAP-authentication-post\"",
               "refId": "A",
               "timeField": "@timestamp"
             }

--- a/grafana-reporting/James_JVM-1504068360629-dashboard.json
+++ b/grafana-reporting/James_JVM-1504068360629-dashboard.json
@@ -110,7 +110,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:jvm.file.descriptor",
+              "query": "name:\"jvm.file.descriptor\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -216,7 +216,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:jvm.threads.count",
+              "query": "name:\"jvm.threads.count\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -322,7 +322,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:jvm.threads.deadlock.count",
+              "query": "name:\"jvm.threads.deadlock.count\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -432,7 +432,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:jvm.memory.total.max",
+              "query": "name:\"jvm.memory.total.max\"",
               "refId": "A",
               "timeField": "@timestamp"
             },
@@ -459,7 +459,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:jvm.memory.total.used",
+              "query": "name:\"jvm.memory.total.used\"",
               "refId": "B",
               "timeField": "@timestamp"
             }
@@ -557,7 +557,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:jvm.memory.heap.max",
+              "query": "name:\"jvm.memory.heap.max\"",
               "refId": "A",
               "timeField": "@timestamp"
             },
@@ -585,7 +585,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:jvm.memory.heap.used",
+              "query": "name:\"jvm.memory.heap.used\"",
               "refId": "B",
               "timeField": "@timestamp"
             }
@@ -683,7 +683,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:jvm.memory.non-heap.max",
+              "query": "name:\"jvm.memory.non-heap.max\"",
               "refId": "A",
               "timeField": "@timestamp"
             },
@@ -711,7 +711,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:jvm.memory.non-heap.used",
+              "query": "name:\"jvm.memory.non-heap.used\"",
               "refId": "B",
               "timeField": "@timestamp"
             }
@@ -809,7 +809,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:jvm.class.loading.loaded",
+              "query": "name:\"jvm.class.loading.loaded\"",
               "refId": "A",
               "timeField": "@timestamp"
             },
@@ -837,7 +837,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:jvm.class.loading.unloaded",
+              "query": "name:\"jvm.class.loading.unloaded\"",
               "refId": "B",
               "timeField": "@timestamp"
             }
@@ -955,7 +955,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:jvm.gc.count",
+              "query": "name:\"jvm.gc.count\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1061,7 +1061,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:jvm.gc.time",
+              "query": "name:\"jvm.gc.time\"",
               "refId": "A",
               "timeField": "@timestamp"
             }

--- a/grafana-reporting/MAILET-1490071694187-dashboard.json
+++ b/grafana-reporting/MAILET-1490071694187-dashboard.json
@@ -117,7 +117,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:LocalDelivery",
+              "query": "name:\"LocalDelivery\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -230,7 +230,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:spoolProcessing",
+              "query": "name:\"spoolProcessing\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -343,7 +343,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:RemoteDelivery",
+              "query": "name:\"RemoteDelivery\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -456,7 +456,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:ToProcessor",
+              "query": "name:\"ToProcessor\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -581,7 +581,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:PostmasterAlias",
+              "query": "name:\"PostmasterAlias\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -694,7 +694,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:Bounce",
+              "query": "name:\"Bounce\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -807,7 +807,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:ToRepository",
+              "query": "name:\"ToRepository\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -920,7 +920,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:MetricsMailet",
+              "query": "name:\"MetricsMailet\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1045,7 +1045,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:SetMimeHeader",
+              "query": "name:\"SetMimeHeader\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1158,7 +1158,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:RemoveMimeHeader",
+              "query": "name:\"RemoveMimeHeader\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1271,7 +1271,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:RecipientRewriteTable",
+              "query": "name:\"RecipientRewriteTable\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1384,7 +1384,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:StripAttachment",
+              "query": "name:\"StripAttachment\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1509,7 +1509,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:MimeDecodingMailet",
+              "query": "name:\"MimeDecodingMailet\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1622,7 +1622,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:ICalendarParser",
+              "query": "name:\"ICalendarParser\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1735,7 +1735,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:ICALToHeader",
+              "query": "name:\"ICALToHeader\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1848,7 +1848,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:ICALToJsonAttribute",
+              "query": "name:\"ICALToJsonAttribute\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1973,7 +1973,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:AmqpForwardAttribute",
+              "query": "name:\"AmqpForwardAttribute\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -2086,7 +2086,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:VacationMailet",
+              "query": "name:\"VacationMailet\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -2199,7 +2199,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:RemoteDeliveryTrial",
+              "query": "name:\"RemoteDeliveryTrial\"",
               "refId": "A",
               "timeField": "@timestamp"
             }

--- a/grafana-reporting/MATCHER-1490071813409-dashboard.json
+++ b/grafana-reporting/MATCHER-1490071813409-dashboard.json
@@ -117,7 +117,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:All",
+              "query": "name:\"All\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -230,7 +230,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:spoolProcessing",
+              "query": "name:\"spoolProcessing\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -343,7 +343,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:SMTPAuthSuccessful",
+              "query": "name:\"SMTPAuthSuccessful\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -468,7 +468,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:RecipientIsLocal",
+              "query": "name:\"RecipientIsLocal\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -581,7 +581,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:HasMailAttribute",
+              "query": "name:\"HasMailAttribute\"",
               "refId": "A",
               "timeField": "@timestamp"
             }

--- a/grafana-reporting/MailQueue-1490071879988-dashboard.json
+++ b/grafana-reporting/MailQueue-1490071879988-dashboard.json
@@ -997,7 +997,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:spoolProcessing",
+              "query": "name:\"spoolProcessing\"",
               "refId": "A",
               "timeField": "@timestamp"
             }

--- a/grafana-reporting/MailboxListeners rate-1552903378376.json
+++ b/grafana-reporting/MailboxListeners rate-1552903378376.json
@@ -109,7 +109,7 @@
               "type": "avg"
             }
           ],
-          "query": "name:mailbox-listener-ElasticSearchListeningMessageSearchIndex",
+          "query": "name:\"mailbox-listener-ElasticSearchListeningMessageSearchIndex\"",
           "refId": "A",
           "timeField": "@timestamp"
         }
@@ -236,7 +236,7 @@
               "type": "avg"
             }
           ],
-          "query": "name:mailbox-listener-ElasticSearchQuotaMailboxListener",
+          "query": "name:\"mailbox-listener-ElasticSearchQuotaMailboxListener\"",
           "refId": "A",
           "timeField": "@timestamp"
         }
@@ -363,7 +363,7 @@
               "type": "avg"
             }
           ],
-          "query": "name:mailbox-listener-SpamAssassinListener",
+          "query": "name:\"mailbox-listener-SpamAssassinListener\"",
           "refId": "A",
           "timeField": "@timestamp"
         }
@@ -490,7 +490,7 @@
               "type": "avg"
             }
           ],
-          "query": "name:mailbox-listener-ListeningCurrentQuotaUpdater",
+          "query": "name:\"mailbox-listener-ListeningCurrentQuotaUpdater\"",
           "refId": "A",
           "timeField": "@timestamp"
         }
@@ -617,7 +617,7 @@
               "type": "avg"
             }
           ],
-          "query": "name:mailbox-listener-MailboxAnnotationListener",
+          "query": "name:\"mailbox-listener-MailboxAnnotationListener\"",
           "refId": "A",
           "timeField": "@timestamp"
         }
@@ -744,7 +744,7 @@
               "type": "avg"
             }
           ],
-          "query": "name: mailbox-listener-QuotaThresholdCrossingListener",
+          "query": "name:\" mailbox-listener-QuotaThresholdCrossingListener\"",
           "refId": "A",
           "timeField": "@timestamp"
         }

--- a/grafana-reporting/MailboxListeners-1528958667486-dashboard.json
+++ b/grafana-reporting/MailboxListeners-1528958667486-dashboard.json
@@ -117,7 +117,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:mailbox-listener-ElasticSearchListeningMessageSearchIndex",
+              "query": "name:\"mailbox-listener-ElasticSearchListeningMessageSearchIndex\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -230,7 +230,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:mailbox-listener-ElasticSearchQuotaMailboxListener",
+              "query": "name:\"mailbox-listener-ElasticSearchQuotaMailboxListener\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -343,7 +343,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:mailbox-listener-SpamAssassinListener",
+              "query": "name:\"mailbox-listener-SpamAssassinListener\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -468,7 +468,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:mailbox-listener-ListeningCurrentQuotaUpdater",
+              "query": "name:\"mailbox-listener-ListeningCurrentQuotaUpdater\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -581,7 +581,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:mailbox-listener-MailboxAnnotationListener",
+              "query": "name:\"mailbox-listener-MailboxAnnotationListener\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -694,7 +694,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name: mailbox-listener-QuotaThresholdCrossingListener",
+              "query": "name:\" mailbox-listener-QuotaThresholdCrossingListener\"",
               "refId": "A",
               "timeField": "@timestamp"
             }

--- a/grafana-reporting/Miscalleneous-1490072265151-dashboard.json
+++ b/grafana-reporting/Miscalleneous-1490072265151-dashboard.json
@@ -98,7 +98,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:imapConnections",
+              "query": "name:\"imapConnections\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -191,7 +191,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:smtpConnections",
+              "query": "name:\"smtpConnections\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -284,7 +284,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:lmtpConnections",
+              "query": "name:\"lmtpConnections\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -389,7 +389,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:imapCommands",
+              "query": "name:\"imapCommands\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -482,7 +482,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:smtpCommands",
+              "query": "name:\"smtpCommands\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -575,7 +575,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:lmtpCommands",
+              "query": "name:\"lmtpCommands\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -668,7 +668,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:JMAP-request",
+              "query": "name:\"JMAP-request\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -773,7 +773,7 @@
                   "type": "cardinality"
                 }
               ],
-              "query": "name:outgoingMails",
+              "query": "name:\"outgoingMails\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -959,7 +959,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:localDeliveredMails",
+              "query": "name:\"localDeliveredMails\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1157,7 +1157,7 @@
                   "type": "cardinality"
                 }
               ],
-              "query": "name:mailet-relay-denied",
+              "query": "name:\"mailet-relay-denied\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1250,7 +1250,7 @@
                   "type": "cardinality"
                 }
               ],
-              "query": "name:mailet-local-address-error",
+              "query": "name:\"mailet-local-address-error\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1343,7 +1343,7 @@
                   "type": "cardinality"
                 }
               ],
-              "query": "name:mailet-bounce",
+              "query": "name:\"mailet-bounce\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1436,7 +1436,7 @@
                   "type": "cardinality"
                 }
               ],
-              "query": "name:mailet-error",
+              "query": "name:\"mailet-error\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -1561,7 +1561,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:webAdmin",
+              "query": "name:\"webAdmin\"",
               "refId": "A",
               "timeField": "@timestamp"
             }

--- a/grafana-reporting/PreDeletionHooks-1553684324244-dashboard.json
+++ b/grafana-reporting/PreDeletionHooks-1553684324244-dashboard.json
@@ -97,7 +97,7 @@
               "type": "avg"
             }
           ],
-          "query": "name:preDeletionHook",
+          "query": "name:\"preDeletionHook\"",
           "refId": "A",
           "timeField": "@timestamp"
         }

--- a/grafana-reporting/SMTP_board-1488774774172-dashboard.json
+++ b/grafana-reporting/SMTP_board-1488774774172-dashboard.json
@@ -97,7 +97,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:smtpConnections",
+              "query": "name:\"smtpConnections\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -210,7 +210,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:SMTP-ehlo",
+              "query": "name:\"SMTP-ehlo\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -335,7 +335,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:SMTP-quit",
+              "query": "name:\"SMTP-quit\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -448,7 +448,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:SMTP-DATA",
+              "query": "name:\"SMTP-DATA\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -573,7 +573,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:SMTP-rcpt",
+              "query": "name:\"SMTP-rcpt\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -686,7 +686,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:SMTP-mail",
+              "query": "name:\"SMTP-mail\"",
               "refId": "A",
               "timeField": "@timestamp"
             }

--- a/grafana-reporting/SMTP_count_board-1488774761350-dashboard.json
+++ b/grafana-reporting/SMTP_count_board-1488774761350-dashboard.json
@@ -97,7 +97,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:smtpConnections",
+              "query": "name:\"smtpConnections\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -202,7 +202,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:SMTP-ehlo",
+              "query": "name:\"SMTP-ehlo\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -319,7 +319,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:SMTP-DATA",
+              "query": "name:\"SMTP-DATA\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -424,7 +424,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:SMTP-quit",
+              "query": "name:\"SMTP-quit\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -541,7 +541,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:SMTP-rcpt",
+              "query": "name:\"SMTP-rcpt\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -646,7 +646,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:SMTP-mail",
+              "query": "name:\"SMTP-mail\"",
               "refId": "A",
               "timeField": "@timestamp"
             }

--- a/grafana-reporting/SpamAssassin-1522226824255-dashboard.json
+++ b/grafana-reporting/SpamAssassin-1522226824255-dashboard.json
@@ -97,7 +97,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:spamAssassin-check",
+              "query": "name:\"spamAssassin-check\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -210,7 +210,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:spamAssassin-check",
+              "query": "name:\"spamAssassin-check\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -315,7 +315,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:spamAssassin-spam-report",
+              "query": "name:\"spamAssassin-spam-report\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -428,7 +428,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:spamAssassin-spam-report",
+              "query": "name:\"spamAssassin-spam-report\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -533,7 +533,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:spamAssassin-ham-report",
+              "query": "name:\"spamAssassin-ham-report\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -646,7 +646,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:spamAssassin-ham-report",
+              "query": "name:\"spamAssassin-ham-report\"",
               "refId": "A",
               "timeField": "@timestamp"
             }

--- a/grafana-reporting/Tika-1522226794419-dashboard.json
+++ b/grafana-reporting/Tika-1522226794419-dashboard.json
@@ -110,7 +110,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:tikaTextExtraction",
+              "query": "name:\"tikaTextExtraction\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -223,7 +223,7 @@
                   "type": "avg"
                 }
               ],
-              "query": "name:tikaTextExtraction",
+              "query": "name:\"tikaTextExtraction\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -333,7 +333,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:textExtractor.cache.hit.rate",
+              "query": "name:\"textExtractor.cache.hit.rate\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -431,7 +431,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:textExtractor.cache.size",
+              "query": "name:\"textExtractor.cache.size\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -529,7 +529,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:textExtractor.cache.weight",
+              "query": "name:\"textExtractor.cache.weight\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -636,7 +636,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:textExtractor.cache.hit.count",
+              "query": "name:\"textExtractor.cache.hit.count\"",
               "refId": "A",
               "timeField": "@timestamp"
             },
@@ -674,7 +674,7 @@
                   "type": "derivative"
                 }
               ],
-              "query": "name:textExtractor.cache.miss.count",
+              "query": "name:\"textExtractor.cache.miss.count\"",
               "refId": "B",
               "timeField": "@timestamp"
             }
@@ -785,7 +785,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:textExtractor.cache.eviction.count",
+              "query": "name:\"textExtractor.cache.eviction.count\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -884,7 +884,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:textExtractor.cache.load.count",
+              "query": "name:\"textExtractor.cache.load.count\"",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -983,7 +983,7 @@
                   "type": "max"
                 }
               ],
-              "query": "name:textExtractor.cache.load.exception.rate",
+              "query": "name:\"textExtractor.cache.load.exception.rate\"",
               "refId": "A",
               "timeField": "@timestamp"
             }


### PR DESCRIPTION
Quotes query to avoid all the panel of a board using queries containing the same prefix followed by an `-` to display the same values.

Plus fix the IMAP CREATE metric reporting
