### PR TITLE
[WIP] Try to use Refined in Session POJOs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2066,6 +2066,11 @@
                 <version>${qdox.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.typesafe.play</groupId>
+                <artifactId>play-json_${scala.base}</artifactId>
+                <version>2.8.1</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
                 <version>1.9.3</version>
@@ -2734,6 +2739,24 @@
                     <groupId>com.google.cloud.tools</groupId>
                     <artifactId>jib-maven-plugin</artifactId>
                     <version>1.5.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.scalatest</groupId>
+                    <artifactId>scalatest-maven-plugin</artifactId>
+                    <version>2.0.0</version>
+                    <configuration>
+                        <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+                        <junitxml>.</junitxml>
+                        <filereports>WDF TestSuite.txt</filereports>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>test</id>
+                            <goals>
+                                <goal>test</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -85,6 +85,7 @@
 
         <module>protocols/fetchmail</module>
         <module>protocols/jmap-draft</module>
+        <module>protocols/jmap-rfc-8621</module>
         <module>protocols/jmap-draft-integration-testing</module>
         <module>protocols/jwt</module>
         <module>protocols/protocols-imap4</module>

--- a/server/protocols/jmap-rfc-8621/pom.xml
+++ b/server/protocols/jmap-rfc-8621/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.james</groupId>
+        <artifactId>james-server</artifactId>
+        <version>3.5.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>james-server-jmap-rfc-8621</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Apache James :: Server :: JMAP RFC 8621</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.play</groupId>
+            <artifactId>play-json_${scala.base}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatestplus.play</groupId>
+            <artifactId>scalatestplus-play_${scala.base}</artifactId>
+            <version>4.0.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.scalatest</groupId>
+                <artifactId>scalatest-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/server/protocols/jmap-rfc-8621/pom.xml
+++ b/server/protocols/jmap-rfc-8621/pom.xml
@@ -48,6 +48,16 @@
             <version>4.0.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>eu.timepit</groupId>
+            <artifactId>refined-scalaz_2.13</artifactId>
+            <version>0.9.13</version>
+        </dependency>
+        <dependency>
+            <groupId>eu.timepit</groupId>
+            <artifactId>refined-scalacheck_2.13</artifactId>
+            <version>0.9.13</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/Serializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/Serializer.scala
@@ -22,14 +22,13 @@ package org.apache.james.jmap
 import java.net.URL
 
 import org.apache.james.core.Username
-import org.apache.james.jmap.model.{Account, CapabilityIdentifier, CoreCapabilityProperties, Id, MailCapabilityProperties, Session, UnsignedInt}
-import play.api.libs.json.{JsNumber, JsObject, JsString, Json, Writes}
-import org.apache.james.jmap.model._
+import org.apache.james.jmap.model.{Account, CapabilityIdentifier, CoreCapabilityProperties, Id, MailCapabilityProperties, Session, UnsignedInt, _}
+import play.api.libs.json._
 
 class Serializer {
   implicit val unsignedIntWrites: Writes[UnsignedInt] = unsignedInt => JsNumber(unsignedInt.value)
   implicit val usernameWrites: Writes[Username] = username => JsString(username.asString)
-  implicit val idWrites: Writes[Id] = id => JsString(id.value)
+  implicit val idWrites: Writes[Id] = id => JsString(id.asString())
   implicit val urlWrites: Writes[URL] = url => JsString(url.toString)
   implicit val stateWrites: Writes[State] = state => JsString(state.value)
   implicit val capabilityIdentifierWrites: Writes[CapabilityIdentifier] = identifier => JsString(identifier.value.toString)
@@ -62,7 +61,7 @@ class Serializer {
 
   implicit def idMapWrite[Any](implicit vr: Writes[Any]): Writes[Map[Id, Any]] =
     (m: Map[Id, Any]) => {
-      JsObject(m.map { case (k, v) => (k.value, vr.writes(v)) }.toSeq)
+      JsObject(m.map { case (k, v) => (k.asString(), vr.writes(v)) }.toSeq)
     }
 
   def serialize(session: Session): String = {

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/Serializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/Serializer.scala
@@ -1,0 +1,71 @@
+/** **************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                 *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ * ***************************************************************/
+
+package org.apache.james.jmap
+
+import java.net.URL
+
+import org.apache.james.core.Username
+import org.apache.james.jmap.model.{Account, CapabilityIdentifier, CoreCapabilityProperties, Id, MailCapabilityProperties, Session, UnsignedInt}
+import play.api.libs.json.{JsNumber, JsObject, JsString, Json, Writes}
+import org.apache.james.jmap.model._
+
+class Serializer {
+  implicit val unsignedIntWrites: Writes[UnsignedInt] = unsignedInt => JsNumber(unsignedInt.value)
+  implicit val usernameWrites: Writes[Username] = username => JsString(username.asString)
+  implicit val idWrites: Writes[Id] = id => JsString(id.value)
+  implicit val urlWrites: Writes[URL] = url => JsString(url.toString)
+  implicit val stateWrites: Writes[State] = state => JsString(state.value)
+  implicit val capabilityIdentifierWrites: Writes[CapabilityIdentifier] = identifier => JsString(identifier.value.toString)
+  implicit val coreCapabilityWrites: Writes[CoreCapabilityProperties] = Json.writes[CoreCapabilityProperties]
+  implicit val mailCapabilityWrites: Writes[MailCapabilityProperties] = Json.writes[MailCapabilityProperties]
+
+  implicit def identifierMapWrite[Any](implicit idWriter: Writes[Id]): Writes[Map[CapabilityIdentifier, Any]] =
+    (m: Map[CapabilityIdentifier, Any]) => {
+      JsObject(
+        m.map {
+          case (identifier, id: Id) => (identifier.asString(), idWriter.writes(id))
+          case _ => throw new RuntimeException("non supported serializer")
+        }.toSeq
+      )
+    }
+
+  implicit def setCapabilityWrites(implicit corePropertiesWriter: Writes[CoreCapabilityProperties],
+                                   mailCapabilityWrites: Writes[MailCapabilityProperties]): Writes[Set[_ <: Capability]] =
+    (set: Set[_ <: Capability]) => {
+      JsObject(set.map {
+        case capability: CoreCapability => (
+          capability.identifier.asString(), corePropertiesWriter.writes(capability.properties))
+        case capability: MailCapability => (
+          capability.identifier.asString(), mailCapabilityWrites.writes(capability.properties))
+      }.toSeq)
+    }
+
+  implicit val accountWrites: Writes[Account] = Json.writes[Account]
+  implicit val sessionWrites: Writes[Session] = Json.writes[Session]
+
+  implicit def idMapWrite[Any](implicit vr: Writes[Any]): Writes[Map[Id, Any]] =
+    (m: Map[Id, Any]) => {
+      JsObject(m.map { case (k, v) => (k.value, vr.writes(v)) }.toSeq)
+    }
+
+  def serialize(session: Session): String = {
+    sessionWrites.writes(session).toString()
+  }
+}

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/Capability.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/Capability.scala
@@ -1,0 +1,93 @@
+/** *************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                 *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ * ***************************************************************/
+
+package org.apache.james.jmap.model
+
+import java.net.URI
+
+import org.apache.james.jmap.model.CapabilityIdentifier.{JMAP_CORE, JMAP_MAIL}
+
+final case class CapabilityIdentifier(value: URI) {
+  def asString(): String = {
+    value.toString
+  }
+}
+
+object CapabilityIdentifier {
+  val JMAP_CORE = CapabilityIdentifier(new URI("urn:ietf:params:jmap:core"))
+  val JMAP_MAIL = CapabilityIdentifier(new URI("urn:ietf:params:jmap:mail"))
+}
+
+sealed trait CapabilityProperties
+
+sealed trait Capability {
+  def identifier(): CapabilityIdentifier
+  def properties(): CapabilityProperties
+}
+
+final case class CoreCapability(identifier: CapabilityIdentifier = JMAP_CORE,
+                                properties: CoreCapabilityProperties) extends Capability
+
+object CoreCapabilityProperties {
+  def apply(maxSizeUpload: UnsignedInt, maxConcurrentUpload: UnsignedInt,
+            maxSizeRequest: UnsignedInt, maxConcurrentRequests: UnsignedInt,
+            maxCallsInRequest: UnsignedInt, maxObjectsInGet: UnsignedInt,
+            maxObjectsInSet: UnsignedInt, collationAlgorithms: List[String]): CoreCapabilityProperties = {
+
+    require(Option(maxSizeUpload).isDefined, "maxSizeUpload cannot be null")
+    require(Option(maxConcurrentUpload).isDefined, "maxConcurrentUpload cannot be null")
+    require(Option(maxSizeRequest).isDefined, "maxSizeRequest cannot be null")
+    require(Option(maxConcurrentRequests).isDefined, "maxConcurrentRequests cannot be null")
+    require(Option(maxCallsInRequest).isDefined, "maxCallsInRequest cannot be null")
+    require(Option(maxObjectsInGet).isDefined, "maxObjectsInGet cannot be null")
+    require(Option(maxObjectsInSet).isDefined, "maxObjectsInSet cannot be null")
+    require(Option(collationAlgorithms).isDefined, "collationAlgorithms cannot be null")
+
+    new CoreCapabilityProperties(maxSizeUpload, maxConcurrentUpload, maxSizeRequest, maxConcurrentRequests, maxCallsInRequest,
+      maxObjectsInGet, maxObjectsInSet, collationAlgorithms)
+  }
+}
+
+final case class CoreCapabilityProperties private(maxSizeUpload: UnsignedInt, maxConcurrentUpload: UnsignedInt,
+                                                  maxSizeRequest: UnsignedInt, maxConcurrentRequests: UnsignedInt,
+                                                  maxCallsInRequest: UnsignedInt, maxObjectsInGet: UnsignedInt,
+                                                  maxObjectsInSet: UnsignedInt, collationAlgorithms: List[String]) extends CapabilityProperties {
+}
+
+final case class MailCapability(identifier: CapabilityIdentifier = JMAP_MAIL,
+                                properties: MailCapabilityProperties) extends Capability
+
+object MailCapabilityProperties {
+  def apply(maxMailboxesPerEmail: Option[UnsignedInt], maxMailboxDepth: Option[UnsignedInt],
+            maxSizeMailboxName: UnsignedInt, maxSizeAttachmentsPerEmail: UnsignedInt,
+            emailQuerySortOptions: List[String], mayCreateTopLevelMailbox: Boolean): MailCapabilityProperties = {
+    require(Option(maxSizeMailboxName).isDefined, "maxSizeMailboxName cannot be null")
+    require(Option(maxSizeAttachmentsPerEmail).isDefined, "maxSizeAttachmentsPerEmail cannot be null")
+    require(Option(emailQuerySortOptions).isDefined, "emailQuerySortOptions cannot be null")
+
+    new MailCapabilityProperties(maxMailboxesPerEmail, maxMailboxDepth, maxSizeMailboxName, maxSizeAttachmentsPerEmail,
+      emailQuerySortOptions, mayCreateTopLevelMailbox)
+  }
+}
+
+final case class MailCapabilityProperties private(maxMailboxesPerEmail: Option[UnsignedInt], maxMailboxDepth: Option[UnsignedInt],
+                                                  maxSizeMailboxName: UnsignedInt, maxSizeAttachmentsPerEmail: UnsignedInt,
+                                                  emailQuerySortOptions: List[String], mayCreateTopLevelMailbox: Boolean) extends CapabilityProperties {
+}
+

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/Id.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/Id.scala
@@ -1,0 +1,33 @@
+/** **************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                 *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ * ***************************************************************/
+
+package org.apache.james.jmap.model
+
+object Id {
+  def apply(value: String): Id = {
+    require(Option(value).isDefined, "value cannot be null")
+    require(!value.isEmpty, "value cannot be empty")
+    require(value.length <= 255, "value length cannot exceed 255 characters")
+    require(value.matches("^[a-zA-Z0-9-_]*$"), "value should contains only 'URL and Filename Safe' base64 alphabet characters, " +
+      "see Section 5 of [@!RFC4648]")
+    new Id(value)
+  }
+}
+
+final case class Id private(value: String)

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/Id.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/Id.scala
@@ -19,23 +19,12 @@
 
 package org.apache.james.jmap.model
 
-import eu.timepit.refined.api.{Refined, Validate}
-import eu.timepit.refined.boolean.And
+import eu.timepit.refined.api.Refined
 import eu.timepit.refined.string.MatchesRegex
 import org.apache.james.jmap.model.Id.IdConstraints
 
-final case class NonNull()
-
-object NonNull {
-  implicit def matchesNonNull[Any]: Validate.Plain[Any, NonNull] =
-    Validate.fromPredicate(
-      value => value != null,
-      _ => "value cannot be null",
-      NonNull())
-}
-
 object Id {
-  type IdConstraints = NonNull And MatchesRegex["^[a-zA-Z0-9-_]{1,255}$"]
+  type IdConstraints = MatchesRegex["^[a-zA-Z0-9-_]{1,255}$"]
 }
 
 final case class Id private(value: String Refined IdConstraints) {

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/Session.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/Session.scala
@@ -1,0 +1,96 @@
+/** **************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                 *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ * ***************************************************************/
+
+package org.apache.james.jmap.model
+
+import java.net.URL
+
+import org.apache.james.core.Username
+import CapabilityIdentifier.JMAP_CORE
+import CapabilityIdentifier.JMAP_MAIL
+
+object Account {
+  def apply(name: Username,
+            isPersonal: Boolean,
+            isReadOnly: Boolean,
+            accountCapabilities: Set[_ <: Capability]): Account = {
+
+    require(Option(name).isDefined, "name cannot be null")
+    require(Option(accountCapabilities).isDefined, "accountCapabilities cannot be null")
+
+    new Account(name, isPersonal, isReadOnly, accountCapabilities)
+  }
+}
+
+final case class Account private(name: Username,
+                                 isPersonal: Boolean,
+                                 isReadOnly: Boolean,
+                                 accountCapabilities: Set[_ <: Capability])
+
+object State {
+  def apply(value: String): State = {
+    require(Option(value).isDefined, "value cannot be null")
+    require(!value.isEmpty, "value cannot be empty")
+
+    new State(value)
+  }
+}
+
+final case class State private(value: String)
+
+object Session {
+  def apply(capabilities: Set[_ <: Capability],
+            accounts: Map[Id, Account],
+            primaryAccounts: Map[CapabilityIdentifier, Id],
+            username: Username,
+            apiUrl: URL,
+            downloadUrl: URL,
+            uploadUrl: URL,
+            eventSourceUrl: URL,
+            state: State): Session = {
+    require(Option(capabilities).isDefined, "capabilities cannot be null")
+    require(capabilities.exists(_.isInstanceOf[CoreCapability]),
+      s"capabilities should contain ${JMAP_CORE.value.toString} capability")
+    require(capabilities.exists(_.isInstanceOf[MailCapability]),
+      s"capabilities should contain ${JMAP_MAIL.value.toString} capability")
+    require(capabilities.map(_.identifier()).size == capabilities.size,
+      "capabilities should not be duplicated")
+
+    require(Option(accounts).isDefined, "accounts cannot be null")
+    require(Option(primaryAccounts).isDefined, "primaryAccounts cannot be null")
+    require(Option(username).isDefined, "username cannot be null")
+    require(Option(apiUrl).isDefined, "apiUrl cannot be null")
+    require(Option(downloadUrl).isDefined, "downloadUrl cannot be null")
+    require(Option(uploadUrl).isDefined, "uploadUrl cannot be null")
+    require(Option(eventSourceUrl).isDefined, "eventSourceUrl cannot be null")
+    require(Option(state).isDefined, "state cannot be null")
+
+    new Session(capabilities, accounts, primaryAccounts, username, apiUrl, downloadUrl, uploadUrl, eventSourceUrl, state)
+  }
+}
+
+final case class Session private(capabilities: Set[_ <: Capability],
+                           accounts: Map[Id, Account],
+                           primaryAccounts: Map[CapabilityIdentifier, Id],
+                           username: Username,
+                           apiUrl: URL,
+                           downloadUrl: URL,
+                           uploadUrl: URL,
+                           eventSourceUrl: URL,
+                           state: State)

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/UnsignedInt.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/UnsignedInt.scala
@@ -1,0 +1,68 @@
+/** **************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                 *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ * ***************************************************************/
+
+package org.apache.james.jmap.model
+
+import com.google.common.math.LongMath
+import org.slf4j.{Logger, LoggerFactory}
+
+object UnsignedInt {
+  private val LOGGER: Logger = LoggerFactory.getLogger(classOf[UnsignedInt])
+  private val VALIDATION_MESSAGE = "value should be positive and less than 2^53"
+
+  trait Factory[T] {
+    def from(value: Long): T
+  }
+
+  private val ZERO_VALUE: Long = 0
+  val MAX_VALUE: Long = LongMath.pow(2, 53)
+  val ZERO = UnsignedInt.apply(ZERO_VALUE)
+
+  val DEFAULT_FACTORY: UnsignedInt.Factory[Option[UnsignedInt]] = (value: Long) => Some(value)
+    .filter(UnsignedInt.isValid)
+    .map(UnsignedInt.apply)
+
+  val BOUND_SANITIZING_FACTORY: UnsignedInt.Factory[UnsignedInt] = {
+    case x if x < ZERO_VALUE =>
+      LOGGER.warn("Received a negative Number")
+      UnsignedInt.apply(ZERO_VALUE)
+    case x if x > MAX_VALUE =>
+      LOGGER.warn("Received a too big Number")
+      UnsignedInt.apply(MAX_VALUE)
+    case value => UnsignedInt.apply(value)
+  }
+
+  def fromLong(value: Long) = apply(value)
+
+  private def isValid(value: Long) = value >= ZERO_VALUE && value <= MAX_VALUE
+
+  implicit def asValidNumber(x: Long): UnsignedInt = apply(x)
+
+  def apply(value: Long): UnsignedInt = {
+    require(UnsignedInt.isValid(value), UnsignedInt.VALIDATION_MESSAGE)
+
+    new UnsignedInt(value)
+  }
+}
+
+final case class UnsignedInt private(value: Long) extends Ordered[UnsignedInt] {
+  def asLong: Long = value
+
+  override def compare(that: UnsignedInt): Int = this.value.compare(that.value)
+}

--- a/server/protocols/jmap-rfc-8621/src/test/resources/sessionObject.json
+++ b/server/protocols/jmap-rfc-8621/src/test/resources/sessionObject.json
@@ -1,0 +1,80 @@
+{
+  "capabilities": {
+    "urn:ietf:params:jmap:core": {
+      "maxSizeUpload": 50000000,
+      "maxConcurrentUpload": 8,
+      "maxSizeRequest": 10000000,
+      "maxConcurrentRequests": 10000000,
+      "maxCallsInRequest": 32,
+      "maxObjectsInGet": 256,
+      "maxObjectsInSet": 128,
+      "collationAlgorithms": [
+        "i;ascii-numeric",
+        "i;ascii-casemap",
+        "i;unicode-casemap"
+      ]
+    },
+    "urn:ietf:params:jmap:mail": {
+      "maxMailboxesPerEmail": 9359,
+      "maxMailboxDepth": 1432,
+      "maxSizeMailboxName": 9000,
+      "maxSizeAttachmentsPerEmail": 890099,
+      "emailQuerySortOptions": [],
+      "mayCreateTopLevelMailbox": true
+    }
+  },
+  "accounts": {
+    "user1Id": {
+      "name": "user1@james.org",
+      "isPersonal": true,
+      "isReadOnly": false,
+      "accountCapabilities": {
+        "urn:ietf:params:jmap:core": {
+          "maxSizeUpload": 50000000,
+          "maxConcurrentUpload": 8,
+          "maxSizeRequest": 10000000,
+          "maxConcurrentRequests": 10000000,
+          "maxCallsInRequest": 32,
+          "maxObjectsInGet": 256,
+          "maxObjectsInSet": 128,
+          "collationAlgorithms": [
+            "i;ascii-numeric",
+            "i;ascii-casemap",
+            "i;unicode-casemap"
+          ]
+        }
+      }
+    },
+    "user2Id": {
+      "name": "user2@james.org",
+      "isPersonal": false,
+      "isReadOnly": false,
+      "accountCapabilities": {
+        "urn:ietf:params:jmap:core": {
+          "maxSizeUpload": 50000000,
+          "maxConcurrentUpload": 8,
+          "maxSizeRequest": 10000000,
+          "maxConcurrentRequests": 10000000,
+          "maxCallsInRequest": 32,
+          "maxObjectsInGet": 256,
+          "maxObjectsInSet": 128,
+          "collationAlgorithms": [
+            "i;ascii-numeric",
+            "i;ascii-casemap",
+            "i;unicode-casemap"
+          ]
+        }
+      }
+    }
+  },
+  "primaryAccounts": {
+    "urn:ietf:params:jmap:mail": "user1Id",
+    "urn:ietf:params:jmap:contact": "user2Id"
+  },
+  "username": "user1@james.org",
+  "apiUrl": "http://james.org",
+  "downloadUrl": "http://james.org",
+  "uploadUrl": "http://james.org",
+  "eventSourceUrl": "http://james.org",
+  "state": "fda9342jcm"
+}

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/SerializerTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/SerializerTest.scala
@@ -1,0 +1,119 @@
+/** **************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                 *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ * ***************************************************************/
+
+package org.apache.james.jmap
+
+import java.net.{URI, URL}
+
+import org.apache.james.core.Username
+import org.apache.james.jmap.SerializerTest.{SESSION, readResource}
+import org.apache.james.jmap.model._
+import org.scalatestplus.play.PlaySpec
+import play.libs.Json
+
+import scala.io.Source
+import scala.util.Using
+
+object SerializerTest {
+  private val ALGO_1 = "i;ascii-numeric"
+  private val ALGO_2 = "i;ascii-casemap"
+  private val ALGO_3 = "i;unicode-casemap"
+  private val MAX_SIZE_UPLOAD = UnsignedInt(50000000)
+  private val MAX_CONCURRENT_UPLOAD = UnsignedInt(8)
+  private val MAX_SIZE_REQUEST = UnsignedInt(10000000)
+  private val MAX_CONCURRENT_REQUESTS = UnsignedInt(10000000)
+  private val MAX_CALLS_IN_REQUEST = UnsignedInt(32)
+  private val MAX_OBJECTS_IN_GET = UnsignedInt(256)
+  private val MAX_OBJECTS_IN_SET = UnsignedInt(128)
+  private val USER_1 = Username.of("user1@james.org")
+  private val USER_1_ID = Id("user1Id")
+  private val USER_2 = Username.of("user2@james.org")
+  private val USER_2_ID = Id("user2Id")
+  private val URL = new URL("http://james.org")
+  private val STATE = State("fda9342jcm")
+
+  private val MAIL_IDENTIFIER = CapabilityIdentifier(new URI("urn:ietf:params:jmap:mail"))
+  private val CONTACT_IDENTIFIER = CapabilityIdentifier(new URI("urn:ietf:params:jmap:contact"))
+
+  private val CORE_CAPABILITY = CoreCapability(properties = CoreCapabilityProperties(
+    maxSizeUpload = MAX_SIZE_UPLOAD, maxConcurrentUpload = MAX_CONCURRENT_UPLOAD,
+    maxSizeRequest = MAX_SIZE_REQUEST, maxConcurrentRequests = MAX_CONCURRENT_REQUESTS,
+    maxCallsInRequest = MAX_CALLS_IN_REQUEST, maxObjectsInGet = MAX_OBJECTS_IN_GET, maxObjectsInSet = MAX_OBJECTS_IN_SET,
+    collationAlgorithms = List(ALGO_1, ALGO_2, ALGO_3)))
+  private val MAX_MAILBOX_DEPTH = Some(UnsignedInt(1432))
+  private val MAX_MAILBOXES_PER_EMAIL = Some(UnsignedInt(9359))
+  private val MAX_SIZE_MAILBOX_NAME = UnsignedInt(9000)
+  private val MAX_SIZE_ATTACHMENTS_PER_EMAIL = UnsignedInt(890099)
+
+  private val MAIL_CAPABILITY = MailCapability(properties = MailCapabilityProperties(
+    maxMailboxDepth = MAX_MAILBOX_DEPTH,
+    maxMailboxesPerEmail = MAX_MAILBOXES_PER_EMAIL,
+    maxSizeMailboxName = MAX_SIZE_MAILBOX_NAME,
+    maxSizeAttachmentsPerEmail = MAX_SIZE_ATTACHMENTS_PER_EMAIL,
+    emailQuerySortOptions = List(),
+    mayCreateTopLevelMailbox = true))
+
+  private val CAPABILITIES = Set(CORE_CAPABILITY,MAIL_CAPABILITY)
+
+  private val ACCOUNT_1 = Account(
+    name = USER_1,
+    isPersonal = true,
+    isReadOnly = false,
+    accountCapabilities = Set(CORE_CAPABILITY))
+  private val ACCOUNT_2 = Account(
+    name = USER_2,
+    isPersonal = false,
+    isReadOnly = false,
+    accountCapabilities = Set(CORE_CAPABILITY))
+  private val ACCOUNTS = Map(
+    USER_1_ID -> ACCOUNT_1,
+    USER_2_ID -> ACCOUNT_2,
+  )
+  private val PRIMARY_ACCOUNTS = Map(
+    MAIL_IDENTIFIER -> USER_1_ID,
+    CONTACT_IDENTIFIER -> USER_2_ID
+  )
+
+  private val SESSION = Session(
+    capabilities = CAPABILITIES,
+    accounts = ACCOUNTS,
+    primaryAccounts = PRIMARY_ACCOUNTS,
+    username = USER_1,
+    apiUrl = URL,
+    downloadUrl = URL,
+    uploadUrl = URL,
+    eventSourceUrl = URL,
+    state = STATE)
+
+  def readResource(resourceFileName: String): String = {
+    Using(Source.fromURL(getClass.getResource(resourceFileName), "UTF-8")) { source =>
+      source.mkString
+    }.get
+  }
+}
+
+class SerializerTest extends PlaySpec {
+
+  "sessionWrites" should {
+    "serialize session" in {
+      val jsonString = Json.parse(readResource("/sessionObject.json")).toString
+      new Serializer().serialize(SESSION) must equal(jsonString)
+    }
+  }
+}

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/SerializerTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/SerializerTest.scala
@@ -21,6 +21,7 @@ package org.apache.james.jmap
 
 import java.net.{URI, URL}
 
+import eu.timepit.refined.auto._
 import org.apache.james.core.Username
 import org.apache.james.jmap.SerializerTest.{SESSION, readResource}
 import org.apache.james.jmap.model._

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/model/CapabilityTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/model/CapabilityTest.scala
@@ -1,0 +1,192 @@
+/** **************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                 *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ * ***************************************************************/
+
+package org.apache.james.jmap.model
+
+import java.net.URI
+
+import org.apache.james.jmap.model.CapabilityTest.UNSIGNED_INT
+import org.scalatest.{Matchers, WordSpec}
+
+object CapabilityTest {
+  private val UNSIGNED_INT = UnsignedInt(1)
+}
+
+class CapabilityTest extends WordSpec with Matchers {
+
+  "CapabilityIdentifier" should {
+    "return raw value" in {
+      val uri = "apache:james:jmap:filter"
+      val asString = CapabilityIdentifier(new URI(uri)).asString()
+      asString should equal(uri)
+    }
+  }
+
+  "CoreCapabilityProperties" should {
+    "throw when null maxSizeUpload" in {
+      the [IllegalArgumentException] thrownBy {
+        CoreCapabilityProperties(
+          maxSizeUpload = null,
+          maxCallsInRequest = UNSIGNED_INT,
+          maxConcurrentUpload = UNSIGNED_INT,
+          maxSizeRequest = UNSIGNED_INT,
+          maxConcurrentRequests = UNSIGNED_INT,
+          maxObjectsInGet = UNSIGNED_INT,
+          maxObjectsInSet = UNSIGNED_INT,
+          collationAlgorithms = List())
+      } should have message "requirement failed: maxSizeUpload cannot be null"
+    }
+
+    "throw when null maxCallsInRequest" in {
+      the [IllegalArgumentException] thrownBy {
+        CoreCapabilityProperties(
+          maxSizeUpload = UNSIGNED_INT,
+          maxCallsInRequest = null,
+          maxConcurrentUpload = UNSIGNED_INT,
+          maxSizeRequest = UNSIGNED_INT,
+          maxConcurrentRequests = UNSIGNED_INT,
+          maxObjectsInGet = UNSIGNED_INT,
+          maxObjectsInSet = UNSIGNED_INT,
+          collationAlgorithms = List())
+      } should have message "requirement failed: maxCallsInRequest cannot be null"
+    }
+
+    "throw when null maxConcurrentUpload" in {
+      the [IllegalArgumentException] thrownBy {
+        CoreCapabilityProperties(
+          maxSizeUpload = UNSIGNED_INT,
+          maxCallsInRequest = UNSIGNED_INT,
+          maxConcurrentUpload = null,
+          maxSizeRequest = UNSIGNED_INT,
+          maxConcurrentRequests = UNSIGNED_INT,
+          maxObjectsInGet = UNSIGNED_INT,
+          maxObjectsInSet = UNSIGNED_INT,
+          collationAlgorithms = List())
+      } should have message "requirement failed: maxConcurrentUpload cannot be null"
+    }
+
+    "throw when null maxSizeRequest" in {
+      the [IllegalArgumentException] thrownBy {
+        CoreCapabilityProperties(
+          maxSizeUpload = UNSIGNED_INT,
+          maxCallsInRequest = UNSIGNED_INT,
+          maxConcurrentUpload = UNSIGNED_INT,
+          maxSizeRequest = null,
+          maxConcurrentRequests = UNSIGNED_INT,
+          maxObjectsInGet = UNSIGNED_INT,
+          maxObjectsInSet = UNSIGNED_INT,
+          collationAlgorithms = List())
+      } should have message "requirement failed: maxSizeRequest cannot be null"
+    }
+
+    "throw when null maxConcurrentRequests" in {
+      the [IllegalArgumentException] thrownBy {
+        CoreCapabilityProperties(
+          maxSizeUpload = UNSIGNED_INT,
+          maxCallsInRequest = UNSIGNED_INT,
+          maxConcurrentUpload = UNSIGNED_INT,
+          maxSizeRequest = UNSIGNED_INT,
+          maxConcurrentRequests = null,
+          maxObjectsInGet = UNSIGNED_INT,
+          maxObjectsInSet = UNSIGNED_INT,
+          collationAlgorithms = List())
+      } should have message "requirement failed: maxConcurrentRequests cannot be null"
+    }
+
+    "throw when null maxObjectsInGet" in {
+      the [IllegalArgumentException] thrownBy {
+        CoreCapabilityProperties(
+          maxSizeUpload = UNSIGNED_INT,
+          maxCallsInRequest = UNSIGNED_INT,
+          maxConcurrentUpload = UNSIGNED_INT,
+          maxSizeRequest = UNSIGNED_INT,
+          maxConcurrentRequests = UNSIGNED_INT,
+          maxObjectsInGet = null,
+          maxObjectsInSet = UNSIGNED_INT,
+          collationAlgorithms = List())
+      } should have message "requirement failed: maxObjectsInGet cannot be null"
+    }
+
+    "throw when null maxObjectsInSet" in {
+      the [IllegalArgumentException] thrownBy {
+        CoreCapabilityProperties(
+          maxSizeUpload = UNSIGNED_INT,
+          maxCallsInRequest = UNSIGNED_INT,
+          maxConcurrentUpload = UNSIGNED_INT,
+          maxSizeRequest = UNSIGNED_INT,
+          maxConcurrentRequests = UNSIGNED_INT,
+          maxObjectsInGet = UNSIGNED_INT,
+          maxObjectsInSet = null,
+          collationAlgorithms = List())
+      } should have message "requirement failed: maxObjectsInSet cannot be null"
+    }
+
+    "throw when null collationAlgorithms" in {
+      the [IllegalArgumentException] thrownBy {
+        CoreCapabilityProperties(
+          maxSizeUpload = UNSIGNED_INT,
+          maxCallsInRequest = UNSIGNED_INT,
+          maxConcurrentUpload = UNSIGNED_INT,
+          maxSizeRequest = UNSIGNED_INT,
+          maxConcurrentRequests = UNSIGNED_INT,
+          maxObjectsInGet = UNSIGNED_INT,
+          maxObjectsInSet = UNSIGNED_INT,
+          collationAlgorithms = null)
+      } should have message "requirement failed: collationAlgorithms cannot be null"
+    }
+  }
+
+  "MailCapabilityProperties" should {
+    "throw when null maxSizeMailboxName" in {
+      the [IllegalArgumentException] thrownBy {
+        MailCapabilityProperties(
+          maxMailboxesPerEmail = Some(UNSIGNED_INT),
+          maxMailboxDepth = Some(UNSIGNED_INT),
+          maxSizeMailboxName = null,
+          maxSizeAttachmentsPerEmail = UNSIGNED_INT,
+          emailQuerySortOptions = List(),
+          mayCreateTopLevelMailbox = true)
+      } should have message "requirement failed: maxSizeMailboxName cannot be null"
+    }
+
+    "throw when null maxSizeAttachmentsPerEmail" in {
+      the [IllegalArgumentException] thrownBy {
+        MailCapabilityProperties(
+          maxMailboxesPerEmail = Some(UNSIGNED_INT),
+          maxMailboxDepth = Some(UNSIGNED_INT),
+          maxSizeMailboxName = UNSIGNED_INT,
+          maxSizeAttachmentsPerEmail = null,
+          emailQuerySortOptions = List(),
+          mayCreateTopLevelMailbox = true)
+      } should have message "requirement failed: maxSizeAttachmentsPerEmail cannot be null"
+    }
+
+    "throw when null mayCreateTopLevelMailbox" in {
+      the [IllegalArgumentException] thrownBy {
+        MailCapabilityProperties(
+          maxMailboxesPerEmail = Some(UNSIGNED_INT),
+          maxMailboxDepth = Some(UNSIGNED_INT),
+          maxSizeMailboxName = UNSIGNED_INT,
+          maxSizeAttachmentsPerEmail = UNSIGNED_INT,
+          emailQuerySortOptions = null,
+          mayCreateTopLevelMailbox = true)
+      } should have message "requirement failed: emailQuerySortOptions cannot be null"
+    }
+  }
+}

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/model/IdTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/model/IdTest.scala
@@ -1,0 +1,55 @@
+/** **************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                 *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ * ***************************************************************/
+
+package org.apache.james.jmap.model
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class IdTest extends FlatSpec with Matchers {
+
+  private val INVALID_CHARACTERS = List("\"", "(", ")", ",", ":", ";", "<", ">", "@", "[", "\\", "]", " ")
+
+  "apply" should "throw when null value" in {
+    the [IllegalArgumentException] thrownBy {
+      Id(null)
+    } should have message "requirement failed: value cannot be null"
+  }
+
+  "apply" should "throw when empty value" in {
+    the [IllegalArgumentException] thrownBy {
+      Id("")
+    } should have message "requirement failed: value cannot be empty"
+  }
+
+  "apply" should "throw when too long value" in {
+    val idWith256Chars = "a" * 256
+    the [IllegalArgumentException] thrownBy {
+      Id(idWith256Chars)
+    } should have message "requirement failed: value length cannot exceed 255 characters"
+  }
+
+  "apply" should "throw when invalid value" in {
+    INVALID_CHARACTERS.foreach { invalidChar =>
+      the [IllegalArgumentException] thrownBy {
+        Id(invalidChar)
+      } should have message
+        "requirement failed: value should contains only 'URL and Filename Safe' base64 alphabet characters, see Section 5 of [@!RFC4648]"
+    }
+  }
+}

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/model/IdTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/model/IdTest.scala
@@ -26,15 +26,12 @@ import org.scalatest.{Matchers, WordSpec}
 
 class IdTest extends WordSpec with Matchers {
 
-  private val INVALID_CHARACTERS = List("\"", "(", ")", ",", ":", ";", "<", ">", "@", "[", "\\", "]", " ")
-
   "apply" when {
     "in Runtime" should {
-      // this test is disabled, NonNull doesn't fail fast, and then null String causes NPE at RegexMatcher
-      "return left(error message) when null value" ignore {
-        val nullString: String = null
-        val either: Either[String, String Refined IdConstraints] = refineV[IdConstraints](nullString)
-        either.isLeft should be(true)
+      "throws when null" in {
+        assertThrows[NullPointerException] {
+          val either: Either[String, String Refined IdConstraints] = refineV[IdConstraints](null)
+        }
       }
 
       "return left(error message) when empty value" in {

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/model/SessionTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/model/SessionTest.scala
@@ -1,0 +1,278 @@
+/** **************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                 *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ * ***************************************************************/
+
+package org.apache.james.jmap.model
+
+import java.net.{URL => JavaNetURL}
+
+import org.apache.james.core.Username
+import org.apache.james.jmap.model.SessionTest._
+import org.scalatest.{Matchers, WordSpec}
+
+object SessionTest {
+  private val USERNAME = Username.of("bob@james.org")
+  private val URL = new JavaNetURL("http://james.org")
+  private val STATE = State("fda9342jcm")
+  private val UNSIGNED_INT = UnsignedInt(1)
+  private val CORE_CAPABILITY = CoreCapability(properties = CoreCapabilityProperties(
+    maxSizeUpload = UNSIGNED_INT,
+    maxCallsInRequest = UNSIGNED_INT,
+    maxConcurrentUpload = UNSIGNED_INT,
+    maxSizeRequest = UNSIGNED_INT,
+    maxConcurrentRequests = UNSIGNED_INT,
+    maxObjectsInGet = UNSIGNED_INT,
+    maxObjectsInSet = UNSIGNED_INT,
+    collationAlgorithms = List()))
+  private val MAIL_CAPABILITY = MailCapability(properties = MailCapabilityProperties(
+    maxMailboxDepth = Some(UNSIGNED_INT),
+    maxMailboxesPerEmail = Some(UNSIGNED_INT),
+    maxSizeMailboxName = UNSIGNED_INT,
+    maxSizeAttachmentsPerEmail = UNSIGNED_INT,
+    emailQuerySortOptions = List(),
+    mayCreateTopLevelMailbox = true))
+  private val ANOTHER_MAIL_CAPABILITY = MailCapability(properties = MailCapabilityProperties(
+    maxMailboxDepth = Some(UNSIGNED_INT),
+    maxMailboxesPerEmail = Some(UNSIGNED_INT),
+    maxSizeMailboxName = UNSIGNED_INT,
+    maxSizeAttachmentsPerEmail = UNSIGNED_INT,
+    emailQuerySortOptions = List("flags", "subject"),
+    mayCreateTopLevelMailbox = false))
+  private val CAPABILITIES = Set(CORE_CAPABILITY, MAIL_CAPABILITY)
+}
+
+class SessionTest extends WordSpec with Matchers {
+
+  "Account" should {
+    "throw when null name" in {
+      the [IllegalArgumentException] thrownBy {
+        Account(
+          name = null,
+          isPersonal = true,
+          isReadOnly = false,
+          accountCapabilities = CAPABILITIES)
+      } should have message "requirement failed: name cannot be null"
+    }
+
+    "throw when null accountCapabilities" in {
+      the [IllegalArgumentException] thrownBy {
+        Account(
+          name = USERNAME,
+          isPersonal = true,
+          isReadOnly = false,
+          accountCapabilities = null)
+      } should have message "requirement failed: accountCapabilities cannot be null"
+    }
+  }
+
+  "State" should {
+    "throw when null value" in {
+      the [IllegalArgumentException] thrownBy {
+        State(null)
+      } should have message "requirement failed: value cannot be null"
+    }
+
+    "throw when empty value" in {
+      the [IllegalArgumentException] thrownBy {
+        State("")
+      } should have message "requirement failed: value cannot be empty"
+    }
+  }
+
+  "apply" should {
+    "throw when null capabilities" in {
+      the [IllegalArgumentException] thrownBy {
+        Session(
+          capabilities = null,
+          accounts = Map(),
+          primaryAccounts = Map(),
+          username = USERNAME,
+          apiUrl = URL,
+          downloadUrl = URL,
+          uploadUrl = URL,
+          eventSourceUrl = URL,
+          state = STATE)
+      } should have message "requirement failed: capabilities cannot be null"
+    }
+
+    "throw when missing core capability" in {
+      the [IllegalArgumentException] thrownBy {
+        Session(
+          capabilities = Set(MAIL_CAPABILITY),
+          accounts = Map(),
+          primaryAccounts = Map(),
+          username = USERNAME,
+          apiUrl = URL,
+          downloadUrl = URL,
+          uploadUrl = URL,
+          eventSourceUrl = URL,
+          state = STATE)
+      } should have message "requirement failed: capabilities should contain urn:ietf:params:jmap:core capability"
+    }
+
+    "throw when missing mail capability" in {
+      the [IllegalArgumentException] thrownBy {
+        Session(
+          capabilities = Set(CORE_CAPABILITY),
+          accounts = Map(),
+          primaryAccounts = Map(),
+          username = USERNAME,
+          apiUrl = URL,
+          downloadUrl = URL,
+          uploadUrl = URL,
+          eventSourceUrl = URL,
+          state = STATE)
+      } should have message "requirement failed: capabilities should contain urn:ietf:params:jmap:mail capability"
+    }
+
+    "throw when missing duplicate capability identifier" in {
+      the [IllegalArgumentException] thrownBy {
+        Session(
+          capabilities = Set(CORE_CAPABILITY, MAIL_CAPABILITY, ANOTHER_MAIL_CAPABILITY),
+          accounts = Map(),
+          primaryAccounts = Map(),
+          username = USERNAME,
+          apiUrl = URL,
+          downloadUrl = URL,
+          uploadUrl = URL,
+          eventSourceUrl = URL,
+          state = STATE)
+      } should have message "requirement failed: capabilities should not be duplicated"
+    }
+
+    "throw when null accounts" in {
+      the [IllegalArgumentException] thrownBy {
+        Session(
+          capabilities = CAPABILITIES,
+          accounts = null,
+          primaryAccounts = Map(),
+          username = USERNAME,
+          apiUrl = URL,
+          downloadUrl = URL,
+          uploadUrl = URL,
+          eventSourceUrl = URL,
+          state = STATE)
+      } should have message "requirement failed: accounts cannot be null"
+    }
+
+    "throw when null primaryAccount" in {
+      the [IllegalArgumentException] thrownBy {
+        Session(
+          capabilities = CAPABILITIES,
+          accounts = Map(),
+          primaryAccounts = null,
+          username = USERNAME,
+          apiUrl = URL,
+          downloadUrl = URL,
+          uploadUrl = URL,
+          eventSourceUrl = URL,
+          state = STATE)
+      } should have message "requirement failed: primaryAccounts cannot be null"
+    }
+
+    "throw when null username" in {
+      the [IllegalArgumentException] thrownBy {
+        Session(
+          capabilities = CAPABILITIES,
+          accounts = Map(),
+          primaryAccounts = Map(),
+          username = null,
+          apiUrl = URL,
+          downloadUrl = URL,
+          uploadUrl = URL,
+          eventSourceUrl = URL,
+          state = STATE)
+      } should have message "requirement failed: username cannot be null"
+    }
+
+    "throw when null apiUrl" in {
+      the [IllegalArgumentException] thrownBy {
+        Session(
+          capabilities = CAPABILITIES,
+          accounts = Map(),
+          primaryAccounts = Map(),
+          username = USERNAME,
+          apiUrl = null,
+          downloadUrl = URL,
+          uploadUrl = URL,
+          eventSourceUrl = URL,
+          state = STATE)
+      } should have message "requirement failed: apiUrl cannot be null"
+    }
+
+    "throw when null downloadUrl" in {
+      the [IllegalArgumentException] thrownBy {
+        Session(
+          capabilities = CAPABILITIES,
+          accounts = Map(),
+          primaryAccounts = Map(),
+          username = USERNAME,
+          apiUrl = URL,
+          downloadUrl = null,
+          uploadUrl = URL,
+          eventSourceUrl = URL,
+          state = STATE)
+      } should have message "requirement failed: downloadUrl cannot be null"
+    }
+
+    "throw when null uploadUrl" in {
+      the [IllegalArgumentException] thrownBy {
+        Session(
+          capabilities = CAPABILITIES,
+          accounts = Map(),
+          primaryAccounts = Map(),
+          username = USERNAME,
+          apiUrl = URL,
+          downloadUrl = URL,
+          uploadUrl = null,
+          eventSourceUrl = URL,
+          state = STATE)
+      } should have message "requirement failed: uploadUrl cannot be null"
+    }
+
+    "throw when null eventSourceUrl" in {
+      the [IllegalArgumentException] thrownBy {
+        Session(
+          capabilities = CAPABILITIES,
+          accounts = Map(),
+          primaryAccounts = Map(),
+          username = USERNAME,
+          apiUrl = URL,
+          downloadUrl = URL,
+          uploadUrl = URL,
+          eventSourceUrl = null,
+          state = STATE)
+      } should have message "requirement failed: eventSourceUrl cannot be null"
+    }
+
+    "throw when null state" in {
+      the [IllegalArgumentException] thrownBy {
+        Session(
+          capabilities = CAPABILITIES,
+          accounts = Map(),
+          primaryAccounts = Map(),
+          username = USERNAME,
+          apiUrl = URL,
+          downloadUrl = URL,
+          uploadUrl = URL,
+          eventSourceUrl = URL,
+          state = null)
+      } should have message "requirement failed: state cannot be null"
+    }
+  }
+}

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/model/UnsignedIntTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/model/UnsignedIntTest.scala
@@ -1,0 +1,61 @@
+/** **************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ * *
+ * http://www.apache.org/licenses/LICENSE-2.0                 *
+ * *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ * ***************************************************************/
+
+package org.apache.james.jmap.model
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class UnsignedIntTest extends FlatSpec with Matchers {
+
+  "apply" should "throw when negative value" in {
+    the [IllegalArgumentException] thrownBy {
+      UnsignedInt(-1)
+    } should have message "requirement failed: value should be positive and less than 2^53"
+  }
+
+  "apply" should "throw when greater than max value" in {
+    the [IllegalArgumentException] thrownBy {
+      UnsignedInt(UnsignedInt.MAX_VALUE + 1)
+    } should have message "requirement failed: value should be positive and less than 2^53"
+  }
+
+  "apply" should "not throw when zero value" in {
+    noException should be thrownBy UnsignedInt(0)
+  }
+
+  "apply" should "not throw when positive value" in {
+    noException should be thrownBy UnsignedInt(1)
+  }
+
+  "asLong" should "return max value when max value" in {
+    UnsignedInt(UnsignedInt.MAX_VALUE)
+      .asLong should equal(UnsignedInt.MAX_VALUE)
+  }
+
+  "fromOutbound" should "return min value when negative value" in {
+    UnsignedInt.BOUND_SANITIZING_FACTORY
+      .from(-1) should equal(UnsignedInt.ZERO)
+  }
+
+  "fromOutbound" should "return max value when greater than max value" in {
+    UnsignedInt.BOUND_SANITIZING_FACTORY
+      .from(UnsignedInt.MAX_VALUE + 1)
+      .asLong should equal(UnsignedInt.MAX_VALUE)
+  }
+}


### PR DESCRIPTION
My summary: Have two ways to use Refined (compile time and runtime). 

## Compile Time
We can use the syntax:
```
val x: Int Refined Positive = 10
val x: Id("myId")
```
It's true for constants, values are defined at compile time. It doesn't work with values defined at runtime.

## Run Time

should use refineV
```
val x: Int = 10
val y: Either[String, Int Refined Positive] = refineV[Positive](10)
```

as `refineV` is runtime safe, it doesn't throw any exception but return an `Either` (left is error message, right is the real value - if succeed). 

I demonstrated `refineV` usages and mapping it into `Id` in `IdTest.scala` as I think we will mostly deal with Id computation in runtime. 

## Issues
I cannot get over the tests where passing a null string(run time). Reason is commented down in test code