### PR TITLE
JAMES-3073: HybridBlobStore: Option to always write to ObjectStorage

### DIFF
--- a/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/blob.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/blob.properties
@@ -12,8 +12,9 @@ implementation=objectstorage
 # Optional, defaults to 32768 bytes (32KB), must be positive
 hybrid.size.threshold=32768
 
-# A option to store data both in cassandra and objectstorage for in case of rough backup.
-hybrid.duplicate.writes=true
+# An optional to store data both in cassandra and objectstorage for in case of rough backup.
+# Enabling this option in the only way to make the adoption of hybrid blob store reversible, however you will loose performance/cost gains on writes
+hybrid.duplicate.writes=false
 
 # ============================================== ObjectStorage ============================================
 

--- a/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/blob.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/blob.properties
@@ -12,6 +12,9 @@ implementation=objectstorage
 # Optional, defaults to 32768 bytes (32KB), must be positive
 hybrid.size.threshold=32768
 
+# A option to store data both in cassandra and objectstorage for in case of rough backup.
+hybrid.duplicate.writes=true
+
 # ============================================== ObjectStorage ============================================
 
 # ========================================= ObjectStorage Codec ======================================

--- a/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/blob.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/blob.properties
@@ -12,8 +12,10 @@ implementation=objectstorage
 # Optional, defaults to 32768 bytes (32KB), must be positive
 hybrid.size.threshold=32768
 
-# A option to store data both in cassandra and objectstorage for in case of rough backup.
-hybrid.duplicate.writes=true
+# An optional to store data both in cassandra and objectstorage for in case of rough backup.
+# Enabling this option in the only way to make the adoption of hybrid blob store reversible, however you will loose performance/cost gains on writes
+# By setting this 'true'
+hybrid.duplicate.writes=false
 
 # ============================================== ObjectStorage ============================================
 

--- a/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/blob.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/blob.properties
@@ -12,6 +12,9 @@ implementation=objectstorage
 # Optional, defaults to 32768 bytes (32KB), must be positive
 hybrid.size.threshold=32768
 
+# A option to store data both in cassandra and objectstorage for in case of rough backup.
+hybrid.duplicate.writes=true
+
 # ============================================== ObjectStorage ============================================
 
 # ========================================= ObjectStorage Codec ======================================

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobStore.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobStore.java
@@ -27,8 +27,7 @@ public interface BlobStore {
 
     enum StoragePolicy {
         SIZE_BASED,
-        LOW_COST,
-        HIGH_PERFORMANCE
+        LOW_COST
     }
 
     Publisher<BlobId> save(BucketName bucketName, byte[] data, StoragePolicy storagePolicy);

--- a/server/blob/blob-union/src/main/java/org/apache/james/blob/union/HybridBlobStore.java
+++ b/server/blob/blob-union/src/main/java/org/apache/james/blob/union/HybridBlobStore.java
@@ -20,23 +20,22 @@
 package org.apache.james.blob.union;
 
 import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
-import java.util.function.Supplier;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BucketName;
 import org.apache.james.blob.api.ObjectNotFoundException;
-import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public class HybridBlobStore implements BlobStore {
@@ -78,11 +77,11 @@ public class HybridBlobStore implements BlobStore {
         public static final int DEFAULT_SIZE_THRESHOLD = 32 * 1024;
         public static final boolean DEFAULT_DUPLICATE_WRITE = false;
         public static final Configuration DEFAULT = new Configuration(DEFAULT_SIZE_THRESHOLD, DEFAULT_DUPLICATE_WRITE);
-        private static final String PROPERTY_NAME = "hybrid.size.threshold";
+        private static final String SIZE_THRESHOLD_PROPERTY = "hybrid.size.threshold";
         private static final String DUPLICATE_WRITE_PROPERTY = "hybrid.duplicate.writes";
 
         public static Configuration from(org.apache.commons.configuration2.Configuration propertiesConfiguration) {
-            return new Configuration(propertiesConfiguration.getInteger(PROPERTY_NAME, DEFAULT_SIZE_THRESHOLD),
+            return new Configuration(propertiesConfiguration.getInteger(SIZE_THRESHOLD_PROPERTY, DEFAULT_SIZE_THRESHOLD),
                 propertiesConfiguration.getBoolean(DUPLICATE_WRITE_PROPERTY, DEFAULT_DUPLICATE_WRITE));
         }
 
@@ -90,10 +89,17 @@ public class HybridBlobStore implements BlobStore {
         private final boolean duplicateWrite;
 
         public Configuration(int sizeThreshold, boolean duplicateWrite) {
-            Preconditions.checkArgument(sizeThreshold >= 0, "'" + PROPERTY_NAME + "' needs to be positive");
+            Preconditions.checkArgument(sizeThreshold >= 0, "'%s' needs to be positive", SIZE_THRESHOLD_PROPERTY);
 
             this.sizeThreshold = sizeThreshold;
             this.duplicateWrite = duplicateWrite;
+        }
+
+        public Configuration(int sizeThreshold) {
+            Preconditions.checkArgument(sizeThreshold >= 0, "'%s' needs to be positive", SIZE_THRESHOLD_PROPERTY);
+
+            this.sizeThreshold = sizeThreshold;
+            this.duplicateWrite = false;
         }
 
         public int getSizeThreshold() {
@@ -139,58 +145,60 @@ public class HybridBlobStore implements BlobStore {
 
     @Override
     public Mono<BlobId> save(BucketName bucketName, byte[] data, StoragePolicy storagePolicy) {
-        return Flux.from(selectBlobStores(storagePolicy, Mono.just(data.length > configuration.getSizeThreshold())))
-            .flatMap(blobStore -> blobStore.save(bucketName, data, storagePolicy))
-            .distinct()
-            .single();
+        return save(bucketName, new ByteArrayInputStream(data), storagePolicy);
     }
 
     @Override
     public Mono<BlobId> save(BucketName bucketName, InputStream data, StoragePolicy storagePolicy) {
         Preconditions.checkNotNull(data);
 
-        Supplier<byte[]> byteSupplier = () -> {
-            try {
-                return readAllBytes(new BufferedInputStream(data, configuration.getSizeThreshold() + 1));
-            } catch (IOException e) {
-                LOGGER.error("Error when reading bytes from InputStream, cause: {}", e.getMessage());
-            }
-            return new byte[0];
-        };
-
-        return save(bucketName, byteSupplier.get(), storagePolicy);
-    }
-
-    private Publisher<BlobStore> selectBlobStores(StoragePolicy storagePolicy, Mono<Boolean> largeData) {
         switch (storagePolicy) {
             case LOW_COST:
-                return Mono.just(lowCostBlobStore);
+                return Mono.from(lowCostBlobStore.save(bucketName, data, storagePolicy))
+                    .doFinally(any -> closeInputStream(data));
 
             case SIZE_BASED:
-                return largeData.flux()
+                BufferedInputStream bufferedInputStream = new BufferedInputStream(data, configuration.getSizeThreshold() + 1);
+                return Mono.fromCallable(() -> isLargeStream(bufferedInputStream))
                     .filter(Boolean::booleanValue)
-                    .map(ignored -> lowCostBlobStore)
-                    .switchIfEmpty(
-                        Flux.just(configuration.isDuplicateWrite())
-                            .filter(duplicateWrite -> !duplicateWrite)
-                            .map(ignored -> highPerformanceBlobStore)
-                            .switchIfEmpty(Flux.just(highPerformanceBlobStore, lowCostBlobStore)));
-
-            case HIGH_PERFORMANCE:
-                return Flux.just(this.configuration.isDuplicateWrite())
-                    .filter(duplicateWrite -> !duplicateWrite)
-                    .map(ignored -> highPerformanceBlobStore)
-                    .switchIfEmpty(Flux.just(highPerformanceBlobStore, lowCostBlobStore));
+                    .flatMap(ignored -> Mono.from(lowCostBlobStore.save(bucketName, bufferedInputStream, storagePolicy)))
+                    .switchIfEmpty(checkingDuplicateWriteThenSave(bucketName, readAllBytes(bufferedInputStream), storagePolicy))
+                    .doFinally(any -> closeInputStream(data));
 
             default:
                 throw new RuntimeException("Unknown storage policy: " + storagePolicy);
         }
     }
 
-    private byte[] readAllBytes(InputStream inputStream) throws IOException {
-        byte[] bytes = new byte[inputStream.available()];
-        inputStream.read(bytes);
-        return bytes;
+    private void closeInputStream(InputStream inputStream) {
+        try {
+            inputStream.close();
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+    }
+
+    private Mono<BlobId> checkingDuplicateWriteThenSave(BucketName bucketName, Mono<byte[]> bytesData, StoragePolicy storagePolicy) {
+        return Mono.fromCallable(configuration::isDuplicateWrite)
+            .filter(Boolean::booleanValue)
+            .flatMap(allowDuplicateWrite ->
+                bytesData.flatMap(bytes ->
+                    Mono.from(lowCostBlobStore.save(bucketName, bytes, storagePolicy))
+                        .then(Mono.from(highPerformanceBlobStore.save(bucketName, bytes, storagePolicy)))))
+            .switchIfEmpty(bytesData.flatMap(bytes -> Mono.from(highPerformanceBlobStore.save(bucketName, bytes, storagePolicy))));
+    }
+
+    private boolean isLargeStream(BufferedInputStream bufferedData) throws IOException {
+        bufferedData.mark(0);
+        bufferedData.skip(configuration.getSizeThreshold());
+        boolean isItABigStream = bufferedData.read() != -1;
+        bufferedData.reset();
+        return isItABigStream;
+    }
+
+    private Mono<byte[]> readAllBytes(BufferedInputStream bufferedInputStream) {
+        // In this case: InputStream are small and we need to reused data from InputStream
+        return Mono.fromCallable(() -> IOUtils.toByteArray(bufferedInputStream));
     }
 
     @Override

--- a/src/site/xdoc/server/config-blobstore.xml
+++ b/src/site/xdoc/server/config-blobstore.xml
@@ -56,6 +56,14 @@
                 </dl>
             </subsection>
 
+            <subsection name="Hybrid BlobStore option to always write to ObjectStorage">
+                <dl>
+                    <dt><strong>hybrid.duplicate.writes</strong></dt>
+                    <dd>DEFAULT: false, must be true/false. It happen only 'value = true' and it stored in cassandra.</dd>
+                    <dd>Enabling this option in the only way to make the adoption of hybrid blob store reversible, however you will lose performance/cost gains on writes</dd>
+                </dl>
+            </subsection>
+
             <subsection name="ObjectStorage BlobStore Codec Configuration">
                 <dl>
                     <dt><strong>objectstorage.payload.codec</strong></dt>


### PR DESCRIPTION
About storing small blobs in Cassandra, I think we should also be able to store them (duplicate them) in the object storage.
More precisely, even if an e-mail is so small we can entirely store it in Cassandra, we should have an option to say: "let's store it also in the object storage". So that there one location with all e-mails, in case of rough backup.
