### PR TITLE
JAMES-2893 Move test-run.log in target

### DIFF
--- a/testing/base/src/main/resources/logback-test.xml
+++ b/testing/base/src/main/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
         <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-                <file>test-run.log</file>
+                <file>target/test-run.log</file>
                 <append>false</append>
                 <!-- set immediateFlush to false for much higher logging throughput -->
                 <immediateFlush>false</immediateFlush>


### PR DESCRIPTION
This prevents intelliJ from thinking this is a build file and to think
log FQDN is a class reference...