### PR TITLE
JAMES-3057 make MailboxId of Mailbox object immutable

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/Mailbox.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/Mailbox.java
@@ -29,7 +29,7 @@ import com.google.common.base.Objects;
  * Models long term mailbox data.
  */
 public class Mailbox {
-    private MailboxId id = null;
+    private final MailboxId id;
     private String namespace;
     private Username user;
     private String name;
@@ -42,10 +42,6 @@ public class Mailbox {
         this.user = path.getUser();
         this.name = path.getName();
         this.uidValidity = uidValidity;
-    }
-
-    public Mailbox(MailboxPath path, long uidValidity) {
-        this(path, uidValidity, null);
     }
 
     public Mailbox(Mailbox mailbox) {
@@ -123,11 +119,6 @@ public class Mailbox {
 
     public MailboxPath generateAssociatedPath() {
         return new MailboxPath(getNamespace(), getUser(), getName());
-    }
-
-
-    public void setMailboxId(MailboxId id) {
-        this.id = id;
     }
 
     /**

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxAssertingToolTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxAssertingToolTest.java
@@ -38,20 +38,16 @@ class MailboxAssertingToolTest {
     class MailboxAssertTest {
         @Test
         void isEqualToShouldNotFailWithEqualMailbox() {
-            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            mailbox1.setMailboxId(MAILBOX_ID);
-            mailbox2.setMailboxId(MAILBOX_ID);
+            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
+            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
 
             MailboxAssertingTool.assertThat(mailbox1).isEqualTo(mailbox2);
         }
 
         @Test
         void isEqualToShouldFailWithNotEqualNamespace() {
-            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            Mailbox mailbox2 = new Mailbox(new MailboxPath("other_namespace", USER, "name"), UID_VALIDITY);
-            mailbox1.setMailboxId(MAILBOX_ID);
-            mailbox2.setMailboxId(MAILBOX_ID);
+            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
+            Mailbox mailbox2 = new Mailbox(new MailboxPath("other_namespace", USER, "name"), UID_VALIDITY, MAILBOX_ID);
 
             assertThatThrownBy(() -> MailboxAssertingTool.assertThat(mailbox1).isEqualTo(mailbox2))
                 .isInstanceOf(AssertionError.class);
@@ -59,10 +55,8 @@ class MailboxAssertingToolTest {
 
         @Test
         void isEqualToShouldFailWithNotEqualUser() {
-            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            Mailbox mailbox2 = new Mailbox(new MailboxPath("namespace", Username.of("other_user"), "name"), UID_VALIDITY);
-            mailbox1.setMailboxId(MAILBOX_ID);
-            mailbox2.setMailboxId(MAILBOX_ID);
+            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
+            Mailbox mailbox2 = new Mailbox(new MailboxPath("namespace", Username.of("other_user"), "name"), UID_VALIDITY, MAILBOX_ID);
 
             assertThatThrownBy(() -> MailboxAssertingTool.assertThat(mailbox1).isEqualTo(mailbox2))
                 .isInstanceOf(AssertionError.class);
@@ -70,10 +64,8 @@ class MailboxAssertingToolTest {
 
         @Test
         void isEqualToShouldFailWithNotEqualName() {
-            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            Mailbox mailbox2 = new Mailbox(new MailboxPath("namespace", USER, "other_name"), UID_VALIDITY);
-            mailbox1.setMailboxId(MAILBOX_ID);
-            mailbox2.setMailboxId(MAILBOX_ID);
+            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
+            Mailbox mailbox2 = new Mailbox(new MailboxPath("namespace", USER, "other_name"), UID_VALIDITY, MAILBOX_ID);
 
             assertThatThrownBy(() -> MailboxAssertingTool.assertThat(mailbox1).isEqualTo(mailbox2))
                 .isInstanceOf(AssertionError.class);
@@ -81,10 +73,8 @@ class MailboxAssertingToolTest {
 
         @Test
         void isEqualToShouldFailWithNotEqualId() {
-            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            mailbox1.setMailboxId(MAILBOX_ID);
-            mailbox2.setMailboxId(TestId.of(MAILBOX_ID.id + 1));
+            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
+            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, TestId.of(MAILBOX_ID.id + 1));
 
             assertThatThrownBy(() -> MailboxAssertingTool.assertThat(mailbox1).isEqualTo(mailbox2))
                 .isInstanceOf(AssertionError.class);
@@ -92,10 +82,8 @@ class MailboxAssertingToolTest {
 
         @Test
         void isEqualToShouldFailWithNotEqualUidValidity() {
-            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY + 1);
-            mailbox1.setMailboxId(MAILBOX_ID);
-            mailbox2.setMailboxId(MAILBOX_ID);
+            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
+            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY + 1, MAILBOX_ID);
 
             assertThatThrownBy(() -> MailboxAssertingTool.assertThat(mailbox1).isEqualTo(mailbox2))
                 .isInstanceOf(AssertionError.class);
@@ -108,10 +96,8 @@ class MailboxAssertingToolTest {
 
         @Test
         void isEqualToShouldNotFailWithEqualMailbox() {
-            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            mailbox1.setMailboxId(MAILBOX_ID);
-            mailbox2.setMailboxId(MAILBOX_ID);
+            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
+            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
 
             SoftAssertions.assertSoftly(softly -> {
                 MailboxAssertingTool.softly(softly)
@@ -122,10 +108,8 @@ class MailboxAssertingToolTest {
 
         @Test
         void isEqualToShouldFailWithNotEqualNamespace() {
-            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            Mailbox mailbox2 = new Mailbox(new MailboxPath("other_namespace", USER, "name"), UID_VALIDITY);
-            mailbox1.setMailboxId(MAILBOX_ID);
-            mailbox2.setMailboxId(MAILBOX_ID);
+            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
+            Mailbox mailbox2 = new Mailbox(new MailboxPath("other_namespace", USER, "name"), UID_VALIDITY, MAILBOX_ID);
 
             assertThatThrownBy(() -> {
                     SoftAssertions.assertSoftly(softly -> {
@@ -140,10 +124,8 @@ class MailboxAssertingToolTest {
 
         @Test
         void isEqualToShouldFailWithNotEqualName() {
-            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "other_name"), UID_VALIDITY);
-            mailbox1.setMailboxId(MAILBOX_ID);
-            mailbox2.setMailboxId(MAILBOX_ID);
+            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
+            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "other_name"), UID_VALIDITY, MAILBOX_ID);
 
             assertThatThrownBy(() -> {
                     SoftAssertions.assertSoftly(softly -> {
@@ -158,10 +140,8 @@ class MailboxAssertingToolTest {
 
         @Test
         void isEqualToShouldFailWithNotEqualId() {
-            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            mailbox1.setMailboxId(MAILBOX_ID);
-            mailbox2.setMailboxId(TestId.of(MAILBOX_ID.id + 1));
+            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
+            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, TestId.of(MAILBOX_ID.id + 1));
 
             assertThatThrownBy(() -> {
                     SoftAssertions.assertSoftly(softly -> {
@@ -176,10 +156,8 @@ class MailboxAssertingToolTest {
 
         @Test
         void isEqualToShouldFailWithNotEqualUidValidity() {
-            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY + 1);
-            mailbox1.setMailboxId(MAILBOX_ID);
-            mailbox2.setMailboxId(MAILBOX_ID);
+            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
+            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY + 1, MAILBOX_ID);
 
             assertThatThrownBy(() -> {
                     SoftAssertions.assertSoftly(softly -> {
@@ -194,10 +172,8 @@ class MailboxAssertingToolTest {
 
         @Test
         void isEqualToShouldFailWithNotSameSizeEntries() throws Exception {
-            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            mailbox1.setMailboxId(MAILBOX_ID);
-            mailbox2.setMailboxId(MAILBOX_ID);
+            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
+            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
 
             mailbox1.setACL(new MailboxACL(
                 new MailboxACL.Entry(USER.asString(), MailboxACL.Right.Write)));
@@ -218,10 +194,8 @@ class MailboxAssertingToolTest {
 
         @Test
         void isEqualToShouldFailWithSameSizeButDifferentEntries() throws Exception {
-            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            mailbox1.setMailboxId(MAILBOX_ID);
-            mailbox2.setMailboxId(MAILBOX_ID);
+            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
+            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
 
             mailbox1.setACL(new MailboxACL(
                 new MailboxACL.Entry(USER.asString(), MailboxACL.Right.Write)));
@@ -241,10 +215,8 @@ class MailboxAssertingToolTest {
 
         @Test
         void isEqualToShouldPassWithSameSizeEntriesButDifferentOrder() throws Exception {
-            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY);
-            mailbox1.setMailboxId(MAILBOX_ID);
-            mailbox2.setMailboxId(MAILBOX_ID);
+            Mailbox mailbox1 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
+            Mailbox mailbox2 = new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY, MAILBOX_ID);
 
             mailbox1.setACL(new MailboxACL(
                 new MailboxACL.Entry(USER1.asString(), MailboxACL.Right.Read),

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapper.java
@@ -167,18 +167,6 @@ public class CassandraMailboxMapper implements MailboxMapper {
     }
 
     @Override
-    public MailboxId create(Mailbox mailbox) throws MailboxException {
-        Preconditions.checkArgument(mailbox.getMailboxId() == null, "A mailbox we want to create should not have a mailboxId set already");
-
-        CassandraId cassandraId = CassandraId.timeBased();
-        mailbox.setMailboxId(cassandraId);
-        if (!tryCreate(mailbox, cassandraId)) {
-            throw new MailboxExistsException(mailbox.generateAssociatedPath().asString());
-        }
-        return cassandraId;
-    }
-
-    @Override
     public Mailbox create(MailboxPath mailboxPath, long uidValidity) throws MailboxException {
         CassandraId cassandraId = CassandraId.timeBased();
         Mailbox mailbox = new Mailbox(mailboxPath, uidValidity, cassandraId);

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapper.java
@@ -178,6 +178,17 @@ public class CassandraMailboxMapper implements MailboxMapper {
         return cassandraId;
     }
 
+    @Override
+    public Mailbox create(MailboxPath mailboxPath, long uidValidity) throws MailboxException {
+        CassandraId cassandraId = CassandraId.timeBased();
+        Mailbox mailbox = new Mailbox(mailboxPath, uidValidity, cassandraId);
+
+        if (!tryCreate(mailbox, cassandraId)) {
+            throw new MailboxExistsException(mailbox.generateAssociatedPath().asString());
+        }
+        return mailbox;
+    }
+
     private boolean tryCreate(Mailbox cassandraMailbox, CassandraId cassandraId) {
         return mailboxPathV2DAO.save(cassandraMailbox.generateAssociatedPath(), cassandraId)
             .filter(isCreated -> isCreated)

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperAclTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperAclTest.java
@@ -22,11 +22,9 @@ package org.apache.james.mailbox.cassandra.mail;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
-import org.apache.james.mailbox.cassandra.ids.CassandraId;
 import org.apache.james.mailbox.cassandra.mail.utils.GuiceUtils;
 import org.apache.james.mailbox.cassandra.modules.CassandraAclModule;
 import org.apache.james.mailbox.cassandra.modules.CassandraMailboxModule;
-import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.apache.james.mailbox.store.mail.model.MailboxMapperACLTest;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -45,10 +43,5 @@ class CassandraMailboxMapperAclTest extends MailboxMapperACLTest {
     protected MailboxMapper createMailboxMapper() {
         return GuiceUtils.testInjector(cassandraCluster.getCassandraCluster())
             .getInstance(CassandraMailboxMapper.class);
-    }
-
-    @Override
-    protected MailboxId generateId() {
-        return CassandraId.timeBased();
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
@@ -64,7 +64,7 @@ class CassandraMailboxMapperConcurrencyTest {
     @Test
     void createShouldBeThreadSafe() throws Exception {
         ConcurrentTestRunner.builder()
-            .operation((a, b) -> testee.create(new Mailbox(MAILBOX_PATH, UID_VALIDITY)))
+            .operation((a, b) -> testee.create(MAILBOX_PATH, UID_VALIDITY))
             .threadCount(THREAD_COUNT)
             .operationCount(OPERATION_COUNT)
             .runAcceptingErrorsWithin(Duration.ofMinutes(1));
@@ -74,8 +74,7 @@ class CassandraMailboxMapperConcurrencyTest {
 
     @Test
     void renameWithUpdateShouldBeThreadSafe() throws Exception {
-        Mailbox mailbox = new Mailbox(MAILBOX_PATH, UID_VALIDITY);
-        testee.create(mailbox);
+        Mailbox mailbox = testee.create(MAILBOX_PATH, UID_VALIDITY);
 
         mailbox.setName("newName");
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperConcurrencyTest.java
@@ -62,9 +62,9 @@ class CassandraMailboxMapperConcurrencyTest {
     }
 
     @Test
-    void saveShouldBeThreadSafe() throws Exception {
+    void createShouldBeThreadSafe() throws Exception {
         ConcurrentTestRunner.builder()
-            .operation((a, b) -> testee.save(new Mailbox(MAILBOX_PATH, UID_VALIDITY)))
+            .operation((a, b) -> testee.create(new Mailbox(MAILBOX_PATH, UID_VALIDITY)))
             .threadCount(THREAD_COUNT)
             .operationCount(OPERATION_COUNT)
             .runAcceptingErrorsWithin(Duration.ofMinutes(1));
@@ -73,14 +73,14 @@ class CassandraMailboxMapperConcurrencyTest {
     }
 
     @Test
-    void saveWithUpdateShouldBeThreadSafe() throws Exception {
+    void renameWithUpdateShouldBeThreadSafe() throws Exception {
         Mailbox mailbox = new Mailbox(MAILBOX_PATH, UID_VALIDITY);
-        testee.save(mailbox);
+        testee.create(mailbox);
 
         mailbox.setName("newName");
 
         ConcurrentTestRunner.builder()
-            .operation((a, b) -> testee.save(mailbox))
+            .operation((a, b) -> testee.rename(mailbox))
             .threadCount(THREAD_COUNT)
             .operationCount(OPERATION_COUNT)
             .runAcceptingErrorsWithin(Duration.ofMinutes(1));

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperTest.java
@@ -45,6 +45,7 @@ import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.MailboxNotFoundException;
 import org.apache.james.mailbox.exception.TooLongMailboxNameException;
 import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.search.ExactName;
 import org.apache.james.mailbox.model.search.MailboxQuery;
@@ -112,7 +113,6 @@ class CassandraMailboxMapperTest {
 
         private MailboxPath inboxPath;
         private MailboxPath inboxPathRenamed;
-        private Mailbox inboxRenamed;
         private MailboxQuery.UserBound allMailboxesSearchQuery;
         private MailboxQuery.UserBound inboxSearchQuery;
         private MailboxQuery.UserBound inboxRenamedSearchQuery;
@@ -121,7 +121,6 @@ class CassandraMailboxMapperTest {
         void setUp() {
             inboxPath = MailboxPath.forUser(USER, INBOX);
             inboxPathRenamed = MailboxPath.forUser(USER, INBOX_RENAMED);
-            inboxRenamed = new Mailbox(inboxPathRenamed, UID_VALIDITY);
             allMailboxesSearchQuery = MailboxQuery.builder()
                 .userAndNamespaceFrom(inboxPath)
                 .expression(Wildcard.INSTANCE)
@@ -161,7 +160,7 @@ class CassandraMailboxMapperTest {
         void renameThenFailToRetrieveMailboxShouldBeConsistentWhenFindByInbox() throws Exception {
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
-            inboxRenamed.setMailboxId(inboxId);
+            Mailbox inboxRenamed = createInboxRenamedMailbox(inboxId);
 
             when(mailboxDAO.retrieveMailbox(inboxId))
                 .thenReturn(Mono.error(new RuntimeException("mock exception")))
@@ -188,7 +187,7 @@ class CassandraMailboxMapperTest {
         void renameThenFailToRetrieveMailboxShouldBeConsistentWhenFindAll() throws Exception {
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
-            inboxRenamed.setMailboxId(inboxId);
+            Mailbox inboxRenamed = createInboxRenamedMailbox(inboxId);
 
             when(mailboxDAO.retrieveMailbox(inboxId))
                 .thenReturn(Mono.error(new RuntimeException("mock exception")))
@@ -209,7 +208,7 @@ class CassandraMailboxMapperTest {
         void renameThenFailToRetrieveMailboxShouldBeConsistentWhenFindByRenamedInbox() throws Exception {
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
-            inboxRenamed.setMailboxId(inboxId);
+            Mailbox inboxRenamed = createInboxRenamedMailbox(inboxId);
 
             when(mailboxDAO.retrieveMailbox(inboxId))
                 .thenReturn(Mono.error(new RuntimeException("mock exception")))
@@ -229,7 +228,7 @@ class CassandraMailboxMapperTest {
         void renameThenFailToDeleteMailboxPathShouldBeConsistentWhenFindByInbox() throws Exception {
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
-            inboxRenamed.setMailboxId(inboxId);
+            Mailbox inboxRenamed = createInboxRenamedMailbox(inboxId);
 
             when(mailboxPathV2DAO.delete(inboxPath))
                 .thenReturn(Mono.error(new RuntimeException("mock exception")))
@@ -256,7 +255,7 @@ class CassandraMailboxMapperTest {
         void renameThenFailToDeleteMailboxPathShouldBeConsistentWhenFindAll() throws Exception {
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
-            inboxRenamed.setMailboxId(inboxId);
+            Mailbox inboxRenamed = createInboxRenamedMailbox(inboxId);
 
             when(mailboxPathV2DAO.delete(inboxPath))
                 .thenReturn(Mono.error(new RuntimeException("mock exception")))
@@ -277,7 +276,7 @@ class CassandraMailboxMapperTest {
         void renameThenFailToDeleteMailboxPathShouldBeConsistentWhenFindByRenamedInbox() throws Exception {
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
-            inboxRenamed.setMailboxId(inboxId);
+            Mailbox inboxRenamed = createInboxRenamedMailbox(inboxId);
 
             when(mailboxPathV2DAO.delete(inboxPath))
                 .thenReturn(Mono.error(new RuntimeException("mock exception")))
@@ -426,7 +425,7 @@ class CassandraMailboxMapperTest {
         void renameAfterRenameFailOnRetrieveMailboxShouldRenameTheMailbox() throws Exception {
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
-            inboxRenamed.setMailboxId(inboxId);
+            Mailbox inboxRenamed = createInboxRenamedMailbox(inboxId);
 
             when(mailboxDAO.retrieveMailbox(inboxId))
                 .thenReturn(Mono.error(new RuntimeException("mock exception")))
@@ -460,7 +459,7 @@ class CassandraMailboxMapperTest {
         void renameAfterRenameFailOnDeletePathShouldRenameTheMailbox() throws Exception {
             Mailbox inbox = testee.create(inboxPath, UID_VALIDITY);
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
-            inboxRenamed.setMailboxId(inboxId);
+            Mailbox inboxRenamed = createInboxRenamedMailbox(inboxId);
 
             when(mailboxPathV2DAO.delete(inboxPath))
                 .thenReturn(Mono.error(new RuntimeException("mock exception")))
@@ -496,6 +495,10 @@ class CassandraMailboxMapperTest {
             } catch (Throwable th) {
                 // ignore
             }
+        }
+
+        private Mailbox createInboxRenamedMailbox(MailboxId mailboxId) {
+            return new Mailbox(inboxPathRenamed, UID_VALIDITY, mailboxId);
         }
     }
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraModSeqProviderTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraModSeqProviderTest.java
@@ -55,8 +55,7 @@ class CassandraModSeqProviderTest {
     void setUp(CassandraCluster cassandra) {
         modSeqProvider = new CassandraModSeqProvider(cassandra.getConf(), CassandraConfiguration.DEFAULT_CONFIGURATION);
         MailboxPath path = new MailboxPath("gsoc", Username.of("ieugen"), "Trash");
-        mailbox = new Mailbox(path, 1234);
-        mailbox.setMailboxId(CASSANDRA_ID);
+        mailbox = new Mailbox(path, 1234, CASSANDRA_ID);
     }
 
     @Test

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraUidProviderTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraUidProviderTest.java
@@ -55,8 +55,7 @@ class CassandraUidProviderTest {
     void setUp(CassandraCluster cassandra) {
         uidProvider = new CassandraUidProvider(cassandra.getConf(), CassandraConfiguration.DEFAULT_CONFIGURATION);
         MailboxPath path = new MailboxPath("gsoc", Username.of("ieugen"), "Trash");
-        mailbox = new Mailbox(path, 1234);
-        mailbox.setMailboxId(CASSANDRA_ID);
+        mailbox = new Mailbox(path, 1234, CASSANDRA_ID);
     }
 
     @Test

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/MailboxPathV2MigrationTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/MailboxPathV2MigrationTest.java
@@ -41,7 +41,6 @@ import org.apache.james.mailbox.cassandra.modules.CassandraMailboxModule;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -66,11 +65,6 @@ class MailboxPathV2MigrationTest {
     private CassandraMailboxMapper mailboxMapper;
     private CassandraMailboxDAO mailboxDAO;
 
-    @BeforeAll
-    static void setUpClass() {
-        MAILBOX_1.setMailboxId(MAILBOX_ID_1);
-    }
-
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
         daoV1 = new CassandraMailboxPathDAOImpl(
@@ -89,19 +83,21 @@ class MailboxPathV2MigrationTest {
             daoV2,
             userMailboxRightsDAO,
             new CassandraACLMapper(cassandra.getConf(), userMailboxRightsDAO, CassandraConfiguration.DEFAULT_CONFIGURATION));
+
+        MAILBOX_1.setMailboxId(null);
     }
 
     @Test
     void newValuesShouldBeSavedInMostRecentDAO() throws Exception {
-        mailboxMapper.save(MAILBOX_1);
+        CassandraId mailboxId = (CassandraId) mailboxMapper.create(MAILBOX_1);
 
         assertThat(daoV2.retrieveId(MAILBOX_PATH_1).blockOptional())
-            .contains(new CassandraIdAndPath(MAILBOX_ID_1, MAILBOX_PATH_1));
+            .contains(new CassandraIdAndPath(mailboxId, MAILBOX_PATH_1));
     }
 
     @Test
     void newValuesShouldNotBeSavedInOldDAO() throws Exception {
-        mailboxMapper.save(MAILBOX_1);
+        mailboxMapper.create(MAILBOX_1);
 
         assertThat(daoV1.retrieveId(MAILBOX_PATH_1).blockOptional())
             .isEmpty();
@@ -109,6 +105,8 @@ class MailboxPathV2MigrationTest {
 
     @Test
     void readingOldValuesShouldMigrateThem() throws Exception {
+        MAILBOX_1.setMailboxId(MAILBOX_ID_1);
+
         daoV1.save(MAILBOX_PATH_1, MAILBOX_ID_1).block();
         mailboxDAO.save(MAILBOX_1).block();
 

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndexTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndexTest.java
@@ -177,8 +177,7 @@ class ElasticSearchListeningMessageSearchIndexTest {
             messageToElasticSearchJson, sessionProvider, new MailboxIdRoutingKeyFactory());
         session = sessionProvider.createSystemSession(USERNAME);
 
-        mailbox = new Mailbox(MailboxPath.forUser(USERNAME, DefaultMailboxes.INBOX), MAILBOX_ID.id);
-        mapperFactory.getMailboxMapper(session).create(mailbox);
+        mailbox = mapperFactory.getMailboxMapper(session).create(MailboxPath.forUser(USERNAME, DefaultMailboxes.INBOX), MAILBOX_ID.id);
     }
 
     @Test

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndexTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndexTest.java
@@ -178,7 +178,7 @@ class ElasticSearchListeningMessageSearchIndexTest {
         session = sessionProvider.createSystemSession(USERNAME);
 
         mailbox = new Mailbox(MailboxPath.forUser(USERNAME, DefaultMailboxes.INBOX), MAILBOX_ID.id);
-        mapperFactory.getMailboxMapper(session).save(mailbox);
+        mapperFactory.getMailboxMapper(session).create(mailbox);
     }
 
     @Test

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMailboxMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMailboxMapper.java
@@ -113,7 +113,6 @@ public class JPAMailboxMapper extends JPATransactionalMapper implements MailboxM
             JPAMailbox persistedMailbox = jpaMailbox(mailbox);
 
             getEntityManager().persist(persistedMailbox);
-            mailbox.setMailboxId(persistedMailbox.getMailboxId());
             return persistedMailbox.getMailboxId();
         } catch (PersistenceException e) {
             throw new MailboxException("Save of mailbox " + mailbox.getName() + " failed", e);

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMailboxMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMailboxMapper.java
@@ -82,26 +82,6 @@ public class JPAMailboxMapper extends JPATransactionalMapper implements MailboxM
             throw new MailboxException("Commit of transaction failed", e);
         }
     }
-
-    @Override
-    public MailboxId create(Mailbox mailbox) throws MailboxException {
-        Preconditions.checkArgument(mailbox.getMailboxId() == null, "A mailbox we want to create should not have a mailboxId set already");
-
-        try {
-            if (isPathAlreadyUsedByAnotherMailbox(mailbox.generateAssociatedPath())) {
-                throw new MailboxExistsException(mailbox.getName());
-            }
-
-            this.lastMailboxName = mailbox.getName();
-            JPAMailbox persistedMailbox = JPAMailbox.from(mailbox);
-
-            getEntityManager().persist(persistedMailbox);
-            mailbox.setMailboxId(persistedMailbox.getMailboxId());
-            return persistedMailbox.getMailboxId();
-        } catch (PersistenceException e) {
-            throw new MailboxException("Save of mailbox " + mailbox.getName() + " failed", e);
-        }
-    }
     
     @Override
     public Mailbox create(MailboxPath mailboxPath, long uidValidity) throws MailboxException {

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMailboxMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMailboxMapper.java
@@ -88,7 +88,7 @@ public class JPAMailboxMapper extends JPATransactionalMapper implements MailboxM
         Preconditions.checkArgument(mailbox.getMailboxId() == null, "A mailbox we want to create should not have a mailboxId set already");
 
         try {
-            if (isPathAlreadyUsedByAnotherMailbox(mailbox)) {
+            if (isPathAlreadyUsedByAnotherMailbox(mailbox.generateAssociatedPath())) {
                 throw new MailboxExistsException(mailbox.getName());
             }
 
@@ -104,11 +104,28 @@ public class JPAMailboxMapper extends JPATransactionalMapper implements MailboxM
     }
     
     @Override
+    public Mailbox create(MailboxPath mailboxPath, long uidValidity) throws MailboxException {
+        try {
+            if (isPathAlreadyUsedByAnotherMailbox(mailboxPath)) {
+                throw new MailboxExistsException(mailboxPath.getName());
+            }
+
+            this.lastMailboxName = mailboxPath.getName();
+            JPAMailbox persistedMailbox = new JPAMailbox(mailboxPath, uidValidity);
+            getEntityManager().persist(persistedMailbox);
+
+            return new Mailbox(mailboxPath, uidValidity, persistedMailbox.getMailboxId());
+        } catch (PersistenceException e) {
+            throw new MailboxException("Save of mailbox " + mailboxPath.getName() + " failed", e);
+        }
+    }
+
+    @Override
     public MailboxId rename(Mailbox mailbox) throws MailboxException {
         Preconditions.checkNotNull(mailbox.getMailboxId(), "A mailbox we want to rename should have a defined mailboxId");
 
         try {
-            if (isPathAlreadyUsedByAnotherMailbox(mailbox)) {
+            if (isPathAlreadyUsedByAnotherMailbox(mailbox.generateAssociatedPath())) {
                 throw new MailboxExistsException(mailbox.getName());
             }
 
@@ -131,9 +148,9 @@ public class JPAMailboxMapper extends JPATransactionalMapper implements MailboxM
         return result;
     }
 
-    private boolean isPathAlreadyUsedByAnotherMailbox(Mailbox mailbox) throws MailboxException {
+    private boolean isPathAlreadyUsedByAnotherMailbox(MailboxPath mailboxPath) throws MailboxException {
         try {
-            findMailboxByPath(mailbox.generateAssociatedPath());
+            findMailboxByPath(mailboxPath);
             return true;
         } catch (MailboxNotFoundException e) {
             return false;

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMailboxMapper.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/JPAMailboxMapper.java
@@ -46,7 +46,7 @@ import org.apache.james.mailbox.store.MailboxExpressionBackwardCompatibility;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 
 import com.github.steveash.guavate.Guavate;
-import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 /**
@@ -82,9 +82,31 @@ public class JPAMailboxMapper extends JPATransactionalMapper implements MailboxM
             throw new MailboxException("Commit of transaction failed", e);
         }
     }
+
+    @Override
+    public MailboxId create(Mailbox mailbox) throws MailboxException {
+        Preconditions.checkArgument(mailbox.getMailboxId() == null, "A mailbox we want to create should not have a mailboxId set already");
+
+        try {
+            if (isPathAlreadyUsedByAnotherMailbox(mailbox)) {
+                throw new MailboxExistsException(mailbox.getName());
+            }
+
+            this.lastMailboxName = mailbox.getName();
+            JPAMailbox persistedMailbox = JPAMailbox.from(mailbox);
+
+            getEntityManager().persist(persistedMailbox);
+            mailbox.setMailboxId(persistedMailbox.getMailboxId());
+            return persistedMailbox.getMailboxId();
+        } catch (PersistenceException e) {
+            throw new MailboxException("Save of mailbox " + mailbox.getName() + " failed", e);
+        }
+    }
     
     @Override
-    public MailboxId save(Mailbox mailbox) throws MailboxException {
+    public MailboxId rename(Mailbox mailbox) throws MailboxException {
+        Preconditions.checkNotNull(mailbox.getMailboxId(), "A mailbox we want to rename should have a defined mailboxId");
+
         try {
             if (isPathAlreadyUsedByAnotherMailbox(mailbox)) {
                 throw new MailboxExistsException(mailbox.getName());
@@ -101,25 +123,18 @@ public class JPAMailboxMapper extends JPATransactionalMapper implements MailboxM
         } 
     }
 
-    private JPAMailbox jpaMailbox(Mailbox mailbox) {
-        if (mailbox.getMailboxId() == null) {
-            return JPAMailbox.from(mailbox);
-        }
-        try {
-            JPAMailbox result = loadJpaMailbox(mailbox.getMailboxId());
-            result.setNamespace(mailbox.getNamespace());
-            result.setUser(mailbox.getUser().asString());
-            result.setName(mailbox.getName());
-            return result;
-        } catch (MailboxNotFoundException e) {
-            return JPAMailbox.from(mailbox);
-        }
+    private JPAMailbox jpaMailbox(Mailbox mailbox) throws MailboxException {
+        JPAMailbox result = loadJpaMailbox(mailbox.getMailboxId());
+        result.setNamespace(mailbox.getNamespace());
+        result.setUser(mailbox.getUser().asString());
+        result.setName(mailbox.getName());
+        return result;
     }
 
     private boolean isPathAlreadyUsedByAnotherMailbox(Mailbox mailbox) throws MailboxException {
         try {
-            Mailbox storedMailbox = findMailboxByPath(mailbox.generateAssociatedPath());
-            return !Objects.equal(storedMailbox.getMailboxId(), mailbox.getMailboxId());
+            findMailboxByPath(mailbox.generateAssociatedPath());
+            return true;
         } catch (MailboxNotFoundException e) {
             return false;
         }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMailboxMapper.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMailboxMapper.java
@@ -53,11 +53,6 @@ public class TransactionalMailboxMapper implements MailboxMapper {
     }
 
     @Override
-    public MailboxId create(Mailbox mailbox) throws MailboxException {
-        return wrapped.execute(() -> wrapped.create(mailbox));
-    }
-
-    @Override
     public Mailbox create(MailboxPath mailboxPath, long uidValidity) throws MailboxException {
         return wrapped.execute(() -> wrapped.create(mailboxPath, uidValidity));
     }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMailboxMapper.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMailboxMapper.java
@@ -58,6 +58,11 @@ public class TransactionalMailboxMapper implements MailboxMapper {
     }
 
     @Override
+    public Mailbox create(MailboxPath mailboxPath, long uidValidity) throws MailboxException {
+        return wrapped.execute(() -> wrapped.create(mailboxPath, uidValidity));
+    }
+
+    @Override
     public MailboxId rename(Mailbox mailbox) throws MailboxException {
         return wrapped.execute(() -> wrapped.rename(mailbox));
     }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMailboxMapper.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/TransactionalMailboxMapper.java
@@ -53,8 +53,13 @@ public class TransactionalMailboxMapper implements MailboxMapper {
     }
 
     @Override
-    public MailboxId save(Mailbox mailbox) throws MailboxException {
-        return wrapped.execute(() -> wrapped.save(mailbox));
+    public MailboxId create(Mailbox mailbox) throws MailboxException {
+        return wrapped.execute(() -> wrapped.create(mailbox));
+    }
+
+    @Override
+    public MailboxId rename(Mailbox mailbox) throws MailboxException {
+        return wrapped.execute(() -> wrapped.rename(mailbox));
     }
 
     @Override

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/MaildirStore.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/MaildirStore.java
@@ -131,8 +131,7 @@ public class MaildirStore implements UidProvider, ModSeqProvider {
         MaildirFolder folder = new MaildirFolder(mailboxFile.getAbsolutePath(), mailboxPath, locker);
         folder.setMessageNameStrictParse(isMessageNameStrictParse());
         try {
-            Mailbox loadedMailbox = new Mailbox(mailboxPath, folder.getUidValidity());
-            loadedMailbox.setMailboxId(folder.readMailboxId());
+            Mailbox loadedMailbox = new Mailbox(mailboxPath, folder.getUidValidity(), folder.readMailboxId());
             loadedMailbox.setACL(folder.getACL());
             return loadedMailbox;
         } catch (IOException e) {

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMailboxMapper.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMailboxMapper.java
@@ -180,7 +180,6 @@ public class MaildirMailboxMapper extends NonTransactionalMapper implements Mail
         try {
             folder.setUidValidity(mailbox.getUidValidity());
             folder.setMailboxId(maildirId);
-            mailbox.setMailboxId(maildirId);
         } catch (IOException ioe) {
             throw new MailboxException("Failed to save Mailbox " + mailbox, ioe);
 

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMailboxMapper.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMailboxMapper.java
@@ -51,7 +51,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.steveash.guavate.Guavate;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 public class MaildirMailboxMapper extends NonTransactionalMapper implements MailboxMapper {
@@ -156,40 +155,6 @@ public class MaildirMailboxMapper extends NonTransactionalMapper implements Mail
             .build()
             .asUserBound());
         return mailboxes.size() > 0;
-    }
-
-    @Override
-    public MailboxId create(Mailbox mailbox) throws MailboxException {
-        Preconditions.checkArgument(mailbox.getMailboxId() == null, "A mailbox we want to create should not have a mailboxId set already");
-
-        MaildirId maildirId = MaildirId.random();
-        MaildirFolder folder = maildirStore.createMaildirFolder(mailbox);
-
-        if (!folder.exists()) {
-            boolean folderExist = folder.getRootFile().exists();
-            if (!folderExist && !folder.getRootFile().mkdirs()) {
-                throw new MailboxException("Failed to save Mailbox " + mailbox);
-            }
-
-            boolean isCreated = folder.getCurFolder().mkdir()
-                && folder.getNewFolder().mkdir()
-                && folder.getTmpFolder().mkdir();
-            if (!isCreated) {
-                throw new MailboxException("Failed to save Mailbox " + mailbox, new IOException("Needed folder structure can not be created"));
-            }
-        }
-
-        try {
-            folder.setUidValidity(mailbox.getUidValidity());
-            folder.setMailboxId(maildirId);
-            mailbox.setMailboxId(maildirId);
-        } catch (IOException ioe) {
-            throw new MailboxException("Failed to save Mailbox " + mailbox, ioe);
-
-        }
-        folder.setACL(mailbox.getACL());
-
-        return maildirId;
     }
 
     @Override

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMailboxMapper.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMailboxMapper.java
@@ -23,7 +23,6 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.FileUtils;
@@ -52,6 +51,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.steveash.guavate.Guavate;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 public class MaildirMailboxMapper extends NonTransactionalMapper implements MailboxMapper {
@@ -71,7 +71,6 @@ public class MaildirMailboxMapper extends NonTransactionalMapper implements Mail
 
     @Override
     public void delete(Mailbox mailbox) throws MailboxException {
-        
         String folderName = maildirStore.getFolderName(mailbox);
         File folder = new File(folderName);
         if (folder.isDirectory()) {
@@ -160,104 +159,105 @@ public class MaildirMailboxMapper extends NonTransactionalMapper implements Mail
     }
 
     @Override
-    public MailboxId save(Mailbox mailbox) throws MailboxException {
-        MaildirId maildirId = Optional.ofNullable(mailbox.getMailboxId())
-            .map(mailboxId -> (MaildirId) mailboxId)
-            .orElseGet(MaildirId::random);
-        try {
-            Mailbox originalMailbox = findMailboxById(mailbox.getMailboxId());
-            MaildirFolder folder = maildirStore.createMaildirFolder(mailbox);
-            // equals with null check
-            if (originalMailbox.getName() == null ? mailbox.getName() != null : !originalMailbox.getName().equals(mailbox.getName())) {
-                if (folder.exists()) {
-                    throw new MailboxExistsException(mailbox.getName());
-                }
-                
-                MaildirFolder originalFolder = maildirStore.createMaildirFolder(originalMailbox);
-                // renaming the INBOX means to move its contents to the new folder 
-                if (originalMailbox.getName().equals(MailboxConstants.INBOX)) {
-                    try {
-                        File inboxFolder = originalFolder.getRootFile();
-                        File newFolder = folder.getRootFile();
-                        FileUtils.forceMkdir(newFolder);
-                        if (!originalFolder.getCurFolder().renameTo(folder.getCurFolder())) {
-                            throw new IOException("Could not rename folder " + originalFolder.getCurFolder() + " to " + folder.getCurFolder());
-                        }
-                        if (!originalFolder.getMailboxIdFile().renameTo(folder.getMailboxIdFile())) {
-                            throw new IOException("Could not rename folder " + originalFolder.getCurFolder() + " to " + folder.getCurFolder());
-                        }
-                        if (!originalFolder.getNewFolder().renameTo(folder.getNewFolder())) {
-                            throw new IOException("Could not rename folder " + originalFolder.getNewFolder() + " to " + folder.getNewFolder());
-                        }
-                        if (!originalFolder.getTmpFolder().renameTo(folder.getTmpFolder())) {
-                            throw new IOException("Could not rename folder " + originalFolder.getTmpFolder() + " to " + folder.getTmpFolder());
-                        }
-                        File oldUidListFile = new File(inboxFolder, MaildirFolder.UIDLIST_FILE);
-                        File newUidListFile = new File(newFolder, MaildirFolder.UIDLIST_FILE);
-                        if (!oldUidListFile.renameTo(newUidListFile)) {
-                            throw new IOException("Could not rename file " + oldUidListFile + " to " + newUidListFile);
-                        }
-                        File oldValidityFile = new File(inboxFolder, MaildirFolder.VALIDITY_FILE);
-                        File newValidityFile = new File(newFolder, MaildirFolder.VALIDITY_FILE);
-                        if (!oldValidityFile.renameTo(newValidityFile)) {
-                            throw new IOException("Could not rename file " + oldValidityFile + " to " + newValidityFile);
-                        }
-                        // recreate the INBOX folders, uidvalidity and uidlist will
-                        // automatically be recreated later
-                        FileUtils.forceMkdir(originalFolder.getCurFolder());
-                        FileUtils.forceMkdir(originalFolder.getNewFolder());
-                        FileUtils.forceMkdir(originalFolder.getTmpFolder());
-                        originalFolder.setMailboxId(MaildirId.random());
-                    } catch (IOException e) {
-                        throw new MailboxException("Failed to save Mailbox " + mailbox, e);
-                    }
-                } else {
-                    if (!originalFolder.getRootFile().renameTo(folder.getRootFile())) {
-                        throw new MailboxException("Failed to save Mailbox " + mailbox,
-                            new IOException("Could not rename folder " + originalFolder));
-                    }
-                }
-            }
-            folder.setACL(mailbox.getACL());
-        } catch (MailboxNotFoundException e) {
-            // it cannot be found and is thus new
-            MaildirFolder folder = maildirStore.createMaildirFolder(mailbox);
-            if (!folder.exists()) {
-                boolean success = folder.getRootFile().exists();
-                if (!success) {
-                    success = folder.getRootFile().mkdirs();
-                }
-                if (!success) {
-                    throw new MailboxException("Failed to save Mailbox " + mailbox);
-                }
-                success = folder.getCurFolder().mkdir();
-                success = success && folder.getNewFolder().mkdir();
-                success = success && folder.getTmpFolder().mkdir();
-                if (!success) {
-                    throw new MailboxException("Failed to save Mailbox " + mailbox, new IOException("Needed folder structure can not be created"));
-                }
+    public MailboxId create(Mailbox mailbox) throws MailboxException {
+        Preconditions.checkArgument(mailbox.getMailboxId() == null, "A mailbox we want to create should not have a mailboxId set already");
 
-            }
-            try {
-                folder.setUidValidity(mailbox.getUidValidity());
-                folder.setMailboxId(maildirId);
-                mailbox.setMailboxId(maildirId);
-            } catch (IOException ioe) {
-                throw new MailboxException("Failed to save Mailbox " + mailbox, ioe);
+        MaildirId maildirId = MaildirId.random();
+        MaildirFolder folder = maildirStore.createMaildirFolder(mailbox);
 
+        if (!folder.exists()) {
+            boolean folderExist = folder.getRootFile().exists();
+            if (!folderExist && !folder.getRootFile().mkdirs()) {
+                throw new MailboxException("Failed to save Mailbox " + mailbox);
             }
-            folder.setACL(mailbox.getACL());
+
+            boolean isCreated = folder.getCurFolder().mkdir()
+                && folder.getNewFolder().mkdir()
+                && folder.getTmpFolder().mkdir();
+            if (!isCreated) {
+                throw new MailboxException("Failed to save Mailbox " + mailbox, new IOException("Needed folder structure can not be created"));
+            }
         }
+
+        try {
+            folder.setUidValidity(mailbox.getUidValidity());
+            folder.setMailboxId(maildirId);
+            mailbox.setMailboxId(maildirId);
+        } catch (IOException ioe) {
+            throw new MailboxException("Failed to save Mailbox " + mailbox, ioe);
+
+        }
+        folder.setACL(mailbox.getACL());
+
+        return maildirId;
+    }
+
+    @Override
+    public MailboxId rename(Mailbox mailbox) throws MailboxException {
+        MaildirId maildirId = (MaildirId) mailbox.getMailboxId();
+
+        Mailbox originalMailbox = findMailboxById(mailbox.getMailboxId());
+        MaildirFolder folder = maildirStore.createMaildirFolder(mailbox);
+        // equals with null check
+        if (originalMailbox.getName() == null ? mailbox.getName() != null : !originalMailbox.getName().equals(mailbox.getName())) {
+            if (folder.exists()) {
+                throw new MailboxExistsException(mailbox.getName());
+            }
+
+            MaildirFolder originalFolder = maildirStore.createMaildirFolder(originalMailbox);
+            // renaming the INBOX means to move its contents to the new folder
+            if (originalMailbox.getName().equals(MailboxConstants.INBOX)) {
+                try {
+                    File inboxFolder = originalFolder.getRootFile();
+                    File newFolder = folder.getRootFile();
+                    FileUtils.forceMkdir(newFolder);
+                    if (!originalFolder.getCurFolder().renameTo(folder.getCurFolder())) {
+                        throw new IOException("Could not rename folder " + originalFolder.getCurFolder() + " to " + folder.getCurFolder());
+                    }
+                    if (!originalFolder.getMailboxIdFile().renameTo(folder.getMailboxIdFile())) {
+                        throw new IOException("Could not rename folder " + originalFolder.getCurFolder() + " to " + folder.getCurFolder());
+                    }
+                    if (!originalFolder.getNewFolder().renameTo(folder.getNewFolder())) {
+                        throw new IOException("Could not rename folder " + originalFolder.getNewFolder() + " to " + folder.getNewFolder());
+                    }
+                    if (!originalFolder.getTmpFolder().renameTo(folder.getTmpFolder())) {
+                        throw new IOException("Could not rename folder " + originalFolder.getTmpFolder() + " to " + folder.getTmpFolder());
+                    }
+                    File oldUidListFile = new File(inboxFolder, MaildirFolder.UIDLIST_FILE);
+                    File newUidListFile = new File(newFolder, MaildirFolder.UIDLIST_FILE);
+                    if (!oldUidListFile.renameTo(newUidListFile)) {
+                        throw new IOException("Could not rename file " + oldUidListFile + " to " + newUidListFile);
+                    }
+                    File oldValidityFile = new File(inboxFolder, MaildirFolder.VALIDITY_FILE);
+                    File newValidityFile = new File(newFolder, MaildirFolder.VALIDITY_FILE);
+                    if (!oldValidityFile.renameTo(newValidityFile)) {
+                        throw new IOException("Could not rename file " + oldValidityFile + " to " + newValidityFile);
+                    }
+                    // recreate the INBOX folders, uidvalidity and uidlist will
+                    // automatically be recreated later
+                    FileUtils.forceMkdir(originalFolder.getCurFolder());
+                    FileUtils.forceMkdir(originalFolder.getNewFolder());
+                    FileUtils.forceMkdir(originalFolder.getTmpFolder());
+                    originalFolder.setMailboxId(MaildirId.random());
+                } catch (IOException e) {
+                    throw new MailboxException("Failed to save Mailbox " + mailbox, e);
+                }
+            } else {
+                if (!originalFolder.getRootFile().renameTo(folder.getRootFile())) {
+                    throw new MailboxException("Failed to save Mailbox " + mailbox,
+                        new IOException("Could not rename folder " + originalFolder));
+                }
+            }
+        }
+        folder.setACL(mailbox.getACL());
+
         return maildirId;
     }
 
     @Override
     public List<Mailbox> list() throws MailboxException {
-        
        File maildirRoot = maildirStore.getMaildirRoot();
        List<Mailbox> mailboxList = new ArrayList<>();
-        
-
 
        if (maildirStore.getMaildirLocation().endsWith("/" + MaildirStore.PATH_DOMAIN + "/" + MaildirStore.PATH_USER)) {
            File[] domains = maildirRoot.listFiles();
@@ -271,7 +271,6 @@ public class MaildirMailboxMapper extends NonTransactionalMapper implements Mail
         File[] users = maildirRoot.listFiles();
         visitUsersForMailboxList(null, users, mailboxList);
         return mailboxList;
-        
     }
 
     @Override
@@ -280,12 +279,9 @@ public class MaildirMailboxMapper extends NonTransactionalMapper implements Mail
     }
 
     private void visitUsersForMailboxList(File domain, File[] users, List<Mailbox> mailboxList) throws MailboxException {
-        
         String userName = null;
         
         for (File user: users) {
-            
-            
             if (domain == null) {
                 userName = user.getName();
             } else {
@@ -294,24 +290,24 @@ public class MaildirMailboxMapper extends NonTransactionalMapper implements Mail
             
             // Special case for INBOX: Let's use the user's folder.
             MailboxPath inboxMailboxPath = MailboxPath.forUser(Username.of(userName), MailboxConstants.INBOX);
-            mailboxList.add(maildirStore.loadMailbox(session, inboxMailboxPath));
+
+            try {
+                mailboxList.add(maildirStore.loadMailbox(session, inboxMailboxPath));
+            } catch (MailboxException e) {
+                //do nothing, we should still be able to list the mailboxes even if INBOX does not exist
+            }
+
             
             // List all INBOX sub folders.
-            
             File[] mailboxes = user.listFiles(pathname -> pathname.getName().startsWith("."));
             
             for (File mailbox: mailboxes) {
-               
-                
                 MailboxPath mailboxPath = new MailboxPath(MailboxConstants.USER_NAMESPACE, 
                         Username.of(userName),
                         mailbox.getName().substring(1));
                 mailboxList.add(maildirStore.loadMailbox(session, mailboxPath));
-
             }
-
         }
-        
     }
 
     @Override

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerTest.java
@@ -24,7 +24,6 @@ import org.apache.james.mailbox.events.EventBus;
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class FullUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreMailboxManager> {
@@ -33,52 +32,6 @@ class FullUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreMailboxM
         " element of the Vault")
     @Nested
     class HookTests {
-    }
-
-    @Nested
-    class BasicFeaturesTests extends MailboxManagerTest<StoreMailboxManager>.BasicFeaturesTests {
-        @Disabled("MAILBOX-389 Mailbox rename fails with Maildir")
-        @Test
-        protected void renameMailboxShouldChangeTheMailboxPathOfAMailbox() {
-        }
-
-        @Disabled("MAILBOX-389 Mailbox rename fails with Maildir")
-        @Test
-        protected void renameMailboxByIdShouldChangeTheMailboxPathOfAMailbox() {
-        }
-
-        @Disabled("MAILBOX-389 Mailbox rename fails with Maildir")
-        @Test
-        protected void user1ShouldBeAbleToDeleteSubmailboxByid() {
-        }
-
-        @Disabled("MAILBOX-389 Mailbox rename fails with Maildir")
-        @Test
-        protected void user1ShouldBeAbleToDeleteInboxById() {
-        }
-
-        @Disabled("JAMES-2993 mailboxId support for Maildir is partial")
-        @Test
-        protected void getMailboxByIdShouldReturnMailboxWhenBelongingToUser() {
-        }
-    }
-
-    @Nested
-    class MailboxNameLimitTests extends MailboxManagerTest<StoreMailboxManager>.MailboxNameLimitTests {
-        @Disabled("MAILBOX-389 Mailbox rename fails with Maildir")
-        @Test
-        protected void renamingMailboxByIdShouldNotThrowWhenNameWithoutEmptyHierarchicalLevel() {
-        }
-
-        @Disabled("MAILBOX-389 Mailbox rename fails with Maildir")
-        @Test
-        protected void renamingMailboxByIdShouldNotFailWhenLimitNameLength() {
-        }
-
-        @Disabled("MAILBOX-389 Mailbox rename fails with Maildir")
-        @Test
-        protected void renamingMailboxByIdShouldNotThrowWhenNameWithASingleToBeNormalizedTrailingDelimiter() {
-        }
     }
 
     @RegisterExtension

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMailboxMapper.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMailboxMapper.java
@@ -105,6 +105,16 @@ public class InMemoryMailboxMapper implements MailboxMapper {
     }
 
     @Override
+    public Mailbox create(MailboxPath mailboxPath, long uidValidity) throws MailboxException {
+        InMemoryId id = InMemoryId.of(mailboxIdGenerator.incrementAndGet());
+        Mailbox mailbox = new Mailbox(mailboxPath, uidValidity, id);
+
+        saveMailbox(mailbox);
+
+        return mailbox;
+    }
+
+    @Override
     public MailboxId rename(Mailbox mailbox) throws MailboxException {
         Preconditions.checkNotNull(mailbox.getMailboxId(), "A mailbox we want to rename should have a defined mailboxId");
 

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMailboxMapper.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMailboxMapper.java
@@ -93,18 +93,6 @@ public class InMemoryMailboxMapper implements MailboxMapper {
     }
 
     @Override
-    public MailboxId create(Mailbox mailbox) throws MailboxException {
-        Preconditions.checkArgument(mailbox.getMailboxId() == null, "A mailbox we want to create should not have a mailboxId set already");
-
-        InMemoryId id = InMemoryId.of(mailboxIdGenerator.incrementAndGet());
-        mailbox.setMailboxId(id);
-
-        saveMailbox(mailbox);
-
-        return mailbox.getMailboxId();
-    }
-
-    @Override
     public Mailbox create(MailboxPath mailboxPath, long uidValidity) throws MailboxException {
         InMemoryId id = InMemoryId.of(mailboxIdGenerator.incrementAndGet());
         Mailbox mailbox = new Mailbox(mailboxPath, uidValidity, id);

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMailboxMapper.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMailboxMapper.java
@@ -41,6 +41,7 @@ import org.apache.james.mailbox.store.mail.MailboxMapper;
 
 import com.github.steveash.guavate.Guavate;
 import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
 
 public class InMemoryMailboxMapper implements MailboxMapper {
     
@@ -92,24 +93,35 @@ public class InMemoryMailboxMapper implements MailboxMapper {
     }
 
     @Override
-    public MailboxId save(Mailbox mailbox) throws MailboxException {
+    public MailboxId create(Mailbox mailbox) throws MailboxException {
+        Preconditions.checkArgument(mailbox.getMailboxId() == null, "A mailbox we want to create should not have a mailboxId set already");
+
+        InMemoryId id = InMemoryId.of(mailboxIdGenerator.incrementAndGet());
+        mailbox.setMailboxId(id);
+
+        saveMailbox(mailbox);
+
+        return mailbox.getMailboxId();
+    }
+
+    @Override
+    public MailboxId rename(Mailbox mailbox) throws MailboxException {
+        Preconditions.checkNotNull(mailbox.getMailboxId(), "A mailbox we want to rename should have a defined mailboxId");
+
         InMemoryId id = (InMemoryId) mailbox.getMailboxId();
-        if (id == null) {
-            id = InMemoryId.of(mailboxIdGenerator.incrementAndGet());
-            mailbox.setMailboxId(id);
-        } else {
-            try {
-                Mailbox mailboxWithPreviousName = findMailboxById(id);
-                mailboxesByPath.remove(mailboxWithPreviousName.generateAssociatedPath());
-            } catch (MailboxNotFoundException e) {
-                // No need to remove the previous mailbox
-            }
-        }
+        Mailbox mailboxWithPreviousName = findMailboxById(id);
+
+        saveMailbox(mailbox);
+        mailboxesByPath.remove(mailboxWithPreviousName.generateAssociatedPath());
+
+        return mailbox.getMailboxId();
+    }
+
+    private void saveMailbox(Mailbox mailbox) throws MailboxException {
         Mailbox previousMailbox = mailboxesByPath.putIfAbsent(mailbox.generateAssociatedPath(), mailbox);
         if (previousMailbox != null) {
             throw new MailboxExistsException(mailbox.getName());
         }
-        return mailbox.getMailboxId();
     }
 
     @Override

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/mail/MemoryMailboxMapperAclTest.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/mail/MemoryMailboxMapperAclTest.java
@@ -21,8 +21,6 @@ package org.apache.james.mailbox.inmemory.mail;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.james.mailbox.inmemory.InMemoryId;
-import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.apache.james.mailbox.store.mail.model.MailboxMapperACLTest;
 
@@ -32,10 +30,5 @@ class MemoryMailboxMapperAclTest extends MailboxMapperACLTest {
     @Override
     protected MailboxMapper createMailboxMapper() {
         return new InMemoryMailboxMapper();
-    }
-
-    @Override
-    protected MailboxId generateId() {
-        return InMemoryId.of(counter.incrementAndGet());
     }
 }

--- a/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
+++ b/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
@@ -85,15 +85,14 @@ class SpamAssassinListenerTest {
         spamAssassin = mock(SpamAssassin.class);
         mapperFactory = mailboxManager.getMapperFactory();
         MailboxMapper mailboxMapper = mapperFactory.createMailboxMapper(MAILBOX_SESSION);
-        inbox = new Mailbox(MailboxPath.forUser(USER, DefaultMailboxes.INBOX), UID_VALIDITY);
-        mailbox1 = new Mailbox(MailboxPath.forUser(USER, "mailbox1"), UID_VALIDITY);
-        mailbox2 = new Mailbox(MailboxPath.forUser(USER, "mailbox2"), UID_VALIDITY);
-        mailboxMapper.create(inbox);
-        mailboxId1 = mailboxMapper.create(mailbox1);
-        mailboxId2 = mailboxMapper.create(mailbox2);
-        spamMailboxId = mailboxMapper.create(new Mailbox(MailboxPath.forUser(USER, "Spam"), UID_VALIDITY));
-        spamCapitalMailboxId = mailboxMapper.create(new Mailbox(MailboxPath.forUser(USER, "SPAM"), UID_VALIDITY));
-        trashMailboxId = mailboxMapper.create(new Mailbox(MailboxPath.forUser(USER, "Trash"), UID_VALIDITY));
+        inbox = mailboxMapper.create(MailboxPath.forUser(USER, DefaultMailboxes.INBOX), UID_VALIDITY);
+        mailbox1 = mailboxMapper.create(MailboxPath.forUser(USER, "mailbox1"), UID_VALIDITY);
+        mailbox2 = mailboxMapper.create(MailboxPath.forUser(USER, "mailbox2"), UID_VALIDITY);
+        mailboxId1 = mailbox1.getMailboxId();
+        mailboxId2 = mailbox2.getMailboxId();
+        spamMailboxId = mailboxMapper.create(MailboxPath.forUser(USER, "Spam"), UID_VALIDITY).getMailboxId();
+        spamCapitalMailboxId = mailboxMapper.create(MailboxPath.forUser(USER, "SPAM"), UID_VALIDITY).getMailboxId();
+        trashMailboxId = mailboxMapper.create(MailboxPath.forUser(USER, "Trash"), UID_VALIDITY).getMailboxId();
 
         listener = new SpamAssassinListener(spamAssassin, systemMailboxesProvider, mailboxManager, mapperFactory, MailboxListener.ExecutionMode.SYNCHRONOUS);
     }

--- a/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
+++ b/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
@@ -88,12 +88,12 @@ class SpamAssassinListenerTest {
         inbox = new Mailbox(MailboxPath.forUser(USER, DefaultMailboxes.INBOX), UID_VALIDITY);
         mailbox1 = new Mailbox(MailboxPath.forUser(USER, "mailbox1"), UID_VALIDITY);
         mailbox2 = new Mailbox(MailboxPath.forUser(USER, "mailbox2"), UID_VALIDITY);
-        mailboxMapper.save(inbox);
-        mailboxId1 = mailboxMapper.save(mailbox1);
-        mailboxId2 = mailboxMapper.save(mailbox2);
-        spamMailboxId = mailboxMapper.save(new Mailbox(MailboxPath.forUser(USER, "Spam"), UID_VALIDITY));
-        spamCapitalMailboxId = mailboxMapper.save(new Mailbox(MailboxPath.forUser(USER, "SPAM"), UID_VALIDITY));
-        trashMailboxId = mailboxMapper.save(new Mailbox(MailboxPath.forUser(USER, "Trash"), UID_VALIDITY));
+        mailboxMapper.create(inbox);
+        mailboxId1 = mailboxMapper.create(mailbox1);
+        mailboxId2 = mailboxMapper.create(mailbox2);
+        spamMailboxId = mailboxMapper.create(new Mailbox(MailboxPath.forUser(USER, "Spam"), UID_VALIDITY));
+        spamCapitalMailboxId = mailboxMapper.create(new Mailbox(MailboxPath.forUser(USER, "SPAM"), UID_VALIDITY));
+        trashMailboxId = mailboxMapper.create(new Mailbox(MailboxPath.forUser(USER, "Trash"), UID_VALIDITY));
 
         listener = new SpamAssassinListener(spamAssassin, systemMailboxesProvider, mailboxManager, mapperFactory, MailboxListener.ExecutionMode.SYNCHRONOUS);
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -530,7 +530,7 @@ public class StoreMailboxManager implements MailboxManager {
         mailbox.setNamespace(newMailboxPath.getNamespace());
         mailbox.setUser(newMailboxPath.getUser());
         mailbox.setName(newMailboxPath.getName());
-        mapper.save(mailbox);
+        mapper.rename(mailbox);
 
         eventBus.dispatch(EventFactory.mailboxRenamed()
             .randomEventId()
@@ -555,7 +555,7 @@ public class StoreMailboxManager implements MailboxManager {
                 String subNewName = newMailboxPath.getName() + subOriginalName.substring(from.getName().length());
                 MailboxPath fromPath = new MailboxPath(from, subOriginalName);
                 sub.setName(subNewName);
-                mapper.save(sub);
+                mapper.rename(sub);
                 eventBus.dispatch(EventFactory.mailboxRenamed()
                     .randomEventId()
                     .mailboxSession(session)

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MailboxMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MailboxMapper.java
@@ -40,11 +40,6 @@ import org.apache.james.mailbox.store.transaction.Mapper;
 public interface MailboxMapper extends Mapper {
 
     /**
-     * Create the given {@link Mailbox} to the underlying storage
-     */
-    MailboxId create(Mailbox mailbox) throws MailboxException;
-
-    /**
      * Create a {@link Mailbox} with the given {@link MailboxPath} and uid to the underlying storage
      */
     Mailbox create(MailboxPath mailboxPath, long uidValidity) throws MailboxException;

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MailboxMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MailboxMapper.java
@@ -45,6 +45,11 @@ public interface MailboxMapper extends Mapper {
     MailboxId create(Mailbox mailbox) throws MailboxException;
 
     /**
+     * Create a {@link Mailbox} with the given {@link MailboxPath} and uid to the underlying storage
+     */
+    Mailbox create(MailboxPath mailboxPath, long uidValidity) throws MailboxException;
+
+    /**
      * Rename the given {@link Mailbox} to the underlying storage
      */
     MailboxId rename(Mailbox mailbox) throws MailboxException;

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MailboxMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MailboxMapper.java
@@ -32,8 +32,6 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.search.MailboxQuery;
 import org.apache.james.mailbox.store.transaction.Mapper;
 
-import com.google.common.base.Preconditions;
-
 /**
  * Mapper for {@link Mailbox} actions. A {@link MailboxMapper} has a lifecycle from the start of a request 
  * to the end of the request.
@@ -44,16 +42,12 @@ public interface MailboxMapper extends Mapper {
     /**
      * Create the given {@link Mailbox} to the underlying storage
      */
-    default MailboxId create(Mailbox mailbox) throws MailboxException {
-        Preconditions.checkArgument(mailbox.getMailboxId() == null, "A mailbox we want to create should not have a mailboxId set already");
-
-        return save(mailbox);
-    }
+    MailboxId create(Mailbox mailbox) throws MailboxException;
 
     /**
-     * Save the give {@link Mailbox} to the underlying storage
+     * Rename the given {@link Mailbox} to the underlying storage
      */
-    MailboxId save(Mailbox mailbox) throws MailboxException;
+    MailboxId rename(Mailbox mailbox) throws MailboxException;
     
     /**
      * Delete the given {@link Mailbox} from the underlying storage

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreRightManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreRightManagerTest.java
@@ -48,14 +48,18 @@ import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxACL.ACLCommand;
 import org.apache.james.mailbox.model.MailboxACL.Right;
 import org.apache.james.mailbox.model.MailboxConstants;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.TestId;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class StoreRightManagerTest {
 
+    static final MailboxId MAILBOX_ID = TestId.of(42);
     static final long UID_VALIDITY = 3421L;
+
     StoreRightManager storeRightManager;
     MailboxSession aliceSession;
     MailboxACLResolver mailboxAclResolver;
@@ -89,7 +93,7 @@ class StoreRightManagerTest {
 
     @Test
     void hasRightShouldReturnTrueWhenTheUserOwnTheMailbox() throws MailboxException {
-        Mailbox mailbox = new Mailbox(MailboxPath.forUser(ALICE, MailboxConstants.INBOX), UID_VALIDITY);
+        Mailbox mailbox = new Mailbox(MailboxPath.forUser(ALICE, MailboxConstants.INBOX), UID_VALIDITY, MAILBOX_ID);
 
         assertThat(storeRightManager.hasRight(mailbox, Right.Write, aliceSession))
             .isTrue();
@@ -97,7 +101,7 @@ class StoreRightManagerTest {
 
     @Test
     void hasRightShouldReturnTrueWhenTheUserDoesNotOwnTheMailboxButHaveTheCorrectRightOnIt() throws MailboxException {
-        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY);
+        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY, MAILBOX_ID);
         mailbox.setACL(new MailboxACL(new MailboxACL.Entry(MailboxFixture.ALICE.asString(), Right.Write)));
 
         assertThat(storeRightManager.hasRight(mailbox, Right.Write, aliceSession))
@@ -106,7 +110,7 @@ class StoreRightManagerTest {
 
     @Test
     void hasRightShouldReturnTrueWhenTheUserDoesNotOwnTheMailboxButHasAtLeastTheCorrectRightOnIt() throws MailboxException {
-        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY);
+        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY, MAILBOX_ID);
         mailbox.setACL(new MailboxACL(new MailboxACL.Entry(MailboxFixture.ALICE.asString(), Right.Write, Right.Lookup)));
 
         assertThat(storeRightManager.hasRight(mailbox, Right.Write, aliceSession))
@@ -115,7 +119,7 @@ class StoreRightManagerTest {
 
     @Test
     void hasRightShouldReturnFalseWhenTheUserDoesNotOwnTheMailboxAndHasNoRightOnIt() throws MailboxException {
-        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY);
+        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY, MAILBOX_ID);
 
         assertThat(storeRightManager.hasRight(mailbox, Right.Write, aliceSession))
             .isFalse();
@@ -124,7 +128,7 @@ class StoreRightManagerTest {
     @Test
     void isReadWriteShouldReturnTrueWhenUserHasInsertRightOnMailbox() throws Exception {
         Flags flags = new Flags();
-        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY);
+        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY, MAILBOX_ID);
         mailbox.setACL(new MailboxACL(new MailboxACL.Entry(MailboxFixture.ALICE.asString(), Right.Insert)));
 
         assertThat(storeRightManager.isReadWrite(aliceSession, mailbox, flags))
@@ -134,7 +138,7 @@ class StoreRightManagerTest {
     @Test
     void isReadWriteShouldReturnTrueWhenUserHasPerformExpungeRightOnMailbox() throws Exception {
         Flags flags = new Flags();
-        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY);
+        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY, MAILBOX_ID);
         mailbox.setACL(new MailboxACL(new MailboxACL.Entry(MailboxFixture.ALICE.asString(), Right.PerformExpunge)));
 
         assertThat(storeRightManager.isReadWrite(aliceSession, mailbox, flags))
@@ -144,7 +148,7 @@ class StoreRightManagerTest {
     @Test
     void isReadWriteShouldReturnTrueWhenUserHasDeleteMessagesRightOnMailboxAndFlagsContainDeletedFlag() throws Exception {
         Flags flags = new Flags(Flags.Flag.DELETED);
-        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY);
+        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY, MAILBOX_ID);
         mailbox.setACL(new MailboxACL(new MailboxACL.Entry(MailboxFixture.ALICE.asString(), Right.DeleteMessages)));
 
         assertThat(storeRightManager.isReadWrite(aliceSession, mailbox, flags))
@@ -154,7 +158,7 @@ class StoreRightManagerTest {
     @Test
     void isReadWriteShouldReturnFalseWhenUserHasDeleteMessagesRightOnMailboxButFlagsDoesNotContainDeletedFlag() throws Exception {
         Flags flags = new Flags();
-        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY);
+        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY, MAILBOX_ID);
         mailbox.setACL(new MailboxACL(new MailboxACL.Entry(MailboxFixture.ALICE.asString(), Right.DeleteMessages)));
 
         assertThat(storeRightManager.isReadWrite(aliceSession, mailbox, flags))
@@ -164,7 +168,7 @@ class StoreRightManagerTest {
     @Test
     void isReadWriteShouldReturnTrueWhenUserHasWriteSeenFlagRightOnMailboxAndFlagsContainSeenFlag() throws Exception {
         Flags flags = new Flags(Flags.Flag.SEEN);
-        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY);
+        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY, MAILBOX_ID);
         mailbox.setACL(new MailboxACL(new MailboxACL.Entry(MailboxFixture.ALICE.asString(), Right.WriteSeenFlag)));
 
         assertThat(storeRightManager.isReadWrite(aliceSession, mailbox, flags))
@@ -174,7 +178,7 @@ class StoreRightManagerTest {
     @Test
     void isReadWriteShouldReturnFalseWhenUserHasWriteSeenFlagRightOnMailboxAndFlagsDoesNotContainSeenFlag() throws Exception {
         Flags flags = new Flags();
-        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY);
+        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY, MAILBOX_ID);
         mailbox.setACL(new MailboxACL(new MailboxACL.Entry(MailboxFixture.ALICE.asString(), Right.WriteSeenFlag)));
 
         assertThat(storeRightManager.isReadWrite(aliceSession, mailbox, flags))
@@ -184,7 +188,7 @@ class StoreRightManagerTest {
     @Test
     void isReadWriteShouldReturnTrueWhenUserHasWriteRightOnMailboxAndFlagsContainAnsweredFlag() throws Exception {
         Flags flags = new Flags(Flags.Flag.ANSWERED);
-        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY);
+        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY, MAILBOX_ID);
         mailbox.setACL(new MailboxACL(new MailboxACL.Entry(MailboxFixture.ALICE.asString(), Right.Write)));
 
         assertThat(storeRightManager.isReadWrite(aliceSession, mailbox, flags))
@@ -193,7 +197,7 @@ class StoreRightManagerTest {
 
     @Test
     void isReadWriteShouldReturnFalseWhenUserDoesNotHaveInsertOrPerformExpungeRightOnMailboxAndNullFlag() throws Exception {
-        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY);
+        Mailbox mailbox = new Mailbox(MailboxPath.forUser(BOB, MailboxConstants.INBOX), UID_VALIDITY, MAILBOX_ID);
         mailbox.setACL(new MailboxACL(new MailboxACL.Entry(MailboxFixture.ALICE.asString(), Right.Administer)));
 
         assertThat(storeRightManager.isReadWrite(aliceSession, mailbox, new Flags()))
@@ -206,7 +210,7 @@ class StoreRightManagerTest {
             .apply(MailboxACL.command().rights(Right.Read, Right.Write).forUser(BOB).asAddition())
             .apply(MailboxACL.command().rights(Right.Read, Right.Write, Right.Administer).forUser(CEDRIC).asAddition());
         MailboxACL actual = StoreRightManager.filteredForSession(
-            new Mailbox(INBOX_ALICE, UID_VALIDITY), acl, aliceSession);
+            new Mailbox(INBOX_ALICE, UID_VALIDITY, MAILBOX_ID), acl, aliceSession);
         assertThat(actual).isEqualTo(acl);
     }
 
@@ -216,7 +220,7 @@ class StoreRightManagerTest {
             .apply(MailboxACL.command().rights(Right.Read, Right.Write).forUser(BOB).asAddition())
             .apply(MailboxACL.command().rights(Right.Read, Right.Write, Right.Administer).forUser(CEDRIC).asAddition());
         MailboxACL actual = StoreRightManager.filteredForSession(
-            new Mailbox(INBOX_ALICE, UID_VALIDITY), acl, MailboxSessionUtil.create(CEDRIC));
+            new Mailbox(INBOX_ALICE, UID_VALIDITY, MAILBOX_ID), acl, MailboxSessionUtil.create(CEDRIC));
         assertThat(actual).isEqualTo(acl);
     }
 
@@ -226,7 +230,7 @@ class StoreRightManagerTest {
             .apply(MailboxACL.command().rights(Right.Read, Right.Write).forUser(BOB).asAddition())
             .apply(MailboxACL.command().rights(Right.Read, Right.Write, Right.Administer).forUser(CEDRIC).asAddition());
         MailboxACL actual = StoreRightManager.filteredForSession(
-            new Mailbox(INBOX_ALICE, UID_VALIDITY), acl, MailboxSessionUtil.create(BOB));
+            new Mailbox(INBOX_ALICE, UID_VALIDITY, MAILBOX_ID), acl, MailboxSessionUtil.create(BOB));
         assertThat(actual.getEntries()).containsKey(MailboxACL.EntryKey.createUserEntryKey(BOB));
     }
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMailboxAssertTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMailboxAssertTest.java
@@ -26,7 +26,9 @@ import java.util.List;
 
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.TestId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -38,16 +40,18 @@ class ListMailboxAssertTest {
     static final Username USER = Username.of("user");
     static final String NAMESPACE = "namespace";
     static final long UID_VALIDITY = 42;
-    static final Mailbox mailbox1 = new Mailbox(new MailboxPath(NAMESPACE, USER, NAME), UID_VALIDITY);
-    static final Mailbox mailbox2 = new Mailbox(new MailboxPath(OTHER_NAMESPACE, USER, NAME), UID_VALIDITY);
+    static final MailboxId MAILBOX_ID_1 = TestId.of(1);
+    static final MailboxId MAILBOX_ID_2 = TestId.of(2);
+    static final Mailbox MAILBOX_1 = new Mailbox(new MailboxPath(NAMESPACE, USER, NAME), UID_VALIDITY, MAILBOX_ID_1);
+    static final Mailbox MAILBOX_2 = new Mailbox(new MailboxPath(OTHER_NAMESPACE, USER, NAME), UID_VALIDITY, MAILBOX_ID_2);
 
     ListMailboxAssert listMaiboxAssert;
-    List<Mailbox> actualMailbox;
+    List<Mailbox> actualMailboxes;
 
     @BeforeEach
     void setUp() {
-        actualMailbox = ImmutableList.of(mailbox1, mailbox2);
-        listMaiboxAssert = ListMailboxAssert.assertMailboxes(actualMailbox);
+        actualMailboxes = ImmutableList.of(MAILBOX_1, MAILBOX_2);
+        listMaiboxAssert = ListMailboxAssert.assertMailboxes(actualMailboxes);
     }
 
     @Test
@@ -57,7 +61,7 @@ class ListMailboxAssertTest {
 
     @Test
     void assertListMailboxShouldWork() {
-        assertMailboxes(actualMailbox).containOnly(new Mailbox(new MailboxPath(NAMESPACE, USER, NAME), UID_VALIDITY),
-            new Mailbox(new MailboxPath(OTHER_NAMESPACE, USER, NAME), UID_VALIDITY));
+        assertMailboxes(actualMailboxes).containOnly(new Mailbox(new MailboxPath(NAMESPACE, USER, NAME), UID_VALIDITY, MAILBOX_ID_1),
+            new Mailbox(new MailboxPath(OTHER_NAMESPACE, USER, NAME), UID_VALIDITY, MAILBOX_ID_2));
     }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMessageAssertTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMessageAssertTest.java
@@ -97,10 +97,7 @@ class ListMessageAssertTest {
     }
 
     private Mailbox createMailbox(MailboxPath mailboxPath) {
-        Mailbox mailbox = new Mailbox(mailboxPath, UID_VALIDITY);
-        mailbox.setMailboxId(MAILBOX_ID);
-
-        return mailbox;
+        return new Mailbox(mailboxPath, UID_VALIDITY, MAILBOX_ID);
     }
 
     private MailboxMessage createMessage(Mailbox mailbox, MessageId messageId, String content, int bodyStart, PropertyBuilder propertyBuilder) {

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMapperACLTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMapperACLTest.java
@@ -54,8 +54,7 @@ public abstract class MailboxMapperACLTest {
     void setUp() throws Exception {
         mailboxMapper = createMailboxMapper();
         MailboxPath benwaInboxPath = MailboxPath.forUser(Username.of("benwa"), "INBOX");
-        benwaInboxMailbox = createMailbox(benwaInboxPath);
-        mailboxMapper.create(benwaInboxMailbox);
+        benwaInboxMailbox = mailboxMapper.create(benwaInboxPath, UID_VALIDITY);
     }
 
     @Test
@@ -229,11 +228,6 @@ public abstract class MailboxMapperACLTest {
                 .getEntries())
             .hasSize(1)
             .containsEntry(key, rights);
-    }
-
-    private Mailbox createMailbox(MailboxPath mailboxPath) {
-        Mailbox mailbox = new Mailbox(mailboxPath, UID_VALIDITY);
-        return mailbox;
     }
 
     @Test

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMapperACLTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMapperACLTest.java
@@ -29,7 +29,6 @@ import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxACL.EntryKey;
 import org.apache.james.mailbox.model.MailboxACL.Rfc4314Rights;
 import org.apache.james.mailbox.model.MailboxACL.Right;
-import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.store.mail.MailboxMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,14 +50,12 @@ public abstract class MailboxMapperACLTest {
 
     protected abstract MailboxMapper createMailboxMapper();
 
-    protected abstract MailboxId generateId();
-
     @BeforeEach
     void setUp() throws Exception {
         mailboxMapper = createMailboxMapper();
         MailboxPath benwaInboxPath = MailboxPath.forUser(Username.of("benwa"), "INBOX");
         benwaInboxMailbox = createMailbox(benwaInboxPath);
-        mailboxMapper.save(benwaInboxMailbox);
+        mailboxMapper.create(benwaInboxMailbox);
     }
 
     @Test
@@ -236,7 +233,6 @@ public abstract class MailboxMapperACLTest {
 
     private Mailbox createMailbox(MailboxPath mailboxPath) {
         Mailbox mailbox = new Mailbox(mailboxPath, UID_VALIDITY);
-        mailbox.setMailboxId(generateId());
         return mailbox;
     }
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMapperTest.java
@@ -89,7 +89,6 @@ public abstract class MailboxMapperTest {
 
     @Test
     void createShouldPersistTheMailbox() throws MailboxException {
-        benwaInboxMailbox.setMailboxId(null);
         mailboxMapper.create(benwaInboxMailbox);
 
         assertThat(mailboxMapper.findMailboxByPath(benwaInboxPath)).isEqualTo(benwaInboxMailbox);
@@ -98,7 +97,6 @@ public abstract class MailboxMapperTest {
 
     @Test
     void createShouldThrowWhenMailboxAlreadyExists() throws MailboxException {
-        benwaInboxMailbox.setMailboxId(null);
         mailboxMapper.create(benwaInboxMailbox);
 
         Mailbox mailbox = new Mailbox(benwaInboxMailbox);
@@ -110,7 +108,6 @@ public abstract class MailboxMapperTest {
 
     @Test
     void createShouldSetAMailboxIdForMailbox() throws MailboxException {
-        benwaInboxMailbox.setMailboxId(null);
         MailboxId mailboxId = mailboxMapper.create(benwaInboxMailbox);
 
         assertThat(mailboxId).isNotNull();
@@ -118,30 +115,58 @@ public abstract class MailboxMapperTest {
 
     @Test
     void createShouldThrowWhenMailboxIdNotNull() {
+        benwaInboxMailbox.setMailboxId(generateId());
+
         assertThatThrownBy(() -> mailboxMapper.create(benwaInboxMailbox))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    void saveShouldPersistTheMailbox() throws MailboxException {
-        mailboxMapper.save(benwaInboxMailbox);
-        assertThat(mailboxMapper.findMailboxByPath(benwaInboxPath)).isEqualTo(benwaInboxMailbox);
+    void renameShouldThrowWhenMailboxIdIsNull() {
+        assertThatThrownBy(() -> mailboxMapper.rename(benwaInboxMailbox))
+            .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    void saveShouldThrowWhenMailboxAlreadyExist() throws MailboxException {
-        mailboxMapper.save(benwaInboxMailbox);
+    void renameShouldRenameTheMailbox() throws MailboxException {
+        MailboxId mailboxId = mailboxMapper.create(benwaInboxMailbox);
 
-        Mailbox mailbox = new Mailbox(benwaInboxMailbox);
-        mailbox.setMailboxId(null);
+        benwaWorkMailbox.setMailboxId(mailboxId);
+        mailboxMapper.rename(benwaWorkMailbox);
 
-        assertThatThrownBy(() -> mailboxMapper.save(mailbox))
+        assertThat(mailboxMapper.findMailboxById(mailboxId)).isEqualTo(benwaWorkMailbox);
+    }
+
+    @Test
+    void renameShouldThrowWhenMailboxAlreadyExist() throws MailboxException {
+        mailboxMapper.create(benwaInboxMailbox);
+
+        assertThatThrownBy(() -> mailboxMapper.rename(benwaInboxMailbox))
             .isInstanceOf(MailboxExistsException.class);
     }
 
     @Test
+    void renameShouldThrowWhenMailboxDoesNotExist() {
+        benwaInboxMailbox.setMailboxId(generateId());
+
+        assertThatThrownBy(() -> mailboxMapper.rename(benwaInboxMailbox))
+            .isInstanceOf(MailboxNotFoundException.class);
+    }
+
+    @Test
+    void renameShouldRemoveOldMailboxPath() throws MailboxException {
+        MailboxId mailboxId = mailboxMapper.create(benwaInboxMailbox);
+
+        benwaWorkMailbox.setMailboxId(mailboxId);
+        mailboxMapper.rename(benwaWorkMailbox);
+
+        assertThatThrownBy(() -> mailboxMapper.findMailboxByPath(benwaInboxPath))
+            .isInstanceOf(MailboxNotFoundException.class);
+    }
+
+    @Test
     void listShouldRetrieveAllMailbox() throws MailboxException {
-        saveAll();
+        createAll();
         List<Mailbox> mailboxes = mailboxMapper.list();
 
         assertMailboxes(mailboxes)
@@ -151,25 +176,25 @@ public abstract class MailboxMapperTest {
     
     @Test
     void hasChildrenShouldReturnFalseWhenNoChildrenExists() throws MailboxException {
-        saveAll();
+        createAll();
         assertThat(mailboxMapper.hasChildren(benwaWorkTodoMailbox, DELIMITER)).isFalse();
     }
 
     @Test
     void hasChildrenShouldReturnTrueWhenChildrenExists() throws MailboxException {
-        saveAll();
+        createAll();
         assertThat(mailboxMapper.hasChildren(benwaInboxMailbox, DELIMITER)).isTrue();
     }
 
     @Test
     void hasChildrenShouldNotBeAcrossUsersAndNamespace() throws MailboxException {
-        saveAll();
+        createAll();
         assertThat(mailboxMapper.hasChildren(bobInboxMailbox, '.')).isFalse();
     }
 
     @Test
     void findMailboxWithPathLikeShouldBeLimitedToUserAndNamespace() throws MailboxException {
-        saveAll();
+        createAll();
         MailboxQuery.UserBound mailboxQuery = MailboxQuery.builder()
             .userAndNamespaceFrom(bobInboxPath)
             .expression(new PrefixedWildcard("IN"))
@@ -183,7 +208,7 @@ public abstract class MailboxMapperTest {
     
     @Test
     void deleteShouldEraseTheGivenMailbox() throws MailboxException {
-        saveAll();
+        createAll();
         mailboxMapper.delete(benwaInboxMailbox);
 
         assertThatThrownBy(() -> mailboxMapper.findMailboxByPath(benwaInboxPath))
@@ -192,7 +217,7 @@ public abstract class MailboxMapperTest {
 
     @Test
     void findMailboxWithPathLikeWithChildRegexShouldRetrieveChildren() throws MailboxException {
-        saveAll();
+        createAll();
         MailboxQuery.UserBound mailboxQuery = MailboxQuery.builder()
             .userAndNamespaceFrom(benwaWorkPath)
             .expression(new PrefixedWildcard(benwaWorkPath.getName()))
@@ -206,7 +231,7 @@ public abstract class MailboxMapperTest {
 
     @Test
     void findMailboxWithPathLikeWithRegexShouldRetrieveCorrespondingMailbox() throws MailboxException {
-        saveAll();
+        createAll();
         MailboxQuery.UserBound mailboxQuery = MailboxQuery.builder()
             .userAndNamespaceFrom(benwaWorkPath)
             .expression(new ExactName("INBOX"))
@@ -220,7 +245,7 @@ public abstract class MailboxMapperTest {
 
     @Test
     void findMailboxWithPathLikeShouldEscapeMailboxName() throws MailboxException {
-        saveAll();
+        createAll();
         MailboxQuery.UserBound mailboxQuery = MailboxQuery.builder()
             .userAndNamespaceFrom(benwaInboxPath)
             .expression(new ExactName("INB?X"))
@@ -232,14 +257,14 @@ public abstract class MailboxMapperTest {
 
     @Test
     void findMailboxByIdShouldReturnExistingMailbox() throws MailboxException {
-        saveAll();
+        createAll();
         Mailbox actual = mailboxMapper.findMailboxById(benwaInboxMailbox.getMailboxId());
         assertThat(actual).isEqualTo(benwaInboxMailbox);
     }
     
     @Test
     void findMailboxByIdShouldFailWhenAbsent() throws MailboxException {
-        saveAll();
+        createAll();
         MailboxId removed = benwaInboxMailbox.getMailboxId();
         mailboxMapper.delete(benwaInboxMailbox);
         assertThatThrownBy(() -> mailboxMapper.findMailboxById(removed))
@@ -266,21 +291,19 @@ public abstract class MailboxMapperTest {
         bobDifferentNamespaceMailbox = createMailbox(bobDifferentNamespacePath);
     }
 
-    private void saveAll() throws MailboxException {
-        mailboxMapper.save(benwaInboxMailbox);
-        mailboxMapper.save(benwaWorkMailbox);
-        mailboxMapper.save(benwaWorkTodoMailbox);
-        mailboxMapper.save(benwaPersoMailbox);
-        mailboxMapper.save(benwaWorkDoneMailbox);
-        mailboxMapper.save(bobyMailbox);
-        mailboxMapper.save(bobDifferentNamespaceMailbox);
-        mailboxMapper.save(bobInboxMailbox);
+    private void createAll() throws MailboxException {
+        mailboxMapper.create(benwaInboxMailbox);
+        mailboxMapper.create(benwaWorkMailbox);
+        mailboxMapper.create(benwaWorkTodoMailbox);
+        mailboxMapper.create(benwaPersoMailbox);
+        mailboxMapper.create(benwaWorkDoneMailbox);
+        mailboxMapper.create(bobyMailbox);
+        mailboxMapper.create(bobDifferentNamespaceMailbox);
+        mailboxMapper.create(bobInboxMailbox);
     }
 
     private Mailbox createMailbox(MailboxPath mailboxPath) {
-        Mailbox mailbox = new Mailbox(mailboxPath, UID_VALIDITY);
-        mailbox.setMailboxId(generateId());
-        return mailbox;
+        return new Mailbox(mailboxPath, UID_VALIDITY);
     }
 
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
@@ -162,8 +162,7 @@ public abstract class MessageIdMapperTest {
 
     @Test
     void saveShouldThrowWhenMailboxDoesntExist() throws Exception {
-        Mailbox notPersistedMailbox = new Mailbox(MailboxPath.forUser(BENWA, "mybox"), UID_VALIDITY);
-        notPersistedMailbox.setMailboxId(mapperProvider.generateId());
+        Mailbox notPersistedMailbox = new Mailbox(MailboxPath.forUser(BENWA, "mybox"), UID_VALIDITY, mapperProvider.generateId());
         SimpleMailboxMessage message = createMessage(notPersistedMailbox, "Subject: Test \n\nBody\n.\n", BODY_START, new PropertyBuilder());
         message.setUid(mapperProvider.generateMessageUid());
         message.setModSeq(mapperProvider.generateModSeq(notPersistedMailbox));
@@ -207,8 +206,7 @@ public abstract class MessageIdMapperTest {
         message1.setModSeq(mapperProvider.generateModSeq(benwaInboxMailbox));
         sut.save(message1);
 
-        Mailbox notPersistedMailbox = new Mailbox(MailboxPath.forUser(BENWA, "mybox"), UID_VALIDITY);
-        notPersistedMailbox.setMailboxId(mapperProvider.generateId());
+        Mailbox notPersistedMailbox = new Mailbox(MailboxPath.forUser(BENWA, "mybox"), UID_VALIDITY, mapperProvider.generateId());
 
         SimpleMailboxMessage message1InOtherMailbox = SimpleMailboxMessage.copy(notPersistedMailbox.getMailboxId(), message1);
         message1InOtherMailbox.setUid(mapperProvider.generateMessageUid());

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
@@ -958,9 +958,7 @@ public abstract class MessageIdMapperTest {
     }
 
     private Mailbox createMailbox(MailboxPath mailboxPath) throws MailboxException {
-        Mailbox mailbox = new Mailbox(mailboxPath, UID_VALIDITY);
-        mailboxMapper.create(mailbox);
-        return mailbox;
+        return mailboxMapper.create(mailboxPath, UID_VALIDITY);
     }
     
     protected void saveMessages() throws MailboxException {

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
@@ -959,8 +959,7 @@ public abstract class MessageIdMapperTest {
 
     private Mailbox createMailbox(MailboxPath mailboxPath) throws MailboxException {
         Mailbox mailbox = new Mailbox(mailboxPath, UID_VALIDITY);
-        mailbox.setMailboxId(mapperProvider.generateId());
-        mailboxMapper.save(mailbox);
+        mailboxMapper.create(mailbox);
         return mailbox;
     }
     

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -1187,11 +1187,7 @@ public abstract class MessageMapperTest {
     }
 
     private Mailbox createMailbox(MailboxPath mailboxPath) throws MailboxException {
-        Mailbox mailbox = new Mailbox(mailboxPath, UID_VALIDITY);
-        
-        mailboxMapper.create(mailbox);
-
-        return mailbox;
+        return mailboxMapper.create(mailboxPath, UID_VALIDITY);
     }
     
     private void saveMessages() throws MailboxException {

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -1188,9 +1188,8 @@ public abstract class MessageMapperTest {
 
     private Mailbox createMailbox(MailboxPath mailboxPath) throws MailboxException {
         Mailbox mailbox = new Mailbox(mailboxPath, UID_VALIDITY);
-        mailbox.setMailboxId(mapperProvider.generateId());
         
-        mailboxMapper.save(mailbox);
+        mailboxMapper.create(mailbox);
 
         return mailbox;
     }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMoveTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMoveTest.java
@@ -134,10 +134,7 @@ public abstract class MessageMoveTest {
     }
 
     private Mailbox createMailbox(MailboxPath mailboxPath) throws MailboxException {
-        Mailbox mailbox = new Mailbox(mailboxPath, UID_VALIDITY);
-        mailboxMapper.create(mailbox);
-        
-        return mailbox;
+        return mailboxMapper.create(mailboxPath, UID_VALIDITY);
     }
 
     private MailboxMessage retrieveMessageFromStorage(Mailbox mailbox, MailboxMessage message) throws MailboxException {

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMoveTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMoveTest.java
@@ -29,7 +29,6 @@ import javax.mail.util.SharedByteArrayInputStream;
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Mailbox;
-import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.MessageMetaData;
@@ -136,9 +135,7 @@ public abstract class MessageMoveTest {
 
     private Mailbox createMailbox(MailboxPath mailboxPath) throws MailboxException {
         Mailbox mailbox = new Mailbox(mailboxPath, UID_VALIDITY);
-        MailboxId id = mapperProvider.generateId();
-        mailbox.setMailboxId(id);
-        mailboxMapper.save(mailbox);
+        mailboxMapper.create(mailbox);
         
         return mailbox;
     }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageWithAttachmentMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageWithAttachmentMapperTest.java
@@ -36,7 +36,6 @@ import org.apache.james.mailbox.model.Attachment;
 import org.apache.james.mailbox.model.AttachmentId;
 import org.apache.james.mailbox.model.Cid;
 import org.apache.james.mailbox.model.Mailbox;
-import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.MessageAttachment;
 import org.apache.james.mailbox.model.MessageId;
@@ -185,10 +184,7 @@ public abstract class MessageWithAttachmentMapperTest {
     }
 
     private Mailbox createMailbox(MailboxPath mailboxPath) {
-        Mailbox mailbox = new Mailbox(mailboxPath, UID_VALIDITY);
-        MailboxId id = mapperProvider.generateId();
-        mailbox.setMailboxId(id);
-        return mailbox;
+        return new Mailbox(mailboxPath, UID_VALIDITY, mapperProvider.generateId());
     }
     
     private void saveMessages() throws MailboxException {

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/quota/DefaultUserQuotaRootResolverTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/quota/DefaultUserQuotaRootResolverTest.java
@@ -46,12 +46,12 @@ import com.google.common.collect.Lists;
 class DefaultUserQuotaRootResolverTest {
 
     static final Username BENWA = Username.of("benwa");
-    static final MailboxPath MAILBOX_PATH = MailboxPath.inbox(BENWA);
-    static final Mailbox MAILBOX = new Mailbox(MAILBOX_PATH, 10);
-    static final MailboxPath MAILBOX_PATH_2 = MailboxPath.forUser(BENWA, "test");
-    static final Mailbox MAILBOX_2 = new Mailbox(MAILBOX_PATH_2, 10);
-    static final QuotaRoot QUOTA_ROOT = QuotaRoot.quotaRoot("#private&benwa", Optional.empty());
     static final MailboxId MAILBOX_ID = TestId.of(42);
+    static final MailboxPath MAILBOX_PATH = MailboxPath.inbox(BENWA);
+    static final Mailbox MAILBOX = new Mailbox(MAILBOX_PATH, 10, MAILBOX_ID);
+    static final MailboxPath MAILBOX_PATH_2 = MailboxPath.forUser(BENWA, "test");
+    static final Mailbox MAILBOX_2 = new Mailbox(MAILBOX_PATH_2, 10, MAILBOX_ID);
+    static final QuotaRoot QUOTA_ROOT = QuotaRoot.quotaRoot("#private&benwa", Optional.empty());
     static final MailboxSession MAILBOX_SESSION = null;
 
     DefaultUserQuotaRootResolver testee;

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/quota/QuotaCheckerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/quota/QuotaCheckerTest.java
@@ -33,9 +33,11 @@ import org.apache.james.core.quota.QuotaSizeUsage;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.OverQuotaException;
 import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.Quota;
 import org.apache.james.mailbox.model.QuotaRoot;
+import org.apache.james.mailbox.model.TestId;
 import org.apache.james.mailbox.quota.QuotaManager;
 import org.apache.james.mailbox.quota.QuotaRootResolver;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,8 +46,9 @@ import org.junit.jupiter.api.Test;
 class QuotaCheckerTest {
 
     static final QuotaRoot QUOTA_ROOT = QuotaRoot.quotaRoot("benwa", Optional.empty());
+    static final MailboxId MAILBOX_ID = TestId.of(42);
     static final MailboxPath MAILBOX_PATH = MailboxPath.inbox(Username.of("benwa"));
-    static final Mailbox MAILBOX = new Mailbox(MAILBOX_PATH, 10);
+    static final Mailbox MAILBOX = new Mailbox(MAILBOX_PATH, 10, MAILBOX_ID);
 
     QuotaRootResolver mockedQuotaRootResolver;
     QuotaManager mockedQuotaManager;

--- a/server/container/mailbox-jmx/src/test/java/org/apache/james/adapter/mailbox/MailboxManagementTest.java
+++ b/server/container/mailbox-jmx/src/test/java/org/apache/james/adapter/mailbox/MailboxManagementTest.java
@@ -65,21 +65,21 @@ public class MailboxManagementTest {
 
     @Test
     void deleteMailboxesShouldDeleteMailboxes() throws Exception {
-        mapperFactory.createMailboxMapper(session).save(new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY));
+        mapperFactory.createMailboxMapper(session).create(new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY));
         mailboxManagerManagement.deleteMailboxes(USER.asString());
         assertThat(mapperFactory.createMailboxMapper(session).list()).isEmpty();
     }
 
     @Test
     void deleteMailboxesShouldDeleteInbox() throws Exception {
-        mapperFactory.createMailboxMapper(session).save(new Mailbox(MailboxPath.inbox(USER), UID_VALIDITY));
+        mapperFactory.createMailboxMapper(session).create(new Mailbox(MailboxPath.inbox(USER), UID_VALIDITY));
         mailboxManagerManagement.deleteMailboxes(USER.asString());
         assertThat(mapperFactory.createMailboxMapper(session).list()).isEmpty();
     }
 
     @Test
     void deleteMailboxesShouldDeleteMailboxesChildren() throws Exception {
-        mapperFactory.createMailboxMapper(session).save(new Mailbox(MailboxPath.forUser(USER, "INBOX.test"), UID_VALIDITY));
+        mapperFactory.createMailboxMapper(session).create(new Mailbox(MailboxPath.forUser(USER, "INBOX.test"), UID_VALIDITY));
         mailboxManagerManagement.deleteMailboxes(USER.asString());
         assertThat(mapperFactory.createMailboxMapper(session).list()).isEmpty();
     }
@@ -87,7 +87,7 @@ public class MailboxManagementTest {
     @Test
     void deleteMailboxesShouldNotDeleteMailboxesBelongingToNotPrivateNamespace() throws Exception {
         Mailbox mailbox = new Mailbox(new MailboxPath("#top", USER, "name"), UID_VALIDITY);
-        mapperFactory.createMailboxMapper(session).save(mailbox);
+        mapperFactory.createMailboxMapper(session).create(mailbox);
         mailboxManagerManagement.deleteMailboxes(USER.asString());
         assertThat(mapperFactory.createMailboxMapper(session).list()).containsExactly(mailbox);
     }
@@ -95,14 +95,14 @@ public class MailboxManagementTest {
     @Test
     void deleteMailboxesShouldNotDeleteMailboxesBelongingToOtherUsers() throws Exception {
         Mailbox mailbox = new Mailbox(MailboxPath.forUser(Username.of("userbis"), "name"), UID_VALIDITY);
-        mapperFactory.createMailboxMapper(session).save(mailbox);
+        mapperFactory.createMailboxMapper(session).create(mailbox);
         mailboxManagerManagement.deleteMailboxes(USER.asString());
         assertThat(mapperFactory.createMailboxMapper(session).list()).containsExactly(mailbox);
     }
 
     @Test
     void deleteMailboxesShouldDeleteMailboxesWithEmptyNames() throws Exception {
-        mapperFactory.createMailboxMapper(session).save(new Mailbox(MailboxPath.forUser(USER, ""), UID_VALIDITY));
+        mapperFactory.createMailboxMapper(session).create(new Mailbox(MailboxPath.forUser(USER, ""), UID_VALIDITY));
         mailboxManagerManagement.deleteMailboxes(USER.asString());
         assertThat(mapperFactory.createMailboxMapper(session).list()).isEmpty();
     }
@@ -121,9 +121,9 @@ public class MailboxManagementTest {
 
     @Test
     void deleteMailboxesShouldDeleteMultipleMailboxes() throws Exception {
-        mapperFactory.createMailboxMapper(session).save(new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY));
-        mapperFactory.createMailboxMapper(session).save(new Mailbox(MailboxPath.forUser(USER, "INBOX"), UID_VALIDITY));
-        mapperFactory.createMailboxMapper(session).save(new Mailbox(MailboxPath.forUser(USER, "INBOX.test"), UID_VALIDITY));
+        mapperFactory.createMailboxMapper(session).create(new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY));
+        mapperFactory.createMailboxMapper(session).create(new Mailbox(MailboxPath.forUser(USER, "INBOX"), UID_VALIDITY));
+        mapperFactory.createMailboxMapper(session).create(new Mailbox(MailboxPath.forUser(USER, "INBOX.test"), UID_VALIDITY));
         mailboxManagerManagement.deleteMailboxes(USER.asString());
         assertThat(mapperFactory.createMailboxMapper(session).list()).isEmpty();
     }
@@ -139,7 +139,7 @@ public class MailboxManagementTest {
     void createMailboxShouldThrowIfMailboxAlreadyExists() throws Exception {
         MailboxPath path = MailboxPath.forUser(USER, "name");
         Mailbox mailbox = new Mailbox(path, UID_VALIDITY);
-        mapperFactory.createMailboxMapper(session).save(mailbox);
+        mapperFactory.createMailboxMapper(session).create(mailbox);
 
         assertThatThrownBy(() -> mailboxManagerManagement.createMailbox(MailboxConstants.USER_NAMESPACE, USER.asString(), "name"))
             .isInstanceOf(RuntimeException.class)
@@ -150,7 +150,7 @@ public class MailboxManagementTest {
     void createMailboxShouldNotCreateAdditionalMailboxesIfMailboxAlreadyExists() throws Exception {
         MailboxPath path = MailboxPath.forUser(USER, "name");
         Mailbox mailbox = new Mailbox(path, UID_VALIDITY);
-        mapperFactory.createMailboxMapper(session).save(mailbox);
+        mapperFactory.createMailboxMapper(session).create(mailbox);
 
         assertThat(mapperFactory.createMailboxMapper(session).list()).containsExactly(mailbox);
     }
@@ -199,12 +199,12 @@ public class MailboxManagementTest {
         Mailbox mailbox4 = new Mailbox(MailboxPath.forUser(USER, "name4"), UID_VALIDITY);
         Mailbox mailbox5 = new Mailbox(MailboxPath.forUser(USER, "INBOX"), UID_VALIDITY);
         Mailbox mailbox6 = new Mailbox(MailboxPath.forUser(USER, "INBOX.toto"), UID_VALIDITY);
-        mapperFactory.createMailboxMapper(session).save(mailbox1);
-        mapperFactory.createMailboxMapper(session).save(mailbox2);
-        mapperFactory.createMailboxMapper(session).save(mailbox3);
-        mapperFactory.createMailboxMapper(session).save(mailbox4);
-        mapperFactory.createMailboxMapper(session).save(mailbox5);
-        mapperFactory.createMailboxMapper(session).save(mailbox6);
+        mapperFactory.createMailboxMapper(session).create(mailbox1);
+        mapperFactory.createMailboxMapper(session).create(mailbox2);
+        mapperFactory.createMailboxMapper(session).create(mailbox3);
+        mapperFactory.createMailboxMapper(session).create(mailbox4);
+        mapperFactory.createMailboxMapper(session).create(mailbox5);
+        mapperFactory.createMailboxMapper(session).create(mailbox6);
         assertThat(mailboxManagerManagement.listMailboxes(USER.asString())).containsOnly("name2", "name4", "INBOX", "INBOX.toto");
     }
 
@@ -222,7 +222,7 @@ public class MailboxManagementTest {
 
     @Test
     void deleteMailboxShouldDeleteGivenMailbox() throws Exception {
-        mapperFactory.createMailboxMapper(session).save(new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY));
+        mapperFactory.createMailboxMapper(session).create(new Mailbox(MailboxPath.forUser(USER, "name"), UID_VALIDITY));
         mailboxManagerManagement.deleteMailbox(MailboxConstants.USER_NAMESPACE, USER.asString(), "name");
         assertThat(mapperFactory.createMailboxMapper(session).list()).isEmpty();
     }
@@ -230,7 +230,7 @@ public class MailboxManagementTest {
     @Test
     void deleteMailboxShouldNotDeleteGivenMailboxIfWrongNamespace() throws Exception {
         Mailbox mailbox = new Mailbox(new MailboxPath("#top", USER, "name"), UID_VALIDITY);
-        mapperFactory.createMailboxMapper(session).save(mailbox);
+        mapperFactory.createMailboxMapper(session).create(mailbox);
         mailboxManagerManagement.deleteMailbox(MailboxConstants.USER_NAMESPACE, USER.asString(), "name");
         assertThat(mapperFactory.createMailboxMapper(session).list()).containsOnly(mailbox);
     }
@@ -238,7 +238,7 @@ public class MailboxManagementTest {
     @Test
     void deleteMailboxShouldNotDeleteGivenMailboxIfWrongUser() throws Exception {
         Mailbox mailbox = new Mailbox(MailboxPath.forUser(Username.of("userbis"), "name"), UID_VALIDITY);
-        mapperFactory.createMailboxMapper(session).save(mailbox);
+        mapperFactory.createMailboxMapper(session).create(mailbox);
         mailboxManagerManagement.deleteMailbox(MailboxConstants.USER_NAMESPACE, USER.asString(), "name");
         assertThat(mapperFactory.createMailboxMapper(session).list()).containsOnly(mailbox);
     }
@@ -246,7 +246,7 @@ public class MailboxManagementTest {
     @Test
     void deleteMailboxShouldNotDeleteGivenMailboxIfWrongName() throws Exception {
         Mailbox mailbox = new Mailbox(MailboxPath.forUser(USER, "wrong_name"), UID_VALIDITY);
-        mapperFactory.createMailboxMapper(session).save(mailbox);
+        mapperFactory.createMailboxMapper(session).create(mailbox);
         mailboxManagerManagement.deleteMailbox(MailboxConstants.USER_NAMESPACE, USER.asString(), "name");
         assertThat(mapperFactory.createMailboxMapper(session).list()).containsOnly(mailbox);
     }
@@ -255,7 +255,7 @@ public class MailboxManagementTest {
     void importEmlFileToMailboxShouldImportEmlFileToGivenMailbox() throws Exception {
         Mailbox mailbox = new Mailbox(MailboxPath.forUser(USER, "name"),
                 UID_VALIDITY);
-        mapperFactory.createMailboxMapper(session).save(mailbox);
+        mapperFactory.createMailboxMapper(session).create(mailbox);
         String emlpath = ClassLoader.getSystemResource("eml/frnog.eml").getFile();
         mailboxManagerManagement.importEmlFileToMailbox(MailboxConstants.USER_NAMESPACE, USER.asString(), "name", emlpath);
 
@@ -272,7 +272,7 @@ public class MailboxManagementTest {
     void importEmlFileToMailboxShouldNotImportEmlFileWithWrongPathToGivenMailbox() throws Exception {
         Mailbox mailbox = new Mailbox(MailboxPath.forUser(USER, "name"),
                 UID_VALIDITY);
-        mapperFactory.createMailboxMapper(session).save(mailbox);
+        mapperFactory.createMailboxMapper(session).create(mailbox);
         String emlpath = ClassLoader.getSystemResource("eml/frnog.eml").getFile();
         mailboxManagerManagement.importEmlFileToMailbox(MailboxConstants.USER_NAMESPACE, USER.asString(), "name", "wrong_path" + emlpath);
 


### PR DESCRIPTION
For this, we need a pre-step of changing the existing `MailboxMapper.create(Mailbox)` to `MailboxMapper.create(MailboxPath, uidValidity)`, returning a Mailbox object instead of a MailboxId.

From there, the rest was not complicated...