### PR TITLE
JAMES-3120 RemoveMimeHeader mailet should not save mail if doing nothing

### DIFF
--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/RemoveMimeHeader.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/RemoveMimeHeader.java
@@ -65,7 +65,7 @@ public class RemoveMimeHeader extends GenericMailet {
     public void service(Mail mail) throws MessagingException {
         MimeMessage message = mail.getMessage();
 
-        boolean headersToRemove = message.getMatchingHeaderLines(headers.toArray(new String[headers.size()]))
+        boolean hasHeadersToRemove = message.getMatchingHeaderLines(headers.toArray(new String[0]))
             .hasMoreElements();
 
         for (String header : headers) {
@@ -74,13 +74,13 @@ public class RemoveMimeHeader extends GenericMailet {
 
         removeSpecific(mail);
 
-        if (headersToRemove) {
+        if (hasHeadersToRemove) {
             message.saveChanges();
         }
     }
 
     protected void removeSpecific(Mail mail) {
-        new ArrayList<>(mail.getPerRecipientSpecificHeaders().getRecipientsWithSpecificHeaders()) // Streaming for concurrent modifications
+        new ArrayList<>(mail.getPerRecipientSpecificHeaders().getRecipientsWithSpecificHeaders()) // Copying to avoid concurrent modifications
                 .forEach(recipient -> {
                     mail.getPerRecipientSpecificHeaders()
                         .getHeadersForRecipient(recipient)

--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/RemoveMimeHeader.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/RemoveMimeHeader.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.transport.mailets;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.mail.MessagingException;
@@ -80,7 +79,7 @@ public class RemoveMimeHeader extends GenericMailet {
     }
 
     protected void removeSpecific(Mail mail) {
-        new ArrayList<>(mail.getPerRecipientSpecificHeaders().getRecipientsWithSpecificHeaders()) // Copying to avoid concurrent modifications
+        ImmutableList.copyOf(mail.getPerRecipientSpecificHeaders().getRecipientsWithSpecificHeaders()) // Copying to avoid concurrent modifications
                 .forEach(recipient -> {
                     mail.getPerRecipientSpecificHeaders()
                         .getHeadersForRecipient(recipient)

--- a/mailet/standard/src/test/java/org/apache/james/transport/mailets/RemoveMimeHeaderTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/mailets/RemoveMimeHeaderTest.java
@@ -21,6 +21,7 @@
 package org.apache.james.transport.mailets;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -29,11 +30,13 @@ import javax.mail.MessagingException;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.builder.MimeMessageBuilder;
+import org.apache.james.util.MimeMessageUtil;
 import org.apache.mailet.Mail;
 import org.apache.mailet.PerRecipientHeaders.Header;
 import org.apache.mailet.base.GenericMailet;
 import org.apache.mailet.base.test.FakeMail;
 import org.apache.mailet.base.test.FakeMailetConfig;
+import org.apache.mailet.base.test.MailUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -171,6 +174,20 @@ class RemoveMimeHeaderTest {
 
         assertThat(mail.getMessage().getHeader(HEADER1)).isNotNull();
         assertThat(mail.getMessage().getHeader(HEADER2)).isNotNull();
+    }
+
+    @Test
+    void serviceShouldNotThrowWhenNoneMatchingAndIncorrectHeaders() throws MessagingException {
+        FakeMailetConfig mailetConfig = FakeMailetConfig.builder()
+                .mailetName("Test")
+                .setProperty("name", "")
+                .build();
+        mailet.init(mailetConfig);
+
+        Mail mail = MailUtil.createMockMail2Recipients(
+                MimeMessageUtil.mimeMessageFromStream(
+                        ClassLoader.getSystemResourceAsStream("mime/incorrect-headers.mime")));
+        assertThatCode(() -> mailet.service(mail)).doesNotThrowAnyException();
     }
 
     @Test

--- a/mailet/standard/src/test/resources/mime/incorrect-headers.mime
+++ b/mailet/standard/src/test/resources/mime/incorrect-headers.mime
@@ -1,0 +1,87 @@
+Return-Path: <james@linagora.com>
+Subject: Fwd: Invitation: (Aucun objet) - ven. 20 janv. 2017 14:00 - 15:00
+ (CET) (james@linagora.com)
+To: =?UTF-8?Q?Beno=c3=aet_SOMEONE?= <someone@linagora.com>
+From: james <james@linagora.com>
+X-Forwarded-Message-Id: <001a114380a6a260d105467765ab@google.com>
+Message-ID: <f18fa52e-2e9d-1125-327d-2100b23f8a6b@linagora.com>
+Date: Thu, 19 Jan 2017 20:36:37 +0100
+MIME-Version: 1.0
+In-Reply-To: <001a114380a6a260d105467765ab@google.com>
+Content-Type: multipart/mixed;charset=charset=us-ascii;
+ boundary="------------17D96D411CBD55D8239A8C1F"
+
+This is a multi-part message in MIME format.
+--------------17D96D411CBD55D8239A8C1F
+Content-Type: multipart/alternative;
+ boundary="------------64D716A3DDAEC185D3E67448"
+
+
+--------------64D716A3DDAEC185D3E67448
+Content-Type: text/plain; charset=utf-8; format=flowed
+Content-Transfer-Encoding: 8bit
+
+
+
+
+-------- Message transéré --------
+Sujet : 	Invitation: (Aucun objet) - ven. 20 janv. 2017 14:00 - 15:00
+(CET) (jamef@linagora.com)
+Date : 	Thu, 19 Jan 2017 19:18:23 +0000
+De : 	James <james@gmail.com>
+RÃ©pondre Ã  : 	james@gmail.com
+Pour : 	james@linagora.com
+
+
+
+
+--------------64D716A3DDAEC185D3E67448
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 8bit
+
+<html>
+  <head>
+
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  </head>
+  <body bgcolor="#FFFFFF" text="#000000">
+    <p><br>
+    </p>
+    <div class="moz-forward-container"><br>
+      <br>
+      -------- Message transéré --------
+      <table class="moz-email-headers-table" border="0" cellpadding="0"
+        cellspacing="0">
+        <tbody>
+          <tr>
+            <th align="RIGHT" valign="BASELINE" nowrap="nowrap">SujetÂ :
+            </th>
+            <td>Invitation: (Aucun objet) - ven. 20 janv. 2017 14:00 -
+              15:00 (CET) (<a class="moz-txt-link-abbreviated" href="mailto:james@linagora.com">james@linagora.com</a>)</td>
+          </tr>
+          <tr>
+            <th align="RIGHT" valign="BASELINE" nowrap="nowrap">DateÂ : </th>
+            <td>Thu, 19 Jan 2017 19:18:23 +0000</td>
+          </tr>
+          <tr>
+            <th align="RIGHT" valign="BASELINE" nowrap="nowrap">DeÂ : </th>
+            <td>Antoine james <a class="moz-txt-link-rfc2396E" href="mailto:james@gmail.com">&lt;james@gmail.com&gt;</a></td>
+          </tr>
+          <tr>
+            <th align="RIGHT" valign="BASELINE" nowrap="nowrap">RÃ©pondre
+              Ã Â : </th>
+            <td><a class="moz-txt-link-abbreviated" href="mailto:james@gmail.com">james@gmail.com</a></td>
+          </tr>
+          <tr>
+            <th align="RIGHT" valign="BASELINE" nowrap="nowrap">PourÂ : </th>
+            <td><a class="moz-txt-link-abbreviated" href="mailto:james@linagora.com">james@linagora.com</a></td>
+          </tr>
+        </tbody>
+      </table>
+      <br>
+      <br>
+    </div>
+  </body>
+</html>
+
+--------------64D716A3DDAEC185D3E67448--


### PR DESCRIPTION
If the mailet save the mail after having removed a header when there is invalid headers in the mail, then javax.mail will fail to save the mail and the mailet will throw and stop the processing of the mail.

We should not try to save the mail when no header has been removed
