### PR TITLE
[Performance] Optimize a bit GetMessageList

### DIFF
--- a/server/protocols/webadmin-integration-test/webadmin-integration-test-common/src/main/java/org/apache/james/webadmin/integration/vault/DeletedMessageVaultIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/webadmin-integration-test-common/src/main/java/org/apache/james/webadmin/integration/vault/DeletedMessageVaultIntegrationTest.java
@@ -30,7 +30,7 @@ import static org.apache.james.jmap.JMAPTestingConstants.calmlyAwait;
 import static org.apache.james.jmap.JMAPTestingConstants.jmapRequestSpecBuilder;
 import static org.apache.james.jmap.JmapCommonRequests.deleteMessages;
 import static org.apache.james.jmap.JmapCommonRequests.getAllMailboxesIds;
-import static org.apache.james.jmap.JmapCommonRequests.getLastMessageId;
+import static org.apache.james.jmap.JmapCommonRequests.getLatestMessageId;
 import static org.apache.james.jmap.JmapCommonRequests.getOutboxId;
 import static org.apache.james.jmap.JmapCommonRequests.listMessageIdsForAccount;
 import static org.apache.james.jmap.LocalHostURIBuilder.baseUri;
@@ -823,7 +823,7 @@ public abstract class DeletedMessageVaultIntegrationTest {
         exportVaultContent(webAdminApi, exportRequest);
 
         WAIT_TWO_MINUTES.until(() -> listMessageIdsForAccount(shareeAccessToken).size() == currentNumberOfMessages + 1);
-        String exportingMessageId = getLastMessageId(shareeAccessToken);
+        String exportingMessageId = getLatestMessageId(shareeAccessToken, Role.INBOX);
 
         return exportedFileLocationFromMailHeader(exportingMessageId, shareeAccessToken);
     }
@@ -832,7 +832,7 @@ public abstract class DeletedMessageVaultIntegrationTest {
         return with()
                 .header("Authorization", accessToken.asString())
                 .body("[[\"getMessages\", {\"ids\": [\"" + messageId + "\"]}, \"#0\"]]")
-                .post("/jmap")
+                .post("/jmap").prettyPeek()
             .jsonPath()
                 .getList(ARGUMENTS + ".list.headers.corresponding-file", String.class)
                 .get(0);

--- a/server/protocols/webadmin-integration-test/webadmin-integration-test-common/src/main/java/org/apache/james/webadmin/integration/vault/DeletedMessageVaultIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/webadmin-integration-test-common/src/main/java/org/apache/james/webadmin/integration/vault/DeletedMessageVaultIntegrationTest.java
@@ -832,7 +832,7 @@ public abstract class DeletedMessageVaultIntegrationTest {
         return with()
                 .header("Authorization", accessToken.asString())
                 .body("[[\"getMessages\", {\"ids\": [\"" + messageId + "\"]}, \"#0\"]]")
-                .post("/jmap").prettyPeek()
+                .post("/jmap")
             .jsonPath()
                 .getList(ARGUMENTS + ".list.headers.corresponding-file", String.class)
                 .get(0);

--- a/server/testing/src/main/java/org/apache/james/jmap/JmapCommonRequests.java
+++ b/server/testing/src/main/java/org/apache/james/jmap/JmapCommonRequests.java
@@ -133,10 +133,10 @@ public class JmapCommonRequests {
     }
 
     public static String getLatestMessageId(AccessToken accessToken, Role mailbox) {
-        String inboxId = getMailboxId(accessToken, mailbox);
+        String mailboxId = getMailboxId(accessToken, mailbox);
         return with()
                 .header("Authorization", accessToken.asString())
-                .body("[[\"getMessageList\", {\"filter\":{\"inMailboxes\":[\"" + inboxId + "\"]}, \"sort\":[\"date desc\"]}, \"#0\"]]")
+                .body("[[\"getMessageList\", {\"filter\":{\"inMailboxes\":[\"" + mailboxId + "\"]}, \"sort\":[\"date desc\"]}, \"#0\"]]")
                 .post("/jmap")
             .then()
                 .extract()


### PR DESCRIPTION
Avoid loading mailbox counters for getAllReadableMailboxes

Glowroot flameGraph suggest we spend 60% of GetMessageList time loading
mailbox counters while we do not need them

![Capture d’écran de 2020-03-30 14-17-43](https://user-images.githubusercontent.com/6928740/77886030-57ad7a80-7292-11ea-92e9-dfc0c48e7a16.png)

