### PR TITLE
[Performance] Avoid empty getMessages(FULL) when all messages have preview

### DIFF
--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MessageFastViewFactory.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MessageFastViewFactory.java
@@ -140,6 +140,9 @@ public class MessageFastViewFactory implements MessageViewFactory<MessageFastVie
     }
 
     private Mono<List<MessageResult>> fetch(Collection<MessageId> messageIds, FetchGroup fetchGroup, MailboxSession mailboxSession) {
+        if (messageIds.isEmpty()) {
+            return Mono.empty();
+        }
         return Mono.fromCallable(() -> messageIdManager.getMessages(messageIds, fetchGroup, mailboxSession))
             .onErrorResume(MailboxException.class, ex -> {
                 LOGGER.error("cannot read messages {}", messageIds, ex);


### PR DESCRIPTION
```
Flux.merge(
    fetch(withProjectionEntry, FetchGroup.HEADERS, mailboxSession)
        .map(messageResults -> Helpers.toMessageViews(messageResults, new FromMessageResultAndPreview(blobManager, fastProjections))),
    fetch(withoutProjectionEntry, FetchGroup.FULL_CONTENT, mailboxSession)
        .map(messageResults -> Helpers.toMessageViews(messageResults, messageFullViewFactory::fromMessageResults)))
```

Calling code results in fetch called with empty message list. We should
avoid propagating the query which results in a needless empty call on
messageManager layer (gain of reactor pipeline evaluation)