### PR TITLE
JAMES-3059 Leverage retry to decrease mailbox inconsistencies probability

### DIFF
--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/TestingSession.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/TestingSession.java
@@ -1,0 +1,280 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.cassandra;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.CloseFuture;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.RegularStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
+import com.google.common.util.concurrent.ListenableFuture;
+
+public class TestingSession implements Session {
+    @FunctionalInterface
+    interface Behavior {
+        Behavior THROW = (session, statement) -> {
+            RuntimeException injected_failure = new RuntimeException("Injected failure");
+            injected_failure.printStackTrace();
+            throw injected_failure;
+        };
+
+        Behavior EXECUTE_NORMALLY = Session::executeAsync;
+
+        static Behavior awaitOn(Barrier barrier) {
+            return (session, statement) -> {
+                barrier.call();
+                return session.executeAsync(statement);
+            };
+        }
+
+        ResultSetFuture execute(Session session, Statement statement);
+    }
+
+    public static class Barrier {
+        private final CountDownLatch callerLatch = new CountDownLatch(1);
+        private final CountDownLatch awaitCallerLatch;
+
+        public Barrier() {
+            this(1);
+        }
+
+        public Barrier(int callerCount) {
+            awaitCallerLatch = new CountDownLatch(callerCount);
+        }
+
+        public void awaitCaller() throws InterruptedException {
+            awaitCallerLatch.await();
+        }
+
+        public void releaseCaller() {
+            callerLatch.countDown();
+        }
+
+        void call() {
+            awaitCallerLatch.countDown();
+            try {
+                callerLatch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface StatementPredicate extends Predicate<Statement> {
+
+    }
+
+    static class BoundStatementStartingWith implements StatementPredicate {
+        private final String queryStringPrefix;
+
+        BoundStatementStartingWith(String queryStringPrefix) {
+            this.queryStringPrefix = queryStringPrefix;
+        }
+
+        @Override
+        public boolean test(Statement statement) {
+            if (statement instanceof BoundStatement) {
+                BoundStatement boundStatement = (BoundStatement) statement;
+                return boundStatement.preparedStatement()
+                    .getQueryString()
+                    .startsWith(queryStringPrefix);
+            }
+            return false;
+        }
+    }
+
+    @FunctionalInterface
+    public interface RequiresCondition {
+        RequiresApplyCount condition(StatementPredicate statementPredicate);
+
+        default RequiresApplyCount always() {
+            return condition(ALL_STATEMENTS);
+        }
+
+        default RequiresApplyCount whenBoundStatementStartsWith(String queryStringPrefix) {
+            return condition(new BoundStatementStartingWith(queryStringPrefix));
+        }
+    }
+
+    @FunctionalInterface
+    public interface RequiresApplyCount {
+        FinalStage times(int applyCount);
+    }
+
+    @FunctionalInterface
+    public interface FinalStage {
+        void setExecutionHook();
+    }
+
+    private static class ExecutionHook {
+        final StatementPredicate statementPredicate;
+        final Behavior behavior;
+        final AtomicInteger remaining;
+
+        private ExecutionHook(StatementPredicate statementPredicate, Behavior behavior, int applyCount) {
+            this.statementPredicate = statementPredicate;
+            this.behavior = behavior;
+            this.remaining = new AtomicInteger(applyCount);
+        }
+
+        ResultSetFuture execute(Session session, Statement statement) {
+            if (statementPredicate.test(statement)) {
+                int hookPosition = remaining.getAndDecrement();
+                if (hookPosition > 0) {
+                    return behavior.execute(session, statement);
+                }
+            }
+            return Behavior.EXECUTE_NORMALLY.execute(session, statement);
+        }
+    }
+
+    private static StatementPredicate ALL_STATEMENTS = statement -> true;
+    private static ExecutionHook NO_EXECUTION_HOOK = new ExecutionHook(ALL_STATEMENTS, Behavior.EXECUTE_NORMALLY, 0);
+
+    private final Session delegate;
+    private volatile ExecutionHook executionHook;
+
+    TestingSession(Session delegate) {
+        this.delegate = delegate;
+        this.executionHook = NO_EXECUTION_HOOK;
+    }
+
+    public RequiresCondition fail() {
+        return condition -> applyCount -> () -> executionHook = new ExecutionHook(condition, Behavior.THROW, applyCount);
+    }
+
+    public RequiresCondition awaitOn(Barrier barrier) {
+        return condition -> applyCount -> () -> executionHook = new ExecutionHook(condition, Behavior.awaitOn(barrier), applyCount);
+    }
+
+    public void resetExecutionHook() {
+        executionHook = NO_EXECUTION_HOOK;
+    }
+
+    @Override
+    public String getLoggedKeyspace() {
+        return delegate.getLoggedKeyspace();
+    }
+
+    @Override
+    public Session init() {
+        return delegate.init();
+    }
+
+    @Override
+    public ListenableFuture<Session> initAsync() {
+        return delegate.initAsync();
+    }
+
+    @Override
+    public ResultSet execute(String query) {
+        return delegate.execute(query);
+    }
+
+    @Override
+    public ResultSet execute(String query, Object... values) {
+        return delegate.execute(query, values);
+    }
+
+    @Override
+    public ResultSet execute(String query, Map<String, Object> values) {
+        return delegate.execute(query, values);
+    }
+
+    @Override
+    public ResultSet execute(Statement statement) {
+        return delegate.execute(statement);
+    }
+
+    @Override
+    public ResultSetFuture executeAsync(String query) {
+        return delegate.executeAsync(query);
+    }
+
+    @Override
+    public ResultSetFuture executeAsync(String query, Object... values) {
+        return delegate.executeAsync(query, values);
+    }
+
+    @Override
+    public ResultSetFuture executeAsync(String query, Map<String, Object> values) {
+        return delegate.executeAsync(query, values);
+    }
+
+    @Override
+    public ResultSetFuture executeAsync(Statement statement) {
+        return executionHook.execute(delegate, statement);
+    }
+
+    @Override
+    public PreparedStatement prepare(String query) {
+        return delegate.prepare(query);
+    }
+
+    @Override
+    public PreparedStatement prepare(RegularStatement statement) {
+        return delegate.prepare(statement);
+    }
+
+    @Override
+    public ListenableFuture<PreparedStatement> prepareAsync(String query) {
+        return delegate.prepareAsync(query);
+    }
+
+    @Override
+    public ListenableFuture<PreparedStatement> prepareAsync(RegularStatement statement) {
+        return delegate.prepareAsync(statement);
+    }
+
+    @Override
+    public CloseFuture closeAsync() {
+        return delegate.closeAsync();
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return delegate.isClosed();
+    }
+
+    @Override
+    public Cluster getCluster() {
+        return delegate.getCluster();
+    }
+
+    @Override
+    public State getState() {
+        return delegate.getState();
+    }
+}

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/TestingSessionTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/TestingSessionTest.java
@@ -1,0 +1,232 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.james.backends.cassandra.TestingSession.Barrier;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionDAO;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.backends.cassandra.versions.SchemaVersion;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+class TestingSessionTest {
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(CassandraSchemaVersionModule.MODULE);
+
+    private CassandraSchemaVersionDAO dao;
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandra) {
+        dao = new CassandraSchemaVersionDAO(cassandra.getConf());
+    }
+
+    @Test
+    void daoOperationShouldNotBeInstrumentedByDefault() {
+        assertThatCode(() -> dao.getCurrentSchemaVersion().block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void daoOperationShouldNotBeInstrumentedWhenNotMatching(CassandraCluster cassandra) {
+        cassandra.getConf()
+            .fail()
+            .whenBoundStatementStartsWith("non matching")
+            .times(1)
+            .setExecutionHook();
+
+        assertThatCode(() -> dao.getCurrentSchemaVersion().block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void daoOperationShouldNotBeInstrumentedWhenTimesIsZero(CassandraCluster cassandra) {
+        cassandra.getConf()
+            .fail()
+            .whenBoundStatementStartsWith("SELECT value FROM schemaVersion;")
+            .times(0)
+            .setExecutionHook();
+
+        assertThatCode(() -> dao.getCurrentSchemaVersion().block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void daoOperationShouldNotBeInstrumentedWhenTimesIsNegative(CassandraCluster cassandra) {
+        cassandra.getConf()
+            .fail()
+            .whenBoundStatementStartsWith("SELECT value FROM schemaVersion;")
+            .times(-1)
+            .setExecutionHook();
+
+        assertThatCode(() -> dao.getCurrentSchemaVersion().block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void daoOperationShouldFailWhenInstrumented(CassandraCluster cassandra) {
+        cassandra.getConf()
+            .fail()
+            .whenBoundStatementStartsWith("SELECT value FROM schemaVersion;")
+            .times(1)
+            .setExecutionHook();
+
+        assertThatThrownBy(() -> dao.getCurrentSchemaVersion().block())
+            .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void daoShouldNotBeInstrumentedWhenTimesIsExceeded(CassandraCluster cassandra) {
+        cassandra.getConf()
+            .fail()
+            .whenBoundStatementStartsWith("SELECT value FROM schemaVersion;")
+            .times(1)
+            .setExecutionHook();
+
+        try {
+            dao.getCurrentSchemaVersion().block();
+        } catch (Exception e) {
+            // discard expected exception
+        }
+
+        assertThatCode(() -> dao.getCurrentSchemaVersion().block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void timesShouldSpecifyExactlyTheFailureCount(CassandraCluster cassandra) {
+        cassandra.getConf()
+            .fail()
+            .whenBoundStatementStartsWith("SELECT value FROM schemaVersion;")
+            .times(2)
+            .setExecutionHook();
+
+        SoftAssertions.assertSoftly(softly -> {
+            assertThatThrownBy(() -> dao.getCurrentSchemaVersion().block())
+                .isInstanceOf(RuntimeException.class);
+            assertThatThrownBy(() -> dao.getCurrentSchemaVersion().block())
+                .isInstanceOf(RuntimeException.class);
+            assertThatCode(() -> dao.getCurrentSchemaVersion().block())
+                .doesNotThrowAnyException();
+        });
+    }
+
+    @Test
+    void resetExecutionHookShouldClearInstrumentation(CassandraCluster cassandra) {
+        cassandra.getConf()
+            .fail()
+            .whenBoundStatementStartsWith("SELECT value FROM schemaVersion;")
+            .times(1)
+            .setExecutionHook();
+
+        cassandra.getConf().resetExecutionHook();
+
+        assertThatCode(() -> dao.getCurrentSchemaVersion().block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void timesShouldBeTakenIntoAccountOnlyForMatchingStatements(CassandraCluster cassandra) {
+        cassandra.getConf()
+            .fail()
+            .whenBoundStatementStartsWith("SELECT value FROM schemaVersion;")
+            .times(1)
+            .setExecutionHook();
+
+        dao.updateVersion(new SchemaVersion(36)).block();
+
+        assertThatThrownBy(() -> dao.getCurrentSchemaVersion().block())
+            .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void statementShouldNotBeAppliedBeforeBarrierIsReleased(CassandraCluster cassandra) throws Exception {
+        SchemaVersion originalSchemaVersion = new SchemaVersion(32);
+        dao.updateVersion(originalSchemaVersion).block();
+        Barrier barrier = new Barrier();
+        cassandra.getConf()
+            .awaitOn(barrier)
+            .whenBoundStatementStartsWith("INSERT INTO schemaVersion")
+            .times(1)
+            .setExecutionHook();
+
+        dao.updateVersion(new SchemaVersion(36)).subscribeOn(Schedulers.elastic()).subscribe();
+
+        Thread.sleep(100);
+
+        assertThat(dao.getCurrentSchemaVersion().block())
+            .contains(originalSchemaVersion);
+    }
+
+    @Test
+    void statementShouldBeAppliedWhenBarrierIsReleased(CassandraCluster cassandra) throws Exception {
+        SchemaVersion originalSchemaVersion = new SchemaVersion(32);
+        SchemaVersion newVersion = new SchemaVersion(36);
+
+        dao.updateVersion(originalSchemaVersion).block();
+        Barrier barrier = new Barrier();
+        cassandra.getConf()
+            .awaitOn(barrier)
+            .whenBoundStatementStartsWith("INSERT INTO schemaVersion")
+            .times(1)
+            .setExecutionHook();
+
+        Mono<Void> operation = dao.updateVersion(newVersion).cache();
+
+        operation.subscribeOn(Schedulers.elastic()).subscribe();
+        barrier.releaseCaller();
+        operation.block();
+
+        assertThat(dao.getCurrentSchemaVersion().block())
+            .contains(newVersion);
+    }
+
+    @Test
+    void testShouldBeAbleToAwaitCaller(CassandraCluster cassandra) throws Exception {
+        SchemaVersion originalSchemaVersion = new SchemaVersion(32);
+        SchemaVersion newVersion = new SchemaVersion(36);
+
+        dao.updateVersion(originalSchemaVersion).block();
+        Barrier barrier = new Barrier();
+        cassandra.getConf()
+            .awaitOn(barrier)
+            .whenBoundStatementStartsWith("INSERT INTO schemaVersion")
+            .times(1)
+            .setExecutionHook();
+
+        Mono<Void> operation = dao.updateVersion(newVersion).cache();
+
+        operation.subscribeOn(Schedulers.elastic()).subscribe();
+        barrier.awaitCaller();
+        barrier.releaseCaller();
+        operation.block();
+
+        assertThat(dao.getCurrentSchemaVersion().block())
+            .contains(newVersion);
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapper.java
@@ -260,15 +260,10 @@ public class CassandraMailboxMapper implements MailboxMapper {
     @Override
     public List<Mailbox> findNonPersonalMailboxes(Username userName, Right right) {
         return userMailboxRightsDAO.listRightsForUser(userName)
-            .filter(mailboxId -> authorizedMailbox(mailboxId.getRight(), right))
+            .filter(mailboxId -> mailboxId.getRight().contains(right))
             .map(Pair::getLeft)
             .flatMap(this::retrieveMailbox)
             .collectList()
             .block();
     }
-
-    private boolean authorizedMailbox(MailboxACL.Rfc4314Rights rights, Right right) {
-        return rights.contains(right);
-    }
-
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapper.java
@@ -19,11 +19,7 @@
 
 package org.apache.james.mailbox.cassandra.mail;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.StringTokenizer;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -53,8 +49,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public class CassandraMailboxMapper implements MailboxMapper {
-
-    private static final String WILDCARD = "%";
     public static final Logger LOGGER = LoggerFactory.getLogger(CassandraMailboxMapper.class);
 
     private final CassandraMailboxDAO mailboxDAO;
@@ -252,22 +246,6 @@ public class CassandraMailboxMapper implements MailboxMapper {
     @Override
     public void endRequest() {
         // Do nothing
-    }
-
-    private String constructEscapedRegexForMailboxNameMatching(MailboxPath path) {
-        return Collections
-            .list(new StringTokenizer(path.getName(), WILDCARD, true))
-            .stream()
-            .map(this::tokenToPatternPart)
-            .collect(Collectors.joining());
-    }
-
-    private String tokenToPatternPart(Object token) {
-        if (token.equals(WILDCARD)) {
-            return ".*";
-        } else {
-            return Pattern.quote((String) token);
-        }
     }
 
     private Mono<Mailbox> toMailboxWithAcl(Mailbox mailbox) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapper.java
@@ -228,7 +228,6 @@ public class CassandraMailboxMapper implements MailboxMapper {
     public List<Mailbox> list() {
         return mailboxDAO.retrieveAllMailboxes()
             .flatMap(this::toMailboxWithAcl)
-            .map(simpleMailboxes -> (Mailbox) simpleMailboxes)
             .collectList()
             .block();
     }
@@ -286,7 +285,6 @@ public class CassandraMailboxMapper implements MailboxMapper {
             .filter(mailboxId -> authorizedMailbox(mailboxId.getRight(), right))
             .map(Pair::getLeft)
             .flatMap(this::retrieveMailbox)
-            .map(simpleMailboxes -> (Mailbox) simpleMailboxes)
             .collectList()
             .block();
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapper.java
@@ -213,9 +213,13 @@ public class CassandraMailboxMapper implements MailboxMapper {
         return Flux.merge(
                 mailboxPathDAO.listUserMailboxes(mailbox.getNamespace(), mailbox.getUser()),
                 mailboxPathV2DAO.listUserMailboxes(mailbox.getNamespace(), mailbox.getUser()))
-            .filter(idAndPath -> idAndPath.getMailboxPath().getName().startsWith(mailbox.getName() + String.valueOf(delimiter)))
+            .filter(idAndPath -> isPathChildOfMailbox(idAndPath, mailbox, delimiter))
             .hasElements()
             .block();
+    }
+
+    private boolean isPathChildOfMailbox(CassandraIdAndPath idAndPath, Mailbox mailbox, char delimiter) {
+        return idAndPath.getMailboxPath().getName().startsWith(mailbox.getName() + String.valueOf(delimiter));
     }
 
     @Override

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerConsistencyTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerConsistencyTest.java
@@ -45,6 +45,7 @@ class CassandraMailboxManagerConsistencyTest {
     private static final Username USER = Username.of("user");
     private static final String INBOX = "INBOX";
     private static final String INBOX_RENAMED = "INBOX_RENAMED";
+    private static final int TRY_COUNT_BEFORE_FAILURE = 6;
 
     @RegisterExtension
     static CassandraClusterExtension cassandra = new CassandraClusterExtension(MailboxAggregateModule.MODULE_WITH_QUOTA);
@@ -81,7 +82,7 @@ class CassandraMailboxManagerConsistencyTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("INSERT INTO mailbox (id,name,uidvalidity,mailboxbase) VALUES (:id,:name,:uidvalidity,:mailboxbase);")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.createMailbox(inboxPath, mailboxSession));
@@ -101,7 +102,7 @@ class CassandraMailboxManagerConsistencyTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("INSERT INTO mailboxPathV2")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.createMailbox(inboxPath, mailboxSession));
@@ -122,7 +123,7 @@ class CassandraMailboxManagerConsistencyTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("INSERT INTO mailbox (id,name,uidvalidity,mailboxbase) VALUES (:id,:name,:uidvalidity,:mailboxbase);")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.createMailbox(inboxPath, mailboxSession));
@@ -136,7 +137,7 @@ class CassandraMailboxManagerConsistencyTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("INSERT INTO mailboxPathV2")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.createMailbox(inboxPath, mailboxSession));
@@ -163,7 +164,7 @@ class CassandraMailboxManagerConsistencyTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("INSERT INTO mailbox (id,name,uidvalidity,mailboxbase) VALUES (:id,:name,:uidvalidity,:mailboxbase);")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.createMailbox(inboxPath, mailboxSession));
@@ -181,7 +182,7 @@ class CassandraMailboxManagerConsistencyTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("INSERT INTO mailboxPathV2")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.createMailbox(inboxPath, mailboxSession));
@@ -216,7 +217,7 @@ class CassandraMailboxManagerConsistencyTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("INSERT INTO mailbox (id,name,uidvalidity,mailboxbase) VALUES (:id,:name,:uidvalidity,:mailboxbase);")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.renameMailbox(inboxPath, inboxPathRenamed, mailboxSession));
@@ -242,7 +243,7 @@ class CassandraMailboxManagerConsistencyTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("INSERT INTO mailboxPathV2")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.renameMailbox(inboxPath, inboxPathRenamed, mailboxSession));
@@ -269,7 +270,7 @@ class CassandraMailboxManagerConsistencyTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("INSERT INTO mailbox (id,name,uidvalidity,mailboxbase) VALUES (:id,:name,:uidvalidity,:mailboxbase);")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.renameMailbox(inboxPath, inboxPathRenamed, mailboxSession));
@@ -303,7 +304,7 @@ class CassandraMailboxManagerConsistencyTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("INSERT INTO mailboxPathV2")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.renameMailbox(inboxPath, inboxPathRenamed, mailboxSession));
@@ -338,7 +339,7 @@ class CassandraMailboxManagerConsistencyTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("INSERT INTO mailbox (id,name,uidvalidity,mailboxbase) VALUES (:id,:name,:uidvalidity,:mailboxbase);")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.renameMailbox(inboxPath, inboxPathRenamed, mailboxSession));
@@ -358,7 +359,7 @@ class CassandraMailboxManagerConsistencyTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("INSERT INTO mailboxPathV2")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.renameMailbox(inboxPath, inboxPathRenamed, mailboxSession));
@@ -395,7 +396,7 @@ class CassandraMailboxManagerConsistencyTest {
                 cassandra.getConf()
                     .fail()
                     .whenBoundStatementStartsWith("DELETE FROM mailbox WHERE id=:id;")
-                    .times(6)
+                    .times(TRY_COUNT_BEFORE_FAILURE)
                     .setExecutionHook();
 
                 doQuietly(() -> testee.deleteMailbox(inboxPath, mailboxSession));
@@ -422,7 +423,7 @@ class CassandraMailboxManagerConsistencyTest {
                 cassandra.getConf()
                     .fail()
                     .whenBoundStatementStartsWith("DELETE FROM mailbox WHERE id=:id;")
-                    .times(6)
+                    .times(TRY_COUNT_BEFORE_FAILURE)
                     .setExecutionHook();
 
                 doQuietly(() -> testee.deleteMailbox(inboxId, mailboxSession));
@@ -448,7 +449,7 @@ class CassandraMailboxManagerConsistencyTest {
                 cassandra.getConf()
                     .fail()
                     .whenBoundStatementStartsWith("DELETE FROM mailboxPathV2")
-                    .times(6)
+                    .times(TRY_COUNT_BEFORE_FAILURE)
                     .setExecutionHook();
 
                 doQuietly(() -> testee.deleteMailbox(inboxPath, mailboxSession));
@@ -474,7 +475,7 @@ class CassandraMailboxManagerConsistencyTest {
                 cassandra.getConf()
                     .fail()
                     .whenBoundStatementStartsWith("DELETE FROM mailboxPathV2")
-                    .times(6)
+                    .times(TRY_COUNT_BEFORE_FAILURE)
                     .setExecutionHook();
 
                 doQuietly(() -> testee.deleteMailbox(inboxId, mailboxSession));
@@ -503,7 +504,7 @@ class CassandraMailboxManagerConsistencyTest {
                 cassandra.getConf()
                     .fail()
                     .whenBoundStatementStartsWith("DELETE FROM mailbox WHERE id=:id;")
-                    .times(6)
+                    .times(TRY_COUNT_BEFORE_FAILURE)
                     .setExecutionHook();
 
                 doQuietly(() -> testee.deleteMailbox(inboxPath, mailboxSession));
@@ -532,7 +533,7 @@ class CassandraMailboxManagerConsistencyTest {
                 cassandra.getConf()
                     .fail()
                     .whenBoundStatementStartsWith("DELETE FROM mailbox WHERE id=:id;")
-                    .times(6)
+                    .times(TRY_COUNT_BEFORE_FAILURE)
                     .setExecutionHook();
 
                 doQuietly(() -> testee.deleteMailbox(inboxId, mailboxSession));
@@ -561,7 +562,7 @@ class CassandraMailboxManagerConsistencyTest {
                 cassandra.getConf()
                     .fail()
                     .whenBoundStatementStartsWith("DELETE FROM mailboxPathV2")
-                    .times(6)
+                    .times(TRY_COUNT_BEFORE_FAILURE)
                     .setExecutionHook();
 
                 doQuietly(() -> testee.deleteMailbox(inboxPath, mailboxSession));
@@ -591,7 +592,7 @@ class CassandraMailboxManagerConsistencyTest {
                 cassandra.getConf()
                     .fail()
                     .whenBoundStatementStartsWith("DELETE FROM mailboxPathV2")
-                    .times(6)
+                    .times(TRY_COUNT_BEFORE_FAILURE)
                     .setExecutionHook();
 
                 doQuietly(() -> testee.deleteMailbox(inboxId, mailboxSession));
@@ -624,7 +625,7 @@ class CassandraMailboxManagerConsistencyTest {
                 cassandra.getConf()
                     .fail()
                     .whenBoundStatementStartsWith("DELETE FROM mailbox WHERE id=:id;")
-                    .times(6)
+                    .times(TRY_COUNT_BEFORE_FAILURE)
                     .setExecutionHook();
 
                 doQuietly(() -> testee.deleteMailbox(inboxPath, mailboxSession));
@@ -651,7 +652,7 @@ class CassandraMailboxManagerConsistencyTest {
                 cassandra.getConf()
                     .fail()
                     .whenBoundStatementStartsWith("DELETE FROM mailbox WHERE id=:id;")
-                    .times(6)
+                    .times(TRY_COUNT_BEFORE_FAILURE)
                     .setExecutionHook();
 
                 doQuietly(() -> testee.deleteMailbox(inboxId, mailboxSession));
@@ -675,7 +676,7 @@ class CassandraMailboxManagerConsistencyTest {
                 cassandra.getConf()
                     .fail()
                     .whenBoundStatementStartsWith("DELETE FROM mailboxPathV2")
-                    .times(6)
+                    .times(TRY_COUNT_BEFORE_FAILURE)
                     .setExecutionHook();
 
                 doQuietly(() -> testee.deleteMailbox(inboxPath, mailboxSession));
@@ -700,7 +701,7 @@ class CassandraMailboxManagerConsistencyTest {
                 cassandra.getConf()
                     .fail()
                     .whenBoundStatementStartsWith("DELETE FROM mailboxPathV2")
-                    .times(6)
+                    .times(TRY_COUNT_BEFORE_FAILURE)
                     .setExecutionHook();
 
                 doQuietly(() -> testee.deleteMailbox(inboxId, mailboxSession));
@@ -728,7 +729,7 @@ class CassandraMailboxManagerConsistencyTest {
                 cassandra.getConf()
                     .fail()
                     .whenBoundStatementStartsWith("DELETE FROM mailbox WHERE id=:id;")
-                    .times(6)
+                    .times(TRY_COUNT_BEFORE_FAILURE)
                     .setExecutionHook();
 
                 doQuietly(() -> testee.deleteMailbox(inboxPath, mailboxSession));
@@ -758,7 +759,7 @@ class CassandraMailboxManagerConsistencyTest {
                 cassandra.getConf()
                     .fail()
                     .whenBoundStatementStartsWith("DELETE FROM mailbox WHERE id=:id;")
-                    .times(6)
+                    .times(TRY_COUNT_BEFORE_FAILURE)
                     .setExecutionHook();
 
                 doQuietly(() -> testee.deleteMailbox(inboxId, mailboxSession));
@@ -787,7 +788,7 @@ class CassandraMailboxManagerConsistencyTest {
                 cassandra.getConf()
                     .fail()
                     .whenBoundStatementStartsWith("DELETE FROM mailboxPathV2")
-                    .times(6)
+                    .times(TRY_COUNT_BEFORE_FAILURE)
                     .setExecutionHook();
 
                 doQuietly(() -> testee.deleteMailbox(inboxPath, mailboxSession));
@@ -817,7 +818,7 @@ class CassandraMailboxManagerConsistencyTest {
                 cassandra.getConf()
                     .fail()
                     .whenBoundStatementStartsWith("DELETE FROM mailboxPathV2")
-                    .times(6)
+                    .times(TRY_COUNT_BEFORE_FAILURE)
                     .setExecutionHook();
 
                 doQuietly(() -> testee.deleteMailbox(inboxId, mailboxSession));

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerStressTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerStressTest.java
@@ -47,8 +47,7 @@ class CassandraMailboxManagerStressTest implements MailboxManagerStressContract<
     @BeforeEach
     void setUp() {
         this.mailboxManager = CassandraMailboxManagerProvider.provideMailboxManager(
-            cassandra.getCassandraCluster().getConf(),
-            cassandra.getCassandraCluster().getTypesProvider(),
+            cassandra.getCassandraCluster(),
             PreDeletionHooks.NO_PRE_DELETION_HOOK);
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerTest.java
@@ -33,8 +33,7 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
     @Override
     protected CassandraMailboxManager provideMailboxManager() {
         return CassandraMailboxManagerProvider.provideMailboxManager(
-            cassandra.getCassandraCluster().getConf(),
-            cassandra.getCassandraCluster().getTypesProvider(),
+            cassandra.getCassandraCluster(),
             new PreDeletionHooks(preDeletionHooks(), new RecordingMetricFactory()));
     }
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
@@ -59,10 +59,7 @@ class CassandraTestSystemFixture {
     static CassandraMailboxSessionMapperFactory createMapperFactory(CassandraCluster cassandra) {
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
 
-        return TestCassandraMailboxSessionMapperFactory.forTests(
-            cassandra.getConf(),
-            cassandra.getTypesProvider(),
-            messageIdFactory);
+        return TestCassandraMailboxSessionMapperFactory.forTests(cassandra, messageIdFactory);
     }
 
     static CassandraMailboxManager createMailboxManager(CassandraMailboxSessionMapperFactory mapperFactory) {

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/TestCassandraMailboxSessionMapperFactory.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/TestCassandraMailboxSessionMapperFactory.java
@@ -19,24 +19,22 @@
 
 package org.apache.james.mailbox.cassandra;
 
-import org.apache.james.backends.cassandra.init.CassandraTypesProvider;
+import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.init.configuration.CassandraConfiguration;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
 import org.apache.james.mailbox.cassandra.mail.utils.GuiceUtils;
 
-import com.datastax.driver.core.Session;
-
 public class TestCassandraMailboxSessionMapperFactory {
 
-    public static CassandraMailboxSessionMapperFactory forTests(Session session, CassandraTypesProvider typesProvider,
+    public static CassandraMailboxSessionMapperFactory forTests(CassandraCluster cassandra,
                                                                 CassandraMessageId.Factory factory) {
-        return forTests(session, typesProvider, factory, CassandraConfiguration.DEFAULT_CONFIGURATION);
+        return forTests(cassandra, factory, CassandraConfiguration.DEFAULT_CONFIGURATION);
     }
 
-    public static CassandraMailboxSessionMapperFactory forTests(Session session, CassandraTypesProvider typesProvider,
+    public static CassandraMailboxSessionMapperFactory forTests(CassandraCluster cassandra,
                                                                 CassandraMessageId.Factory factory, CassandraConfiguration cassandraConfiguration) {
 
-        return GuiceUtils.testInjector(session, typesProvider, factory, cassandraConfiguration)
+        return GuiceUtils.testInjector(cassandra.getConf(), cassandra.getTypesProvider(), factory, cassandraConfiguration)
             .getInstance(CassandraMailboxSessionMapperFactory.class);
     }
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxManagerAttachmentTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxManagerAttachmentTest.java
@@ -71,8 +71,7 @@ class CassandraMailboxManagerAttachmentTest extends AbstractMailboxManagerAttach
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
 
         mailboxSessionMapperFactory = TestCassandraMailboxSessionMapperFactory.forTests(
-            cassandraCluster.getCassandraCluster().getConf(),
-            cassandraCluster.getCassandraCluster().getTypesProvider(),
+            cassandraCluster.getCassandraCluster(),
             messageIdFactory);
         Authenticator noAuthenticator = null;
         Authorizator noAuthorizator = null;

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperTest.java
@@ -22,11 +22,6 @@ package org.apache.james.mailbox.cassandra.mail;
 import static org.apache.james.mailbox.model.MailboxAssertingTool.softly;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 import java.util.List;
 
@@ -60,8 +55,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.github.fge.lambdas.Throwing;
 import com.github.fge.lambdas.runnable.ThrowingRunnable;
 
-import reactor.core.publisher.Mono;
-
 class CassandraMailboxMapperTest {
     private static final int UID_VALIDITY = 52;
     private static final Username USER = Username.of("user");
@@ -87,19 +80,18 @@ class CassandraMailboxMapperTest {
     private CassandraMailboxPathDAOImpl mailboxPathDAO;
     private CassandraMailboxPathV2DAO mailboxPathV2DAO;
     private CassandraMailboxMapper testee;
-    private CassandraACLMapper aclMapper;
 
     @BeforeEach
     void setUp() {
         CassandraCluster cassandra = cassandraCluster.getCassandraCluster();
-        mailboxDAO = spy(new CassandraMailboxDAO(cassandra.getConf(), cassandra.getTypesProvider()));
-        mailboxPathDAO = spy(new CassandraMailboxPathDAOImpl(cassandra.getConf(), cassandra.getTypesProvider()));
-        mailboxPathV2DAO = spy(new CassandraMailboxPathV2DAO(cassandra.getConf(), CassandraUtils.WITH_DEFAULT_CONFIGURATION));
+        mailboxDAO = new CassandraMailboxDAO(cassandra.getConf(), cassandra.getTypesProvider());
+        mailboxPathDAO = new CassandraMailboxPathDAOImpl(cassandra.getConf(), cassandra.getTypesProvider());
+        mailboxPathV2DAO = new CassandraMailboxPathV2DAO(cassandra.getConf(), CassandraUtils.WITH_DEFAULT_CONFIGURATION);
         CassandraUserMailboxRightsDAO userMailboxRightsDAO = new CassandraUserMailboxRightsDAO(cassandra.getConf(), CassandraUtils.WITH_DEFAULT_CONFIGURATION);
-        aclMapper = spy(new CassandraACLMapper(
+        CassandraACLMapper aclMapper = new CassandraACLMapper(
             cassandra.getConf(),
             new CassandraUserMailboxRightsDAO(cassandra.getConf(), CassandraUtils.WITH_DEFAULT_CONFIGURATION),
-            CassandraConfiguration.DEFAULT_CONFIGURATION));
+            CassandraConfiguration.DEFAULT_CONFIGURATION);
         testee = new CassandraMailboxMapper(
             mailboxDAO,
             mailboxPathDAO,
@@ -138,13 +130,130 @@ class CassandraMailboxMapperTest {
                 .asUserBound();
         }
 
+        @Nested
+        class Retries {
+            @Test
+            void renameShouldRetryFailedDeleteMailboxPath(CassandraCluster cassandra) throws Exception {
+                Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
+                MailboxId inboxId = inbox.getMailboxId();
+                Mailbox inboxRenamed = createInboxRenamedMailbox(inboxId);
+
+                cassandra.getConf()
+                    .fail()
+                    .whenBoundStatementStartsWith("DELETE FROM mailboxPathV2 WHERE namespace=:namespace AND user=:user AND mailboxName=:mailboxName;")
+                    .times(1)
+                    .setExecutionHook();
+
+                testee.rename(inboxRenamed);
+
+                cassandra.getConf().resetExecutionHook();
+
+                SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
+                    softly(softly)
+                        .assertThat(testee.findMailboxById(inboxId))
+                        .isEqualTo(inboxRenamed);
+                    softly(softly)
+                        .assertThat(testee.findMailboxByPath(inboxPathRenamed))
+                        .isEqualTo(inboxRenamed);
+                    softly.assertThat(testee.findMailboxWithPathLike(allMailboxesSearchQuery))
+                        .hasOnlyOneElementSatisfying(searchMailbox -> softly(softly)
+                            .assertThat(searchMailbox)
+                            .isEqualTo(inboxRenamed));
+                }));
+            }
+
+            @Test
+            void renameShouldRetryFailedMailboxSaving(CassandraCluster cassandra) throws Exception {
+                Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
+                MailboxId inboxId = inbox.getMailboxId();
+                Mailbox inboxRenamed = createInboxRenamedMailbox(inboxId);
+
+                cassandra.getConf()
+                    .fail()
+                    .whenBoundStatementStartsWith("INSERT INTO mailbox (id,name,uidvalidity,mailboxbase) VALUES (:id,:name,:uidvalidity,:mailboxbase);")
+                    .times(1)
+                    .setExecutionHook();
+
+                testee.rename(inboxRenamed);
+
+                cassandra.getConf().resetExecutionHook();
+
+                SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
+                    softly(softly)
+                        .assertThat(testee.findMailboxById(inboxId))
+                        .isEqualTo(inboxRenamed);
+                    softly(softly)
+                        .assertThat(testee.findMailboxByPath(inboxPathRenamed))
+                        .isEqualTo(inboxRenamed);
+                    softly.assertThat(testee.findMailboxWithPathLike(allMailboxesSearchQuery))
+                        .hasOnlyOneElementSatisfying(searchMailbox -> softly(softly)
+                            .assertThat(searchMailbox)
+                            .isEqualTo(inboxRenamed));
+                }));
+            }
+
+            @Test
+            void createShouldRetryFailedMailboxSaving(CassandraCluster cassandra) throws Exception {
+                cassandra.getConf()
+                    .fail()
+                    .whenBoundStatementStartsWith("INSERT INTO mailbox (id,name,uidvalidity,mailboxbase) VALUES (:id,:name,:uidvalidity,:mailboxbase);")
+                    .times(1)
+                    .setExecutionHook();
+
+                Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
+
+                cassandra.getConf().resetExecutionHook();
+
+                SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
+                    softly(softly)
+                        .assertThat(testee.findMailboxById(inbox.getMailboxId()))
+                        .isEqualTo(inbox);
+                    softly(softly)
+                        .assertThat(testee.findMailboxByPath(inboxPath))
+                        .isEqualTo(inbox);
+                    softly.assertThat(testee.findMailboxWithPathLike(allMailboxesSearchQuery))
+                        .hasOnlyOneElementSatisfying(searchMailbox -> softly(softly)
+                            .assertThat(searchMailbox)
+                            .isEqualTo(inbox));
+                }));
+            }
+
+            @Test
+            void deleteShouldRetryFailedMailboxDeletion(CassandraCluster cassandra) throws Exception {
+                Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
+
+                cassandra.getConf()
+                    .fail()
+                    .whenBoundStatementStartsWith("DELETE FROM mailbox WHERE id=:id;")
+                    .times(1)
+                    .setExecutionHook();
+
+                testee.delete(inbox);
+
+                cassandra.getConf().resetExecutionHook();
+
+                SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
+                    assertThatThrownBy(() -> testee.findMailboxById(inbox.getMailboxId()))
+                        .isInstanceOf(MailboxNotFoundException.class);
+                    assertThatThrownBy(() -> testee.findMailboxByPath(inboxPath))
+                        .isInstanceOf(MailboxNotFoundException.class);
+                    softly.assertThat(testee.findMailboxWithPathLike(allMailboxesSearchQuery))
+                        .isEmpty();
+                }));
+            }
+        }
+
         @Test
-        void createShouldBeConsistentWhenFailToPersistMailbox() {
-            doReturn(Mono.error(new RuntimeException("mock exception")))
-                .when(mailboxDAO)
-                .save(any());
+        void createShouldBeConsistentWhenFailToPersistMailbox(CassandraCluster cassandra) {
+            cassandra.getConf()
+                .fail()
+                .whenBoundStatementStartsWith("INSERT INTO mailbox (id,name,uidvalidity,mailboxbase) VALUES (:id,:name,:uidvalidity,:mailboxbase);")
+                .times(10)
+                .setExecutionHook();
 
             doQuietly(() -> testee.create(inboxPath, UID_VALIDITY));
+
+            cassandra.getConf().resetExecutionHook();
 
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThatThrownBy(() -> testee.findMailboxByPath(inboxPath))
@@ -157,16 +266,20 @@ class CassandraMailboxMapperTest {
         }
 
         @Test
-        void renameThenFailToRetrieveMailboxShouldBeConsistentWhenFindByInbox() throws Exception {
+        void renameThenFailToRetrieveMailboxShouldBeConsistentWhenFindByInbox(CassandraCluster cassandra) throws Exception {
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
             Mailbox inboxRenamed = createInboxRenamedMailbox(inboxId);
 
-            when(mailboxDAO.retrieveMailbox(inboxId))
-                .thenReturn(Mono.error(new RuntimeException("mock exception")))
-                .thenCallRealMethod();
+            cassandra.getConf()
+                .fail()
+                .whenBoundStatementStartsWith("SELECT id,mailboxbase,uidvalidity,name FROM mailbox WHERE id=:id;")
+                .times(6)
+                .setExecutionHook();
 
             doQuietly(() -> testee.rename(inboxRenamed));
+
+            cassandra.getConf().resetExecutionHook();
 
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
                 softly(softly)
@@ -184,16 +297,20 @@ class CassandraMailboxMapperTest {
 
         @Disabled("JAMES-3056 returning two mailboxes with same name and id")
         @Test
-        void renameThenFailToRetrieveMailboxShouldBeConsistentWhenFindAll() throws Exception {
+        void renameThenFailToRetrieveMailboxShouldBeConsistentWhenFindAll(CassandraCluster cassandra) throws Exception {
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
             Mailbox inboxRenamed = createInboxRenamedMailbox(inboxId);
 
-            when(mailboxDAO.retrieveMailbox(inboxId))
-                .thenReturn(Mono.error(new RuntimeException("mock exception")))
-                .thenCallRealMethod();
+            cassandra.getConf()
+                .fail()
+                .whenBoundStatementStartsWith("SELECT id,mailboxbase,uidvalidity,name FROM mailbox WHERE id=:id;")
+                .times(6)
+                .setExecutionHook();
 
             doQuietly(() -> testee.rename(inboxRenamed));
+
+            cassandra.getConf().resetExecutionHook();
 
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
                 softly.assertThat(testee.findMailboxWithPathLike(allMailboxesSearchQuery))
@@ -205,16 +322,20 @@ class CassandraMailboxMapperTest {
 
         @Disabled("JAMES-3056 find by renamed name returns unexpected results")
         @Test
-        void renameThenFailToRetrieveMailboxShouldBeConsistentWhenFindByRenamedInbox() throws Exception {
+        void renameThenFailToRetrieveMailboxShouldBeConsistentWhenFindByRenamedInbox(CassandraCluster cassandra) throws Exception {
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
             Mailbox inboxRenamed = createInboxRenamedMailbox(inboxId);
 
-            when(mailboxDAO.retrieveMailbox(inboxId))
-                .thenReturn(Mono.error(new RuntimeException("mock exception")))
-                .thenCallRealMethod();
+            cassandra.getConf()
+                .fail()
+                .whenBoundStatementStartsWith("SELECT id,mailboxbase,uidvalidity,name FROM mailbox WHERE id=:id;")
+                .times(6)
+                .setExecutionHook();
 
             doQuietly(() -> testee.rename(inboxRenamed));
+
+            cassandra.getConf().resetExecutionHook();
 
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
                 softly.assertThatThrownBy(() -> testee.findMailboxByPath(inboxPathRenamed))
@@ -225,16 +346,20 @@ class CassandraMailboxMapperTest {
         }
 
         @Test
-        void renameThenFailToDeleteMailboxPathShouldBeConsistentWhenFindByInbox() throws Exception {
+        void renameThenFailToDeleteMailboxPathShouldBeConsistentWhenFindByInbox(CassandraCluster cassandra) throws Exception {
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
             Mailbox inboxRenamed = createInboxRenamedMailbox(inboxId);
 
-            when(mailboxPathV2DAO.delete(inboxPath))
-                .thenReturn(Mono.error(new RuntimeException("mock exception")))
-                .thenCallRealMethod();
+            cassandra.getConf()
+                .fail()
+                .whenBoundStatementStartsWith("DELETE FROM mailboxPathV2 WHERE namespace=:namespace AND user=:user AND mailboxName=:mailboxName;")
+                .times(6)
+                .setExecutionHook();
 
             doQuietly(() -> testee.rename(inboxRenamed));
+
+            cassandra.getConf().resetExecutionHook();
 
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
                 softly(softly)
@@ -252,14 +377,16 @@ class CassandraMailboxMapperTest {
 
         @Disabled("JAMES-3056 returning two mailboxes with same name and id")
         @Test
-        void renameThenFailToDeleteMailboxPathShouldBeConsistentWhenFindAll() throws Exception {
+        void renameThenFailToDeleteMailboxPathShouldBeConsistentWhenFindAll(CassandraCluster cassandra) throws Exception {
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
             Mailbox inboxRenamed = createInboxRenamedMailbox(inboxId);
 
-            when(mailboxPathV2DAO.delete(inboxPath))
-                .thenReturn(Mono.error(new RuntimeException("mock exception")))
-                .thenCallRealMethod();
+            cassandra.getConf()
+                .fail()
+                .whenBoundStatementStartsWith("DELETE FROM mailboxPathV2 WHERE namespace=:namespace AND user=:user AND mailboxName=:mailboxName;")
+                .times(6)
+                .setExecutionHook();
 
             doQuietly(() -> testee.rename(inboxRenamed));
 
@@ -273,16 +400,20 @@ class CassandraMailboxMapperTest {
 
         @Disabled("JAMES-3056 find by renamed name returns unexpected results")
         @Test
-        void renameThenFailToDeleteMailboxPathShouldBeConsistentWhenFindByRenamedInbox() throws Exception {
+        void renameThenFailToDeleteMailboxPathShouldBeConsistentWhenFindByRenamedInbox(CassandraCluster cassandra) throws Exception {
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
             Mailbox inboxRenamed = createInboxRenamedMailbox(inboxId);
 
-            when(mailboxPathV2DAO.delete(inboxPath))
-                .thenReturn(Mono.error(new RuntimeException("mock exception")))
-                .thenCallRealMethod();
+            cassandra.getConf()
+                .fail()
+                .whenBoundStatementStartsWith("DELETE FROM mailboxPathV2 WHERE namespace=:namespace AND user=:user AND mailboxName=:mailboxName;")
+                .times(6)
+                .setExecutionHook();
 
             doQuietly(() -> testee.rename(inboxRenamed));
+
+            cassandra.getConf().resetExecutionHook();
 
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
                 softly.assertThatThrownBy(() -> testee.findMailboxByPath(inboxPathRenamed))
@@ -294,15 +425,19 @@ class CassandraMailboxMapperTest {
 
         @Disabled("JAMES-3056 find by mailbox name returns unexpected results")
         @Test
-        void deleteShouldBeConsistentWhenFailToDeleteMailbox() throws Exception {
+        void deleteShouldBeConsistentWhenFailToDeleteMailbox(CassandraCluster cassandra) throws Exception {
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
 
-            doReturn(Mono.error(new RuntimeException("mock exception")))
-                .when(mailboxDAO)
-                .delete(inboxId);
+            cassandra.getConf()
+                .fail()
+                .whenBoundStatementStartsWith("DELETE FROM mailbox WHERE id=:id;")
+                .times(6)
+                .setExecutionHook();
 
             doQuietly(() -> testee.delete(inbox));
+
+            cassandra.getConf().resetExecutionHook();
 
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
                 softly.assertThatCode(() -> testee.findMailboxById(inboxId))
@@ -341,12 +476,16 @@ class CassandraMailboxMapperTest {
 
         @Disabled("JAMES-3057 org.apache.james.mailbox.exception.MailboxNotFoundException: INBOX can not be found")
         @Test
-        void createAfterPreviousFailedCreateShouldCreateAMailbox() throws MailboxException {
-            when(mailboxDAO.save(any()))
-                .thenReturn(Mono.error(new RuntimeException("mock exception")))
-                .thenCallRealMethod();
+        void createAfterPreviousFailedCreateShouldCreateAMailbox(CassandraCluster cassandra) throws MailboxException {
+            cassandra.getConf()
+                .fail()
+                .whenBoundStatementStartsWith("INSERT INTO mailbox (id,name,uidvalidity,mailboxbase) VALUES (:id,:name,:uidvalidity,:mailboxbase);")
+                .times(6)
+                .setExecutionHook();
 
             doQuietly(() -> testee.create(inboxPath, UID_VALIDITY));
+
+            cassandra.getConf().resetExecutionHook();
 
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
 
@@ -366,17 +505,17 @@ class CassandraMailboxMapperTest {
         }
 
         @Test
-        void createAfterPreviousDeleteOnFailedCreateShouldCreateAMailbox() throws MailboxException {
-            doReturn(Mono.error(new RuntimeException("mock exception")))
-                .when(mailboxDAO)
-                .save(any());
+        void createAfterPreviousDeleteOnFailedCreateShouldCreateAMailbox(CassandraCluster cassandra) throws MailboxException {
+            cassandra.getConf()
+                .fail()
+                .whenBoundStatementStartsWith("INSERT INTO mailbox (id,name,uidvalidity,mailboxbase) VALUES (:id,:name,:uidvalidity,:mailboxbase);")
+                .times(6)
+                .setExecutionHook();
 
             doQuietly(() -> testee.create(inboxPath, UID_VALIDITY));
             doQuietly(() -> testee.delete(new Mailbox(inboxPath, UID_VALIDITY, CassandraId.timeBased())));
 
-            doCallRealMethod()
-                .when(mailboxDAO)
-                .save(any());
+            cassandra.getConf().resetExecutionHook();
 
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
 
@@ -396,15 +535,20 @@ class CassandraMailboxMapperTest {
         }
 
         @Test
-        void deleteAfterAFailedDeleteShouldDeleteTheMailbox() throws Exception {
+        void deleteAfterAFailedDeleteShouldDeleteTheMailbox(CassandraCluster cassandra) throws Exception {
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
 
-            when(mailboxDAO.delete(inboxId))
-                .thenReturn(Mono.error(new RuntimeException("mock exception")))
-                .thenCallRealMethod();
+            cassandra.getConf()
+                .fail()
+                .whenBoundStatementStartsWith("DELETE FROM mailbox WHERE id=:id;")
+                .times(6)
+                .setExecutionHook();
 
             doQuietly(() -> testee.delete(inbox));
+
+            cassandra.getConf().resetExecutionHook();
+
             doQuietly(() -> testee.delete(inbox));
 
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
@@ -422,16 +566,21 @@ class CassandraMailboxMapperTest {
         @Disabled("JAMES-3056 mailbox name is not updated to INBOX_RENAMED).isEqualTo(" +
             "findMailboxWithPathLike() returns a list with two same mailboxes")
         @Test
-        void renameAfterRenameFailOnRetrieveMailboxShouldRenameTheMailbox() throws Exception {
+        void renameAfterRenameFailOnRetrieveMailboxShouldRenameTheMailbox(CassandraCluster cassandra) throws Exception {
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
             Mailbox inboxRenamed = createInboxRenamedMailbox(inboxId);
 
-            when(mailboxDAO.retrieveMailbox(inboxId))
-                .thenReturn(Mono.error(new RuntimeException("mock exception")))
-                .thenCallRealMethod();
+            cassandra.getConf()
+                .fail()
+                .whenBoundStatementStartsWith("SELECT id,mailboxbase,uidvalidity,name FROM mailbox WHERE id=:id;")
+                .times(6)
+                .setExecutionHook();
 
             doQuietly(() -> testee.rename(inboxRenamed));
+
+            cassandra.getConf().resetExecutionHook();
+
             doQuietly(() -> testee.rename(inboxRenamed));
 
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
@@ -456,16 +605,21 @@ class CassandraMailboxMapperTest {
 
         @Disabled("JAMES-3056 mailbox name is not updated to INBOX_RENAMED")
         @Test
-        void renameAfterRenameFailOnDeletePathShouldRenameTheMailbox() throws Exception {
+        void renameAfterRenameFailOnDeletePathShouldRenameTheMailbox(CassandraCluster cassandra) throws Exception {
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
             Mailbox inboxRenamed = createInboxRenamedMailbox(inboxId);
 
-            when(mailboxPathV2DAO.delete(inboxPath))
-                .thenReturn(Mono.error(new RuntimeException("mock exception")))
-                .thenCallRealMethod();
+            cassandra.getConf()
+                .fail()
+                .whenBoundStatementStartsWith("DELETE FROM mailboxPathV2 WHERE namespace=:namespace AND user=:user AND mailboxName=:mailboxName;")
+                .times(6)
+                .setExecutionHook();
 
             doQuietly(() -> testee.rename(inboxRenamed));
+
+            cassandra.getConf().resetExecutionHook();
+
             doQuietly(() -> testee.rename(inboxRenamed));
 
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperTest.java
@@ -72,6 +72,7 @@ class CassandraMailboxMapperTest {
         CassandraMailboxModule.MODULE,
         CassandraSchemaVersionModule.MODULE,
         CassandraAclModule.MODULE);
+    private static final int TRY_COUNT_BEFORE_FAILURE = 6;
 
     @RegisterExtension
     static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(MODULES);
@@ -274,7 +275,7 @@ class CassandraMailboxMapperTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("SELECT id,mailboxbase,uidvalidity,name FROM mailbox WHERE id=:id;")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.rename(inboxRenamed));
@@ -305,7 +306,7 @@ class CassandraMailboxMapperTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("SELECT id,mailboxbase,uidvalidity,name FROM mailbox WHERE id=:id;")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.rename(inboxRenamed));
@@ -330,7 +331,7 @@ class CassandraMailboxMapperTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("SELECT id,mailboxbase,uidvalidity,name FROM mailbox WHERE id=:id;")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.rename(inboxRenamed));
@@ -354,7 +355,7 @@ class CassandraMailboxMapperTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("DELETE FROM mailboxPathV2 WHERE namespace=:namespace AND user=:user AND mailboxName=:mailboxName;")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.rename(inboxRenamed));
@@ -385,7 +386,7 @@ class CassandraMailboxMapperTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("DELETE FROM mailboxPathV2 WHERE namespace=:namespace AND user=:user AND mailboxName=:mailboxName;")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.rename(inboxRenamed));
@@ -408,7 +409,7 @@ class CassandraMailboxMapperTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("DELETE FROM mailboxPathV2 WHERE namespace=:namespace AND user=:user AND mailboxName=:mailboxName;")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.rename(inboxRenamed));
@@ -432,7 +433,7 @@ class CassandraMailboxMapperTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("DELETE FROM mailbox WHERE id=:id;")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.delete(inbox));
@@ -480,7 +481,7 @@ class CassandraMailboxMapperTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("INSERT INTO mailbox (id,name,uidvalidity,mailboxbase) VALUES (:id,:name,:uidvalidity,:mailboxbase);")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.create(inboxPath, UID_VALIDITY));
@@ -509,7 +510,7 @@ class CassandraMailboxMapperTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("INSERT INTO mailbox (id,name,uidvalidity,mailboxbase) VALUES (:id,:name,:uidvalidity,:mailboxbase);")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.create(inboxPath, UID_VALIDITY));
@@ -542,7 +543,7 @@ class CassandraMailboxMapperTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("DELETE FROM mailbox WHERE id=:id;")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.delete(inbox));
@@ -574,7 +575,7 @@ class CassandraMailboxMapperTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("SELECT id,mailboxbase,uidvalidity,name FROM mailbox WHERE id=:id;")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.rename(inboxRenamed));
@@ -613,7 +614,7 @@ class CassandraMailboxMapperTest {
             cassandra.getConf()
                 .fail()
                 .whenBoundStatementStartsWith("DELETE FROM mailboxPathV2 WHERE namespace=:namespace AND user=:user AND mailboxName=:mailboxName;")
-                .times(6)
+                .times(TRY_COUNT_BEFORE_FAILURE)
                 .setExecutionHook();
 
             doQuietly(() -> testee.rename(inboxRenamed));

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMapperProvider.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMapperProvider.java
@@ -82,8 +82,7 @@ public class CassandraMapperProvider implements MapperProvider {
     }
 
     private CassandraMailboxSessionMapperFactory createMapperFactory() {
-        return TestCassandraMailboxSessionMapperFactory.forTests(cassandra.getConf(),
-            cassandra.getTypesProvider(),
+        return TestCassandraMailboxSessionMapperFactory.forTests(cassandra,
             new CassandraMessageId.Factory());
     }
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapperTest.java
@@ -54,8 +54,7 @@ class CassandraMessageIdMapperTest extends MessageIdMapperTest {
     void findShouldReturnCorrectElementsWhenChunking() throws Exception {
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
         CassandraMailboxSessionMapperFactory mapperFactory = TestCassandraMailboxSessionMapperFactory.forTests(
-            cassandraCluster.getCassandraCluster().getConf(),
-            cassandraCluster.getCassandraCluster().getTypesProvider(),
+            cassandraCluster.getCassandraCluster(),
             messageIdFactory,
             CassandraConfiguration.builder()
                 .messageReadChunkSize(3)

--- a/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/CassandraReIndexerImplTest.java
+++ b/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/CassandraReIndexerImplTest.java
@@ -64,8 +64,7 @@ public class CassandraReIndexerImplTest {
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
-        mailboxManager = CassandraMailboxManagerProvider.provideMailboxManager(cassandra.getConf(), cassandra.getTypesProvider(),
-            PreDeletionHooks.NO_PRE_DELETION_HOOK);
+        mailboxManager = CassandraMailboxManagerProvider.provideMailboxManager(cassandra, PreDeletionHooks.NO_PRE_DELETION_HOOK);
         MailboxSessionMapperFactory mailboxSessionMapperFactory = mailboxManager.getMapperFactory();
         messageSearchIndex = mock(ListeningMessageSearchIndex.class);
         reIndexer = new ReIndexerImpl(new ReIndexerPerformer(mailboxManager, messageSearchIndex, mailboxSessionMapperFactory),

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
@@ -88,9 +88,7 @@ public class CassandraHostSystem extends JamesImapHostSystem {
         com.datastax.driver.core.Session session = cassandra.getConf();
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
         CassandraMailboxSessionMapperFactory mapperFactory = TestCassandraMailboxSessionMapperFactory.forTests(
-            cassandra.getConf(),
-            cassandra.getTypesProvider(),
-            messageIdFactory);
+            cassandra, messageIdFactory);
 
 
         InVMEventBus eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()));


### PR DESCRIPTION
Current work is limited by the testing strategy (mocking mono to simulate a count of failure - a defer is needed to force mono regeneration from "mockito" upon retries).

Proposals for alternatives are welcome (and avoid using defer()).