### PR TITLE
JAMES-3038 Smtp send mail from alias

### DIFF
--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/data/CassandraRecipientRewriteTableModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/data/CassandraRecipientRewriteTableModule.java
@@ -19,11 +19,13 @@
 package org.apache.james.modules.data;
 
 import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.rrt.api.CanSendFrom;
 import org.apache.james.rrt.api.RecipientRewriteTable;
 import org.apache.james.rrt.cassandra.CassandraMappingsSourcesDAO;
 import org.apache.james.rrt.cassandra.CassandraRRTModule;
 import org.apache.james.rrt.cassandra.CassandraRecipientRewriteTable;
 import org.apache.james.rrt.cassandra.CassandraRecipientRewriteTableDAO;
+import org.apache.james.rrt.lib.CanSendFromImpl;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
 import org.apache.james.utils.InitializationOperation;
 import org.apache.james.utils.InitilizationOperationBuilder;
@@ -40,6 +42,8 @@ public class CassandraRecipientRewriteTableModule extends AbstractModule {
         bind(CassandraRecipientRewriteTableDAO.class).in(Scopes.SINGLETON);
         bind(CassandraMappingsSourcesDAO.class).in(Scopes.SINGLETON);
         bind(RecipientRewriteTable.class).to(CassandraRecipientRewriteTable.class);
+        bind(CanSendFromImpl.class).in(Scopes.SINGLETON);
+        bind(CanSendFrom.class).to(CanSendFromImpl.class);
         Multibinder<CassandraModule> cassandraDataDefinitions = Multibinder.newSetBinder(binder(), CassandraModule.class);
         cassandraDataDefinitions.addBinding().toInstance(CassandraRRTModule.MODULE);
     }

--- a/server/container/guice/jpa-common-guice/src/main/java/org/apache/james/modules/data/JPARecipientRewriteTableModule.java
+++ b/server/container/guice/jpa-common-guice/src/main/java/org/apache/james/modules/data/JPARecipientRewriteTableModule.java
@@ -18,8 +18,10 @@
  ****************************************************************/
 package org.apache.james.modules.data;
 
+import org.apache.james.rrt.api.CanSendFrom;
 import org.apache.james.rrt.api.RecipientRewriteTable;
 import org.apache.james.rrt.jpa.JPARecipientRewriteTable;
+import org.apache.james.rrt.lib.CanSendFromImpl;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
 import org.apache.james.utils.InitializationOperation;
 import org.apache.james.utils.InitilizationOperationBuilder;
@@ -33,6 +35,8 @@ public class JPARecipientRewriteTableModule extends AbstractModule {
     public void configure() {
         bind(JPARecipientRewriteTable.class).in(Scopes.SINGLETON);
         bind(RecipientRewriteTable.class).to(JPARecipientRewriteTable.class);
+        bind(CanSendFromImpl.class).in(Scopes.SINGLETON);
+        bind(CanSendFrom.class).to(CanSendFromImpl.class);
     }
 
     @ProvidesIntoSet

--- a/server/container/guice/memory-guice/src/main/java/org/apache/james/modules/data/MemoryDataModule.java
+++ b/server/container/guice/memory-guice/src/main/java/org/apache/james/modules/data/MemoryDataModule.java
@@ -32,7 +32,9 @@ import org.apache.james.mailrepository.memory.MailRepositoryStoreConfiguration;
 import org.apache.james.mailrepository.memory.MemoryMailRepository;
 import org.apache.james.mailrepository.memory.MemoryMailRepositoryUrlStore;
 import org.apache.james.modules.server.MailStoreRepositoryModule;
+import org.apache.james.rrt.api.CanSendFrom;
 import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.lib.CanSendFromImpl;
 import org.apache.james.rrt.memory.MemoryRecipientRewriteTable;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
 import org.apache.james.user.api.UsersRepository;
@@ -65,6 +67,9 @@ public class MemoryDataModule extends AbstractModule {
 
         bind(MemoryRecipientRewriteTable.class).in(Scopes.SINGLETON);
         bind(RecipientRewriteTable.class).to(MemoryRecipientRewriteTable.class);
+
+        bind(CanSendFromImpl.class).in(Scopes.SINGLETON);
+        bind(CanSendFrom.class).to(CanSendFromImpl.class);
 
         bind(MemoryMailRepositoryUrlStore.class).in(Scopes.SINGLETON);
         bind(MailRepositoryUrlStore.class).to(MemoryMailRepositoryUrlStore.class);

--- a/server/container/guice/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/JMAPCommonModule.java
+++ b/server/container/guice/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/JMAPCommonModule.java
@@ -80,8 +80,6 @@ public class JMAPCommonModule extends AbstractModule {
         bind(MessageHeaderViewFactory.class).in(Scopes.SINGLETON);
         bind(MessageFastViewFactory.class).in(Scopes.SINGLETON);
 
-        bind(CanSendFrom.class).to(CanSendFromImpl.class).in(Scopes.SINGLETON);
-
         bind(MessageContentExtractor.class).in(Scopes.SINGLETON);
         bind(HeadersAuthenticationExtractor.class).in(Scopes.SINGLETON);
         bind(SecurityKeyLoader.class).in(Scopes.SINGLETON);

--- a/server/container/guice/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/JMAPCommonModule.java
+++ b/server/container/guice/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/JMAPCommonModule.java
@@ -43,8 +43,6 @@ import org.apache.james.jmap.draft.utils.HeadersAuthenticationExtractor;
 import org.apache.james.jmap.event.ComputeMessageFastViewProjectionListener;
 import org.apache.james.lifecycle.api.StartUpCheck;
 import org.apache.james.mailbox.events.MailboxListener;
-import org.apache.james.rrt.api.CanSendFrom;
-import org.apache.james.rrt.lib.CanSendFromImpl;
 import org.apache.james.util.date.DefaultZonedDateTimeProvider;
 import org.apache.james.util.date.ZonedDateTimeProvider;
 import org.apache.james.util.mime.MessageContentExtractor;

--- a/server/container/spring/src/main/resources/META-INF/org/apache/james/spring-server.xml
+++ b/server/container/spring/src/main/resources/META-INF/org/apache/james/spring-server.xml
@@ -326,4 +326,5 @@
 
     <bean id="jspfLogger" class="org.apache.james.smtpserver.fastfail.SPFHandler.SPFLogger"/>
 
+    <bean id="cansendfrom" class="org.apache.james.rrt.lib.CanSendFromImpl" />
 </beans>

--- a/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SenderAuthIdentifyVerificationRcptHook.java
+++ b/server/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/SenderAuthIdentifyVerificationRcptHook.java
@@ -29,6 +29,7 @@ import org.apache.james.domainlist.api.DomainListException;
 import org.apache.james.protocols.smtp.SMTPSession;
 import org.apache.james.protocols.smtp.core.AbstractSenderAuthIdentifyVerificationRcptHook;
 import org.apache.james.protocols.smtp.hook.HookResult;
+import org.apache.james.rrt.api.CanSendFrom;
 import org.apache.james.user.api.UsersRepository;
 import org.apache.james.user.api.UsersRepositoryException;
 
@@ -38,11 +39,13 @@ import org.apache.james.user.api.UsersRepositoryException;
 public class SenderAuthIdentifyVerificationRcptHook extends AbstractSenderAuthIdentifyVerificationRcptHook {
     private final DomainList domains;
     private final UsersRepository users;
+    private final CanSendFrom canSendFrom;
 
     @Inject
-    public SenderAuthIdentifyVerificationRcptHook(DomainList domains, UsersRepository users) {
+    public SenderAuthIdentifyVerificationRcptHook(DomainList domains, UsersRepository users, CanSendFrom canSendFrom) {
         this.domains = domains;
         this.users = users;
+        this.canSendFrom = canSendFrom;
     }
 
     @Override
@@ -74,7 +77,7 @@ public class SenderAuthIdentifyVerificationRcptHook extends AbstractSenderAuthId
     }
 
     @Override
-    protected boolean isSenderAllowed(Username user, Username sender) {
-        return user.equals(sender);
+    protected boolean isSenderAllowed(Username connectedUser, Username sender) {
+        return canSendFrom.userCanSendFrom(connectedUser, sender);
     }
 }

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
@@ -95,6 +95,10 @@ import com.google.inject.TypeLiteral;
 
 public class SMTPServerTest {
 
+    public static final String LOCAL_DOMAIN = "example.local";
+    public static final String USER_LOCALHOST = "test_user_smtp@localhost";
+    public static final String USER_LOCAL_DOMAIN = "test_user_smtp@example.local";
+
     final class AlterableDNSServer implements DNSService {
 
         private InetAddress localhostByName = null;
@@ -125,7 +129,7 @@ public class SMTPServerTest {
             }
 
             if ("1.0.0.127.bl.spamcop.net.".equals(host)) {
-                return InetAddress.getByName("localhost");
+                return InetAddress.getByName(Domain.LOCALHOST.asString());
             }
 
             if ("james.apache.org".equals(host)) {
@@ -202,15 +206,15 @@ public class SMTPServerTest {
     public void setUp() throws Exception {
 
         domainList = new MemoryDomainList(new InMemoryDNSService()
-            .registerMxRecord("localhost", "127.0.0.1")
-            .registerMxRecord("example.local", "127.0.0.1")
+            .registerMxRecord(Domain.LOCALHOST.asString(), "127.0.0.1")
+            .registerMxRecord(LOCAL_DOMAIN, "127.0.0.1")
             .registerMxRecord("examplebis.local", "127.0.0.1")
             .registerMxRecord("127.0.0.1", "127.0.0.1"));
         domainList.setAutoDetect(false);
         domainList.setAutoDetectIP(false);
 
         domainList.addDomain(Domain.LOCALHOST);
-        domainList.addDomain(Domain.of("example.local"));
+        domainList.addDomain(Domain.of(LOCAL_DOMAIN));
         domainList.addDomain(Domain.of("examplebis.local"));
         usersRepository = MemoryUsersRepository.withVirtualHosting(domainList);
 
@@ -1289,9 +1293,9 @@ public class SMTPServerTest {
         // assertTrue("anouncing auth required",
         // capabilitieslist.contains("AUTH=LOGIN PLAIN"));
 
-        String userName = "test_user_smtp@localhost";
+        String userName = USER_LOCALHOST;
         String noexistUserName = "noexist_test_user_smtp";
-        String sender = "test_user_smtp@localhost";
+        String sender = USER_LOCALHOST;
         smtpProtocol.sendCommand("AUTH FOO", null);
         assertThat(smtpProtocol.getReplyCode())
             .as("expected error: unrecognized authentication type")
@@ -1363,8 +1367,8 @@ public class SMTPServerTest {
             capabilitieslist.add(capabilityRes[i].substring(4));
         }
 
-        String userName = "test_user_smtp@localhost";
-        String sender = "test_user_smtp@localhost";
+        String userName = USER_LOCALHOST;
+        String sender = USER_LOCALHOST;
 
         usersRepository.addUser(Username.of(userName), "pwd");
 
@@ -1404,7 +1408,7 @@ public class SMTPServerTest {
             capabilitieslist.add(capabilityRes[i].substring(4));
         }
 
-        String userName = "test_user_smtp@example.local";
+        String userName = USER_LOCAL_DOMAIN;
         String sender = "alias_test_user_smtp@example.local";
 
         usersRepository.addUser(Username.of(userName), "pwd");
@@ -1446,11 +1450,11 @@ public class SMTPServerTest {
             capabilitieslist.add(capabilityRes[i].substring(4));
         }
 
-        String userName = "test_user_smtp@example.local";
+        String userName = USER_LOCAL_DOMAIN;
         String sender = "test_user_smtp@examplebis.local";
 
         usersRepository.addUser(Username.of(userName), "pwd");
-        rewriteTable.addAliasDomainMapping(MappingSource.fromDomain(Domain.of("examplebis.local")), Domain.of("example.local"));
+        rewriteTable.addAliasDomainMapping(MappingSource.fromDomain(Domain.of("examplebis.local")), Domain.of(LOCAL_DOMAIN));
 
         smtpProtocol.sendCommand("AUTH PLAIN");
         smtpProtocol.sendCommand(Base64.getEncoder().encodeToString(("\0" + userName + "\0pwd\0").getBytes(UTF_8)));
@@ -1488,7 +1492,7 @@ public class SMTPServerTest {
             capabilitieslist.add(capabilityRes[i].substring(4));
         }
 
-        String userName = "test_user_smtp@example.local";
+        String userName = USER_LOCAL_DOMAIN;
         String sender = "group@example.local";
 
         usersRepository.addUser(Username.of(userName), "pwd");
@@ -1528,7 +1532,7 @@ public class SMTPServerTest {
 
         smtpProtocol.sendCommand("ehlo " + InetAddress.getLocalHost());
 
-        String userName = "test_user_smtp@localhost";
+        String userName = USER_LOCALHOST;
         usersRepository.addUser(Username.of(userName), "pwd");
 
         smtpProtocol.setSender("");
@@ -1745,8 +1749,8 @@ public class SMTPServerTest {
         // is this required or just for compatibility? assertTrue("anouncing
         // auth required", capabilitieslist.contains("AUTH=LOGIN PLAIN"));
 
-        String userName = "test_user_smtp@localhost";
-        String sender = "test_user_smtp@localhost";
+        String userName = USER_LOCALHOST;
+        String sender = USER_LOCALHOST;
 
         smtpProtocol.setSender(sender);
 
@@ -1787,7 +1791,7 @@ public class SMTPServerTest {
 
         smtpProtocol.sendCommand("ehlo", InetAddress.getLocalHost().toString());
 
-        String sender = "test_user_smtp@localhost";
+        String sender = USER_LOCALHOST;
 
         smtpProtocol.setSender(sender);
 

--- a/src/site/xdoc/server/config-smtp-lmtp.xml
+++ b/src/site/xdoc/server/config-smtp-lmtp.xml
@@ -108,7 +108,7 @@
       if SMTP authentication is required.  If the parameter is set to true then the sender address for the submitted message
       will be verified against the authenticated subject. Verify sender addresses, ensuring that
          the sender address matches the user who has authenticated.
-         It will verify that the sender address match the address of the user or one of its alias(from user or domain alias).
+         It will verify that the sender address matches the address of the user or one of its alias (from user or domain aliases).
          This prevents a user of your mail server from acting as someone else
          If unspecified, default value is true.</dd>
       <dt><strong>handler.maxmessagesize</strong></dt>

--- a/src/site/xdoc/server/config-smtp-lmtp.xml
+++ b/src/site/xdoc/server/config-smtp-lmtp.xml
@@ -108,6 +108,7 @@
       if SMTP authentication is required.  If the parameter is set to true then the sender address for the submitted message
       will be verified against the authenticated subject. Verify sender addresses, ensuring that
          the sender address matches the user who has authenticated.
+         It will verify that the sender address match the address of the user or one of its alias(from user or domain alias).
          This prevents a user of your mail server from acting as someone else
          If unspecified, default value is true.</dd>
       <dt><strong>handler.maxmessagesize</strong></dt>


### PR DESCRIPTION
Currently James checks that the user connected matches the user is the From header of a mail being sent.
Instead, James should allow that the From header contains any alias of the connected user.
The alias the user can send from should be the one from its user alias and domain alias.
It should not be allowed to send from a group alias.
This also matches the current JMAP specification security considerations: https://jmap.io/spec-mail.html#permission-to-send-from-an-address



It is the equivalent for the SMTP protocol of https://issues.apache.org/jira/browse/JAMES-3032 which targeted JMAP.
