### PR TITLE
James 3080 - persist message on disk in rabbitMQ for the task manager workqueue

### DIFF
--- a/server/task/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueue.java
+++ b/server/task/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueue.java
@@ -36,10 +36,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Delivery;
-
 import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.UnicastProcessor;
@@ -93,11 +93,15 @@ public class RabbitMQWorkQueue implements WorkQueue {
     }
 
     private void startWorkqueue() {
+        declareQueue();
+        consumeWorkqueue();
+    }
+
+    @VisibleForTesting
+    void declareQueue() {
         channelPool.getSender().declareExchange(ExchangeSpecification.exchange(EXCHANGE_NAME)).block();
         channelPool.getSender().declare(QueueSpecification.queue(QUEUE_NAME).durable(true).arguments(Constants.WITH_SINGLE_ACTIVE_CONSUMER)).block();
         channelPool.getSender().bind(BindingSpecification.binding(EXCHANGE_NAME, ROUTING_KEY, QUEUE_NAME)).block();
-
-        consumeWorkqueue();
     }
 
     private void consumeWorkqueue() {

--- a/server/task/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueue.java
+++ b/server/task/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueue.java
@@ -59,8 +59,6 @@ import reactor.rabbitmq.Sender;
 public class RabbitMQWorkQueue implements WorkQueue {
     private static final Logger LOGGER = LoggerFactory.getLogger(RabbitMQWorkQueue.class);
 
-    // Need at least one by receivers plus a shared one for senders
-    static final Integer MAX_CHANNELS_NUMBER = 5;
     static final String EXCHANGE_NAME = "taskManagerWorkQueueExchange";
     static final String QUEUE_NAME = "taskManagerWorkQueue";
     static final String ROUTING_KEY = "taskManagerWorkQueueRoutingKey";
@@ -73,7 +71,6 @@ public class RabbitMQWorkQueue implements WorkQueue {
     private final TaskManagerWorker worker;
     private final ReactorRabbitMQChannelPool channelPool;
     private final JsonTaskSerializer taskSerializer;
-    private Sender sender;
     private Receiver receiver;
     private UnicastProcessor<TaskId> sendCancelRequestsQueue;
     private Disposable sendCancelRequestsQueueHandle;

--- a/server/task/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueue.java
+++ b/server/task/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueue.java
@@ -42,6 +42,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Delivery;
+
 import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.UnicastProcessor;

--- a/server/task/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueue.java
+++ b/server/task/task-distributed/src/main/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueue.java
@@ -20,6 +20,8 @@
 
 package org.apache.james.task.eventsourcing.distributed;
 
+import static com.rabbitmq.client.MessageProperties.PERSISTENT_TEXT_PLAIN;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.UUID;
@@ -184,8 +186,12 @@ public class RabbitMQWorkQueue implements WorkQueue {
         try {
             byte[] payload = taskSerializer.serialize(taskWithId.getTask()).getBytes(StandardCharsets.UTF_8);
             AMQP.BasicProperties basicProperties = new AMQP.BasicProperties.Builder()
+                .deliveryMode(PERSISTENT_TEXT_PLAIN.getDeliveryMode())
+                .priority(PERSISTENT_TEXT_PLAIN.getPriority())
+                .contentType(PERSISTENT_TEXT_PLAIN.getContentType())
                 .headers(ImmutableMap.of(TASK_ID, taskWithId.getId().asString()))
                 .build();
+
             OutboundMessage outboundMessage = new OutboundMessage(EXCHANGE_NAME, ROUTING_KEY, basicProperties, payload);
             channelPool.getSender().send(Mono.just(outboundMessage)).block();
         } catch (JsonProcessingException e) {

--- a/server/task/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/ImmediateWorker.java
+++ b/server/task/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/ImmediateWorker.java
@@ -1,0 +1,60 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.task.eventsourcing.distributed;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.task.TaskId;
+import org.apache.james.task.TaskManagerWorker;
+import org.apache.james.task.TaskWithId;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+class ImmediateWorker implements TaskManagerWorker {
+
+    ConcurrentLinkedQueue<TaskWithId> tasks = new ConcurrentLinkedQueue<>();
+    ConcurrentLinkedQueue<Task.Result> results = new ConcurrentLinkedQueue<>();
+    ConcurrentLinkedQueue<TaskId> failedTasks = new ConcurrentLinkedQueue<>();
+
+    @Override
+    public Mono<Task.Result> executeTask(TaskWithId taskWithId) {
+        tasks.add(taskWithId);
+        return Mono.fromCallable(() -> taskWithId.getTask().run())
+            .doOnNext(result -> results.add(result))
+            .subscribeOn(Schedulers.elastic());
+    }
+
+    @Override
+    public void cancelTask(TaskId taskId) {
+    }
+
+    @Override
+    public void fail(TaskId taskId, Optional<TaskExecutionDetails.AdditionalInformation> additionalInformation, String errorMessage, Throwable reason) {
+        failedTasks.add(taskId);
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+}

--- a/server/task/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueuePersistenceTest.java
+++ b/server/task/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueuePersistenceTest.java
@@ -35,7 +35,6 @@ import org.apache.james.task.TaskId;
 import org.apache.james.task.TaskWithId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -70,7 +69,6 @@ class RabbitMQWorkQueuePersistenceTest {
      * start a workqueue which consume messages
      * verify that the message is treated
      */
-    @Disabled("JAMES-3080 rabbitMQ messages need to be persisted")
     @Test
     void submittedMessageShouldSurviveRabbitMQRestart() throws Exception {
         Task TASK = new MemoryReferenceTask(() -> Task.Result.COMPLETED);

--- a/server/task/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueuePersistenceTest.java
+++ b/server/task/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueuePersistenceTest.java
@@ -1,0 +1,109 @@
+/**
+ * *************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                   *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ***************************************************************/
+package org.apache.james.task.eventsourcing.distributed;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Duration.FIVE_HUNDRED_MILLISECONDS;
+import static org.awaitility.Duration.FIVE_SECONDS;
+import static org.mockito.Mockito.spy;
+
+import org.apache.james.backends.rabbitmq.RabbitMQExtension;
+import org.apache.james.server.task.json.JsonTaskSerializer;
+import org.apache.james.server.task.json.dto.MemoryReferenceTaskStore;
+import org.apache.james.server.task.json.dto.TestTaskDTOModules;
+import org.apache.james.task.MemoryReferenceTask;
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskId;
+import org.apache.james.task.TaskWithId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class RabbitMQWorkQueuePersistenceTest {
+    private static final TaskId TASK_ID = TaskId.fromString("2c7f4081-aa30-11e9-bf6c-2d3b9e84aafd");
+
+    @RegisterExtension
+    RabbitMQExtension rabbitMQExtension = RabbitMQExtension.defaultRabbitMQ()
+        .restartPolicy(RabbitMQExtension.DockerRestartPolicy.PER_TEST);
+
+    private RabbitMQWorkQueue testee;
+    private ImmediateWorker worker;
+    private JsonTaskSerializer serializer;
+
+    @BeforeEach
+    void setUp() {
+        worker = spy(new ImmediateWorker());
+        serializer = JsonTaskSerializer.of(TestTaskDTOModules.COMPLETED_TASK_MODULE, TestTaskDTOModules.MEMORY_REFERENCE_TASK_MODULE.apply(new MemoryReferenceTaskStore()));
+        testee = new RabbitMQWorkQueue(worker, rabbitMQExtension.getRabbitChannelPool(), serializer);
+        //declare the queue but do not start consuming from it
+        testee.declareQueue();
+    }
+
+    @AfterEach
+    void tearDown() {
+        testee.close();
+    }
+
+    /**
+     * submit on a workqueue which do not consume
+     * restart rabbit
+     * start a workqueue which consume messages
+     * verify that the message is treated
+     */
+    @Disabled("JAMES-3080 rabbitMQ messages need to be persisted")
+    @Test
+    void submittedMessageShouldSurviveRabbitMQRestart() throws Exception {
+        Task TASK = new MemoryReferenceTask(() -> Task.Result.COMPLETED);
+
+        TaskWithId TASK_WITH_ID = new TaskWithId(TASK_ID, TASK);
+
+        testee.submit(TASK_WITH_ID);
+
+        //wait for submit to be effective
+        Thread.sleep(500);
+        testee.close();
+
+        restartRabbitMQ();
+
+        startNewWorkqueue();
+
+        await().atMost(FIVE_HUNDRED_MILLISECONDS).until(() -> !worker.results.isEmpty());
+
+        assertThat(worker.tasks).containsExactly(TASK_WITH_ID);
+        assertThat(worker.results).containsExactly(Task.Result.COMPLETED);
+    }
+
+    private void startNewWorkqueue() {
+        worker = spy(new ImmediateWorker());
+        testee = new RabbitMQWorkQueue(worker, rabbitMQExtension.getRabbitChannelPool(), serializer);
+        testee.start();
+    }
+
+    private void restartRabbitMQ() throws Exception {
+        rabbitMQExtension.getRabbitMQ().stopApp();
+        rabbitMQExtension.getRabbitMQ().startApp();
+        //wait until healthcheck is ok
+        await().atMost(FIVE_SECONDS).until(() -> rabbitMQExtension.managementAPI().listQueues().size() > 0);
+        rabbitMQExtension.getRabbitChannelPool().start();
+    }
+}

--- a/server/task/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueueTest.java
+++ b/server/task/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/RabbitMQWorkQueueTest.java
@@ -27,10 +27,6 @@ import static org.awaitility.Duration.FIVE_HUNDRED_MILLISECONDS;
 import static org.awaitility.Duration.TWO_SECONDS;
 import static org.mockito.Mockito.spy;
 
-import java.io.IOException;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.IntStream;
 
@@ -42,9 +38,7 @@ import org.apache.james.server.task.json.dto.TestTaskDTOModules;
 import org.apache.james.task.CompletedTask;
 import org.apache.james.task.MemoryReferenceTask;
 import org.apache.james.task.Task;
-import org.apache.james.task.TaskExecutionDetails;
 import org.apache.james.task.TaskId;
-import org.apache.james.task.TaskManagerWorker;
 import org.apache.james.task.TaskWithId;
 import org.awaitility.core.ConditionTimeoutException;
 import org.hamcrest.CoreMatchers;
@@ -52,9 +46,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-
-import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 class RabbitMQWorkQueueTest {
     private static final TaskId TASK_ID = TaskId.fromString("2c7f4081-aa30-11e9-bf6c-2d3b9e84aafd");
@@ -73,33 +64,6 @@ class RabbitMQWorkQueueTest {
     private ImmediateWorker worker;
     private JsonTaskSerializer serializer;
 
-    private static class ImmediateWorker implements TaskManagerWorker {
-
-        ConcurrentLinkedQueue<TaskWithId> tasks = new ConcurrentLinkedQueue<>();
-        ConcurrentLinkedQueue<Task.Result> results = new ConcurrentLinkedQueue<>();
-        ConcurrentLinkedQueue<TaskId> failedTasks = new ConcurrentLinkedQueue<>();
-
-        @Override
-        public Mono<Task.Result> executeTask(TaskWithId taskWithId) {
-            tasks.add(taskWithId);
-            return Mono.fromCallable(() -> taskWithId.getTask().run())
-                .doOnNext(result -> results.add(result))
-                .subscribeOn(Schedulers.elastic());
-        }
-
-        @Override
-        public void cancelTask(TaskId taskId) {
-        }
-
-        @Override
-        public void fail(TaskId taskId, Optional<TaskExecutionDetails.AdditionalInformation> additionalInformation,String errorMessage, Throwable reason) {
-            failedTasks.add(taskId);
-        }
-
-        @Override
-        public void close() throws IOException {
-        }
-    }
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
Regarding the persistence of messages in rabbitmq : To achieve this there are two steps :

    the queue must be declared as durable (the declaration of the queue is persisted rabbitmq is restarted)
    when sending a message, it must have a property setting its delivery_mode to persistent. (the messages with this property are persisted in case of a restart of rabbitmq)

At the time being the rabbitmq workqueue in james :

    the queue is declared durable => Good
    the delivery_mode property is not set => Not good
    the exchange is not declared durable => Seems not good, but need testing

What should be done is :

    set the `delivery_mode` property to '2' ( see https://www.rabbitmq.com/releases/rabbitmq-java-client/v2.4.1/rabbitmq-java-client-javadoc-2.4.1/index.html?com/rabbitmq/client/MessageProperties.html )

    verify if the exchange need to be declared 'durable' too. if so it will need an entry in the migration guide. As it will need to be deleted an created back with the new properties.