### PR TITLE
JAMES-3032 allow user to send an email with a from address containing…

### DIFF
--- a/server/container/guice/guice-common/src/main/java/org/apache/james/utils/DataProbeImpl.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/utils/DataProbeImpl.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import org.apache.james.core.Domain;
+import org.apache.james.core.MailAddress;
 import org.apache.james.core.Username;
 import org.apache.james.domainlist.api.DomainList;
 import org.apache.james.probe.DataProbe;
@@ -120,5 +121,10 @@ public class DataProbeImpl implements GuiceProbe, DataProbe {
     @Override
     public void addDomainAliasMapping(String aliasDomain, String deliveryDomain) throws Exception {
         recipientRewriteTable.addAliasDomainMapping(MappingSource.fromDomain(Domain.of(aliasDomain)), Domain.of(deliveryDomain));
+    }
+
+    @Override
+    public void addGroupAliasMapping(String fromGroup, String toAddress) throws Exception {
+        recipientRewriteTable.addGroupMapping(MappingSource.fromMailAddress(new MailAddress(fromGroup)), toAddress);
     }
 }

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/utils/DataProbeImpl.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/utils/DataProbeImpl.java
@@ -112,6 +112,12 @@ public class DataProbeImpl implements GuiceProbe, DataProbe {
     }
 
     @Override
+    public void addUserAliasMapping(String fromUser, String fromDomain, String toAddress) throws Exception {
+        MappingSource source = MappingSource.fromUser(fromUser, fromDomain);
+        recipientRewriteTable.addAliasMapping(source, toAddress);
+    }
+
+    @Override
     public void addDomainAliasMapping(String aliasDomain, String deliveryDomain) throws Exception {
         recipientRewriteTable.addAliasDomainMapping(MappingSource.fromDomain(Domain.of(aliasDomain)), Domain.of(deliveryDomain));
     }

--- a/server/container/guice/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/JMAPCommonModule.java
+++ b/server/container/guice/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/JMAPCommonModule.java
@@ -43,6 +43,8 @@ import org.apache.james.jmap.draft.utils.HeadersAuthenticationExtractor;
 import org.apache.james.jmap.event.ComputeMessageFastViewProjectionListener;
 import org.apache.james.lifecycle.api.StartUpCheck;
 import org.apache.james.mailbox.events.MailboxListener;
+import org.apache.james.rrt.api.CanSendFrom;
+import org.apache.james.rrt.lib.CanSendFromImpl;
 import org.apache.james.util.date.DefaultZonedDateTimeProvider;
 import org.apache.james.util.date.ZonedDateTimeProvider;
 import org.apache.james.util.mime.MessageContentExtractor;
@@ -77,6 +79,8 @@ public class JMAPCommonModule extends AbstractModule {
         bind(MessageMetadataViewFactory.class).in(Scopes.SINGLETON);
         bind(MessageHeaderViewFactory.class).in(Scopes.SINGLETON);
         bind(MessageFastViewFactory.class).in(Scopes.SINGLETON);
+
+        bind(CanSendFrom.class).to(CanSendFromImpl.class).in(Scopes.SINGLETON);
 
         bind(MessageContentExtractor.class).in(Scopes.SINGLETON);
         bind(HeadersAuthenticationExtractor.class).in(Scopes.SINGLETON);

--- a/server/data/data-api/src/main/java/org/apache/james/probe/DataProbe.java
+++ b/server/data/data-api/src/main/java/org/apache/james/probe/DataProbe.java
@@ -76,4 +76,6 @@ public interface DataProbe {
     void addUserAliasMapping(String fromUser, String fromDomain, String toAddress) throws Exception;
 
     void addDomainAliasMapping(String aliasDomain, String deliveryDomain) throws Exception;
+
+    void addGroupAliasMapping(String fromGroup, String toAddress) throws Exception;
 }

--- a/server/data/data-api/src/main/java/org/apache/james/probe/DataProbe.java
+++ b/server/data/data-api/src/main/java/org/apache/james/probe/DataProbe.java
@@ -73,5 +73,7 @@ public interface DataProbe {
 
     void addAddressMapping(String fromUser, String fromDomain, String toAddress) throws Exception;
 
+    void addUserAliasMapping(String fromUser, String fromDomain, String toAddress) throws Exception;
+
     void addDomainAliasMapping(String aliasDomain, String deliveryDomain) throws Exception;
 }

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/CanSendFrom.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/CanSendFrom.java
@@ -1,0 +1,30 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.rrt.api;
+
+import org.apache.james.core.Username;
+
+public interface CanSendFrom {
+
+    /**
+     * Indicate if the connectedUser can send a mail using the fromUser in the from clause.
+     */
+    boolean userCanSendFrom(Username connectedUser, Username fromUser);
+
+}

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
@@ -94,7 +94,15 @@ public interface RecipientRewriteTable {
      * @throws ErrorMappingException
      *             get thrown if an error mapping was found
      */
-    Mappings getResolvedMappings(String user, Domain domain) throws ErrorMappingException, RecipientRewriteTableException;
+    default Mappings getResolvedMappings(String user, Domain domain) throws ErrorMappingException, RecipientRewriteTableException {
+            return getResolvedMappings(user, domain, EnumSet.allOf(Mapping.Type.class));
+    }
+
+    /**
+     * Return the Mappings for the given source, only the mapping with the given mapping types are considered during the resolution.
+     * Return empty object if no matched mapping was found
+     */
+    Mappings getResolvedMappings(String user, Domain domain, EnumSet<Mapping.Type> mappingTypes) throws ErrorMappingException, RecipientRewriteTableException;
 
     /**
      * Return the explicit mapping stored for the given user and domain. Return empty object

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTableManagementMBean.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTableManagementMBean.java
@@ -85,30 +85,6 @@ public interface RecipientRewriteTableManagementMBean {
      */
     void removeAddressMapping(String fromUser, String fromDomain, String toAddress) throws Exception;
 
-    /***
-     * Add a user alias mapping that, for a user from@fromDomain would redirect
-     * mails to toAddress
-     *
-     * @param fromUser
-     *            the username. Null if no username should be used
-     * @param fromDomain
-     *            the domain. Null if no domain should be used
-     * @param toAddress
-     *            the address.
-     */
-    void addUserAliasMapping(String fromUser, String fromDomain, String toAddress) throws Exception;
-
-    /**
-     * Remove a user alias mapping. The API takes the same arguments as addUserAliasMapping
-     *
-     * @param fromUser
-     *            the username. Null if no username should be used
-     * @param fromDomain
-     *            the domain. Null if no domain should be used
-     * @param toAddress
-     */
-    void removeUserAliasMapping(String fromUser, String fromDomain, String toAddress) throws Exception;
-
     /**
      * Add error mapping
      * 

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTableManagementMBean.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTableManagementMBean.java
@@ -59,6 +59,8 @@ public interface RecipientRewriteTableManagementMBean {
     /***
      * Add address mapping that, for a user from@fromDomain would redirect
      * mails to toAddress
+     *
+     * Prefer using the specific methods addUserAliasMapping, addDomainMapping... which create an alias with a more specific Mapping.Type
      * 
      * @param fromUser
      *            the username. Null if no username should be used
@@ -66,6 +68,7 @@ public interface RecipientRewriteTableManagementMBean {
      *            the domain. Null if no domain should be used
      * @param toAddress
      *            the address.
+     *
      */
     void addAddressMapping(String fromUser, String fromDomain, String toAddress) throws Exception;
 
@@ -77,8 +80,33 @@ public interface RecipientRewriteTableManagementMBean {
      * @param fromDomain
      *            the domain. Null if no domain should be used
      * @param toAddress
+     *
      */
     void removeAddressMapping(String fromUser, String fromDomain, String toAddress) throws Exception;
+
+    /***
+     * Add a user alias mapping that, for a user from@fromDomain would redirect
+     * mails to toAddress
+     *
+     * @param fromUser
+     *            the username. Null if no username should be used
+     * @param fromDomain
+     *            the domain. Null if no domain should be used
+     * @param toAddress
+     *            the address.
+     */
+    void addUserAliasMapping(String fromUser, String fromDomain, String toAddress) throws Exception;
+
+    /**
+     * Remove a user alias mapping. The API takes the same arguments as addUserAliasMapping
+     *
+     * @param fromUser
+     *            the username. Null if no username should be used
+     * @param fromDomain
+     *            the domain. Null if no domain should be used
+     * @param toAddress
+     */
+    void removeUserAliasMapping(String fromUser, String fromDomain, String toAddress) throws Exception;
 
     /**
      * Add error mapping

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTableManagementMBean.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTableManagementMBean.java
@@ -60,7 +60,8 @@ public interface RecipientRewriteTableManagementMBean {
      * Add address mapping that, for a user from@fromDomain would redirect
      * mails to toAddress
      *
-     * Prefer using the specific methods addUserAliasMapping, addDomainMapping... which create an alias with a more specific Mapping.Type
+     * Prefer using the specific methods addUserAliasMapping, addDomainMapping...
+     * which create an alias with a more specific Mapping.Type
      * 
      * @param fromUser
      *            the username. Null if no username should be used

--- a/server/data/data-api/src/test/java/org/apache/james/rrt/lib/CanSendFromContract.java
+++ b/server/data/data-api/src/test/java/org/apache/james/rrt/lib/CanSendFromContract.java
@@ -1,0 +1,96 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.rrt.lib;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.rrt.api.CanSendFrom;
+import org.junit.jupiter.api.Test;
+
+public interface CanSendFromContract {
+
+    Domain DOMAIN = Domain.of("example.com");
+    Domain OTHER_DOMAIN = Domain.of("other.org");
+    Username USER = Username.of("user@example.com");
+    Username USER_ALIAS = Username.of("alias@example.com");
+    Username OTHER_USER = Username.of("other@example.com");
+
+    CanSendFrom canSendFrom();
+
+    void addAliasMapping(Username alias, Username user) throws Exception;
+
+    void addDomainMapping(Domain alias, Domain domain) throws Exception;
+
+    void addGroupMapping(String group, Username user) throws Exception;
+
+
+    @Test
+    default void assertUserCanSendFromShouldBeFalseWhenSenderIsNotTheUser() {
+        assertThat(canSendFrom().userCanSendFrom(USER, OTHER_USER)).isFalse();
+    }
+
+    @Test
+    default void assertUserCanSendFromShouldBeTrueWhenSenderIsTheUser() {
+        assertThat(canSendFrom().userCanSendFrom(USER, USER)).isTrue();
+    }
+
+    @Test
+    default void assertUserCanSendFromShouldBeFalseWhenSenderIsAnAliasOfAnotherUser() throws Exception {
+        addAliasMapping(USER_ALIAS, OTHER_USER);
+
+        assertThat(canSendFrom().userCanSendFrom(USER, USER_ALIAS)).isFalse();
+    }
+
+    @Test
+    default void assertUserCanSendFromShouldBeTrueWhenSenderIsAnAliasOfTheUser() throws Exception {
+        addAliasMapping(USER_ALIAS, USER);
+
+        assertThat(canSendFrom().userCanSendFrom(USER, USER_ALIAS)).isTrue();
+    }
+
+    @Test
+    default void assertUserCanSendFromShouldBeTrueWhenSenderIsAnAliasOfAnAliasOfTheUser() throws Exception {
+        Username userAliasBis = Username.of("aliasbis@" + DOMAIN.asString());
+        addAliasMapping(userAliasBis, USER_ALIAS);
+        addAliasMapping(USER_ALIAS, USER);
+
+        assertThat(canSendFrom().userCanSendFrom(USER, userAliasBis)).isTrue();
+    }
+
+    @Test
+    default void assertUserCanSendFromShouldBeTrueWhenSenderIsAnAliasOfTheDomainUser() throws Exception {
+        Username fromUser = Username.of(USER.getLocalPart() + "@" + OTHER_DOMAIN.asString());
+
+        addDomainMapping(OTHER_DOMAIN, DOMAIN);
+
+        assertThat(canSendFrom().userCanSendFrom(USER, fromUser)).isTrue();
+    }
+
+    @Test
+    default void assertUserCanSendFromShouldBeFalseWhenWhenSenderIsAnAliasOfTheUserFromAGroupAlias() throws Exception {
+        Username fromGroup = Username.of("group@example.com");
+
+        addGroupMapping("group@example.com", USER);
+
+        assertThat(canSendFrom().userCanSendFrom(USER, fromGroup)).isFalse();
+
+    }
+}

--- a/server/data/data-library/src/main/java/org/apache/james/rrt/lib/AbstractRecipientRewriteTable.java
+++ b/server/data/data-library/src/main/java/org/apache/james/rrt/lib/AbstractRecipientRewriteTable.java
@@ -18,6 +18,7 @@
  ****************************************************************/
 package org.apache.james.rrt.lib;
 
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -101,11 +102,12 @@ public abstract class AbstractRecipientRewriteTable implements RecipientRewriteT
     }
 
     @Override
-    public Mappings getResolvedMappings(String user, Domain domain) throws ErrorMappingException, RecipientRewriteTableException {
-        return getMappings(Username.fromLocalPartWithDomain(user, domain), mappingLimit);
+    public Mappings getResolvedMappings(String user, Domain domain, EnumSet<Type> mappingTypes) throws ErrorMappingException, RecipientRewriteTableException {
+
+        return getMappings(Username.fromLocalPartWithDomain(user, domain), mappingLimit, mappingTypes);
     }
 
-    private Mappings getMappings(Username username, int mappingLimit) throws ErrorMappingException, RecipientRewriteTableException {
+    private Mappings getMappings(Username username, int mappingLimit, EnumSet<Type> mappingTypes) throws ErrorMappingException, RecipientRewriteTableException {
 
         // We have to much mappings throw ErrorMappingException to avoid
         // infinity loop
@@ -113,23 +115,25 @@ public abstract class AbstractRecipientRewriteTable implements RecipientRewriteT
             throw new TooManyMappingException("554 Too many mappings to process");
         }
 
-        Mappings targetMappings = mapAddress(username.getLocalPart(), username.getDomainPart().get());
-
+        Domain domain = username.getDomainPart().get();
+        String localPart = username.getLocalPart();
+        Stream<Mapping> targetMappings = mapAddress(localPart, domain).asStream()
+                .filter(mapping -> mappingTypes.contains(mapping.getType()));
 
         try {
             return MappingsImpl.fromMappings(
-                targetMappings.asStream()
-                    .flatMap(Throwing.function((Mapping target) -> convertAndRecurseMapping(username, target, mappingLimit)).sneakyThrow()));
+                targetMappings
+                    .flatMap(Throwing.function((Mapping target) -> convertAndRecurseMapping(mappingTypes, username, target, mappingLimit)).sneakyThrow()));
         } catch (SkipMappingProcessingException e) {
             return MappingsImpl.empty();
         }
     }
 
-    private Stream<Mapping> convertAndRecurseMapping(Username originalUsername, Mapping associatedMapping, int remainingLoops) throws ErrorMappingException, RecipientRewriteTableException, SkipMappingProcessingException, AddressException {
+    private Stream<Mapping> convertAndRecurseMapping(EnumSet<Type> mappingTypes, Username originalUsername, Mapping associatedMapping, int remainingLoops) throws ErrorMappingException, SkipMappingProcessingException, AddressException {
 
         Function<Username, Stream<Mapping>> convertAndRecurseMapping =
             Throwing
-                .function((Username rewrittenUser) -> convertAndRecurseMapping(associatedMapping, originalUsername, rewrittenUser, remainingLoops))
+                .function((Username rewrittenUser) -> convertAndRecurseMapping(mappingTypes, associatedMapping, originalUsername, rewrittenUser, remainingLoops))
                 .sneakyThrow();
 
         return associatedMapping.rewriteUser(originalUsername)
@@ -138,7 +142,7 @@ public abstract class AbstractRecipientRewriteTable implements RecipientRewriteT
             .orElse(Stream.empty());
     }
 
-    private Stream<Mapping> convertAndRecurseMapping(Mapping mapping, Username originalUsername, Username rewrittenUsername, int remainingLoops) throws ErrorMappingException, RecipientRewriteTableException {
+    private Stream<Mapping> convertAndRecurseMapping(EnumSet<Type> mappingTypes, Mapping mapping, Username originalUsername, Username rewrittenUsername, int remainingLoops) throws ErrorMappingException, RecipientRewriteTableException {
         LOGGER.debug("Valid virtual user mapping {} to {}", originalUsername.asString(), rewrittenUsername.asString());
 
         Stream<Mapping> nonRecursiveResult = Stream.of(toMapping(rewrittenUsername, mapping.getType()));
@@ -150,12 +154,12 @@ public abstract class AbstractRecipientRewriteTable implements RecipientRewriteT
         if (originalUsername.equals(rewrittenUsername)) {
             return mapping.handleIdentity(nonRecursiveResult);
         } else {
-            return recurseMapping(nonRecursiveResult, rewrittenUsername, remainingLoops);
+            return recurseMapping(mappingTypes, nonRecursiveResult, rewrittenUsername, remainingLoops);
         }
     }
 
-    private Stream<Mapping> recurseMapping(Stream<Mapping> nonRecursiveResult, Username targetUsername, int remainingLoops) throws ErrorMappingException, RecipientRewriteTableException {
-        Mappings childMappings = getMappings(targetUsername, remainingLoops - 1);
+    private Stream<Mapping> recurseMapping(EnumSet<Type> mappingTypes, Stream<Mapping> nonRecursiveResult, Username targetUsername, int remainingLoops) throws ErrorMappingException, RecipientRewriteTableException {
+        Mappings childMappings = getMappings(targetUsername, remainingLoops - 1, mappingTypes);
 
         if (childMappings.isEmpty()) {
             return nonRecursiveResult;

--- a/server/data/data-library/src/main/java/org/apache/james/rrt/lib/CanSendFromImpl.java
+++ b/server/data/data-library/src/main/java/org/apache/james/rrt/lib/CanSendFromImpl.java
@@ -1,0 +1,63 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.rrt.lib;
+
+import static org.apache.james.rrt.lib.Mapping.Type.Alias;
+import static org.apache.james.rrt.lib.Mapping.Type.Domain;
+
+import java.util.EnumSet;
+
+import javax.inject.Inject;
+
+import org.apache.james.core.Username;
+import org.apache.james.rrt.api.CanSendFrom;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+import org.apache.james.util.OptionalUtils;
+
+public class CanSendFromImpl implements CanSendFrom {
+
+    public static final EnumSet<Mapping.Type> ALIAS_TYPES_ACCEPTED_IN_FROM = EnumSet.of(Alias, Domain);
+    private final RecipientRewriteTable recipientRewriteTable;
+
+    @Inject
+    public CanSendFromImpl(RecipientRewriteTable recipientRewriteTable) {
+        this.recipientRewriteTable = recipientRewriteTable;
+    }
+
+    @Override
+    public boolean userCanSendFrom(Username connectedUser, Username fromUser) {
+        try {
+            return connectedUser.equals(fromUser) || emailIsAnAliasOfTheConnectedUser(connectedUser, fromUser);
+        } catch (RecipientRewriteTableException | RecipientRewriteTable.ErrorMappingException e) {
+            return false;
+        }
+    }
+
+    private boolean emailIsAnAliasOfTheConnectedUser(Username connectedUser, Username fromUser) throws RecipientRewriteTable.ErrorMappingException, RecipientRewriteTableException {
+        return fromUser.getDomainPart().isPresent()
+            && recipientRewriteTable.getResolvedMappings(fromUser.getLocalPart(), fromUser.getDomainPart().get(), ALIAS_TYPES_ACCEPTED_IN_FROM)
+            .asStream()
+            .map(Mapping::asMailAddress)
+            .flatMap(OptionalUtils::toStream)
+            .map(Username::fromMailAddress)
+            .anyMatch(alias -> alias.equals(connectedUser));
+    }
+
+}

--- a/server/data/data-library/src/main/java/org/apache/james/rrt/lib/RecipientRewriteTableManagement.java
+++ b/server/data/data-library/src/main/java/org/apache/james/rrt/lib/RecipientRewriteTableManagement.java
@@ -69,6 +69,18 @@ public class RecipientRewriteTableManagement extends StandardMBean implements Re
     }
 
     @Override
+    public void addUserAliasMapping(String fromUser, String fromDomain, String toAddress) throws RecipientRewriteTableException {
+        MappingSource source = MappingSource.fromUser(fromUser, fromDomain);
+        rrt.addAliasMapping(source, toAddress);
+    }
+
+    @Override
+    public void removeUserAliasMapping(String fromUser, String fromDomain, String toAddress) throws RecipientRewriteTableException {
+        MappingSource source = MappingSource.fromUser(fromUser, fromDomain);
+        rrt.removeAliasMapping(source, toAddress);
+    }
+
+    @Override
     public void addErrorMapping(String user, String domain, String error) throws RecipientRewriteTableException {
         MappingSource source = MappingSource.fromUser(user, domain);
         rrt.addErrorMapping(source, error);

--- a/server/data/data-library/src/main/java/org/apache/james/rrt/lib/RecipientRewriteTableManagement.java
+++ b/server/data/data-library/src/main/java/org/apache/james/rrt/lib/RecipientRewriteTableManagement.java
@@ -69,18 +69,6 @@ public class RecipientRewriteTableManagement extends StandardMBean implements Re
     }
 
     @Override
-    public void addUserAliasMapping(String fromUser, String fromDomain, String toAddress) throws RecipientRewriteTableException {
-        MappingSource source = MappingSource.fromUser(fromUser, fromDomain);
-        rrt.addAliasMapping(source, toAddress);
-    }
-
-    @Override
-    public void removeUserAliasMapping(String fromUser, String fromDomain, String toAddress) throws RecipientRewriteTableException {
-        MappingSource source = MappingSource.fromUser(fromUser, fromDomain);
-        rrt.removeAliasMapping(source, toAddress);
-    }
-
-    @Override
     public void addErrorMapping(String user, String domain, String error) throws RecipientRewriteTableException {
         MappingSource source = MappingSource.fromUser(user, domain);
         rrt.addErrorMapping(source, error);

--- a/server/data/data-memory/pom.xml
+++ b/server/data/data-memory/pom.xml
@@ -98,5 +98,10 @@
             <artifactId>cucumber-picocontainer</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/server/data/data-memory/src/test/java/org/apache/james/rrt/lib/CanSendFromImplTest.java
+++ b/server/data/data-memory/src/test/java/org/apache/james/rrt/lib/CanSendFromImplTest.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.rrt.lib;
 
+import static org.mockito.Mockito.mock;
+
 import org.apache.james.core.Domain;
 import org.apache.james.core.Username;
 import org.apache.james.dnsservice.api.DNSService;
@@ -26,7 +28,6 @@ import org.apache.james.domainlist.memory.MemoryDomainList;
 import org.apache.james.rrt.api.CanSendFrom;
 import org.apache.james.rrt.memory.MemoryRecipientRewriteTable;
 import org.junit.jupiter.api.BeforeEach;
-import org.mockito.Mockito;
 
 public class CanSendFromImplTest implements CanSendFromContract {
 
@@ -37,7 +38,7 @@ public class CanSendFromImplTest implements CanSendFromContract {
     void setup() throws Exception {
         recipientRewriteTable = new MemoryRecipientRewriteTable();
 
-        DNSService dnsService = Mockito.mock(DNSService.class);
+        DNSService dnsService = mock(DNSService.class);
         MemoryDomainList domainList = new MemoryDomainList(dnsService);
         domainList.configure(DomainListConfiguration.builder()
             .autoDetect(false)

--- a/server/data/data-memory/src/test/java/org/apache/james/rrt/lib/CanSendFromImplTest.java
+++ b/server/data/data-memory/src/test/java/org/apache/james/rrt/lib/CanSendFromImplTest.java
@@ -1,0 +1,71 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.rrt.lib;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.dnsservice.api.DNSService;
+import org.apache.james.domainlist.lib.DomainListConfiguration;
+import org.apache.james.domainlist.memory.MemoryDomainList;
+import org.apache.james.rrt.api.CanSendFrom;
+import org.apache.james.rrt.memory.MemoryRecipientRewriteTable;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mockito;
+
+public class CanSendFromImplTest implements CanSendFromContract {
+
+    AbstractRecipientRewriteTable recipientRewriteTable;
+    CanSendFrom canSendFrom;
+
+    @BeforeEach
+    void setup() throws Exception {
+        recipientRewriteTable = new MemoryRecipientRewriteTable();
+
+        DNSService dnsService = Mockito.mock(DNSService.class);
+        MemoryDomainList domainList = new MemoryDomainList(dnsService);
+        domainList.configure(DomainListConfiguration.builder()
+            .autoDetect(false)
+            .autoDetectIp(false));
+        domainList.addDomain(DOMAIN);
+        domainList.addDomain(OTHER_DOMAIN);
+        recipientRewriteTable.setDomainList(domainList);
+
+        canSendFrom = new CanSendFromImpl(recipientRewriteTable);
+    }
+
+    @Override
+    public CanSendFrom canSendFrom() {
+        return canSendFrom;
+    }
+
+    @Override
+    public void addAliasMapping(Username alias, Username user) throws Exception {
+        recipientRewriteTable.addAliasMapping(MappingSource.fromUser(alias.getLocalPart(), alias.getDomainPart().get()), user.asString());
+    }
+
+    @Override
+    public void addDomainMapping(Domain alias, Domain domain) throws Exception {
+        recipientRewriteTable.addAliasDomainMapping(MappingSource.fromDomain(alias), domain);
+    }
+
+    @Override
+    public void addGroupMapping(String group, Username user) throws Exception {
+        recipientRewriteTable.addGroupMapping(MappingSource.fromUser(Username.of(group)), user.asString());
+    }
+}

--- a/server/protocols/jmap-draft/pom.xml
+++ b/server/protocols/jmap-draft/pom.xml
@@ -99,6 +99,11 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-dnsservice-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-filesystem-api</artifactId>
             <scope>test</scope>
             <type>test-jar</type>

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/SetMessagesCreationProcessorTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/SetMessagesCreationProcessorTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.jmap.draft.methods;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -28,11 +29,18 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.UnknownHostException;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.james.core.Domain;
 import org.apache.james.core.Username;
+import org.apache.james.dnsservice.api.DNSService;
+import org.apache.james.domainlist.api.DomainListException;
+import org.apache.james.domainlist.lib.DomainListConfiguration;
+import org.apache.james.domainlist.memory.MemoryDomainList;
 import org.apache.james.jmap.draft.exceptions.MailboxNotOwnedException;
 import org.apache.james.jmap.draft.model.CreationMessage;
 import org.apache.james.jmap.draft.model.CreationMessage.DraftEmailer;
@@ -64,6 +72,12 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.TestMessageId;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
+import org.apache.james.rrt.api.CanSendFrom;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+import org.apache.james.rrt.lib.Mapping;
+import org.apache.james.rrt.lib.MappingSource;
+import org.apache.james.rrt.lib.CanSendFromImpl;
+import org.apache.james.rrt.memory.MemoryRecipientRewriteTable;
 import org.apache.james.util.OptionalUtils;
 import org.apache.james.util.html.HtmlTextExtractor;
 import org.apache.james.util.mime.MessageContentExtractor;
@@ -80,6 +94,7 @@ import com.google.common.collect.ImmutableMap;
 public class SetMessagesCreationProcessorTest {
     
     private static final Username USER = Username.of("user@example.com");
+    private static final Username OTHER_USER = Username.of("other@example.com");
     private static final String OUTBOX = "outbox";
     private static final InMemoryId OUTBOX_ID = InMemoryId.of(12345);
     private static final String DRAFTS = "drafts";
@@ -108,6 +123,8 @@ public class SetMessagesCreationProcessorTest {
     private AttachmentManager mockedAttachmentManager;
     private MailboxManager mockedMailboxManager;
     private Factory mockedMailboxIdFactory;
+    private MemoryRecipientRewriteTable recipientRewriteTable;
+    private CanSendFrom canSendFrom;
     private SetMessagesCreationProcessor sut;
     private MessageManager outbox;
     private MessageManager drafts;
@@ -121,12 +138,23 @@ public class SetMessagesCreationProcessorTest {
     private ReferenceUpdater referenceUpdater;
 
     @Before
-    public void setUp() throws MailboxException {
+    public void setUp() throws MailboxException, DomainListException, UnknownHostException, ConfigurationException {
         MessageContentExtractor messageContentExtractor = new MessageContentExtractor();
         HtmlTextExtractor htmlTextExtractor = new JsoupHtmlTextExtractor();
         BlobManager blobManager = mock(BlobManager.class);
         when(blobManager.toBlobId(any(MessageId.class))).thenReturn(org.apache.james.mailbox.model.BlobId.fromString("fake"));
         MessageIdManager messageIdManager = mock(MessageIdManager.class);
+        recipientRewriteTable = new MemoryRecipientRewriteTable();
+
+        DNSService dnsService = mock(DNSService.class);
+        MemoryDomainList domainList = new MemoryDomainList(dnsService);
+        domainList.configure(DomainListConfiguration.builder()
+            .autoDetect(false)
+            .autoDetectIp(false));
+        domainList.addDomain(Domain.of("example.com"));
+        domainList.addDomain(Domain.of("other.org"));
+        recipientRewriteTable.setDomainList(domainList);
+        canSendFrom = new CanSendFromImpl(recipientRewriteTable);
         messageFullViewFactory = new MessageFullViewFactory(blobManager, messageContentExtractor, htmlTextExtractor,
             messageIdManager,
             new MemoryMessageFastViewProjection(new RecordingMetricFactory()));
@@ -150,7 +178,8 @@ public class SetMessagesCreationProcessorTest {
             mockedMailboxIdFactory,
             messageAppender,
             messageSender,
-            referenceUpdater);
+            referenceUpdater,
+            canSendFrom);
         
         outbox = mock(MessageManager.class);
         when(mockedMailboxIdFactory.fromString(OUTBOX_ID.serialize()))
@@ -234,7 +263,7 @@ public class SetMessagesCreationProcessorTest {
     @Test
     public void processShouldReturnNonEmptyCreatedWhenRequestHasNonEmptyCreate() throws MailboxException {
         // Given
-        sut = new SetMessagesCreationProcessor(messageFullViewFactory, fakeSystemMailboxesProvider, new AttachmentChecker(mockedAttachmentManager), new RecordingMetricFactory(), mockedMailboxManager, mockedMailboxIdFactory, messageAppender, messageSender, referenceUpdater);
+        sut = new SetMessagesCreationProcessor(messageFullViewFactory, fakeSystemMailboxesProvider, new AttachmentChecker(mockedAttachmentManager), new RecordingMetricFactory(), mockedMailboxManager, mockedMailboxIdFactory, messageAppender, messageSender, referenceUpdater, canSendFrom);
 
         // When
         SetMessagesResponse result = sut.process(createMessageInOutbox, session);
@@ -253,7 +282,8 @@ public class SetMessagesCreationProcessorTest {
             new AttachmentChecker(mockedAttachmentManager), new RecordingMetricFactory(), mockedMailboxManager, mockedMailboxIdFactory,
             messageAppender,
             messageSender,
-            referenceUpdater);
+            referenceUpdater,
+            canSendFrom);
         // When
         SetMessagesResponse actual = sut.process(createMessageInOutbox, session);
         
@@ -370,7 +400,81 @@ public class SetMessagesCreationProcessorTest {
 
         sut.assertIsUserOwnerOfMailboxes(ImmutableList.of(mailboxId), session);
     }
-    
+
+    @Test
+    public void assertUserCanSendFromShouldThrowWhenSenderIsNotTheConnectedUser() {
+        DraftEmailer sender = DraftEmailer
+            .builder()
+            .name("other")
+            .email("other@example.com").build();
+
+        assertThatThrownBy(() -> sut.assertUserCanSendFrom(USER, Optional.of(sender)))
+            .isInstanceOf(MailboxSendingNotAllowedException.class);
+    }
+
+    @Test
+    public void assertUserCanSendFromShouldNotThrowWhenSenderIsTheConnectedUser() {
+        DraftEmailer sender = DraftEmailer
+            .builder()
+            .name("user")
+            .email(USER.asString()).build();
+
+        assertThatCode(() -> sut.assertUserCanSendFrom(USER, Optional.of(sender)))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void assertUserCanSendFromShouldThrowWhenSenderIsAnAliasOfAnotherUser() throws Exception {
+        DraftEmailer sender = DraftEmailer
+            .builder()
+            .name("alias")
+            .email("alias@example.com").build();
+
+        recipientRewriteTable.addAliasMapping(MappingSource.fromUser("alias", "example.com"), OTHER_USER.asString());
+
+        assertThatThrownBy(() -> sut.assertUserCanSendFrom(USER, Optional.of(sender)))
+            .isInstanceOf(MailboxSendingNotAllowedException.class);
+    }
+
+    @Test
+    public void assertUserCanSendFromShouldNotThrowWhenSenderIsAnAliasOfTheConnectedUser() throws RecipientRewriteTableException {
+        DraftEmailer sender = DraftEmailer
+            .builder()
+            .name("alias")
+            .email("alias@example.com").build();
+
+        recipientRewriteTable.addAliasMapping(MappingSource.fromUser("alias", "example.com"), USER.asString());
+
+        assertThatCode(() -> sut.assertUserCanSendFrom(USER, Optional.of(sender)))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void assertUserCanSendFromShouldNotThrowWhenSenderIsAnAliasOfTheConnectedUserFromADomainAlias() throws RecipientRewriteTableException {
+        DraftEmailer sender = DraftEmailer
+            .builder()
+            .name("user")
+            .email("user@other.org").build();
+
+           recipientRewriteTable.addMapping(MappingSource.fromDomain(Domain.of("other.org")), Mapping.domain(Domain.of("example.com")));
+
+        assertThatCode(() -> sut.assertUserCanSendFrom(USER, Optional.of(sender)))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void assertUserCanSendFromShouldThrowWhenSenderIsAnAliasOfTheConnectedUserFromAGroupAlias() throws RecipientRewriteTableException {
+        DraftEmailer sender = DraftEmailer
+            .builder()
+            .name("group")
+            .email("group@example.com").build();
+
+        recipientRewriteTable.addGroupMapping(MappingSource.fromUser("group", "example.com"), USER.asString());
+
+        assertThatThrownBy(() -> sut.assertUserCanSendFrom(USER, Optional.of(sender)))
+            .isInstanceOf(MailboxSendingNotAllowedException.class);
+    }
+
     public static class TestSystemMailboxesProvider implements SystemMailboxesProvider {
 
         private final Supplier<Optional<MessageManager>> outboxSupplier;

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/SetMessagesCreationProcessorTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/SetMessagesCreationProcessorTest.java
@@ -406,7 +406,8 @@ public class SetMessagesCreationProcessorTest {
         DraftEmailer sender = DraftEmailer
             .builder()
             .name("other")
-            .email("other@example.com").build();
+            .email("other@example.com")
+            .build();
 
         assertThatThrownBy(() -> sut.assertUserCanSendFrom(USER, Optional.of(sender)))
             .isInstanceOf(MailboxSendingNotAllowedException.class);
@@ -417,7 +418,8 @@ public class SetMessagesCreationProcessorTest {
         DraftEmailer sender = DraftEmailer
             .builder()
             .name("user")
-            .email(USER.asString()).build();
+            .email(USER.asString())
+            .build();
 
         assertThatCode(() -> sut.assertUserCanSendFrom(USER, Optional.of(sender)))
             .doesNotThrowAnyException();
@@ -428,7 +430,8 @@ public class SetMessagesCreationProcessorTest {
         DraftEmailer sender = DraftEmailer
             .builder()
             .name("alias")
-            .email("alias@example.com").build();
+            .email("alias@example.com")
+            .build();
 
         recipientRewriteTable.addAliasMapping(MappingSource.fromUser("alias", "example.com"), OTHER_USER.asString());
 
@@ -441,7 +444,8 @@ public class SetMessagesCreationProcessorTest {
         DraftEmailer sender = DraftEmailer
             .builder()
             .name("alias")
-            .email("alias@example.com").build();
+            .email("alias@example.com")
+            .build();
 
         recipientRewriteTable.addAliasMapping(MappingSource.fromUser("alias", "example.com"), USER.asString());
 
@@ -454,7 +458,8 @@ public class SetMessagesCreationProcessorTest {
         DraftEmailer sender = DraftEmailer
             .builder()
             .name("user")
-            .email("user@other.org").build();
+            .email("user@other.org")
+            .build();
 
            recipientRewriteTable.addMapping(MappingSource.fromDomain(Domain.of("other.org")), Mapping.domain(Domain.of("example.com")));
 
@@ -467,7 +472,8 @@ public class SetMessagesCreationProcessorTest {
         DraftEmailer sender = DraftEmailer
             .builder()
             .name("group")
-            .email("group@example.com").build();
+            .email("group@example.com")
+            .build();
 
         recipientRewriteTable.addGroupMapping(MappingSource.fromUser("group", "example.com"), USER.asString());
 

--- a/server/testing/src/main/java/org/apache/james/jmap/JMAPTestingConstants.java
+++ b/server/testing/src/main/java/org/apache/james/jmap/JMAPTestingConstants.java
@@ -56,6 +56,7 @@ public interface JMAPTestingConstants {
     String SECOND_ARGUMENTS = "[1][1]";
 
     String DOMAIN = "domain.tld";
+    String DOMAIN_ALIAS = "domain-alias.tld";
     Username BOB = Username.of("bob@" + DOMAIN);
     String BOB_PASSWORD = "123456";
     Username ALICE = Username.of("alice@" + DOMAIN);


### PR DESCRIPTION
… one of her alias

Currently James checks that the user connected matches the user is the From header of a mail being sent.
Instead, James should allow that the From header contains any alias of the connected user.
This also matches the current JMAP specification security considerations: [](https://jmap.io/spec-mail.html#permission-to-send-from-an-address)