### PR TITLE
JAMES-3107 Log request when P99 is exceeded

### DIFF
--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/MailboxListenerExecutor.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/MailboxListenerExecutor.java
@@ -36,11 +36,13 @@ public class MailboxListenerExecutor {
 
     void execute(MailboxListener listener, MDCBuilder mdcBuilder, Event event) throws Exception {
         if (listener.isHandling(event)) {
-            TimeMetric timer = metricFactory.timer(timerName(listener));
             try (Closeable mdc = buildMDC(listener, mdcBuilder, event)) {
-                listener.event(event);
-            } finally {
-                timer.stopAndPublish();
+                TimeMetric timer = metricFactory.timer(timerName(listener));
+                try {
+                    listener.event(event);
+                } finally {
+                    timer.stopAndPublish();
+                }
             }
         }
     }

--- a/metrics/metrics-api/src/main/java/org/apache/james/metrics/api/MetricFactory.java
+++ b/metrics/metrics-api/src/main/java/org/apache/james/metrics/api/MetricFactory.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.metrics.api;
 
+import static org.apache.james.metrics.api.TimeMetric.ExecutionResult.DEFAULT_100_MS_THRESHOLD;
+
 import java.util.function.Supplier;
 
 import org.reactivestreams.Publisher;
@@ -35,6 +37,15 @@ public interface MetricFactory {
             return operation.get();
         } finally {
             timer.stopAndPublish();
+        }
+    }
+
+    default <T> T runPublishingTimerMetricLogP99(String name, Supplier<T> operation) {
+        TimeMetric timer = timer(name);
+        try {
+            return operation.get();
+        } finally {
+            timer.stopAndPublish().logWhenExceedP99(DEFAULT_100_MS_THRESHOLD);
         }
     }
 

--- a/metrics/metrics-api/src/main/java/org/apache/james/metrics/api/TimeMetric.java
+++ b/metrics/metrics-api/src/main/java/org/apache/james/metrics/api/TimeMetric.java
@@ -18,14 +18,16 @@
  ****************************************************************/
 package org.apache.james.metrics.api;
 
+import java.time.Duration;
+
 public interface TimeMetric {
 
     interface ExecutionResult {
-        long DEFAULT_100_MS_THRESHOLD = 100 * 1000;
+        Duration DEFAULT_100_MS_THRESHOLD = Duration.ofMillis(100);
 
-        long elaspedInNanoSeconds();
+        Duration elasped();
 
-        ExecutionResult logWhenExceedP99(long thresholdInNanoSeconds);
+        ExecutionResult logWhenExceedP99(Duration thresholdInNanoSeconds);
     }
 
     String name();

--- a/metrics/metrics-api/src/main/java/org/apache/james/metrics/api/TimeMetric.java
+++ b/metrics/metrics-api/src/main/java/org/apache/james/metrics/api/TimeMetric.java
@@ -20,8 +20,16 @@ package org.apache.james.metrics.api;
 
 public interface TimeMetric {
 
+    interface ExecutionResult {
+        long DEFAULT_100_MS_THRESHOLD = 100 * 1000;
+
+        long elaspedInNanoSeconds();
+
+        ExecutionResult logWhenExceedP99(long thresholdInNanoSeconds);
+    }
+
     String name();
 
-    long stopAndPublish();
+    ExecutionResult stopAndPublish();
 
 }

--- a/metrics/metrics-dropwizard/src/main/java/org/apache/james/metrics/dropwizard/DropWizardMetricFactory.java
+++ b/metrics/metrics-dropwizard/src/main/java/org/apache/james/metrics/dropwizard/DropWizardMetricFactory.java
@@ -53,7 +53,7 @@ public class DropWizardMetricFactory implements MetricFactory, Startable {
 
     @Override
     public TimeMetric timer(String name) {
-        return new DropWizardTimeMetric(name, metricRegistry.timer(name).time());
+        return new DropWizardTimeMetric(name, metricRegistry.timer(name));
     }
 
     @Override

--- a/metrics/metrics-logger/src/main/java/org/apache/james/metrics/logger/DefaultTimeMetric.java
+++ b/metrics/metrics-logger/src/main/java/org/apache/james/metrics/logger/DefaultTimeMetric.java
@@ -25,6 +25,23 @@ import org.apache.james.metrics.api.TimeMetric;
 import com.google.common.base.Stopwatch;
 
 public class DefaultTimeMetric implements TimeMetric {
+    static class DefaultExecutionResult implements ExecutionResult {
+        private final long elaspedInNanoSeconds;
+
+        DefaultExecutionResult(long elaspedInNanoSeconds) {
+            this.elaspedInNanoSeconds = elaspedInNanoSeconds;
+        }
+
+        @Override
+        public long elaspedInNanoSeconds() {
+            return elaspedInNanoSeconds;
+        }
+
+        @Override
+        public ExecutionResult logWhenExceedP99(long thresholdInNanoSeconds) {
+            return this;
+        }
+    }
 
     private final String name;
     private final Stopwatch stopwatch;
@@ -40,10 +57,10 @@ public class DefaultTimeMetric implements TimeMetric {
     }
 
     @Override
-    public long stopAndPublish() {
+    public ExecutionResult stopAndPublish() {
         long elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);
         DefaultMetricFactory.LOGGER.info("Time spent in {}: {} ms.", name, elapsed);
-        return elapsed;
+        return new DefaultExecutionResult(elapsed);
     }
 
 }

--- a/metrics/metrics-logger/src/main/java/org/apache/james/metrics/logger/DefaultTimeMetric.java
+++ b/metrics/metrics-logger/src/main/java/org/apache/james/metrics/logger/DefaultTimeMetric.java
@@ -18,6 +18,7 @@
  ****************************************************************/
 package org.apache.james.metrics.logger;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.james.metrics.api.TimeMetric;
@@ -26,19 +27,19 @@ import com.google.common.base.Stopwatch;
 
 public class DefaultTimeMetric implements TimeMetric {
     static class DefaultExecutionResult implements ExecutionResult {
-        private final long elaspedInNanoSeconds;
+        private final Duration elasped;
 
-        DefaultExecutionResult(long elaspedInNanoSeconds) {
-            this.elaspedInNanoSeconds = elaspedInNanoSeconds;
+        DefaultExecutionResult(Duration elasped) {
+            this.elasped = elasped;
         }
 
         @Override
-        public long elaspedInNanoSeconds() {
-            return elaspedInNanoSeconds;
+        public Duration elasped() {
+            return elasped;
         }
 
         @Override
-        public ExecutionResult logWhenExceedP99(long thresholdInNanoSeconds) {
+        public ExecutionResult logWhenExceedP99(Duration thresholdInNanoSeconds) {
             return this;
         }
     }
@@ -60,7 +61,7 @@ public class DefaultTimeMetric implements TimeMetric {
     public ExecutionResult stopAndPublish() {
         long elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);
         DefaultMetricFactory.LOGGER.info("Time spent in {}: {} ms.", name, elapsed);
-        return new DefaultExecutionResult(elapsed);
+        return new DefaultExecutionResult(Duration.ofNanos(elapsed));
     }
 
 }

--- a/metrics/metrics-tests/src/main/java/org/apache/james/metrics/tests/RecordingTimeMetric.java
+++ b/metrics/metrics-tests/src/main/java/org/apache/james/metrics/tests/RecordingTimeMetric.java
@@ -28,6 +28,24 @@ import org.apache.james.metrics.api.TimeMetric;
 import com.google.common.base.Stopwatch;
 
 public class RecordingTimeMetric implements TimeMetric {
+    static class DefaultExecutionResult implements ExecutionResult {
+        private final long elaspedInNanoSeconds;
+
+        DefaultExecutionResult(long elaspedInNanoSeconds) {
+            this.elaspedInNanoSeconds = elaspedInNanoSeconds;
+        }
+
+        @Override
+        public long elaspedInNanoSeconds() {
+            return elaspedInNanoSeconds;
+        }
+
+        @Override
+        public ExecutionResult logWhenExceedP99(long thresholdInNanoSeconds) {
+            return this;
+        }
+    }
+
     private final String name;
     private final Stopwatch stopwatch = Stopwatch.createStarted();
     private final Consumer<Duration> publishCallback;
@@ -43,9 +61,9 @@ public class RecordingTimeMetric implements TimeMetric {
     }
 
     @Override
-    public long stopAndPublish() {
+    public ExecutionResult stopAndPublish() {
         long elapsed = stopwatch.elapsed(TimeUnit.NANOSECONDS);
         publishCallback.accept(Duration.ofNanos(elapsed));
-        return elapsed;
+        return new DefaultExecutionResult(elapsed);
     }
 }

--- a/metrics/metrics-tests/src/main/java/org/apache/james/metrics/tests/RecordingTimeMetric.java
+++ b/metrics/metrics-tests/src/main/java/org/apache/james/metrics/tests/RecordingTimeMetric.java
@@ -29,19 +29,19 @@ import com.google.common.base.Stopwatch;
 
 public class RecordingTimeMetric implements TimeMetric {
     static class DefaultExecutionResult implements ExecutionResult {
-        private final long elaspedInNanoSeconds;
+        private final Duration elasped;
 
-        DefaultExecutionResult(long elaspedInNanoSeconds) {
-            this.elaspedInNanoSeconds = elaspedInNanoSeconds;
+        DefaultExecutionResult(Duration elasped) {
+            this.elasped = elasped;
         }
 
         @Override
-        public long elaspedInNanoSeconds() {
-            return elaspedInNanoSeconds;
+        public Duration elasped() {
+            return elasped;
         }
 
         @Override
-        public ExecutionResult logWhenExceedP99(long thresholdInNanoSeconds) {
+        public ExecutionResult logWhenExceedP99(Duration thresholdInNanoSeconds) {
             return this;
         }
     }
@@ -62,8 +62,8 @@ public class RecordingTimeMetric implements TimeMetric {
 
     @Override
     public ExecutionResult stopAndPublish() {
-        long elapsed = stopwatch.elapsed(TimeUnit.NANOSECONDS);
-        publishCallback.accept(Duration.ofNanos(elapsed));
+        Duration elapsed = Duration.ofNanos(stopwatch.elapsed(TimeUnit.NANOSECONDS));
+        publishCallback.accept(elapsed);
         return new DefaultExecutionResult(elapsed);
     }
 }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractMailboxProcessor.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.imap.processor;
 
+import static org.apache.james.metrics.api.TimeMetric.ExecutionResult.DEFAULT_100_MS_THRESHOLD;
+
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -105,7 +107,7 @@ public abstract class AbstractMailboxProcessor<R extends ImapRequest> extends Ab
             LOGGER.error("Unexpected error during IMAP processing", unexpectedException);
             no(acceptableMessage, responder, HumanReadableText.GENERIC_FAILURE_DURING_PROCESSING);
         }
-        timeMetric.stopAndPublish();
+        timeMetric.stopAndPublish().logWhenExceedP99(DEFAULT_100_MS_THRESHOLD);
     }
 
     protected void flags(Responder responder, SelectedMailbox selected) {

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailSpooler.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailSpooler.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mailetcontainer.impl;
 
+import static org.apache.james.metrics.api.TimeMetric.ExecutionResult.DEFAULT_100_MS_THRESHOLD;
+
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -119,7 +121,7 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
         try {
             return Mono.fromCallable(processingActive::incrementAndGet)
                 .flatMap(ignore -> processMail(queueItem).subscribeOn(spooler))
-                .doOnSuccess(any -> timeMetric.stopAndPublish())
+                .doOnSuccess(any -> timeMetric.stopAndPublish().logWhenExceedP99(DEFAULT_100_MS_THRESHOLD))
                 .doOnSuccess(any -> processingActive.decrementAndGet());
         } catch (Throwable e) {
             return Mono.error(e);

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/CamelProcessor.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/CamelProcessor.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.mailetcontainer.impl.camel;
 
+import static org.apache.james.metrics.api.TimeMetric.ExecutionResult.DEFAULT_100_MS_THRESHOLD;
+
 import java.io.Closeable;
 import java.util.List;
 import java.util.Locale;
@@ -97,7 +99,7 @@ public class CamelProcessor {
             }
 
         } finally {
-            timeMetric.stopAndPublish();
+            timeMetric.stopAndPublish().logWhenExceedP99(DEFAULT_100_MS_THRESHOLD);
             MailetPipelineLogging.logEndOfMailetProcess(mailet, mail);
             List<MailetProcessorListener> listeners = processor.getListeners();
             long complete = System.currentTimeMillis() - start;

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/MatcherSplitter.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/camel/MatcherSplitter.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mailetcontainer.impl.camel;
 
+import static org.apache.james.metrics.api.TimeMetric.ExecutionResult.DEFAULT_100_MS_THRESHOLD;
+
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -174,7 +176,7 @@ public class MatcherSplitter {
 
             return mails;
         } finally {
-            timeMetric.stopAndPublish();
+            timeMetric.stopAndPublish().logWhenExceedP99(DEFAULT_100_MS_THRESHOLD);
             long complete = System.currentTimeMillis() - start;
             List<MailetProcessorListener> listeners = container.getListeners();
             for (MailetProcessorListener listener : listeners) {

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/DeliveryRunnable.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/DeliveryRunnable.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.transport.mailets.remote.delivery;
 
+import static org.apache.james.metrics.api.TimeMetric.ExecutionResult.DEFAULT_100_MS_THRESHOLD;
+
 import java.time.Duration;
 import java.util.Date;
 import java.util.function.Supplier;
@@ -92,7 +94,7 @@ public class DeliveryRunnable implements Disposable {
         TimeMetric timeMetric = metricFactory.timer(REMOTE_DELIVERY_TRIAL);
         try {
             return processMail(queueItem)
-                .doOnSuccess(any -> timeMetric.stopAndPublish());
+                .doOnSuccess(any -> timeMetric.stopAndPublish().logWhenExceedP99(DEFAULT_100_MS_THRESHOLD));
         } catch (Throwable e) {
             return Mono.error(e);
         }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/AuthenticationServlet.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/AuthenticationServlet.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.jmap.draft;
 
+import static org.apache.james.metrics.api.TimeMetric.ExecutionResult.DEFAULT_100_MS_THRESHOLD;
+
 import java.io.IOException;
 
 import javax.inject.Inject;
@@ -97,7 +99,7 @@ public class AuthenticationServlet extends HttpServlet {
             LOG.error("Internal error", e);
             resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         } finally {
-            timeMetric.stopAndPublish();
+            timeMetric.stopAndPublish().logWhenExceedP99(DEFAULT_100_MS_THRESHOLD);
         }
     }
     

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/UserProvisioningFilter.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/UserProvisioningFilter.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.jmap.draft;
 
+import static org.apache.james.metrics.api.TimeMetric.ExecutionResult.DEFAULT_100_MS_THRESHOLD;
+
 import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
@@ -77,7 +79,7 @@ public class UserProvisioningFilter implements Filter {
         } catch (UsersRepositoryException e) {
             throw new RuntimeException(e);
         } finally {
-            timeMetric.stopAndPublish();
+            timeMetric.stopAndPublish().logWhenExceedP99(DEFAULT_100_MS_THRESHOLD);
         }
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetFilterMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetFilterMethod.java
@@ -73,10 +73,13 @@ public class GetFilterMethod implements Method {
 
         GetFilterRequest filterRequest = (GetFilterRequest) request;
 
-        return metricFactory.runPublishingTimerMetric(JMAP_PREFIX + METHOD_NAME.getName(),
-            MDCBuilder.create()
-                .addContext(MDCBuilder.ACTION, "GET_FILTER")
-                .wrapArround(() -> process(methodCallId, mailboxSession, filterRequest)));
+
+        return MDCBuilder.create()
+            .addContext(MDCBuilder.ACTION, "GET_FILTER")
+            .wrapArround(
+                () -> metricFactory.runPublishingTimerMetricLogP99(JMAP_PREFIX + METHOD_NAME.getName(),
+                    () -> process(methodCallId, mailboxSession, filterRequest)))
+            .get();
     }
 
     private Stream<JmapResponse> process(MethodCallId methodCallId, MailboxSession mailboxSession, GetFilterRequest request) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMailboxesMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMailboxesMethod.java
@@ -91,13 +91,16 @@ public class GetMailboxesMethod implements Method {
     public Stream<JmapResponse> process(JmapRequest request, MethodCallId methodCallId, MailboxSession mailboxSession) {
         Preconditions.checkArgument(request instanceof GetMailboxesRequest);
         GetMailboxesRequest mailboxesRequest = (GetMailboxesRequest) request;
-        return metricFactory.runPublishingTimerMetric(JMAP_PREFIX + METHOD_NAME.getName(),
-            MDCBuilder.create()
-                .addContext(MDCBuilder.ACTION, "GET_MAILBOXES")
-                .addContext("accountId", mailboxesRequest.getAccountId())
-                .addContext("mailboxIds", mailboxesRequest.getIds())
-                .addContext("properties", mailboxesRequest.getProperties())
-                .wrapArround(() -> process(methodCallId, mailboxSession, mailboxesRequest)));
+
+        return MDCBuilder.create()
+            .addContext(MDCBuilder.ACTION, "GET_MAILBOXES")
+            .addContext("accountId", mailboxesRequest.getAccountId())
+            .addContext("mailboxIds", mailboxesRequest.getIds())
+            .addContext("properties", mailboxesRequest.getProperties())
+            .wrapArround(
+                () -> metricFactory.runPublishingTimerMetricLogP99(JMAP_PREFIX + METHOD_NAME.getName(),
+                    () -> process(methodCallId, mailboxSession, mailboxesRequest)))
+            .get();
     }
 
     private Stream<JmapResponse> process(MethodCallId methodCallId, MailboxSession mailboxSession, GetMailboxesRequest mailboxesRequest) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMessageListMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMessageListMethod.java
@@ -94,7 +94,7 @@ public class GetMessageListMethod implements Method {
 
         GetMessageListRequest messageListRequest = (GetMessageListRequest) request;
 
-        return metricFactory.runPublishingTimerMetric(JMAP_PREFIX + METHOD_NAME.getName(), MDCBuilder.create()
+        return MDCBuilder.create()
             .addContext(MDCBuilder.ACTION, "GET_MESSAGE_LIST")
             .addContext("accountId", messageListRequest.getAccountId())
             .addContext("limit", messageListRequest.getLimit())
@@ -107,7 +107,9 @@ public class GetMessageListMethod implements Method {
             .addContext("isFetchMessage", messageListRequest.isFetchMessages())
             .addContext("isCollapseThread", messageListRequest.isCollapseThreads())
             .wrapArround(
-                () -> process(methodCallId, mailboxSession, messageListRequest)));
+                () -> metricFactory.runPublishingTimerMetricLogP99(JMAP_PREFIX + METHOD_NAME.getName(),
+                    () -> process(methodCallId, mailboxSession, messageListRequest)))
+            .get();
     }
 
     private Stream<JmapResponse> process(MethodCallId methodCallId, MailboxSession mailboxSession, GetMessageListRequest messageListRequest) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetVacationResponseMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetVacationResponseMethod.java
@@ -70,15 +70,17 @@ public class GetVacationResponseMethod implements Method {
         Preconditions.checkNotNull(mailboxSession);
         Preconditions.checkArgument(request instanceof GetVacationRequest);
 
-        return metricFactory.runPublishingTimerMetric(JMAP_PREFIX + METHOD_NAME.getName(),
-            MDCBuilder.create()
-                .addContext(MDCBuilder.ACTION, "VACATION")
-                .wrapArround(
+
+        return MDCBuilder.create()
+            .addContext(MDCBuilder.ACTION, "VACATION")
+            .wrapArround(
+                () -> metricFactory.runPublishingTimerMetricLogP99(JMAP_PREFIX + METHOD_NAME.getName(),
                     () -> Stream.of(JmapResponse.builder()
                         .methodCallId(methodCallId)
                         .responseName(RESPONSE_NAME)
                         .response(process(mailboxSession))
-                        .build())));
+                        .build())))
+            .get();
     }
 
     private GetVacationResponse process(MailboxSession mailboxSession) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SendMDNProcessor.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SendMDNProcessor.java
@@ -84,7 +84,7 @@ public class SendMDNProcessor implements SetMessagesProcessor {
 
     @Override
     public SetMessagesResponse process(SetMessagesRequest request, MailboxSession mailboxSession) {
-        return metricFactory.runPublishingTimerMetric(JMAP_PREFIX + "SendMDN",
+        return metricFactory.runPublishingTimerMetricLogP99(JMAP_PREFIX + "SendMDN",
             () -> handleMDNCreation(request, mailboxSession));
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetFilterMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetFilterMethod.java
@@ -111,12 +111,13 @@ public class SetFilterMethod implements Method {
 
         SetFilterRequest setFilterRequest = (SetFilterRequest) request;
 
-        return metricFactory.runPublishingTimerMetric(JMAP_PREFIX + METHOD_NAME.getName(),
-            MDCBuilder.create()
-                .addContext(MDCBuilder.ACTION, "SET_FILTER")
-                .addContext("update", setFilterRequest.getSingleton())
-                .wrapArround(
-                    () -> process(methodCallId, mailboxSession, setFilterRequest)));
+        return MDCBuilder.create()
+            .addContext(MDCBuilder.ACTION, "SET_FILTER")
+            .addContext("update", setFilterRequest.getSingleton())
+            .wrapArround(
+                () -> metricFactory.runPublishingTimerMetricLogP99(JMAP_PREFIX + METHOD_NAME.getName(),
+                    () -> process(methodCallId, mailboxSession, setFilterRequest)))
+            .get();
     }
 
     private Stream<JmapResponse> process(MethodCallId methodCallId, MailboxSession mailboxSession, SetFilterRequest request) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMailboxesMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMailboxesMethod.java
@@ -67,18 +67,20 @@ public class SetMailboxesMethod implements Method {
 
         SetMailboxesRequest setMailboxesRequest = (SetMailboxesRequest) request;
 
-        return metricFactory.runPublishingTimerMetric(JMAP_PREFIX + METHOD_NAME.getName(),
-            MDCBuilder.create()
-                .addContext(MDCBuilder.ACTION, "SET_MAILBOXES")
-                .addContext("create", setMailboxesRequest.getCreate())
-                .addContext("update", setMailboxesRequest.getUpdate())
-                .addContext("destroy", setMailboxesRequest.getDestroy())
-                .wrapArround(
+
+        return MDCBuilder.create()
+            .addContext(MDCBuilder.ACTION, "SET_MAILBOXES")
+            .addContext("create", setMailboxesRequest.getCreate())
+            .addContext("update", setMailboxesRequest.getUpdate())
+            .addContext("destroy", setMailboxesRequest.getDestroy())
+            .wrapArround(
+                () -> metricFactory.runPublishingTimerMetricLogP99(JMAP_PREFIX + METHOD_NAME.getName(),
                     () -> Stream.of(
                         JmapResponse.builder().methodCallId(methodCallId)
                             .response(setMailboxesResponse(setMailboxesRequest, mailboxSession))
                             .responseName(RESPONSE_NAME)
-                            .build())));
+                            .build())))
+            .get();
     }
 
     private SetMailboxesResponse setMailboxesResponse(SetMailboxesRequest request, MailboxSession mailboxSession) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetMessagesMethod.java
@@ -63,19 +63,21 @@ public class SetMessagesMethod implements Method {
         Preconditions.checkArgument(request instanceof SetMessagesRequest);
         SetMessagesRequest setMessagesRequest = (SetMessagesRequest) request;
 
-        return metricFactory.runPublishingTimerMetric(JMAP_PREFIX + METHOD_NAME.getName(),
-            MDCBuilder.create()
-                .addContext(MDCBuilder.ACTION, "SET_MESSAGES")
-                .addContext("accountId", setMessagesRequest.getAccountId())
-                .addContext("create", setMessagesRequest.getCreate())
-                .addContext("destroy", setMessagesRequest.getDestroy())
-                .addContext("ifInState", setMessagesRequest.getIfInState())
-                .wrapArround(
+
+        return MDCBuilder.create()
+            .addContext(MDCBuilder.ACTION, "SET_MESSAGES")
+            .addContext("accountId", setMessagesRequest.getAccountId())
+            .addContext("create", setMessagesRequest.getCreate())
+            .addContext("destroy", setMessagesRequest.getDestroy())
+            .addContext("ifInState", setMessagesRequest.getIfInState())
+            .wrapArround(
+                () -> metricFactory.runPublishingTimerMetricLogP99(JMAP_PREFIX + METHOD_NAME.getName(),
                     () ->  Stream.of(
                         JmapResponse.builder().methodCallId(methodCallId)
                             .response(setMessagesResponse(setMessagesRequest, mailboxSession))
                             .responseName(RESPONSE_NAME)
-                            .build())));
+                            .build())))
+            .get();
     }
 
     private SetMessagesResponse setMessagesResponse(SetMessagesRequest request, MailboxSession mailboxSession) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetVacationResponseMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/SetVacationResponseMethod.java
@@ -76,12 +76,14 @@ public class SetVacationResponseMethod implements Method {
         Preconditions.checkArgument(request instanceof SetVacationRequest);
         SetVacationRequest setVacationRequest = (SetVacationRequest) request;
 
-        return metricFactory.runPublishingTimerMetric(JMAP_PREFIX + METHOD_NAME.getName(),
-            MDCBuilder.create()
-                .addContext(MDCBuilder.ACTION, "SET_VACATION")
-                .addContext("update", setVacationRequest.getUpdate())
-                .wrapArround(
-                    () -> process(methodCallId, mailboxSession, setVacationRequest)));
+
+        return MDCBuilder.create()
+            .addContext(MDCBuilder.ACTION, "SET_VACATION")
+            .addContext("update", setVacationRequest.getUpdate())
+            .wrapArround(
+                () -> metricFactory.runPublishingTimerMetricLogP99(JMAP_PREFIX + METHOD_NAME.getName(),
+                    () -> process(methodCallId, mailboxSession, setVacationRequest)))
+            .get();
     }
 
     private Stream<JmapResponse> process(MethodCallId methodCallId, MailboxSession mailboxSession, SetVacationRequest setVacationRequest) {


### PR DESCRIPTION
Given our current tooling I struggle to correctly review slow requests
from James.

My current procedure is:
  - In grafana identify timestamp of a spike
  - Groke logs in kibana until I find something that could correspond
  - Pray and hope my analisys stands.

This is both time consumming, hard to do and unreliable.

Identifying slow queries is important as it can point us to critical
path to optimize.

Hence I propose to log an info message when p99 is exceeded for high
level function (JMAP methods, IMAP processors, matcher mailet and
overall processing, mailbox listeners, and remote delivery).

In order to avoid log spamming I propose to only log when a
function-specified threshold is exceeded (defaulting to 100ms)

I belive it will help us coming up with more meaningful performance
analysis and better fixes for the greater goods of our prduction
platforms.

Where easily doable I took care of keeping the MDC context.