### PR TITLE
JAMES-3102 Allow to bypass alias user existence check

### DIFF
--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/AliasRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/AliasRoutes.java
@@ -81,6 +81,7 @@ public class AliasRoutes implements Routes {
     private static final String MAILADDRESS_ASCII_DISCLAIMER = "Note that email addresses are restricted to ASCII character set. " +
         "Mail addresses not matching this criteria will be rejected.";
     private static final String ADDRESS_TYPE = "alias";
+    private static final String BYPASS_USER_CHECK_QUERY_PARAM = "bypassUserCheck";
 
     private final UsersRepository usersRepository;
     private final JsonTransformer jsonTransformer;
@@ -146,7 +147,10 @@ public class AliasRoutes implements Routes {
     })
     public HaltException addAlias(Request request, Response response) throws UsersRepositoryException, RecipientRewriteTableException {
         MailAddress aliasSourceAddress = MailAddressParser.parseMailAddress(request.params(ALIAS_SOURCE_ADDRESS), ADDRESS_TYPE);
-        ensureUserDoesNotExist(aliasSourceAddress);
+        boolean bypass = request.queryParams().contains(BYPASS_USER_CHECK_QUERY_PARAM);
+        if (!bypass) {
+            ensureUserDoesNotExist(aliasSourceAddress);
+        }
         MailAddress destinationAddress = MailAddressParser.parseMailAddress(request.params(ALIAS_DESTINATION_ADDRESS), ADDRESS_TYPE);
         MappingSource source = MappingSource.fromUser(Username.fromMailAddress(aliasSourceAddress));
         addAlias(source, destinationAddress);

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/AliasRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/AliasRoutesTest.java
@@ -231,6 +231,29 @@ class AliasRoutesTest {
         }
 
         @Test
+        void putExistingUserAsAliasSourceShouldBePossibleWhenByPass() {
+            given()
+                .queryParam("bypassUserCheck")
+                .put(BOB + SEPARATOR + "sources" + SEPARATOR + ALICE)
+            .then()
+                .statusCode(HttpStatus.NO_CONTENT_204);
+        }
+
+        @Test
+        void putExistingUserAsAliasSourceShouldCreateTheAliasWhenByPass() {
+            with()
+                .queryParam("bypassUserCheck")
+                .put(BOB + SEPARATOR + "sources" + SEPARATOR + ALICE);
+
+            when()
+                .get(BOB)
+            .then()
+                .contentType(ContentType.JSON)
+                .statusCode(HttpStatus.OK_200)
+                .body("source", hasItems(ALICE));
+        }
+
+        @Test
         void putSameSourceAndDestinationShouldReturnBadRequest() {
             Map<String, Object> errors = when()
                 .put(BOB_ALIAS + SEPARATOR + "sources" + SEPARATOR + BOB_ALIAS)

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -1802,6 +1802,15 @@ curl -XPUT http://ip:port/address/aliases/user@domain.com/sources/alias@domain.c
 
 Will add alias@domain.com to user@domain.com, creating the alias if needed
 
+And additional `bypassUserCheck` allows to use an existing username as a source of the alias, allowing effective email 
+traffic redirection.
+
+Example:
+
+```
+curl -XPUT http://ip:port/address/aliases/user@domain.com/sources/alias@domain.com?bypassUserCheck
+```
+
 Response codes:
 
  - 204: OK


### PR DESCRIPTION
User A had been changing name (to user B) and both entries exist in the LDAP.

We want User B to send and receive mails from UserA address.

We are using LDAP repository. We cannot delete user A from the LDAP. We can not create the alias as user A exists.

Thus we want to be able to 'force' the alias insertion despite the rule that a user can't be used as an alias source.

Traffic of user A will effectively be redirected to user B. Moreover User B will still be able to send mails using user A identify (not possible with forwards).

The proposal is to introduce a new query parameter allowing to bypass the check, while keeping the behaviour untouched otherwise.

Example:

curl -XPUT http://ip:port/address/aliases/user@domain.com/sources/alias@domain.com?bypassUserCheck