### PR TITLE
 JAMES-3142 Enforce all groups to be initialized at most once 

### DIFF
--- a/examples/custom-listeners/src/main/java/org/apache/james/examples/custom/listeners/SetCustomFlagOnBigMessages.java
+++ b/examples/custom-listeners/src/main/java/org/apache/james/examples/custom/listeners/SetCustomFlagOnBigMessages.java
@@ -35,6 +35,8 @@ import org.apache.james.mailbox.model.MessageRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Preconditions;
+
 /**
  * A Listener to determine the size of added messages.
  *
@@ -58,6 +60,7 @@ class SetCustomFlagOnBigMessages implements MailboxListener.GroupMailboxListener
 
     @Inject
     SetCustomFlagOnBigMessages(MailboxManager mailboxManager) {
+        Preconditions.checkNotNull(mailboxManager);
         this.mailboxManager = mailboxManager;
     }
 

--- a/examples/custom-listeners/src/test/java/org/apache/james/examples/custom/listeners/SetCustomFlagOnBigMessagesTest.java
+++ b/examples/custom-listeners/src/test/java/org/apache/james/examples/custom/listeners/SetCustomFlagOnBigMessagesTest.java
@@ -57,7 +57,6 @@ class SetCustomFlagOnBigMessagesTest {
     private static final Event.EventId RANDOM_EVENT_ID = Event.EventId.random();
     private static final MailboxPath INBOX_PATH = MailboxPath.inbox(USER);
 
-    private SetCustomFlagOnBigMessages testee;
     private MessageManager inboxMessageManager;
     private MailboxId inboxId;
     private MailboxSession mailboxSession;
@@ -65,15 +64,14 @@ class SetCustomFlagOnBigMessagesTest {
 
     @BeforeEach
     void beforeEach() throws Exception {
-        InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultResources();
+        InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultBuilder()
+            .registerListener((manager, messageIdManager) -> new SetCustomFlagOnBigMessages(manager))
+            .build();
+
         mailboxManager = resources.getMailboxManager();
         mailboxSession = MailboxSessionUtil.create(USER);
         inboxId = mailboxManager.createMailbox(INBOX_PATH, mailboxSession).get();
         inboxMessageManager = mailboxManager.getMailbox(inboxId, mailboxSession);
-
-        testee = new SetCustomFlagOnBigMessages(mailboxManager);
-
-        resources.getEventBus().register(testee);
     }
 
     @Test
@@ -138,7 +136,7 @@ class SetCustomFlagOnBigMessagesTest {
             .addMetaData(oneMBMetaData)
             .build();
 
-        testee.event(eventWithAFakeMessageSize);
+        new SetCustomFlagOnBigMessages(mailboxManager).event(eventWithAFakeMessageSize);
 
         assertThat(getMessageFlags(composedIdOfSmallMessage.getUid()))
             .allSatisfy(flags -> assertThat(flags.contains(BIG_MESSAGE)).isTrue());

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/events/EventBus.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/events/EventBus.java
@@ -19,8 +19,13 @@
 
 package org.apache.james.mailbox.events;
 
+import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 
+import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Mono;
@@ -46,7 +51,7 @@ public interface EventBus {
 
     Registration register(MailboxListener listener, RegistrationKey key);
 
-    Registration register(MailboxListener listener, Group group) throws GroupAlreadyRegistered;
+    void initialize(Map<Group, MailboxListener> listeners) throws GroupsAlreadyRegistered;
 
     Mono<Void> dispatch(Event event, Set<RegistrationKey> key);
 
@@ -56,7 +61,28 @@ public interface EventBus {
         return dispatch(event, ImmutableSet.of(key));
     }
 
-    default Registration register(MailboxListener.GroupMailboxListener groupMailboxListener) {
-        return register(groupMailboxListener, groupMailboxListener.getDefaultGroup());
+    /**
+     * @throws GroupsAlreadyRegistered when any initialize method had already been called
+     */
+    default void initialize(MailboxListener listener, Group group) throws GroupsAlreadyRegistered {
+        initialize(ImmutableMap.of(group, listener));
+    }
+
+    /**
+     * @throws GroupsAlreadyRegistered when any initialize method had already been called
+     */
+    default void initialize(MailboxListener.GroupMailboxListener... groupMailboxListeners) throws GroupsAlreadyRegistered {
+        initialize(ImmutableList.copyOf(groupMailboxListeners));
+    }
+
+    /**
+     * @throws GroupsAlreadyRegistered when any initialize method had already been called
+     */
+    default void initialize(Collection<MailboxListener.GroupMailboxListener> groupMailboxListeners) throws GroupsAlreadyRegistered {
+        Map<Group, MailboxListener> collect = groupMailboxListeners.stream()
+            .collect(Guavate.toImmutableMap(
+                MailboxListener.GroupMailboxListener::getDefaultGroup,
+                MailboxListener.class::cast));
+        initialize(collect);
     }
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/events/GroupsAlreadyRegistered.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/events/GroupsAlreadyRegistered.java
@@ -19,15 +19,6 @@
 
 package org.apache.james.mailbox.events;
 
-public class GroupAlreadyRegistered extends RuntimeException {
-    private final Group group;
+public class GroupsAlreadyRegistered extends RuntimeException {
 
-    public GroupAlreadyRegistered(Group group) {
-        super(group.asString() + " is already Registered and thus can not be used.");
-        this.group = group;
-    }
-
-    public Group getGroup() {
-        return group;
-    }
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -716,7 +716,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             inboxId = mailboxManager.createMailbox(inbox, session).get();
             inboxManager = mailboxManager.getMailbox(inbox, session);
 
-            retrieveEventBus(mailboxManager).register(groupListener);
+            retrieveEventBus(mailboxManager).initialize(groupListener);
         }
 
         @Test

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -699,6 +699,7 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
     class EventTests {
         private final QuotaRoot quotaRoot = QuotaRoot.quotaRoot("#private&user_1", Optional.empty());
         private EventCollector listener;
+        private EventCollector groupListener;
         private MailboxPath inbox;
         private MailboxId inboxId;
         private MessageManager inboxManager;
@@ -711,8 +712,11 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             newPath = MailboxPath.forUser(USER_1, "specialMailbox");
 
             listener = new EventCollector();
+            groupListener = new EventCollector();
             inboxId = mailboxManager.createMailbox(inbox, session).get();
             inboxManager = mailboxManager.getMailbox(inbox, session);
+
+            retrieveEventBus(mailboxManager).register(groupListener);
         }
 
         @Test
@@ -753,11 +757,9 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void createMailboxShouldFireMailboxAddedEvent() throws Exception {
-            retrieveEventBus(mailboxManager).register(listener);
-
             Optional<MailboxId> newId = mailboxManager.createMailbox(newPath, session);
 
-            assertThat(listener.getEvents())
+            assertThat(groupListener.getEvents())
                 .filteredOn(event -> event instanceof MailboxListener.MailboxAdded)
                 .hasSize(1)
                 .extracting(event -> (MailboxListener.MailboxAdded) event)
@@ -768,12 +770,11 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
         @Test
         void addingMessageShouldFireQuotaUpdateEvent() throws Exception {
             assumeTrue(mailboxManager.hasCapability(MailboxCapabilities.Quota));
-            retrieveEventBus(mailboxManager).register(listener);
 
             inboxManager.appendMessage(MessageManager.AppendCommand.builder()
                     .build(message), session);
 
-            assertThat(listener.getEvents())
+            assertThat(groupListener.getEvents())
                 .filteredOn(event -> event instanceof MailboxListener.QuotaUsageUpdatedEvent)
                 .hasSize(1)
                 .extracting(event -> (MailboxListener.QuotaUsageUpdatedEvent) event)
@@ -981,10 +982,9 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             mailboxManager.createMailbox(newPath, session);
             inboxManager.appendMessage(AppendCommand.builder().build(message), session);
 
-            retrieveEventBus(mailboxManager).register(listener);
             mailboxManager.copyMessages(MessageRange.all(), inbox, newPath, session);
 
-            assertThat(listener.getEvents())
+            assertThat(groupListener.getEvents())
                 .filteredOn(event -> event instanceof MailboxListener.Expunged)
                 .isEmpty();
         }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/ErrorHandlingContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/ErrorHandlingContract.java
@@ -77,6 +77,7 @@ interface ErrorHandlingContract extends EventBusContract {
 
     @Test
     default void retryingIsNotAppliedForKeyRegistrations() {
+        eventBus().initialize();
         EventCollector eventCollector = eventCollector();
 
         doThrow(new RuntimeException())
@@ -217,6 +218,7 @@ interface ErrorHandlingContract extends EventBusContract {
 
     @Test
     default void deadLettersIsNotAppliedForKeyRegistrations() throws Exception {
+        eventBus().initialize();
         EventCollector eventCollector = eventCollector();
 
         //do throw  RetryBackoffConfiguration.DEFAULT.DEFAULT_MAX_RETRIES + 1 times

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/ErrorHandlingContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/ErrorHandlingContract.java
@@ -98,7 +98,7 @@ interface ErrorHandlingContract extends EventBusContract {
             .doCallRealMethod()
             .when(eventCollector).event(EVENT);
 
-        eventBus().register(eventCollector, GROUP_A);
+        eventBus().initialize(eventCollector, GROUP_A);
         eventBus().dispatch(EVENT, NO_KEYS).block();
 
         getSpeedProfile().shortWaitCondition()
@@ -120,7 +120,7 @@ interface ErrorHandlingContract extends EventBusContract {
             .doCallRealMethod()
             .when(eventCollector).event(EVENT);
 
-        eventBus().register(eventCollector, GROUP_A);
+        eventBus().initialize(eventCollector, GROUP_A);
         eventBus().dispatch(EVENT, NO_KEYS).block();
 
         getSpeedProfile().longWaitCondition()
@@ -144,7 +144,7 @@ interface ErrorHandlingContract extends EventBusContract {
             .doCallRealMethod()
             .when(eventCollector).event(EVENT);
 
-        eventBus().register(eventCollector, GROUP_A);
+        eventBus().initialize(eventCollector, GROUP_A);
         eventBus().dispatch(EVENT, NO_KEYS).block();
 
         TimeUnit.SECONDS.sleep(1);
@@ -156,7 +156,7 @@ interface ErrorHandlingContract extends EventBusContract {
     default void exceedingMaxRetriesShouldStopConsumingFailedEvent() throws Exception {
         ThrowingListener throwingListener = throwingListener();
 
-        eventBus().register(throwingListener, GROUP_A);
+        eventBus().initialize(throwingListener, GROUP_A);
         eventBus().dispatch(EVENT, NO_KEYS).block();
 
         Thread.sleep(getSpeedProfile().getLongWaitTime().toMillis());
@@ -171,7 +171,7 @@ interface ErrorHandlingContract extends EventBusContract {
     default void retriesBackOffShouldDelayByExponentialGrowth() throws Exception {
         ThrowingListener throwingListener = throwingListener();
 
-        eventBus().register(throwingListener, GROUP_A);
+        eventBus().initialize(throwingListener, GROUP_A);
         eventBus().dispatch(EVENT, NO_KEYS).block();
 
         Thread.sleep(getSpeedProfile().getLongWaitTime().toMillis());
@@ -209,7 +209,7 @@ interface ErrorHandlingContract extends EventBusContract {
             }
         };
 
-        eventBus().register(listener, GROUP_A);
+        eventBus().initialize(listener, GROUP_A);
         eventBus().dispatch(EVENT, NO_KEYS).block();
 
         getSpeedProfile().shortWaitCondition().until(successfulRetry::get);
@@ -252,7 +252,7 @@ interface ErrorHandlingContract extends EventBusContract {
             .doCallRealMethod()
             .when(eventCollector).event(EVENT);
 
-        eventBus().register(eventCollector, new EventBusTestFixture.GroupA());
+        eventBus().initialize(eventCollector, new EventBusTestFixture.GroupA());
         eventBus().dispatch(EVENT, NO_KEYS).block();
 
         getSpeedProfile().shortWaitCondition()
@@ -278,7 +278,7 @@ interface ErrorHandlingContract extends EventBusContract {
             .doCallRealMethod()
             .when(eventCollector).event(EVENT);
 
-        eventBus().register(eventCollector, GROUP_A);
+        eventBus().initialize(eventCollector, GROUP_A);
         eventBus().dispatch(EVENT, NO_KEYS).block();
 
         getSpeedProfile().longWaitCondition()
@@ -307,7 +307,7 @@ interface ErrorHandlingContract extends EventBusContract {
             .doCallRealMethod()
             .when(eventCollector).event(EVENT);
 
-        eventBus().register(eventCollector, GROUP_A);
+        eventBus().initialize(eventCollector, GROUP_A);
         eventBus().reDeliver(GROUP_A, EVENT).block();
 
         getSpeedProfile().longWaitCondition()
@@ -339,7 +339,7 @@ interface ErrorHandlingContract extends EventBusContract {
             .doCallRealMethod()
             .when(eventCollector).event(EVENT);
 
-        eventBus().register(eventCollector, GROUP_A);
+        eventBus().initialize(eventCollector, GROUP_A);
         eventBus().reDeliver(GROUP_A, EVENT).block();
 
         getSpeedProfile().longWaitCondition()
@@ -351,7 +351,7 @@ interface ErrorHandlingContract extends EventBusContract {
         EventCollector eventCollector = eventCollector();
         EventCollector eventCollector2 = eventCollector();
 
-        eventBus().register(eventCollector, GROUP_A);
+        eventBus().initialize(eventCollector, GROUP_A);
         eventBus().register(eventCollector2, KEY_1);
         eventBus().reDeliver(GROUP_A, EVENT).block();
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/EventBusConcurrentTestContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/EventBusConcurrentTestContract.java
@@ -37,6 +37,7 @@ import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 public interface EventBusConcurrentTestContract {
@@ -68,9 +69,10 @@ public interface EventBusConcurrentTestContract {
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener2 = newCountingListener();
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener3 = newCountingListener();
 
-            eventBus().register(countingListener1, new EventBusTestFixture.GroupA());
-            eventBus().register(countingListener2, new EventBusTestFixture.GroupB());
-            eventBus().register(countingListener3, new EventBusTestFixture.GroupC());
+            eventBus().initialize(ImmutableMap.of(
+                new GroupTest.GroupA(), countingListener1,
+                new GroupTest.GroupB(), countingListener2,
+                new GroupTest.GroupC(), countingListener3));
             int totalGlobalRegistrations = 3; // GroupA + GroupB + GroupC
 
             ConcurrentTestRunner.builder()
@@ -113,9 +115,10 @@ public interface EventBusConcurrentTestContract {
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener2 = newCountingListener();
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener3 = newCountingListener();
 
-            eventBus().register(countingListener1, new EventBusTestFixture.GroupA());
-            eventBus().register(countingListener2, new EventBusTestFixture.GroupB());
-            eventBus().register(countingListener3, new EventBusTestFixture.GroupC());
+            eventBus().initialize(ImmutableMap.of(
+                new GroupTest.GroupA(), countingListener1,
+                new GroupTest.GroupB(), countingListener2,
+                new GroupTest.GroupC(), countingListener3));
 
             int totalGlobalRegistrations = 3; // GroupA + GroupB + GroupC
             int totalEventDeliveredGlobally = totalGlobalRegistrations * TOTAL_DISPATCH_OPERATIONS;
@@ -148,13 +151,15 @@ public interface EventBusConcurrentTestContract {
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener2 = newCountingListener();
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener3 = newCountingListener();
 
-            eventBus().register(countingListener1, new EventBusTestFixture.GroupA());
-            eventBus().register(countingListener2, new EventBusTestFixture.GroupB());
-            eventBus().register(countingListener3, new EventBusTestFixture.GroupC());
+            eventBus().initialize(ImmutableMap.of(
+                new GroupTest.GroupA(), countingListener1,
+                new GroupTest.GroupB(), countingListener2,
+                new GroupTest.GroupC(), countingListener3));
 
-            eventBus2().register(countingListener1, new EventBusTestFixture.GroupA());
-            eventBus2().register(countingListener2, new EventBusTestFixture.GroupB());
-            eventBus2().register(countingListener3, new EventBusTestFixture.GroupC());
+            eventBus2().initialize(ImmutableMap.of(
+                new GroupTest.GroupA(), countingListener1,
+                new GroupTest.GroupB(), countingListener2,
+                new GroupTest.GroupC(), countingListener3));
 
             int totalGlobalRegistrations = 3; // GroupA + GroupB + GroupC
 
@@ -203,9 +208,10 @@ public interface EventBusConcurrentTestContract {
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener2 = newCountingListener();
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener3 = newCountingListener();
 
-            eventBus2().register(countingListener1, GROUP_A);
-            eventBus2().register(countingListener2, new EventBusTestFixture.GroupB());
-            eventBus2().register(countingListener3, new EventBusTestFixture.GroupC());
+            eventBus2().initialize(ImmutableMap.of(
+                GROUP_A, countingListener1,
+                new EventBusTestFixture.GroupB(), countingListener2,
+                new EventBusTestFixture.GroupC(), countingListener3));
             int totalGlobalRegistrations = 3; // GroupA + GroupB + GroupC
             int totalEventDeliveredGlobally = totalGlobalRegistrations * TOTAL_DISPATCH_OPERATIONS;
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/GroupContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/GroupContract.java
@@ -185,18 +185,6 @@ public interface GroupContract {
         }
 
         @Test
-        default void registerShouldNotDispatchPastEventsForGroups() throws Exception {
-            MailboxListener listener = newListener();
-
-            eventBus().dispatch(EVENT, NO_KEYS).block();
-
-            eventBus().initialize(listener, GROUP_A);
-
-            verify(listener, after(FIVE_HUNDRED_MS.toMillis()).never())
-                .event(any());
-        }
-
-        @Test
         default void listenerGroupShouldReceiveEvents() throws Exception {
             MailboxListener listener = newListener();
 
@@ -333,6 +321,7 @@ public interface GroupContract {
 
         @Test
         default void redeliverShouldThrowWhenGroupNotRegistered() {
+            eventBus().initialize();
             assertThatThrownBy(() -> eventBus().reDeliver(GROUP_A, EVENT).block())
                 .isInstanceOf(GroupRegistrationNotFound.class);
         }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/KeyContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/KeyContract.java
@@ -63,6 +63,7 @@ public interface KeyContract extends EventBusContract {
     interface SingleEventBusKeyContract extends EventBusContract {
         @Test
         default void notificationShouldNotExceedRate() {
+            eventBus().initialize();
             int eventCount = 50;
             AtomicInteger nbCalls = new AtomicInteger(0);
             AtomicInteger finishedExecutions = new AtomicInteger(0);
@@ -88,6 +89,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void notificationShouldDeliverASingleEventToAllListenersAtTheSameTime() {
+            eventBus().initialize();
             CountDownLatch countDownLatch = new CountDownLatch(1);
             try {
                 ConcurrentLinkedQueue<String> threads = new ConcurrentLinkedQueue<>();
@@ -144,6 +146,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void dispatchShouldNotThrowWhenARegisteredListenerFails() throws Exception {
+            eventBus().initialize();
             MailboxListener listener = newListener();
             doThrow(new RuntimeException()).when(listener).event(any());
 
@@ -155,6 +158,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void dispatchShouldNotNotifyRegisteredListenerWhenEmptyKeySet() throws Exception {
+            eventBus().initialize();
             MailboxListener listener = newListener();
             eventBus().register(listener, KEY_1);
 
@@ -166,6 +170,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void dispatchShouldNotNotifyListenerRegisteredOnOtherKeys() throws Exception {
+            eventBus().initialize();
             MailboxListener listener = newListener();
             eventBus().register(listener, KEY_1);
 
@@ -177,6 +182,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void dispatchShouldNotifyRegisteredListeners() throws Exception {
+            eventBus().initialize();
             MailboxListener listener = newListener();
             eventBus().register(listener, KEY_1);
 
@@ -187,6 +193,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void dispatchShouldNotifyLocalRegisteredListenerWithoutDelay() throws Exception {
+            eventBus().initialize();
             MailboxListener listener = newListener();
             eventBus().register(listener, KEY_1);
 
@@ -197,6 +204,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void dispatchShouldNotifyOnlyRegisteredListener() throws Exception {
+            eventBus().initialize();
             MailboxListener listener = newListener();
             MailboxListener listener2 = newListener();
             eventBus().register(listener, KEY_1);
@@ -211,6 +219,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void dispatchShouldNotifyAllListenersRegisteredOnAKey() throws Exception {
+            eventBus().initialize();
             MailboxListener listener = newListener();
             MailboxListener listener2 = newListener();
             eventBus().register(listener, KEY_1);
@@ -225,6 +234,7 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void registerShouldAllowDuplicatedRegistration() throws Exception {
             MailboxListener listener = newListener();
+            eventBus().initialize();
             eventBus().register(listener, KEY_1);
             eventBus().register(listener, KEY_1);
 
@@ -235,6 +245,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void unregisterShouldRemoveDoubleRegisteredListener() throws Exception {
+            eventBus().initialize();
             MailboxListener listener = newListener();
             eventBus().register(listener, KEY_1);
             eventBus().register(listener, KEY_1).unregister();
@@ -247,6 +258,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void registerShouldNotDispatchPastEvents() throws Exception {
+            eventBus().initialize();
             MailboxListener listener = newListener();
 
             eventBus().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
@@ -259,6 +271,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void callingAllUnregisterMethodShouldUnregisterTheListener() throws Exception {
+            eventBus().initialize();
             MailboxListener listener = newListener();
             Registration registration = eventBus().register(listener, KEY_1);
             eventBus().register(listener, KEY_1).unregister();
@@ -272,6 +285,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void unregisterShouldHaveNotNotifyWhenCalledOnDifferentKeys() throws Exception {
+            eventBus().initialize();
             MailboxListener listener = newListener();
             eventBus().register(listener, KEY_1);
             eventBus().register(listener, KEY_2).unregister();
@@ -294,6 +308,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void dispatchShouldAcceptSeveralKeys() throws Exception {
+            eventBus().initialize();
             MailboxListener listener = newListener();
             eventBus().register(listener, KEY_1);
 
@@ -304,6 +319,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void dispatchShouldCallListenerOnceWhenSeveralKeysMatching() throws Exception {
+            eventBus().initialize();
             MailboxListener listener = newListener();
             eventBus().register(listener, KEY_1);
             eventBus().register(listener, KEY_2);
@@ -315,6 +331,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void dispatchShouldNotNotifyUnregisteredListener() throws Exception {
+            eventBus().initialize();
             MailboxListener listener = newListener();
             eventBus().register(listener, KEY_1).unregister();
 
@@ -327,6 +344,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void dispatchShouldNotifyAsynchronousListener() throws Exception {
+            eventBus().initialize();
             MailboxListener listener = newListener();
             when(listener.getExecutionMode()).thenReturn(MailboxListener.ExecutionMode.ASYNCHRONOUS);
             eventBus().register(listener, KEY_1);
@@ -338,6 +356,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void dispatchShouldNotBlockAsynchronousListener() throws Exception {
+            eventBus().initialize();
             MailboxListener listener = newListener();
             when(listener.getExecutionMode()).thenReturn(MailboxListener.ExecutionMode.ASYNCHRONOUS);
             CountDownLatch latch = new CountDownLatch(1);
@@ -355,6 +374,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void failingRegisteredListenersShouldNotAbortRegisteredDelivery() {
+            eventBus().initialize();
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution listener = new EventBusTestFixture.EventMatcherThrowingListener(ImmutableSet.of(EVENT));
             eventBus().register(listener, KEY_1);
 
@@ -367,6 +387,7 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void allRegisteredListenersShouldBeExecutedWhenARegisteredListenerFails() throws Exception {
+            eventBus().initialize();
             MailboxListener listener = newListener();
 
             MailboxListener failingListener = mock(MailboxListener.class);

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/util/EventCollector.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/util/EventCollector.java
@@ -54,4 +54,8 @@ public class EventCollector implements MailboxListener.GroupMailboxListener {
         events.add(event);
     }
 
+    public void reset() {
+        events.clear();
+    }
+
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraCombinationManagerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraCombinationManagerTest.java
@@ -38,6 +38,7 @@ class CassandraCombinationManagerTest extends AbstractCombinationManagerTest {
     @Override
     public CombinationManagerTestSystem createTestingData() {
         InVMEventBus eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, new MemoryEventDeadLetters());
+        eventBus.initialize();
         return CassandraCombinationManagerTestSystem.createTestingData(cassandraCluster.getCassandraCluster(), new NoQuotaManager(), eventBus);
     }
     

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraCombinationManagerTestSystem.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraCombinationManagerTestSystem.java
@@ -43,7 +43,7 @@ public class CassandraCombinationManagerTestSystem extends CombinationManagerTes
 
         return new CassandraCombinationManagerTestSystem(CassandraTestSystemFixture.createMessageIdManager(mapperFactory, quotaManager, eventBus, PreDeletionHooks.NO_PRE_DELETION_HOOK),
             mapperFactory,
-            CassandraTestSystemFixture.createMailboxManager(mapperFactory));
+            CassandraTestSystemFixture.createMailboxManager(mapperFactory, eventBus));
     }
 
     private CassandraCombinationManagerTestSystem(MessageIdManager messageIdManager, CassandraMailboxSessionMapperFactory mapperFactory, MailboxManager cassandraMailboxManager) {

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerConsistencyTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerConsistencyTest.java
@@ -27,6 +27,7 @@ import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.cassandra.mail.MailboxAggregateModule;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.search.MailboxQuery;
@@ -41,6 +42,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.github.fge.lambdas.Throwing;
 import com.github.fge.lambdas.runnable.ThrowingRunnable;
+import com.google.common.collect.ImmutableList;
 
 class CassandraMailboxManagerConsistencyTest {
 
@@ -48,6 +50,7 @@ class CassandraMailboxManagerConsistencyTest {
     private static final String INBOX = "INBOX";
     private static final String INBOX_RENAMED = "INBOX_RENAMED";
     private static final int TRY_COUNT_BEFORE_FAILURE = 6;
+    public static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENER = ImmutableList.of();
 
     @RegisterExtension
     static CassandraClusterExtension cassandra = new CassandraClusterExtension(MailboxAggregateModule.MODULE_WITH_QUOTA);
@@ -63,7 +66,8 @@ class CassandraMailboxManagerConsistencyTest {
     void setUp(CassandraCluster cassandra) {
         testee = CassandraMailboxManagerProvider.provideMailboxManager(
             cassandra,
-            PreDeletionHooks.NO_PRE_DELETION_HOOK);
+            PreDeletionHooks.NO_PRE_DELETION_HOOK,
+            NO_ADDITIONAL_LISTENER);
 
         mailboxSession = testee.createSystemSession(USER);
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerProvider.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerProvider.java
@@ -103,8 +103,8 @@ public class CassandraMailboxManagerProvider {
             messageParser, messageIdFactory, eventBus, annotationManager, storeRightManager,
             quotaComponents, index, MailboxManagerConfiguration.DEFAULT, preDeletionHooks);
 
-        eventBus.register(quotaUpdater);
-        eventBus.register(new MailboxAnnotationListener(mapperFactory, sessionProvider));
+        eventBus.initialize(quotaUpdater,
+            new MailboxAnnotationListener(mapperFactory, sessionProvider));
 
         return manager;
     }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerStressTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerStressTest.java
@@ -23,11 +23,15 @@ import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.mailbox.MailboxManagerStressContract;
 import org.apache.james.mailbox.cassandra.mail.MailboxAggregateModule;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.store.PreDeletionHooks;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.google.common.collect.ImmutableList;
+
 class CassandraMailboxManagerStressTest implements MailboxManagerStressContract<CassandraMailboxManager> {
+    private static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENERS = ImmutableList.of();
 
     @RegisterExtension
     static CassandraClusterExtension cassandra = new CassandraClusterExtension(MailboxAggregateModule.MODULE_WITH_QUOTA);
@@ -48,6 +52,7 @@ class CassandraMailboxManagerStressTest implements MailboxManagerStressContract<
     void setUp() {
         this.mailboxManager = CassandraMailboxManagerProvider.provideMailboxManager(
             cassandra.getCassandraCluster(),
-            PreDeletionHooks.NO_PRE_DELETION_HOOK);
+            PreDeletionHooks.NO_PRE_DELETION_HOOK,
+            NO_ADDITIONAL_LISTENERS);
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerTest.java
@@ -22,11 +22,16 @@ import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.mailbox.MailboxManagerTest;
 import org.apache.james.mailbox.cassandra.mail.MailboxAggregateModule;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.store.PreDeletionHooks;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.google.common.collect.ImmutableList;
+
 public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMailboxManager> {
+    private static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENERS = ImmutableList.of();
+
     @RegisterExtension
     static CassandraClusterExtension cassandra = new CassandraClusterExtension(MailboxAggregateModule.MODULE_WITH_QUOTA);
 
@@ -34,7 +39,16 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
     protected CassandraMailboxManager provideMailboxManager() {
         return CassandraMailboxManagerProvider.provideMailboxManager(
             cassandra.getCassandraCluster(),
-            new PreDeletionHooks(preDeletionHooks(), new RecordingMetricFactory()));
+            new PreDeletionHooks(preDeletionHooks(), new RecordingMetricFactory()),
+            NO_ADDITIONAL_LISTENERS);
+    }
+
+    @Override
+    protected CassandraMailboxManager provideMailboxManager(MailboxListener.GroupMailboxListener listener) {
+        return CassandraMailboxManagerProvider.provideMailboxManager(
+            cassandra.getCassandraCluster(),
+            new PreDeletionHooks(preDeletionHooks(), new RecordingMetricFactory()),
+            ImmutableList.of(listener));
     }
 
     @Override

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerSideEffectTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerSideEffectTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.mailbox.cassandra.mail.MailboxAggregateModule;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.InVMEventBus;
 import org.apache.james.mailbox.extension.PreDeletionHook;
 import org.apache.james.mailbox.quota.QuotaManager;
 import org.apache.james.mailbox.store.AbstractMessageIdManagerSideEffectTest;
@@ -36,7 +37,8 @@ class CassandraMessageIdManagerSideEffectTest extends AbstractMessageIdManagerSi
     static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(MailboxAggregateModule.MODULE);
 
     @Override
-    protected MessageIdManagerTestSystem createTestSystem(QuotaManager quotaManager, EventBus eventBus, Set<PreDeletionHook> preDeletionHooks) {
+    protected MessageIdManagerTestSystem createTestSystem(QuotaManager quotaManager, InVMEventBus eventBus, Set<PreDeletionHook> preDeletionHooks) {
+        eventBus.initialize();
         return CassandraMessageIdManagerTestSystem.createTestingData(cassandraCluster.getCassandraCluster(), quotaManager, eventBus, preDeletionHooks);
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerStorageTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerStorageTest.java
@@ -39,6 +39,7 @@ class CassandraMessageIdManagerStorageTest extends AbstractMessageIdManagerStora
     @Override
     protected MessageIdManagerTestSystem createTestingData() {
         InVMEventBus eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, new MemoryEventDeadLetters());
+        eventBus.initialize();
         return CassandraMessageIdManagerTestSystem.createTestingData(cassandraCluster.getCassandraCluster(), new NoQuotaManager(), eventBus, PreDeletionHook.NO_PRE_DELETION_HOOK);
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerTestSystem.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerTestSystem.java
@@ -40,9 +40,7 @@ class CassandraMessageIdManagerTestSystem {
                                                         Set<PreDeletionHook> preDeletionHooks) {
         CassandraMailboxSessionMapperFactory mapperFactory = CassandraTestSystemFixture.createMapperFactory(cassandra);
 
-        CassandraMailboxManager mailboxManager = CassandraTestSystemFixture.createMailboxManager(mapperFactory);
-
-        mailboxManager.getEventBus().initialize(new MailboxAnnotationListener(mapperFactory, mailboxManager));
+        CassandraMailboxManager mailboxManager = CassandraTestSystemFixture.createMailboxManager(mapperFactory, eventBus);
 
         return new MessageIdManagerTestSystem(CassandraTestSystemFixture.createMessageIdManager(mapperFactory, quotaManager, eventBus, new PreDeletionHooks(preDeletionHooks, new RecordingMetricFactory())),
             new CassandraMessageId.Factory(),

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerTestSystem.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerTestSystem.java
@@ -53,7 +53,7 @@ class CassandraMessageIdManagerTestSystem {
         ListeningCurrentQuotaUpdater listeningCurrentQuotaUpdater = new ListeningCurrentQuotaUpdater(
             (StoreCurrentQuotaManager) currentQuotaManager,
             mailboxManager.getQuotaComponents().getQuotaRootResolver(), mailboxManager.getEventBus(), quotaManager);
-        mailboxManager.getEventBus().register(listeningCurrentQuotaUpdater);
+        mailboxManager.getEventBus().initialize(listeningCurrentQuotaUpdater);
         return new MessageIdManagerTestSystem(CassandraTestSystemFixture.createMessageIdManager(mapperFactory, quotaManager, mailboxManager.getEventBus(),
             PreDeletionHooks.NO_PRE_DELETION_HOOK),
             new CassandraMessageId.Factory(),

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
@@ -73,18 +73,18 @@ class CassandraTestSystemFixture {
 
         QuotaComponents quotaComponents = QuotaComponents.disabled(sessionProvider, mapperFactory);
         MessageSearchIndex index = new SimpleMessageSearchIndex(mapperFactory, mapperFactory, new DefaultTextExtractor());
-        CassandraMailboxManager cassandraMailboxManager = new CassandraMailboxManager(mapperFactory, sessionProvider,
+
+        return new CassandraMailboxManager(mapperFactory, sessionProvider,
             new NoMailboxPathLocker(), new MessageParser(), new CassandraMessageId.Factory(),
             eventBus, annotationManager, storeRightManager, quotaComponents, index, MailboxManagerConfiguration.DEFAULT, PreDeletionHooks.NO_PRE_DELETION_HOOK);
-
-        eventBus.initialize(new MailboxAnnotationListener(mapperFactory, sessionProvider));
-
-        return cassandraMailboxManager;
     }
 
     static StoreMessageIdManager createMessageIdManager(CassandraMailboxSessionMapperFactory mapperFactory, QuotaManager quotaManager, EventBus eventBus,
                                                         PreDeletionHooks preDeletionHooks) {
         CassandraMailboxManager mailboxManager = createMailboxManager(mapperFactory);
+
+        mailboxManager.getEventBus().initialize(new MailboxAnnotationListener(mapperFactory, mailboxManager));
+
         return new StoreMessageIdManager(
             mailboxManager,
             mapperFactory,

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
@@ -77,7 +77,7 @@ class CassandraTestSystemFixture {
             new NoMailboxPathLocker(), new MessageParser(), new CassandraMessageId.Factory(),
             eventBus, annotationManager, storeRightManager, quotaComponents, index, MailboxManagerConfiguration.DEFAULT, PreDeletionHooks.NO_PRE_DELETION_HOOK);
 
-        eventBus.register(new MailboxAnnotationListener(mapperFactory, sessionProvider));
+        eventBus.initialize(new MailboxAnnotationListener(mapperFactory, sessionProvider));
 
         return cassandraMailboxManager;
     }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
@@ -66,6 +66,10 @@ class CassandraTestSystemFixture {
 
     static CassandraMailboxManager createMailboxManager(CassandraMailboxSessionMapperFactory mapperFactory) {
         InVMEventBus eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, new MemoryEventDeadLetters());
+        return createMailboxManager(mapperFactory, eventBus);
+    }
+
+    static CassandraMailboxManager createMailboxManager(CassandraMailboxSessionMapperFactory mapperFactory, EventBus eventBus) {
         StoreRightManager storeRightManager = new StoreRightManager(mapperFactory, new UnionMailboxACLResolver(), new SimpleGroupMembershipResolver(), eventBus);
         StoreMailboxAnnotationManager annotationManager = new StoreMailboxAnnotationManager(mapperFactory, storeRightManager);
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxManagerAttachmentTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxManagerAttachmentTest.java
@@ -78,6 +78,7 @@ class CassandraMailboxManagerAttachmentTest extends AbstractMailboxManagerAttach
         Authenticator noAuthenticator = null;
         Authorizator noAuthorizator = null;
         InVMEventBus eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, new MemoryEventDeadLetters());
+        eventBus.initialize();
         StoreRightManager storeRightManager = new StoreRightManager(mailboxSessionMapperFactory, new UnionMailboxACLResolver(), new SimpleGroupMembershipResolver(), eventBus);
         StoreMailboxAnnotationManager annotationManager = new StoreMailboxAnnotationManager(mailboxSessionMapperFactory, storeRightManager);
 

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupRegistrationHandler.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupRegistrationHandler.java
@@ -58,11 +58,11 @@ class GroupRegistrationHandler {
         groupRegistrations.values().forEach(GroupRegistration::unregister);
     }
 
-    Registration register(MailboxListener listener, Group group) {
-        return groupRegistrations
+    void register(MailboxListener listener, Group group) {
+        groupRegistrations
             .compute(group, (groupToRegister, oldGroupRegistration) -> {
                 if (oldGroupRegistration != null) {
-                    throw new GroupAlreadyRegistered(group);
+                    throw new GroupsAlreadyRegistered();
                 }
                 return newGroupRegistration(listener, groupToRegister);
             })

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/RabbitMQEventBus.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/RabbitMQEventBus.java
@@ -130,11 +130,13 @@ public class RabbitMQEventBus implements EventBus, Startable {
     @Override
     public void initialize(Map<Group, MailboxListener> listeners) throws GroupsAlreadyRegistered {
         Preconditions.checkState(isRunning, NOT_RUNNING_ERROR_MESSAGE);
-        if (groupsInitialized) {
-            throw new GroupsAlreadyRegistered();
+        synchronized (groupRegistrationHandler) {
+            if (groupsInitialized) {
+                throw new GroupsAlreadyRegistered();
+            }
+            listeners.forEach((group, listener) -> groupRegistrationHandler.register(listener, group));
+            groupsInitialized = true;
         }
-        listeners.forEach((group, listener) -> groupRegistrationHandler.register(listener, group));
-        groupsInitialized = true;
     }
 
     @Override

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/RabbitMQEventBus.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/RabbitMQEventBus.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mailbox.events;
 
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.PreDestroy;
@@ -55,6 +56,7 @@ public class RabbitMQEventBus implements EventBus, Startable {
     private GroupRegistrationHandler groupRegistrationHandler;
     private KeyRegistrationHandler keyRegistrationHandler;
     private EventDispatcher eventDispatcher;
+    private boolean groupsInitialized;
 
     @Inject
     public RabbitMQEventBus(Sender sender, ReceiverProvider receiverProvider, EventSerializer eventSerializer,
@@ -71,6 +73,7 @@ public class RabbitMQEventBus implements EventBus, Startable {
         this.eventDeadLetters = eventDeadLetters;
         this.isRunning = false;
         this.isStopping = false;
+        this.groupsInitialized = false;
     }
 
     public void start() {
@@ -125,9 +128,12 @@ public class RabbitMQEventBus implements EventBus, Startable {
     }
 
     @Override
-    public Registration register(MailboxListener listener, Group group) {
+    public void initialize(Map<Group, MailboxListener> listeners) throws GroupsAlreadyRegistered {
         Preconditions.checkState(isRunning, NOT_RUNNING_ERROR_MESSAGE);
-        return groupRegistrationHandler.register(listener, group);
+        if (groupsInitialized) {
+            throw new GroupsAlreadyRegistered();
+        }
+        listeners.forEach((group, listener) -> groupRegistrationHandler.register(listener, group));
     }
 
     @Override

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/RabbitMQEventBus.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/RabbitMQEventBus.java
@@ -134,6 +134,7 @@ public class RabbitMQEventBus implements EventBus, Startable {
             throw new GroupsAlreadyRegistered();
         }
         listeners.forEach((group, listener) -> groupRegistrationHandler.register(listener, group));
+        groupsInitialized = true;
     }
 
     @Override

--- a/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusTest.java
+++ b/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusTest.java
@@ -176,7 +176,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
     void registerGroupShouldCreateRetryExchange() throws Exception {
         MailboxListener listener = newListener();
         EventBusTestFixture.GroupA registeredGroup = new EventBusTestFixture.GroupA();
-        eventBus.register(listener, registeredGroup);
+        eventBus.initialize(listener, registeredGroup);
 
         GroupConsumerRetry.RetryExchangeName retryExchangeName = GroupConsumerRetry.RetryExchangeName.of(registeredGroup);
         assertThat(rabbitMQExtension.managementAPI().listExchanges())
@@ -194,7 +194,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
         @Test
         void rabbitMQEventBusShouldHandleBulksGracefully() throws Exception {
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener1 = newCountingListener();
-            eventBus().register(countingListener1, new EventBusTestFixture.GroupA());
+            eventBus().initialize(countingListener1, new EventBusTestFixture.GroupA());
             int totalGlobalRegistrations = 1; // GroupA
 
             int threadCount = 10;
@@ -246,9 +246,9 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
             doAnswer(callEventAndSleepForever).when(eventBusListener).event(any());
             doAnswer(callEventAndSleepForever).when(eventBus2Listener).event(any());
 
-            eventBus.register(eventBusListener, GROUP_A);
-            eventBus2.register(eventBus2Listener, GROUP_A);
-            eventBus3.register(eventBus3Listener, GROUP_A);
+            eventBus.initialize(eventBusListener, GROUP_A);
+            eventBus2.initialize(eventBus2Listener, GROUP_A);
+            eventBus3.initialize(eventBus3Listener, GROUP_A);
 
             eventBus.dispatch(EVENT, NO_KEYS).block();
             getSpeedProfile().shortWaitCondition()
@@ -349,7 +349,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
                 void dispatchShouldWorkAfterNetworkIssuesForOldRegistration() {
                     rabbitMQEventBusWithNetWorkIssue.start();
                     MailboxListener listener = newListener();
-                    rabbitMQEventBusWithNetWorkIssue.register(listener, GROUP_A);
+                    rabbitMQEventBusWithNetWorkIssue.initialize(listener, GROUP_A);
 
                     rabbitMQNetWorkIssueExtension.getRabbitMQ().pause();
 
@@ -397,7 +397,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
             void dispatchShouldWorkAfterRestartForOldRegistration() throws Exception {
                 eventBus.start();
                 MailboxListener listener = newListener();
-                eventBus.register(listener, GROUP_A);
+                eventBus.initialize(listener, GROUP_A);
 
                 rabbitMQExtension.getRabbitMQ().restart();
 
@@ -412,7 +412,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
 
                 rabbitMQExtension.getRabbitMQ().restart();
 
-                eventBus.register(listener, GROUP_A);
+                eventBus.initialize(listener, GROUP_A);
 
                 eventBus.dispatch(EVENT, NO_KEYS).block();
 
@@ -424,7 +424,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
             void redeliverShouldWorkAfterRestartForOldRegistration() throws Exception {
                 eventBus.start();
                 MailboxListener listener = newListener();
-                eventBus.register(listener, GROUP_A);
+                eventBus.initialize(listener, GROUP_A);
 
                 rabbitMQExtension.getRabbitMQ().restart();
 
@@ -439,7 +439,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
 
                 rabbitMQExtension.getRabbitMQ().restart();
 
-                eventBus.register(listener, GROUP_A);
+                eventBus.initialize(listener, GROUP_A);
 
                 eventBus.reDeliver(GROUP_A, EVENT).block();
                 assertThatListenerReceiveOneEvent(listener);
@@ -498,7 +498,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
 
                 rabbitMQExtension.getRabbitMQ().unpause();
 
-                eventBus.register(listener, GROUP_A);
+                eventBus.initialize(listener, GROUP_A);
                 eventBus.dispatch(EVENT, NO_KEYS).block();
                 assertThatListenerReceiveOneEvent(listener);
             }
@@ -515,7 +515,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
 
                 rabbitMQExtension.getRabbitMQ().unpause();
 
-                eventBus.register(listener, GROUP_A);
+                eventBus.initialize(listener, GROUP_A);
                 eventBus.reDeliver(GROUP_A, EVENT).block();
                 assertThatListenerReceiveOneEvent(listener);
             }
@@ -570,7 +570,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
             @Test
             void stopShouldNotDeleteGroupRegistrationWorkQueue() {
                 eventBus.start();
-                eventBus.register(mock(MailboxListener.class), GROUP_A);
+                eventBus.initialize(mock(MailboxListener.class), GROUP_A);
                 eventBus.stop();
 
                 assertThat(rabbitManagementAPI.listQueues())
@@ -596,7 +596,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
                 eventBus.start();
 
                 MailboxListenerCountingSuccessfulExecution listener = new MailboxListenerCountingSuccessfulExecution();
-                eventBus.register(listener, GROUP_A);
+                eventBus.initialize(listener, GROUP_A);
 
                 try (Closeable closeable = ConcurrentTestRunner.builder()
                     .operation((threadNumber, step) -> eventBus.dispatch(EVENT, KEY_1).block())
@@ -662,7 +662,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
 
             @Test
             void multipleEventBusStopShouldNotDeleteGroupRegistrationWorkQueue() {
-                eventBus.register(mock(MailboxListener.class), GROUP_A);
+                eventBus.initialize(mock(MailboxListener.class), GROUP_A);
 
                 eventBus.stop();
                 eventBus2.stop();
@@ -691,8 +691,8 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
                 eventBus2.start();
 
                 MailboxListenerCountingSuccessfulExecution listener = new MailboxListenerCountingSuccessfulExecution();
-                eventBus.register(listener, GROUP_A);
-                eventBus2.register(listener, GROUP_A);
+                eventBus.initialize(listener, GROUP_A);
+                eventBus2.initialize(listener, GROUP_A);
 
                 try (Closeable closeable = ConcurrentTestRunner.builder()
                     .operation((threadNumber, step) -> eventBus.dispatch(EVENT, KEY_1).block())

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxManagerTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxManagerTest.java
@@ -58,7 +58,8 @@ class JPAMailboxManagerTest extends MailboxManagerTest<OpenJPAMailboxManager> {
         if (!openJPAMailboxManager.isPresent()) {
             openJPAMailboxManager = Optional.of(JpaMailboxManagerProvider.provideMailboxManager(JPA_TEST_CLUSTER, ImmutableList.of(mailboxListener)));
         }
-        return openJPAMailboxManager.get();    }
+        return openJPAMailboxManager.get();
+    }
 
     @AfterEach
     void tearDownJpa() {

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxManagerTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxManagerTest.java
@@ -47,10 +47,7 @@ class JPAMailboxManagerTest extends MailboxManagerTest<OpenJPAMailboxManager> {
     
     @Override
     protected OpenJPAMailboxManager provideMailboxManager() {
-        if (!openJPAMailboxManager.isPresent()) {
-            openJPAMailboxManager = Optional.of(JpaMailboxManagerProvider.provideMailboxManager(JPA_TEST_CLUSTER, NO_ADDITIONAL_LISTENERS));
-        }
-        return openJPAMailboxManager.get();
+        return JpaMailboxManagerProvider.provideMailboxManager(JPA_TEST_CLUSTER, NO_ADDITIONAL_LISTENERS);
     }
 
     @Override

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxManagerTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxManagerTest.java
@@ -23,13 +23,18 @@ import java.util.Optional;
 import org.apache.james.backends.jpa.JpaTestCluster;
 import org.apache.james.mailbox.MailboxManagerTest;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.jpa.openjpa.OpenJPAMailboxManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableList;
+
 class JPAMailboxManagerTest extends MailboxManagerTest<OpenJPAMailboxManager> {
+
+    public static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENERS = ImmutableList.of();
 
     @Disabled("JPAMailboxManager is using DefaultMessageId which doesn't support full feature of a messageId, which is an essential" +
         " element of the Vault")
@@ -43,10 +48,17 @@ class JPAMailboxManagerTest extends MailboxManagerTest<OpenJPAMailboxManager> {
     @Override
     protected OpenJPAMailboxManager provideMailboxManager() {
         if (!openJPAMailboxManager.isPresent()) {
-            openJPAMailboxManager = Optional.of(JpaMailboxManagerProvider.provideMailboxManager(JPA_TEST_CLUSTER));
+            openJPAMailboxManager = Optional.of(JpaMailboxManagerProvider.provideMailboxManager(JPA_TEST_CLUSTER, NO_ADDITIONAL_LISTENERS));
         }
         return openJPAMailboxManager.get();
     }
+
+    @Override
+    protected OpenJPAMailboxManager provideMailboxManager(MailboxListener.GroupMailboxListener mailboxListener) {
+        if (!openJPAMailboxManager.isPresent()) {
+            openJPAMailboxManager = Optional.of(JpaMailboxManagerProvider.provideMailboxManager(JPA_TEST_CLUSTER, ImmutableList.of(mailboxListener)));
+        }
+        return openJPAMailboxManager.get();    }
 
     @AfterEach
     void tearDownJpa() {

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JpaMailboxManagerStressTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JpaMailboxManagerStressTest.java
@@ -24,13 +24,18 @@ import java.util.Optional;
 import org.apache.james.backends.jpa.JpaTestCluster;
 import org.apache.james.mailbox.MailboxManagerStressContract;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.jpa.openjpa.OpenJPAMailboxManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
+import com.google.common.collect.ImmutableList;
+
 class JpaMailboxManagerStressTest implements MailboxManagerStressContract<OpenJPAMailboxManager> {
 
     static final JpaTestCluster JPA_TEST_CLUSTER = JpaTestCluster.create(JPAMailboxFixture.MAILBOX_PERSISTANCE_CLASSES);
+    static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENERS = ImmutableList.of();
+
     Optional<OpenJPAMailboxManager> openJPAMailboxManager = Optional.empty();
 
     @Override
@@ -46,7 +51,7 @@ class JpaMailboxManagerStressTest implements MailboxManagerStressContract<OpenJP
     @BeforeEach
     void setUp() {
         if (!openJPAMailboxManager.isPresent()) {
-            openJPAMailboxManager = Optional.of(JpaMailboxManagerProvider.provideMailboxManager(JPA_TEST_CLUSTER));
+            openJPAMailboxManager = Optional.of(JpaMailboxManagerProvider.provideMailboxManager(JPA_TEST_CLUSTER, NO_ADDITIONAL_LISTENERS));
         }
     }
 

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/DomainUserMaildirMailboxManagerStressTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/DomainUserMaildirMailboxManagerStressTest.java
@@ -23,12 +23,17 @@ import java.io.File;
 
 import org.apache.james.mailbox.MailboxManagerStressContract;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
+import com.google.common.collect.ImmutableList;
+
 class DomainUserMaildirMailboxManagerStressTest implements MailboxManagerStressContract<StoreMailboxManager> {
+    private static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENERS = ImmutableList.of();
+
     @TempDir
     File tmpFolder;
 
@@ -46,6 +51,6 @@ class DomainUserMaildirMailboxManagerStressTest implements MailboxManagerStressC
 
     @BeforeEach
     void setUp() throws MailboxException {
-        this.mailboxManager = MaildirMailboxManagerProvider.createMailboxManager("/%domain/%user", tmpFolder);
+        this.mailboxManager = MaildirMailboxManagerProvider.createMailboxManager("/%domain/%user", tmpFolder, NO_ADDITIONAL_LISTENERS);
     }
 }

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/DomainUserMaildirMailboxManagerTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/DomainUserMaildirMailboxManagerTest.java
@@ -21,13 +21,17 @@ package org.apache.james.mailbox.maildir;
 import org.apache.james.junit.TemporaryFolderExtension;
 import org.apache.james.mailbox.MailboxManagerTest;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.google.common.collect.ImmutableList;
+
 class DomainUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreMailboxManager> {
+    private static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENERS = ImmutableList.of();
 
     @Disabled("Maildir is using DefaultMessageId which doesn't support full feature of a messageId, which is an essential" +
         " element of the Vault")
@@ -87,7 +91,18 @@ class DomainUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreMailbo
     @Override
     protected StoreMailboxManager provideMailboxManager() {
         try {
-            return MaildirMailboxManagerProvider.createMailboxManager("/%domain/%user", temporaryFolder.getTemporaryFolder().getTempDir());
+            return MaildirMailboxManagerProvider.createMailboxManager("/%domain/%user",
+                temporaryFolder.getTemporaryFolder().getTempDir(), NO_ADDITIONAL_LISTENERS);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected StoreMailboxManager provideMailboxManager(MailboxListener.GroupMailboxListener mailboxListener) {
+        try {
+            return MaildirMailboxManagerProvider.createMailboxManager("/%fulluser",
+                temporaryFolder.getTemporaryFolder().getTempDir(), ImmutableList.of(mailboxListener));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerStressTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerStressTest.java
@@ -23,12 +23,17 @@ import java.io.File;
 
 import org.apache.james.mailbox.MailboxManagerStressContract;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
+import com.google.common.collect.ImmutableList;
+
 class FullUserMaildirMailboxManagerStressTest implements MailboxManagerStressContract<StoreMailboxManager> {
+    private static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENERS = ImmutableList.of();
+
     @TempDir
     File tmpFolder;
 
@@ -46,6 +51,6 @@ class FullUserMaildirMailboxManagerStressTest implements MailboxManagerStressCon
 
     @BeforeEach
     void setUp() throws MailboxException {
-        this.mailboxManager = MaildirMailboxManagerProvider.createMailboxManager("/%fulluser", tmpFolder);
+        this.mailboxManager = MaildirMailboxManagerProvider.createMailboxManager("/%fulluser", tmpFolder, NO_ADDITIONAL_LISTENERS);
     }
 }

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerTest.java
@@ -21,12 +21,16 @@ package org.apache.james.mailbox.maildir;
 import org.apache.james.junit.TemporaryFolderExtension;
 import org.apache.james.mailbox.MailboxManagerTest;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.google.common.collect.ImmutableList;
+
 class FullUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreMailboxManager> {
+    private static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENERS = ImmutableList.of();
 
     @Disabled("Maildir is using DefaultMessageId which doesn't support full feature of a messageId, which is an essential" +
         " element of the Vault")
@@ -40,7 +44,17 @@ class FullUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreMailboxM
     @Override
     protected StoreMailboxManager provideMailboxManager() {
         try {
-            return MaildirMailboxManagerProvider.createMailboxManager("/%fulluser", temporaryFolder.getTemporaryFolder().getTempDir());
+            return MaildirMailboxManagerProvider.createMailboxManager("/%fulluser", temporaryFolder.getTemporaryFolder().getTempDir(), NO_ADDITIONAL_LISTENERS);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected StoreMailboxManager provideMailboxManager(MailboxListener.GroupMailboxListener mailboxListener) {
+        try {
+            return MaildirMailboxManagerProvider.createMailboxManager("/%fulluser",
+                temporaryFolder.getTemporaryFolder().getTempDir(), ImmutableList.of(mailboxListener));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/MaildirMailboxManagerProvider.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/MaildirMailboxManagerProvider.java
@@ -27,6 +27,7 @@ import org.apache.james.mailbox.acl.SimpleGroupMembershipResolver;
 import org.apache.james.mailbox.acl.UnionMailboxACLResolver;
 import org.apache.james.mailbox.events.EventBusTestFixture;
 import org.apache.james.mailbox.events.InVMEventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.events.MemoryEventDeadLetters;
 import org.apache.james.mailbox.events.delivery.InVmEventDelivery;
 import org.apache.james.mailbox.store.Authenticator;
@@ -46,9 +47,11 @@ import org.apache.james.mailbox.store.search.MessageSearchIndex;
 import org.apache.james.mailbox.store.search.SimpleMessageSearchIndex;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
 
+import com.google.common.collect.ImmutableList;
+
 public class MaildirMailboxManagerProvider {
 
-    public static StoreMailboxManager createMailboxManager(String configuration, File tempFile) {
+    public static StoreMailboxManager createMailboxManager(String configuration, File tempFile, ImmutableList<MailboxListener.GroupMailboxListener> listeners) {
         MaildirStore store = new MaildirStore(tempFile.getPath() + configuration, new JVMMailboxPathLocker());
         MaildirMailboxSessionMapperFactory mf = new MaildirMailboxSessionMapperFactory(store);
 
@@ -70,6 +73,8 @@ public class MaildirMailboxManagerProvider {
         StoreMailboxManager manager = new StoreMailboxManager(mf, sessionProvider, new JVMMailboxPathLocker(),
             messageParser, new DefaultMessageId.Factory(), annotationManager, eventBus, storeRightManager,
             quotaComponents, index, MailboxManagerConfiguration.DEFAULT, PreDeletionHooks.NO_PRE_DELETION_HOOK);
+
+        eventBus.initialize(listeners);
 
         return manager;
     }

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/UserMaildirMailboxManagerStressTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/UserMaildirMailboxManagerStressTest.java
@@ -23,12 +23,17 @@ import java.io.File;
 
 import org.apache.james.mailbox.MailboxManagerStressContract;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
+import com.google.common.collect.ImmutableList;
+
 class UserMaildirMailboxManagerStressTest implements MailboxManagerStressContract<StoreMailboxManager> {
+    private static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENERS = ImmutableList.of();
+
     @TempDir
     File tmpFolder;
 
@@ -46,6 +51,6 @@ class UserMaildirMailboxManagerStressTest implements MailboxManagerStressContrac
 
     @BeforeEach
     void setUp() throws MailboxException {
-        this.mailboxManager = MaildirMailboxManagerProvider.createMailboxManager("/%user", tmpFolder);
+        this.mailboxManager = MaildirMailboxManagerProvider.createMailboxManager("/%user", tmpFolder, NO_ADDITIONAL_LISTENERS);
     }
 }

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/MemoryMailboxManagerProvider.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/MemoryMailboxManagerProvider.java
@@ -21,6 +21,7 @@ package org.apache.james.mailbox.inmemory;
 
 import java.util.Set;
 
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.extension.PreDeletionHook;
 import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
 
@@ -38,6 +39,21 @@ public class MemoryMailboxManagerProvider {
             .scanningSearchIndex()
             .preDeletionHooks(preDeletionHooks)
             .storeQuotaManager()
+            .build()
+            .getMailboxManager();
+    }
+
+    public static InMemoryMailboxManager provideMailboxManager(Set<PreDeletionHook> preDeletionHooks, MailboxListener.GroupMailboxListener listener) {
+        return InMemoryIntegrationResources.builder()
+            .preProvisionnedFakeAuthenticator()
+            .fakeAuthorizator()
+            .inVmEventBus()
+            .annotationLimits(LIMIT_ANNOTATIONS, LIMIT_ANNOTATION_SIZE)
+            .defaultMessageParser()
+            .scanningSearchIndex()
+            .preDeletionHooks(preDeletionHooks)
+            .storeQuotaManager()
+            .registerListener((any, any2) -> listener)
             .build()
             .getMailboxManager();
     }

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/MemoryMailboxManagerTest.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/MemoryMailboxManagerTest.java
@@ -21,6 +21,9 @@ package org.apache.james.mailbox.inmemory;
 
 import org.apache.james.mailbox.MailboxManagerTest;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
+
+import com.google.common.collect.ImmutableList;
 
 class MemoryMailboxManagerTest extends MailboxManagerTest<InMemoryMailboxManager> {
 
@@ -32,5 +35,10 @@ class MemoryMailboxManagerTest extends MailboxManagerTest<InMemoryMailboxManager
     @Override
     protected EventBus retrieveEventBus(InMemoryMailboxManager mailboxManager) {
         return mailboxManager.getEventBus();
+    }
+
+    @Override
+    protected InMemoryMailboxManager provideMailboxManager(MailboxListener.GroupMailboxListener mailboxListener) {
+        return MemoryMailboxManagerProvider.provideMailboxManager(preDeletionHooks(), mailboxListener);
     }
 }

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/manager/InMemoryIntegrationResources.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/manager/InMemoryIntegrationResources.java
@@ -357,7 +357,7 @@ public class InMemoryIntegrationResources implements IntegrationResources<StoreM
                 quotaManager,
                 quotaRootResolver,
                 manager.getPreDeletionHooks());
-            groupListenerFactory.build().forEach(c -> c.accept(manager, messageIdManager));
+            groupListenerFactory.build().forEach(groupListenerRegistrer -> groupListenerRegistrer.accept(manager, messageIdManager));
 
             eventBus.initialize(ImmutableList.<MailboxListener.GroupMailboxListener>builder()
                 .addAll(listenersToBeRegistered.build())

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/manager/InMemoryIntegrationResources.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/manager/InMemoryIntegrationResources.java
@@ -357,11 +357,13 @@ public class InMemoryIntegrationResources implements IntegrationResources<StoreM
                 quotaManager,
                 quotaRootResolver,
                 manager.getPreDeletionHooks());
-
-            eventBus.register(listeningCurrentQuotaUpdater);
-            eventBus.register(new MailboxAnnotationListener(mailboxSessionMapperFactory, sessionProvider));
             groupListenerFactory.build().forEach(c -> c.accept(manager, messageIdManager));
-            listenersToBeRegistered.build().forEach(eventBus::register);
+
+            eventBus.initialize(ImmutableList.<MailboxListener.GroupMailboxListener>builder()
+                .addAll(listenersToBeRegistered.build())
+                .add(listeningCurrentQuotaUpdater)
+                .add(new MailboxAnnotationListener(mailboxSessionMapperFactory, sessionProvider))
+                .build());
 
             return new InMemoryIntegrationResources(manager, storeRightManager, messageIdFactory, currentQuotaManager,
                 quotaRootResolver, maxQuotaManager, quotaManager, index, eventBus, messageIdManager);

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/manager/InMemoryMessageIdManagerSideEffectTest.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/manager/InMemoryMessageIdManagerSideEffectTest.java
@@ -21,7 +21,7 @@ package org.apache.james.mailbox.inmemory.manager;
 
 import java.util.Set;
 
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.InVMEventBus;
 import org.apache.james.mailbox.extension.PreDeletionHook;
 import org.apache.james.mailbox.inmemory.InMemoryMessageId;
 import org.apache.james.mailbox.quota.QuotaManager;
@@ -31,7 +31,7 @@ import org.apache.james.mailbox.store.MessageIdManagerTestSystem;
 class InMemoryMessageIdManagerSideEffectTest extends AbstractMessageIdManagerSideEffectTest {
 
     @Override
-    protected MessageIdManagerTestSystem createTestSystem(QuotaManager quotaManager, EventBus eventBus, Set<PreDeletionHook> preDeletionHooks) {
+    protected MessageIdManagerTestSystem createTestSystem(QuotaManager quotaManager, InVMEventBus eventBus, Set<PreDeletionHook> preDeletionHooks) {
         InMemoryMessageId.Factory messageIdFactory = new InMemoryMessageId.Factory();
 
         InMemoryIntegrationResources resources = InMemoryIntegrationResources.builder()

--- a/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdListenersTestSystem.java
+++ b/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdListenersTestSystem.java
@@ -53,7 +53,7 @@ class QuotaThresholdListenersTestSystem {
         QuotaThresholdCrossingListener thresholdCrossingListener =
             new QuotaThresholdCrossingListener(mailetContext, MemoryUsersRepository.withVirtualHosting(NO_DOMAIN_LIST), fileSystem, eventStore, configuration);
 
-        eventBus.register(thresholdCrossingListener);
+        eventBus.initialize(thresholdCrossingListener);
     }
 
     void event(Event event) {

--- a/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/ElasticSearchQuotaSearchTestSystemExtension.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/ElasticSearchQuotaSearchTestSystemExtension.java
@@ -60,7 +60,7 @@ public class ElasticSearchQuotaSearchTestSystemExtension implements ParameterRes
                 elasticSearch.configuration());
 
             InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultBuilder()
-                .registerListener((m, m2) -> new ElasticSearchQuotaMailboxListener(
+                .registerListener((manager, messageIdManager) -> new ElasticSearchQuotaMailboxListener(
                     new ElasticSearchIndexer(client,
                         QuotaRatioElasticSearchConstants.DEFAULT_QUOTA_RATIO_WRITE_ALIAS),
                     new QuotaRatioToElasticSearchJson(),

--- a/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/ElasticSearchQuotaSearchTestSystemExtension.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/ElasticSearchQuotaSearchTestSystemExtension.java
@@ -59,19 +59,17 @@ public class ElasticSearchQuotaSearchTestSystemExtension implements ParameterRes
                 elasticSearch.clientProvider().get(),
                 elasticSearch.configuration());
 
-            InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultResources();
+            InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultBuilder()
+                .registerListener((m, m2) -> new ElasticSearchQuotaMailboxListener(
+                    new ElasticSearchIndexer(client,
+                        QuotaRatioElasticSearchConstants.DEFAULT_QUOTA_RATIO_WRITE_ALIAS),
+                    new QuotaRatioToElasticSearchJson(),
+                    new UserRoutingKeyFactory()))
+                .build();
 
             DNSService dnsService = mock(DNSService.class);
             MemoryDomainList domainList = new MemoryDomainList(dnsService);
             MemoryUsersRepository usersRepository = MemoryUsersRepository.withVirtualHosting(domainList);
-
-            ElasticSearchQuotaMailboxListener listener = new ElasticSearchQuotaMailboxListener(
-                new ElasticSearchIndexer(client,
-                    QuotaRatioElasticSearchConstants.DEFAULT_QUOTA_RATIO_WRITE_ALIAS),
-                new QuotaRatioToElasticSearchJson(),
-                new UserRoutingKeyFactory());
-
-            resources.getMailboxManager().getEventBus().register(listener);
 
             QuotaComponents quotaComponents = resources.getMailboxManager().getQuotaComponents();
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerSideEffectTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerSideEffectTest.java
@@ -109,7 +109,6 @@ public abstract class AbstractMessageIdManagerSideEffectTest {
     @BeforeEach
     void setUp() throws Exception {
         eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, new MemoryEventDeadLetters());
-        eventBus.initialize();
         eventCollector = new EventCollector();
         quotaManager = mock(QuotaManager.class);
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerSideEffectTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerSideEffectTest.java
@@ -109,6 +109,7 @@ public abstract class AbstractMessageIdManagerSideEffectTest {
     @BeforeEach
     void setUp() throws Exception {
         eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, new MemoryEventDeadLetters());
+        eventBus.initialize();
         eventCollector = new EventCollector();
         quotaManager = mock(QuotaManager.class);
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerSideEffectTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerSideEffectTest.java
@@ -100,16 +100,15 @@ public abstract class AbstractMessageIdManagerSideEffectTest {
     private QuotaManager quotaManager;
     private MessageIdManagerTestSystem testingData;
     private EventCollector eventCollector;
-    private EventBus eventBus;
+    private InVMEventBus eventBus;
     private PreDeletionHook preDeletionHook1;
     private PreDeletionHook preDeletionHook2;
 
-    protected abstract MessageIdManagerTestSystem createTestSystem(QuotaManager quotaManager, EventBus eventBus, Set<PreDeletionHook> preDeletionHooks) throws Exception;
+    protected abstract MessageIdManagerTestSystem createTestSystem(QuotaManager quotaManager, InVMEventBus eventBus, Set<PreDeletionHook> preDeletionHooks) throws Exception;
 
     @BeforeEach
     void setUp() throws Exception {
         eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, new MemoryEventDeadLetters());
-        eventBus.initialize();
         eventCollector = new EventCollector();
         quotaManager = mock(QuotaManager.class);
 

--- a/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/CassandraReIndexerImplTest.java
+++ b/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/CassandraReIndexerImplTest.java
@@ -36,6 +36,7 @@ import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.cassandra.CassandraMailboxManager;
 import org.apache.james.mailbox.cassandra.CassandraMailboxManagerProvider;
 import org.apache.james.mailbox.cassandra.mail.MailboxAggregateModule;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.indexer.ReIndexer;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxId;
@@ -50,10 +51,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 
 public class CassandraReIndexerImplTest {
     private static final Username USERNAME = Username.of("benwa@apache.org");
     public static final MailboxPath INBOX = MailboxPath.inbox(USERNAME);
+    private static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_MAILBOX_LISTENERS = ImmutableList.of();
+
     private CassandraMailboxManager mailboxManager;
     private ListeningMessageSearchIndex messageSearchIndex;
 
@@ -64,7 +68,7 @@ public class CassandraReIndexerImplTest {
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
-        mailboxManager = CassandraMailboxManagerProvider.provideMailboxManager(cassandra, PreDeletionHooks.NO_PRE_DELETION_HOOK);
+        mailboxManager = CassandraMailboxManagerProvider.provideMailboxManager(cassandra, PreDeletionHooks.NO_PRE_DELETION_HOOK, NO_ADDITIONAL_MAILBOX_LISTENERS);
         MailboxSessionMapperFactory mailboxSessionMapperFactory = mailboxManager.getMapperFactory();
         messageSearchIndex = mock(ListeningMessageSearchIndex.class);
         reIndexer = new ReIndexerImpl(new ReIndexerPerformer(mailboxManager, messageSearchIndex, mailboxSessionMapperFactory),

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
@@ -115,7 +115,7 @@ public class CassandraHostSystem extends JamesImapHostSystem {
             new JVMMailboxPathLocker(), new MessageParser(), messageIdFactory,
             eventBus, annotationManager, storeRightManager, quotaComponents, index, MailboxManagerConfiguration.DEFAULT, PreDeletionHooks.NO_PRE_DELETION_HOOK);
 
-        eventBus.register(quotaUpdater);
+        eventBus.initialize(quotaUpdater);
 
         SubscriptionManager subscriptionManager = new StoreSubscriptionManager(mapperFactory);
 

--- a/mpt/impl/imap-mailbox/jpa/src/test/java/org/apache/james/mpt/imapmailbox/jpa/host/JPAHostSystem.java
+++ b/mpt/impl/imap-mailbox/jpa/src/test/java/org/apache/james/mpt/imapmailbox/jpa/host/JPAHostSystem.java
@@ -118,8 +118,8 @@ public class JPAHostSystem extends JamesImapHostSystem {
         mailboxManager = new OpenJPAMailboxManager(mapperFactory, sessionProvider, messageParser, new DefaultMessageId.Factory(),
             eventBus, annotationManager, storeRightManager, quotaComponents, index);
 
-        eventBus.register(quotaUpdater);
-        eventBus.register(new MailboxAnnotationListener(mapperFactory, sessionProvider));
+        eventBus.initialize(quotaUpdater,
+            new MailboxAnnotationListener(mapperFactory, sessionProvider));
 
         SubscriptionManager subscriptionManager = new StoreSubscriptionManager(mapperFactory);
         

--- a/mpt/impl/imap-mailbox/maildir/src/test/java/org/apache/james/mpt/imapmailbox/maildir/host/MaildirHostSystem.java
+++ b/mpt/impl/imap-mailbox/maildir/src/test/java/org/apache/james/mpt/imapmailbox/maildir/host/MaildirHostSystem.java
@@ -80,6 +80,7 @@ public class MaildirHostSystem extends JamesImapHostSystem {
         MessageParser messageParser = new MessageParser();
 
         InVMEventBus eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, new MemoryEventDeadLetters());
+        eventBus.initialize();
         StoreRightManager storeRightManager = new StoreRightManager(mailboxSessionMapperFactory, aclResolver, groupMembershipResolver, eventBus);
         StoreMailboxAnnotationManager annotationManager = new StoreMailboxAnnotationManager(mailboxSessionMapperFactory, storeRightManager);
         SessionProviderImpl sessionProvider = new SessionProviderImpl(authenticator, authorizator);

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenersLoader.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenersLoader.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.modules.mailbox;
 
+import java.util.Map;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.mailbox.events.Group;
 import org.apache.james.mailbox.events.MailboxListener;
@@ -25,5 +27,5 @@ import org.apache.james.mailbox.events.MailboxListener;
 public interface MailboxListenersLoader {
     Pair<Group, MailboxListener> createListener(ListenerConfiguration configuration);
 
-    void register(Pair<Group, MailboxListener> listener);
+    void register(Map<Group, MailboxListener> listeners);
 }

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenersLoaderImpl.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenersLoaderImpl.java
@@ -78,7 +78,7 @@ public class MailboxListenersLoaderImpl implements Configurable, MailboxListener
 
     @Override
     public void register(Map<Group, MailboxListener> listeners) {
-        listeners.forEach((key, value) -> eventBus.register(value, key));
+        eventBus.initialize(listeners);
     }
 
     @Override

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenersLoaderImpl.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenersLoaderImpl.java
@@ -64,7 +64,8 @@ public class MailboxListenersLoaderImpl implements Configurable, MailboxListener
         ImmutableMap<Group, MailboxListener.GroupMailboxListener> guiceListenersAsMap = guiceDefinedListeners.stream()
             .collect(Guavate.toImmutableMap(MailboxListener.GroupMailboxListener::getDefaultGroup));
 
-        ImmutableMap<Group, MailboxListener> registeredListenersAsMap = listenersConfiguration.getListenersConfiguration().stream()
+        ImmutableMap<Group, MailboxListener> registeredListenersAsMap = listenersConfiguration.getListenersConfiguration()
+            .stream()
             .map(this::createListener)
             .collect(Guavate.toImmutableMap(
                 Pair::getLeft,

--- a/server/container/guice/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/JmapGuiceProbe.java
+++ b/server/container/guice/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/JmapGuiceProbe.java
@@ -35,6 +35,7 @@ import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.events.EventBus;
 import org.apache.james.mailbox.events.MailboxListener;
+import org.apache.james.mailbox.events.RegistrationKey;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageId;
@@ -66,8 +67,8 @@ public class JmapGuiceProbe implements GuiceProbe {
         return jmapServer.getPort();
     }
 
-    public void addMailboxListener(MailboxListener.GroupMailboxListener listener) {
-        eventBus.register(listener);
+    public void addMailboxListener(MailboxListener listener, RegistrationKey registrationKey) {
+        eventBus.register(listener, registrationKey);
     }
 
     public void modifyVacation(AccountId accountId, VacationPatch vacationPatch) {

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMessagesMethodTest.java
@@ -66,7 +66,6 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -90,6 +89,7 @@ import org.apache.james.mailbox.DefaultMailboxes;
 import org.apache.james.mailbox.FlagsBuilder;
 import org.apache.james.mailbox.Role;
 import org.apache.james.mailbox.events.Event;
+import org.apache.james.mailbox.events.MailboxIdRegistrationKey;
 import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Attachment;
@@ -132,6 +132,7 @@ import org.junit.experimental.categories.Category;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
+
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.filter.log.LogDetail;
@@ -2463,7 +2464,9 @@ public abstract class SetMessagesMethodTest {
             "]";
 
         EventCollector eventCollector = new EventCollector();
-        jmapServer.getProbe(JmapGuiceProbe.class).addMailboxListener(eventCollector);
+        jmapServer.getProbe(JmapGuiceProbe.class).addMailboxListener(eventCollector,
+            new MailboxIdRegistrationKey(jmapServer.getProbe(MailboxProbeImpl.class)
+                .getMailboxId(MailboxConstants.USER_NAMESPACE, USERNAME.asString(), DefaultMailboxes.OUTBOX)));
 
         String messageId = with()
             .header("Authorization", accessToken.asString())

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/event/PropagateLookupRightListenerTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/event/PropagateLookupRightListenerTest.java
@@ -58,7 +58,6 @@ public class PropagateLookupRightListenerTest {
 
     private StoreRightManager storeRightManager;
     private StoreMailboxManager storeMailboxManager;
-    private PropagateLookupRightListener testee;
 
     private MailboxSession mailboxSession = MailboxSessionUtil.create(OWNER_USER);
 
@@ -73,13 +72,12 @@ public class PropagateLookupRightListenerTest {
 
     @Before
     public void setup() throws Exception {
-        InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultResources();
+        InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultBuilder()
+            .registerListener((manager, messageIdManager) -> new PropagateLookupRightListener(manager, manager))
+            .build();
         storeMailboxManager = resources.getMailboxManager();
         storeRightManager = resources.getStoreRightManager();
         mailboxMapper = storeMailboxManager.getMapperFactory();
-
-        testee = new PropagateLookupRightListener(storeRightManager, storeMailboxManager);
-        storeMailboxManager.getEventBus().register(testee);
 
         parentMailboxId = storeMailboxManager.createMailbox(PARENT_MAILBOX, mailboxSession).get();
         parentMailboxId1 = storeMailboxManager.createMailbox(PARENT_MAILBOX1, mailboxSession).get();
@@ -98,7 +96,9 @@ public class PropagateLookupRightListenerTest {
 
     @Test
     public void getExecutionModeShouldReturnAsynchronous() throws Exception {
-        assertThat(testee.getExecutionMode()).isEqualTo(MailboxListener.ExecutionMode.SYNCHRONOUS);
+        assertThat(new PropagateLookupRightListener(storeRightManager, storeMailboxManager)
+            .getExecutionMode())
+            .isEqualTo(MailboxListener.ExecutionMode.SYNCHRONOUS);
     }
 
     @Test

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/ElasticSearchQuotaSearchExtension.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/ElasticSearchQuotaSearchExtension.java
@@ -67,7 +67,6 @@ public class ElasticSearchQuotaSearchExtension implements ParameterResolver, Bef
                     .addHost(elasticSearch.getHttpHost())
                     .build());
 
-            InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultResources();
 
 
             DNSService dnsService = mock(DNSService.class);
@@ -79,7 +78,9 @@ public class ElasticSearchQuotaSearchExtension implements ParameterResolver, Bef
                 new QuotaRatioToElasticSearchJson(),
                 new UserRoutingKeyFactory());
 
-            resources.getMailboxManager().getEventBus().register(listener);
+            InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultBuilder()
+                .registerListener((manager, messageIdManager) -> listener)
+                .build();
 
             QuotaComponents quotaComponents = resources.getMailboxManager().getQuotaComponents();
 

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
@@ -67,6 +67,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -384,8 +385,8 @@ class EventDeadLettersRoutesTest {
             eventCollectorB = new EventCollector();
             groupA = new EventBusTestFixture.GroupA();
             groupB = new EventBusTestFixture.GroupB();
-            eventBus.register(eventCollectorA, groupA);
-            eventBus.register(eventCollectorB, groupB);
+            eventBus.initialize(ImmutableMap.of(groupA, eventCollectorA,
+                groupB, eventCollectorB));
         }
 
         @Test
@@ -572,7 +573,7 @@ class EventDeadLettersRoutesTest {
         void nestedBeforeEach() {
             eventCollector = new EventCollector();
             groupA = new EventBusTestFixture.GroupA();
-            eventBus.register(eventCollector, groupA);
+            eventBus.initialize(eventCollector, groupA);
         }
 
         @Test
@@ -792,7 +793,7 @@ class EventDeadLettersRoutesTest {
         void nestedBeforeEach() {
             eventCollector = new EventCollector();
             groupA = new EventBusTestFixture.GroupA();
-            eventBus.register(eventCollector, groupA);
+            eventBus.initialize(eventCollector, groupA);
         }
 
         @Test


### PR DESCRIPTION
To be handling unregistration of groups upon start, and track group registration changes, we need to register all groups at once (and now when to be tracking changes)

As a side effect, group dynamic unregistration no longer makes sense too.