### PR TITLE
JAMES-2720 Fix linagora/linshare-ldap-for-tests docker image tag to 1…

### DIFF
--- a/third-party/linshare/src/test/java/org/apache/james/linshare/Linshare.java
+++ b/third-party/linshare/src/test/java/org/apache/james/linshare/Linshare.java
@@ -114,7 +114,7 @@ public class Linshare {
 
     @SuppressWarnings("resource")
     private GenericContainer<?> createDockerLdap() {
-        return new GenericContainer<>("linagora/linshare-ldap-for-tests:1.0")
+        return new GenericContainer<>("linagora/linshare-ldap-for-tests:1.0.0")
             .withLogConsumer(frame -> LOGGER.debug("<linshare-ldap-for-tests> " + frame.getUtf8String()))
             .withNetworkAliases("ldap")
             .withNetwork(network);


### PR DESCRIPTION
….0.0

We should not rely on 2 digits tag versions but 3 if possible.
Recently a new version, 1.0.1, was introduced for this image, upgrading then as well
the 1.0 tag, introducing errors in our test suite. 1.0.0 is the one that has been
initially tested and approved.