### PR TITLE
JAMES-3058 Concurrency testing for fixing Cassandra mailbox inconsistencies

### DIFF
--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAO.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionDAO.java
@@ -22,6 +22,7 @@ package org.apache.james.backends.cassandra.versions;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.truncate;
 import static org.apache.james.backends.cassandra.versions.table.CassandraSchemaVersionTable.KEY;
 import static org.apache.james.backends.cassandra.versions.table.CassandraSchemaVersionTable.TABLE_NAME;
 import static org.apache.james.backends.cassandra.versions.table.CassandraSchemaVersionTable.VALUE;
@@ -36,6 +37,7 @@ import org.apache.james.backends.cassandra.versions.table.CassandraSchemaVersion
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.utils.UUIDs;
+import com.google.common.annotations.VisibleForTesting;
 
 import reactor.core.publisher.Mono;
 
@@ -78,6 +80,11 @@ public class CassandraSchemaVersionDAO {
             writeVersionStatement.bind()
                 .setUUID(KEY, UUIDs.timeBased())
                 .setInt(VALUE, newVersion.getValue()));
+    }
+
+    @VisibleForTesting
+    public Mono<Void> truncateVersion() {
+        return cassandraAsyncExecutor.executeVoid(truncate(TABLE_NAME));
     }
 }
 

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/TestingSession.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/TestingSession.java
@@ -1,0 +1,280 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.cassandra;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.CloseFuture;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.RegularStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
+import com.google.common.util.concurrent.ListenableFuture;
+
+public class TestingSession implements Session {
+    @FunctionalInterface
+    interface Behavior {
+        Behavior THROW = (session, statement) -> {
+            RuntimeException injected_failure = new RuntimeException("Injected failure");
+            injected_failure.printStackTrace();
+            throw injected_failure;
+        };
+
+        Behavior EXECUTE_NORMALLY = Session::executeAsync;
+
+        static Behavior awaitOn(Barrier barrier) {
+            return (session, statement) -> {
+                barrier.call();
+                return session.executeAsync(statement);
+            };
+        }
+
+        ResultSetFuture execute(Session session, Statement statement);
+    }
+
+    public static class Barrier {
+        private final CountDownLatch callerLatch = new CountDownLatch(1);
+        private final CountDownLatch awaitCallerLatch;
+
+        public Barrier() {
+            this(1);
+        }
+
+        public Barrier(int callerCount) {
+            awaitCallerLatch = new CountDownLatch(callerCount);
+        }
+
+        public void awaitCaller() throws InterruptedException {
+            awaitCallerLatch.await();
+        }
+
+        public void releaseCaller() {
+            callerLatch.countDown();
+        }
+
+        void call() {
+            awaitCallerLatch.countDown();
+            try {
+                callerLatch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface StatementPredicate extends Predicate<Statement> {
+
+    }
+
+    static class BoundStatementStartingWith implements StatementPredicate {
+        private final String queryStringPrefix;
+
+        BoundStatementStartingWith(String queryStringPrefix) {
+            this.queryStringPrefix = queryStringPrefix;
+        }
+
+        @Override
+        public boolean test(Statement statement) {
+            if (statement instanceof BoundStatement) {
+                BoundStatement boundStatement = (BoundStatement) statement;
+                return boundStatement.preparedStatement()
+                    .getQueryString()
+                    .startsWith(queryStringPrefix);
+            }
+            return false;
+        }
+    }
+
+    @FunctionalInterface
+    public interface RequiresCondition {
+        RequiresApplyCount condition(StatementPredicate statementPredicate);
+
+        default RequiresApplyCount always() {
+            return condition(ALL_STATEMENTS);
+        }
+
+        default RequiresApplyCount whenBoundStatementStartsWith(String queryStringPrefix) {
+            return condition(new BoundStatementStartingWith(queryStringPrefix));
+        }
+    }
+
+    @FunctionalInterface
+    public interface RequiresApplyCount {
+        FinalStage times(int applyCount);
+    }
+
+    @FunctionalInterface
+    public interface FinalStage {
+        void setExecutionHook();
+    }
+
+    private static class ExecutionHook {
+        final StatementPredicate statementPredicate;
+        final Behavior behavior;
+        final AtomicInteger remaining;
+
+        private ExecutionHook(StatementPredicate statementPredicate, Behavior behavior, int applyCount) {
+            this.statementPredicate = statementPredicate;
+            this.behavior = behavior;
+            this.remaining = new AtomicInteger(applyCount);
+        }
+
+        ResultSetFuture execute(Session session, Statement statement) {
+            if (statementPredicate.test(statement)) {
+                int hookPosition = remaining.getAndDecrement();
+                if (hookPosition > 0) {
+                    return behavior.execute(session, statement);
+                }
+            }
+            return Behavior.EXECUTE_NORMALLY.execute(session, statement);
+        }
+    }
+
+    private static StatementPredicate ALL_STATEMENTS = statement -> true;
+    private static ExecutionHook NO_EXECUTION_HOOK = new ExecutionHook(ALL_STATEMENTS, Behavior.EXECUTE_NORMALLY, 0);
+
+    private final Session delegate;
+    private volatile ExecutionHook executionHook;
+
+    TestingSession(Session delegate) {
+        this.delegate = delegate;
+        this.executionHook = NO_EXECUTION_HOOK;
+    }
+
+    public RequiresCondition fail() {
+        return condition -> applyCount -> () -> executionHook = new ExecutionHook(condition, Behavior.THROW, applyCount);
+    }
+
+    public RequiresCondition awaitOn(Barrier barrier) {
+        return condition -> applyCount -> () -> executionHook = new ExecutionHook(condition, Behavior.awaitOn(barrier), applyCount);
+    }
+
+    public void resetExecutionHook() {
+        executionHook = NO_EXECUTION_HOOK;
+    }
+
+    @Override
+    public String getLoggedKeyspace() {
+        return delegate.getLoggedKeyspace();
+    }
+
+    @Override
+    public Session init() {
+        return delegate.init();
+    }
+
+    @Override
+    public ListenableFuture<Session> initAsync() {
+        return delegate.initAsync();
+    }
+
+    @Override
+    public ResultSet execute(String query) {
+        return delegate.execute(query);
+    }
+
+    @Override
+    public ResultSet execute(String query, Object... values) {
+        return delegate.execute(query, values);
+    }
+
+    @Override
+    public ResultSet execute(String query, Map<String, Object> values) {
+        return delegate.execute(query, values);
+    }
+
+    @Override
+    public ResultSet execute(Statement statement) {
+        return delegate.execute(statement);
+    }
+
+    @Override
+    public ResultSetFuture executeAsync(String query) {
+        return delegate.executeAsync(query);
+    }
+
+    @Override
+    public ResultSetFuture executeAsync(String query, Object... values) {
+        return delegate.executeAsync(query, values);
+    }
+
+    @Override
+    public ResultSetFuture executeAsync(String query, Map<String, Object> values) {
+        return delegate.executeAsync(query, values);
+    }
+
+    @Override
+    public ResultSetFuture executeAsync(Statement statement) {
+        return executionHook.execute(delegate, statement);
+    }
+
+    @Override
+    public PreparedStatement prepare(String query) {
+        return delegate.prepare(query);
+    }
+
+    @Override
+    public PreparedStatement prepare(RegularStatement statement) {
+        return delegate.prepare(statement);
+    }
+
+    @Override
+    public ListenableFuture<PreparedStatement> prepareAsync(String query) {
+        return delegate.prepareAsync(query);
+    }
+
+    @Override
+    public ListenableFuture<PreparedStatement> prepareAsync(RegularStatement statement) {
+        return delegate.prepareAsync(statement);
+    }
+
+    @Override
+    public CloseFuture closeAsync() {
+        return delegate.closeAsync();
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return delegate.isClosed();
+    }
+
+    @Override
+    public Cluster getCluster() {
+        return delegate.getCluster();
+    }
+
+    @Override
+    public State getState() {
+        return delegate.getState();
+    }
+}

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/TestingSessionTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/TestingSessionTest.java
@@ -1,0 +1,232 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.james.backends.cassandra.TestingSession.Barrier;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionDAO;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.backends.cassandra.versions.SchemaVersion;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+class TestingSessionTest {
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(CassandraSchemaVersionModule.MODULE);
+
+    private CassandraSchemaVersionDAO dao;
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandra) {
+        dao = new CassandraSchemaVersionDAO(cassandra.getConf());
+    }
+
+    @Test
+    void daoOperationShouldNotBeInstrumentedByDefault() {
+        assertThatCode(() -> dao.getCurrentSchemaVersion().block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void daoOperationShouldNotBeInstrumentedWhenNotMatching(CassandraCluster cassandra) {
+        cassandra.getConf()
+            .fail()
+            .whenBoundStatementStartsWith("non matching")
+            .times(1)
+            .setExecutionHook();
+
+        assertThatCode(() -> dao.getCurrentSchemaVersion().block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void daoOperationShouldNotBeInstrumentedWhenTimesIsZero(CassandraCluster cassandra) {
+        cassandra.getConf()
+            .fail()
+            .whenBoundStatementStartsWith("SELECT value FROM schemaVersion;")
+            .times(0)
+            .setExecutionHook();
+
+        assertThatCode(() -> dao.getCurrentSchemaVersion().block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void daoOperationShouldNotBeInstrumentedWhenTimesIsNegative(CassandraCluster cassandra) {
+        cassandra.getConf()
+            .fail()
+            .whenBoundStatementStartsWith("SELECT value FROM schemaVersion;")
+            .times(-1)
+            .setExecutionHook();
+
+        assertThatCode(() -> dao.getCurrentSchemaVersion().block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void daoOperationShouldFailWhenInstrumented(CassandraCluster cassandra) {
+        cassandra.getConf()
+            .fail()
+            .whenBoundStatementStartsWith("SELECT value FROM schemaVersion;")
+            .times(1)
+            .setExecutionHook();
+
+        assertThatThrownBy(() -> dao.getCurrentSchemaVersion().block())
+            .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void daoShouldNotBeInstrumentedWhenTimesIsExceeded(CassandraCluster cassandra) {
+        cassandra.getConf()
+            .fail()
+            .whenBoundStatementStartsWith("SELECT value FROM schemaVersion;")
+            .times(1)
+            .setExecutionHook();
+
+        try {
+            dao.getCurrentSchemaVersion().block();
+        } catch (Exception e) {
+            // discard expected exception
+        }
+
+        assertThatCode(() -> dao.getCurrentSchemaVersion().block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void timesShouldSpecifyExactlyTheFailureCount(CassandraCluster cassandra) {
+        cassandra.getConf()
+            .fail()
+            .whenBoundStatementStartsWith("SELECT value FROM schemaVersion;")
+            .times(2)
+            .setExecutionHook();
+
+        SoftAssertions.assertSoftly(softly -> {
+            assertThatThrownBy(() -> dao.getCurrentSchemaVersion().block())
+                .isInstanceOf(RuntimeException.class);
+            assertThatThrownBy(() -> dao.getCurrentSchemaVersion().block())
+                .isInstanceOf(RuntimeException.class);
+            assertThatCode(() -> dao.getCurrentSchemaVersion().block())
+                .doesNotThrowAnyException();
+        });
+    }
+
+    @Test
+    void resetExecutionHookShouldClearInstrumentation(CassandraCluster cassandra) {
+        cassandra.getConf()
+            .fail()
+            .whenBoundStatementStartsWith("SELECT value FROM schemaVersion;")
+            .times(1)
+            .setExecutionHook();
+
+        cassandra.getConf().resetExecutionHook();
+
+        assertThatCode(() -> dao.getCurrentSchemaVersion().block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void timesShouldBeTakenIntoAccountOnlyForMatchingStatements(CassandraCluster cassandra) {
+        cassandra.getConf()
+            .fail()
+            .whenBoundStatementStartsWith("SELECT value FROM schemaVersion;")
+            .times(1)
+            .setExecutionHook();
+
+        dao.updateVersion(new SchemaVersion(36)).block();
+
+        assertThatThrownBy(() -> dao.getCurrentSchemaVersion().block())
+            .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void statementShouldNotBeAppliedBeforeBarrierIsReleased(CassandraCluster cassandra) throws Exception {
+        SchemaVersion originalSchemaVersion = new SchemaVersion(32);
+        dao.updateVersion(originalSchemaVersion).block();
+        Barrier barrier = new Barrier();
+        cassandra.getConf()
+            .awaitOn(barrier)
+            .whenBoundStatementStartsWith("INSERT INTO schemaVersion")
+            .times(1)
+            .setExecutionHook();
+
+        dao.updateVersion(new SchemaVersion(36)).subscribeOn(Schedulers.elastic()).subscribe();
+
+        Thread.sleep(100);
+
+        assertThat(dao.getCurrentSchemaVersion().block())
+            .contains(originalSchemaVersion);
+    }
+
+    @Test
+    void statementShouldBeAppliedWhenBarrierIsReleased(CassandraCluster cassandra) throws Exception {
+        SchemaVersion originalSchemaVersion = new SchemaVersion(32);
+        SchemaVersion newVersion = new SchemaVersion(36);
+
+        dao.updateVersion(originalSchemaVersion).block();
+        Barrier barrier = new Barrier();
+        cassandra.getConf()
+            .awaitOn(barrier)
+            .whenBoundStatementStartsWith("INSERT INTO schemaVersion")
+            .times(1)
+            .setExecutionHook();
+
+        Mono<Void> operation = dao.updateVersion(newVersion).cache();
+
+        operation.subscribeOn(Schedulers.elastic()).subscribe();
+        barrier.releaseCaller();
+        operation.block();
+
+        assertThat(dao.getCurrentSchemaVersion().block())
+            .contains(newVersion);
+    }
+
+    @Test
+    void testShouldBeAbleToAwaitCaller(CassandraCluster cassandra) throws Exception {
+        SchemaVersion originalSchemaVersion = new SchemaVersion(32);
+        SchemaVersion newVersion = new SchemaVersion(36);
+
+        dao.updateVersion(originalSchemaVersion).block();
+        Barrier barrier = new Barrier();
+        cassandra.getConf()
+            .awaitOn(barrier)
+            .whenBoundStatementStartsWith("INSERT INTO schemaVersion")
+            .times(1)
+            .setExecutionHook();
+
+        Mono<Void> operation = dao.updateVersion(newVersion).cache();
+
+        operation.subscribeOn(Schedulers.elastic()).subscribe();
+        barrier.awaitCaller();
+        barrier.releaseCaller();
+        operation.block();
+
+        assertThat(dao.getCurrentSchemaVersion().block())
+            .contains(newVersion);
+    }
+}

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/Mailbox.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/Mailbox.java
@@ -156,6 +156,7 @@ public class Mailbox {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
+            .add("id", getMailboxId().serialize())
             .add("namespace", namespace)
             .add("user", user)
             .add("name", name)

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxPath.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxPath.java
@@ -179,7 +179,7 @@ public class MailboxPath {
     }
 
     public String asString() {
-        return namespace + ":" + user + ":" + name;
+        return namespace + ":" + user.asString() + ":" + name;
     }
 
     public boolean isInbox() {

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxPathTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxPathTest.java
@@ -45,6 +45,12 @@ class MailboxPathTest {
     }
 
     @Test
+    void asStringShouldFormatUser() {
+        assertThat(MailboxPath.forUser(USER, "inbox.folder.subfolder").asString())
+            .isEqualTo("#private:user:inbox.folder.subfolder");
+    }
+
+    @Test
     void getHierarchyLevelsShouldBeOrdered() {
         assertThat(MailboxPath.forUser(USER, "inbox.folder.subfolder")
             .getHierarchyLevels('.'))

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxPathV2DAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxPathV2DAO.java
@@ -58,6 +58,7 @@ public class CassandraMailboxPathV2DAO implements CassandraMailboxPathDAO {
     private final PreparedStatement delete;
     private final PreparedStatement insert;
     private final PreparedStatement select;
+    private final PreparedStatement selectUser;
     private final PreparedStatement selectAll;
 
     @Inject
@@ -67,6 +68,7 @@ public class CassandraMailboxPathV2DAO implements CassandraMailboxPathDAO {
         this.insert = prepareInsert(session);
         this.delete = prepareDelete(session);
         this.select = prepareSelect(session);
+        this.selectUser = prepareSelectUser(session);
         this.selectAll = prepareSelectAll(session);
     }
 
@@ -95,11 +97,16 @@ public class CassandraMailboxPathV2DAO implements CassandraMailboxPathDAO {
             .and(eq(MAILBOX_NAME, bindMarker(MAILBOX_NAME))));
     }
 
-    private PreparedStatement prepareSelectAll(Session session) {
+    private PreparedStatement prepareSelectUser(Session session) {
         return session.prepare(select(FIELDS)
             .from(TABLE_NAME)
             .where(eq(NAMESPACE, bindMarker(NAMESPACE)))
             .and(eq(USER, bindMarker(USER))));
+    }
+
+    private PreparedStatement prepareSelectAll(Session session) {
+        return session.prepare(select(FIELDS)
+            .from(TABLE_NAME));
     }
 
     @Override
@@ -117,9 +124,17 @@ public class CassandraMailboxPathV2DAO implements CassandraMailboxPathDAO {
     @Override
     public Flux<CassandraIdAndPath> listUserMailboxes(String namespace, Username user) {
         return cassandraAsyncExecutor.execute(
-            selectAll.bind()
+            selectUser.bind()
                 .setString(NAMESPACE, namespace)
                 .setString(USER, sanitizeUser(user)))
+            .flatMapMany(resultSet -> cassandraUtils.convertToFlux(resultSet)
+                .map(this::fromRowToCassandraIdAndPath)
+                .map(FunctionalUtils.toFunction(this::logReadSuccess)));
+    }
+
+    public Flux<CassandraIdAndPath> listAll() {
+        return cassandraAsyncExecutor.execute(
+            selectAll.bind())
             .flatMapMany(resultSet -> cassandraUtils.convertToFlux(resultSet)
                 .map(this::fromRowToCassandraIdAndPath)
                 .map(FunctionalUtils.toFunction(this::logReadSuccess)));

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/MailboxPathV2Migration.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/MailboxPathV2Migration.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
 public class MailboxPathV2Migration implements Migration {
-
     static class MailboxPathV2MigrationTask implements Task {
         private final MailboxPathV2Migration migration;
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/ConflictingEntry.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/ConflictingEntry.java
@@ -1,0 +1,136 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.task;
+
+import java.util.Objects;
+
+import org.apache.james.mailbox.cassandra.mail.CassandraIdAndPath;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MailboxPath;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ConflictingEntry {
+    public static class DaoEntry {
+        private final String mailboxPath;
+        private final String mailboxId;
+
+        public DaoEntry(MailboxPath mailboxPath,
+                        MailboxId mailboxId) {
+            this(mailboxPath.asString(), mailboxId.serialize());
+        }
+
+        private DaoEntry(@JsonProperty("mailboxPath") String mailboxPath,
+                        @JsonProperty("mailboxId") String mailboxId) {
+            this.mailboxPath = mailboxPath;
+            this.mailboxId = mailboxId;
+        }
+
+        public String getMailboxPath() {
+            return mailboxPath;
+        }
+
+        public String getMailboxId() {
+            return mailboxId;
+        }
+
+        @Override
+        public final boolean equals(Object o) {
+            if (o instanceof DaoEntry) {
+                DaoEntry daoEntry = (DaoEntry) o;
+
+                return Objects.equals(this.mailboxPath, daoEntry.mailboxPath)
+                    && Objects.equals(this.mailboxId, daoEntry.mailboxId);
+            }
+            return false;
+        }
+
+        @Override
+        public final int hashCode() {
+            return Objects.hash(mailboxPath, mailboxId);
+        }
+    }
+
+    public interface Builder {
+        @FunctionalInterface
+        interface RequireMailboxDaoEntry {
+            RequireMailboxPathDaoEntry mailboxDaoEntry(DaoEntry daoEntry);
+
+            default RequireMailboxPathDaoEntry mailboxDaoEntry(Mailbox mailbox) {
+                return mailboxDaoEntry(mailbox.generateAssociatedPath(), mailbox.getMailboxId());
+            }
+
+            default RequireMailboxPathDaoEntry mailboxDaoEntry(MailboxPath path, MailboxId id) {
+                return mailboxDaoEntry(new DaoEntry(path, id));
+            }
+        }
+
+        @FunctionalInterface
+        interface RequireMailboxPathDaoEntry {
+            ConflictingEntry mailboxPathDaoEntry(DaoEntry daoEntry);
+
+            default ConflictingEntry mailboxPathDaoEntry(CassandraIdAndPath mailbox) {
+                return mailboxPathDaoEntry(mailbox.getMailboxPath(), mailbox.getCassandraId());
+            }
+
+            default ConflictingEntry mailboxPathDaoEntry(MailboxPath path, MailboxId id) {
+                return mailboxPathDaoEntry(new DaoEntry(path, id));
+            }
+        }
+    }
+
+    public static Builder.RequireMailboxDaoEntry builder() {
+        return mailboxDaoEntry -> mailboxPathDaoEntry -> new ConflictingEntry(mailboxDaoEntry, mailboxPathDaoEntry);
+    }
+
+    private final DaoEntry mailboxDaoEntry;
+    private final DaoEntry mailboxPathDaoEntry;
+
+    private ConflictingEntry(@JsonProperty("mailboxDaoEntry") DaoEntry mailboxDaoEntry,
+                            @JsonProperty("mailboxPathDaoEntry") DaoEntry mailboxPathDaoEntry) {
+        this.mailboxDaoEntry = mailboxDaoEntry;
+        this.mailboxPathDaoEntry = mailboxPathDaoEntry;
+    }
+
+    public DaoEntry getMailboxDaoEntry() {
+        return mailboxDaoEntry;
+    }
+
+    public DaoEntry getMailboxPathDaoEntry() {
+        return mailboxPathDaoEntry;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof ConflictingEntry) {
+            ConflictingEntry that = (ConflictingEntry) o;
+
+            return Objects.equals(this.mailboxDaoEntry, that.mailboxDaoEntry)
+                && Objects.equals(this.mailboxPathDaoEntry, that.mailboxPathDaoEntry);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(mailboxDaoEntry, mailboxPathDaoEntry);
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/MailboxMergingTaskDTO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/MailboxMergingTaskDTO.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class MailboxMergingTaskDTO implements TaskDTO {
     private static final CassandraId.Factory CASSANDRA_ID_FACTORY = new CassandraId.Factory();
 
-    private static MailboxMergingTaskDTO fromDTO(MailboxMergingTask domainObject, String typeName) {
+    private static MailboxMergingTaskDTO toDTO(MailboxMergingTask domainObject, String typeName) {
         return new MailboxMergingTaskDTO(
             typeName,
             domainObject.getContext().getTotalMessageCount(),
@@ -43,8 +43,8 @@ public class MailboxMergingTaskDTO implements TaskDTO {
         return DTOModule
             .forDomainObject(MailboxMergingTask.class)
             .convertToDTO(MailboxMergingTaskDTO.class)
-            .toDomainObjectConverter(dto -> dto.toDTO(taskRunner))
-            .toDTOConverter(MailboxMergingTaskDTO::fromDTO)
+            .toDomainObjectConverter(dto -> dto.toDomainObject(taskRunner))
+            .toDTOConverter(MailboxMergingTaskDTO::toDTO)
             .typeName(MailboxMergingTask.MAILBOX_MERGING.asString())
             .withFactory(TaskDTOModule::new);
     }
@@ -65,13 +65,12 @@ public class MailboxMergingTaskDTO implements TaskDTO {
         this.newMailboxId = newMailboxId;
     }
 
-    private MailboxMergingTask toDTO(MailboxMergingTaskRunner taskRunner) {
+    private MailboxMergingTask toDomainObject(MailboxMergingTaskRunner taskRunner) {
         return new MailboxMergingTask(
             taskRunner,
             totalMessageCount,
             CASSANDRA_ID_FACTORY.fromString(oldMailboxId),
-            CASSANDRA_ID_FACTORY.fromString(newMailboxId)
-        );
+            CASSANDRA_ID_FACTORY.fromString(newMailboxId));
     }
 
     @Override

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesService.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesService.java
@@ -1,0 +1,359 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.task;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.inject.Inject;
+
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionDAO;
+import org.apache.james.backends.cassandra.versions.SchemaVersion;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.mail.CassandraIdAndPath;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathV2DAO;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.task.Task;
+import org.apache.james.task.Task.Result;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class SolveMailboxInconsistenciesService {
+    public static final Logger LOGGER = LoggerFactory.getLogger(SolveMailboxInconsistenciesService.class);
+
+    @FunctionalInterface
+    interface Inconsistency {
+        Mono<Result> fix(Context context, CassandraMailboxDAO mailboxDAO, CassandraMailboxPathV2DAO pathV2DAO);
+    }
+
+    private static Inconsistency NO_INCONSISTENCY = (context, mailboxDAO1, pathV2DAO) -> Mono.just(Result.COMPLETED);
+
+    /**
+     * The Mailbox is referenced in MailboxDAO but the corresponding
+     * reference is missing in MailboxPathDao.
+     *
+     * In order to solve this inconsistency, we can simply re-reference the mailboxPath.
+     */
+    private static class OrphanMailboxDAOEntry implements Inconsistency {
+        private final Mailbox mailbox;
+
+        private OrphanMailboxDAOEntry(Mailbox mailbox) {
+            this.mailbox = mailbox;
+        }
+
+        @Override
+        public Mono<Result> fix(Context context, CassandraMailboxDAO mailboxDAO, CassandraMailboxPathV2DAO pathV2DAO) {
+            return pathV2DAO.save(mailbox.generateAssociatedPath(), (CassandraId) mailbox.getMailboxId())
+                .map(success -> {
+                    if (success) {
+                        LOGGER.info("Inconsistency fixed for orphan mailbox {} - {}",
+                            mailbox.getMailboxId().serialize(),
+                            mailbox.generateAssociatedPath().asString());
+                        context.fixedInconsistencies.incrementAndGet();
+                        return Result.COMPLETED;
+                    } else {
+                        context.errors.incrementAndGet();
+                        LOGGER.warn("Failed fixing inconsistency for orphan mailbox {} - {}",
+                            mailbox.getMailboxId().serialize(),
+                            mailbox.generateAssociatedPath().asString());
+                        return Result.PARTIAL;
+                    }
+                });
+        }
+    }
+
+    /**
+     * The Mailbox is referenced in MailboxPathDao but the corresponding
+     * entry is missing in MailboxDao.
+     *
+     * CassandraIds are guaranteed to be unique, and are immutable once set to a mailbox.
+     *
+     * This inconsistency arise if mailbox creation fails or upon partial deletes.
+     *
+     * In both case removing the dandling path registration solves the inconsistency
+     *
+     * In order to solve this inconsistency, we can simply re-reference the mailboxPath.
+     */
+    private static class OrphanMailboxPathDAOEntry implements Inconsistency {
+        private final CassandraIdAndPath pathRegistration;
+
+        private OrphanMailboxPathDAOEntry(CassandraIdAndPath pathRegistration) {
+            this.pathRegistration = pathRegistration;
+        }
+
+        @Override
+        public Mono<Result> fix(Context context, CassandraMailboxDAO mailboxDAO, CassandraMailboxPathV2DAO pathV2DAO) {
+            return pathV2DAO.delete(pathRegistration.getMailboxPath())
+                .doOnSuccess(any -> {
+                    LOGGER.info("Inconsistency fixed for orphan mailboxPath {} - {}",
+                        pathRegistration.getCassandraId().serialize(),
+                        pathRegistration.getMailboxPath().asString());
+                    context.fixedInconsistencies.incrementAndGet();
+                })
+                .map(any -> Result.COMPLETED)
+                .switchIfEmpty(Mono.just(Result.COMPLETED))
+                .onErrorResume(e -> {
+                    LOGGER.error("Failed fixing inconsistency for orphan mailboxPath {} - {}",
+                        pathRegistration.getCassandraId().serialize(),
+                        pathRegistration.getMailboxPath().asString(),
+                        e);
+                    context.errors.incrementAndGet();
+                    return Mono.just(Result.PARTIAL);
+                });
+        }
+    }
+
+    /**
+     * The Mailbox is referenced in MailboxDAO but the corresponding
+     * reference is pointing to another mailbox in MailboxPathDao.
+     *
+     * This error can not be recovered as some data-loss might be involved. It is preferable to
+     * ask the admin to review then merge the two mailbowes together using {@link MailboxMergingTask}.
+     *
+     * See https://github.com/apache/james-project/blob/master/src/site/markdown/server/manage-webadmin.md#correcting-ghost-mailbox
+     */
+    private static class ConflictingEntryInconsistency implements Inconsistency {
+        private final ConflictingEntry conflictingEntry;
+
+        private ConflictingEntryInconsistency(Mailbox mailbox, CassandraIdAndPath pathRegistration) {
+            boolean samePath = mailbox.generateAssociatedPath().equals(pathRegistration.getMailboxPath());
+            boolean sameId = mailbox.getMailboxId().equals(pathRegistration.getCassandraId());
+
+            Preconditions.checkState(samePath != sameId);
+
+            this.conflictingEntry = ConflictingEntry.builder()
+                .mailboxDaoEntry(mailbox)
+                .mailboxPathDaoEntry(pathRegistration);
+        }
+
+        @Override
+        public Mono<Result> fix(Context context, CassandraMailboxDAO mailboxDAO, CassandraMailboxPathV2DAO pathV2DAO) {
+            LOGGER.error("MailboxDAO contains mailbox {} {} which conflict with corresponding registration {} {}. " +
+                "We recommend merging these mailboxes together to prevent mail data loss.",
+                conflictingEntry.getMailboxDaoEntry().getMailboxId(), conflictingEntry.getMailboxDaoEntry().getMailboxPath(),
+                conflictingEntry.getMailboxPathDaoEntry().getMailboxId(), conflictingEntry.getMailboxPathDaoEntry().getMailboxPath());
+            context.conflictingEntries.add(conflictingEntry);
+            return Mono.just(Result.PARTIAL);
+        }
+    }
+
+    static class Context {
+        static class Builder {
+            private Optional<Long> processedMailboxEntries;
+            private Optional<Long> processedMailboxPathEntries;
+            private Optional<Long> fixedInconsistencies;
+            private ImmutableList.Builder<ConflictingEntry> conflictingEntries;
+            private Optional<Long> errors;
+
+            Builder() {
+                processedMailboxPathEntries = Optional.empty();
+                fixedInconsistencies = Optional.empty();
+                conflictingEntries = ImmutableList.builder();
+                errors = Optional.empty();
+                processedMailboxEntries = Optional.empty();
+            }
+
+            public Builder processedMailboxEntries(long count) {
+                processedMailboxEntries = Optional.of(count);
+                return this;
+            }
+
+            public Builder processedMailboxPathEntries(long count) {
+                processedMailboxPathEntries = Optional.of(count);
+                return this;
+            }
+
+            public Builder fixedInconsistencies(long count) {
+                fixedInconsistencies = Optional.of(count);
+                return this;
+            }
+
+            public Builder addConflictingEntry(ConflictingEntry conflictingEntry) {
+                conflictingEntries.add(conflictingEntry);
+                return this;
+            }
+
+            public Builder errors(long count) {
+                errors = Optional.of(count);
+                return this;
+            }
+
+            public Context build() {
+                return new Context(
+                    processedMailboxEntries.orElse(0L),
+                    processedMailboxPathEntries.orElse(0L),
+                    fixedInconsistencies.orElse(0L),
+                    conflictingEntries.build(),
+                    errors.orElse(0L));
+            }
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        private final AtomicLong processedMailboxEntries;
+        private final AtomicLong processedMailboxPathEntries;
+        private final AtomicLong fixedInconsistencies;
+        private final ConcurrentLinkedDeque<ConflictingEntry> conflictingEntries;
+        private final AtomicLong errors;
+
+        Context() {
+            this(new AtomicLong(), new AtomicLong(), new AtomicLong(), ImmutableList.of(), new AtomicLong());
+        }
+
+        Context(long processedMailboxEntries, long processedMailboxPathEntries, long fixedInconsistencies, Collection<ConflictingEntry> conflictingEntries, long errors) {
+            this(new AtomicLong(processedMailboxEntries),
+                new AtomicLong(processedMailboxPathEntries),
+                new AtomicLong(fixedInconsistencies),
+                conflictingEntries,
+                new AtomicLong(errors));
+        }
+
+        private Context(AtomicLong processedMailboxEntries, AtomicLong processedMailboxPathEntries, AtomicLong fixedInconsistencies, Collection<ConflictingEntry> conflictingEntries, AtomicLong errors) {
+            this.processedMailboxEntries = processedMailboxEntries;
+            this.processedMailboxPathEntries = processedMailboxPathEntries;
+            this.fixedInconsistencies = fixedInconsistencies;
+            this.conflictingEntries = new ConcurrentLinkedDeque<>(conflictingEntries);
+            this.errors = errors;
+        }
+
+        long getProcessedMailboxEntries() {
+            return processedMailboxEntries.get();
+        }
+
+        long getProcessedMailboxPathEntries() {
+            return processedMailboxPathEntries.get();
+        }
+
+        long getFixedInconsistencies() {
+            return fixedInconsistencies.get();
+        }
+
+        ImmutableList<ConflictingEntry> getConflictingEntries() {
+            return ImmutableList.copyOf(conflictingEntries);
+        }
+
+        long getErrors() {
+            return errors.get();
+        }
+
+        @Override
+        public final boolean equals(Object o) {
+            if (o instanceof Context) {
+                Context that = (Context) o;
+
+                return Objects.equals(this.processedMailboxEntries.get(), that.processedMailboxEntries.get())
+                    && Objects.equals(this.processedMailboxPathEntries.get(), that.processedMailboxPathEntries.get())
+                    && Objects.equals(this.fixedInconsistencies.get(), that.fixedInconsistencies.get())
+                    && Objects.equals(this.getConflictingEntries(), that.getConflictingEntries())
+                    && Objects.equals(this.errors.get(), that.errors.get());
+            }
+            return false;
+        }
+
+        @Override
+        public final int hashCode() {
+            return Objects.hash(processedMailboxEntries.get(), processedMailboxPathEntries.get(), fixedInconsistencies.get(), getConflictingEntries(), errors.get());
+        }
+    }
+
+    private static final SchemaVersion MAILBOX_PATH_V_2_MIGRATION_PERFORMED_VERSION = new SchemaVersion(6);
+
+    private final CassandraMailboxDAO mailboxDAO;
+    private final CassandraMailboxPathV2DAO mailboxPathV2DAO;
+    private final CassandraSchemaVersionDAO versionDAO;
+
+    @Inject
+    SolveMailboxInconsistenciesService(CassandraMailboxDAO mailboxDAO, CassandraMailboxPathV2DAO mailboxPathV2DAO, CassandraSchemaVersionDAO versionDAO) {
+        this.mailboxDAO = mailboxDAO;
+        this.mailboxPathV2DAO = mailboxPathV2DAO;
+        this.versionDAO = versionDAO;
+    }
+
+    Mono<Result> fixMailboxInconsistencies(Context context) {
+        assertValidVersion();
+        return Flux.merge(
+                processMailboxDaoInconsistencies(context),
+                processMailboxPathDaoInconsistencies(context))
+            .reduce(Result.COMPLETED, Task::combine);
+    }
+
+    private void assertValidVersion() {
+        Optional<SchemaVersion> maybeVersion = versionDAO.getCurrentSchemaVersion().block();
+
+        boolean isVersionValid = maybeVersion
+            .map(version -> version.isAfterOrEquals(MAILBOX_PATH_V_2_MIGRATION_PERFORMED_VERSION))
+            .orElse(false);
+
+        Preconditions.checkState(isVersionValid,
+            "Schema version %s is required in order to ensure mailboxPathV2DAO to be correctly populated, got %s",
+            MAILBOX_PATH_V_2_MIGRATION_PERFORMED_VERSION.getValue(),
+            maybeVersion.map(SchemaVersion::getValue));
+    }
+
+    private Flux<Result> processMailboxPathDaoInconsistencies(Context context) {
+        return mailboxPathV2DAO.listAll()
+            .flatMap(this::detectInconsistency)
+            .flatMap(inconsistency -> inconsistency.fix(context, mailboxDAO, mailboxPathV2DAO))
+            .doOnNext(any -> context.processedMailboxPathEntries.incrementAndGet());
+    }
+
+    private Flux<Result> processMailboxDaoInconsistencies(Context context) {
+        return mailboxDAO.retrieveAllMailboxes()
+            .flatMap(this::detectInconsistency)
+            .flatMap(inconsistency -> inconsistency.fix(context, mailboxDAO, mailboxPathV2DAO))
+            .doOnNext(any -> context.processedMailboxEntries.incrementAndGet());
+    }
+
+    private Mono<Inconsistency> detectInconsistency(Mailbox mailbox) {
+        return mailboxPathV2DAO.retrieveId(mailbox.generateAssociatedPath())
+            .map(pathRegistration -> {
+                if (pathRegistration.getCassandraId().equals(mailbox.getMailboxId())) {
+                    return NO_INCONSISTENCY;
+                }
+                // Path entry references another mailbox.
+                return new ConflictingEntryInconsistency(mailbox, pathRegistration);
+            })
+            .switchIfEmpty(Mono.just(new OrphanMailboxDAOEntry(mailbox)));
+    }
+
+    private Mono<Inconsistency> detectInconsistency(CassandraIdAndPath pathRegistration) {
+        return mailboxDAO.retrieveMailbox(pathRegistration.getCassandraId())
+            .map(mailbox -> {
+                if (mailbox.generateAssociatedPath().equals(pathRegistration.getMailboxPath())) {
+                    return NO_INCONSISTENCY;
+                }
+                // Mailbox references another path
+                return new ConflictingEntryInconsistency(mailbox, pathRegistration);
+            })
+            .switchIfEmpty(Mono.just(new OrphanMailboxPathDAOEntry(pathRegistration)));
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesTask.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesTask.java
@@ -1,0 +1,110 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.task;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.task.TaskType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+
+public class SolveMailboxInconsistenciesTask implements Task {
+    static final TaskType SOLVE_MAILBOX_INCONSISTENCIES = TaskType.of("solve-mailbox-inconsistencies");
+    public static final Logger LOGGER = LoggerFactory.getLogger(SolveMailboxInconsistenciesTask.class);
+    private SolveMailboxInconsistenciesService.Context context;
+
+    public static class Details implements TaskExecutionDetails.AdditionalInformation {
+        private final Instant instant;
+        private final long processedMailboxEntries;
+        private final long processedMailboxPathEntries;
+        private final long fixedInconsistencies;
+        private final ImmutableList<ConflictingEntry> conflictingEntries;
+        private final long errors;
+
+        Details(Instant instant, long processedMailboxEntries, long processedMailboxPathEntries, long fixedInconsistencies,
+                ImmutableList<ConflictingEntry> conflictingEntries, long errors) {
+            this.instant = instant;
+            this.processedMailboxEntries = processedMailboxEntries;
+            this.processedMailboxPathEntries = processedMailboxPathEntries;
+            this.fixedInconsistencies = fixedInconsistencies;
+            this.conflictingEntries = conflictingEntries;
+            this.errors = errors;
+        }
+
+        @Override
+        public Instant timestamp() {
+            return instant;
+        }
+
+        long getProcessedMailboxEntries() {
+            return processedMailboxEntries;
+        }
+
+        long getProcessedMailboxPathEntries() {
+            return processedMailboxPathEntries;
+        }
+
+        long getFixedInconsistencies() {
+            return fixedInconsistencies;
+        }
+
+        ImmutableList<ConflictingEntry> getConflictingEntries() {
+            return conflictingEntries;
+        }
+
+        long getErrors() {
+            return errors;
+        }
+    }
+
+    private final SolveMailboxInconsistenciesService service;
+
+    SolveMailboxInconsistenciesTask(SolveMailboxInconsistenciesService service) {
+        this.service = service;
+        this.context = new SolveMailboxInconsistenciesService.Context();
+    }
+
+    @Override
+    public Result run() {
+        return service.fixMailboxInconsistencies(context)
+            .block();
+    }
+
+    @Override
+    public TaskType type() {
+        return SOLVE_MAILBOX_INCONSISTENCIES;
+    }
+
+    @Override
+    public Optional<TaskExecutionDetails.AdditionalInformation> details() {
+        return Optional.of(new Details(Clock.systemUTC().instant(),
+            context.getProcessedMailboxEntries(),
+            context.getProcessedMailboxPathEntries(),
+            context.getFixedInconsistencies(),
+            context.getConflictingEntries(),
+            context.getErrors()));
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesTaskAdditionalInformationDTO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesTaskAdditionalInformationDTO.java
@@ -1,0 +1,115 @@
+/**
+ * *************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                   *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ***************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.task;
+
+import java.time.Instant;
+
+import org.apache.james.json.DTOModule;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+public class SolveMailboxInconsistenciesTaskAdditionalInformationDTO implements AdditionalInformationDTO {
+    private static SolveMailboxInconsistenciesTaskAdditionalInformationDTO fromDomainObject(SolveMailboxInconsistenciesTask.Details details, String type) {
+        return new SolveMailboxInconsistenciesTaskAdditionalInformationDTO(
+            type,
+            details.getProcessedMailboxEntries(),
+            details.getProcessedMailboxPathEntries(),
+            details.getFixedInconsistencies(),
+            details.getConflictingEntries(),
+            details.getErrors(),
+            details.timestamp());
+    }
+
+    public static final AdditionalInformationDTOModule<SolveMailboxInconsistenciesTask.Details, SolveMailboxInconsistenciesTaskAdditionalInformationDTO> MODULE =
+        DTOModule
+            .forDomainObject(SolveMailboxInconsistenciesTask.Details.class)
+            .convertToDTO(SolveMailboxInconsistenciesTaskAdditionalInformationDTO.class)
+            .toDomainObjectConverter(SolveMailboxInconsistenciesTaskAdditionalInformationDTO::toDomainObject)
+            .toDTOConverter(SolveMailboxInconsistenciesTaskAdditionalInformationDTO::fromDomainObject)
+            .typeName(SolveMailboxInconsistenciesTask.SOLVE_MAILBOX_INCONSISTENCIES.asString())
+            .withFactory(AdditionalInformationDTOModule::new);
+
+    private final String type;
+    private final long processedMailboxEntries;
+    private final long processedMailboxPathEntries;
+    private final long fixedInconsistencies;
+    private final ImmutableList<ConflictingEntry> conflictingEntries;
+    private final long errors;
+    private final Instant timestamp;
+
+    public SolveMailboxInconsistenciesTaskAdditionalInformationDTO(@JsonProperty("type") String type,
+                                                                   @JsonProperty("processedMailboxEntries") long processedMailboxEntries,
+                                                                   @JsonProperty("processedMailboxPathEntries") long processedMailboxPathEntries,
+                                                                   @JsonProperty("fixedInconsistencies") long fixedInconsistencies,
+                                                                   @JsonProperty("conflictingEntries") ImmutableList<ConflictingEntry> conflictingEntries,
+                                                                   @JsonProperty("errors") long errors,
+                                                                   @JsonProperty("timestamp") Instant timestamp) {
+        this.type = type;
+        this.processedMailboxEntries = processedMailboxEntries;
+        this.timestamp = timestamp;
+        this.processedMailboxPathEntries = processedMailboxPathEntries;
+        this.fixedInconsistencies = fixedInconsistencies;
+        this.conflictingEntries = conflictingEntries;
+        this.errors = errors;
+    }
+
+    public long getProcessedMailboxEntries() {
+        return processedMailboxEntries;
+    }
+
+    public long getProcessedMailboxPathEntries() {
+        return processedMailboxPathEntries;
+    }
+
+    public long getFixedInconsistencies() {
+        return fixedInconsistencies;
+    }
+
+    public ImmutableList<ConflictingEntry> getConflictingEntries() {
+        return conflictingEntries;
+    }
+
+    public long getErrors() {
+        return errors;
+    }
+
+    @Override
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    private SolveMailboxInconsistenciesTask.Details toDomainObject() {
+        return new SolveMailboxInconsistenciesTask.Details(timestamp,
+            processedMailboxEntries,
+            processedMailboxPathEntries,
+            fixedInconsistencies,
+            conflictingEntries,
+            errors);
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesTaskDTO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesTaskDTO.java
@@ -1,0 +1,62 @@
+/**
+ * *************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                   *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ***************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.task;
+
+import org.apache.james.json.DTOModule;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.server.task.json.dto.TaskDTO;
+import org.apache.james.server.task.json.dto.TaskDTOModule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SolveMailboxInconsistenciesTaskDTO implements TaskDTO {
+    private static final CassandraId.Factory CASSANDRA_ID_FACTORY = new CassandraId.Factory();
+
+    private static SolveMailboxInconsistenciesTaskDTO toDTO(SolveMailboxInconsistenciesTask domainObject, String typeName) {
+        return new SolveMailboxInconsistenciesTaskDTO(
+            typeName);
+    }
+
+    public static TaskDTOModule<SolveMailboxInconsistenciesTask, SolveMailboxInconsistenciesTaskDTO> module(SolveMailboxInconsistenciesService service) {
+        return DTOModule
+            .forDomainObject(SolveMailboxInconsistenciesTask.class)
+            .convertToDTO(SolveMailboxInconsistenciesTaskDTO.class)
+            .toDomainObjectConverter(dto -> dto.toDomainObject(service))
+            .toDTOConverter(SolveMailboxInconsistenciesTaskDTO::toDTO)
+            .typeName(SolveMailboxInconsistenciesTask.SOLVE_MAILBOX_INCONSISTENCIES.asString())
+            .withFactory(TaskDTOModule::new);
+    }
+
+    private final String type;
+
+    public SolveMailboxInconsistenciesTaskDTO(@JsonProperty("type") String type) {
+        this.type = type;
+    }
+
+    private SolveMailboxInconsistenciesTask toDomainObject(SolveMailboxInconsistenciesService service) {
+        return new SolveMailboxInconsistenciesTask(service);
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxPathDAOImplTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxPathDAOImplTest.java
@@ -24,10 +24,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.junit.jupiter.api.Test;
 
-class CassandraMailboxPathDAOImplTest extends CassandraMailboxPathDAOTest {
+class CassandraMailboxPathDAOImplTest extends CassandraMailboxPathDAOTest<CassandraMailboxPathDAOImpl> {
 
     @Override
-    CassandraMailboxPathDAO testee(CassandraCluster cassandra) {
+    CassandraMailboxPathDAOImpl testee(CassandraCluster cassandra) {
         return new CassandraMailboxPathDAOImpl(cassandra.getConf(), cassandra.getTypesProvider());
     }
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxPathDAOImplTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxPathDAOImplTest.java
@@ -37,17 +37,13 @@ class CassandraMailboxPathDAOImplTest extends CassandraMailboxPathDAOTest<Cassan
         testee.save(USER_OUTBOX_MAILBOXPATH, OUTBOX_ID).block();
         testee.save(OTHER_USER_MAILBOXPATH, otherMailboxId).block();
 
-        CassandraMailboxPathDAOImpl daoV1 = (CassandraMailboxPathDAOImpl) testee;
-
-        assertThat(daoV1.countAll().block())
+        assertThat(testee.countAll().block())
             .isEqualTo(3);
     }
 
     @Test
     void countAllShouldReturnZeroByDefault() {
-        CassandraMailboxPathDAOImpl daoV1 = (CassandraMailboxPathDAOImpl) testee;
-
-        assertThat(daoV1.countAll().block())
+        assertThat(testee.countAll().block())
             .isEqualTo(0);
     }
 
@@ -57,9 +53,7 @@ class CassandraMailboxPathDAOImplTest extends CassandraMailboxPathDAOTest<Cassan
         testee.save(USER_OUTBOX_MAILBOXPATH, OUTBOX_ID).block();
         testee.save(OTHER_USER_MAILBOXPATH, otherMailboxId).block();
 
-        CassandraMailboxPathDAOImpl daoV1 = (CassandraMailboxPathDAOImpl) testee;
-
-        assertThat(daoV1.readAll().toIterable())
+        assertThat(testee.readAll().toIterable())
             .containsOnly(
                 new CassandraIdAndPath(INBOX_ID, USER_INBOX_MAILBOXPATH),
                 new CassandraIdAndPath(OUTBOX_ID, USER_OUTBOX_MAILBOXPATH),
@@ -68,9 +62,7 @@ class CassandraMailboxPathDAOImplTest extends CassandraMailboxPathDAOTest<Cassan
 
     @Test
     void readAllShouldReturnEmptyByDefault() {
-        CassandraMailboxPathDAOImpl daoV1 = (CassandraMailboxPathDAOImpl) testee;
-
-        assertThat(daoV1.readAll().toIterable())
+        assertThat(testee.readAll().toIterable())
             .isEmpty();
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxPathDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxPathDAOTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public abstract class CassandraMailboxPathDAOTest {
+public abstract class CassandraMailboxPathDAOTest<T extends CassandraMailboxPathDAO> {
     private static final Username USER = Username.of("user");
     private static final Username OTHER_USER = Username.of("other");
 
@@ -53,9 +53,9 @@ public abstract class CassandraMailboxPathDAOTest {
     static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(CassandraModule.aggregateModules(
         CassandraMailboxModule.MODULE, CassandraSchemaVersionModule.MODULE));
 
-    protected CassandraMailboxPathDAO testee;
+    protected T testee;
 
-    abstract CassandraMailboxPathDAO testee(CassandraCluster cassandra);
+    abstract T testee(CassandraCluster cassandra);
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxPathV2DAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxPathV2DAOTest.java
@@ -19,12 +19,49 @@
 
 package org.apache.james.mailbox.cassandra.mail;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.utils.CassandraUtils;
+import org.junit.jupiter.api.Test;
 
-class CassandraMailboxPathV2DAOTest extends CassandraMailboxPathDAOTest {
+class CassandraMailboxPathV2DAOTest extends CassandraMailboxPathDAOTest<CassandraMailboxPathV2DAO> {
     @Override
-    CassandraMailboxPathDAO testee(CassandraCluster cassandra) {
+    CassandraMailboxPathV2DAO testee(CassandraCluster cassandra) {
         return new CassandraMailboxPathV2DAO(cassandra.getConf(), CassandraUtils.WITH_DEFAULT_CONFIGURATION);
+    }
+
+    @Test
+    void listAllShouldBeEmptyByDefault() {
+        assertThat(testee.listAll().collectList().block()).isEmpty();
+    }
+
+    @Test
+    void listAllShouldContainAddedEntry() {
+        testee.save(USER_INBOX_MAILBOXPATH, INBOX_ID).block();
+
+        assertThat(testee.listAll().collectList().block())
+            .containsExactlyInAnyOrder(INBOX_ID_AND_PATH);
+    }
+
+    @Test
+    void listAllShouldNotContainDeletedEntry() {
+        testee.save(USER_INBOX_MAILBOXPATH, INBOX_ID).block();
+
+        testee.delete(USER_INBOX_MAILBOXPATH).block();
+
+        assertThat(testee.listAll().collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void listAllShouldContainAddedEntries() {
+        testee.save(USER_INBOX_MAILBOXPATH, INBOX_ID).block();
+        testee.save(OTHER_USER_MAILBOXPATH, otherMailboxId).block();
+
+        assertThat(testee.listAll().collectList().block())
+            .containsExactlyInAnyOrder(
+                INBOX_ID_AND_PATH,
+                new CassandraIdAndPath(otherMailboxId, OTHER_USER_MAILBOXPATH));
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesServiceTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesServiceTest.java
@@ -67,6 +67,7 @@ class SolveMailboxInconsistenciesServiceTest {
     private static final MailboxPath NEW_MAILBOX_PATH = MailboxPath.forUser(USER, "xyz");
     private static final int GRACE_PERIOD_MILLIS = 500;
     private static final Duration GRACE_PERIOD = Duration.ofMillis(GRACE_PERIOD_MILLIS);
+    private static final int TRY_COUNT_BEFORE_FAILURE = 6;
     private static CassandraId CASSANDRA_ID_1 = CassandraId.timeBased();
     private static final Mailbox MAILBOX = new Mailbox(MAILBOX_PATH, UID_VALIDITY_1, CASSANDRA_ID_1);
     private static CassandraId CASSANDRA_ID_2 = CassandraId.timeBased();
@@ -433,7 +434,7 @@ class SolveMailboxInconsistenciesServiceTest {
         cassandra.getConf()
             .awaitOn(barrier)
             .whenBoundStatementStartsWith("INSERT INTO mailbox ")
-            .times(6)
+            .times(TRY_COUNT_BEFORE_FAILURE)
             .setExecutionHook();
 
         // Start create a mailbox. Path registration entry will be created.

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesServiceTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesServiceTest.java
@@ -524,6 +524,7 @@ class SolveMailboxInconsistenciesServiceTest {
             assertThat(mailboxPathV2DAO.retrieveId(MAILBOX_PATH).blockOptional()).isEmpty();
         });
     }
+    
     @Test
     void concurrentCreateThenNonConcurrentDeleteShouldNotBeConsideredAsAnInconsistency(CassandraCluster cassandra) throws Exception {
         Barrier barrier = new Barrier();

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesServiceTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesServiceTest.java
@@ -1,0 +1,403 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.utils.CassandraUtils;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionDAO;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.backends.cassandra.versions.SchemaVersion;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.mail.CassandraIdAndPath;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathV2DAO;
+import org.apache.james.mailbox.cassandra.mail.task.SolveMailboxInconsistenciesService.Context;
+import org.apache.james.mailbox.cassandra.modules.CassandraAclModule;
+import org.apache.james.mailbox.cassandra.modules.CassandraMailboxModule;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.task.Task.Result;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class SolveMailboxInconsistenciesServiceTest {
+    private static final int UID_VALIDITY_1 = 145;
+    private static final int UID_VALIDITY_2 = 147;
+    private static final Username USER = Username.of("user");
+    private static final MailboxPath MAILBOX_PATH = MailboxPath.forUser(USER, "abc");
+    private static final MailboxPath NEW_MAILBOX_PATH = MailboxPath.forUser(USER, "xyz");
+    private static CassandraId CASSANDRA_ID_1 = CassandraId.timeBased();
+    private static final Mailbox MAILBOX = new Mailbox(MAILBOX_PATH, UID_VALIDITY_1, CASSANDRA_ID_1);
+    private static CassandraId CASSANDRA_ID_2 = CassandraId.timeBased();
+
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(
+        CassandraModule.aggregateModules(
+            CassandraSchemaVersionModule.MODULE,
+            CassandraMailboxModule.MODULE,
+            CassandraAclModule.MODULE));
+
+
+    CassandraMailboxDAO mailboxDAO;
+    CassandraMailboxPathV2DAO mailboxPathV2DAO;
+    CassandraSchemaVersionDAO versionDAO;
+    SolveMailboxInconsistenciesService testee;
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandra) {
+        mailboxDAO = new CassandraMailboxDAO(cassandra.getConf(), cassandra.getTypesProvider());
+        mailboxPathV2DAO = new CassandraMailboxPathV2DAO(cassandra.getConf(), CassandraUtils.WITH_DEFAULT_CONFIGURATION);
+        versionDAO = new CassandraSchemaVersionDAO(cassandra.getConf());
+        testee = new SolveMailboxInconsistenciesService(mailboxDAO, mailboxPathV2DAO, versionDAO);
+
+        versionDAO.updateVersion(new SchemaVersion(7)).block();
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldFailWhenIsBelowMailboxPathV2Migration() {
+        versionDAO.truncateVersion().block();
+        versionDAO.updateVersion(new SchemaVersion(5)).block();
+
+        assertThatThrownBy(() -> testee.fixMailboxInconsistencies(new Context()).block())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Schema version 6 is required in order to ensure mailboxPathV2DAO to be correctly populated, got Optional[5]");
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldFailWhenVersionIsMissing() {
+        versionDAO.truncateVersion().block();
+
+        assertThatThrownBy(() -> testee.fixMailboxInconsistencies(new Context()).block())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Schema version 6 is required in order to ensure mailboxPathV2DAO to be correctly populated, got Optional.empty");
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldNotFailWhenIsEqualToMailboxPathV2Migration() {
+        versionDAO.truncateVersion().block();
+        versionDAO.updateVersion(new SchemaVersion(6)).block();
+
+        assertThatCode(() -> testee.fixMailboxInconsistencies(new Context()).block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldNotFailWhenIsAboveMailboxPathV2Migration() {
+        versionDAO.truncateVersion().block();
+        versionDAO.updateVersion(new SchemaVersion(7)).block();
+
+        assertThatCode(() -> testee.fixMailboxInconsistencies(new Context()).block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldReturnCompletedWhenNoData() {
+        assertThat(testee.fixMailboxInconsistencies(new Context()).block())
+            .isEqualTo(Result.COMPLETED);
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldReturnCompletedWhenConsistentData() {
+        mailboxDAO.save(MAILBOX).block();
+        mailboxPathV2DAO.save(MAILBOX_PATH, CASSANDRA_ID_1).block();
+
+        assertThat(testee.fixMailboxInconsistencies(new Context()).block())
+            .isEqualTo(Result.COMPLETED);
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldReturnCompletedWhenOrphanMailboxData() {
+        mailboxDAO.save(MAILBOX).block();
+
+        assertThat(testee.fixMailboxInconsistencies(new Context()).block())
+            .isEqualTo(Result.COMPLETED);
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldReturnCompletedWhenOrphanPathData() {
+        mailboxPathV2DAO.save(MAILBOX_PATH, CASSANDRA_ID_1).block();
+
+        assertThat(testee.fixMailboxInconsistencies(new Context()).block())
+            .isEqualTo(Result.COMPLETED);
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldReturnPartialWhenDAOMisMatchOnId() {
+        mailboxDAO.save(MAILBOX).block();
+        mailboxPathV2DAO.save(MAILBOX_PATH, CASSANDRA_ID_2).block();
+
+        assertThat(testee.fixMailboxInconsistencies(new Context()).block())
+            .isEqualTo(Result.PARTIAL);
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldReturnPartialWhenDAOMisMatchOnPath() {
+        mailboxDAO.save(MAILBOX).block();
+        mailboxPathV2DAO.save(NEW_MAILBOX_PATH, CASSANDRA_ID_1).block();
+
+        assertThat(testee.fixMailboxInconsistencies(new Context()).block())
+            .isEqualTo(Result.PARTIAL);
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldNotUpdateContextWhenNoData() {
+        Context context = new Context();
+
+        testee.fixMailboxInconsistencies(context).block();
+
+        assertThat(context).isEqualToComparingFieldByFieldRecursively(new Context());
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldUpdateContextWhenConsistentData() {
+        Context context = new Context();
+        mailboxDAO.save(MAILBOX).block();
+        mailboxPathV2DAO.save(MAILBOX_PATH, CASSANDRA_ID_1).block();
+
+        testee.fixMailboxInconsistencies(context).block();
+
+        assertThat(context)
+            .isEqualTo(Context.builder()
+                .processedMailboxEntries(1)
+                .processedMailboxPathEntries(1)
+                .build());
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldUpdateContextWhenOrphanMailboxData() {
+        Context context = new Context();
+        mailboxDAO.save(MAILBOX).block();
+
+        testee.fixMailboxInconsistencies(context).block();
+
+        assertThat(context)
+            .isEqualTo(Context.builder()
+                .processedMailboxEntries(1)
+                .fixedInconsistencies(1)
+                .build());
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldUpdateContextWhenOrphanPathData() {
+        Context context = new Context();
+        mailboxPathV2DAO.save(MAILBOX_PATH, CASSANDRA_ID_1).block();
+
+        testee.fixMailboxInconsistencies(context).block();
+
+        assertThat(context)
+            .isEqualTo(Context.builder()
+                .processedMailboxPathEntries(1)
+                .fixedInconsistencies(1)
+                .build());
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldUpdateContextWhenDAOMisMatchOnId() {
+        Context context = new Context();
+        mailboxDAO.save(MAILBOX).block();
+        mailboxPathV2DAO.save(MAILBOX_PATH, CASSANDRA_ID_2).block();
+        mailboxDAO.save(new Mailbox(MAILBOX_PATH, UID_VALIDITY_2, CASSANDRA_ID_2)).block();
+
+        testee.fixMailboxInconsistencies(context).block();
+
+        assertThat(context)
+            .isEqualTo(Context.builder()
+                .processedMailboxEntries(2)
+                .processedMailboxPathEntries(1)
+                .fixedInconsistencies(0)
+                .addConflictingEntry(ConflictingEntry.builder()
+                    .mailboxDaoEntry(MAILBOX)
+                    .mailboxPathDaoEntry(MAILBOX_PATH, CASSANDRA_ID_2))
+                .build());
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldUpdateContextWhenDAOMisMatchOnPath() {
+        Context context = new Context();
+        mailboxDAO.save(MAILBOX).block();
+        mailboxPathV2DAO.save(NEW_MAILBOX_PATH, CASSANDRA_ID_1).block();
+
+        testee.fixMailboxInconsistencies(context).block();
+
+        assertThat(context)
+            .isEqualTo(Context.builder()
+                .processedMailboxEntries(1)
+                .processedMailboxPathEntries(1)
+                .fixedInconsistencies(1)
+                .addConflictingEntry(ConflictingEntry.builder()
+                    .mailboxDaoEntry(MAILBOX)
+                    .mailboxPathDaoEntry(NEW_MAILBOX_PATH, CASSANDRA_ID_1))
+                .build());
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldNotAlterStateWhenEmpty() {
+        testee.fixMailboxInconsistencies(new Context()).block();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(mailboxDAO.retrieveAllMailboxes().collectList().block()).isEmpty();
+            softly.assertThat(mailboxPathV2DAO.listAll().collectList().block()).isEmpty();
+        });
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldNotAlterStateWhenConsistent() {
+        mailboxDAO.save(MAILBOX).block();
+        mailboxPathV2DAO.save(MAILBOX_PATH, CASSANDRA_ID_1).block();
+
+        testee.fixMailboxInconsistencies(new Context()).block();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(mailboxDAO.retrieveAllMailboxes().collectList().block())
+                .containsExactlyInAnyOrder(MAILBOX);
+            softly.assertThat(mailboxPathV2DAO.listAll().collectList().block())
+                .containsExactlyInAnyOrder(new CassandraIdAndPath(CASSANDRA_ID_1, MAILBOX_PATH));
+        });
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldAlterStateWhenOrphanMailbox() {
+        mailboxDAO.save(MAILBOX).block();
+
+        testee.fixMailboxInconsistencies(new Context()).block();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(mailboxDAO.retrieveAllMailboxes().collectList().block())
+                .containsExactlyInAnyOrder(MAILBOX);
+            softly.assertThat(mailboxPathV2DAO.listAll().collectList().block())
+                .containsExactlyInAnyOrder(new CassandraIdAndPath(CASSANDRA_ID_1, MAILBOX_PATH));
+        });
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldAlterStateWhenOrphanMailboxPath() {
+        mailboxPathV2DAO.save(MAILBOX_PATH, CASSANDRA_ID_1).block();
+
+        testee.fixMailboxInconsistencies(new Context()).block();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(mailboxDAO.retrieveAllMailboxes().collectList().block())
+                .isEmpty();
+            softly.assertThat(mailboxPathV2DAO.listAll().collectList().block())
+                .isEmpty();
+        });
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldNotAlterStateWhenLoop() {
+        mailboxDAO.save(MAILBOX).block();
+        Mailbox mailbox2 = new Mailbox(NEW_MAILBOX_PATH, UID_VALIDITY_2, CASSANDRA_ID_2);
+        mailboxDAO.save(mailbox2).block();
+        mailboxPathV2DAO.save(MAILBOX_PATH, CASSANDRA_ID_2).block();
+        mailboxPathV2DAO.save(NEW_MAILBOX_PATH, CASSANDRA_ID_1).block();
+
+        testee.fixMailboxInconsistencies(new Context()).block();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(mailboxDAO.retrieveAllMailboxes().collectList().block())
+                .containsExactlyInAnyOrder(MAILBOX, mailbox2);
+            softly.assertThat(mailboxPathV2DAO.listAll().collectList().block())
+                .containsExactlyInAnyOrder(
+                    new CassandraIdAndPath(CASSANDRA_ID_1, NEW_MAILBOX_PATH),
+                    new CassandraIdAndPath(CASSANDRA_ID_2, MAILBOX_PATH));
+        });
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldAlterStateWhenDaoMisMatchOnPath() {
+        // Note that CASSANDRA_ID_1 becomes usable
+        // However in order to avoid data loss, merging CASSANDRA_ID_1 and CASSANDRA_ID_2 is still required
+        mailboxDAO.save(MAILBOX).block();
+        mailboxPathV2DAO.save(NEW_MAILBOX_PATH, CASSANDRA_ID_1).block();
+
+        testee.fixMailboxInconsistencies(new Context()).block();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(mailboxDAO.retrieveAllMailboxes().collectList().block())
+                .containsExactlyInAnyOrder(MAILBOX);
+            softly.assertThat(mailboxPathV2DAO.listAll().collectList().block())
+                .containsExactlyInAnyOrder(
+                    new CassandraIdAndPath(CASSANDRA_ID_1, NEW_MAILBOX_PATH),
+                    new CassandraIdAndPath(CASSANDRA_ID_1, MAILBOX_PATH));
+        });
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldAlterStateWhenDaoMisMatchOnId() {
+        mailboxDAO.save(MAILBOX).block();
+        mailboxPathV2DAO.save(MAILBOX_PATH, CASSANDRA_ID_2).block();
+
+        testee.fixMailboxInconsistencies(new Context()).block();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(mailboxDAO.retrieveAllMailboxes().collectList().block())
+                .containsExactlyInAnyOrder(MAILBOX);
+            softly.assertThat(mailboxPathV2DAO.listAll().collectList().block())
+                .isEmpty();
+        });
+    }
+
+    @Test
+    void multipleRunShouldDaoMisMatchOnId() {
+        mailboxDAO.save(MAILBOX).block();
+        mailboxPathV2DAO.save(MAILBOX_PATH, CASSANDRA_ID_2).block();
+
+        testee.fixMailboxInconsistencies(new Context()).block();
+        testee.fixMailboxInconsistencies(new Context()).block();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(mailboxDAO.retrieveAllMailboxes().collectList().block())
+                .containsExactlyInAnyOrder(MAILBOX);
+            softly.assertThat(mailboxPathV2DAO.listAll().collectList().block())
+                .containsExactlyInAnyOrder(new CassandraIdAndPath(CASSANDRA_ID_1, MAILBOX_PATH));
+        });
+    }
+
+    @Test
+    void fixMailboxInconsistenciesShouldNotAlterStateWhenTwoEntriesWithSamePath() {
+        // Both mailbox merge is required
+        Mailbox mailbox2 = new Mailbox(MAILBOX_PATH, UID_VALIDITY_2, CASSANDRA_ID_2);
+
+        mailboxDAO.save(MAILBOX).block();
+        mailboxPathV2DAO.save(MAILBOX_PATH, CASSANDRA_ID_2).block();
+        mailboxDAO.save(mailbox2).block();
+
+        testee.fixMailboxInconsistencies(new Context()).block();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(mailboxDAO.retrieveAllMailboxes().collectList().block())
+                .containsExactlyInAnyOrder(MAILBOX, mailbox2);
+            softly.assertThat(mailboxPathV2DAO.listAll().collectList().block())
+                .containsExactlyInAnyOrder(
+                    new CassandraIdAndPath(CASSANDRA_ID_2, MAILBOX_PATH));
+        });
+    }
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesTaskSerializationTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesTaskSerializationTest.java
@@ -1,0 +1,85 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.task;
+
+import static org.mockito.Mockito.mock;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.apache.james.JsonSerializationVerifier;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.model.MailboxConstants;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+class SolveMailboxInconsistenciesTaskSerializationTest {
+    private static final Instant TIMESTAMP = Instant.parse("2018-11-13T12:00:55Z");
+    private static final Username USERNAME = Username.of("user");
+    private static final MailboxPath MAILBOX_PATH = new MailboxPath(MailboxConstants.USER_NAMESPACE, USERNAME, "mailboxName");
+    private static final MailboxPath MAILBOX_PATH_2 = new MailboxPath(MailboxConstants.USER_NAMESPACE, USERNAME, "mailboxName2");
+    private static final CassandraId MAILBOX_ID = CassandraId.of(UUID.fromString("464765a0-e4e7-11e4-aba4-710c1de3782b"));
+
+    private static final SolveMailboxInconsistenciesService SERVICE = mock(SolveMailboxInconsistenciesService.class);
+    private static final SolveMailboxInconsistenciesTask TASK = new SolveMailboxInconsistenciesTask(SERVICE);
+    private static final String SERIALIZED_TASK = "{\"type\": \"solve-mailbox-inconsistencies\"}";
+    private static final ConflictingEntry CONFLICTING_ENTRY = ConflictingEntry.builder()
+        .mailboxDaoEntry(MAILBOX_PATH, MAILBOX_ID)
+        .mailboxPathDaoEntry(MAILBOX_PATH_2, MAILBOX_ID);
+    private static final ImmutableList<ConflictingEntry> CONFLICTING_ENTRIES = ImmutableList.of(CONFLICTING_ENTRY);
+    private static final SolveMailboxInconsistenciesTask.Details DETAILS = new SolveMailboxInconsistenciesTask.Details(TIMESTAMP, 0, 1, 2, CONFLICTING_ENTRIES, 3);
+    private static final String SERIALIZED_ADDITIONAL_INFORMATION = "{" +
+        "  \"type\":\"solve-mailbox-inconsistencies\"," +
+        "  \"processedMailboxEntries\":0," +
+        "  \"processedMailboxPathEntries\":1," +
+        "  \"fixedInconsistencies\":2," +
+        "  \"conflictingEntries\":[{" +
+        "    \"mailboxDaoEntry\":{" +
+        "      \"mailboxPath\":\"#private:user:mailboxName\"," +
+        "      \"mailboxId\":\"464765a0-e4e7-11e4-aba4-710c1de3782b\"" +
+        "    }," +
+        "    \"mailboxPathDaoEntry\":{" +
+        "      \"mailboxPath\":\"#private:user:mailboxName2\"," +
+        "      \"mailboxId\":\"464765a0-e4e7-11e4-aba4-710c1de3782b\"" +
+        "    }" +
+        "  }]," +
+        "  \"errors\":3," +
+        "  \"timestamp\":\"2018-11-13T12:00:55Z\"" +
+        "}";
+
+    @Test
+    void taskShouldBeSerializable() throws Exception {
+        JsonSerializationVerifier.dtoModule(SolveMailboxInconsistenciesTaskDTO.module(SERVICE))
+            .bean(TASK)
+            .json(SERIALIZED_TASK)
+            .verify();
+    }
+
+    @Test
+    void additionalInformationShouldBeSerializable() throws Exception {
+        JsonSerializationVerifier.dtoModule(SolveMailboxInconsistenciesTaskAdditionalInformationDTO.MODULE)
+            .bean(DETAILS)
+            .json(SERIALIZED_ADDITIONAL_INFORMATION)
+            .verify();
+    }
+}

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/TaskSerializationModule.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/TaskSerializationModule.java
@@ -34,6 +34,9 @@ import org.apache.james.json.DTOModule;
 import org.apache.james.mailbox.cassandra.mail.task.MailboxMergingTaskAdditionalInformationDTO;
 import org.apache.james.mailbox.cassandra.mail.task.MailboxMergingTaskDTO;
 import org.apache.james.mailbox.cassandra.mail.task.MailboxMergingTaskRunner;
+import org.apache.james.mailbox.cassandra.mail.task.SolveMailboxInconsistenciesService;
+import org.apache.james.mailbox.cassandra.mail.task.SolveMailboxInconsistenciesTaskAdditionalInformationDTO;
+import org.apache.james.mailbox.cassandra.mail.task.SolveMailboxInconsistenciesTaskDTO;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.queue.api.MailQueueFactory;
@@ -251,6 +254,11 @@ public class TaskSerializationModule extends AbstractModule {
     }
 
     @ProvidesIntoSet
+    public TaskDTOModule<?, ?> solveMailboxInconsistenciesTask(SolveMailboxInconsistenciesService service) {
+        return SolveMailboxInconsistenciesTaskDTO.module(service);
+    }
+
+    @ProvidesIntoSet
     public TaskDTOModule<?, ?> messageIdReindexingTask(MessageIdReIndexingTask.Factory factory) {
         return MessageIdReindexingTaskDTO.module(factory);
     }
@@ -353,6 +361,11 @@ public class TaskSerializationModule extends AbstractModule {
     @ProvidesIntoSet
     public AdditionalInformationDTOModule<?, ?> mailboxMergingAdditionalInformation() {
         return MailboxMergingTaskAdditionalInformationDTO.SERIALIZATION_MODULE;
+    }
+
+    @ProvidesIntoSet
+    public AdditionalInformationDTOModule<?, ?> solveMailboxInconsistenciesAdditionalInformation() {
+        return SolveMailboxInconsistenciesTaskAdditionalInformationDTO.MODULE;
     }
 
     @ProvidesIntoSet


### PR DESCRIPTION
Instrument the Cassandra delay to enable on-statement synchronisation.

I demonstrate in this work that the `Cassandra mailbox inconsistencies` do not cancel a "create mailbox" statement it did a dirty-read on.

(The test was originaly failing)