### PR TITLE
JAMES-3042 ImapRequestFrameDecoder should be more resilient

### DIFF
--- a/server/protocols/protocols-imap4/pom.xml
+++ b/server/protocols/protocols-imap4/pom.xml
@@ -80,6 +80,11 @@
             <artifactId>commons-configuration2</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
@@ -230,13 +230,11 @@ public class ImapRequestFrameDecoder extends FrameDecoder implements NettyConsta
             @SuppressWarnings("unchecked")
             int size = (Integer) sizeAsObject;
 
-            if (inMemorySizeLimit > 0 && size > 0) {
-                return ChannelBuffers.dynamicBuffer(Math.min(size, inMemorySizeLimit), ctx.getChannel().getConfig().getBufferFactory());
-            } else {
+            if (size > 0) {
+                int sanitizedInMemorySizeLimit = Math.max(0, inMemorySizeLimit);
+                int sanitizedSize = Math.min(sanitizedInMemorySizeLimit, size);
 
-                if (size > 0) {
-                    return ChannelBuffers.dynamicBuffer(size, ctx.getChannel().getConfig().getBufferFactory());
-                }
+                return ChannelBuffers.dynamicBuffer(sanitizedSize, ctx.getChannel().getConfig().getBufferFactory());
             }
         }
         return super.newCumulationBuffer(ctx, minimumCapacity);

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
@@ -221,17 +221,21 @@ public class ImapRequestFrameDecoder extends FrameDecoder implements NettyConsta
 
     @Override
     protected synchronized ChannelBuffer newCumulationBuffer(ChannelHandlerContext ctx, int minimumCapacity) {
-        @SuppressWarnings("unchecked")
         Map<String, Object> attachment = (Map<String, Object>) ctx.getAttachment();
-        int size = (Integer) attachment.get(NEEDED_DATA);
-        
-        if (inMemorySizeLimit > 0) {
-            return ChannelBuffers.dynamicBuffer(Math.min(size, inMemorySizeLimit), ctx.getChannel().getConfig().getBufferFactory());
-        } else {
+        if (attachment.containsKey(NEEDED_DATA)) {
+            @SuppressWarnings("unchecked")
+            int size = (Integer) attachment.get(NEEDED_DATA);
 
-            if (size > 0) {
-                return ChannelBuffers.dynamicBuffer(size, ctx.getChannel().getConfig().getBufferFactory());
+            if (inMemorySizeLimit > 0) {
+                return ChannelBuffers.dynamicBuffer(Math.min(size, inMemorySizeLimit), ctx.getChannel().getConfig().getBufferFactory());
+            } else {
+
+                if (size > 0) {
+                    return ChannelBuffers.dynamicBuffer(size, ctx.getChannel().getConfig().getBufferFactory());
+                }
+                return super.newCumulationBuffer(ctx, minimumCapacity);
             }
+        } else {
             return super.newCumulationBuffer(ctx, minimumCapacity);
         }
     }

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
@@ -233,11 +233,9 @@ public class ImapRequestFrameDecoder extends FrameDecoder implements NettyConsta
                 if (size > 0) {
                     return ChannelBuffers.dynamicBuffer(size, ctx.getChannel().getConfig().getBufferFactory());
                 }
-                return super.newCumulationBuffer(ctx, minimumCapacity);
             }
-        } else {
-            return super.newCumulationBuffer(ctx, minimumCapacity);
         }
+        return super.newCumulationBuffer(ctx, minimumCapacity);
     }
 
 }

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
@@ -225,9 +225,10 @@ public class ImapRequestFrameDecoder extends FrameDecoder implements NettyConsta
     @Override
     protected synchronized ChannelBuffer newCumulationBuffer(ChannelHandlerContext ctx, int minimumCapacity) {
         Map<String, Object> attachment = (Map<String, Object>) ctx.getAttachment();
-        if (attachment.containsKey(NEEDED_DATA)) {
+        Object sizeAsObject = attachment.get(NEEDED_DATA);
+        if (sizeAsObject != null) {
             @SuppressWarnings("unchecked")
-            int size = (Integer) attachment.get(NEEDED_DATA);
+            int size = (Integer) sizeAsObject;
 
             if (inMemorySizeLimit > 0 && size > 0) {
                 return ChannelBuffers.dynamicBuffer(Math.min(size, inMemorySizeLimit), ctx.getChannel().getConfig().getBufferFactory());

--- a/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
+++ b/server/protocols/protocols-imap4/src/main/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoder.java
@@ -42,6 +42,8 @@ import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.channel.ChannelStateEvent;
 import org.jboss.netty.handler.codec.frame.FrameDecoder;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * {@link FrameDecoder} which will decode via and {@link ImapDecoder} instance
  */
@@ -50,7 +52,8 @@ public class ImapRequestFrameDecoder extends FrameDecoder implements NettyConsta
     private final ImapDecoder decoder;
     private final int inMemorySizeLimit;
     private final int literalSizeLimit;
-    private static final String NEEDED_DATA = "NEEDED_DATA";
+    @VisibleForTesting
+    static final String NEEDED_DATA = "NEEDED_DATA";
     private static final String STORED_DATA = "STORED_DATA";
     private static final String WRITTEN_DATA = "WRITTEN_DATA";
     private static final String OUTPUT_STREAM = "OUTPUT_STREAM";
@@ -226,7 +229,7 @@ public class ImapRequestFrameDecoder extends FrameDecoder implements NettyConsta
             @SuppressWarnings("unchecked")
             int size = (Integer) attachment.get(NEEDED_DATA);
 
-            if (inMemorySizeLimit > 0) {
+            if (inMemorySizeLimit > 0 && size > 0) {
                 return ChannelBuffers.dynamicBuffer(Math.min(size, inMemorySizeLimit), ctx.getChannel().getConfig().getBufferFactory());
             } else {
 

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoderTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoderTest.java
@@ -1,0 +1,63 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.imapserver.netty;
+
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.james.imap.decode.ImapDecoder;
+import org.jboss.netty.buffer.ChannelBufferFactory;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelConfig;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+class ImapRequestFrameDecoderTest {
+    ImapRequestFrameDecoder testee;
+
+    @BeforeEach
+    void setUp() {
+        testee = new ImapRequestFrameDecoder(
+            mock(ImapDecoder.class),
+            12,
+            18);
+    }
+
+    @Test
+    void newCumulationBufferShouldNotThrowWhenNoAttachments() {
+        ChannelHandlerContext channelHandler = mock(ChannelHandlerContext.class);
+        Channel channel = mock(Channel.class);
+        ChannelConfig channelConfig = mock(ChannelConfig.class);
+
+        when(channelConfig.getBufferFactory()).thenReturn(mock(ChannelBufferFactory.class));
+        when(channelHandler.getChannel()).thenReturn(channel);
+        when(channel.getConfig()).thenReturn(channelConfig);
+
+        when(channelHandler.getAttachment()).thenReturn(ImmutableMap.<String, Object>of());
+
+        assertThatCode(() -> testee.newCumulationBuffer(channelHandler, 36))
+            .doesNotThrowAnyException();
+    }
+}

--- a/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoderTest.java
+++ b/server/protocols/protocols-imap4/src/test/java/org/apache/james/imapserver/netty/ImapRequestFrameDecoderTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.imapserver.netty;
 
 
+import static org.apache.james.imapserver.netty.ImapRequestFrameDecoder.NEEDED_DATA;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -56,6 +57,22 @@ class ImapRequestFrameDecoderTest {
         when(channel.getConfig()).thenReturn(channelConfig);
 
         when(channelHandler.getAttachment()).thenReturn(ImmutableMap.<String, Object>of());
+
+        assertThatCode(() -> testee.newCumulationBuffer(channelHandler, 36))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void newCumulationBufferShouldNotThrowOnNegativeSize() {
+        ChannelHandlerContext channelHandler = mock(ChannelHandlerContext.class);
+        Channel channel = mock(Channel.class);
+        ChannelConfig channelConfig = mock(ChannelConfig.class);
+
+        when(channelConfig.getBufferFactory()).thenReturn(mock(ChannelBufferFactory.class));
+        when(channelHandler.getChannel()).thenReturn(channel);
+        when(channel.getConfig()).thenReturn(channelConfig);
+
+        when(channelHandler.getAttachment()).thenReturn(ImmutableMap.<String, Object>of(NEEDED_DATA, -1));
 
         assertThatCode(() -> testee.newCumulationBuffer(channelHandler, 36))
             .doesNotThrowAnyException();


### PR DESCRIPTION
`newCumulationBuffer` ended up throwing nullPointer exceptions when NEEDED_DATA
attachment was not well positioned.

We can call super method when this attachment is not here in order to be more resilient
(as only the sizing of a buffer is chosen).