### PR TITLE
JAMES-2813 Task executionListing is enough

### DIFF
--- a/server/task/task-memory/src/main/scala/org/apache/james/task/eventsourcing/EventSourcingTaskManager.scala
+++ b/server/task/task-memory/src/main/scala/org/apache/james/task/eventsourcing/EventSourcingTaskManager.scala
@@ -25,8 +25,8 @@ import java.util
 import com.google.common.annotations.VisibleForTesting
 import javax.annotation.PreDestroy
 import javax.inject.Inject
-import org.apache.james.eventsourcing.{AggregateId, EventSourcingSystem, Subscriber}
 import org.apache.james.eventsourcing.eventstore.{EventStore, History}
+import org.apache.james.eventsourcing.{AggregateId, EventSourcingSystem, Subscriber}
 import org.apache.james.lifecycle.api.Startable
 import org.apache.james.task.TaskManager.ReachedTimeoutException
 import org.apache.james.task._
@@ -90,7 +90,6 @@ class EventSourcingTaskManager @Inject @VisibleForTesting private[eventsourcing]
 
   private def listScala: List[TaskExecutionDetails] = executionDetailsProjection
     .list
-    .flatMap(details => executionDetailsProjection.load(details.taskId))
 
   override def cancel(id: TaskId): Unit = {
     val command = RequestCancel(id)


### PR DESCRIPTION
We already have the item in the list, we don't need an extra DB read per
item to read it.

According to glowroot, this can leed to a 40% improvment when listing tasks:

![Capture d’écran de 2020-03-30 11-08-46](https://user-images.githubusercontent.com/6928740/77874415-0ba10c80-7277-11ea-9f94-f41a8d5de5b2.png)
