### PR TITLE
JAMES-2648 Avoid reading schemaVersion upon each alias resolution

### DIFF
--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionManager.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionManager.java
@@ -41,6 +41,7 @@ public class CassandraSchemaVersionManager {
 
     private final SchemaVersion minVersion;
     private final SchemaVersion maxVersion;
+    private final SchemaVersion initialSchemaVersion;
     private final CassandraSchemaVersionDAO schemaVersionDAO;
 
     public enum SchemaState {
@@ -63,6 +64,14 @@ public class CassandraSchemaVersionManager {
         this.schemaVersionDAO = schemaVersionDAO;
         this.minVersion = minVersion;
         this.maxVersion = maxVersion;
+
+        this.initialSchemaVersion = computeVersion();
+    }
+
+    public boolean isBefore(SchemaVersion minimum) {
+        return initialSchemaVersion.isBefore(minimum)
+            // If we started with a legacy james then maybe schema version had been updated since then
+            && computeVersion().isBefore(minimum);
     }
 
     public SchemaVersion computeVersion() {

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionManagerTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionManagerTest.java
@@ -63,6 +63,54 @@ class CassandraSchemaVersionManagerTest {
     }
 
     @Test
+    void isBeforeShouldReturnTrueWhenBefore() {
+        SchemaVersion currentVersion = minVersion;
+
+        when(schemaVersionDAO.getCurrentSchemaVersion())
+            .thenReturn(Mono.just(Optional.of(currentVersion)));
+
+        CassandraSchemaVersionManager testee = new CassandraSchemaVersionManager(
+            schemaVersionDAO,
+            minVersion,
+            maxVersion);
+
+        assertThat(testee.isBefore(maxVersion)).isTrue();
+    }
+
+    @Test
+    void isBeforeShouldReturnFalseWhenEquals() {
+        SchemaVersion currentVersion = maxVersion;
+
+        when(schemaVersionDAO.getCurrentSchemaVersion())
+            .thenReturn(Mono.just(Optional.of(currentVersion)));
+
+        CassandraSchemaVersionManager testee = new CassandraSchemaVersionManager(
+            schemaVersionDAO,
+            minVersion,
+            maxVersion);
+
+        assertThat(testee.isBefore(maxVersion)).isFalse();
+    }
+
+    @Test
+    void isBeforeShouldReturnFalseWhenUpdatedToEquals() {
+        SchemaVersion currentVersion = maxVersion;
+
+        when(schemaVersionDAO.getCurrentSchemaVersion())
+            .thenReturn(Mono.just(Optional.of(minVersion)));
+
+        CassandraSchemaVersionManager testee = new CassandraSchemaVersionManager(
+            schemaVersionDAO,
+            minVersion,
+            maxVersion);
+
+        when(schemaVersionDAO.getCurrentSchemaVersion())
+            .thenReturn(Mono.just(Optional.of(maxVersion)));
+
+        assertThat(testee.isBefore(maxVersion)).isFalse();
+    }
+
+    @Test
     void computeSchemaStateShouldReturnTooOldWhenVersionIsMoreThanMaxVersion() {
         SchemaVersion currentVersion = maxVersion.next();
 

--- a/server/data/data-cassandra/src/main/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTable.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTable.java
@@ -110,7 +110,7 @@ public class CassandraRecipientRewriteTable extends AbstractRecipientRewriteTabl
     private boolean isLegacy() {
         return isLegacy(initialSchemaVersion)
             // If we started with a legacy james then maybe schema version had been updated since then
-            || isLegacy(versionManager.computeVersion());
+            && isLegacy(versionManager.computeVersion());
     }
 
     private boolean isLegacy(SchemaVersion schemaVersion) {

--- a/server/data/data-cassandra/src/test/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTableV6Test.java
+++ b/server/data/data-cassandra/src/test/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTableV6Test.java
@@ -19,12 +19,12 @@
 
 package org.apache.james.rrt.cassandra;
 
-import org.apache.commons.configuration2.BaseHierarchicalConfiguration;
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.DockerCassandraRule;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.utils.CassandraUtils;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionDAO;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
 import org.apache.james.backends.cassandra.versions.SchemaVersion;
 import org.apache.james.rrt.lib.AbstractRecipientRewriteTable;
@@ -60,15 +60,14 @@ public class CassandraRecipientRewriteTableV6Test extends AbstractRecipientRewri
     }
 
     @Override
-    protected AbstractRecipientRewriteTable getRecipientRewriteTable() throws Exception {
+    protected AbstractRecipientRewriteTable getRecipientRewriteTable() {
         CassandraSchemaVersionDAO cassandraSchemaVersionDAO = new CassandraSchemaVersionDAO(
-            cassandra.getConf()
-        );
+            cassandra.getConf());
 
         CassandraRecipientRewriteTable rrt = new CassandraRecipientRewriteTable(
             new CassandraRecipientRewriteTableDAO(cassandra.getConf(), CassandraUtils.WITH_DEFAULT_CONFIGURATION),
             new CassandraMappingsSourcesDAO(cassandra.getConf()),
-            cassandraSchemaVersionDAO);
+            new CassandraSchemaVersionManager(cassandraSchemaVersionDAO));
 
         cassandraSchemaVersionDAO.updateVersion(SCHEMA_VERSION_V6);
 

--- a/server/data/data-cassandra/src/test/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTableV6Test.java
+++ b/server/data/data-cassandra/src/test/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTableV6Test.java
@@ -63,14 +63,11 @@ public class CassandraRecipientRewriteTableV6Test extends AbstractRecipientRewri
     protected AbstractRecipientRewriteTable getRecipientRewriteTable() {
         CassandraSchemaVersionDAO cassandraSchemaVersionDAO = new CassandraSchemaVersionDAO(
             cassandra.getConf());
+        cassandraSchemaVersionDAO.updateVersion(SCHEMA_VERSION_V6).block();
 
-        CassandraRecipientRewriteTable rrt = new CassandraRecipientRewriteTable(
+        return new CassandraRecipientRewriteTable(
             new CassandraRecipientRewriteTableDAO(cassandra.getConf(), CassandraUtils.WITH_DEFAULT_CONFIGURATION),
             new CassandraMappingsSourcesDAO(cassandra.getConf()),
             new CassandraSchemaVersionManager(cassandraSchemaVersionDAO));
-
-        cassandraSchemaVersionDAO.updateVersion(SCHEMA_VERSION_V6);
-
-        return rrt;
     }
 }

--- a/server/data/data-cassandra/src/test/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTableV7BeforeStartTest.java
+++ b/server/data/data-cassandra/src/test/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTableV7BeforeStartTest.java
@@ -33,7 +33,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 
-public class CassandraRecipientRewriteTableV7Test extends AbstractRecipientRewriteTableTest {
+public class CassandraRecipientRewriteTableV7BeforeStartTest extends AbstractRecipientRewriteTableTest {
     private static final SchemaVersion SCHEMA_VERSION_V7 = new SchemaVersion(7);
 
     private static final CassandraModule MODULE = CassandraModule.aggregateModules(
@@ -64,13 +64,11 @@ public class CassandraRecipientRewriteTableV7Test extends AbstractRecipientRewri
         CassandraSchemaVersionDAO cassandraSchemaVersionDAO = new CassandraSchemaVersionDAO(
             cassandra.getConf());
 
-        CassandraRecipientRewriteTable rrt = new CassandraRecipientRewriteTable(
+        cassandraSchemaVersionDAO.updateVersion(SCHEMA_VERSION_V7).block();
+
+        return new CassandraRecipientRewriteTable(
             new CassandraRecipientRewriteTableDAO(cassandra.getConf(), CassandraUtils.WITH_DEFAULT_CONFIGURATION),
             new CassandraMappingsSourcesDAO(cassandra.getConf()),
             new CassandraSchemaVersionManager(cassandraSchemaVersionDAO));
-
-        cassandraSchemaVersionDAO.updateVersion(SCHEMA_VERSION_V7).block();
-
-        return rrt;
     }
 }

--- a/server/data/data-cassandra/src/test/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTableV7Test.java
+++ b/server/data/data-cassandra/src/test/java/org/apache/james/rrt/cassandra/CassandraRecipientRewriteTableV7Test.java
@@ -19,12 +19,12 @@
 
 package org.apache.james.rrt.cassandra;
 
-import org.apache.commons.configuration2.BaseHierarchicalConfiguration;
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.DockerCassandraRule;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.utils.CassandraUtils;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionDAO;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
 import org.apache.james.backends.cassandra.versions.SchemaVersion;
 import org.apache.james.rrt.lib.AbstractRecipientRewriteTable;
@@ -60,15 +60,14 @@ public class CassandraRecipientRewriteTableV7Test extends AbstractRecipientRewri
     }
 
     @Override
-    protected AbstractRecipientRewriteTable getRecipientRewriteTable() throws Exception {
+    protected AbstractRecipientRewriteTable getRecipientRewriteTable() {
         CassandraSchemaVersionDAO cassandraSchemaVersionDAO = new CassandraSchemaVersionDAO(
-            cassandra.getConf()
-        );
+            cassandra.getConf());
 
         CassandraRecipientRewriteTable rrt = new CassandraRecipientRewriteTable(
             new CassandraRecipientRewriteTableDAO(cassandra.getConf(), CassandraUtils.WITH_DEFAULT_CONFIGURATION),
             new CassandraMappingsSourcesDAO(cassandra.getConf()),
-            cassandraSchemaVersionDAO);
+            new CassandraSchemaVersionManager(cassandraSchemaVersionDAO));
 
         cassandraSchemaVersionDAO.updateVersion(SCHEMA_VERSION_V7);
 

--- a/server/data/data-cassandra/src/test/java/org/apache/james/rrt/cassandra/CassandraStepdefs.java
+++ b/server/data/data-cassandra/src/test/java/org/apache/james/rrt/cassandra/CassandraStepdefs.java
@@ -23,6 +23,7 @@ import org.apache.james.backends.cassandra.DockerCassandraRule;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.utils.CassandraUtils;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionDAO;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
 import org.apache.james.rrt.lib.AbstractRecipientRewriteTable;
 import org.apache.james.rrt.lib.RecipientRewriteTableFixture;
@@ -30,6 +31,7 @@ import org.apache.james.rrt.lib.RewriteTablesStepdefs;
 import org.junit.Rule;
 
 import com.github.fge.lambdas.Throwing;
+
 import cucumber.api.java.After;
 import cucumber.api.java.Before;
 
@@ -47,7 +49,7 @@ public class CassandraStepdefs {
     }
 
     @Before
-    public void setup() throws Throwable {
+    public void setup() {
         cassandra = CassandraCluster.create(
             CassandraModule.aggregateModules(CassandraRRTModule.MODULE, CassandraSchemaVersionModule.MODULE),
             cassandraServer.getHost());
@@ -63,7 +65,7 @@ public class CassandraStepdefs {
         CassandraRecipientRewriteTable rrt = new CassandraRecipientRewriteTable(
             new CassandraRecipientRewriteTableDAO(cassandra.getConf(), CassandraUtils.WITH_DEFAULT_CONFIGURATION),
             new CassandraMappingsSourcesDAO(cassandra.getConf()),
-            new CassandraSchemaVersionDAO(cassandra.getConf()));
+            new CassandraSchemaVersionManager(new CassandraSchemaVersionDAO(cassandra.getConf())));
         rrt.setDomainList(RecipientRewriteTableFixture.domainListForCucumberTests());
         return rrt;
     }


### PR DESCRIPTION
Reading it once upon James startup is enough for up-to-date James server.

We shall keep this pattern when James is not yet up to date.

Why?

Because upon alias resolution we spend more than half of our time resolving the schema version...

![Capture d’écran de 2020-03-30 10-50-13](https://user-images.githubusercontent.com/6928740/77874031-e3fd7480-7275-11ea-9464-8ca334913ff1.png)
