### PR TITLE
Use enabled cipher suites in createPipelineFactory

### DIFF
--- a/protocols/netty/src/main/java/org/apache/james/protocols/netty/NettyServer.java
+++ b/protocols/netty/src/main/java/org/apache/james/protocols/netty/NettyServer.java
@@ -121,6 +121,7 @@ public class NettyServer extends AbstractAsyncServer {
             maxCurConnections,
             maxCurConnectionsPerIP,
             group,
+            secure != null ? secure.getEnabledCipherSuites() : null,
             eHandler,
             getFrameHandlerFactory(),
             hashedWheelTimer) {

--- a/server/blob/blob-api/pom.xml
+++ b/server/blob/blob-api/pom.xml
@@ -70,6 +70,11 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/MetricableBlobStoreContract.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/MetricableBlobStoreContract.java
@@ -27,11 +27,14 @@ import static org.apache.james.blob.api.MetricableBlobStore.READ_TIMER_NAME;
 import static org.apache.james.blob.api.MetricableBlobStore.SAVE_BYTES_TIMER_NAME;
 import static org.apache.james.blob.api.MetricableBlobStore.SAVE_INPUT_STREAM_TIMER_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.james.metrics.tests.RecordingMetricFactory;
+import org.awaitility.Duration;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -67,8 +70,9 @@ public interface MetricableBlobStoreContract extends BlobStoreContract {
         Mono.from(store.save(store.getDefaultBucketName(), BYTES_CONTENT, LOW_COST)).block();
         Mono.from(store.save(store.getDefaultBucketName(), BYTES_CONTENT, LOW_COST)).block();
 
-        assertThat(metricsTestExtension.getMetricFactory().executionTimesFor(SAVE_BYTES_TIMER_NAME))
-            .hasSize(2);
+        await().atMost(Duration.FIVE_SECONDS)
+            .untilAsserted(() ->  assertThat(metricsTestExtension.getMetricFactory().executionTimesFor(SAVE_BYTES_TIMER_NAME))
+                .hasSize(2));
     }
 
     @Test
@@ -78,8 +82,9 @@ public interface MetricableBlobStoreContract extends BlobStoreContract {
         Mono.from(store.save(store.getDefaultBucketName(), STRING_CONTENT, LOW_COST)).block();
         Mono.from(store.save(store.getDefaultBucketName(), STRING_CONTENT, LOW_COST)).block();
 
-        assertThat(metricsTestExtension.getMetricFactory().executionTimesFor(SAVE_BYTES_TIMER_NAME))
-            .hasSize(2);
+        await().atMost(Duration.FIVE_SECONDS)
+            .untilAsserted(() ->  assertThat(metricsTestExtension.getMetricFactory().executionTimesFor(SAVE_BYTES_TIMER_NAME))
+                .hasSize(2));
     }
 
     @Test
@@ -89,8 +94,9 @@ public interface MetricableBlobStoreContract extends BlobStoreContract {
         Mono.from(store.save(store.getDefaultBucketName(), new ByteArrayInputStream(BYTES_CONTENT), LOW_COST)).block();
         Mono.from(store.save(store.getDefaultBucketName(), new ByteArrayInputStream(BYTES_CONTENT), LOW_COST)).block();
 
-        assertThat(metricsTestExtension.getMetricFactory().executionTimesFor(SAVE_INPUT_STREAM_TIMER_NAME))
-            .hasSize(2);
+        await().atMost(Duration.FIVE_SECONDS)
+            .untilAsserted(() ->  assertThat(metricsTestExtension.getMetricFactory().executionTimesFor(SAVE_INPUT_STREAM_TIMER_NAME))
+                .hasSize(2));
     }
 
     @Test
@@ -101,8 +107,9 @@ public interface MetricableBlobStoreContract extends BlobStoreContract {
         Mono.from(store.readBytes(store.getDefaultBucketName(), blobId)).block();
         Mono.from(store.readBytes(store.getDefaultBucketName(), blobId)).block();
 
-        assertThat(metricsTestExtension.getMetricFactory().executionTimesFor(READ_BYTES_TIMER_NAME))
-            .hasSize(2);
+        await().atMost(Duration.FIVE_SECONDS)
+            .untilAsserted(() ->  assertThat(metricsTestExtension.getMetricFactory().executionTimesFor(READ_BYTES_TIMER_NAME))
+                .hasSize(2));
     }
 
     @Test
@@ -113,8 +120,9 @@ public interface MetricableBlobStoreContract extends BlobStoreContract {
         store.read(store.getDefaultBucketName(), blobId);
         store.read(store.getDefaultBucketName(), blobId);
 
-        assertThat(metricsTestExtension.getMetricFactory().executionTimesFor(READ_TIMER_NAME))
-            .hasSize(2);
+        await().atMost(Duration.FIVE_SECONDS)
+            .untilAsserted(() ->  assertThat(metricsTestExtension.getMetricFactory().executionTimesFor(READ_TIMER_NAME))
+                .hasSize(2));
     }
 
     @Test
@@ -127,8 +135,9 @@ public interface MetricableBlobStoreContract extends BlobStoreContract {
 
         Mono.from(store.deleteBucket(bucketName)).block();
 
-        assertThat(metricsTestExtension.getMetricFactory().executionTimesFor(DELETE_BUCKET_TIMER_NAME))
-            .hasSize(1);
+        await().atMost(Duration.FIVE_SECONDS)
+            .untilAsserted(() ->  assertThat(metricsTestExtension.getMetricFactory().executionTimesFor(DELETE_BUCKET_TIMER_NAME))
+                .hasSize(1));
     }
 
     @Test
@@ -141,7 +150,8 @@ public interface MetricableBlobStoreContract extends BlobStoreContract {
         Mono.from(store.delete(BucketName.DEFAULT, blobId1)).block();
         Mono.from(store.delete(BucketName.DEFAULT, blobId2)).block();
 
-        assertThat(metricsTestExtension.getMetricFactory().executionTimesFor(DELETE_TIMER_NAME))
-            .hasSize(2);
+        await().atMost(Duration.FIVE_SECONDS)
+            .untilAsserted(() ->  assertThat(metricsTestExtension.getMetricFactory().executionTimesFor(DELETE_TIMER_NAME))
+                .hasSize(2));
     }
 }

--- a/server/blob/blob-cassandra/pom.xml
+++ b/server/blob/blob-cassandra/pom.xml
@@ -72,6 +72,11 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/server/blob/blob-memory/pom.xml
+++ b/server/blob/blob-memory/pom.xml
@@ -66,6 +66,11 @@
             <artifactId>reactor-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/server/blob/blob-objectstorage/pom.xml
+++ b/server/blob/blob-objectstorage/pom.xml
@@ -112,6 +112,11 @@
             <version>${jclouds.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
For the created ChannelPipelineFactory to actually take into account the enabled cipher suites that have been set while constructing the NettyServer instance, they have to be given to the AbstractSSLAwareChannelPipelineFactory constructor.

See https://github.com/apache/james-project/pull/183