### PR TITLE
Suppress concurrent test runner logs in case of huge number of operations

### DIFF
--- a/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusTest.java
+++ b/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusTest.java
@@ -555,6 +555,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
                     .operation((threadNumber, step) -> eventBus.dispatch(EVENT, KEY_1).block())
                     .threadCount(THREAD_COUNT)
                     .operationCount(OPERATION_COUNT)
+                    .noErrorLogs()
                     .run()) {
 
                     TimeUnit.SECONDS.sleep(2);
@@ -647,6 +648,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
                     .operation((threadNumber, step) -> eventBus.dispatch(EVENT, KEY_1).block())
                     .threadCount(THREAD_COUNT)
                     .operationCount(OPERATION_COUNT)
+                    .noErrorLogs()
                     .run()) {
 
                     TimeUnit.SECONDS.sleep(2);


### PR DESCRIPTION
The test executes 10 x 100.000 operations. My guess that it's the cause of the logs size increasing on CI

![log](https://user-images.githubusercontent.com/39297818/75234471-42ee4a80-57ed-11ea-98f0-cad1c37bea19.png)
