### PR TITLE
[Build time] RabbitMQ reset don't need a stopped app

### DIFF
--- a/backends-common/rabbitmq/src/test/java/org/apache/james/backends/rabbitmq/DockerRabbitMQ.java
+++ b/backends-common/rabbitmq/src/test/java/org/apache/james/backends/rabbitmq/DockerRabbitMQ.java
@@ -190,14 +190,10 @@ public class DockerRabbitMQ {
     }
 
     public void reset() throws Exception {
-        stopApp();
-
         String stdout = container()
             .execInContainer("rabbitmqctl", "reset")
             .getStdout();
         LOGGER.debug("reset: {}", stdout);
-
-        startApp();
     }
 
     public void forgetNode(String removalClusterNodeName) throws Exception {


### PR DESCRIPTION
This allows to gain 4 minutes in RabbitMQ eventBus test, lowering test
time from 14 minutes to 10 minutes

## Before

![Capture d’écran de 2020-04-01 19-28-16](https://user-images.githubusercontent.com/6928740/78137418-7d33b300-744f-11ea-81ed-4a4ca8c49ddd.png)

## After

![Capture d’écran de 2020-04-01 18-27-13](https://user-images.githubusercontent.com/6928740/78137444-8755b180-744f-11ea-9808-8bbd672dd7a0.png)
