### PR TITLE
JAMES-3105 Corrective task for fixing mailbox counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ of tasks being currently executed.
 - JAMES-3066 Add "allowed From headers" webadmin endpoint
 - JAMES-3062 EventDeadLettersHealthCheck
 - JAMES-3058 WebAdmin offline task to correct mailbox inconsistencies on top of Cassandra products
+- JAMES-3105 WebAdmin offline task to recompute mailbox counters on top of Cassandra products
 
 ### Changed
 - Multiple changes have been made to enhance ElasticSearch performance:

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxCounters.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxCounters.java
@@ -21,6 +21,7 @@ package org.apache.james.mailbox.model;
 
 import java.util.Optional;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
@@ -95,5 +96,14 @@ public class MailboxCounters {
     @Override
     public final int hashCode() {
         return Objects.hashCode(count, unseen, mailboxId);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("mailboxId", mailboxId)
+            .add("count", count)
+            .add("unseen", unseen)
+            .toString();
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/ids/CassandraMessageId.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/ids/CassandraMessageId.java
@@ -41,7 +41,7 @@ public class CassandraMessageId implements MessageId {
         }
 
         @Override
-        public MessageId fromString(String serialized) {
+        public CassandraMessageId fromString(String serialized) {
             return of(UUID.fromString(serialized));
         }
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
@@ -21,17 +21,20 @@ package org.apache.james.mailbox.cassandra.mail;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.decr;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.delete;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.incr;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.update;
+import static org.apache.james.mailbox.cassandra.table.CassandraMailboxCountersTable.COUNT;
+import static org.apache.james.mailbox.cassandra.table.CassandraMailboxCountersTable.MAILBOX_ID;
+import static org.apache.james.mailbox.cassandra.table.CassandraMailboxCountersTable.TABLE_NAME;
+import static org.apache.james.mailbox.cassandra.table.CassandraMailboxCountersTable.UNSEEN;
 
 import javax.inject.Inject;
 
 import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
 import org.apache.james.mailbox.cassandra.ids.CassandraId;
-import org.apache.james.mailbox.cassandra.table.CassandraMailboxCountersTable;
-import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxCounters;
 
@@ -46,8 +49,11 @@ public class CassandraMailboxCounterDAO {
 
     private final CassandraAsyncExecutor cassandraAsyncExecutor;
     private final PreparedStatement readStatement;
+    private final PreparedStatement deleteStatement;
     private final PreparedStatement incrementUnseenCountStatement;
     private final PreparedStatement incrementMessageCountStatement;
+    private final PreparedStatement addToCounters;
+    private final PreparedStatement removeToCounters;
     private final PreparedStatement decrementUnseenCountStatement;
     private final PreparedStatement decrementMessageCountStatement;
 
@@ -55,36 +61,89 @@ public class CassandraMailboxCounterDAO {
     public CassandraMailboxCounterDAO(Session session) {
         cassandraAsyncExecutor = new CassandraAsyncExecutor(session);
         readStatement = createReadStatement(session);
-        incrementMessageCountStatement = updateMailboxStatement(session, incr(CassandraMailboxCountersTable.COUNT));
-        incrementUnseenCountStatement = updateMailboxStatement(session, incr(CassandraMailboxCountersTable.UNSEEN));
-        decrementMessageCountStatement = updateMailboxStatement(session, decr(CassandraMailboxCountersTable.COUNT));
-        decrementUnseenCountStatement = updateMailboxStatement(session, decr(CassandraMailboxCountersTable.UNSEEN));
+        deleteStatement = createReadStatement(session);
+        incrementMessageCountStatement = updateMailboxStatement(session, incr(COUNT));
+        incrementUnseenCountStatement = updateMailboxStatement(session, incr(UNSEEN));
+        addToCounters = session.prepare(update(TABLE_NAME)
+            .with(incr(COUNT, bindMarker(COUNT)))
+            .and(incr(UNSEEN, bindMarker(UNSEEN)))
+            .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID))));
+        removeToCounters = session.prepare(update(TABLE_NAME)
+            .with(decr(COUNT, bindMarker(COUNT)))
+            .and(decr(UNSEEN, bindMarker(UNSEEN)))
+            .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID))));
+        decrementMessageCountStatement = updateMailboxStatement(session, decr(COUNT));
+        decrementUnseenCountStatement = updateMailboxStatement(session, decr(UNSEEN));
     }
 
     private PreparedStatement createReadStatement(Session session) {
         return session.prepare(
-            select(CassandraMailboxCountersTable.UNSEEN, CassandraMailboxCountersTable.COUNT)
-                .from(CassandraMailboxCountersTable.TABLE_NAME)
-                .where(eq(CassandraMailboxCountersTable.MAILBOX_ID, bindMarker(CassandraMailboxCountersTable.MAILBOX_ID))));
+            select(UNSEEN, COUNT)
+                .from(TABLE_NAME)
+                .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID))));
+    }
+
+    private PreparedStatement createDeleteStatement(Session session) {
+        return session.prepare(delete()
+            .from(TABLE_NAME)
+                .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID))));
     }
 
     private PreparedStatement updateMailboxStatement(Session session, Assignment operation) {
         return session.prepare(
-            update(CassandraMailboxCountersTable.TABLE_NAME)
+            update(TABLE_NAME)
                 .with(operation)
-                .where(eq(CassandraMailboxCountersTable.MAILBOX_ID, bindMarker(CassandraMailboxCountersTable.MAILBOX_ID))));
+                .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID))));
     }
 
     public Mono<MailboxCounters> retrieveMailboxCounters(CassandraId mailboxId) {
         return cassandraAsyncExecutor.executeSingleRow(bindWithMailbox(mailboxId, readStatement))
             .map(row ->  MailboxCounters.builder()
                 .mailboxId(mailboxId)
-                .count(row.getLong(CassandraMailboxCountersTable.COUNT))
-                .unseen(row.getLong(CassandraMailboxCountersTable.UNSEEN))
+                .count(row.getLong(COUNT))
+                .unseen(row.getLong(UNSEEN))
                 .build());
     }
 
-    public Mono<Long> countMessagesInMailbox(Mailbox mailbox) throws MailboxException {
+    public Mono<Void> resetCounter(MailboxCounters counters) {
+        CassandraId mailboxId = ((CassandraId) counters.getMailboxId());
+
+        return retrieveMailboxCounters(mailboxId)
+            .switchIfEmpty(Mono.just(emptyCounters(mailboxId)))
+            .flatMap(storedCounters -> {
+                if (storedCounters.equals(counters)) {
+                    return Mono.empty();
+                }
+                return remove(storedCounters)
+                    .then(add(counters));
+            });
+    }
+
+    private MailboxCounters emptyCounters(CassandraId mailboxId) {
+        return MailboxCounters.builder()
+            .count(0)
+            .unseen(0)
+            .mailboxId(mailboxId)
+            .build();
+    }
+
+    private Mono<Void> add(MailboxCounters counters) {
+        CassandraId mailboxId = ((CassandraId) counters.getMailboxId());
+        return cassandraAsyncExecutor.executeVoid(
+            bindWithMailbox(mailboxId, addToCounters)
+                .setLong(COUNT, counters.getCount())
+                .setLong(UNSEEN, counters.getUnseen()));
+    }
+
+    private Mono<Void> remove(MailboxCounters counters) {
+        CassandraId mailboxId = ((CassandraId) counters.getMailboxId());
+        return cassandraAsyncExecutor.executeVoid(
+            bindWithMailbox(mailboxId, removeToCounters)
+                .setLong(COUNT, counters.getCount())
+                .setLong(UNSEEN, counters.getUnseen()));
+    }
+
+    public Mono<Long> countMessagesInMailbox(Mailbox mailbox) {
         CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
 
         return countMessagesInMailbox(mailboxId);
@@ -92,14 +151,14 @@ public class CassandraMailboxCounterDAO {
 
     public Mono<Long> countMessagesInMailbox(CassandraId cassandraId) {
         return cassandraAsyncExecutor.executeSingleRow(bindWithMailbox(cassandraId, readStatement))
-            .map(row -> row.getLong(CassandraMailboxCountersTable.COUNT));
+            .map(row -> row.getLong(COUNT));
     }
 
-    public Mono<Long> countUnseenMessagesInMailbox(Mailbox mailbox) throws MailboxException {
+    public Mono<Long> countUnseenMessagesInMailbox(Mailbox mailbox) {
         CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
 
         return cassandraAsyncExecutor.executeSingleRow(bindWithMailbox(mailboxId, readStatement))
-            .map(row -> row.getLong(CassandraMailboxCountersTable.UNSEEN));
+            .map(row -> row.getLong(UNSEEN));
     }
 
     public Mono<Void> decrementCount(CassandraId mailboxId) {
@@ -120,6 +179,6 @@ public class CassandraMailboxCounterDAO {
 
     private BoundStatement bindWithMailbox(CassandraId mailboxId, PreparedStatement statement) {
         return statement.bind()
-            .setUUID(CassandraMailboxCountersTable.MAILBOX_ID, mailboxId.asUuid());
+            .setUUID(MAILBOX_ID, mailboxId.asUuid());
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
@@ -96,7 +96,7 @@ public class CassandraMailboxCounterDAO {
                 .build());
     }
 
-    public Mono<Void> resetCounter(MailboxCounters counters) {
+    public Mono<Void> resetCounters(MailboxCounters counters) {
         CassandraId mailboxId = (CassandraId) counters.getMailboxId();
 
         return retrieveMailboxCounters(mailboxId)

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersService.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersService.java
@@ -177,7 +177,7 @@ public class RecomputeMailboxCountersService {
         return imapUidToMessageIdDAO.retrieveMessages(mailboxId, MessageRange.all())
             .flatMap(message -> latestMetadata(mailboxId, message))
             .doOnNext(counter::process)
-            .then(Mono.defer(() -> counterDAO.resetCounter(counter.snapshot())))
+            .then(Mono.defer(() -> counterDAO.resetCounters(counter.snapshot())))
             .then(Mono.just(Result.COMPLETED))
             .doOnNext(any -> {
                 LOGGER.info("Counters recomputed for {}", mailboxId.serialize());

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersService.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersService.java
@@ -1,0 +1,198 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.task;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.inject.Inject;
+import javax.mail.Flags;
+
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxCounterDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdToImapUidDAO;
+import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxCounters;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.task.Task;
+import org.apache.james.task.Task.Result;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class RecomputeMailboxCountersService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RecomputeMailboxCountersService.class);
+
+    private static class Counter {
+        private final CassandraId mailboxId;
+        private final AtomicLong total;
+        private final AtomicLong unseen;
+
+        private Counter(CassandraId mailboxId) {
+            this.mailboxId = mailboxId;
+            unseen = new AtomicLong();
+            total = new AtomicLong();
+        }
+
+        void process(ComposedMessageIdWithMetaData metadata) {
+            total.incrementAndGet();
+            if (!metadata.getFlags().contains(Flags.Flag.SEEN)) {
+                unseen.incrementAndGet();
+            }
+        }
+
+        MailboxCounters snapshot() {
+            return MailboxCounters.builder()
+                .mailboxId(mailboxId)
+                .count(total.get())
+                .unseen(unseen.get())
+                .build();
+        }
+    }
+
+    static class Context {
+        static class Snapshot {
+            private final long processedMailboxCount;
+            private final ImmutableList<CassandraId> failedMailboxes;
+
+            private Snapshot(long processedMailboxCount, ImmutableList<CassandraId> failedMailboxes) {
+                this.processedMailboxCount = processedMailboxCount;
+                this.failedMailboxes = failedMailboxes;
+            }
+
+            long getProcessedMailboxCount() {
+                return processedMailboxCount;
+            }
+
+            ImmutableList<CassandraId> getFailedMailboxes() {
+                return failedMailboxes;
+            }
+
+            @Override
+            public final boolean equals(Object o) {
+                if (o instanceof Snapshot) {
+                    Snapshot snapshot = (Snapshot) o;
+
+                    return Objects.equals(this.processedMailboxCount, snapshot.processedMailboxCount)
+                        && Objects.equals(this.failedMailboxes, snapshot.failedMailboxes);
+                }
+                return false;
+            }
+
+            @Override
+            public final int hashCode() {
+                return Objects.hash(processedMailboxCount, failedMailboxes);
+            }
+
+            @Override
+            public String toString() {
+                return MoreObjects.toStringHelper(this)
+                    .add("processedMailboxCount", processedMailboxCount)
+                    .add("failedMailboxes", failedMailboxes)
+                    .toString();
+            }
+        }
+
+        private final AtomicLong processedMailboxCount;
+        private final ConcurrentLinkedDeque<CassandraId> failedMailboxes;
+
+        Context() {
+            processedMailboxCount = new AtomicLong();
+            failedMailboxes = new ConcurrentLinkedDeque<>();
+        }
+
+        void incrementProcessed() {
+            processedMailboxCount.incrementAndGet();
+        }
+
+        void addToFailedMailboxes(CassandraId cassandraId) {
+            failedMailboxes.add(cassandraId);
+        }
+
+        Snapshot snapshot() {
+            return new Snapshot(processedMailboxCount.get(),
+                ImmutableList.copyOf(failedMailboxes));
+        }
+    }
+
+    private final CassandraMailboxDAO mailboxDAO;
+    private final CassandraMessageIdDAO imapUidToMessageIdDAO;
+    private final CassandraMessageIdToImapUidDAO messageIdToImapUidDAO;
+    private final CassandraMailboxCounterDAO counterDAO;
+
+    @Inject
+    RecomputeMailboxCountersService(CassandraMailboxDAO mailboxDAO,
+                                    CassandraMessageIdDAO imapUidToMessageIdDAO,
+                                    CassandraMessageIdToImapUidDAO messageIdToImapUidDAO,
+                                    CassandraMailboxCounterDAO counterDAO) {
+        this.mailboxDAO = mailboxDAO;
+        this.imapUidToMessageIdDAO = imapUidToMessageIdDAO;
+        this.messageIdToImapUidDAO = messageIdToImapUidDAO;
+        this.counterDAO = counterDAO;
+    }
+
+    Mono<Result> recomputeMailboxCounters(Context context) {
+        return mailboxDAO.retrieveAllMailboxes()
+            .flatMap(mailbox -> recomputeMailboxCounter(context, mailbox))
+            .reduce(Result.COMPLETED, Task::combine)
+            .onErrorResume(e -> {
+                LOGGER.error("Error listing mailboxes", e);
+                return Mono.just(Result.PARTIAL);
+            });
+    }
+
+    private Mono<Result> recomputeMailboxCounter(Context context, Mailbox mailbox) {
+        CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
+        Counter counter = new Counter(mailboxId);
+
+        return imapUidToMessageIdDAO.retrieveMessages(mailboxId, MessageRange.all())
+            .flatMap(message -> latestMetadata(mailboxId, message))
+            .doOnNext(counter::process)
+            .then(Mono.defer(() -> counterDAO.resetCounter(counter.snapshot())))
+            .then(Mono.just(Result.COMPLETED))
+            .doOnNext(any -> {
+                LOGGER.info("Counters recomputed for {}", mailboxId.serialize());
+                context.incrementProcessed();
+            })
+            .onErrorResume(e -> {
+                context.addToFailedMailboxes(mailboxId);
+                LOGGER.error("Error while recomputing counters for {}", mailboxId.serialize(), e);
+                return Mono.just(Result.PARTIAL);
+            });
+    }
+
+    private Flux<ComposedMessageIdWithMetaData> latestMetadata(CassandraId mailboxId, ComposedMessageIdWithMetaData message) {
+        CassandraMessageId messageId = (CassandraMessageId) message.getComposedMessageId().getMessageId();
+
+        return messageIdToImapUidDAO.retrieve(messageId, Optional.of(mailboxId));
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersTask.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersTask.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mailbox.cassandra.mail.task;
 
+import static org.apache.james.mailbox.cassandra.mail.task.RecomputeMailboxCountersService.Context.Snapshot;
+
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Optional;
@@ -89,7 +91,7 @@ public class RecomputeMailboxCountersTask implements Task {
 
     @Override
     public Optional<TaskExecutionDetails.AdditionalInformation> details() {
-        RecomputeMailboxCountersService.Context.Snapshot snapshot = context.snapshot();
+        Snapshot snapshot = context.snapshot();
 
         return Optional.of(new Details(Clock.systemUTC().instant(),
             snapshot.getProcessedMailboxCount(),

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersTask.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersTask.java
@@ -1,0 +1,100 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.task;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.task.TaskType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+
+import reactor.core.scheduler.Schedulers;
+
+public class RecomputeMailboxCountersTask implements Task {
+    public static final Logger LOGGER = LoggerFactory.getLogger(RecomputeMailboxCountersTask.class);
+    static final TaskType RECOMPUTE_MAILBOX_COUNTERS = TaskType.of("recompute-mailbox-counters");
+
+    public static class Details implements TaskExecutionDetails.AdditionalInformation {
+        private final Instant instant;
+        private final long processedMailboxes;
+        private final ImmutableList<String> failedMailboxes;
+
+        Details(Instant instant, long processedMailboxes, ImmutableList<String> failedMailboxes) {
+            this.instant = instant;
+            this.processedMailboxes = processedMailboxes;
+            this.failedMailboxes = failedMailboxes;
+        }
+
+        @Override
+        public Instant timestamp() {
+            return instant;
+        }
+
+        @JsonProperty("processedMailboxes")
+        long getProcessedMailboxes() {
+            return processedMailboxes;
+        }
+
+        @JsonProperty("failedMailboxes")
+        ImmutableList<String> getFailedMailboxes() {
+            return failedMailboxes;
+        }
+    }
+
+    private final RecomputeMailboxCountersService service;
+    private RecomputeMailboxCountersService.Context context;
+
+    public RecomputeMailboxCountersTask(RecomputeMailboxCountersService service) {
+        this.service = service;
+        this.context = new RecomputeMailboxCountersService.Context();
+    }
+
+    @Override
+    public Result run() {
+        return service.recomputeMailboxCounters(context)
+            .subscribeOn(Schedulers.elastic())
+            .block();
+    }
+
+    @Override
+    public TaskType type() {
+        return RECOMPUTE_MAILBOX_COUNTERS;
+    }
+
+    @Override
+    public Optional<TaskExecutionDetails.AdditionalInformation> details() {
+        RecomputeMailboxCountersService.Context.Snapshot snapshot = context.snapshot();
+
+        return Optional.of(new Details(Clock.systemUTC().instant(),
+            snapshot.getProcessedMailboxCount(),
+            snapshot.getFailedMailboxes().stream()
+                .map(MailboxId::serialize)
+                .collect(Guavate.toImmutableList())));
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersTaskAdditionalInformationDTO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersTaskAdditionalInformationDTO.java
@@ -1,0 +1,87 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.task;
+
+import java.time.Instant;
+
+import org.apache.james.json.DTOModule;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+public class RecomputeMailboxCountersTaskAdditionalInformationDTO implements AdditionalInformationDTO {
+    private static RecomputeMailboxCountersTaskAdditionalInformationDTO fromDomainObject(RecomputeMailboxCountersTask.Details details, String type) {
+        return new RecomputeMailboxCountersTaskAdditionalInformationDTO(
+            type,
+            details.getProcessedMailboxes(),
+            details.getFailedMailboxes(),
+            details.timestamp());
+    }
+
+    public static final AdditionalInformationDTOModule<RecomputeMailboxCountersTask.Details, RecomputeMailboxCountersTaskAdditionalInformationDTO> MODULE =
+        DTOModule
+            .forDomainObject(RecomputeMailboxCountersTask.Details.class)
+            .convertToDTO(RecomputeMailboxCountersTaskAdditionalInformationDTO.class)
+            .toDomainObjectConverter(RecomputeMailboxCountersTaskAdditionalInformationDTO::toDomainObject)
+            .toDTOConverter(RecomputeMailboxCountersTaskAdditionalInformationDTO::fromDomainObject)
+            .typeName(RecomputeMailboxCountersTask.RECOMPUTE_MAILBOX_COUNTERS.asString())
+            .withFactory(AdditionalInformationDTOModule::new);
+
+    private final String type;
+    private final long processedMailboxes;
+    private final ImmutableList<String> failedMailboxes;
+    private final Instant timestamp;
+
+    public RecomputeMailboxCountersTaskAdditionalInformationDTO(@JsonProperty("type")String type,
+                                                                @JsonProperty("processedMailboxes")long processedMailboxes,
+                                                                @JsonProperty("failedMailboxes")ImmutableList<String> failedMailboxes,
+                                                                @JsonProperty("timestamp")Instant timestamp) {
+        this.type = type;
+        this.processedMailboxes = processedMailboxes;
+        this.failedMailboxes = failedMailboxes;
+        this.timestamp = timestamp;
+    }
+
+    public long getProcessedMailboxes() {
+        return processedMailboxes;
+    }
+
+    public ImmutableList<String> getFailedMailboxes() {
+        return failedMailboxes;
+    }
+
+    @Override
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    private RecomputeMailboxCountersTask.Details toDomainObject() {
+        return new RecomputeMailboxCountersTask.Details(timestamp,
+            processedMailboxes,
+            failedMailboxes);
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersTaskAdditionalInformationDTO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersTaskAdditionalInformationDTO.java
@@ -51,10 +51,10 @@ public class RecomputeMailboxCountersTaskAdditionalInformationDTO implements Add
     private final ImmutableList<String> failedMailboxes;
     private final Instant timestamp;
 
-    public RecomputeMailboxCountersTaskAdditionalInformationDTO(@JsonProperty("type")String type,
-                                                                @JsonProperty("processedMailboxes")long processedMailboxes,
-                                                                @JsonProperty("failedMailboxes")ImmutableList<String> failedMailboxes,
-                                                                @JsonProperty("timestamp")Instant timestamp) {
+    public RecomputeMailboxCountersTaskAdditionalInformationDTO(@JsonProperty("type") String type,
+                                                                @JsonProperty("processedMailboxes") long processedMailboxes,
+                                                                @JsonProperty("failedMailboxes") ImmutableList<String> failedMailboxes,
+                                                                @JsonProperty("timestamp") Instant timestamp) {
         this.type = type;
         this.processedMailboxes = processedMailboxes;
         this.failedMailboxes = failedMailboxes;

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersTaskDTO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersTaskDTO.java
@@ -1,0 +1,56 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.mailbox.cassandra.mail.task;
+
+import org.apache.james.json.DTOModule;
+import org.apache.james.server.task.json.dto.TaskDTO;
+import org.apache.james.server.task.json.dto.TaskDTOModule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RecomputeMailboxCountersTaskDTO implements TaskDTO {
+    private static RecomputeMailboxCountersTaskDTO toDTO(RecomputeMailboxCountersTask domainObject, String typeName) {
+        return new RecomputeMailboxCountersTaskDTO(typeName);
+    }
+
+    public static TaskDTOModule<RecomputeMailboxCountersTask, RecomputeMailboxCountersTaskDTO> module(RecomputeMailboxCountersService service) {
+        return DTOModule
+            .forDomainObject(RecomputeMailboxCountersTask.class)
+            .convertToDTO(RecomputeMailboxCountersTaskDTO.class)
+            .toDomainObjectConverter(dto -> dto.toDomainObject(service))
+            .toDTOConverter(RecomputeMailboxCountersTaskDTO::toDTO)
+            .typeName(RecomputeMailboxCountersTask.RECOMPUTE_MAILBOX_COUNTERS.asString())
+            .withFactory(TaskDTOModule::new);
+    }
+
+    private final String type;
+
+    public RecomputeMailboxCountersTaskDTO(@JsonProperty("type") String type) {
+        this.type = type;
+    }
+
+    private RecomputeMailboxCountersTask toDomainObject(RecomputeMailboxCountersService service) {
+        return new RecomputeMailboxCountersTask(service);
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAOTest.java
@@ -52,36 +52,36 @@ class CassandraMailboxCounterDAOTest {
     }
 
     @Test
-    void countMessagesInMailboxShouldReturnEmptyByDefault() throws Exception {
+    void countMessagesInMailboxShouldReturnEmptyByDefault() {
         assertThat(testee.countMessagesInMailbox(mailbox).hasElement().block()).isFalse();
     }
 
     @Test
-    void countUnseenMessagesInMailboxShouldReturnEmptyByDefault() throws Exception {
+    void countUnseenMessagesInMailboxShouldReturnEmptyByDefault() {
         assertThat(testee.countUnseenMessagesInMailbox(mailbox).hasElement().block()).isFalse();
     }
 
     @Test
-    void retrieveMailboxCounterShouldReturnEmptyByDefault() throws Exception {
+    void retrieveMailboxCounterShouldReturnEmptyByDefault() {
         assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).hasElement().block()).isFalse();
     }
 
     @Test
-    void incrementCountShouldAddOneWhenAbsent() throws Exception {
+    void incrementCountShouldAddOneWhenAbsent() {
         testee.incrementCount(MAILBOX_ID).block();
 
         assertThat(testee.countMessagesInMailbox(mailbox).block()).isEqualTo(1L);
     }
 
     @Test
-    void incrementUnseenShouldAddOneWhenAbsent() throws Exception {
+    void incrementUnseenShouldAddOneWhenAbsent() {
         testee.incrementUnseen(MAILBOX_ID).block();
 
         assertThat(testee.countUnseenMessagesInMailbox(mailbox).block()).isEqualTo(1L);
     }
 
     @Test
-    void incrementUnseenShouldAddOneWhenAbsentOnMailboxCounters() throws Exception {
+    void incrementUnseenShouldAddOneWhenAbsentOnMailboxCounters() {
         testee.incrementUnseen(MAILBOX_ID).block();
 
         assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).block())
@@ -93,7 +93,7 @@ class CassandraMailboxCounterDAOTest {
     }
 
     @Test
-    void incrementCountShouldAddOneWhenAbsentOnMailboxCounters() throws Exception {
+    void incrementCountShouldAddOneWhenAbsentOnMailboxCounters() {
         testee.incrementCount(MAILBOX_ID).block();
 
         assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).block())
@@ -105,7 +105,7 @@ class CassandraMailboxCounterDAOTest {
     }
 
     @Test
-    void retrieveMailboxCounterShouldWorkWhenFullRow() throws Exception {
+    void retrieveMailboxCounterShouldWorkWhenFullRow() {
         testee.incrementCount(MAILBOX_ID).block();
         testee.incrementUnseen(MAILBOX_ID).block();
 
@@ -118,7 +118,7 @@ class CassandraMailboxCounterDAOTest {
     }
 
     @Test
-    void decrementCountShouldRemoveOne() throws Exception {
+    void decrementCountShouldRemoveOne() {
         testee.incrementCount(MAILBOX_ID).block();
 
         testee.decrementCount(MAILBOX_ID).block();
@@ -128,7 +128,7 @@ class CassandraMailboxCounterDAOTest {
     }
 
     @Test
-    void decrementUnseenShouldRemoveOne() throws Exception {
+    void decrementUnseenShouldRemoveOne() {
         testee.incrementUnseen(MAILBOX_ID).block();
 
         testee.decrementUnseen(MAILBOX_ID).block();
@@ -138,7 +138,7 @@ class CassandraMailboxCounterDAOTest {
     }
 
     @Test
-    void incrementUnseenShouldHaveNoImpactOnMessageCount() throws Exception {
+    void incrementUnseenShouldHaveNoImpactOnMessageCount() {
         testee.incrementUnseen(MAILBOX_ID).block();
 
         assertThat(testee.countMessagesInMailbox(mailbox).block())
@@ -146,7 +146,7 @@ class CassandraMailboxCounterDAOTest {
     }
 
     @Test
-    void incrementCountShouldHaveNoEffectOnUnseenCount() throws Exception {
+    void incrementCountShouldHaveNoEffectOnUnseenCount() {
         testee.incrementCount(MAILBOX_ID).block();
 
         assertThat(testee.countUnseenMessagesInMailbox(mailbox).block())
@@ -154,7 +154,7 @@ class CassandraMailboxCounterDAOTest {
     }
 
     @Test
-    void decrementUnseenShouldHaveNoEffectOnMessageCount() throws Exception {
+    void decrementUnseenShouldHaveNoEffectOnMessageCount() {
         testee.incrementCount(MAILBOX_ID).block();
 
         testee.decrementUnseen(MAILBOX_ID).block();
@@ -164,7 +164,7 @@ class CassandraMailboxCounterDAOTest {
     }
 
     @Test
-    void decrementCountShouldHaveNoEffectOnUnseenCount() throws Exception {
+    void decrementCountShouldHaveNoEffectOnUnseenCount() {
         testee.incrementUnseen(MAILBOX_ID).block();
 
         testee.decrementCount(MAILBOX_ID).block();
@@ -174,7 +174,7 @@ class CassandraMailboxCounterDAOTest {
     }
 
     @Test
-    void decrementCountCanLeadToNegativeValue() throws Exception {
+    void decrementCountCanLeadToNegativeValue() {
         testee.decrementCount(MAILBOX_ID).block();
 
         assertThat(testee.countMessagesInMailbox(mailbox).block())
@@ -182,10 +182,121 @@ class CassandraMailboxCounterDAOTest {
     }
 
     @Test
-    void decrementUnseenCanLeadToNegativeValue() throws Exception {
+    void decrementUnseenCanLeadToNegativeValue() {
         testee.decrementUnseen(MAILBOX_ID).block();
 
         assertThat(testee.countUnseenMessagesInMailbox(mailbox).block())
             .isEqualTo(-1L);
+    }
+
+    @Test
+    void resetCounterShouldNoopWhenZeroAndNoData() {
+        MailboxCounters counters = MailboxCounters.builder()
+            .unseen(0)
+            .count(0)
+            .mailboxId(MAILBOX_ID)
+            .build();
+
+        testee.resetCounter(counters).block();
+
+        assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).blockOptional())
+            .isEmpty();
+    }
+
+    @Test
+    void resetCounterShouldNoopWhenZeroAndZeroData() {
+        MailboxCounters counters = MailboxCounters.builder()
+            .unseen(0)
+            .count(0)
+            .mailboxId(MAILBOX_ID)
+            .build();
+
+        testee.incrementUnseen(MAILBOX_ID).block();
+        testee.decrementUnseen(MAILBOX_ID).block();
+
+        testee.resetCounter(counters).block();
+
+        assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).blockOptional())
+            .contains(counters);
+    }
+
+    @Test
+    void resetCounterShouldReInitCountWhenNothing() {
+        MailboxCounters counters = MailboxCounters.builder()
+            .unseen(45)
+            .count(78)
+            .mailboxId(MAILBOX_ID)
+            .build();
+
+        testee.resetCounter(counters).block();
+
+        assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).blockOptional())
+            .contains(counters);
+    }
+
+    @Test
+    void resetCounterShouldReInitCountWhenData() {
+        MailboxCounters counters = MailboxCounters.builder()
+            .unseen(45)
+            .count(78)
+            .mailboxId(MAILBOX_ID)
+            .build();
+
+        testee.incrementCount(MAILBOX_ID).block();
+        testee.incrementUnseen(MAILBOX_ID).block();
+
+        testee.resetCounter(counters).block();
+
+        assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).blockOptional())
+            .contains(counters);
+    }
+
+    @Test
+    void resetShouldBeIdempotent() {
+        MailboxCounters counters = MailboxCounters.builder()
+            .unseen(45)
+            .count(78)
+            .mailboxId(MAILBOX_ID)
+            .build();
+
+        testee.resetCounter(counters).block();
+        testee.resetCounter(counters).block();
+
+        assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).blockOptional())
+            .contains(counters);
+    }
+
+    @Test
+    void resetCounterShouldReInitCountWhenZeroUnseen() {
+        MailboxCounters counters = MailboxCounters.builder()
+            .unseen(0)
+            .count(78)
+            .mailboxId(MAILBOX_ID)
+            .build();
+
+        testee.incrementCount(MAILBOX_ID).block();
+        testee.incrementUnseen(MAILBOX_ID).block();
+
+        testee.resetCounter(counters).block();
+
+        assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).blockOptional())
+            .contains(counters);
+    }
+
+    @Test
+    void resetCounterShouldReInitCountWhenZeroCount() {
+        MailboxCounters counters = MailboxCounters.builder()
+            .unseen(46)
+            .count(0)
+            .mailboxId(MAILBOX_ID)
+            .build();
+
+        testee.incrementCount(MAILBOX_ID).block();
+        testee.incrementUnseen(MAILBOX_ID).block();
+
+        testee.resetCounter(counters).block();
+
+        assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).blockOptional())
+            .contains(counters);
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAOTest.java
@@ -190,21 +190,21 @@ class CassandraMailboxCounterDAOTest {
     }
 
     @Test
-    void resetCounterShouldNoopWhenZeroAndNoData() {
+    void resetCountersShouldNoopWhenZeroAndNoData() {
         MailboxCounters counters = MailboxCounters.builder()
             .unseen(0)
             .count(0)
             .mailboxId(MAILBOX_ID)
             .build();
 
-        testee.resetCounter(counters).block();
+        testee.resetCounters(counters).block();
 
         assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).blockOptional())
             .isEmpty();
     }
 
     @Test
-    void resetCounterShouldNoopWhenZeroAndZeroData() {
+    void resetCountersShouldNoopWhenZeroAndZeroData() {
         MailboxCounters counters = MailboxCounters.builder()
             .unseen(0)
             .count(0)
@@ -214,28 +214,28 @@ class CassandraMailboxCounterDAOTest {
         testee.incrementUnseen(MAILBOX_ID).block();
         testee.decrementUnseen(MAILBOX_ID).block();
 
-        testee.resetCounter(counters).block();
+        testee.resetCounters(counters).block();
 
         assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).blockOptional())
             .contains(counters);
     }
 
     @Test
-    void resetCounterShouldReInitCountWhenNothing() {
+    void resetCountersShouldReInitCountWhenNothing() {
         MailboxCounters counters = MailboxCounters.builder()
             .unseen(45)
             .count(78)
             .mailboxId(MAILBOX_ID)
             .build();
 
-        testee.resetCounter(counters).block();
+        testee.resetCounters(counters).block();
 
         assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).blockOptional())
             .contains(counters);
     }
 
     @Test
-    void resetCounterShouldReInitCountWhenData() {
+    void resetCountersShouldReInitCountWhenData() {
         MailboxCounters counters = MailboxCounters.builder()
             .unseen(45)
             .count(78)
@@ -245,29 +245,29 @@ class CassandraMailboxCounterDAOTest {
         testee.incrementCount(MAILBOX_ID).block();
         testee.incrementUnseen(MAILBOX_ID).block();
 
-        testee.resetCounter(counters).block();
+        testee.resetCounters(counters).block();
 
         assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).blockOptional())
             .contains(counters);
     }
 
     @Test
-    void resetShouldBeIdempotent() {
+    void resetCountersShouldBeIdempotent() {
         MailboxCounters counters = MailboxCounters.builder()
             .unseen(45)
             .count(78)
             .mailboxId(MAILBOX_ID)
             .build();
 
-        testee.resetCounter(counters).block();
-        testee.resetCounter(counters).block();
+        testee.resetCounters(counters).block();
+        testee.resetCounters(counters).block();
 
         assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).blockOptional())
             .contains(counters);
     }
 
     @Test
-    void resetCounterShouldReInitCountWhenZeroUnseen() {
+    void resetCountersShouldReInitCountWhenZeroUnseen() {
         MailboxCounters counters = MailboxCounters.builder()
             .unseen(0)
             .count(78)
@@ -277,14 +277,14 @@ class CassandraMailboxCounterDAOTest {
         testee.incrementCount(MAILBOX_ID).block();
         testee.incrementUnseen(MAILBOX_ID).block();
 
-        testee.resetCounter(counters).block();
+        testee.resetCounters(counters).block();
 
         assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).blockOptional())
             .contains(counters);
     }
 
     @Test
-    void resetCounterShouldReInitCountWhenZeroCount() {
+    void resetCountersShouldReInitCountWhenZeroCount() {
         MailboxCounters counters = MailboxCounters.builder()
             .unseen(46)
             .count(0)
@@ -294,7 +294,7 @@ class CassandraMailboxCounterDAOTest {
         testee.incrementCount(MAILBOX_ID).block();
         testee.incrementUnseen(MAILBOX_ID).block();
 
-        testee.resetCounter(counters).block();
+        testee.resetCounters(counters).block();
 
         assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).blockOptional())
             .contains(counters);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersServiceTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersServiceTest.java
@@ -1,0 +1,289 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import javax.mail.Flags;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.ModSeq;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxCounterDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdToImapUidDAO;
+import org.apache.james.mailbox.cassandra.mail.task.RecomputeMailboxCountersService.Context;
+import org.apache.james.mailbox.cassandra.modules.CassandraAclModule;
+import org.apache.james.mailbox.cassandra.modules.CassandraMailboxCounterModule;
+import org.apache.james.mailbox.cassandra.modules.CassandraMailboxModule;
+import org.apache.james.mailbox.cassandra.modules.CassandraMessageModule;
+import org.apache.james.mailbox.model.ComposedMessageId;
+import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxCounters;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.UidValidity;
+import org.apache.james.task.Task.Result;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.datastax.driver.core.utils.UUIDs;
+
+class RecomputeMailboxCountersServiceTest {
+    private static final UidValidity UID_VALIDITY_1 = UidValidity.ofValid(145);
+    private static final Username USER = Username.of("user");
+    private static final MailboxPath MAILBOX_PATH = MailboxPath.forUser(USER, "abc");
+    private static final CassandraMessageId.Factory MESSAGE_ID_FACTORY = new CassandraMessageId.Factory();
+    private static final CassandraMessageId MESSAGE_ID_1 = MESSAGE_ID_FACTORY.fromString("40ff9e30-6022-11ea-9a94-d300cbf968c0");
+    private static CassandraId CASSANDRA_ID_1 = CassandraId.of(UUID.fromString("16d681e0-6023-11ea-a7f2-0f94ad804b0d"));
+    private static final ComposedMessageIdWithMetaData METADATA_UNSEEN = new ComposedMessageIdWithMetaData(new ComposedMessageId(CASSANDRA_ID_1, MESSAGE_ID_1, MessageUid.of(45)), new Flags(), ModSeq.of(45));
+    private static final ComposedMessageIdWithMetaData METADATA_SEEN = new ComposedMessageIdWithMetaData(new ComposedMessageId(CASSANDRA_ID_1, MESSAGE_ID_1, MessageUid.of(45)), new Flags(Flags.Flag.SEEN), ModSeq.of(45));
+    private static final Mailbox MAILBOX = new Mailbox(MAILBOX_PATH, UID_VALIDITY_1, CASSANDRA_ID_1);
+
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(
+        CassandraModule.aggregateModules(
+            CassandraSchemaVersionModule.MODULE,
+            CassandraMailboxModule.MODULE,
+            CassandraMessageModule.MODULE,
+            CassandraMailboxCounterModule.MODULE,
+            CassandraAclModule.MODULE));
+
+    CassandraMailboxDAO mailboxDAO;
+    CassandraMessageIdDAO imapUidToMessageIdDAO;
+    CassandraMessageIdToImapUidDAO messageIdToImapUidDAO;
+    CassandraMailboxCounterDAO counterDAO;
+    RecomputeMailboxCountersService testee;
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandra) {
+        mailboxDAO = new CassandraMailboxDAO(cassandra.getConf(), cassandra.getTypesProvider());
+        imapUidToMessageIdDAO = new CassandraMessageIdDAO(cassandra.getConf(), MESSAGE_ID_FACTORY);
+        messageIdToImapUidDAO = new CassandraMessageIdToImapUidDAO(cassandra.getConf(), MESSAGE_ID_FACTORY);
+        counterDAO = new CassandraMailboxCounterDAO(cassandra.getConf());
+        testee = new RecomputeMailboxCountersService(mailboxDAO, imapUidToMessageIdDAO, messageIdToImapUidDAO, counterDAO);
+    }
+
+    @Test
+    void recomputeMailboxCountersShouldReturnCompletedWhenNoMailboxes() {
+        assertThat(testee.recomputeMailboxCounters(new Context()).block())
+            .isEqualTo(Result.COMPLETED);
+    }
+
+    @Test
+    void recomputeMailboxCountersShouldReturnCompletedWhenMailboxWithNoMessages() {
+        mailboxDAO.save(MAILBOX).block();
+
+        assertThat(testee.recomputeMailboxCounters(new Context()).block())
+            .isEqualTo(Result.COMPLETED);
+    }
+
+    @Test
+    void recomputeMailboxCountersShouldReturnCompletedWhenMailboxWithMessages() {
+        mailboxDAO.save(MAILBOX).block();
+        imapUidToMessageIdDAO.insert(METADATA_UNSEEN).block();
+        messageIdToImapUidDAO.insert(METADATA_UNSEEN).block();
+        counterDAO.incrementUnseen(CASSANDRA_ID_1).block();
+        counterDAO.incrementCount(CASSANDRA_ID_1).block();
+
+        testee.recomputeMailboxCounters(new Context()).block();
+
+        assertThat(testee.recomputeMailboxCounters(new Context()).block())
+            .isEqualTo(Result.COMPLETED);
+    }
+
+    @Test
+    void recomputeMailboxCountersShouldReturnCompletedWhenMessageDenormalizationIssue() {
+        mailboxDAO.save(MAILBOX).block();
+        imapUidToMessageIdDAO.insert(METADATA_UNSEEN).block();
+        messageIdToImapUidDAO.insert(METADATA_SEEN).block();
+        counterDAO.incrementUnseen(CASSANDRA_ID_1).block();
+        counterDAO.incrementCount(CASSANDRA_ID_1).block();
+
+        testee.recomputeMailboxCounters(new Context()).block();
+
+        assertThat(testee.recomputeMailboxCounters(new Context()).block())
+            .isEqualTo(Result.COMPLETED);
+    }
+
+    @Test
+    void recomputeMailboxCountersShouldReturnCountersAreIncorrect() {
+        mailboxDAO.save(MAILBOX).block();
+        imapUidToMessageIdDAO.insert(METADATA_UNSEEN).block();
+        messageIdToImapUidDAO.insert(METADATA_UNSEEN).block();
+
+        testee.recomputeMailboxCounters(new Context()).block();
+
+        assertThat(testee.recomputeMailboxCounters(new Context()).block())
+            .isEqualTo(Result.COMPLETED);
+    }
+
+    @Test
+    void recomputeMailboxCountersShouldReturnCompletedWhenOrphanMailboxRegistration() {
+        mailboxDAO.save(MAILBOX).block();
+        imapUidToMessageIdDAO.insert(METADATA_UNSEEN).block();
+        counterDAO.incrementUnseen(CASSANDRA_ID_1).block();
+        counterDAO.incrementCount(CASSANDRA_ID_1).block();
+
+        testee.recomputeMailboxCounters(new Context()).block();
+
+        assertThat(testee.recomputeMailboxCounters(new Context()).block())
+            .isEqualTo(Result.COMPLETED);
+    }
+
+    @Test
+    void recomputeMailboxCountersShouldReturnCompletedMailboxListReferenceIsMissing() {
+        mailboxDAO.save(MAILBOX).block();
+        messageIdToImapUidDAO.insert(METADATA_UNSEEN).block();
+        counterDAO.incrementUnseen(CASSANDRA_ID_1).block();
+        counterDAO.incrementCount(CASSANDRA_ID_1).block();
+
+        testee.recomputeMailboxCounters(new Context()).block();
+
+        assertThat(testee.recomputeMailboxCounters(new Context()).block())
+            .isEqualTo(Result.COMPLETED);
+    }
+
+    @Test
+    void recomputeMailboxCountersShouldNoopWhenMailboxWithoutMessage() {
+        mailboxDAO.save(MAILBOX).block();
+
+        testee.recomputeMailboxCounters(new Context()).block();
+
+        assertThat(counterDAO.retrieveMailboxCounters(CASSANDRA_ID_1).blockOptional())
+            .isEmpty();
+    }
+
+    @Test
+    void recomputeMailboxCountersShouldNoopWhenValidCounters() {
+        mailboxDAO.save(MAILBOX).block();
+        imapUidToMessageIdDAO.insert(METADATA_UNSEEN).block();
+        messageIdToImapUidDAO.insert(METADATA_UNSEEN).block();
+        counterDAO.incrementUnseen(CASSANDRA_ID_1).block();
+        counterDAO.incrementCount(CASSANDRA_ID_1).block();
+
+        testee.recomputeMailboxCounters(new Context()).block();
+
+        assertThat(counterDAO.retrieveMailboxCounters(CASSANDRA_ID_1).blockOptional())
+            .contains(MailboxCounters.builder()
+                .mailboxId(CASSANDRA_ID_1)
+                .count(1)
+                .unseen(1)
+                .build());
+    }
+
+    @Test
+    void recomputeMailboxCountersShouldRecreateMissingCounters() {
+        mailboxDAO.save(MAILBOX).block();
+        imapUidToMessageIdDAO.insert(METADATA_UNSEEN).block();
+        messageIdToImapUidDAO.insert(METADATA_UNSEEN).block();
+
+        testee.recomputeMailboxCounters(new Context()).block();
+
+        assertThat(counterDAO.retrieveMailboxCounters(CASSANDRA_ID_1).blockOptional())
+            .contains(MailboxCounters.builder()
+                .mailboxId(CASSANDRA_ID_1)
+                .count(1)
+                .unseen(1)
+                .build());
+    }
+
+    @Test
+    void recomputeMailboxCountersShouldResetIncorrectCounters() {
+        mailboxDAO.save(MAILBOX).block();
+        imapUidToMessageIdDAO.insert(METADATA_UNSEEN).block();
+        messageIdToImapUidDAO.insert(METADATA_UNSEEN).block();
+        counterDAO.incrementCount(CASSANDRA_ID_1).block();
+
+        testee.recomputeMailboxCounters(new Context()).block();
+
+        assertThat(counterDAO.retrieveMailboxCounters(CASSANDRA_ID_1).blockOptional())
+            .contains(MailboxCounters.builder()
+                .mailboxId(CASSANDRA_ID_1)
+                .count(1)
+                .unseen(1)
+                .build());
+    }
+
+    @Test
+    void recomputeMailboxCountersShouldTakeSeenIntoAccount() {
+        mailboxDAO.save(MAILBOX).block();
+        imapUidToMessageIdDAO.insert(METADATA_SEEN).block();
+        messageIdToImapUidDAO.insert(METADATA_SEEN).block();
+        counterDAO.incrementCount(CASSANDRA_ID_1).block();
+
+        testee.recomputeMailboxCounters(new Context()).block();
+
+        assertThat(counterDAO.retrieveMailboxCounters(CASSANDRA_ID_1).blockOptional())
+            .contains(MailboxCounters.builder()
+                .mailboxId(CASSANDRA_ID_1)
+                .count(1)
+                .unseen(0)
+                .build());
+    }
+
+    @Test
+    void recomputeMailboxCountersShouldUseSourceOfTruthForComputation() {
+        mailboxDAO.save(MAILBOX).block();
+        imapUidToMessageIdDAO.insert(METADATA_SEEN).block();
+        messageIdToImapUidDAO.insert(METADATA_UNSEEN).block();
+
+        testee.recomputeMailboxCounters(new Context()).block();
+
+        assertThat(counterDAO.retrieveMailboxCounters(CASSANDRA_ID_1).blockOptional())
+            .contains(MailboxCounters.builder()
+                .mailboxId(CASSANDRA_ID_1)
+                .count(1)
+                .unseen(1)
+                .build());
+    }
+
+    @Test
+    void recomputeMailboxCountersShouldIgnoreMissingMailboxListReferences() {
+        mailboxDAO.save(MAILBOX).block();
+        imapUidToMessageIdDAO.insert(METADATA_SEEN).block();
+
+        testee.recomputeMailboxCounters(new Context()).block();
+
+        assertThat(counterDAO.retrieveMailboxCounters(CASSANDRA_ID_1).blockOptional())
+            .isEmpty();
+    }
+
+    @Test
+    void recomputeMailboxCountersShouldIgnoreOrphanMailboxListReference() {
+        mailboxDAO.save(MAILBOX).block();
+        imapUidToMessageIdDAO.insert(METADATA_UNSEEN).block();
+
+        testee.recomputeMailboxCounters(new Context()).block();
+
+        assertThat(counterDAO.retrieveMailboxCounters(CASSANDRA_ID_1).blockOptional())
+            .isEmpty();
+    }
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersServiceTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersServiceTest.java
@@ -54,8 +54,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.datastax.driver.core.utils.UUIDs;
-
 class RecomputeMailboxCountersServiceTest {
     private static final UidValidity UID_VALIDITY_1 = UidValidity.ofValid(145);
     private static final Username USER = Username.of("user");
@@ -159,7 +157,7 @@ class RecomputeMailboxCountersServiceTest {
     }
 
     @Test
-    void recomputeMailboxCountersShouldReturnCompletedMailboxListReferenceIsMissing() {
+    void recomputeMailboxCountersShouldReturnCompletedWhenMailboxListReferenceIsMissing() {
         mailboxDAO.save(MAILBOX).block();
         messageIdToImapUidDAO.insert(METADATA_UNSEEN).block();
         counterDAO.incrementUnseen(CASSANDRA_ID_1).block();

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersTaskSerializationTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersTaskSerializationTest.java
@@ -1,0 +1,66 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.task;
+
+import static org.mockito.Mockito.mock;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.apache.james.JsonSerializationVerifier;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.model.MailboxConstants;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+class RecomputeMailboxCountersTaskSerializationTest {
+    private static final Instant TIMESTAMP = Instant.parse("2018-11-13T12:00:55Z");
+    private static final String MAILBOX_ID_AS_STRING = "464765a0-e4e7-11e4-aba4-710c1de3782b";
+
+    private static final RecomputeMailboxCountersService SERVICE = mock(RecomputeMailboxCountersService.class);
+    private static final RecomputeMailboxCountersTask TASK = new RecomputeMailboxCountersTask(SERVICE);
+    private static final String SERIALIZED_TASK = "{\"type\": \"recompute-mailbox-counters\"}";
+    private static final RecomputeMailboxCountersTask.Details DETAILS = new RecomputeMailboxCountersTask.Details(TIMESTAMP, 12, ImmutableList.of(MAILBOX_ID_AS_STRING));
+    private static final String SERIALIZED_ADDITIONAL_INFORMATION = "{" +
+        "  \"type\":\"recompute-mailbox-counters\"," +
+        "  \"processedMailboxes\":12," +
+        "  \"failedMailboxes\":[\"464765a0-e4e7-11e4-aba4-710c1de3782b\"]," +
+        "  \"timestamp\":\"2018-11-13T12:00:55Z\"" +
+        "}";
+
+    @Test
+    void taskShouldBeSerializable() throws Exception {
+        JsonSerializationVerifier.dtoModule(RecomputeMailboxCountersTaskDTO.module(SERVICE))
+            .bean(TASK)
+            .json(SERIALIZED_TASK)
+            .verify();
+    }
+
+    @Test
+    void additionalInformationShouldBeSerializable() throws Exception {
+        JsonSerializationVerifier.dtoModule(RecomputeMailboxCountersTaskAdditionalInformationDTO.MODULE)
+            .bean(DETAILS)
+            .json(SERIALIZED_ADDITIONAL_INFORMATION)
+            .verify();
+    }
+}

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/webadmin/InconsistencySolvingRoutesModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/webadmin/InconsistencySolvingRoutesModule.java
@@ -19,9 +19,12 @@
 
 package org.apache.james.modules.webadmin;
 
+import org.apache.james.mailbox.cassandra.mail.task.RecomputeMailboxCountersService;
+import org.apache.james.mailbox.cassandra.mail.task.SolveMailboxInconsistenciesService;
 import org.apache.james.webadmin.Routes;
 import org.apache.james.webadmin.routes.CassandraMappingsRoutes;
 import org.apache.james.webadmin.routes.MailboxesRoutes;
+import org.apache.james.webadmin.routes.RecomputeMailboxCountersRequestToTask;
 import org.apache.james.webadmin.routes.SolveMailboxInconsistenciesRequestToTask;
 import org.apache.james.webadmin.service.CassandraMappingsService;
 import org.apache.james.webadmin.tasks.TaskFromRequestRegistry;
@@ -46,9 +49,14 @@ public class InconsistencySolvingRoutesModule extends AbstractModule {
     public static class SolveMailboxInconsistenciesModules extends AbstractModule {
         @Override
         protected void configure() {
-            Multibinder.newSetBinder(binder(), TaskFromRequestRegistry.TaskRegistration.class,
-                Names.named(MailboxesRoutes.ALL_MAILBOXES_TASKS))
-                .addBinding().to(SolveMailboxInconsistenciesRequestToTask.class);
+            bind(RecomputeMailboxCountersService.class).in(Scopes.SINGLETON);
+            bind(SolveMailboxInconsistenciesService.class).in(Scopes.SINGLETON);
+
+            Multibinder<TaskFromRequestRegistry.TaskRegistration> multiBinder = Multibinder.newSetBinder(binder(),
+                TaskFromRequestRegistry.TaskRegistration.class, Names.named(MailboxesRoutes.ALL_MAILBOXES_TASKS));
+
+            multiBinder.addBinding().to(SolveMailboxInconsistenciesRequestToTask.class);
+            multiBinder.addBinding().to(RecomputeMailboxCountersRequestToTask.class);
         }
     }
 

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/TaskSerializationModule.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/TaskSerializationModule.java
@@ -35,6 +35,9 @@ import org.apache.james.json.DTOModule;
 import org.apache.james.mailbox.cassandra.mail.task.MailboxMergingTaskAdditionalInformationDTO;
 import org.apache.james.mailbox.cassandra.mail.task.MailboxMergingTaskDTO;
 import org.apache.james.mailbox.cassandra.mail.task.MailboxMergingTaskRunner;
+import org.apache.james.mailbox.cassandra.mail.task.RecomputeMailboxCountersService;
+import org.apache.james.mailbox.cassandra.mail.task.RecomputeMailboxCountersTaskAdditionalInformationDTO;
+import org.apache.james.mailbox.cassandra.mail.task.RecomputeMailboxCountersTaskDTO;
 import org.apache.james.mailbox.cassandra.mail.task.SolveMailboxInconsistenciesService;
 import org.apache.james.mailbox.cassandra.mail.task.SolveMailboxInconsistenciesTaskAdditionalInformationDTO;
 import org.apache.james.mailbox.cassandra.mail.task.SolveMailboxInconsistenciesTaskDTO;
@@ -260,6 +263,11 @@ public class TaskSerializationModule extends AbstractModule {
     }
 
     @ProvidesIntoSet
+    public TaskDTOModule<? extends Task, ? extends TaskDTO> recomputeMailboxCountersTask(RecomputeMailboxCountersService service) {
+        return RecomputeMailboxCountersTaskDTO.module(service);
+    }
+
+    @ProvidesIntoSet
     public TaskDTOModule<? extends Task, ? extends TaskDTO> messageIdReindexingTask(MessageIdReIndexingTask.Factory factory) {
         return MessageIdReindexingTaskDTO.module(factory);
     }
@@ -367,6 +375,11 @@ public class TaskSerializationModule extends AbstractModule {
     @ProvidesIntoSet
     public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends  AdditionalInformationDTO> solveMailboxInconsistenciesAdditionalInformation() {
         return SolveMailboxInconsistenciesTaskAdditionalInformationDTO.MODULE;
+    }
+
+    @ProvidesIntoSet
+    public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends  AdditionalInformationDTO> recomputeMailboxCountersAdditionalInformation() {
+        return RecomputeMailboxCountersTaskAdditionalInformationDTO.MODULE;
     }
 
     @ProvidesIntoSet

--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/RabbitMQWebAdminServerTaskSerializationIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/RabbitMQWebAdminServerTaskSerializationIntegrationTest.java
@@ -739,6 +739,26 @@ class RabbitMQWebAdminServerTaskSerializationIntegrationTest {
             .body("additionalInformation.errorMappingsCount", is(0));
     }
 
+    @Test
+    void recomputeMailboxCountersShouldComplete() {
+        String taskId = with()
+                .basePath("/mailboxes")
+                .queryParam("task", "RecomputeMailboxCounters")
+            .post()
+                .jsonPath()
+                .get("taskId");
+
+        given()
+            .basePath(TasksRoutes.BASE)
+        .when()
+            .get(taskId + "/await")
+        .then()
+            .body("status", is("completed"))
+            .body("taskId", is(taskId))
+            .body("type", is("recompute-mailbox-counters"))
+            .body("additionalInformation.processedMailboxes", is(0));
+    }
+
     private MailboxListener.MailboxAdded createMailboxAdded() {
         String uuid = "6e0dd59d-660e-4d9b-b22f-0354479f47b4";
         return EventFactory.mailboxAdded()

--- a/server/protocols/webadmin/webadmin-cassandra/src/main/java/org/apache/james/webadmin/routes/RecomputeMailboxCountersRequestToTask.java
+++ b/server/protocols/webadmin/webadmin-cassandra/src/main/java/org/apache/james/webadmin/routes/RecomputeMailboxCountersRequestToTask.java
@@ -1,0 +1,37 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.webadmin.routes;
+
+import javax.inject.Inject;
+
+import org.apache.james.mailbox.cassandra.mail.task.RecomputeMailboxCountersService;
+import org.apache.james.mailbox.cassandra.mail.task.RecomputeMailboxCountersTask;
+import org.apache.james.webadmin.tasks.TaskFromRequestRegistry;
+import org.apache.james.webadmin.tasks.TaskRegistrationKey;
+
+public class RecomputeMailboxCountersRequestToTask extends TaskFromRequestRegistry.TaskRegistration {
+    private static final TaskRegistrationKey REGISTRATION_KEY = TaskRegistrationKey.of("RecomputeMailboxCounters");
+
+    @Inject
+    public RecomputeMailboxCountersRequestToTask(RecomputeMailboxCountersService service) {
+        super(REGISTRATION_KEY,
+            request -> new RecomputeMailboxCountersTask(service));
+    }
+}

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -478,7 +478,7 @@ The scheduled task will have the following type `recompute-mailbox-counters` and
 }
 ```
 
-Note that conflicting entry inconsistencies will not be fixed and will require to explicitly use 
+Note that conflicting inconsistencies entries will not be fixed and will require to explicitly use 
 [ghost mailbox](#correcting-ghost-mailbox) endpoint in order to merge the conflicting mailboxes and prevent any message
 loss.
 

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -453,6 +453,41 @@ A dirty read is when data is read between the two writes of the denormalization 
 In order to ensure being offline, stop the traffic on SMTP, JMAP and IMAP ports, for example via re-configuration or 
 firewall rules.
 
+#### Recomputing mailbox counters
+
+This task is only available on top of Guice Cassandra products.
+
+```
+curl -XPOST /mailboxes?task=RecomputeMailboxCounters
+```
+
+Will recompute counters (unseen & total count) for the mailbox object stored in Cassandra.
+
+Cassandra maintains a per mailbox projection for message count and unseen message count. As with any projection, it can 
+go out of sync, leading to inconsistent results being returned to the client.
+
+[More details about endpoints returning a task](#Endpoints_returning_a_task).
+
+The scheduled task will have the following type `recompute-mailbox-counters` and the following `additionalInformation`:
+
+```
+{
+  "type":"recompute-mailbox-counters",
+  "processedMailboxes": 3,
+  "failedMailboxes": ["464765a0-e4e7-11e4-aba4-710c1de3782b"]
+}
+```
+
+Note that conflicting entry inconsistencies will not be fixed and will require to explicitly use 
+[ghost mailbox](#correcting-ghost-mailbox) endpoint in order to merge the conflicting mailboxes and prevent any message
+loss.
+
+**WARNING**: this task do not take into account concurrent modifications upon a single mailbox counter recomputation. 
+Rerunning the task will *eventually* provide the consistent result. As such we advise to run this task offline. 
+
+In order to ensure being offline, stop the traffic on SMTP, JMAP and IMAP ports, for example via re-configuration or 
+firewall rules.
+
 #### Recomputing Global JMAP fast message view projection
 
 This action is only available for backends supporting JMAP protocol.


### PR DESCRIPTION
Cassandra maintains a per mailbox projection for message count and unseen message count.

As with any projection, it can go out of sync, leading to inconsistent results being returned to the client, which is not acceptable.

We need to expose a corrective task, resetting mailbox counters to their correct value.

The proposed endpoint is:

```
curl -XPST http://ip:port/mailbox?task=RecomputeMailboxCounters
```

This endpoints will:
 - List existing mailboxes
 - List their messages
 - Check them against their source of truth
 - Compute mailbox counter values
 - And reset the value of the counter if needed

Of course, this endpoint won't be friendly in the face of concurrent operations, which would be ignored during the recomputation of the counter of the given mailbox. However the source of truth is unaffected hence, upon rerunning the task, the result will be eventually correct.

To be noted that we rely on the "listing messages by mailbox" projection (that we recheck). Missing entries in there will be ignored until the given projection is healed (currently unsupported). We furthermore can piggy back a partial check of the message denormalization upon counter recomputation (partial because we cannot detect missing entries in the "list messages in mailbox" denormalization table)