### PR TITLE
JAMES-3043 IMAP selected mailbox checks should rely on mailboxId

### DIFF
--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
@@ -387,7 +387,7 @@ abstract class AbstractSelectionProcessor<R extends AbstractMailboxSelectionRequ
 
         final SelectedMailbox sessionMailbox;
         final SelectedMailbox currentMailbox = session.getSelected();
-        if (currentMailbox == null || !currentMailbox.getPath().equals(mailboxPath)) {
+        if (currentMailbox == null || !currentMailbox.getMailboxId().equals(mailbox.getId())) {
             
             // QRESYNC EXTENSION
             //

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AppendProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AppendProcessor.java
@@ -126,7 +126,7 @@ public class AppendProcessor extends AbstractMailboxProcessor<AppendRequest> {
             final MailboxSession mailboxSession = session.getMailboxSession();
             final SelectedMailbox selectedMailbox = session.getSelected();
             final MailboxManager mailboxManager = getMailboxManager();
-            final boolean isSelectedMailbox = selectedMailbox != null && selectedMailbox.getPath().equals(mailboxPath);
+            final boolean isSelectedMailbox = selectedMailbox != null && selectedMailbox.getMailboxId().equals(mailbox.getId());
             final ComposedMessageId messageId = mailbox.appendMessage(message, datetime, mailboxSession, !isSelectedMailbox, flagsToBeSet);
             if (isSelectedMailbox) {
                 selectedMailbox.addRecent(messageId.getUid());


### PR DESCRIPTION
 Currently they rely on mailboxPath...

 Doing them by mailboxId will:
  - avoid a mailboxPath lookup
  - avoid rename concurrency issues

 Concerned processors: Append, Select, Examine