### PR TITLE
JAMES-3040 LinShare blob export mechanism should rely on delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ of tasks being currently executed.
 - Unhealthy health checks now return HTTP 503 instead of 500, degraded now returns 200 instead of 500. See JAMES-2576.
 - In order to fasten JMAP-draft message retrieval upon calls on properties expected to be fast to fetch, we now compute the preview and hasAttachment properties asynchronously and persist them in Cassandra to improve performance. See JAMES-2919.
 - It is now forbidden to create new Usernames with the following set of characters in its local part : `"(),:; <>@\[]`, as we prefer it to stay simple to handle. However, the read of Usernames already existing with some of those characters is still allowed, to not introduce any breaking change. See JAMES-2950.
+- Linshare blob export configuration and mechanism change. See JAMES-3040.
 
 ### Fixed
 - JAMES-2828 & JAMES-2929 bugs affecting JDBCMailRepository usage with PostgresSQL thanks to Jörg Thomas & Sergey B

--- a/dockerfiles/run/guice/cassandra-ldap/destination/conf/blob.properties
+++ b/dockerfiles/run/guice/cassandra-ldap/destination/conf/blob.properties
@@ -18,6 +18,9 @@ blob.export.localFile.directory=file://var/blobExporting
 # Mandatory if you choose LinShare, url to connect to LinShare service
 # blob.export.linshare.url=http://linshare:8080
 
-# Mandatory if you choose LinShare, access token to connect to LinShare service. It will be formalized to `Bearer` + a space + access token
-# So, no need to pass (`Bearer` + <space>) prefix
-# blob.export.linshare.token=LinShare-Access-Token-In-String
+# ======================================= LinShare Configuration BasicAuthentication ===================================
+# Authentication is mandatory if you choose LinShare, TechnicalAccount is need to connect to LinShare specific service.
+# For Example: It will be formalized to 'Authorization: Basic {Credential of UUID/password}'
+
+# blob.export.linshare.technical.account.uuid=Technical_Account_UUID
+# blob.export.linshare.technical.account.password=password

--- a/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/blob.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/blob.properties
@@ -131,6 +131,9 @@ blob.export.localFile.directory=file://var/blobExporting
 # Mandatory if you choose LinShare, url to connect to LinShare service
 # blob.export.linshare.url=http://linshare:8080
 
-# Mandatory if you choose LinShare, access token to connect to LinShare service. It will be formalized to `Bearer` + a space + access token
-# So, no need to pass (`Bearer` + <space>) prefix
-# blob.export.linshare.token=LinShare-Access-Token-In-String
+# ======================================= LinShare Configuration BasicAuthentication ===================================
+# Authentication is mandatory if you choose LinShare, TechnicalAccount is need to connect to LinShare specific service.
+# For Example: It will be formalized to 'Authorization: Basic {Credential of UUID/password}'
+
+# blob.export.linshare.technical.account.uuid=Technical_Account_UUID
+# blob.export.linshare.technical.account.password=password

--- a/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/blob.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/blob.properties
@@ -131,6 +131,9 @@ blob.export.localFile.directory=file://var/blobExporting
 # Mandatory if you choose LinShare, url to connect to LinShare service
 # blob.export.linshare.url=http://linshare:8080
 
-# Mandatory if you choose LinShare, access token to connect to LinShare service. It will be formalized to `Bearer` + a space + access token
-# So, no need to pass (`Bearer` + <space>) prefix
-# blob.export.linshare.token=LinShare-Access-Token-In-String
+# ======================================= LinShare Configuration BasicAuthentication ===================================
+# Authentication is mandatory if you choose LinShare, TechnicalAccount is need to connect to LinShare specific service.
+# For Example: It will be formalized to 'Authorization: Basic {Credential of UUID/password}'
+
+# blob.export.linshare.technical.account.uuid=Technical_Account_UUID
+# blob.export.linshare.technical.account.password=password

--- a/dockerfiles/run/guice/cassandra/destination/conf/blob.properties
+++ b/dockerfiles/run/guice/cassandra/destination/conf/blob.properties
@@ -18,6 +18,9 @@ blob.export.localFile.directory=file://var/blobExporting
 # Mandatory if you choose LinShare, url to connect to LinShare service
 # blob.export.linshare.url=http://linshare:8080
 
-# Mandatory if you choose LinShare, access token to connect to LinShare service. It will be formalized to `Bearer` + a space + access token
-# So, no need to pass (`Bearer` + <space>) prefix
-# blob.export.linshare.token=LinShare-Access-Token-In-String
+# ======================================= LinShare Configuration BasicAuthentication ===================================
+# Authentication is mandatory if you choose LinShare, TechnicalAccount is need to connect to LinShare specific service.
+# For Example: It will be formalized to 'Authorization: Basic {Credential of UUID/password}'
+
+# blob.export.linshare.technical.account.uuid=Technical_Account_UUID
+# blob.export.linshare.technical.account.password=password

--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/vault/RabbitMQLinshareBlobExportMechanismIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/vault/RabbitMQLinshareBlobExportMechanismIntegrationTest.java
@@ -31,6 +31,7 @@ import org.apache.james.backends.rabbitmq.DockerRabbitMQSingleton;
 import org.apache.james.mailbox.extractor.TextExtractor;
 import org.apache.james.mailbox.store.search.PDFTextExtractor;
 import org.apache.james.modules.AwsS3BlobStoreExtension;
+import org.apache.james.modules.LinshareGuiceExtension;
 import org.apache.james.modules.RabbitMQExtension;
 import org.apache.james.modules.TestJMAPServerModule;
 import org.apache.james.modules.TestRabbitMQModule;
@@ -40,14 +41,13 @@ import org.apache.james.webadmin.integration.vault.LinshareBlobExportMechanismIn
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class RabbitMQLinshareBlobExportMechanismIntegrationTest extends LinshareBlobExportMechanismIntegrationTest {
-
     @RegisterExtension
     static JamesServerExtension testExtension = new JamesServerBuilder()
         .extension(new DockerElasticSearchExtension())
         .extension(new CassandraExtension())
         .extension(new RabbitMQExtension())
         .extension(new AwsS3BlobStoreExtension())
-        .extension(LinshareBlobExportMechanismIntegrationTest.linshareGuiceExtension)
+        .extension(new LinshareGuiceExtension())
         .server(configuration -> GuiceJamesServer.forConfiguration(configuration)
             .combineWith(CassandraRabbitMQJamesServerMain.MODULES)
             .overrideWith(binder -> binder.bind(TextExtractor.class).to(PDFTextExtractor.class))

--- a/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/memory/vault/MemoryLinshareBlobExportMechanismIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/memory-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/memory/vault/MemoryLinshareBlobExportMechanismIntegrationTest.java
@@ -31,12 +31,9 @@ import org.apache.james.webadmin.integration.vault.LinshareBlobExportMechanismIn
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class MemoryLinshareBlobExportMechanismIntegrationTest extends LinshareBlobExportMechanismIntegrationTest {
-
-    private static final LinshareGuiceExtension linshareGuiceExtension = new LinshareGuiceExtension();
-
     @RegisterExtension
     static JamesServerExtension jamesServerExtension = new JamesServerBuilder()
-        .extension(linshareGuiceExtension)
+        .extension(new LinshareGuiceExtension())
         .server(configuration -> GuiceJamesServer.forConfiguration(configuration)
             .combineWith(MemoryJamesServerMain.IN_MEMORY_SERVER_AGGREGATE_MODULE)
             .overrideWith(TestJMAPServerModule.limitToTenMessages())

--- a/server/protocols/webadmin/webadmin-mailbox-deleted-message-vault/src/main/java/org/apache/james/webadmin/vault/routes/ExportService.java
+++ b/server/protocols/webadmin/webadmin-mailbox-deleted-message-vault/src/main/java/org/apache/james/webadmin/vault/routes/ExportService.java
@@ -78,7 +78,7 @@ class ExportService {
         blobExport.blobId(blobId)
             .with(exportToAddress)
             .explanation(exportMessage(username))
-            .filePrefix(Optional.of("deleted-message-of-" + username.asString() + "_"))
+            .filePrefix(Optional.of(String.format("deleted-message-of-%s_", username.asString())))
             .fileExtension(FileExtension.ZIP)
             .export();
     }

--- a/third-party/linshare/src/test/java/org/apache/james/linshare/LinshareConfigurationTest.java
+++ b/third-party/linshare/src/test/java/org/apache/james/linshare/LinshareConfigurationTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.UUID;
 
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,12 @@ import org.junit.jupiter.api.Test;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 class LinshareConfigurationTest {
+
+    private final static String EMPTY_STRING = "";
+    private final static String SOME_RANDOM_STRING = "laksdhfdksd";
+    private final String DEFAULT_URL = "http://127.0.0.1:8080";
+    private final static String DEFAULT_UUID = UUID.randomUUID().toString();
+
     @Test
     void shouldMatchBeanContract() {
         EqualsVerifier.forClass(LinshareConfiguration.class)
@@ -40,17 +47,59 @@ class LinshareConfigurationTest {
     @Test
     void fromShouldThrowWhenUrlIsNull() {
         PropertiesConfiguration configuration = new PropertiesConfiguration();
-        configuration.addProperty("blob.export.linshare.token", "token");
-        configuration.addProperty("blob.export.linshare.url", null);
+        configuration.addProperty(LinshareConfiguration.URL_PROPERTY, null);
+        configuration.addProperty(LinshareConfiguration.UUID_PROPERTY, DEFAULT_UUID);
+        configuration.addProperty(LinshareConfiguration.PASSWORD_PROPERTY, LinshareFixture.TECHNICAL_ACCOUNT.getPassword());
 
         assertThatThrownBy(() -> LinshareConfiguration.from(configuration)).isInstanceOf(MalformedURLException.class);
     }
 
     @Test
-    void fromShouldThrowWhenTokenIsNull() {
+    void fromShouldThrowWhenBasicAuthIsNull() {
         PropertiesConfiguration configuration = new PropertiesConfiguration();
-        configuration.addProperty("blob.export.linshare.token", null);
-        configuration.addProperty("blob.export.linshare.url", "http://127.0.0.1:8080");
+        configuration.addProperty(LinshareConfiguration.URL_PROPERTY, DEFAULT_URL);
+        configuration.addProperty(LinshareConfiguration.UUID_PROPERTY, null);
+        configuration.addProperty(LinshareConfiguration.PASSWORD_PROPERTY, null);
+
+        assertThatThrownBy(() -> LinshareConfiguration.from(configuration)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void fromShouldThrowWhenUUIDIsNull() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty(LinshareConfiguration.PASSWORD_PROPERTY, SOME_RANDOM_STRING);
+        configuration.addProperty(LinshareConfiguration.UUID_PROPERTY, null);
+        configuration.addProperty(LinshareConfiguration.URL_PROPERTY, DEFAULT_URL);
+
+        assertThatThrownBy(() -> LinshareConfiguration.from(configuration)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void fromShouldThrowWhenUUIDIsEmpty() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty(LinshareConfiguration.UUID_PROPERTY, EMPTY_STRING);
+        configuration.addProperty(LinshareConfiguration.PASSWORD_PROPERTY, SOME_RANDOM_STRING);
+        configuration.addProperty(LinshareConfiguration.URL_PROPERTY, DEFAULT_URL);
+
+        assertThatThrownBy(() -> LinshareConfiguration.from(configuration)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void fromShouldThrowWhenUUIDIsWrongFormat() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty(LinshareConfiguration.UUID_PROPERTY, SOME_RANDOM_STRING);
+        configuration.addProperty(LinshareConfiguration.PASSWORD_PROPERTY, SOME_RANDOM_STRING);
+        configuration.addProperty(LinshareConfiguration.URL_PROPERTY, DEFAULT_URL);
+
+        assertThatThrownBy(() -> LinshareConfiguration.from(configuration)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void fromShouldThrowWhenUUIDIsTooLong() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty(LinshareConfiguration.UUID_PROPERTY, "way-too-long-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        configuration.addProperty(LinshareConfiguration.PASSWORD_PROPERTY, SOME_RANDOM_STRING);
+        configuration.addProperty(LinshareConfiguration.URL_PROPERTY, DEFAULT_URL);
 
         assertThatThrownBy(() -> LinshareConfiguration.from(configuration)).isInstanceOf(IllegalArgumentException.class);
     }
@@ -58,33 +107,46 @@ class LinshareConfigurationTest {
     @Test
     void fromShouldThrowWhenURLIsInvalid() {
         PropertiesConfiguration configuration = new PropertiesConfiguration();
-        configuration.addProperty("blob.export.linshare.token", "token");
-        configuration.addProperty("blob.export.linshare.url", "invalid");
+        configuration.addProperty(LinshareConfiguration.UUID_PROPERTY, DEFAULT_UUID);
+        configuration.addProperty(LinshareConfiguration.PASSWORD_PROPERTY, LinshareFixture.TECHNICAL_ACCOUNT.getPassword());
+        configuration.addProperty(LinshareConfiguration.URL_PROPERTY, "invalid");
 
         assertThatThrownBy(() -> LinshareConfiguration.from(configuration)).isInstanceOf(MalformedURLException.class);
     }
 
     @Test
-    void fromShouldThrowWhenTokenIsEmpty() {
+    void fromShouldThrowWhenPasswordIsNull() {
         PropertiesConfiguration configuration = new PropertiesConfiguration();
-        configuration.addProperty("blob.export.linshare.token", "");
-        configuration.addProperty("blob.export.linshare.url", "http://127.0.0.1:8080");
+        configuration.addProperty(LinshareConfiguration.UUID_PROPERTY, DEFAULT_UUID);
+        configuration.addProperty(LinshareConfiguration.PASSWORD_PROPERTY, null);
+        configuration.addProperty(LinshareConfiguration.URL_PROPERTY, DEFAULT_URL);
+
+        assertThatThrownBy(() -> LinshareConfiguration.from(configuration)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void fromShouldThrowWhenPasswordIsEmpty() {
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty(LinshareConfiguration.UUID_PROPERTY, DEFAULT_UUID);
+        configuration.addProperty(LinshareConfiguration.PASSWORD_PROPERTY, EMPTY_STRING);
+        configuration.addProperty(LinshareConfiguration.URL_PROPERTY, DEFAULT_URL);
 
         assertThatThrownBy(() -> LinshareConfiguration.from(configuration)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void fromShouldReturnProvidedConfiguration() throws Exception {
-        String token = "token";
-        String url = "http://127.0.0.1:8080";
+        String password = LinshareFixture.TECHNICAL_ACCOUNT.getPassword();
+        String url = DEFAULT_URL;
 
         PropertiesConfiguration configuration = new PropertiesConfiguration();
-        configuration.addProperty("blob.export.linshare.token", token);
-        configuration.addProperty("blob.export.linshare.url", url);
+        configuration.addProperty(LinshareConfiguration.UUID_PROPERTY, DEFAULT_UUID);
+        configuration.addProperty(LinshareConfiguration.PASSWORD_PROPERTY, password);
+        configuration.addProperty(LinshareConfiguration.URL_PROPERTY, url);
 
         assertThat(LinshareConfiguration.from(configuration)).isEqualTo(LinshareConfiguration.builder()
             .url(new URL(url))
-            .authorizationToken(new AuthorizationToken(token))
+            .basicAuthorization(DEFAULT_UUID, password)
             .build());
     }
 }

--- a/third-party/linshare/src/test/java/org/apache/james/linshare/LinshareTest.java
+++ b/third-party/linshare/src/test/java/org/apache/james/linshare/LinshareTest.java
@@ -22,9 +22,11 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.config.EncoderConfig.encoderConfig;
 import static io.restassured.config.RestAssuredConfig.newConfig;
 import static org.apache.james.linshare.LinshareFixture.ACCOUNT_ENABLED;
+import static org.apache.james.linshare.LinshareFixture.ADMIN_ACCOUNT;
 import static org.apache.james.linshare.LinshareFixture.TECHNICAL_ACCOUNT;
 import static org.apache.james.linshare.LinshareFixture.TECHNICAL_PERMISSIONS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.apache.james.linshare.LinshareExtension.LinshareAPIForAdminTesting;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -69,7 +71,7 @@ class LinshareTest {
 
     @Test
     void linshareShouldHaveATechnicalAccountConfigured() {
-        List<TechnicalAccountResponse> technicalAccounts = linshareExtension.getAllTechnicalAccounts(LinshareFixture.ADMIN_ACCOUNT);
+        List<TechnicalAccountResponse> technicalAccounts = LinshareAPIForAdminTesting.from(ADMIN_ACCOUNT).allTechnicalAccounts();
 
         assertThat(technicalAccounts).anySatisfy(account -> SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(account.getName()).isEqualTo(TECHNICAL_ACCOUNT.getUsername());

--- a/third-party/linshare/src/test/java/org/apache/james/linshare/client/TechnicalAccountCreationRequest.java
+++ b/third-party/linshare/src/test/java/org/apache/james/linshare/client/TechnicalAccountCreationRequest.java
@@ -72,5 +72,4 @@ public class TechnicalAccountCreationRequest {
     public String getRole() {
         return role;
     }
-
 }

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -16,6 +16,7 @@ Changes to apply between 3.4.x and 3.5.x will be reported here.
 
 Change list:
 
+ - [LinShare blob export mechanism should rely on delegation](#LinShare blob export mechanism should rely on delegation)
  - [RabbitMQ minimal version](#rabbitmq-minimal-version)
  - [Enforce usernames to be lower cased](#enforce-usernames-to-be-lower-cased)
  - [Cassandra keyspace creation configuration](#cassandra-keyspace-creation-configuration)
@@ -39,6 +40,26 @@ Even if this set of characters should be allowed for the local part of a Usernam
 
 However, the read of Usernames already existing with some of those characters is still allowed, to not introduce any breaking change.
 
+### LinShare blob export mechanism should rely on delegation
+Date 12/02/2020
+
+SHA-1 XXX
+
+Concerned products: Guice server, experimental LinShare blob export feature.
+
+JIRA: https://issues.apache.org/jira/browse/JAMES-3040
+
+Blob Export Configuration changed:
+
+File configuration need to be adjusted: `blob.properties`
+
+-You need to add new mandatory properties when `blob.export.implementation` property is set to `linshare`:
+```
+blob.export.linshare.technical.account.uuid
+blob.export.linshare.technical.account.password
+```
+
+-The legacy property `blob.export.linshare.token` will not used anymore, you can remove it.
 ### Hybrid blobStore replaces Union blobStore
 
 Date 6/01/2020


### PR DESCRIPTION
- Upload direct the blob to the end user space.
- No more sharing and triggered email on Linshare side.
- Changes unit test, integration test regarding it.