### PR TITLE
JAMES-2897 Consistency levels for counters

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
@@ -143,15 +143,17 @@ public class CassandraMailboxCounterDAO {
     }
 
     public Mono<Long> countMessagesInMailbox(CassandraId cassandraId) {
-        return cassandraAsyncExecutor.executeSingleRow(bindWithMailbox(cassandraId, readStatement))
-            .map(row -> row.getLong(COUNT));
+        return cassandraAsyncExecutor.executeSingleRow(bindWithMailbox(cassandraId, readStatement)
+                .setConsistencyLevel(QUORUM))
+            .map(row -> row.getLong(CassandraMailboxCountersTable.COUNT));
     }
 
     Mono<Long> countUnseenMessagesInMailbox(Mailbox mailbox) {
         CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
 
-        return cassandraAsyncExecutor.executeSingleRow(bindWithMailbox(mailboxId, readStatement))
-            .map(row -> row.getLong(UNSEEN));
+        return cassandraAsyncExecutor.executeSingleRow(bindWithMailbox(mailboxId, readStatement)
+                .setConsistencyLevel(QUORUM))
+            .map(row -> row.getLong(CassandraMailboxCountersTable.UNSEEN));
     }
 
     Mono<Void> decrementCount(CassandraId mailboxId) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mailbox.cassandra.mail;
 
+import static com.datastax.driver.core.ConsistencyLevel.QUORUM;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.decr;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
@@ -154,19 +155,27 @@ public class CassandraMailboxCounterDAO {
     }
 
     Mono<Void> decrementCount(CassandraId mailboxId) {
-        return cassandraAsyncExecutor.executeVoid(bindWithMailbox(mailboxId, decrementMessageCountStatement));
+        return cassandraAsyncExecutor.executeVoid(
+            bindWithMailbox(mailboxId, decrementMessageCountStatement)
+                .setConsistencyLevel(QUORUM));
     }
 
     Mono<Void> incrementCount(CassandraId mailboxId) {
-        return cassandraAsyncExecutor.executeVoid(bindWithMailbox(mailboxId, incrementMessageCountStatement));
+        return cassandraAsyncExecutor.executeVoid(
+            bindWithMailbox(mailboxId, incrementMessageCountStatement)
+                .setConsistencyLevel(QUORUM));
     }
 
     Mono<Void> decrementUnseen(CassandraId mailboxId) {
-        return cassandraAsyncExecutor.executeVoid(bindWithMailbox(mailboxId, decrementUnseenCountStatement));
+        return cassandraAsyncExecutor.executeVoid(
+            bindWithMailbox(mailboxId, decrementUnseenCountStatement)
+                .setConsistencyLevel(QUORUM));
     }
 
     Mono<Void> incrementUnseen(CassandraId mailboxId) {
-        return cassandraAsyncExecutor.executeVoid(bindWithMailbox(mailboxId, incrementUnseenCountStatement));
+        return cassandraAsyncExecutor.executeVoid(
+            bindWithMailbox(mailboxId, incrementUnseenCountStatement)
+                .setConsistencyLevel(QUORUM));
     }
 
     private BoundStatement bindWithMailbox(CassandraId mailboxId, PreparedStatement statement) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
@@ -58,7 +58,7 @@ public class CassandraMailboxCounterDAO {
     private final PreparedStatement decrementMessageCountStatement;
 
     @Inject
-    CassandraMailboxCounterDAO(Session session) {
+    public CassandraMailboxCounterDAO(Session session) {
         cassandraAsyncExecutor = new CassandraAsyncExecutor(session);
         readStatement = createReadStatement(session);
         incrementMessageCountStatement = updateMailboxStatement(session, incr(COUNT));
@@ -89,7 +89,7 @@ public class CassandraMailboxCounterDAO {
                 .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID))));
     }
 
-    Mono<MailboxCounters> retrieveMailboxCounters(CassandraId mailboxId) {
+    public Mono<MailboxCounters> retrieveMailboxCounters(CassandraId mailboxId) {
         return cassandraAsyncExecutor.executeSingleRow(bindWithMailbox(mailboxId, readStatement))
             .map(row ->  MailboxCounters.builder()
                 .mailboxId(mailboxId)
@@ -164,7 +164,7 @@ public class CassandraMailboxCounterDAO {
                 .setConsistencyLevel(QUORUM));
     }
 
-    Mono<Void> incrementCount(CassandraId mailboxId) {
+    public Mono<Void> incrementCount(CassandraId mailboxId) {
         return cassandraAsyncExecutor.executeVoid(
             bindWithMailbox(mailboxId, incrementMessageCountStatement)
                 .setConsistencyLevel(QUORUM));
@@ -176,7 +176,7 @@ public class CassandraMailboxCounterDAO {
                 .setConsistencyLevel(QUORUM));
     }
 
-    Mono<Void> incrementUnseen(CassandraId mailboxId) {
+    public Mono<Void> incrementUnseen(CassandraId mailboxId) {
         return cassandraAsyncExecutor.executeVoid(
             bindWithMailbox(mailboxId, incrementUnseenCountStatement)
                 .setConsistencyLevel(QUORUM));

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
@@ -125,7 +125,8 @@ public class CassandraMailboxCounterDAO {
         return cassandraAsyncExecutor.executeVoid(
             bindWithMailbox(mailboxId, addToCounters)
                 .setLong(COUNT, counters.getCount())
-                .setLong(UNSEEN, counters.getUnseen()));
+                .setLong(UNSEEN, counters.getUnseen())
+                .setConsistencyLevel(QUORUM));
     }
 
     private Mono<Void> remove(MailboxCounters counters) {
@@ -133,7 +134,8 @@ public class CassandraMailboxCounterDAO {
         return cassandraAsyncExecutor.executeVoid(
             bindWithMailbox(mailboxId, removeToCounters)
                 .setLong(COUNT, counters.getCount())
-                .setLong(UNSEEN, counters.getUnseen()));
+                .setLong(UNSEEN, counters.getUnseen())
+                .setConsistencyLevel(QUORUM));
     }
 
     Mono<Long> countMessagesInMailbox(Mailbox mailbox) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
@@ -34,6 +34,7 @@ import javax.inject.Inject;
 
 import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
 import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.table.CassandraMailboxCountersTable;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxCounters;
 
@@ -56,7 +57,7 @@ public class CassandraMailboxCounterDAO {
     private final PreparedStatement decrementMessageCountStatement;
 
     @Inject
-    public CassandraMailboxCounterDAO(Session session) {
+    CassandraMailboxCounterDAO(Session session) {
         cassandraAsyncExecutor = new CassandraAsyncExecutor(session);
         readStatement = createReadStatement(session);
         incrementMessageCountStatement = updateMailboxStatement(session, incr(COUNT));
@@ -87,7 +88,7 @@ public class CassandraMailboxCounterDAO {
                 .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID))));
     }
 
-    public Mono<MailboxCounters> retrieveMailboxCounters(CassandraId mailboxId) {
+    Mono<MailboxCounters> retrieveMailboxCounters(CassandraId mailboxId) {
         return cassandraAsyncExecutor.executeSingleRow(bindWithMailbox(mailboxId, readStatement))
             .map(row ->  MailboxCounters.builder()
                 .mailboxId(mailboxId)
@@ -134,7 +135,7 @@ public class CassandraMailboxCounterDAO {
                 .setLong(UNSEEN, counters.getUnseen()));
     }
 
-    public Mono<Long> countMessagesInMailbox(Mailbox mailbox) {
+    Mono<Long> countMessagesInMailbox(Mailbox mailbox) {
         CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
 
         return countMessagesInMailbox(mailboxId);
@@ -145,26 +146,26 @@ public class CassandraMailboxCounterDAO {
             .map(row -> row.getLong(COUNT));
     }
 
-    public Mono<Long> countUnseenMessagesInMailbox(Mailbox mailbox) {
+    Mono<Long> countUnseenMessagesInMailbox(Mailbox mailbox) {
         CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
 
         return cassandraAsyncExecutor.executeSingleRow(bindWithMailbox(mailboxId, readStatement))
             .map(row -> row.getLong(UNSEEN));
     }
 
-    public Mono<Void> decrementCount(CassandraId mailboxId) {
+    Mono<Void> decrementCount(CassandraId mailboxId) {
         return cassandraAsyncExecutor.executeVoid(bindWithMailbox(mailboxId, decrementMessageCountStatement));
     }
 
-    public Mono<Void> incrementCount(CassandraId mailboxId) {
+    Mono<Void> incrementCount(CassandraId mailboxId) {
         return cassandraAsyncExecutor.executeVoid(bindWithMailbox(mailboxId, incrementMessageCountStatement));
     }
 
-    public Mono<Void> decrementUnseen(CassandraId mailboxId) {
+    Mono<Void> decrementUnseen(CassandraId mailboxId) {
         return cassandraAsyncExecutor.executeVoid(bindWithMailbox(mailboxId, decrementUnseenCountStatement));
     }
 
-    public Mono<Void> incrementUnseen(CassandraId mailboxId) {
+    Mono<Void> incrementUnseen(CassandraId mailboxId) {
         return cassandraAsyncExecutor.executeVoid(bindWithMailbox(mailboxId, incrementUnseenCountStatement));
     }
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/quota/CassandraCurrentQuotaManager.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/quota/CassandraCurrentQuotaManager.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mailbox.cassandra.quota;
 
+import static com.datastax.driver.core.ConsistencyLevel.QUORUM;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.decr;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
@@ -69,13 +70,15 @@ public class CassandraCurrentQuotaManager implements StoreCurrentQuotaManager {
     @Override
     public void increase(QuotaRoot quotaRoot, long count, long size) {
         checkArguments(count, size);
-        session.execute(increaseStatement.bind(count, size, quotaRoot.getValue()));
+        session.execute(increaseStatement.bind(count, size, quotaRoot.getValue())
+            .setConsistencyLevel(QUORUM));
     }
 
     @Override
     public void decrease(QuotaRoot quotaRoot, long count, long size) {
         checkArguments(count, size);
-        session.execute(decreaseStatement.bind(count, size, quotaRoot.getValue()));
+        session.execute(decreaseStatement.bind(count, size, quotaRoot.getValue())
+            .setConsistencyLevel(QUORUM));
     }
 
     @Override

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/quota/CassandraCurrentQuotaManager.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/quota/CassandraCurrentQuotaManager.java
@@ -31,7 +31,6 @@ import javax.inject.Inject;
 import org.apache.james.core.quota.QuotaCountUsage;
 import org.apache.james.core.quota.QuotaSizeUsage;
 import org.apache.james.mailbox.cassandra.table.CassandraCurrentQuota;
-import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.QuotaRoot;
 import org.apache.james.mailbox.store.quota.StoreCurrentQuotaManager;
 
@@ -68,19 +67,19 @@ public class CassandraCurrentQuotaManager implements StoreCurrentQuotaManager {
     }
 
     @Override
-    public void increase(QuotaRoot quotaRoot, long count, long size) throws MailboxException {
+    public void increase(QuotaRoot quotaRoot, long count, long size) {
         checkArguments(count, size);
         session.execute(increaseStatement.bind(count, size, quotaRoot.getValue()));
     }
 
     @Override
-    public void decrease(QuotaRoot quotaRoot, long count, long size) throws MailboxException {
+    public void decrease(QuotaRoot quotaRoot, long count, long size) {
         checkArguments(count, size);
         session.execute(decreaseStatement.bind(count, size, quotaRoot.getValue()));
     }
 
     @Override
-    public QuotaCountUsage getCurrentMessageCount(QuotaRoot quotaRoot) throws MailboxException {
+    public QuotaCountUsage getCurrentMessageCount(QuotaRoot quotaRoot) {
         ResultSet resultSet = session.execute(getCurrentMessageCountStatement.bind(quotaRoot.getValue()));
         if (resultSet.isExhausted()) {
             return QuotaCountUsage.count(0L);
@@ -89,7 +88,7 @@ public class CassandraCurrentQuotaManager implements StoreCurrentQuotaManager {
     }
 
     @Override
-    public QuotaSizeUsage getCurrentStorage(QuotaRoot quotaRoot) throws MailboxException {
+    public QuotaSizeUsage getCurrentStorage(QuotaRoot quotaRoot) {
         ResultSet resultSet = session.execute(getCurrentStorageStatement.bind(quotaRoot.getValue()));
         if (resultSet.isExhausted()) {
             return QuotaSizeUsage.size(0L);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraIndexTableHandlerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraIndexTableHandlerTest.java
@@ -125,7 +125,7 @@ class CassandraIndexTableHandlerTest {
     }
 
     @Test
-    void updateIndexOnAddShouldIncrementMessageCount() throws Exception {
+    void updateIndexOnAddShouldIncrementMessageCount() {
         MailboxMessage message = mock(MailboxMessage.class);
         when(message.createFlags()).thenReturn(new Flags());
         when(message.getUid()).thenReturn(MESSAGE_UID);
@@ -137,7 +137,7 @@ class CassandraIndexTableHandlerTest {
     }
 
     @Test
-    void updateIndexOnAddShouldIncrementUnseenMessageCountWhenUnseen() throws Exception {
+    void updateIndexOnAddShouldIncrementUnseenMessageCountWhenUnseen() {
         MailboxMessage message = mock(MailboxMessage.class);
         when(message.createFlags()).thenReturn(new Flags());
         when(message.getUid()).thenReturn(MESSAGE_UID);
@@ -149,7 +149,7 @@ class CassandraIndexTableHandlerTest {
     }
 
     @Test
-    void updateIndexOnAddShouldNotIncrementUnseenMessageCountWhenSeen() throws Exception {
+    void updateIndexOnAddShouldNotIncrementUnseenMessageCountWhenSeen() {
         MailboxMessage message = mock(MailboxMessage.class);
         when(message.createFlags()).thenReturn(new Flags(Flags.Flag.SEEN));
         when(message.getUid()).thenReturn(MESSAGE_UID);
@@ -189,7 +189,7 @@ class CassandraIndexTableHandlerTest {
     }
 
     @Test
-    void updateIndexOnDeleteShouldDecrementMessageCount() throws Exception {
+    void updateIndexOnDeleteShouldDecrementMessageCount() {
         MailboxMessage message = mock(MailboxMessage.class);
         when(message.createFlags()).thenReturn(new Flags());
         when(message.getUid()).thenReturn(MESSAGE_UID);
@@ -206,7 +206,7 @@ class CassandraIndexTableHandlerTest {
     }
 
     @Test
-    void updateIndexOnDeleteShouldDecrementUnseenMessageCountWhenUnseen() throws Exception {
+    void updateIndexOnDeleteShouldDecrementUnseenMessageCountWhenUnseen() {
         MailboxMessage message = mock(MailboxMessage.class);
         when(message.createFlags()).thenReturn(new Flags());
         when(message.getUid()).thenReturn(MESSAGE_UID);
@@ -223,7 +223,7 @@ class CassandraIndexTableHandlerTest {
     }
 
     @Test
-    void updateIndexOnDeleteShouldNotDecrementUnseenMessageCountWhenSeen() throws Exception {
+    void updateIndexOnDeleteShouldNotDecrementUnseenMessageCountWhenSeen() {
         MailboxMessage message = mock(MailboxMessage.class);
         when(message.createFlags()).thenReturn(new Flags());
         when(message.getUid()).thenReturn(MESSAGE_UID);
@@ -299,7 +299,7 @@ class CassandraIndexTableHandlerTest {
     }
 
     @Test
-    void updateIndexOnFlagsUpdateShouldNotChangeMessageCount() throws Exception {
+    void updateIndexOnFlagsUpdateShouldNotChangeMessageCount() {
         MailboxMessage message = mock(MailboxMessage.class);
         when(message.createFlags()).thenReturn(new Flags());
         when(message.getUid()).thenReturn(MESSAGE_UID);
@@ -317,7 +317,7 @@ class CassandraIndexTableHandlerTest {
     }
 
     @Test
-    void updateIndexOnFlagsUpdateShouldDecrementUnseenMessageCountWhenSeenIsSet() throws Exception {
+    void updateIndexOnFlagsUpdateShouldDecrementUnseenMessageCountWhenSeenIsSet() {
         MailboxMessage message = mock(MailboxMessage.class);
         when(message.createFlags()).thenReturn(new Flags());
         when(message.getUid()).thenReturn(MESSAGE_UID);
@@ -427,7 +427,7 @@ class CassandraIndexTableHandlerTest {
     }
 
     @Test
-    void updateIndexOnFlagsUpdateShouldIncrementUnseenMessageCountWhenSeenIsUnset() throws Exception {
+    void updateIndexOnFlagsUpdateShouldIncrementUnseenMessageCountWhenSeenIsUnset() {
         MailboxMessage message = mock(MailboxMessage.class);
         when(message.createFlags()).thenReturn(new Flags(Flags.Flag.SEEN));
         when(message.getUid()).thenReturn(MESSAGE_UID);
@@ -445,7 +445,7 @@ class CassandraIndexTableHandlerTest {
     }
 
     @Test
-    void updateIndexOnFlagsUpdateShouldNotChangeUnseenCountWhenBothSeen() throws Exception {
+    void updateIndexOnFlagsUpdateShouldNotChangeUnseenCountWhenBothSeen() {
         MailboxMessage message = mock(MailboxMessage.class);
         when(message.createFlags()).thenReturn(new Flags(Flags.Flag.SEEN));
         when(message.getUid()).thenReturn(MESSAGE_UID);
@@ -463,7 +463,7 @@ class CassandraIndexTableHandlerTest {
     }
 
     @Test
-    void updateIndexOnFlagsUpdateShouldNotChangeUnseenCountWhenBothUnSeen() throws Exception {
+    void updateIndexOnFlagsUpdateShouldNotChangeUnseenCountWhenBothUnSeen() {
         MailboxMessage message = mock(MailboxMessage.class);
         when(message.createFlags()).thenReturn(new Flags());
         when(message.getUid()).thenReturn(MESSAGE_UID);

--- a/server/data/data-cassandra/src/main/java/org/apache/james/sieve/cassandra/CassandraSieveQuotaDAO.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/sieve/cassandra/CassandraSieveQuotaDAO.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.sieve.cassandra;
 
+import static com.datastax.driver.core.ConsistencyLevel.QUORUM;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.delete;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
@@ -112,7 +113,8 @@ public class CassandraSieveQuotaDAO {
         return cassandraAsyncExecutor.executeVoid(
             updateSpaceUsedStatement.bind()
                 .setLong(CassandraSieveSpaceTable.SPACE_USED, spaceUsed)
-                .setString(CassandraSieveSpaceTable.USER_NAME, username.asString()));
+                .setString(CassandraSieveSpaceTable.USER_NAME, username.asString())
+                .setConsistencyLevel(QUORUM));
     }
 
     public Mono<Optional<QuotaSizeLimit>> getQuota() {

--- a/server/data/data-cassandra/src/main/java/org/apache/james/sieve/cassandra/CassandraSieveQuotaDAO.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/sieve/cassandra/CassandraSieveQuotaDAO.java
@@ -100,7 +100,7 @@ public class CassandraSieveQuotaDAO {
                 .where(eq(CassandraSieveQuotaTable.USER_NAME, bindMarker(CassandraSieveQuotaTable.USER_NAME))));
     }
 
-    public Mono<Long> spaceUsedBy(Username username) {
+    Mono<Long> spaceUsedBy(Username username) {
         return cassandraAsyncExecutor.executeSingleRowOptional(
             selectSpaceUsedByUserStatement.bind()
                 .setString(CassandraSieveSpaceTable.USER_NAME, username.asString()))
@@ -108,7 +108,7 @@ public class CassandraSieveQuotaDAO {
                 .orElse(0L));
     }
 
-    public Mono<Void> updateSpaceUsed(Username username, long spaceUsed) {
+    Mono<Void> updateSpaceUsed(Username username, long spaceUsed) {
         return cassandraAsyncExecutor.executeVoid(
             updateSpaceUsedStatement.bind()
                 .setLong(CassandraSieveSpaceTable.SPACE_USED, spaceUsed)
@@ -123,20 +123,20 @@ public class CassandraSieveQuotaDAO {
                 QuotaSizeLimit.size(row.getLong(CassandraSieveClusterQuotaTable.VALUE))));
     }
 
-    public Mono<Void> setQuota(QuotaSizeLimit quota) {
+    Mono<Void> setQuota(QuotaSizeLimit quota) {
         return cassandraAsyncExecutor.executeVoid(
             updateClusterQuotaStatement.bind()
                 .setLong(CassandraSieveClusterQuotaTable.VALUE, quota.asLong())
                 .setString(CassandraSieveClusterQuotaTable.NAME, CassandraSieveClusterQuotaTable.DEFAULT_NAME));
     }
 
-    public Mono<Void> removeQuota() {
+    Mono<Void> removeQuota() {
         return cassandraAsyncExecutor.executeVoid(
             deleteClusterQuotaStatement.bind()
                 .setString(CassandraSieveClusterQuotaTable.NAME, CassandraSieveClusterQuotaTable.DEFAULT_NAME));
     }
 
-    public Mono<Optional<QuotaSizeLimit>> getQuota(Username username) {
+    Mono<Optional<QuotaSizeLimit>> getQuota(Username username) {
         return cassandraAsyncExecutor.executeSingleRowOptional(
             selectUserQuotaStatement.bind()
                 .setString(CassandraSieveQuotaTable.USER_NAME, username.asString()))
@@ -144,14 +144,14 @@ public class CassandraSieveQuotaDAO {
                 QuotaSizeLimit.size(row.getLong(CassandraSieveQuotaTable.QUOTA))));
     }
 
-    public Mono<Void> setQuota(Username username, QuotaSizeLimit quota) {
+    Mono<Void> setQuota(Username username, QuotaSizeLimit quota) {
         return cassandraAsyncExecutor.executeVoid(
             updateUserQuotaStatement.bind()
                 .setLong(CassandraSieveQuotaTable.QUOTA, quota.asLong())
                 .setString(CassandraSieveQuotaTable.USER_NAME, username.asString()));
     }
 
-    public Mono<Void> removeQuota(Username username)  {
+    Mono<Void> removeQuota(Username username)  {
         return cassandraAsyncExecutor.executeVoid(
             deleteUserQuotaStatement.bind()
                 .setString(CassandraSieveQuotaTable.USER_NAME, username.asString()));

--- a/server/data/data-cassandra/src/main/java/org/apache/james/sieve/cassandra/CassandraSieveQuotaDAO.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/sieve/cassandra/CassandraSieveQuotaDAO.java
@@ -104,7 +104,8 @@ public class CassandraSieveQuotaDAO {
     Mono<Long> spaceUsedBy(Username username) {
         return cassandraAsyncExecutor.executeSingleRowOptional(
             selectSpaceUsedByUserStatement.bind()
-                .setString(CassandraSieveSpaceTable.USER_NAME, username.asString()))
+                .setString(CassandraSieveSpaceTable.USER_NAME, username.asString())
+                .setConsistencyLevel(QUORUM))
             .map(optional -> optional.map(row -> row.getLong(CassandraSieveSpaceTable.SPACE_USED))
                 .orElse(0L));
     }

--- a/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryCountDAO.java
+++ b/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryCountDAO.java
@@ -50,7 +50,7 @@ public class CassandraMailRepositoryCountDAO {
     private final PreparedStatement select;
 
     @Inject
-    public CassandraMailRepositoryCountDAO(Session session) {
+    CassandraMailRepositoryCountDAO(Session session) {
         this.executor = new CassandraAsyncExecutor(session);
 
         this.increment = prepareIncrement(session);
@@ -76,17 +76,17 @@ public class CassandraMailRepositoryCountDAO {
             .where(eq(REPOSITORY_NAME, bindMarker(REPOSITORY_NAME))));
     }
 
-    public Mono<Void> increment(MailRepositoryUrl url) {
+    Mono<Void> increment(MailRepositoryUrl url) {
         return executor.executeVoid(increment.bind()
             .setString(REPOSITORY_NAME, url.asString()));
     }
 
-    public Mono<Void> decrement(MailRepositoryUrl url) {
+    Mono<Void> decrement(MailRepositoryUrl url) {
         return executor.executeVoid(decrement.bind()
             .setString(REPOSITORY_NAME, url.asString()));
     }
 
-    public Mono<Long> getCount(MailRepositoryUrl url) {
+    Mono<Long> getCount(MailRepositoryUrl url) {
         return executor.executeSingleRowOptional(select.bind()
                 .setString(REPOSITORY_NAME, url.asString()))
             .map(this::toCount);

--- a/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryCountDAO.java
+++ b/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryCountDAO.java
@@ -91,7 +91,8 @@ public class CassandraMailRepositoryCountDAO {
 
     Mono<Long> getCount(MailRepositoryUrl url) {
         return executor.executeSingleRowOptional(select.bind()
-                .setString(REPOSITORY_NAME, url.asString()))
+                .setString(REPOSITORY_NAME, url.asString())
+                .setConsistencyLevel(QUORUM))
             .map(this::toCount);
     }
 

--- a/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryCountDAO.java
+++ b/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepositoryCountDAO.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mailrepository.cassandra;
 
+import static com.datastax.driver.core.ConsistencyLevel.QUORUM;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.decr;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
@@ -78,12 +79,14 @@ public class CassandraMailRepositoryCountDAO {
 
     Mono<Void> increment(MailRepositoryUrl url) {
         return executor.executeVoid(increment.bind()
-            .setString(REPOSITORY_NAME, url.asString()));
+            .setString(REPOSITORY_NAME, url.asString())
+                .setConsistencyLevel(QUORUM));
     }
 
     Mono<Void> decrement(MailRepositoryUrl url) {
         return executor.executeVoid(decrement.bind()
-            .setString(REPOSITORY_NAME, url.asString()));
+            .setString(REPOSITORY_NAME, url.asString())
+            .setConsistencyLevel(QUORUM));
     }
 
     Mono<Long> getCount(MailRepositoryUrl url) {


### PR DESCRIPTION
On prod we noticed consistency level ONE being used.

Being not idempotent, counters writes are not retried hence failing.

A single node failure can thus lead to the overall operation failure.

I propose to set the consistency level to QUORUM for counters to see if it makes things nicer.