### PR TITLE
JAMES-3110 Be able to limit SpamAssassinListener queue size

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/events/MailboxListener.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/events/MailboxListener.java
@@ -57,29 +57,34 @@ import com.google.common.collect.ImmutableSet;
  */
 public interface MailboxListener {
 
-    class MaxQueueSize {
-        public static final MaxQueueSize NONE = new MaxQueueSize(0);
+    interface MaxQueueSize {
+        UnlimitedMaxQueueSize NONE = new UnlimitedMaxQueueSize();
 
-        public static MaxQueueSize of(int size) {
-            Preconditions.checkArgument(size > 0, "MaxQueueSize should be strictly positive, '{}' given", size);
-            return new MaxQueueSize(size);
+        static LimitedMaxQueueSize of(int size) {
+            return new LimitedMaxQueueSize(size);
         }
+
+        Optional<Integer> asInt();
+    }
+
+    class LimitedMaxQueueSize implements MaxQueueSize {
 
         private final int size;
 
-        private MaxQueueSize(int size) {
+        private LimitedMaxQueueSize(int size) {
+            Preconditions.checkArgument(size > 0, "MaxQueueSize should be strictly positive, '{}' given", size);
             this.size = size;
         }
 
+        @Override
         public Optional<Integer> asInt() {
-            return Optional.of(size)
-                .filter(givenSize -> givenSize > 0);
+            return Optional.of(size);
         }
 
         @Override
         public final boolean equals(Object o) {
-            if (o instanceof MaxQueueSize) {
-                MaxQueueSize that = (MaxQueueSize) o;
+            if (o instanceof LimitedMaxQueueSize) {
+                LimitedMaxQueueSize that = (LimitedMaxQueueSize) o;
 
                 return Objects.equals(this.size, that.size);
             }
@@ -95,6 +100,25 @@ public interface MailboxListener {
         public String toString() {
             return MoreObjects.toStringHelper(this)
                 .add("size", size)
+                .toString();
+        }
+    }
+
+    class UnlimitedMaxQueueSize implements MaxQueueSize {
+
+        @Override
+        public Optional<Integer> asInt() {
+            return Optional.empty();
+        }
+
+        @Override
+        public final boolean equals(Object o) {
+            return o instanceof UnlimitedMaxQueueSize;
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
                 .toString();
         }
     }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/events/MailboxListener.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/events/MailboxListener.java
@@ -58,7 +58,7 @@ import com.google.common.collect.ImmutableSet;
 public interface MailboxListener {
 
     class MaxQueueSize {
-        public static final MaxQueueSize EMPTY = new MaxQueueSize(0);
+        public static final MaxQueueSize NONE = new MaxQueueSize(0);
 
         public static MaxQueueSize of(int size) {
             Preconditions.checkArgument(size > 0, "MaxQueueSize should be strictly positive, '{}' given", size);
@@ -118,7 +118,7 @@ public interface MailboxListener {
     }
 
     default MaxQueueSize getMaxQueueSize() {
-        return MaxQueueSize.EMPTY;
+        return MaxQueueSize.NONE;
     }
 
     /**

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxListenerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxListenerTest.java
@@ -68,6 +68,11 @@ class MailboxListenerTest {
     private static final MessageMetaData META_DATA = new MessageMetaData(UID, ModSeq.of(45), new Flags(), 45, new Date(), TestMessageId.of(75));
 
     @Test
+    void maxQueueSizeShouldMatchBeanContract() {
+        EqualsVerifier.forClass(MailboxListener.MaxQueueSize.class).verify();
+    }
+
+    @Test
     void mailboxAddedShouldMatchBeanContract() {
         EqualsVerifier.forClass(MailboxListener.MailboxAdded.class).verify();
     }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/EventBusTestFixture.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/EventBusTestFixture.java
@@ -123,6 +123,7 @@ public interface EventBusTestFixture {
         MailboxListener listener = mock(MailboxListener.class);
         when(listener.getExecutionMode()).thenReturn(MailboxListener.ExecutionMode.SYNCHRONOUS);
         when(listener.isHandling(any(MailboxListener.MailboxAdded.class))).thenReturn(true);
+        when(listener.getMaxQueueSize()).thenReturn(MailboxListener.MaxQueueSize.NONE);
         return listener;
     }
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/GroupContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/GroupContract.java
@@ -328,6 +328,7 @@ public interface GroupContract {
 
             MailboxListener failingListener = mock(MailboxListener.class);
             when(failingListener.getExecutionMode()).thenReturn(MailboxListener.ExecutionMode.SYNCHRONOUS);
+            when(failingListener.getMaxQueueSize()).thenReturn(MailboxListener.MaxQueueSize.NONE);
             doThrow(new RuntimeException()).when(failingListener).event(any());
 
             eventBus().register(failingListener, GROUP_A);

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupRegistration.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupRegistration.java
@@ -37,7 +37,9 @@ import org.apache.james.event.json.EventSerializer;
 import org.apache.james.util.MDCBuilder;
 
 import com.github.fge.lambdas.Throwing;
+import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
@@ -70,6 +72,7 @@ class GroupRegistration implements Registration {
         }
     }
 
+    public static final Function<Integer, ImmutableMap<String, Object>> LIMIT_QUEUE_SIZE = size -> ImmutableMap.of("x-max-length", size);
     static final String RETRY_COUNT = "retry-count";
     static final int DEFAULT_RETRY_COUNT = 0;
 
@@ -120,7 +123,7 @@ class GroupRegistration implements Registration {
                 .durable(DURABLE)
                 .exclusive(!EXCLUSIVE)
                 .autoDelete(!AUTO_DELETE)
-                .arguments(NO_ARGUMENTS)),
+                .arguments(mailboxListener.getMaxQueueSize().asInt().map(LIMIT_QUEUE_SIZE).orElse(NO_ARGUMENTS))),
             sender.bind(BindingSpecification.binding()
                 .exchange(MAILBOX_EVENT_EXCHANGE_NAME)
                 .queue(queueName.asString())

--- a/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusTest.java
+++ b/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusTest.java
@@ -563,7 +563,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
             @Test
             void stopShouldNotDeleteGroupRegistrationWorkQueue() {
                 eventBus.start();
-                eventBus.register(mock(MailboxListener.class), GROUP_A);
+                eventBus.register(newListener(), GROUP_A);
                 eventBus.stop();
 
                 assertThat(rabbitManagementAPI.listQueues())
@@ -655,7 +655,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
 
             @Test
             void multipleEventBusStopShouldNotDeleteGroupRegistrationWorkQueue() {
-                eventBus.register(mock(MailboxListener.class), GROUP_A);
+                eventBus.register(newListener(), GROUP_A);
 
                 eventBus.stop();
                 eventBus2.stop();

--- a/mailbox/plugin/spamassassin/src/main/java/org/apache/james/mailbox/spamassassin/SpamAssassinListener.java
+++ b/mailbox/plugin/spamassassin/src/main/java/org/apache/james/mailbox/spamassassin/SpamAssassinListener.java
@@ -64,14 +64,21 @@ public class SpamAssassinListener implements SpamEventListener {
     private final MailboxManager mailboxManager;
     private final MailboxSessionMapperFactory mapperFactory;
     private final ExecutionMode executionMode;
+    private final MaxQueueSize maxQueueSize;
 
     @Inject
-    public SpamAssassinListener(SpamAssassin spamAssassin, SystemMailboxesProvider systemMailboxesProvider, MailboxManager mailboxManager, MailboxSessionMapperFactory mapperFactory, ExecutionMode executionMode) {
+    public SpamAssassinListener(SpamAssassin spamAssassin,
+                                SystemMailboxesProvider systemMailboxesProvider,
+                                MailboxManager mailboxManager,
+                                MailboxSessionMapperFactory mapperFactory,
+                                ExecutionMode executionMode,
+                                MaxQueueSize maxQueueSize) {
         this.spamAssassin = spamAssassin;
         this.systemMailboxesProvider = systemMailboxesProvider;
         this.mailboxManager = mailboxManager;
         this.mapperFactory = mapperFactory;
         this.executionMode = executionMode;
+        this.maxQueueSize = maxQueueSize;
     }
 
     @Override
@@ -100,6 +107,11 @@ public class SpamAssassinListener implements SpamEventListener {
             MailboxSession session = mailboxManager.createSystemSession(username);
             handleAdded(event, session, (Added) event);
         }
+    }
+
+    @Override
+    public MaxQueueSize getMaxQueueSize() {
+        return maxQueueSize;
     }
 
     private void handleAdded(Event event, MailboxSession session, Added addedEvent) throws MailboxException {

--- a/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
+++ b/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
@@ -95,7 +95,7 @@ class SpamAssassinListenerTest {
         spamCapitalMailboxId = mailboxMapper.create(MailboxPath.forUser(USER, "SPAM"), UID_VALIDITY).getMailboxId();
         trashMailboxId = mailboxMapper.create(MailboxPath.forUser(USER, "Trash"), UID_VALIDITY).getMailboxId();
 
-        listener = new SpamAssassinListener(spamAssassin, systemMailboxesProvider, mailboxManager, mapperFactory, MailboxListener.ExecutionMode.SYNCHRONOUS);
+        listener = new SpamAssassinListener(spamAssassin, systemMailboxesProvider, mailboxManager, mapperFactory, MailboxListener.ExecutionMode.SYNCHRONOUS, MailboxListener.MaxQueueSize.NONE);
     }
 
     @Test

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/ListenerConfiguration.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/ListenerConfiguration.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 
 import org.apache.commons.configuration2.HierarchicalConfiguration;
 import org.apache.commons.configuration2.tree.ImmutableNode;
+import org.apache.james.mailbox.events.MailboxListener;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -33,11 +34,12 @@ public class ListenerConfiguration {
         Preconditions.checkState(!Strings.isNullOrEmpty(listenerClass), "class name is mandatory");
         Optional<Boolean> isAsync = Optional.ofNullable(configuration.getBoolean("async", null));
         Optional<String> group = Optional.ofNullable(configuration.getString("group", null));
-        return new ListenerConfiguration(listenerClass, group, extractSubconfiguration(configuration), isAsync);
+        Optional<MailboxListener.MaxQueueSize> maxQueueSize = Optional.ofNullable(configuration.getInteger("maxQueueSize", null)).map(MailboxListener.MaxQueueSize::of);
+        return new ListenerConfiguration(listenerClass, group, extractSubconfiguration(configuration), isAsync, maxQueueSize);
     }
 
     public static ListenerConfiguration forClass(String clazz) {
-        return new ListenerConfiguration(clazz, Optional.empty(), Optional.empty(), Optional.empty());
+        return new ListenerConfiguration(clazz, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     private static Optional<HierarchicalConfiguration<ImmutableNode>> extractSubconfiguration(HierarchicalConfiguration<ImmutableNode> configuration) {
@@ -50,12 +52,18 @@ public class ListenerConfiguration {
     private final Optional<String> group;
     private final Optional<HierarchicalConfiguration<ImmutableNode>> configuration;
     private final Optional<Boolean> isAsync;
+    private final Optional<MailboxListener.MaxQueueSize> maxQueueSize;
 
-    private ListenerConfiguration(String clazz, Optional<String> group, Optional<HierarchicalConfiguration<ImmutableNode>> configuration, Optional<Boolean> isAsync) {
+    private ListenerConfiguration(String clazz,
+                                  Optional<String> group,
+                                  Optional<HierarchicalConfiguration<ImmutableNode>> configuration,
+                                  Optional<Boolean> isAsync,
+                                  Optional<MailboxListener.MaxQueueSize> maxQueueSize) {
         this.clazz = clazz;
         this.group = group;
         this.configuration = configuration;
         this.isAsync = isAsync;
+        this.maxQueueSize = maxQueueSize;
     }
 
     public Optional<String> getGroup() {
@@ -72,5 +80,9 @@ public class ListenerConfiguration {
 
     public Optional<Boolean> isAsync() {
         return isAsync;
+    }
+
+    public Optional<MailboxListener.MaxQueueSize> getMaxQueueSize() {
+        return maxQueueSize;
     }
 }

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenerFactory.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenerFactory.java
@@ -41,12 +41,14 @@ public class MailboxListenerFactory {
         private Optional<ClassName> clazz;
         private Optional<MailboxListener.ExecutionMode> executionMode;
         private Optional<HierarchicalConfiguration<ImmutableNode>> configuration;
+        private Optional<MailboxListener.MaxQueueSize> maxQueueSize;
 
         public MailboxListenerBuilder(GuiceGenericLoader genericLoader) {
             this.genericLoader = genericLoader;
             this.clazz = Optional.empty();
             this.executionMode = Optional.empty();
             this.configuration = Optional.empty();
+            this.maxQueueSize = Optional.empty();
         }
 
         public MailboxListenerBuilder withExecutionMode(MailboxListener.ExecutionMode executionMode) {
@@ -59,6 +61,11 @@ public class MailboxListenerFactory {
             return this;
         }
 
+        public MailboxListenerBuilder withMaxQueueSize(MailboxListener.MaxQueueSize maxQueueSize) {
+            this.maxQueueSize = Optional.of(maxQueueSize);
+            return this;
+        }
+
         public MailboxListenerBuilder withExecutionMode(Optional<MailboxListener.ExecutionMode> executionMode) {
             executionMode.ifPresent(this::withExecutionMode);
             return this;
@@ -66,6 +73,11 @@ public class MailboxListenerFactory {
 
         public MailboxListenerBuilder withConfiguration(Optional<HierarchicalConfiguration<ImmutableNode>> configuration) {
             configuration.ifPresent(this::withConfiguration);
+            return this;
+        }
+
+        public MailboxListenerBuilder withMaxQueueSize(Optional<MailboxListener.MaxQueueSize> maxQueueSize) {
+            maxQueueSize.ifPresent(this::withMaxQueueSize);
             return this;
         }
 
@@ -80,7 +92,9 @@ public class MailboxListenerFactory {
                 binder -> binder.bind(MailboxListener.ExecutionMode.class)
                     .toInstance(executionMode.orElse(MailboxListener.ExecutionMode.SYNCHRONOUS)),
                 binder -> binder.bind(new TypeLiteral<HierarchicalConfiguration<ImmutableNode>>() {})
-                    .toInstance(configuration.orElse(new BaseHierarchicalConfiguration())));
+                    .toInstance(configuration.orElse(new BaseHierarchicalConfiguration())),
+                binder -> binder.bind(MailboxListener.MaxQueueSize.class)
+                    .toInstance(maxQueueSize.orElse(MailboxListener.MaxQueueSize.EMPTY)));
 
             return genericLoader.<MailboxListener>withChildModule(childModule)
                 .instantiate(clazz.get());

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenerFactory.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenerFactory.java
@@ -94,7 +94,7 @@ public class MailboxListenerFactory {
                 binder -> binder.bind(new TypeLiteral<HierarchicalConfiguration<ImmutableNode>>() {})
                     .toInstance(configuration.orElse(new BaseHierarchicalConfiguration())),
                 binder -> binder.bind(MailboxListener.MaxQueueSize.class)
-                    .toInstance(maxQueueSize.orElse(MailboxListener.MaxQueueSize.EMPTY)));
+                    .toInstance(maxQueueSize.orElse(MailboxListener.MaxQueueSize.NONE)));
 
             return genericLoader.<MailboxListener>withChildModule(childModule)
                 .instantiate(clazz.get());

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenersLoaderImpl.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenersLoaderImpl.java
@@ -78,6 +78,7 @@ public class MailboxListenersLoaderImpl implements Configurable, MailboxListener
             MailboxListener mailboxListener = mailboxListenerFactory.newInstance()
                 .withConfiguration(configuration.getConfiguration())
                 .withExecutionMode(configuration.isAsync().map(this::getExecutionMode))
+                .withMaxQueueSize(configuration.getMaxQueueSize())
                 .clazz(listenerClass)
                 .build();
 

--- a/server/container/guice/mailbox/src/test/java/org/apache/james/modules/mailbox/ListenerConfigurationTest.java
+++ b/server/container/guice/mailbox/src/test/java/org/apache/james/modules/mailbox/ListenerConfigurationTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.commons.configuration2.BaseHierarchicalConfiguration;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.junit.jupiter.api.Test;
 
 class ListenerConfigurationTest {
@@ -85,5 +86,37 @@ class ListenerConfigurationTest {
         ListenerConfiguration listenerConfiguration = ListenerConfiguration.from(configuration);
 
         assertThat(listenerConfiguration.getGroup()).contains(groupName);
+    }
+
+    @Test
+    void getMaxQueueSizeShouldBeEmptyByDefault() {
+        BaseHierarchicalConfiguration configuration = new BaseHierarchicalConfiguration();
+        configuration.addProperty("class", "MyClassName");
+
+        ListenerConfiguration listenerConfiguration = ListenerConfiguration.from(configuration);
+
+        assertThat(listenerConfiguration.getMaxQueueSize()).isEmpty();
+    }
+
+    @Test
+    void getMaxQueueSizeShouldContainsConfiguredValue() {
+        MailboxListener.MaxQueueSize maxQueueSize = MailboxListener.MaxQueueSize.of(42);
+        BaseHierarchicalConfiguration configuration = new BaseHierarchicalConfiguration();
+        configuration.addProperty("class", "MyClassName");
+        configuration.addProperty("maxQueueSize", maxQueueSize.asInt().get());
+
+        ListenerConfiguration listenerConfiguration = ListenerConfiguration.from(configuration);
+
+        assertThat(listenerConfiguration.getMaxQueueSize()).contains(maxQueueSize);
+    }
+
+    @Test
+    void aNullMaxQueueSizeShouldThrow() {
+        BaseHierarchicalConfiguration configuration = new BaseHierarchicalConfiguration();
+        configuration.addProperty("class", "MyClassName");
+        configuration.addProperty("maxQueueSize", 0);
+
+        assertThatThrownBy(() -> ListenerConfiguration.from(configuration))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/server/container/guice/mailbox/src/test/java/org/apache/james/modules/mailbox/ListenerConfigurationTest.java
+++ b/server/container/guice/mailbox/src/test/java/org/apache/james/modules/mailbox/ListenerConfigurationTest.java
@@ -111,7 +111,7 @@ class ListenerConfigurationTest {
     }
 
     @Test
-    void aNullMaxQueueSizeShouldThrow() {
+    void zeroMaxQueueSizeShouldThrow() {
         BaseHierarchicalConfiguration configuration = new BaseHierarchicalConfiguration();
         configuration.addProperty("class", "MyClassName");
         configuration.addProperty("maxQueueSize", 0);

--- a/src/site/xdoc/server/config-listeners.xml
+++ b/src/site/xdoc/server/config-listeners.xml
@@ -60,7 +60,7 @@
                      Please note that a <code>spamassassin.properties</code> file is needed.<br/>
                      This mailet is asynchronous by default, but this behaviour can be overridden by the <b>async</b>
                      configuration property.
-                     Additionally, a <b>maxQueueSize</b> parameter can be set in order to limit the waiting list.
+                     Additionally, only for <code>SpamAssassinListener</code>, a <b>maxQueueSize</b> parameter can be set in order to limit the waiting list.
                      Once this number is reached, older messages will be dropped.
                  </li>
                  <li><code>org.apache.james.mailbox.cassandra.MailboxOperationLoggingListener</code>:

--- a/src/site/xdoc/server/config-listeners.xml
+++ b/src/site/xdoc/server/config-listeners.xml
@@ -59,7 +59,10 @@
                      Provides per user real-time HAM/SPAM feedback to a SpamAssassin server depending on user actions.
                      Please note that a <code>spamassassin.properties</code> file is needed.<br/>
                      This mailet is asynchronous by default, but this behaviour can be overridden by the <b>async</b>
-                     configuration property.</li>
+                     configuration property.
+                     Additionally, a <b>maxQueueSize</b> parameter can be set in order to limit the waiting list.
+                     Once this number is reached, older messages will be dropped.
+                 </li>
                  <li><code>org.apache.james.mailbox.cassandra.MailboxOperationLoggingListener</code>:
                      For Cassandra guice wiring. Provides more insights on mailbox operations</li>
                  <li><code>org.apache.james.mailbox.quota.mailing.listeners.QuotaThresholdCrossingListener</code>:


### PR DESCRIPTION
Some listener (here) are not critical, hence their queue can grow,
creating a leak in RabbitMQ.

This PR introduces `maxQueueSize` in the `MailboxListener` and
`listener.xml` (only for SpamAssassinListener). When the specified limit
is reached, the oldest message is drop each time a new one in enqueued.