### PR TITLE
 JAMES-3108 Stop james server upon graceful shutdown

### DIFF
--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/CassandraJamesServerMain.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/CassandraJamesServerMain.java
@@ -70,7 +70,6 @@ import org.apache.james.modules.spamassassin.SpamAssassinListenerModule;
 import org.apache.james.modules.vault.DeletedMessageVaultRoutesModule;
 import org.apache.james.modules.webadmin.CassandraRoutesModule;
 import org.apache.james.modules.webadmin.InconsistencySolvingRoutesModule;
-import org.apache.james.server.core.configuration.Configuration;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Module;
@@ -78,7 +77,7 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
 import com.google.inject.util.Modules;
 
-public class CassandraJamesServerMain {
+public class CassandraJamesServerMain implements JamesServerMain {
 
     public static final Module WEBADMIN = Modules.combine(
         new CassandraRoutesModule(),
@@ -157,13 +156,7 @@ public class CassandraJamesServerMain {
     );
 
     public static void main(String[] args) throws Exception {
-        Configuration configuration = Configuration.builder()
-            .useWorkingDirectoryEnvProperty()
-            .build();
-
-        GuiceJamesServer server = GuiceJamesServer.forConfiguration(configuration)
-                    .combineWith(ALL_BUT_JMX_CASSANDRA_MODULE, new JMXServerModule());
-        server.start();
+        JamesServerMain.main(ALL_BUT_JMX_CASSANDRA_MODULE, new JMXServerModule());
     }
 
 }

--- a/server/container/guice/cassandra-ldap-guice/src/main/java/org/apache/james/CassandraLdapJamesServerMain.java
+++ b/server/container/guice/cassandra-ldap-guice/src/main/java/org/apache/james/CassandraLdapJamesServerMain.java
@@ -23,25 +23,17 @@ import static org.apache.james.CassandraJamesServerMain.ALL_BUT_JMX_CASSANDRA_MO
 
 import org.apache.james.data.LdapUsersRepositoryModule;
 import org.apache.james.modules.server.JMXServerModule;
-import org.apache.james.server.core.configuration.Configuration;
 
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
 
-public class CassandraLdapJamesServerMain {
+public class CassandraLdapJamesServerMain implements JamesServerMain {
 
     public static final Module MODULES = Modules.override(ALL_BUT_JMX_CASSANDRA_MODULE)
         .with(new LdapUsersRepositoryModule());
 
     public static void main(String[] args) throws Exception {
-        Configuration configuration = Configuration.builder()
-            .useWorkingDirectoryEnvProperty()
-            .build();
-
-        GuiceJamesServer server = GuiceJamesServer.forConfiguration(configuration)
-            .combineWith(MODULES, new JMXServerModule());
-
-        server.start();
+        JamesServerMain.main(MODULES, new JMXServerModule());
     }
 
 }

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
@@ -27,24 +27,17 @@ import org.apache.james.modules.blobstore.BlobStoreChoosingModule;
 import org.apache.james.modules.event.RabbitMQEventBusModule;
 import org.apache.james.modules.rabbitmq.RabbitMQModule;
 import org.apache.james.modules.server.JMXServerModule;
-import org.apache.james.server.core.configuration.Configuration;
 
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
 
-public class CassandraRabbitMQJamesServerMain {
+public class CassandraRabbitMQJamesServerMain implements JamesServerMain {
     public static final Module MODULES =
         Modules
             .override(Modules.combine(REQUIRE_TASK_MANAGER_MODULE, new DistributedTaskManagerModule()))
             .with(new RabbitMQModule(), new BlobStoreChoosingModule(), new RabbitMQEventBusModule(), new TaskSerializationModule());
 
     public static void main(String[] args) throws Exception {
-        Configuration configuration = Configuration.builder()
-            .useWorkingDirectoryEnvProperty()
-            .build();
-
-        GuiceJamesServer server = GuiceJamesServer.forConfiguration(configuration)
-                    .combineWith(MODULES, new JMXServerModule());
-        server.start();
+        JamesServerMain.main(MODULES, new JMXServerModule());
     }
 }

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/JamesServerMain.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/JamesServerMain.java
@@ -32,5 +32,7 @@ public interface JamesServerMain {
         GuiceJamesServer server = GuiceJamesServer.forConfiguration(configuration)
             .combineWith(modules);
         server.start();
+        
+        Runtime.getRuntime().addShutdownHook(new Thread(server::stop));
     }
 }

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/JamesServerMain.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/JamesServerMain.java
@@ -19,18 +19,18 @@
 
 package org.apache.james;
 
-import org.apache.james.data.LdapUsersRepositoryModule;
-import org.apache.james.modules.server.JMXServerModule;
+import org.apache.james.server.core.configuration.Configuration;
 
 import com.google.inject.Module;
-import com.google.inject.util.Modules;
 
-public class CassandraRabbitMQLdapJamesServerMain implements JamesServerMain {
-    public static final Module MODULES = Modules
-        .override(CassandraRabbitMQJamesServerMain.MODULES)
-        .with(new LdapUsersRepositoryModule());
+public interface JamesServerMain {
+    static void main(Module... modules) throws Exception {
+        Configuration configuration = Configuration.builder()
+            .useWorkingDirectoryEnvProperty()
+            .build();
 
-    public static void main(String[] args) throws Exception {
-        JamesServerMain.main(MODULES, new JMXServerModule());
+        GuiceJamesServer server = GuiceJamesServer.forConfiguration(configuration)
+            .combineWith(modules);
+        server.start();
     }
 }

--- a/server/container/guice/jpa-guice/src/main/java/org/apache/james/JPAJamesServerMain.java
+++ b/server/container/guice/jpa-guice/src/main/java/org/apache/james/JPAJamesServerMain.java
@@ -33,7 +33,6 @@ import org.apache.james.modules.protocols.ManageSieveServerModule;
 import org.apache.james.modules.protocols.POP3ServerModule;
 import org.apache.james.modules.protocols.ProtocolHandlerModule;
 import org.apache.james.modules.protocols.SMTPServerModule;
-import org.apache.james.modules.server.DKIMMailetModule;
 import org.apache.james.modules.server.DataRoutesModules;
 import org.apache.james.modules.server.DefaultProcessorsConfigurationProviderModule;
 import org.apache.james.modules.server.ElasticSearchMetricReporterModule;
@@ -49,12 +48,11 @@ import org.apache.james.modules.server.SwaggerRoutesModule;
 import org.apache.james.modules.server.TaskManagerModule;
 import org.apache.james.modules.server.WebAdminServerModule;
 import org.apache.james.modules.spamassassin.SpamAssassinListenerModule;
-import org.apache.james.server.core.configuration.Configuration;
 
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
 
-public class JPAJamesServerMain {
+public class JPAJamesServerMain implements JamesServerMain {
 
     public static final Module WEBADMIN = Modules.combine(
         new WebAdminServerModule(),
@@ -94,15 +92,7 @@ public class JPAJamesServerMain {
     public static final Module JPA_MODULE_AGGREGATE = Modules.combine(JPA_SERVER_MODULE, PROTOCOLS);
 
     public static void main(String[] args) throws Exception {
-        Configuration configuration = Configuration.builder()
-            .useWorkingDirectoryEnvProperty()
-            .build();
-
-        GuiceJamesServer server = GuiceJamesServer.forConfiguration(configuration)
-                    .combineWith(JPA_MODULE_AGGREGATE,
-                            new JMXServerModule(),
-                            new DKIMMailetModule());
-        server.start();
+        JamesServerMain.main(JPA_MODULE_AGGREGATE, new JMXServerModule());
     }
 
 }

--- a/server/container/guice/jpa-smtp-common/src/main/java/org/apache/james/JPAJamesServerMain.java
+++ b/server/container/guice/jpa-smtp-common/src/main/java/org/apache/james/JPAJamesServerMain.java
@@ -34,12 +34,11 @@ import org.apache.james.modules.server.NoJwtModule;
 import org.apache.james.modules.server.RawPostDequeueDecoratorModule;
 import org.apache.james.modules.server.TaskManagerModule;
 import org.apache.james.modules.server.WebAdminServerModule;
-import org.apache.james.server.core.configuration.Configuration;
 
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
 
-public class JPAJamesServerMain {
+public class JPAJamesServerMain implements JamesServerMain {
 
     public static final Module PROTOCOLS = Modules.combine(
         new ProtocolHandlerModule(),
@@ -60,13 +59,7 @@ public class JPAJamesServerMain {
         new ElasticSearchMetricReporterModule());
 
     public static void main(String[] args) throws Exception {
-        Configuration configuration = Configuration.builder()
-            .useWorkingDirectoryEnvProperty()
-            .build();
-
-        GuiceJamesServer server = GuiceJamesServer.forConfiguration(configuration)
-                    .combineWith(JPA_SERVER_MODULE, PROTOCOLS, new DKIMMailetModule());
-        server.start();
+        JamesServerMain.main(JPA_SERVER_MODULE,  PROTOCOLS, new DKIMMailetModule());
     }
 
 }

--- a/server/container/guice/memory-guice/src/main/java/org/apache/james/MemoryJamesServerMain.java
+++ b/server/container/guice/memory-guice/src/main/java/org/apache/james/MemoryJamesServerMain.java
@@ -55,7 +55,6 @@ import org.apache.james.modules.server.WebAdminServerModule;
 import org.apache.james.modules.spamassassin.SpamAssassinListenerModule;
 import org.apache.james.modules.vault.DeletedMessageVaultModule;
 import org.apache.james.modules.vault.DeletedMessageVaultRoutesModule;
-import org.apache.james.server.core.configuration.Configuration;
 import org.apache.james.webadmin.WebAdminConfiguration;
 import org.apache.james.webadmin.authentication.AuthenticationFilter;
 import org.apache.james.webadmin.authentication.NoAuthenticationFilter;
@@ -63,7 +62,7 @@ import org.apache.james.webadmin.authentication.NoAuthenticationFilter;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
 
-public class MemoryJamesServerMain {
+public class MemoryJamesServerMain implements JamesServerMain {
 
     public static final Module WEBADMIN = Modules.combine(
         new WebAdminServerModule(),
@@ -132,14 +131,7 @@ public class MemoryJamesServerMain {
         new DKIMMailetModule());
 
     public static void main(String[] args) throws Exception {
-        Configuration configuration = Configuration.builder()
-            .useWorkingDirectoryEnvProperty()
-            .build();
-
-        GuiceJamesServer.forConfiguration(configuration)
-            .combineWith(new FakeSearchMailboxModule())
-            .combineWith(IN_MEMORY_SERVER_AGGREGATE_MODULE, new JMXServerModule())
-            .start();
+        JamesServerMain.main(IN_MEMORY_SERVER_AGGREGATE_MODULE, new FakeSearchMailboxModule(), new JMXServerModule());
     }
 
 }


### PR DESCRIPTION
James should not shut down immediatly on SIGTERM, but it gracefully terminates connections.

In a kubernetes context for instance:

```
It might take some time before a component such as kube-proxy or the Ingress controller is notified of the endpoint changes.

Hence, traffic might still flow to the Pod despite it being marked as terminated.

The app should stop accepting new requests on all remaining connections, and close these once the outgoing queue is drained.

If you need a refresher on how endpoints are propagated in your cluster, read this article on how to handle client requests properly.
```

(Source: https://learnk8s.io/production-best-practices)

I think it also makes sens out of this context.

A graceful shutdown furthermore decrease the risk of inconsistencies in the underlying datastores (Cassandra)
