### PR TITLE
 JAMES-3112 Distinguish Domain Alias from Domain Mapping RRTs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ of tasks being currently executed.
 - In order to fasten JMAP-draft message retrieval upon calls on properties expected to be fast to fetch, we now compute the preview and hasAttachment properties asynchronously and persist them in Cassandra to improve performance. See JAMES-2919.
 - It is now forbidden to create new Usernames with the following set of characters in its local part : `"(),:; <>@\[]`, as we prefer it to stay simple to handle. However, the read of Usernames already existing with some of those characters is still allowed, to not introduce any breaking change. See JAMES-2950.
 - Linshare blob export configuration and mechanism change. See JAMES-3040.
+- Differentiation between domain alias and domain mapping. Read upgrade instructions.
 
 ### Fixed
 - JAMES-2828 & JAMES-2929 bugs affecting JDBCMailRepository usage with PostgresSQL thanks to Jörg Thomas & Sergey B

--- a/core/src/main/java/org/apache/james/core/Username.java
+++ b/core/src/main/java/org/apache/james/core/Username.java
@@ -101,6 +101,10 @@ public class Username {
         return new Username(localPart, domain);
     }
 
+    public Username withOtherDomain(Domain domain) {
+        return withOtherDomain(Optional.of(domain));
+    }
+
     public boolean hasDomainPart() {
         return domainPart.isPresent();
     }

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/utils/DataProbeImpl.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/utils/DataProbeImpl.java
@@ -120,7 +120,7 @@ public class DataProbeImpl implements GuiceProbe, DataProbe {
 
     @Override
     public void addDomainAliasMapping(String aliasDomain, String deliveryDomain) throws Exception {
-        recipientRewriteTable.addAliasDomainMapping(MappingSource.fromDomain(Domain.of(aliasDomain)), Domain.of(deliveryDomain));
+        recipientRewriteTable.addDomainAliasMapping(MappingSource.fromDomain(Domain.of(aliasDomain)), Domain.of(deliveryDomain));
     }
 
     @Override

--- a/server/container/guice/guice-utils/src/main/java/org/apache/james/utils/ClassName.java
+++ b/server/container/guice/guice-utils/src/main/java/org/apache/james/utils/ClassName.java
@@ -21,6 +21,7 @@ package org.apache.james.utils;
 
 import java.util.Objects;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 
@@ -64,5 +65,12 @@ public class ClassName {
     @Override
     public final int hashCode() {
         return Objects.hash(name);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("name", name)
+            .toString();
     }
 }

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
@@ -53,7 +53,8 @@ public interface RecipientRewriteTable {
         Mapping.Type.Forward,
         Mapping.Type.Address,
         Mapping.Type.Alias,
-        Mapping.Type.Domain);
+        Mapping.Type.Domain,
+        Mapping.Type.DomainAlias);
 
     void addMapping(MappingSource source, Mapping mapping) throws RecipientRewriteTableException;
 
@@ -71,9 +72,13 @@ public interface RecipientRewriteTable {
 
     void removeErrorMapping(MappingSource source, String error) throws RecipientRewriteTableException;
 
-    void addAliasDomainMapping(MappingSource source, Domain realDomain) throws RecipientRewriteTableException;
+    void addDomainMapping(MappingSource source, Domain realDomain) throws RecipientRewriteTableException;
 
-    void removeAliasDomainMapping(MappingSource source, Domain realDomain) throws RecipientRewriteTableException;
+    void removeDomainMapping(MappingSource source, Domain realDomain) throws RecipientRewriteTableException;
+
+    void addDomainAliasMapping(MappingSource source, Domain realDomain) throws RecipientRewriteTableException;
+
+    void removeDomainAliasMapping(MappingSource source, Domain realDomain) throws RecipientRewriteTableException;
 
     void addForwardMapping(MappingSource source, String address) throws RecipientRewriteTableException;
 

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/lib/Mapping.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/lib/Mapping.java
@@ -85,6 +85,10 @@ public interface Mapping {
         return of(Type.Domain, mapping.asString());
     }
 
+    static Mapping domainAlias(Domain mapping) {
+        return of(Type.DomainAlias, mapping.asString());
+    }
+
     static Mapping forward(String mapping) {
         return of(Type.Forward, mapping);
     }
@@ -116,6 +120,8 @@ public interface Mapping {
         Regex("regex:", new UserRewritter.RegexRewriter(), IdentityMappingPolicy.Throw,
             MailAddressConversionPolicy.ToEmpty, TypeOrder.TYPE_ORDER_4),
         Domain("domain:", new UserRewritter.DomainRewriter(), IdentityMappingPolicy.Throw,
+            MailAddressConversionPolicy.ToEmpty, TypeOrder.TYPE_ORDER_1),
+        DomainAlias("domainAlias:", new UserRewritter.DomainRewriter(), IdentityMappingPolicy.Throw,
             MailAddressConversionPolicy.ToEmpty, TypeOrder.TYPE_ORDER_1),
         Error("error:", new UserRewritter.ThrowingRewriter(), IdentityMappingPolicy.Throw,
             MailAddressConversionPolicy.ToEmpty, TypeOrder.TYPE_ORDER_4),

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/lib/Mapping.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/lib/Mapping.java
@@ -119,29 +119,25 @@ public interface Mapping {
     enum Type {
         /**
          * Applies the regex on the supplied address.
-         *
-         * User will not be allowed to use the source in their FROM address headers.
          */
         Regex("regex:", new UserRewritter.RegexRewriter(), IdentityMappingPolicy.Throw,
             MailAddressConversionPolicy.ToEmpty, TypeOrder.TYPE_ORDER_4),
         /**
          * Rewrites the domain of mail addresses.
          *
-         * Use it for technical purposes, user will not be allowed to use the source in their FROM address headers.
+         * Use it for technical purposes.
          */
         Domain("domain:", new UserRewritter.DomainRewriter(), IdentityMappingPolicy.Throw,
             MailAddressConversionPolicy.ToEmpty, TypeOrder.TYPE_ORDER_1),
         /**
          * Rewrites the domain of mail addresses.
          *
-         * User will be allowed to use the source in their FROM address headers.
+         * User will be able to use this domain as if it was the one of his mail address.
          */
         DomainAlias("domainAlias:", new UserRewritter.DomainRewriter(), IdentityMappingPolicy.Throw,
             MailAddressConversionPolicy.ToEmpty, TypeOrder.TYPE_ORDER_1),
         /**
          * Throws an error upon processing
-         *
-         * User will be allowed to use the source in their FROM address headers.
          */
         Error("error:", new UserRewritter.ThrowingRewriter(), IdentityMappingPolicy.Throw,
             MailAddressConversionPolicy.ToEmpty, TypeOrder.TYPE_ORDER_4),
@@ -149,10 +145,6 @@ public interface Mapping {
          * Replaces the source address by another one.
          *
          * Vehicles the intent of forwarding incoming mails to other users.
-         *
-         * Listing the forward source in the forward destinations keeps a local copy
-         *
-         * User will not be allowed to use the source in their FROM address headers.
          */
         Forward("forward:", new UserRewritter.ReplaceRewriter(), IdentityMappingPolicy.ReturnIdentity,
             MailAddressConversionPolicy.ToMailAddress, TypeOrder.TYPE_ORDER_3),
@@ -161,8 +153,6 @@ public interface Mapping {
          *
          * Vehicles the intent of a group registration: group address will be swapped by group member addresses.
          * (Feature poor mailing list)
-         *
-         * User will not be allowed to use the source in their FROM address headers.
          */
         Group("group:", new UserRewritter.ReplaceRewriter(), IdentityMappingPolicy.Throw,
             MailAddressConversionPolicy.ToMailAddress, TypeOrder.TYPE_ORDER_2),
@@ -170,8 +160,6 @@ public interface Mapping {
          * Replaces the source address by another one.
          *
          * Represents user owned mail address, with which he can interact as if it was his main mail address.
-         *
-         * User will be allowed to use the source in their FROM address headers.
          */
         Alias("alias:", new UserRewritter.ReplaceRewriter(), IdentityMappingPolicy.Throw,
             MailAddressConversionPolicy.ToMailAddress, TypeOrder.TYPE_ORDER_3),
@@ -180,8 +168,6 @@ public interface Mapping {
          *
          * Use for technical purposes, this mapping type do not hold specific intent. Prefer using one of the above
          * mapping types.
-         *
-         * User will not be allowed to use the source in their FROM address headers.
          */
         Address("", new UserRewritter.ReplaceRewriter(), IdentityMappingPolicy.Throw,
             MailAddressConversionPolicy.ToMailAddress, TypeOrder.TYPE_ORDER_4);

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/lib/Mapping.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/lib/Mapping.java
@@ -117,20 +117,72 @@ public interface Mapping {
     }
 
     enum Type {
+        /**
+         * Applies the regex on the supplied address.
+         *
+         * User will not be allowed to use the source in their FROM address headers.
+         */
         Regex("regex:", new UserRewritter.RegexRewriter(), IdentityMappingPolicy.Throw,
             MailAddressConversionPolicy.ToEmpty, TypeOrder.TYPE_ORDER_4),
+        /**
+         * Rewrites the domain of mail addresses.
+         *
+         * Use it for technical purposes, user will not be allowed to use the source in their FROM address headers.
+         */
         Domain("domain:", new UserRewritter.DomainRewriter(), IdentityMappingPolicy.Throw,
             MailAddressConversionPolicy.ToEmpty, TypeOrder.TYPE_ORDER_1),
+        /**
+         * Rewrites the domain of mail addresses.
+         *
+         * User will be allowed to use the source in their FROM address headers.
+         */
         DomainAlias("domainAlias:", new UserRewritter.DomainRewriter(), IdentityMappingPolicy.Throw,
             MailAddressConversionPolicy.ToEmpty, TypeOrder.TYPE_ORDER_1),
+        /**
+         * Throws an error upon processing
+         *
+         * User will be allowed to use the source in their FROM address headers.
+         */
         Error("error:", new UserRewritter.ThrowingRewriter(), IdentityMappingPolicy.Throw,
             MailAddressConversionPolicy.ToEmpty, TypeOrder.TYPE_ORDER_4),
+        /**
+         * Replaces the source address by another one.
+         *
+         * Vehicles the intent of forwarding incoming mails to other users.
+         *
+         * Listing the forward source in the forward destinations keeps a local copy
+         *
+         * User will not be allowed to use the source in their FROM address headers.
+         */
         Forward("forward:", new UserRewritter.ReplaceRewriter(), IdentityMappingPolicy.ReturnIdentity,
             MailAddressConversionPolicy.ToMailAddress, TypeOrder.TYPE_ORDER_3),
+        /**
+         * Replaces the source address by another one.
+         *
+         * Vehicles the intent of a group registration: group address will be swapped by group member addresses.
+         * (Feature poor mailing list)
+         *
+         * User will not be allowed to use the source in their FROM address headers.
+         */
         Group("group:", new UserRewritter.ReplaceRewriter(), IdentityMappingPolicy.Throw,
             MailAddressConversionPolicy.ToMailAddress, TypeOrder.TYPE_ORDER_2),
+        /**
+         * Replaces the source address by another one.
+         *
+         * Represents user owned mail address, with which he can interact as if it was his main mail address.
+         *
+         * User will be allowed to use the source in their FROM address headers.
+         */
         Alias("alias:", new UserRewritter.ReplaceRewriter(), IdentityMappingPolicy.Throw,
             MailAddressConversionPolicy.ToMailAddress, TypeOrder.TYPE_ORDER_3),
+        /**
+         * Replaces the source address by another one.
+         *
+         * Use for technical purposes, this mapping type do not hold specific intent. Prefer using one of the above
+         * mapping types.
+         *
+         * User will not be allowed to use the source in their FROM address headers.
+         */
         Address("", new UserRewritter.ReplaceRewriter(), IdentityMappingPolicy.Throw,
             MailAddressConversionPolicy.ToMailAddress, TypeOrder.TYPE_ORDER_4);
 

--- a/server/data/data-api/src/test/java/org/apache/james/rrt/lib/AliasReverseResolverContract.java
+++ b/server/data/data-api/src/test/java/org/apache/james/rrt/lib/AliasReverseResolverContract.java
@@ -21,7 +21,6 @@ package org.apache.james.rrt.lib;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Optional;
 import java.util.stream.IntStream;
 
 import org.apache.james.core.Domain;
@@ -101,7 +100,7 @@ public interface AliasReverseResolverContract {
 
     @Test
     default void listAddressesShouldContainUserAddressAndAnAliasOfTheDomainUser() throws Exception {
-        Username fromUser = USER.withOtherDomain(Optional.of(OTHER_DOMAIN));
+        Username fromUser = USER.withOtherDomain(OTHER_DOMAIN);
 
         redirectDomain(OTHER_DOMAIN).to(DOMAIN);
 
@@ -111,13 +110,13 @@ public interface AliasReverseResolverContract {
 
     @Test
     default void listAddressesShouldContainUserAddressAndAnAliasOfTheDomainUserFromAnotherDomain() throws Exception {
-        Username userAliasOtherDomain = USER_ALIAS.withOtherDomain(Optional.of(OTHER_DOMAIN));
+        Username userAliasOtherDomain = USER_ALIAS.withOtherDomain(OTHER_DOMAIN);
 
         redirectDomain(OTHER_DOMAIN).to(DOMAIN);
         redirectUser(userAliasOtherDomain).to(USER);
 
-        Username userAliasMainDomain = USER_ALIAS.withOtherDomain(Optional.of(DOMAIN));
-        Username userOtherDomain = USER.withOtherDomain(Optional.of(OTHER_DOMAIN));
+        Username userAliasMainDomain = USER_ALIAS.withOtherDomain(DOMAIN);
+        Username userOtherDomain = USER.withOtherDomain(OTHER_DOMAIN);
         assertThat(aliasReverseResolver().listAddresses(USER))
             .containsExactlyInAnyOrder(USER.asMailAddress(), userAliasOtherDomain.asMailAddress(), userAliasMainDomain.asMailAddress(), userOtherDomain.asMailAddress());
     }

--- a/server/data/data-api/src/test/java/org/apache/james/rrt/lib/AliasReverseResolverContract.java
+++ b/server/data/data-api/src/test/java/org/apache/james/rrt/lib/AliasReverseResolverContract.java
@@ -43,7 +43,7 @@ public interface AliasReverseResolverContract {
 
     void addAliasMapping(Username alias, Username user) throws Exception;
 
-    void addDomainMapping(Domain alias, Domain domain) throws Exception;
+    void addDomainAlias(Domain alias, Domain domain) throws Exception;
 
     void addGroupMapping(String group, Username user) throws Exception;
 
@@ -62,7 +62,7 @@ public interface AliasReverseResolverContract {
     }
 
     default CanSendFromContract.RequireDomain redirectDomain(Domain alias) {
-        return domain -> addDomainMapping(alias, domain);
+        return domain -> addDomainAlias(alias, domain);
     }
 
     default CanSendFromContract.RequireUserName redirectGroup(String group) {

--- a/server/data/data-api/src/test/java/org/apache/james/rrt/lib/AliasReverseResolverContract.java
+++ b/server/data/data-api/src/test/java/org/apache/james/rrt/lib/AliasReverseResolverContract.java
@@ -56,17 +56,14 @@ public interface AliasReverseResolverContract {
         void to(Domain domain) throws Exception;
     }
 
-    default CanSendFromContract.RequireUserName redirectUser(Username alias) {
+    default RequireUserName redirectUser(Username alias) {
         return user -> addAliasMapping(alias, user);
     }
 
-    default CanSendFromContract.RequireDomain redirectDomain(Domain alias) {
+    default RequireDomain redirectDomain(Domain alias) {
         return domain -> addDomainAlias(alias, domain);
     }
 
-    default CanSendFromContract.RequireUserName redirectGroup(String group) {
-        return user -> addGroupMapping(group, user);
-    }
     @Test
     default void listAddressesShouldContainOnlyUserAddressWhenUserHasNoAlias() throws Exception {
         assertThat(aliasReverseResolver().listAddresses(USER))

--- a/server/data/data-api/src/test/java/org/apache/james/rrt/lib/CanSendFromContract.java
+++ b/server/data/data-api/src/test/java/org/apache/james/rrt/lib/CanSendFromContract.java
@@ -20,13 +20,11 @@ package org.apache.james.rrt.lib;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Optional;
 import java.util.stream.IntStream;
 
 import org.apache.james.core.Domain;
 import org.apache.james.core.Username;
 import org.apache.james.rrt.api.CanSendFrom;
-
 import org.junit.jupiter.api.Test;
 
 import com.github.fge.lambdas.Throwing;
@@ -136,7 +134,7 @@ public interface CanSendFromContract {
 
     @Test
     default void userCanSendFromShouldBeTrueWhenSenderIsAnAliasOfTheDomainUser() throws Exception {
-        Username fromUser = USER.withOtherDomain(Optional.of(OTHER_DOMAIN));
+        Username fromUser = USER.withOtherDomain(OTHER_DOMAIN);
 
         redirectDomain(OTHER_DOMAIN).to(DOMAIN);
 
@@ -145,7 +143,7 @@ public interface CanSendFromContract {
 
     @Test
     default void userCanSendFromShouldBeFalseWhenDomainMapping() throws Exception {
-        Username fromUser = USER.withOtherDomain(Optional.of(OTHER_DOMAIN));
+        Username fromUser = USER.withOtherDomain(OTHER_DOMAIN);
 
         addDomainMapping(OTHER_DOMAIN, DOMAIN);
 
@@ -195,7 +193,7 @@ public interface CanSendFromContract {
 
     @Test
     default void allValidFromAddressesShouldContainUserAddressAndAnAliasOfTheDomainUser() throws Exception {
-        Username fromUser = USER.withOtherDomain(Optional.of(OTHER_DOMAIN));
+        Username fromUser = USER.withOtherDomain(OTHER_DOMAIN);
 
         redirectDomain(OTHER_DOMAIN).to(DOMAIN);
 
@@ -205,13 +203,13 @@ public interface CanSendFromContract {
 
     @Test
     default void allValidFromAddressesShouldContainUserAddressAndAnAliasOfTheDomainUserFromAnotherDomain() throws Exception {
-        Username userAliasOtherDomain = USER_ALIAS.withOtherDomain(Optional.of(OTHER_DOMAIN));
+        Username userAliasOtherDomain = USER_ALIAS.withOtherDomain(OTHER_DOMAIN);
 
         redirectDomain(OTHER_DOMAIN).to(DOMAIN);
         redirectUser(userAliasOtherDomain).to(USER);
 
-        Username userAliasMainDomain = USER_ALIAS.withOtherDomain(Optional.of(DOMAIN));
-        Username userOtherDomain = USER.withOtherDomain(Optional.of(OTHER_DOMAIN));
+        Username userAliasMainDomain = USER_ALIAS.withOtherDomain(DOMAIN);
+        Username userOtherDomain = USER.withOtherDomain(OTHER_DOMAIN);
         assertThat(canSendFrom().allValidFromAddressesForUser(USER))
             .containsExactlyInAnyOrder(USER.asMailAddress(), userAliasOtherDomain.asMailAddress(), userAliasMainDomain.asMailAddress(), userOtherDomain.asMailAddress());
     }

--- a/server/data/data-api/src/test/java/org/apache/james/rrt/lib/CanSendFromContract.java
+++ b/server/data/data-api/src/test/java/org/apache/james/rrt/lib/CanSendFromContract.java
@@ -43,6 +43,8 @@ public interface CanSendFromContract {
 
     void addAliasMapping(Username alias, Username user) throws Exception;
 
+    void addDomainAlias(Domain alias, Domain domain) throws Exception;
+
     void addDomainMapping(Domain alias, Domain domain) throws Exception;
 
     void addGroupMapping(String group, Username user) throws Exception;
@@ -62,7 +64,7 @@ public interface CanSendFromContract {
     }
 
     default RequireDomain redirectDomain(Domain alias) {
-        return domain -> addDomainMapping(alias, domain);
+        return domain -> addDomainAlias(alias, domain);
     }
 
     default RequireUserName redirectGroup(String group) {
@@ -139,6 +141,15 @@ public interface CanSendFromContract {
         redirectDomain(OTHER_DOMAIN).to(DOMAIN);
 
         assertThat(canSendFrom().userCanSendFrom(USER, fromUser)).isTrue();
+    }
+
+    @Test
+    default void userCanSendFromShouldBeFalseWhenDomainMapping() throws Exception {
+        Username fromUser = USER.withOtherDomain(Optional.of(OTHER_DOMAIN));
+
+        addDomainMapping(OTHER_DOMAIN, DOMAIN);
+
+        assertThat(canSendFrom().userCanSendFrom(USER, fromUser)).isFalse();
     }
 
     @Test

--- a/server/data/data-api/src/test/java/org/apache/james/rrt/lib/MappingTest.java
+++ b/server/data/data-api/src/test/java/org/apache/james/rrt/lib/MappingTest.java
@@ -188,6 +188,12 @@ public class MappingTest {
     }
 
     @Test
+    void domainAliasFactoryMethodShouldThrowOnNull() {
+        assertThatThrownBy(() -> Mapping.domainAlias(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
     void errorFactoryMethodShouldThrowOnNull() {
         assertThatThrownBy(() -> Mapping.error(null))
             .isInstanceOf(NullPointerException.class);
@@ -272,6 +278,11 @@ public class MappingTest {
     }
 
     @Test
+    void getTypeShouldReturnDomainAliasWhenDomainAliasPrefix() {
+        assertThat(Mapping.domainAlias(Domain.of("abc")).getType()).isEqualTo(Type.DomainAlias);
+    }
+
+    @Test
     void getTypeShouldReturnForwardWhenForwardPrefix() {
         assertThat(Mapping.forward("abc").getType()).isEqualTo(Mapping.Type.Forward);
     }
@@ -327,6 +338,11 @@ public class MappingTest {
     @Test
     void asMailAddressShouldReturnEmptyForDomain() {
         assertThat(Mapping.domain(Domain.of("value")).asMailAddress()).isEmpty();
+    }
+
+    @Test
+    void asMailAddressShouldReturnEmptyForDomainAlias() {
+        assertThat(Mapping.domainAlias(Domain.of("value")).asMailAddress()).isEmpty();
     }
 
     @Test

--- a/server/data/data-library/src/main/java/org/apache/james/rrt/lib/AbstractRecipientRewriteTable.java
+++ b/server/data/data-library/src/main/java/org/apache/james/rrt/lib/AbstractRecipientRewriteTable.java
@@ -158,6 +158,7 @@ public abstract class AbstractRecipientRewriteTable implements RecipientRewriteT
                 return Mapping.of(type, rewrittenUsername.asString());
             case Regex:
             case Domain:
+            case DomainAlias:
             case Error:
             case Address:
                 return Mapping.address(rewrittenUsername.asString());
@@ -242,7 +243,7 @@ public abstract class AbstractRecipientRewriteTable implements RecipientRewriteT
     }
 
     @Override
-    public void addAliasDomainMapping(MappingSource source, Domain realDomain) throws RecipientRewriteTableException {
+    public void addDomainMapping(MappingSource source, Domain realDomain) throws RecipientRewriteTableException {
         checkDomainMappingSourceIsManaged(source);
 
         LOGGER.info("Add domain mapping: {} => {}", source.asDomain().map(Domain::asString).orElse("null"), realDomain);
@@ -250,9 +251,23 @@ public abstract class AbstractRecipientRewriteTable implements RecipientRewriteT
     }
 
     @Override
-    public void removeAliasDomainMapping(MappingSource source, Domain realDomain) throws RecipientRewriteTableException {
+    public void removeDomainMapping(MappingSource source, Domain realDomain) throws RecipientRewriteTableException {
         LOGGER.info("Remove domain mapping: {} => {}", source.asDomain().map(Domain::asString).orElse("null"), realDomain);
         removeMapping(source, Mapping.domain(realDomain));
+    }
+
+    @Override
+    public void addDomainAliasMapping(MappingSource source, Domain realDomain) throws RecipientRewriteTableException {
+        checkDomainMappingSourceIsManaged(source);
+
+        LOGGER.info("Add domain alias mapping: {} => {}", source.asDomain().map(Domain::asString).orElse("null"), realDomain);
+        addMapping(source, Mapping.domainAlias(realDomain));
+    }
+
+    @Override
+    public void removeDomainAliasMapping(MappingSource source, Domain realDomain) throws RecipientRewriteTableException {
+        LOGGER.info("Remove domain alias mapping: {} => {}", source.asDomain().map(Domain::asString).orElse("null"), realDomain);
+        removeMapping(source, Mapping.domainAlias(realDomain));
     }
 
     @Override

--- a/server/data/data-library/src/main/java/org/apache/james/rrt/lib/AliasReverseResolverImpl.java
+++ b/server/data/data-library/src/main/java/org/apache/james/rrt/lib/AliasReverseResolverImpl.java
@@ -97,7 +97,7 @@ public class AliasReverseResolverImpl implements AliasReverseResolver {
             getMappingLimit(),
             Throwing.<Domain, Stream<Domain>>function(targetDomain ->
                 recipientRewriteTable
-                    .listSources(Mapping.domain(targetDomain))
+                    .listSources(Mapping.domainAlias(targetDomain))
                     .map(MappingSource::asDomain)
                     .flatMap(OptionalUtils::toStream)).sneakyThrow()
         );

--- a/server/data/data-library/src/main/java/org/apache/james/rrt/lib/CanSendFromImpl.java
+++ b/server/data/data-library/src/main/java/org/apache/james/rrt/lib/CanSendFromImpl.java
@@ -20,6 +20,7 @@ package org.apache.james.rrt.lib;
 
 import static org.apache.james.rrt.lib.Mapping.Type.Alias;
 import static org.apache.james.rrt.lib.Mapping.Type.Domain;
+import static org.apache.james.rrt.lib.Mapping.Type.DomainAlias;
 
 import java.util.EnumSet;
 import java.util.List;
@@ -43,7 +44,7 @@ public class CanSendFromImpl implements CanSendFrom {
         List<Domain> fetch(Username user);
     }
 
-    public static final EnumSet<Mapping.Type> ALIAS_TYPES_ACCEPTED_IN_FROM = EnumSet.of(Alias, Domain);
+    public static final EnumSet<Mapping.Type> ALIAS_TYPES_ACCEPTED_IN_FROM = EnumSet.of(Alias, DomainAlias);
     private final RecipientRewriteTable recipientRewriteTable;
     private final AliasReverseResolver aliasReverseResolver;
 

--- a/server/data/data-library/src/main/java/org/apache/james/rrt/lib/RecipientRewriteTableManagement.java
+++ b/server/data/data-library/src/main/java/org/apache/james/rrt/lib/RecipientRewriteTableManagement.java
@@ -83,13 +83,13 @@ public class RecipientRewriteTableManagement extends StandardMBean implements Re
     @Override
     public void addDomainMapping(String domain, String targetDomain) throws RecipientRewriteTableException {
         MappingSource source = MappingSource.fromDomain(Domain.of(domain));
-        rrt.addAliasDomainMapping(source, Domain.of(targetDomain));
+        rrt.addDomainMapping(source, Domain.of(targetDomain));
     }
 
     @Override
     public void removeDomainMapping(String domain, String targetDomain) throws RecipientRewriteTableException {
         MappingSource source = MappingSource.fromDomain(Domain.of(domain));
-        rrt.removeAliasDomainMapping(source, Domain.of(targetDomain));
+        rrt.removeDomainMapping(source, Domain.of(targetDomain));
     }
 
     @Override

--- a/server/data/data-library/src/test/java/org/apache/james/rrt/lib/AbstractRecipientRewriteTableTest.java
+++ b/server/data/data-library/src/test/java/org/apache/james/rrt/lib/AbstractRecipientRewriteTableTest.java
@@ -612,8 +612,14 @@ public abstract class AbstractRecipientRewriteTableTest {
     }
 
     @Test
-    public void addAliasDomainMappingShouldThrowWhenSourceDomainIsNotInDomainList() {
-        assertThatThrownBy(() -> virtualUserTable.addAliasDomainMapping(SOURCE_WITH_DOMAIN_NOT_IN_DOMAIN_LIST, SUPPORTED_DOMAIN))
+    public void addDomainMappingShouldThrowWhenSourceDomainIsNotInDomainList() {
+        assertThatThrownBy(() -> virtualUserTable.addDomainMapping(SOURCE_WITH_DOMAIN_NOT_IN_DOMAIN_LIST, SUPPORTED_DOMAIN))
+            .isInstanceOf(SourceDomainIsNotInDomainListException.class);
+    }
+
+    @Test
+    public void addDomainAliasShouldThrowWhenSourceDomainIsNotInDomainList() {
+        assertThatThrownBy(() -> virtualUserTable.addDomainAliasMapping(SOURCE_WITH_DOMAIN_NOT_IN_DOMAIN_LIST, SUPPORTED_DOMAIN))
             .isInstanceOf(SourceDomainIsNotInDomainListException.class);
     }
 

--- a/server/data/data-library/src/test/java/org/apache/james/rrt/lib/MappingsImplTest.java
+++ b/server/data/data-library/src/test/java/org/apache/james/rrt/lib/MappingsImplTest.java
@@ -108,14 +108,18 @@ public class MappingsImplTest {
         MappingsImpl actual = MappingsImpl.fromRawString("error:test");
         assertThat(actual).containsOnly(Mapping.error("test"));
     }
-    
 
     @Test
     public void fromRawStringShouldNotUseColonDelimiterWhenValueStartsWithDomain() {
         MappingsImpl actual = MappingsImpl.fromRawString("domain:test");
         assertThat(actual).containsOnly(Mapping.domain(Domain.of("test")));
     }
-    
+
+    @Test
+    public void fromRawStringShouldNotUseColonDelimiterWhenValueStartsWithDomainAlias() {
+        MappingsImpl actual = MappingsImpl.fromRawString("domainAlias:test");
+        assertThat(actual).containsOnly(Mapping.domainAlias(Domain.of("test")));
+    }
 
     @Test
     public void fromRawStringShouldNotUseColonDelimiterWhenValueStartsWithRegex() {
@@ -328,7 +332,7 @@ public class MappingsImplTest {
     }
     
     @Test
-    public void builderShouldPutDomainAliasFirstThenForwardWhenVariousMappings() {
+    public void builderShouldPutDomainMappingFirstThenForwardWhenVariousMappings() {
         Mapping regexMapping = Mapping.regex("regex");
         Mapping forwardMapping = Mapping.forward("forward");
         Mapping domainMapping = Mapping.domain(Domain.of("domain"));
@@ -338,6 +342,19 @@ public class MappingsImplTest {
                 .add(domainMapping)
                 .build();
         assertThat(mappingsImpl).containsExactly(domainMapping, forwardMapping, regexMapping);
+    }
+
+    @Test
+    public void builderShouldPutDomainAliasFirstThenForwardWhenVariousMappings() {
+        Mapping regexMapping = Mapping.regex("regex");
+        Mapping forwardMapping = Mapping.forward("forward");
+        Mapping domainAlias = Mapping.domainAlias(Domain.of("domain"));
+        MappingsImpl mappingsImpl = MappingsImpl.builder()
+                .add(regexMapping)
+                .add(forwardMapping)
+                .add(domainAlias)
+                .build();
+        assertThat(mappingsImpl).containsExactly(domainAlias, forwardMapping, regexMapping);
     }
 
     @Test

--- a/server/data/data-library/src/test/java/org/apache/james/rrt/lib/RewriteTablesStepdefs.java
+++ b/server/data/data-library/src/test/java/org/apache/james/rrt/lib/RewriteTablesStepdefs.java
@@ -82,9 +82,14 @@ public class RewriteTablesStepdefs {
         storeAddressMappingForUserAtDomain(address, MappingSource.fromDomain(Domain.of(domain)));
     }
 
-    @Given("store \"([^\"]*)\" alias domain mapping for domain \"([^\"]*)\"")
-    public void storeAliasDomainMappingForDomain(String aliasDomain, String domain) throws Throwable {
-        rewriteTable.addAliasDomainMapping(MappingSource.fromDomain(Domain.of(aliasDomain)), Domain.of(domain));
+    @Given("store \"([^\"]*)\" domain mapping for domain \"([^\"]*)\"")
+    public void storeDomainMappingForDomain(String aliasDomain, String domain) throws Throwable {
+        rewriteTable.addDomainMapping(MappingSource.fromDomain(Domain.of(aliasDomain)), Domain.of(domain));
+    }
+
+    @Given("store \"([^\"]*)\" domain alias for domain \"([^\"]*)\"")
+    public void storeDomainAliasMappingForDomain(String aliasDomain, String domain) throws Throwable {
+        rewriteTable.addDomainAliasMapping(MappingSource.fromDomain(Domain.of(aliasDomain)), Domain.of(domain));
     }
 
     @Given("store \"([^\"]*)\" forward mapping for user \"([^\"]*)\" at domain \"([^\"]*)\"")
@@ -161,9 +166,14 @@ public class RewriteTablesStepdefs {
         userAtDomainRemovesAddressMapping(address, MappingSource.fromDomain(Domain.of(domain)));
     }
 
-    @When("alias domain mapping \"([^\"]*)\" for \"([^\"]*)\" domain is removed")
-    public void removeAliasDomainMappingForDomain(String aliasdomain, String domain) throws Throwable {
-        rewriteTable.removeAliasDomainMapping(MappingSource.fromDomain(Domain.of(aliasdomain)), Domain.of(domain));
+    @When("domain mapping \"([^\"]*)\" for \"([^\"]*)\" domain is removed")
+    public void removeDomainMappingForDomain(String aliasdomain, String domain) throws Throwable {
+        rewriteTable.removeDomainMapping(MappingSource.fromDomain(Domain.of(aliasdomain)), Domain.of(domain));
+    }
+
+    @When("domain alias \"([^\"]*)\" for \"([^\"]*)\" domain is removed")
+    public void removeDomainAliasForDomain(String aliasdomain, String domain) throws Throwable {
+        rewriteTable.removeDomainAliasMapping(MappingSource.fromDomain(Domain.of(aliasdomain)), Domain.of(domain));
     }
 
     @Then("mappings should be empty")

--- a/server/data/data-library/src/test/resources/cucumber/rewrite_tables.feature
+++ b/server/data/data-library/src/test/resources/cucumber/rewrite_tables.feature
@@ -134,48 +134,93 @@ Feature: Rewrite Tables tests
 # Alias mapping
 
   Scenario: address mapping should be retrieved when searching with a domain alias
-    Given store "aliasdomain" alias domain mapping for domain "localhost"
+    Given store "aliasdomain" domain mapping for domain "localhost"
     Then mappings for user "test" at domain "aliasdomain" should contain only "test@localhost"
 
   Scenario: address mapping should be retrieved when searching with a domain alias
     Given store "test2@localhost" address mapping for user "test" at domain "localhost"
-    And store "aliasdomain" alias domain mapping for domain "localhost"
+    And store "aliasdomain" domain mapping for domain "localhost"
     Then mappings for user "test" at domain "aliasdomain" should contain only "test2@localhost"
 
   Scenario: address mapping should be retrieved when searching with a domain alias (reverse insertion order)
-    Given store "aliasdomain" alias domain mapping for domain "localhost"
+    Given store "aliasdomain" domain mapping for domain "localhost"
+    And store "test2@localhost" address mapping for user "test" at domain "localhost"
+    Then mappings for user "test" at domain "aliasdomain" should contain only "test2@localhost"
+
+  Scenario: address mapping should be retrieved when searching with a domain alias
+    Given store "aliasdomain" domain alias for domain "localhost"
+    Then mappings for user "test" at domain "aliasdomain" should contain only "test@localhost"
+
+  Scenario: address mapping should be retrieved when searching with a domain alias
+    Given store "test2@localhost" address mapping for user "test" at domain "localhost"
+    And store "aliasdomain" domain alias for domain "localhost"
+    Then mappings for user "test" at domain "aliasdomain" should contain only "test2@localhost"
+
+  Scenario: address mapping should be retrieved when searching with a domain alias (reverse insertion order)
+    Given store "aliasdomain" domain alias for domain "localhost"
     And store "test2@localhost" address mapping for user "test" at domain "localhost"
     Then mappings for user "test" at domain "aliasdomain" should contain only "test2@localhost"
 
   Scenario: address mapping should be retrieved when searching with the correct domain and exists an alias domain
     Given store "test2@localhost" address mapping for user "test" at domain "localhost"
-    And store "aliasdomain" alias domain mapping for domain "localhost"
+    And store "aliasdomain" domain mapping for domain "localhost"
     Then mappings for user "test" at domain "localhost" should contain only "test2@localhost"
 
   Scenario: wildcard address mapping should be retrieved when searching with a domain alias
     Given store "wildcard@localhost" address mapping as wildcard for domain "localhost"
-    And store "aliasdomain" alias domain mapping for domain "localhost"
+    And store "aliasdomain" domain mapping for domain "localhost"
     Then mappings for user "test" at domain "aliasdomain" should contain only "wildcard@localhost"
 
   Scenario: wildcard address mapping should be retrieved when searching with a domain and exists an alias domain
     Given store "wildcard@localhost" address mapping as wildcard for domain "localhost"
-    And store "aliasdomain" alias domain mapping for domain "localhost"
+    And store "aliasdomain" domain mapping for domain "localhost"
     Then mappings for user "test" at domain "localhost" should contain only "wildcard@localhost"
 
   Scenario: both wildcard address mapping and default user address should be retrieved when wildcard address mapping on alias domain
     Given store "wildcard@localhost" address mapping as wildcard for domain "aliasdomain"
-    And store "aliasdomain" alias domain mapping for domain "localhost"
+    And store "aliasdomain" domain mapping for domain "localhost"
     Then mappings for user "test" at domain "aliasdomain" should contain only "test@localhost, wildcard@localhost"
 
   Scenario: both wildcard address mapping and default user address should be retrieved when wildcard address mapping on alias domain (reverse insertion order)
-    Given store "aliasdomain" alias domain mapping for domain "localhost"
+    Given store "aliasdomain" domain mapping for domain "localhost"
     And store "wildcard@localhost" address mapping as wildcard for domain "aliasdomain"
     Then mappings for user "test" at domain "aliasdomain" should contain only "test@localhost, wildcard@localhost"
 
   Scenario: asking for a removed domain alias should fail
     Given store "wildcard@localhost" address mapping as wildcard for domain "localhost"
-    And store "aliasdomain" alias domain mapping for domain "localhost"
-    When alias domain mapping "aliasdomain" for "localhost" domain is removed
+    And store "aliasdomain" domain mapping for domain "localhost"
+    When domain mapping "aliasdomain" for "localhost" domain is removed
+    Then mappings for user "test" at domain "aliasdomain" should be empty
+
+  Scenario: address mapping should be retrieved when searching with the correct domain and exists an alias domain
+    Given store "test2@localhost" address mapping for user "test" at domain "localhost"
+    And store "aliasdomain" domain alias for domain "localhost"
+    Then mappings for user "test" at domain "localhost" should contain only "test2@localhost"
+
+  Scenario: wildcard address mapping should be retrieved when searching with a domain alias
+    Given store "wildcard@localhost" address mapping as wildcard for domain "localhost"
+    And store "aliasdomain" domain alias for domain "localhost"
+    Then mappings for user "test" at domain "aliasdomain" should contain only "wildcard@localhost"
+
+  Scenario: wildcard address mapping should be retrieved when searching with a domain and exists an alias domain
+    Given store "wildcard@localhost" address mapping as wildcard for domain "localhost"
+    And store "aliasdomain" domain alias for domain "localhost"
+    Then mappings for user "test" at domain "localhost" should contain only "wildcard@localhost"
+
+  Scenario: both wildcard address mapping and default user address should be retrieved when wildcard address mapping on alias domain
+    Given store "wildcard@localhost" address mapping as wildcard for domain "aliasdomain"
+    And store "aliasdomain" domain alias for domain "localhost"
+    Then mappings for user "test" at domain "aliasdomain" should contain only "test@localhost, wildcard@localhost"
+
+  Scenario: both wildcard address mapping and default user address should be retrieved when wildcard address mapping on alias domain (reverse insertion order)
+    Given store "aliasdomain" domain alias for domain "localhost"
+    And store "wildcard@localhost" address mapping as wildcard for domain "aliasdomain"
+    Then mappings for user "test" at domain "aliasdomain" should contain only "test@localhost, wildcard@localhost"
+
+  Scenario: asking for a removed domain alias should fail
+    Given store "wildcard@localhost" address mapping as wildcard for domain "localhost"
+    And store "aliasdomain" domain alias for domain "localhost"
+    When domain alias "aliasdomain" for "localhost" domain is removed
     Then mappings for user "test" at domain "aliasdomain" should be empty
 
 # Mixed mapping
@@ -183,7 +228,13 @@ Feature: Rewrite Tables tests
   Scenario: mixed mapping should work
     Given store "test2@localhost" address mapping for user "test" at domain "localhost"
     And store "(.*)@localhost:user@localhost" regexp mapping for user "test" at domain "localhost"
-    And store "aliasdomain" alias domain mapping for domain "localhost"
+    And store "aliasdomain" domain mapping for domain "localhost"
+    Then mappings for user "test" at domain "localhost" should contain only "test2@localhost, user@localhost"
+
+  Scenario: mixed mapping should work
+    Given store "test2@localhost" address mapping for user "test" at domain "localhost"
+    And store "(.*)@localhost:user@localhost" regexp mapping for user "test" at domain "localhost"
+    And store "aliasdomain" domain alias for domain "localhost"
     Then mappings for user "test" at domain "localhost" should contain only "test2@localhost, user@localhost"
 
 # Recursive mapping
@@ -223,9 +274,15 @@ Feature: Rewrite Tables tests
     Then mappings for user "user1" at domain "domain1" should contain only "user2@domain2"
 
   Scenario: recursive mapping should work when three levels on alias domains
-    Given store "domain2" alias domain mapping for domain "domain1"
-    And store "domain3" alias domain mapping for domain "domain2"
-    And store "domain4" alias domain mapping for domain "domain3"
+    Given store "domain2" domain mapping for domain "domain1"
+    And store "domain3" domain mapping for domain "domain2"
+    And store "domain4" domain mapping for domain "domain3"
+    Then mappings for user "test" at domain "domain4" should contain only "test@domain1"
+
+  Scenario: recursive mapping should work when three levels on alias domains
+    Given store "domain2" domain alias for domain "domain1"
+    And store "domain3" domain alias for domain "domain2"
+    And store "domain4" domain alias for domain "domain3"
     Then mappings for user "test" at domain "domain4" should contain only "test@domain1"
 
 # Forward mapping

--- a/server/data/data-memory/src/test/java/org/apache/james/rrt/lib/AliasReverseResolverImplTest.java
+++ b/server/data/data-memory/src/test/java/org/apache/james/rrt/lib/AliasReverseResolverImplTest.java
@@ -64,8 +64,8 @@ public class AliasReverseResolverImplTest implements AliasReverseResolverContrac
     }
 
     @Override
-    public void addDomainMapping(Domain alias, Domain domain) throws Exception {
-        recipientRewriteTable.addAliasDomainMapping(MappingSource.fromDomain(alias), domain);
+    public void addDomainAlias(Domain alias, Domain domain) throws Exception {
+        recipientRewriteTable.addDomainAliasMapping(MappingSource.fromDomain(alias), domain);
     }
 
     @Override

--- a/server/data/data-memory/src/test/java/org/apache/james/rrt/lib/CanSendFromImplTest.java
+++ b/server/data/data-memory/src/test/java/org/apache/james/rrt/lib/CanSendFromImplTest.java
@@ -20,13 +20,14 @@ package org.apache.james.rrt.lib;
 
 import static org.mockito.Mockito.mock;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.core.Domain;
 import org.apache.james.core.Username;
 import org.apache.james.dnsservice.api.DNSService;
 import org.apache.james.domainlist.lib.DomainListConfiguration;
 import org.apache.james.domainlist.memory.MemoryDomainList;
-import org.apache.james.rrt.api.CanSendFrom;
 import org.apache.james.rrt.api.AliasReverseResolver;
+import org.apache.james.rrt.api.CanSendFrom;
 import org.apache.james.rrt.api.RecipientRewriteTableConfiguration;
 import org.apache.james.rrt.memory.MemoryRecipientRewriteTable;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,13 +66,17 @@ public class CanSendFromImplTest implements CanSendFromContract {
     }
 
     @Override
-    public void addDomainAlias(Domain alias, Domain domain) throws Exception {
-        recipientRewriteTable.addDomainAliasMapping(MappingSource.fromDomain(alias), domain);
-    }
-
-    @Override
-    public void addDomainMapping(Domain alias, Domain domain) throws Exception {
-        recipientRewriteTable.addDomainMapping(MappingSource.fromDomain(alias), domain);
+    public void addDomainMapping(Domain alias, Domain domain, Mapping.Type mappingType) throws Exception {
+        switch (mappingType) {
+            case Domain:
+                recipientRewriteTable.addDomainMapping(MappingSource.fromDomain(alias), domain);
+                break;
+            case DomainAlias:
+                recipientRewriteTable.addDomainAliasMapping(MappingSource.fromDomain(alias), domain);
+                break;
+            default:
+                throw new NotImplementedException(mappingType + " is not supported");
+        }
     }
 
     @Override

--- a/server/data/data-memory/src/test/java/org/apache/james/rrt/lib/CanSendFromImplTest.java
+++ b/server/data/data-memory/src/test/java/org/apache/james/rrt/lib/CanSendFromImplTest.java
@@ -65,8 +65,13 @@ public class CanSendFromImplTest implements CanSendFromContract {
     }
 
     @Override
+    public void addDomainAlias(Domain alias, Domain domain) throws Exception {
+        recipientRewriteTable.addDomainAliasMapping(MappingSource.fromDomain(alias), domain);
+    }
+
+    @Override
     public void addDomainMapping(Domain alias, Domain domain) throws Exception {
-        recipientRewriteTable.addAliasDomainMapping(MappingSource.fromDomain(alias), domain);
+        recipientRewriteTable.addDomainMapping(MappingSource.fromDomain(alias), domain);
     }
 
     @Override

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMessagesMethodTest.java
@@ -64,6 +64,7 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -73,6 +74,7 @@ import javax.mail.internet.MimeMessage;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.james.GuiceJamesServer;
+import org.apache.james.core.Domain;
 import org.apache.james.core.Username;
 import org.apache.james.core.quota.QuotaSizeLimit;
 import org.apache.james.jmap.AccessToken;
@@ -2605,7 +2607,7 @@ public abstract class SetMessagesMethodTest {
         dataProbe.addDomainAliasMapping(DOMAIN_ALIAS, DOMAIN);
 
         String messageCreationId = "creationId1337";
-        String alias = USERNAME.getLocalPart() + "@" + DOMAIN_ALIAS;
+        String alias = USERNAME.withOtherDomain(Domain.of(DOMAIN_ALIAS)).asString();
         String requestBody = "[" +
             "  [" +
             "    \"setMessages\"," +

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/SetMessagesCreationProcessorTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/SetMessagesCreationProcessorTest.java
@@ -466,7 +466,7 @@ public class SetMessagesCreationProcessorTest {
             .email("user@other.org")
             .build();
 
-           recipientRewriteTable.addMapping(MappingSource.fromDomain(Domain.of("other.org")), Mapping.domain(Domain.of("example.com")));
+           recipientRewriteTable.addMapping(MappingSource.fromDomain(Domain.of("other.org")), Mapping.domainAlias(Domain.of("example.com")));
 
         assertThatCode(() -> sut.assertUserCanSendFrom(USER, Optional.of(sender)))
             .doesNotThrowAnyException();

--- a/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
+++ b/server/protocols/protocols-smtp/src/test/java/org/apache/james/smtpserver/SMTPServerTest.java
@@ -1460,7 +1460,7 @@ public class SMTPServerTest {
         String sender = "test_user_smtp@examplebis.local";
 
         usersRepository.addUser(Username.of(userName), "pwd");
-        rewriteTable.addAliasDomainMapping(MappingSource.fromDomain(Domain.of("examplebis.local")), Domain.of(LOCAL_DOMAIN));
+        rewriteTable.addDomainAliasMapping(MappingSource.fromDomain(Domain.of("examplebis.local")), Domain.of(LOCAL_DOMAIN));
 
         smtpProtocol.sendCommand("AUTH PLAIN");
         smtpProtocol.sendCommand(Base64.getEncoder().encodeToString(("\0" + userName + "\0pwd\0").getBytes(UTF_8)));

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/DomainMappingsRoutes.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/routes/DomainMappingsRoutes.java
@@ -114,7 +114,7 @@ public class DomainMappingsRoutes implements Routes {
 
     private void addAliasDomainMapping(MappingSource source, Domain destinationDomain) throws RecipientRewriteTableException {
         try {
-            recipientRewriteTable.addAliasDomainMapping(source, destinationDomain);
+            recipientRewriteTable.addDomainAliasMapping(source, destinationDomain);
         } catch (SourceDomainIsNotInDomainListException e) {
             throw ErrorResponder.builder()
                 .statusCode(HttpStatus.BAD_REQUEST_400)
@@ -140,7 +140,7 @@ public class DomainMappingsRoutes implements Routes {
         MappingSource mappingSource = mappingSourceFrom(request);
         Domain destinationDomain = extractDomain(request.body());
 
-        recipientRewriteTable.removeAliasDomainMapping(mappingSource, destinationDomain);
+        recipientRewriteTable.removeDomainMapping(mappingSource, destinationDomain);
         return halt(HttpStatus.NO_CONTENT_204);
     }
 

--- a/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/service/DomainAliasService.java
+++ b/server/protocols/webadmin/webadmin-data/src/main/java/org/apache/james/webadmin/service/DomainAliasService.java
@@ -70,14 +70,14 @@ public class DomainAliasService {
     }
 
     public ImmutableSet<DomainAliasResponse> listDomainAliases(Domain domain) throws RecipientRewriteTableException {
-        return recipientRewriteTable.listSources(Mapping.domain(domain))
+        return recipientRewriteTable.listSources(Mapping.domainAlias(domain))
             .map(DomainAliasResponse::new)
             .collect(Guavate.toImmutableSet());
     }
 
     public boolean hasAliases(Domain domain) throws DomainListException, RecipientRewriteTableException {
         return domainList.containsDomain(domain)
-            || recipientRewriteTable.listSources(Mapping.domain(domain)).findFirst().isPresent();
+            || recipientRewriteTable.listSources(Mapping.domainAlias(domain)).findFirst().isPresent();
     }
 
     public void addDomainAlias(Domain sourceDomain, Domain destinationDomain) throws DomainListException, RecipientRewriteTableException {
@@ -94,7 +94,7 @@ public class DomainAliasService {
         }
 
         checkSameSourceAndDestination(sourceDomain, destinationDomain);
-        operation.perform(MappingSource.fromDomain(sourceDomain), Mapping.domain(destinationDomain));
+        operation.perform(MappingSource.fromDomain(sourceDomain), Mapping.domainAlias(destinationDomain));
     }
 
     private void checkSameSourceAndDestination(Domain source, Domain destination) throws RecipientRewriteTableException {

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/AliasRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/AliasRoutesTest.java
@@ -66,6 +66,7 @@ class AliasRoutesTest {
 
     private static final Domain DOMAIN = Domain.of("b.com");
     private static final Domain ALIAS_DOMAIN = Domain.of("alias");
+    private static final Domain DOMAIN_MAPPING = Domain.of("mapping");
     public static final String BOB = "bob@" + DOMAIN.name();
     public static final String BOB_WITH_SLASH = "bob/@" + DOMAIN.name();
     public static final String BOB_WITH_ENCODED_SLASH = "bob%2F@" + DOMAIN.name();
@@ -113,6 +114,7 @@ class AliasRoutesTest {
                 .autoDetectIp(false));
             domainList.addDomain(DOMAIN);
             domainList.addDomain(ALIAS_DOMAIN);
+            domainList.addDomain(DOMAIN_MAPPING);
             MappingSourceModule module = new MappingSourceModule();
             memoryRecipientRewriteTable.setDomainList(domainList);
 
@@ -406,7 +408,8 @@ class AliasRoutesTest {
             super.setUp();
             memoryRecipientRewriteTable.addErrorMapping(MappingSource.fromUser("error", DOMAIN), "disabled");
             memoryRecipientRewriteTable.addRegexMapping(MappingSource.fromUser("regex", DOMAIN), ".*@b\\.com");
-            memoryRecipientRewriteTable.addAliasDomainMapping(MappingSource.fromDomain(ALIAS_DOMAIN), DOMAIN);
+            memoryRecipientRewriteTable.addDomainAliasMapping(MappingSource.fromDomain(ALIAS_DOMAIN), DOMAIN);
+            memoryRecipientRewriteTable.addDomainMapping(MappingSource.fromDomain(DOMAIN_MAPPING), DOMAIN);
         }
 
     }

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/DomainMappingsRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/DomainMappingsRoutesTest.java
@@ -154,9 +154,9 @@ class DomainMappingsRoutesTest {
             Domain expectedDomain = Domain.of("abc.com");
             MappingSource mappingSource = MappingSource.fromDomain(expectedDomain);
 
-            recipientRewriteTable.addAliasDomainMapping(mappingSource, Domain.of(alias1));
-            recipientRewriteTable.addAliasDomainMapping(mappingSource, Domain.of(alias2));
-            recipientRewriteTable.addAliasDomainMapping(mappingSource, Domain.of(alias3));
+            recipientRewriteTable.addDomainMapping(mappingSource, Domain.of(alias1));
+            recipientRewriteTable.addDomainMapping(mappingSource, Domain.of(alias2));
+            recipientRewriteTable.addDomainMapping(mappingSource, Domain.of(alias3));
 
             Map<String, List<String>> map =
                 when()
@@ -245,7 +245,7 @@ class DomainMappingsRoutesTest {
             MappingSource mappingSource = MappingSource.fromDomain(Domain.of("from.com"));
             String alias = "to.com";
 
-            recipientRewriteTable.addAliasDomainMapping(mappingSource, Domain.of(alias));
+            recipientRewriteTable.addDomainMapping(mappingSource, Domain.of(alias));
 
             Assumptions.assumeTrue(recipientRewriteTable.getStoredMappings(mappingSource) != null);
 
@@ -301,7 +301,7 @@ class DomainMappingsRoutesTest {
             recipientRewriteTable.addGroupMapping(mappingSource, "user@domain.com");
             recipientRewriteTable.addForwardMapping(mappingSource, "user@domain.com");
             recipientRewriteTable.addErrorMapping(mappingSource, "disabled");
-            recipientRewriteTable.addAliasDomainMapping(mappingSource, Domain.of(aliasDomain));
+            recipientRewriteTable.addDomainMapping(mappingSource, Domain.of(aliasDomain));
 
             List<String> body =
                 when()

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/ForwardRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/ForwardRoutesTest.java
@@ -68,6 +68,7 @@ class ForwardRoutesTest {
 
     private static final Domain DOMAIN = Domain.of("b.com");
     private static final Domain ALIAS_DOMAIN = Domain.of("alias");
+    private static final Domain DOMAIN_MAPPING = Domain.of("mapping");
     public static final String CEDRIC = "cedric@" + DOMAIN.name();
     public static final String ALICE = "alice@" + DOMAIN.name();
     public static final String ALICE_WITH_SLASH = "alice/@" + DOMAIN.name();
@@ -112,6 +113,7 @@ class ForwardRoutesTest {
                 .autoDetectIp(false));
             domainList.addDomain(DOMAIN);
             domainList.addDomain(ALIAS_DOMAIN);
+            domainList.addDomain(DOMAIN_MAPPING);
             memoryRecipientRewriteTable.setDomainList(domainList);
             MappingSourceModule mappingSourceModule = new MappingSourceModule();
 
@@ -436,7 +438,8 @@ class ForwardRoutesTest {
             super.setUp();
             memoryRecipientRewriteTable.addErrorMapping(MappingSource.fromUser("error", DOMAIN), "disabled");
             memoryRecipientRewriteTable.addRegexMapping(MappingSource.fromUser("regex", DOMAIN), ".*@b\\.com");
-            memoryRecipientRewriteTable.addAliasDomainMapping(MappingSource.fromDomain(ALIAS_DOMAIN), DOMAIN);
+            memoryRecipientRewriteTable.addDomainMapping(MappingSource.fromDomain(DOMAIN_MAPPING), DOMAIN);
+            memoryRecipientRewriteTable.addDomainAliasMapping(MappingSource.fromDomain(ALIAS_DOMAIN), DOMAIN);
         }
 
     }

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/GroupsRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/GroupsRoutesTest.java
@@ -65,6 +65,7 @@ import io.restassured.http.ContentType;
 class GroupsRoutesTest {
 
     private static final Domain DOMAIN = Domain.of("b.com");
+    private static final Domain DOMAIN_MAPPING = Domain.of("mapping");
     private static final Domain ALIAS_DOMAIN = Domain.of("alias");
     private static final String GROUP1 = "group1" + "@" + DOMAIN.name();
     private static final String GROUP2 = "group2" + "@" + DOMAIN.name();
@@ -106,6 +107,7 @@ class GroupsRoutesTest {
             domainList = new MemoryDomainList(dnsService);
             domainList.addDomain(DOMAIN);
             domainList.addDomain(ALIAS_DOMAIN);
+            domainList.addDomain(DOMAIN_MAPPING);
             memoryRecipientRewriteTable.setDomainList(domainList);
             usersRepository = MemoryUsersRepository.withVirtualHosting(domainList);
             MappingSourceModule mappingSourceModule = new MappingSourceModule();
@@ -427,8 +429,8 @@ class GroupsRoutesTest {
             super.setUp();
             memoryRecipientRewriteTable.addErrorMapping(MappingSource.fromUser("error", DOMAIN), "disabled");
             memoryRecipientRewriteTable.addRegexMapping(MappingSource.fromUser("regex", DOMAIN), ".*@b\\.com");
-            memoryRecipientRewriteTable.addAliasDomainMapping(MappingSource.fromDomain(ALIAS_DOMAIN), DOMAIN);
-
+            memoryRecipientRewriteTable.addDomainMapping(MappingSource.fromDomain(DOMAIN_MAPPING), DOMAIN);
+            memoryRecipientRewriteTable.addDomainAliasMapping(MappingSource.fromDomain(ALIAS_DOMAIN), DOMAIN);
         }
 
     }

--- a/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/MappingRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-data/src/test/java/org/apache/james/webadmin/routes/MappingRoutesTest.java
@@ -69,6 +69,7 @@ class MappingRoutesTest {
         DomainList domainList = new MemoryDomainList(dnsService);
         domainList.addDomain(Domain.of("domain.tld"));
         domainList.addDomain(Domain.of("aliasdomain.tld"));
+        domainList.addDomain(Domain.of("domain.mapping.tld"));
         domainList.addDomain(Domain.of("abc"));
         domainList.addDomain(Domain.of("xyz"));
 
@@ -135,13 +136,13 @@ class MappingRoutesTest {
     }
 
     @Test
-    void getMappingsShouldReturnAliasDomainMappings() throws RecipientRewriteTableException {
+    void getMappingsShouldReturnDomainMappings() throws RecipientRewriteTableException {
         Domain domain = Domain.of("aliasdomain.tld");
 
-        recipientRewriteTable.addAliasDomainMapping(
+        recipientRewriteTable.addDomainMapping(
             MappingSource.fromDomain(domain),
             Domain.of("domain1abc.tld"));
-        recipientRewriteTable.addAliasDomainMapping(
+        recipientRewriteTable.addDomainMapping(
             MappingSource.fromDomain(domain),
             Domain.of("domain2cde.tld"));
 
@@ -164,6 +165,42 @@ class MappingRoutesTest {
                 "    }," +
                 "    {" +
                 "      \"type\": \"Domain\"," +
+                "      \"mapping\" : \"domain2cde.tld\"" +
+                "    }" +
+                "  ]" +
+                "}");
+    }
+
+    @Test
+    void getMappingsShouldReturnDomainAliases() throws RecipientRewriteTableException {
+        Domain domain = Domain.of("aliasdomain.tld");
+
+        recipientRewriteTable.addDomainAliasMapping(
+            MappingSource.fromDomain(domain),
+            Domain.of("domain1abc.tld"));
+        recipientRewriteTable.addDomainAliasMapping(
+            MappingSource.fromDomain(domain),
+            Domain.of("domain2cde.tld"));
+
+        String jsonBody = when()
+                .get()
+            .then()
+                .contentType(ContentType.JSON)
+                .statusCode(HttpStatus.OK_200)
+            .extract()
+                .body()
+                .asString();
+
+        assertThatJson(jsonBody)
+            .when(Option.IGNORING_ARRAY_ORDER)
+            .isEqualTo("{" +
+                "  \"aliasdomain.tld\" : [" +
+                "    {" +
+                "      \"type\": \"DomainAlias\"," +
+                "      \"mapping\": \"domain1abc.tld\"" +
+                "    }," +
+                "    {" +
+                "      \"type\": \"DomainAlias\"," +
                 "      \"mapping\" : \"domain2cde.tld\"" +
                 "    }" +
                 "  ]" +
@@ -348,7 +385,11 @@ class MappingRoutesTest {
             MappingSource.fromUser(Username.of("alias@domain.tld")),
             "user@domain.tld");
 
-        recipientRewriteTable.addAliasDomainMapping(
+        recipientRewriteTable.addDomainMapping(
+            MappingSource.fromDomain(Domain.of("domain.mapping.tld")),
+            Domain.of("realdomain.tld"));
+
+        recipientRewriteTable.addDomainAliasMapping(
             MappingSource.fromDomain(Domain.of("aliasdomain.tld")),
             Domain.of("realdomain.tld"));
 
@@ -386,9 +427,15 @@ class MappingRoutesTest {
                 "      \"mapping\": \"user@domain.tld\"" +
                 "    }" +
                 "  ]," +
-                "  \"aliasdomain.tld\": [" +
+                "  \"domain.mapping.tld\": [" +
                 "    {" +
                 "      \"type\": \"Domain\"," +
+                "      \"mapping\": \"realdomain.tld\"" +
+                "    }" +
+                "  ]," +
+                "  \"aliasdomain.tld\": [" +
+                "    {" +
+                "      \"type\": \"DomainAlias\"," +
                 "      \"mapping\": \"realdomain.tld\"" +
                 "    }" +
                 "  ]," +

--- a/src/site/markdown/server/manage-webadmin.md
+++ b/src/site/markdown/server/manage-webadmin.md
@@ -40,7 +40,7 @@ Finally, please note that in case of a malformed URL the 400 bad request respons
  - [Cassandra Schema upgrades](#Cassandra_Schema_upgrades)
  - [Correcting ghost mailbox](#Correcting_ghost_mailbox)
  - [Creating address aliases](#Creating_address_aliases)
- - [Creating address domain aliases](#Creating_address_domain_aliases)
+ - [Creating domain mappings](#Creating_domain_mappings)
  - [Creating address forwards](#Creating_address_forwards)
  - [Creating address group](#Creating_address_group)
  - [Creating regex mapping](#Creating_regex_mapping)
@@ -1874,7 +1874,7 @@ Response codes:
  - 204: OK
  - 400: Alias structure or member is not valid
 
-## Creating address domain aliases
+## Creating domain mappings
 
 You can use **webadmin** to define domain mappings.
 

--- a/src/site/xdoc/server/config-recipientrewritetable.xml
+++ b/src/site/xdoc/server/config-recipientrewritetable.xml
@@ -29,6 +29,37 @@
 
     <p>Consult <a href="https://github.com/apache/james-project/tree/master/server/app/src/main/resources/recipientrewritetable.xml">recipientrewritetable.xml</a> in GIT to get some examples and hints.</p>
 
+    <subsection name="Mapping types">
+        <ul>James allow using various mapping types for better expressing the intent of your address rewritting logic:
+        <li><b>Domain mapping</b>: Rewrites the domain of mail addresses. Use it for technical purposes, user will not
+            be allowed to use the source in their FROM address headers. Domain mappings can be managed via the CLI and
+            added via <a href="webadmin.html#Creating_domain_mappings">WebAdmin</a></li>
+        <li><b>Domain aliases</b>: Rewrites the domain of mail addresses. Express the idea that both domain can be used
+            inter-changeably. User will be allowed to use the source in their FROM address headers. Domain aliases can
+            be managed via <a href="webadmin.html#Get_the_list_of_aliases_for_a_domain">WebAdmin</a></li>
+        <li><b>Forwards</b>: Replaces the source address by another one. Vehicles the intent of forwarding incoming mails
+            to other users. Listing the forward source in the forward destinations keeps a local copy. User will not be
+            allowed to use the source in their FROM address headers. Forward can
+            be managed via <a href="webadmin.html#Creating_address_forwards">WebAdmin</a></li>
+        <li><b>Groups</b>: Replaces the source address by another one. Vehicles the intent of a group registration: group
+            address will be swapped by group member addresses (Feature poor mailing list). User will not be
+            allowed to use the source in their FROM address headers. Groups can
+            be managed via <a href="webadmin.html#Creating_address_group">WebAdmin</a></li>
+        <li><b>Aliases</b>: Replaces the source address by another one. Represents user owned mail address, with which
+            he can interact as if it was his main mail address. User will be allowed to use the source in their FROM
+            address headers. Aliases can be managed via <a href="webadmin.html#Creating_address_aliases">WebAdmin</a></li>
+        <li><b>Address mappings</b>: Replaces the source address by another one. Use for technical purposes, this mapping type do
+            not hold specific intent. Prefer using one of the above mapping types... User will not be allowed to use the source
+            in their FROM address headers. Address mappings can be managed via the CLI or via
+            <a href="webadmin.html#Address_Mappings">WebAdmin</a></li>
+        <li><b>Regex mappings</b>: Applies the regex on the supplied address. User will not be allowed to use the source
+            in their FROM address headers. Regex mappings can be managed via the CLI or via
+            <a href="webadmin.html#Creating_regex_mapping">WebAdmin</a></li>
+        <li><b>Error</b>: Throws an error upon processing. User will not be allowed to use the source
+            in their FROM address headers. Errors can be managed via the CLI</li>
+        </ul>
+    </subsection>
+
     <subsection name="JPA Recipient Rewrite Table">
     
      <p>The default table for storing James' Recipient Rewrite mappings.</p>

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -49,7 +49,7 @@ to distinguish them from domain mappings (exposed by this
 Read [this page](https://james.apache.org/server/config-recipientrewritetable.html) to understand the difference between 
 Domain Alias and Domain Mapping.
 
-As a consequence, existing value returned by the domain alias endpoint (before this fix this is domain mapping) will be 
+As a consequence, existing values returned by the domain alias endpoint (before this fix this is domain mapping) will be 
 considered as domain mappings and might need to be deleted and re-created.
  
 ### UidValidity and JPA or Cassandra

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -29,6 +29,24 @@ Change list:
  - [New forbidden set of characters in Usernames local part](#new-forbidden-set-of-characters-in-usernames-local-part)
  - [UidValidity and maildir](#uid-validity-and-maildir)
  - [UidValidity and JPA or Cassandra](#uid-validity-and-jpa-or-cassandra)
+ - [Differentiation between domain alias and domain mapping](#differentiation-between-domain-alias-and-domain-mapping)
+ 
+### Differentiation between domain alias and domain mapping
+
+Date 10/03/2020
+
+SHA-1 XXX
+
+JIRA: https://issues.apache.org/jira/browse/JAMES-XXXX
+
+Concerned products: JPA mailbox backend, Cassandra mailbox backend
+
+Non-Maildir backends could generate '0' uid validity with a low probability, which is invalid regarding RFC-3501. 
+We changed the generation mechanism to use valid UidValidity for newly created mailboxes. Regarding persisted mailboxes,
+we regenerate invalid UidValidity upon reads.
+
+While this sanitizing is transparent to the end user and the admin, it might lead to rare IMAP client full mailbox
+ resynchronisation. (one chance out of two billions).
  
 ### UidValidity and JPA or Cassandra
 

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -37,16 +37,20 @@ Date 10/03/2020
 
 SHA-1 XXX
 
-JIRA: https://issues.apache.org/jira/browse/JAMES-XXXX
+JIRA: https://issues.apache.org/jira/browse/JAMES-3112
 
-Concerned products: JPA mailbox backend, Cassandra mailbox backend
+Concerned products: Guice products
 
-Non-Maildir backends could generate '0' uid validity with a low probability, which is invalid regarding RFC-3501. 
-We changed the generation mechanism to use valid UidValidity for newly created mailboxes. Regarding persisted mailboxes,
-we regenerate invalid UidValidity upon reads.
+We added strong typing for Domain aliases (exposed by this 
+[endpoint](https://github.com/apache/james-project/blob/master/src/site/markdown/server/manage-webadmin.md#get-the-list-of-aliases-for-a-domain))
+to distinguish them from domain mappings (exposed by this 
+[endpoint](https://github.com/apache/james-project/blob/master/src/site/markdown/server/manage-webadmin.md#creating-address-domain-aliases)).
 
-While this sanitizing is transparent to the end user and the admin, it might lead to rare IMAP client full mailbox
- resynchronisation. (one chance out of two billions).
+Read [this page](https://james.apache.org/server/config-recipientrewritetable.html) to understand the difference between 
+Domain Alias and Domain Mapping.
+
+As a consequence, existing value returned by the domain alias endpoint (before this fix this is domain mapping) will be 
+considered as domain mappings and might need to be deleted and re-created.
  
 ### UidValidity and JPA or Cassandra
 


### PR DESCRIPTION
Domain mapping is intended for technical purposes, and should not be
taken into account for user allowed from.

Domain aliases are user exposed, and should be taken into account for
user eallowed from.