### PR TITLE
JAMES-3148 Cassandra metadata cleanup

### DIFF
--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -111,9 +111,9 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
     public static final Username USER_2 = Username.of("USER_2");
     private static final int DEFAULT_MAXIMUM_LIMIT = 256;
 
-    private T mailboxManager;
+    protected T mailboxManager;
     private MailboxSession session;
-    private Message.Builder message;
+    protected Message.Builder message;
 
     private PreDeletionHook preDeletionHook1;
     private PreDeletionHook preDeletionHook2;

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
@@ -204,6 +204,7 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
     }
 
     public DeleteMessageListener deleteMessageListener() {
-        return new DeleteMessageListener(imapUidDAO, messageIdDAO, messageDAO, attachmentDAOV2, ownerDAO, attachmentMessageIdDAO, aclMapper, userMailboxRightsDAO);
+        return new DeleteMessageListener(imapUidDAO, messageIdDAO, messageDAO, attachmentDAOV2, ownerDAO,
+            attachmentMessageIdDAO, aclMapper, userMailboxRightsDAO, applicableFlagDAO);
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
@@ -205,6 +205,7 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
 
     public DeleteMessageListener deleteMessageListener() {
         return new DeleteMessageListener(imapUidDAO, messageIdDAO, messageDAO, attachmentDAOV2, ownerDAO,
-            attachmentMessageIdDAO, aclMapper, userMailboxRightsDAO, applicableFlagDAO, firstUnseenDAO, deletedMessageDAO);
+            attachmentMessageIdDAO, aclMapper, userMailboxRightsDAO, applicableFlagDAO, firstUnseenDAO, deletedMessageDAO,
+            mailboxCounterDAO);
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
@@ -202,4 +202,8 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
         }
         return mapper;
     }
+
+    public DeleteMessageListener deleteMessageListener() {
+        return new DeleteMessageListener(imapUidDAO, messageIdDAO, messageDAO, attachmentDAOV2, ownerDAO, attachmentMessageIdDAO);
+    }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
@@ -204,6 +204,6 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
     }
 
     public DeleteMessageListener deleteMessageListener() {
-        return new DeleteMessageListener(imapUidDAO, messageIdDAO, messageDAO, attachmentDAOV2, ownerDAO, attachmentMessageIdDAO);
+        return new DeleteMessageListener(imapUidDAO, messageIdDAO, messageDAO, attachmentDAOV2, ownerDAO, attachmentMessageIdDAO, aclMapper, userMailboxRightsDAO);
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
@@ -206,6 +206,6 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
     public DeleteMessageListener deleteMessageListener() {
         return new DeleteMessageListener(imapUidDAO, messageIdDAO, messageDAO, attachmentDAOV2, ownerDAO,
             attachmentMessageIdDAO, aclMapper, userMailboxRightsDAO, applicableFlagDAO, firstUnseenDAO, deletedMessageDAO,
-            mailboxCounterDAO);
+            mailboxCounterDAO, mailboxRecentsDAO);
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
@@ -205,6 +205,6 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
 
     public DeleteMessageListener deleteMessageListener() {
         return new DeleteMessageListener(imapUidDAO, messageIdDAO, messageDAO, attachmentDAOV2, ownerDAO,
-            attachmentMessageIdDAO, aclMapper, userMailboxRightsDAO, applicableFlagDAO);
+            attachmentMessageIdDAO, aclMapper, userMailboxRightsDAO, applicableFlagDAO, firstUnseenDAO);
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
@@ -205,6 +205,6 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
 
     public DeleteMessageListener deleteMessageListener() {
         return new DeleteMessageListener(imapUidDAO, messageIdDAO, messageDAO, attachmentDAOV2, ownerDAO,
-            attachmentMessageIdDAO, aclMapper, userMailboxRightsDAO, applicableFlagDAO, firstUnseenDAO);
+            attachmentMessageIdDAO, aclMapper, userMailboxRightsDAO, applicableFlagDAO, firstUnseenDAO, deletedMessageDAO);
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/DeleteMessageListener.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/DeleteMessageListener.java
@@ -33,6 +33,7 @@ import org.apache.james.mailbox.cassandra.mail.CassandraApplicableFlagDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentMessageIdDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentOwnerDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraDeletedMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraFirstUnseenDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
@@ -69,13 +70,14 @@ public class DeleteMessageListener implements MailboxListener.GroupMailboxListen
     private final CassandraUserMailboxRightsDAO rightsDAO;
     private final CassandraApplicableFlagDAO applicableFlagDAO;
     private final CassandraFirstUnseenDAO firstUnseenDAO;
+    private final CassandraDeletedMessageDAO deletedMessageDAO;
 
     @Inject
     public DeleteMessageListener(CassandraMessageIdToImapUidDAO imapUidDAO, CassandraMessageIdDAO messageIdDAO, CassandraMessageDAO messageDAO,
                                  CassandraAttachmentDAOV2 attachmentDAO, CassandraAttachmentOwnerDAO ownerDAO,
                                  CassandraAttachmentMessageIdDAO attachmentMessageIdDAO, CassandraACLMapper aclMapper,
                                  CassandraUserMailboxRightsDAO rightsDAO, CassandraApplicableFlagDAO applicableFlagDAO,
-                                 CassandraFirstUnseenDAO firstUnseenDAO) {
+                                 CassandraFirstUnseenDAO firstUnseenDAO, CassandraDeletedMessageDAO deletedMessageDAO) {
         this.imapUidDAO = imapUidDAO;
         this.messageIdDAO = messageIdDAO;
         this.messageDAO = messageDAO;
@@ -86,6 +88,7 @@ public class DeleteMessageListener implements MailboxListener.GroupMailboxListen
         this.rightsDAO = rightsDAO;
         this.applicableFlagDAO = applicableFlagDAO;
         this.firstUnseenDAO = firstUnseenDAO;
+        this.deletedMessageDAO = deletedMessageDAO;
     }
 
     @Override
@@ -124,6 +127,7 @@ public class DeleteMessageListener implements MailboxListener.GroupMailboxListen
                 .then(deleteAcl(mailboxId))
                 .then(applicableFlagDAO.delete(mailboxId))
                 .then(firstUnseenDAO.removeAll(mailboxId))
+                .then(deletedMessageDAO.removeAll(mailboxId))
                 .block();
         }
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/DeleteMessageListener.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/DeleteMessageListener.java
@@ -33,6 +33,7 @@ import org.apache.james.mailbox.cassandra.mail.CassandraApplicableFlagDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentMessageIdDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentOwnerDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraFirstUnseenDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdToImapUidDAO;
@@ -67,11 +68,14 @@ public class DeleteMessageListener implements MailboxListener.GroupMailboxListen
     private final CassandraACLMapper aclMapper;
     private final CassandraUserMailboxRightsDAO rightsDAO;
     private final CassandraApplicableFlagDAO applicableFlagDAO;
+    private final CassandraFirstUnseenDAO firstUnseenDAO;
 
     @Inject
     public DeleteMessageListener(CassandraMessageIdToImapUidDAO imapUidDAO, CassandraMessageIdDAO messageIdDAO, CassandraMessageDAO messageDAO,
                                  CassandraAttachmentDAOV2 attachmentDAO, CassandraAttachmentOwnerDAO ownerDAO,
-                                 CassandraAttachmentMessageIdDAO attachmentMessageIdDAO, CassandraACLMapper aclMapper, CassandraUserMailboxRightsDAO rightsDAO, CassandraApplicableFlagDAO applicableFlagDAO) {
+                                 CassandraAttachmentMessageIdDAO attachmentMessageIdDAO, CassandraACLMapper aclMapper,
+                                 CassandraUserMailboxRightsDAO rightsDAO, CassandraApplicableFlagDAO applicableFlagDAO,
+                                 CassandraFirstUnseenDAO firstUnseenDAO) {
         this.imapUidDAO = imapUidDAO;
         this.messageIdDAO = messageIdDAO;
         this.messageDAO = messageDAO;
@@ -81,6 +85,7 @@ public class DeleteMessageListener implements MailboxListener.GroupMailboxListen
         this.aclMapper = aclMapper;
         this.rightsDAO = rightsDAO;
         this.applicableFlagDAO = applicableFlagDAO;
+        this.firstUnseenDAO = firstUnseenDAO;
     }
 
     @Override
@@ -118,6 +123,7 @@ public class DeleteMessageListener implements MailboxListener.GroupMailboxListen
                     .then(messageIdDAO.delete(mailboxId, metadata.getUid())))
                 .then(deleteAcl(mailboxId))
                 .then(applicableFlagDAO.delete(mailboxId))
+                .then(firstUnseenDAO.removeAll(mailboxId))
                 .block();
         }
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/DeleteMessageListener.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/DeleteMessageListener.java
@@ -1,0 +1,145 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra;
+
+import static org.apache.james.util.FunctionalUtils.negate;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
+import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentMessageIdDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentOwnerDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdToImapUidDAO;
+import org.apache.james.mailbox.cassandra.mail.MessageAttachmentRepresentation;
+import org.apache.james.mailbox.cassandra.mail.MessageRepresentation;
+import org.apache.james.mailbox.events.Event;
+import org.apache.james.mailbox.events.Group;
+import org.apache.james.mailbox.events.MailboxListener;
+import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
+import org.apache.james.mailbox.model.MessageMetaData;
+import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.mailbox.store.mail.MessageMapper;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class DeleteMessageListener implements MailboxListener.GroupMailboxListener {
+    private static final Optional<CassandraId> ALL_MAILBOXES = Optional.empty();
+
+    public static class DeleteMessageListenerGroup extends Group {
+
+    }
+
+    @Inject
+    public DeleteMessageListener(CassandraMessageIdToImapUidDAO imapUidDAO, CassandraMessageIdDAO messageIdDAO, CassandraMessageDAO messageDAO,
+                                 CassandraAttachmentDAOV2 attachmentDAO, CassandraAttachmentOwnerDAO ownerDAO,
+                                 CassandraAttachmentMessageIdDAO attachmentMessageIdDAO) {
+        this.imapUidDAO = imapUidDAO;
+        this.messageIdDAO = messageIdDAO;
+        this.messageDAO = messageDAO;
+        this.attachmentDAO = attachmentDAO;
+        this.ownerDAO = ownerDAO;
+        this.attachmentMessageIdDAO = attachmentMessageIdDAO;
+    }
+
+    private final CassandraMessageIdToImapUidDAO imapUidDAO;
+    private final CassandraMessageIdDAO messageIdDAO;
+    private final CassandraMessageDAO messageDAO;
+    private final CassandraAttachmentDAOV2 attachmentDAO;
+    private final CassandraAttachmentOwnerDAO ownerDAO;
+    private final CassandraAttachmentMessageIdDAO attachmentMessageIdDAO;
+
+    @Override
+    public Group getDefaultGroup() {
+        return new DeleteMessageListenerGroup();
+    }
+
+    @Override
+    public boolean isHandling(Event event) {
+        return event instanceof Expunged || event instanceof MailboxDeletion;
+    }
+
+    @Override
+    public void event(Event event) {
+        if (event instanceof Expunged) {
+            Expunged expunged = (Expunged) event;
+
+            Flux.fromIterable(expunged.getExpunged()
+                .values())
+                .map(MessageMetaData::getMessageId)
+                .map(CassandraMessageId.class::cast)
+                .concatMap(this::handleDeletion)
+                .then()
+                .block();
+        }
+        if (event instanceof MailboxDeletion) {
+            MailboxDeletion mailboxDeletion = (MailboxDeletion) event;
+
+            CassandraId mailboxId = (CassandraId) mailboxDeletion.getMailboxId();
+
+            messageIdDAO.retrieveMessages(mailboxId, MessageRange.all())
+                .map(ComposedMessageIdWithMetaData::getComposedMessageId)
+                .concatMap(metadata -> imapUidDAO.delete((CassandraMessageId) metadata.getMessageId(), mailboxId)
+                    .then(messageIdDAO.delete(mailboxId, metadata.getUid()))
+                    .then(handleDeletion((CassandraMessageId) metadata.getMessageId())))
+                .then()
+                .block();
+        }
+    }
+
+    private Mono<Void> handleDeletion(CassandraMessageId messageId) {
+        return Mono.just(messageId)
+            .filterWhen(this::isReferenced)
+            .flatMap(id -> readMessage(id)
+                .flatMap(this::deleteUnreferencedAttachments)
+                .then(messageDAO.delete(messageId)));
+    }
+
+    private Mono<MessageRepresentation> readMessage(CassandraMessageId id) {
+        return messageDAO.retrieveMessage(id, MessageMapper.FetchType.Metadata);
+    }
+
+    private Mono<Void> deleteUnreferencedAttachments(MessageRepresentation message) {
+        return Flux.fromIterable(message.getAttachments())
+            .filterWhen(attachment -> ownerDAO.retrieveOwners(attachment.getAttachmentId()).hasElements().map(negate()))
+            .filterWhen(attachment -> hasOtherMessagesReferences(message, attachment))
+            .concatMap(attachment -> attachmentDAO.delete(attachment.getAttachmentId()))
+            .then();
+    }
+
+    private Mono<Boolean> hasOtherMessagesReferences(MessageRepresentation message, MessageAttachmentRepresentation attachment) {
+        return attachmentMessageIdDAO.getOwnerMessageIds(attachment.getAttachmentId())
+            .filter(messageId -> !message.getMessageId().equals(messageId))
+            .hasElements()
+            .map(negate());
+    }
+
+    private Mono<Boolean> isReferenced(CassandraMessageId id) {
+        return imapUidDAO.retrieve(id, ALL_MAILBOXES)
+            .hasElements()
+            .map(negate());
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/DeleteMessageListener.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/DeleteMessageListener.java
@@ -36,6 +36,7 @@ import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentOwnerDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraDeletedMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraFirstUnseenDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxCounterDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxRecentsDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdToImapUidDAO;
@@ -73,13 +74,14 @@ public class DeleteMessageListener implements MailboxListener.GroupMailboxListen
     private final CassandraFirstUnseenDAO firstUnseenDAO;
     private final CassandraDeletedMessageDAO deletedMessageDAO;
     private final CassandraMailboxCounterDAO counterDAO;
+    private final CassandraMailboxRecentsDAO recentsDAO;
 
     @Inject
     public DeleteMessageListener(CassandraMessageIdToImapUidDAO imapUidDAO, CassandraMessageIdDAO messageIdDAO, CassandraMessageDAO messageDAO,
                                  CassandraAttachmentDAOV2 attachmentDAO, CassandraAttachmentOwnerDAO ownerDAO,
                                  CassandraAttachmentMessageIdDAO attachmentMessageIdDAO, CassandraACLMapper aclMapper,
                                  CassandraUserMailboxRightsDAO rightsDAO, CassandraApplicableFlagDAO applicableFlagDAO,
-                                 CassandraFirstUnseenDAO firstUnseenDAO, CassandraDeletedMessageDAO deletedMessageDAO, CassandraMailboxCounterDAO counterDAO) {
+                                 CassandraFirstUnseenDAO firstUnseenDAO, CassandraDeletedMessageDAO deletedMessageDAO, CassandraMailboxCounterDAO counterDAO, CassandraMailboxRecentsDAO recentsDAO) {
         this.imapUidDAO = imapUidDAO;
         this.messageIdDAO = messageIdDAO;
         this.messageDAO = messageDAO;
@@ -92,6 +94,7 @@ public class DeleteMessageListener implements MailboxListener.GroupMailboxListen
         this.firstUnseenDAO = firstUnseenDAO;
         this.deletedMessageDAO = deletedMessageDAO;
         this.counterDAO = counterDAO;
+        this.recentsDAO = recentsDAO;
     }
 
     @Override
@@ -132,6 +135,7 @@ public class DeleteMessageListener implements MailboxListener.GroupMailboxListen
                 .then(firstUnseenDAO.removeAll(mailboxId))
                 .then(deletedMessageDAO.removeAll(mailboxId))
                 .then(counterDAO.delete(mailboxId))
+                .then(recentsDAO.delete(mailboxId))
                 .block();
         }
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/DeleteMessageListener.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/DeleteMessageListener.java
@@ -29,6 +29,7 @@ import org.apache.james.mailbox.acl.ACLDiff;
 import org.apache.james.mailbox.cassandra.ids.CassandraId;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
 import org.apache.james.mailbox.cassandra.mail.CassandraACLMapper;
+import org.apache.james.mailbox.cassandra.mail.CassandraApplicableFlagDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentMessageIdDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentOwnerDAO;
@@ -65,11 +66,12 @@ public class DeleteMessageListener implements MailboxListener.GroupMailboxListen
     private final CassandraAttachmentMessageIdDAO attachmentMessageIdDAO;
     private final CassandraACLMapper aclMapper;
     private final CassandraUserMailboxRightsDAO rightsDAO;
+    private final CassandraApplicableFlagDAO applicableFlagDAO;
 
     @Inject
     public DeleteMessageListener(CassandraMessageIdToImapUidDAO imapUidDAO, CassandraMessageIdDAO messageIdDAO, CassandraMessageDAO messageDAO,
                                  CassandraAttachmentDAOV2 attachmentDAO, CassandraAttachmentOwnerDAO ownerDAO,
-                                 CassandraAttachmentMessageIdDAO attachmentMessageIdDAO, CassandraACLMapper aclMapper, CassandraUserMailboxRightsDAO rightsDAO) {
+                                 CassandraAttachmentMessageIdDAO attachmentMessageIdDAO, CassandraACLMapper aclMapper, CassandraUserMailboxRightsDAO rightsDAO, CassandraApplicableFlagDAO applicableFlagDAO) {
         this.imapUidDAO = imapUidDAO;
         this.messageIdDAO = messageIdDAO;
         this.messageDAO = messageDAO;
@@ -78,6 +80,7 @@ public class DeleteMessageListener implements MailboxListener.GroupMailboxListen
         this.attachmentMessageIdDAO = attachmentMessageIdDAO;
         this.aclMapper = aclMapper;
         this.rightsDAO = rightsDAO;
+        this.applicableFlagDAO = applicableFlagDAO;
     }
 
     @Override
@@ -114,6 +117,7 @@ public class DeleteMessageListener implements MailboxListener.GroupMailboxListen
                     .then(imapUidDAO.delete((CassandraMessageId) metadata.getMessageId(), mailboxId))
                     .then(messageIdDAO.delete(mailboxId, metadata.getUid())))
                 .then(deleteAcl(mailboxId))
+                .then(applicableFlagDAO.delete(mailboxId))
                 .block();
         }
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/DeleteMessageListener.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/DeleteMessageListener.java
@@ -55,6 +55,17 @@ import org.apache.james.mailbox.store.mail.MessageMapper;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+/**
+ * This listener cleans Cassandra metadata up. It retrieves dandling unreferenced metadata after the delete operation
+ * had been conducted out. Then it deletes the lower levels first so that upon failures undeleted metadata can still be
+ * reached.
+ *
+ * This cleanup is not needed for strict correctness from a MailboxManager point of view thus it could be carried out
+ * asynchronously, via mailbox listeners so that it can be retried.
+ *
+ * Mailbox listener failures lead to eventBus retrying their execution, it ensures the result of the deletion to be
+ * idempotent.
+ */
 public class DeleteMessageListener implements MailboxListener.GroupMailboxListener {
     private static final Optional<CassandraId> ALL_MAILBOXES = Optional.empty();
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/DeleteMessageListener.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/DeleteMessageListener.java
@@ -35,6 +35,7 @@ import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentMessageIdDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentOwnerDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraDeletedMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraFirstUnseenDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxCounterDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdToImapUidDAO;
@@ -71,13 +72,14 @@ public class DeleteMessageListener implements MailboxListener.GroupMailboxListen
     private final CassandraApplicableFlagDAO applicableFlagDAO;
     private final CassandraFirstUnseenDAO firstUnseenDAO;
     private final CassandraDeletedMessageDAO deletedMessageDAO;
+    private final CassandraMailboxCounterDAO counterDAO;
 
     @Inject
     public DeleteMessageListener(CassandraMessageIdToImapUidDAO imapUidDAO, CassandraMessageIdDAO messageIdDAO, CassandraMessageDAO messageDAO,
                                  CassandraAttachmentDAOV2 attachmentDAO, CassandraAttachmentOwnerDAO ownerDAO,
                                  CassandraAttachmentMessageIdDAO attachmentMessageIdDAO, CassandraACLMapper aclMapper,
                                  CassandraUserMailboxRightsDAO rightsDAO, CassandraApplicableFlagDAO applicableFlagDAO,
-                                 CassandraFirstUnseenDAO firstUnseenDAO, CassandraDeletedMessageDAO deletedMessageDAO) {
+                                 CassandraFirstUnseenDAO firstUnseenDAO, CassandraDeletedMessageDAO deletedMessageDAO, CassandraMailboxCounterDAO counterDAO) {
         this.imapUidDAO = imapUidDAO;
         this.messageIdDAO = messageIdDAO;
         this.messageDAO = messageDAO;
@@ -89,6 +91,7 @@ public class DeleteMessageListener implements MailboxListener.GroupMailboxListen
         this.applicableFlagDAO = applicableFlagDAO;
         this.firstUnseenDAO = firstUnseenDAO;
         this.deletedMessageDAO = deletedMessageDAO;
+        this.counterDAO = counterDAO;
     }
 
     @Override
@@ -128,6 +131,7 @@ public class DeleteMessageListener implements MailboxListener.GroupMailboxListen
                 .then(applicableFlagDAO.delete(mailboxId))
                 .then(firstUnseenDAO.removeAll(mailboxId))
                 .then(deletedMessageDAO.removeAll(mailboxId))
+                .then(counterDAO.delete(mailboxId))
                 .block();
         }
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/AttachmentLoader.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/AttachmentLoader.java
@@ -21,7 +21,9 @@ package org.apache.james.mailbox.cassandra.mail;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.mailbox.model.AttachmentMetadata;
+import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
@@ -41,9 +43,10 @@ public class AttachmentLoader {
         this.attachmentMapper = attachmentMapper;
     }
 
-    public Mono<MailboxMessage> addAttachmentToMessage(MessageRepresentation messageRepresentation, MessageMapper.FetchType fetchType) {
-        return loadAttachments(messageRepresentation.getAttachments().stream(), fetchType)
-            .map(messageRepresentation::toMailboxMessage);
+    public Mono<MailboxMessage> addAttachmentToMessage(Pair<ComposedMessageIdWithMetaData, MessageRepresentation> messageRepresentation,
+                                                       MessageMapper.FetchType fetchType) {
+        return loadAttachments(messageRepresentation.getRight().getAttachments().stream(), fetchType)
+            .map(attachments -> messageRepresentation.getRight().toMailboxMessage(messageRepresentation.getLeft(), attachments));
     }
 
     private Mono<List<MessageAttachmentMetadata>> loadAttachments(Stream<MessageAttachmentRepresentation> messageAttachmentRepresentations, MessageMapper.FetchType fetchType) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraACLMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraACLMapper.java
@@ -112,8 +112,7 @@ public class CassandraACLMapper {
 
     public Mono<MailboxACL> getACL(CassandraId cassandraId) {
         return getStoredACLRow(cassandraId)
-            .map(row -> getAcl(cassandraId, row))
-            .defaultIfEmpty(MailboxACL.EMPTY);
+            .map(row -> getAcl(cassandraId, row));
     }
 
     private MailboxACL getAcl(CassandraId cassandraId, Row row) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2.java
@@ -142,7 +142,7 @@ public class CassandraAttachmentDAOV2 {
     private PreparedStatement prepareDelete(Session session) {
         return session.prepare(
             QueryBuilder.delete().from(TABLE_NAME)
-                .where(eq(ID, bindMarker(ID))));
+                .where(eq(ID_AS_UUID, bindMarker(ID_AS_UUID))));
     }
 
     private PreparedStatement prepareInsert(Session session) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
@@ -227,10 +227,10 @@ public class CassandraMessageDAO {
 
     public Mono<MessageRepresentation> retrieveMessage(ComposedMessageIdWithMetaData id, FetchType fetchType) {
         CassandraMessageId cassandraMessageId = (CassandraMessageId) id.getComposedMessageId().getMessageId();
-        return retrieveMessage(fetchType, cassandraMessageId);
+        return retrieveMessage(cassandraMessageId, fetchType);
     }
 
-    private Mono<MessageRepresentation> retrieveMessage(FetchType fetchType, CassandraMessageId cassandraMessageId) {
+    public Mono<MessageRepresentation> retrieveMessage(CassandraMessageId cassandraMessageId, FetchType fetchType) {
         return retrieveRow(cassandraMessageId, fetchType)
                 .flatMap(resultSet -> message(resultSet, cassandraMessageId, fetchType));
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/MessageRepresentation.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/MessageRepresentation.java
@@ -22,14 +22,9 @@ package org.apache.james.mailbox.cassandra.mail;
 import java.util.Date;
 import java.util.List;
 
-import javax.mail.Flags;
 import javax.mail.util.SharedByteArrayInputStream;
 
-import org.apache.james.mailbox.MessageUid;
-import org.apache.james.mailbox.ModSeq;
-import org.apache.james.mailbox.model.ComposedMessageId;
 import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
-import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
@@ -41,58 +36,41 @@ public class MessageRepresentation {
     private final Long size;
     private final Integer bodySize;
     private final SharedByteArrayInputStream content;
-    private final Flags flags;
     private final PropertyBuilder propertyBuilder;
-    private final MailboxId mailboxId;
-    private final MessageUid messageUid;
-    private final ModSeq modSeq;
     private final boolean hasAttachment;
     private final List<MessageAttachmentRepresentation> attachments;
 
     public MessageRepresentation(MessageId messageId, Date internalDate, Long size, Integer bodySize, SharedByteArrayInputStream content,
-                                 Flags flags, PropertyBuilder propertyBuilder, MailboxId mailboxId, MessageUid messageUid, ModSeq modSeq,
-                                 boolean hasAttachment, List<MessageAttachmentRepresentation> attachments) {
+                                 PropertyBuilder propertyBuilder, boolean hasAttachment, List<MessageAttachmentRepresentation> attachments) {
         this.messageId = messageId;
         this.internalDate = internalDate;
         this.size = size;
         this.bodySize = bodySize;
         this.content = content;
-        this.flags = flags;
         this.propertyBuilder = propertyBuilder;
-        this.mailboxId = mailboxId;
-        this.messageUid = messageUid;
-        this.modSeq = modSeq;
         this.hasAttachment = hasAttachment;
         this.attachments = attachments;
     }
 
-    public SimpleMailboxMessage toMailboxMessage(List<MessageAttachmentMetadata> attachments) {
+    public SimpleMailboxMessage toMailboxMessage(ComposedMessageIdWithMetaData metadata, List<MessageAttachmentMetadata> attachments) {
         return SimpleMailboxMessage.builder()
             .messageId(messageId)
-            .mailboxId(mailboxId)
-            .uid(messageUid)
-            .modseq(modSeq)
+            .mailboxId(metadata.getComposedMessageId().getMailboxId())
+            .uid(metadata.getComposedMessageId().getUid())
+            .modseq(metadata.getModSeq())
             .internalDate(internalDate)
             .bodyStartOctet(bodySize)
             .size(size)
             .content(content)
-            .flags(flags)
+            .flags(metadata.getFlags())
             .propertyBuilder(propertyBuilder)
             .addAttachments(attachments)
             .hasAttachment(hasAttachment)
             .build();
     }
 
-    public MailboxId getMailboxId() {
-        return mailboxId;
-    }
-
     public MessageId getMessageId() {
         return messageId;
-    }
-
-    public ComposedMessageIdWithMetaData getMetadata() {
-        return new ComposedMessageIdWithMetaData(new ComposedMessageId(mailboxId, messageId, messageUid), flags, modSeq);
     }
 
     public SharedByteArrayInputStream getContent() {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/MailboxMergingTaskRunner.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/MailboxMergingTaskRunner.java
@@ -89,8 +89,12 @@ public class MailboxMergingTaskRunner {
 
     private void mergeRights(CassandraId oldMailboxId, CassandraId newMailboxId) {
         try {
-            MailboxACL oldAcl = cassandraACLMapper.getACL(oldMailboxId).block();
-            MailboxACL newAcl = cassandraACLMapper.getACL(newMailboxId).block();
+            MailboxACL oldAcl = cassandraACLMapper.getACL(oldMailboxId)
+                .defaultIfEmpty(MailboxACL.EMPTY)
+                .block();
+            MailboxACL newAcl = cassandraACLMapper.getACL(newMailboxId)
+                .defaultIfEmpty(MailboxACL.EMPTY)
+                .block();
             MailboxACL finalAcl = newAcl.union(oldAcl);
 
             cassandraACLMapper.setACL(newMailboxId, finalAcl);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerProvider.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerProvider.java
@@ -107,6 +107,7 @@ public class CassandraMailboxManagerProvider {
 
         eventBus.register(quotaUpdater);
         eventBus.register(new MailboxAnnotationListener(mapperFactory, sessionProvider));
+        eventBus.register(mapperFactory.deleteMessageListener());
 
         return manager;
     }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerTest.java
@@ -550,7 +550,7 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
         }
 
         @Test
-        void deleteMailboxShouldCleanupACLWhenRightDeleteFails(CassandraCluster cassandraCluster) throws Exception {
+        void deleteMailboxShouldCleanupACLWhenRightsDeleteFails(CassandraCluster cassandraCluster) throws Exception {
             mailboxManager.setRights(inboxId, new MailboxACL(
                 Pair.of(MailboxACL.EntryKey.createUserEntryKey(BOB), new MailboxACL.Rfc4314Rights(MailboxACL.Right.Read))), session);
 
@@ -654,7 +654,8 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
             mailboxManager.deleteMailbox(inbox, session);
 
             assertThat(deletedMessageDAO(cassandraCluster).retrieveDeletedMessage((CassandraId) inboxId, MessageRange.all())
-                .collectList().block())
+                    .collectList()
+                    .block())
                 .isEmpty();
         }
 
@@ -671,7 +672,8 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
             mailboxManager.deleteMailbox(inbox, session);
 
             assertThat(deletedMessageDAO(cassandraCluster).retrieveDeletedMessage((CassandraId) inboxId, MessageRange.all())
-                .collectList().block())
+                    .collectList()
+                    .block())
                 .isEmpty();
         }
 
@@ -683,7 +685,7 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
             mailboxManager.deleteMailbox(inbox, session);
 
             assertThat(countersDAO(cassandraCluster).retrieveMailboxCounters((CassandraId) inboxId)
-                .blockOptional())
+                    .blockOptional())
                 .isEmpty();
         }
 
@@ -699,7 +701,7 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
             mailboxManager.deleteMailbox(inbox, session);
 
             assertThat(countersDAO(cassandraCluster).retrieveMailboxCounters((CassandraId) inboxId)
-                .blockOptional())
+                    .blockOptional())
                 .isEmpty();
         }
 
@@ -712,7 +714,8 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
             mailboxManager.deleteMailbox(inbox, session);
 
             assertThat(new CassandraMailboxRecentsDAO(cassandraCluster.getConf()).getRecentMessageUidsInMailbox((CassandraId) inboxId)
-                .collectList().block())
+                    .collectList()
+                    .block())
                 .isEmpty();
         }
 
@@ -730,7 +733,8 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
             mailboxManager.deleteMailbox(inbox, session);
 
             assertThat(new CassandraMailboxRecentsDAO(cassandraCluster.getConf()).getRecentMessageUidsInMailbox((CassandraId) inboxId)
-                .collectList().block())
+                    .collectList()
+                    .block())
                 .isEmpty();
         }
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerTest.java
@@ -34,6 +34,7 @@ import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.cassandra.ids.CassandraId;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentDAOV2;
+import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentMessageIdDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraAttachmentOwnerDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
@@ -128,8 +129,12 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
 
                 softly.assertThat(attachmentDAO(cassandraCluster).getAttachment(attachmentId).blockOptional())
                     .isEmpty();
+
+                softly.assertThat(attachmentMessageIdDAO(cassandraCluster).getOwnerMessageIds(attachmentId).collectList().block())
+                    .doesNotContain(cassandraMessageId);
             });
         }
+
 
         @Test
         void deleteShouldUnreferenceMessageMetadata(CassandraCluster cassandraCluster) throws Exception {
@@ -153,6 +158,9 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
 
                 softly.assertThat(attachmentDAO(cassandraCluster).getAttachment(attachmentId).blockOptional())
                     .isEmpty();
+
+                softly.assertThat(attachmentMessageIdDAO(cassandraCluster).getOwnerMessageIds(attachmentId).collectList().block())
+                    .doesNotContain(cassandraMessageId);
             });
         }
 
@@ -187,6 +195,9 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
 
                 softly.assertThat(attachmentDAO(cassandraCluster).getAttachment(attachmentId).blockOptional())
                     .isPresent();
+
+                softly.assertThat(attachmentMessageIdDAO(cassandraCluster).getOwnerMessageIds(attachmentId).collectList().block())
+                    .contains(cassandraMessageId);
             });
         }
 
@@ -214,6 +225,9 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
 
                 softly.assertThat(attachmentDAO(cassandraCluster).getAttachment(attachmentId).blockOptional())
                     .isPresent();
+
+                softly.assertThat(attachmentMessageIdDAO(cassandraCluster).getOwnerMessageIds(attachmentId).collectList().block())
+                    .contains(cassandraMessageId);
             });
         }
 
@@ -248,6 +262,9 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
 
                 softly.assertThat(attachmentDAO(cassandraCluster).getAttachment(attachmentId).blockOptional())
                     .isPresent();
+
+                softly.assertThat(attachmentMessageIdDAO(cassandraCluster).getOwnerMessageIds(attachmentId).collectList().block())
+                    .doesNotContain(cassandraMessageId);
             });
         }
 
@@ -269,14 +286,20 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
 
             SoftAssertions.assertSoftly(softly -> {
                 CassandraMessageId cassandraMessageId = (CassandraMessageId) composedMessageId.getMessageId();
-                CassandraId mailboxId = (CassandraId) composedMessageId.getMailboxId();
 
                 softly.assertThat(messageDAO(cassandraCluster).retrieveMessage(cassandraMessageId, MessageMapper.FetchType.Metadata)
                     .blockOptional()).isEmpty();
 
                 softly.assertThat(attachmentDAO(cassandraCluster).getAttachment(attachmentId).blockOptional())
                     .isPresent();
+
+                softly.assertThat(attachmentMessageIdDAO(cassandraCluster).getOwnerMessageIds(attachmentId).collectList().block())
+                    .doesNotContain(cassandraMessageId);
             });
+        }
+
+        private CassandraAttachmentMessageIdDAO attachmentMessageIdDAO(CassandraCluster cassandraCluster) {
+            return new CassandraAttachmentMessageIdDAO(cassandraCluster.getConf(), new CassandraMessageId.Factory());
         }
 
         private CassandraAttachmentDAOV2 attachmentDAO(CassandraCluster cassandraCluster) {

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
@@ -80,6 +80,7 @@ public class CassandraTestSystemFixture {
             eventBus, annotationManager, storeRightManager, quotaComponents, index, MailboxManagerConfiguration.DEFAULT, PreDeletionHooks.NO_PRE_DELETION_HOOK);
 
         eventBus.register(new MailboxAnnotationListener(mapperFactory, sessionProvider));
+        eventBus.register(mapperFactory.deleteMessageListener());
 
         return cassandraMailboxManager;
     }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraACLMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraACLMapperTest.java
@@ -85,7 +85,7 @@ class CassandraACLMapperTest {
 
     @Test
     void retrieveACLWhenNoACLStoredShouldReturnEmptyACL() {
-        assertThat(cassandraACLMapper.getACL(MAILBOX_ID).block()).isEqualTo(MailboxACL.EMPTY);
+        assertThat(cassandraACLMapper.getACL(MAILBOX_ID).blockOptional()).isEmpty();
     }
 
     @Test
@@ -98,7 +98,7 @@ class CassandraACLMapperTest {
 
         cassandraACLMapper.delete(MAILBOX_ID).block();
 
-        assertThat(cassandraACLMapper.getACL(MAILBOX_ID).block()).isEqualTo(MailboxACL.EMPTY);
+        assertThat(cassandraACLMapper.getACL(MAILBOX_ID).blockOptional()).isEmpty();
     }
 
     @Test

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraApplicableFlagDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraApplicableFlagDAOTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.mailbox.cassandra.mail;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import javax.mail.Flags;
 
@@ -70,6 +71,21 @@ class CassandraApplicableFlagDAOTest {
 
         assertThat(testee.retrieveApplicableFlag(CASSANDRA_ID).block())
             .isEqualTo(new Flags(USER_FLAG));
+    }
+
+    @Test
+    void retrieveApplicableFlagShouldReturnEmptyWhenDeleted() {
+        testee.updateApplicableFlags(CASSANDRA_ID, ImmutableSet.of(USER_FLAG)).block();
+
+        testee.delete(CASSANDRA_ID).block();
+
+        assertThat(testee.retrieveApplicableFlag(CASSANDRA_ID).blockOptional())
+            .isEmpty();
+    }
+    @Test
+    void deleteShouldNotThrowWhenEmpty() {
+        assertThatCode(() -> testee.delete(CASSANDRA_ID).block())
+            .doesNotThrowAnyException();
     }
 
     @Test

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraApplicableFlagDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraApplicableFlagDAOTest.java
@@ -74,7 +74,7 @@ class CassandraApplicableFlagDAOTest {
     }
 
     @Test
-    void retrieveApplicableFlagShouldReturnEmptyWhenDeleted() {
+    void retrieveApplicableFlagsShouldReturnEmptyWhenDeleted() {
         testee.updateApplicableFlags(CASSANDRA_ID, ImmutableSet.of(USER_FLAG)).block();
 
         testee.delete(CASSANDRA_ID).block();

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2Test.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentDAOV2Test.java
@@ -81,10 +81,10 @@ class CassandraAttachmentDAOV2Test {
 
     @Test
     void getAttachmentShouldNotReturnDeletedAttachments() {
-        Attachment attachment = Attachment.builder()
+        AttachmentMetadata attachment = AttachmentMetadata.builder()
             .attachmentId(ATTACHMENT_ID)
             .type("application/json")
-            .bytes("{\"property\":`\"value\"}".getBytes(StandardCharsets.UTF_8))
+            .size(36)
             .build();
         BlobId blobId = BLOB_ID_FACTORY.from("blobId");
         DAOAttachment daoAttachment = CassandraAttachmentDAOV2.from(attachment, blobId);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraDeletedMessageDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraDeletedMessageDAOTest.java
@@ -84,8 +84,8 @@ class CassandraDeletedMessageDAOTest {
         testee.removeAll(MAILBOX_ID).block();
 
         List<MessageUid> result = testee.retrieveDeletedMessage(MAILBOX_ID, MessageRange.all())
-                .collectList()
-                .block();
+            .collectList()
+            .block();
 
         assertThat(result).isEmpty();
     }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraDeletedMessageDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraDeletedMessageDAOTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.mailbox.cassandra.mail;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.util.List;
 import java.util.UUID;
@@ -73,6 +74,25 @@ class CassandraDeletedMessageDAOTest {
                 .block();
 
         assertThat(result).containsExactly(UID_1, UID_2);
+    }
+
+    @Test
+    void retrieveDeletedMessageShouldNotReturnDeletedEntries() {
+        testee.addDeleted(MAILBOX_ID, UID_1).block();
+        testee.addDeleted(MAILBOX_ID, UID_2).block();
+
+        testee.removeAll(MAILBOX_ID).block();
+
+        List<MessageUid> result = testee.retrieveDeletedMessage(MAILBOX_ID, MessageRange.all())
+                .collectList()
+                .block();
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void removeAllShouldNotThrowWhenEmpty() {
+        assertThatCode(() -> testee.removeAll(MAILBOX_ID).block()).doesNotThrowAnyException();
     }
 
     @Test

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAOTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.mailbox.cassandra.mail;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
@@ -140,6 +141,22 @@ class CassandraMailboxCounterDAOTest {
                 .count(1L)
                 .unseen(1L)
                 .build());
+    }
+
+    @Test
+    void retrieveMailboxCounterShouldNotReturnDeletedItems() {
+        testee.incrementCount(MAILBOX_ID).block();
+        testee.incrementUnseen(MAILBOX_ID).block();
+
+        testee.delete(MAILBOX_ID).block();
+
+        assertThat(testee.retrieveMailboxCounters(MAILBOX_ID).blockOptional())
+            .isEmpty();
+    }
+
+    @Test
+    void deleteShouldNotThrowWhenNoData() {
+        assertThatCode(() -> testee.delete(MAILBOX_ID).block()).doesNotThrowAnyException();
     }
 
     @Test

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxRecentDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxRecentDAOTest.java
@@ -51,8 +51,8 @@ class CassandraMailboxRecentDAOTest {
     @Test
     void getRecentMessageUidsInMailboxShouldBeEmptyByDefault() {
         assertThat(testee.getRecentMessageUidsInMailbox(CASSANDRA_ID)
-            .collectList()
-            .block())
+                .collectList()
+                .block())
             .isEmpty();
     }
 
@@ -61,8 +61,8 @@ class CassandraMailboxRecentDAOTest {
         testee.addToRecent(CASSANDRA_ID, UID1).block();
 
         assertThat(testee.getRecentMessageUidsInMailbox(CASSANDRA_ID)
-            .collectList()
-            .block())
+                .collectList()
+                .block())
             .containsOnly(UID1);
     }
 
@@ -73,8 +73,8 @@ class CassandraMailboxRecentDAOTest {
         testee.removeFromRecent(CASSANDRA_ID, UID1).block();
 
         assertThat(testee.getRecentMessageUidsInMailbox(CASSANDRA_ID)
-            .collectList()
-            .block())
+                .collectList()
+                .block())
             .isEmpty();
     }
 
@@ -86,8 +86,8 @@ class CassandraMailboxRecentDAOTest {
         testee.delete(CASSANDRA_ID).block();
 
         assertThat(testee.getRecentMessageUidsInMailbox(CASSANDRA_ID)
-            .collectList()
-            .block())
+                .collectList()
+                .block())
             .isEmpty();
     }
 
@@ -101,8 +101,8 @@ class CassandraMailboxRecentDAOTest {
         testee.removeFromRecent(CASSANDRA_ID, UID1).block();
 
         assertThat(testee.getRecentMessageUidsInMailbox(CASSANDRA_ID)
-            .collectList()
-            .block())
+                .collectList()
+                .block())
             .isEmpty();
     }
 
@@ -113,8 +113,8 @@ class CassandraMailboxRecentDAOTest {
         testee.addToRecent(CASSANDRA_ID, UID2).block();
 
         assertThat(testee.getRecentMessageUidsInMailbox(CASSANDRA_ID)
-            .collectList()
-            .block())
+                .collectList()
+                .block())
             .containsOnly(UID1, UID2);
     }
 
@@ -126,8 +126,8 @@ class CassandraMailboxRecentDAOTest {
         testee.removeFromRecent(CASSANDRA_ID, UID2).block();
 
         assertThat(testee.getRecentMessageUidsInMailbox(CASSANDRA_ID)
-            .collectList()
-            .block())
+                .collectList()
+                .block())
             .containsOnly(UID1);
     }
 
@@ -151,8 +151,8 @@ class CassandraMailboxRecentDAOTest {
             .forEach(i -> testee.addToRecent(CASSANDRA_ID, MessageUid.of(i + 1)).block());
 
         assertThat(testee.getRecentMessageUidsInMailbox(CASSANDRA_ID)
-            .collectList()
-            .block())
+                .collectList()
+                .block())
             .hasSize(size);
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxRecentDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxRecentDAOTest.java
@@ -20,6 +20,7 @@
 package org.apache.james.mailbox.cassandra.mail;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.util.stream.IntStream;
 
@@ -75,6 +76,24 @@ class CassandraMailboxRecentDAOTest {
             .collectList()
             .block())
             .isEmpty();
+    }
+
+    @Test
+    void getRecentMessageUidsInMailboxShouldNotReturnDeletedItems() {
+        testee.addToRecent(CASSANDRA_ID, UID1).block();
+        testee.addToRecent(CASSANDRA_ID, UID2).block();
+
+        testee.delete(CASSANDRA_ID).block();
+
+        assertThat(testee.getRecentMessageUidsInMailbox(CASSANDRA_ID)
+            .collectList()
+            .block())
+            .isEmpty();
+    }
+
+    @Test
+    void deleteShouldNotThrowWhenNothing() {
+        assertThatCode(() -> testee.delete(CASSANDRA_ID).block()).doesNotThrowAnyException();
     }
 
     @Test

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraMailboxModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraMailboxModule.java
@@ -38,6 +38,7 @@ import org.apache.james.mailbox.SessionProvider;
 import org.apache.james.mailbox.SubscriptionManager;
 import org.apache.james.mailbox.cassandra.CassandraMailboxManager;
 import org.apache.james.mailbox.cassandra.CassandraMailboxSessionMapperFactory;
+import org.apache.james.mailbox.cassandra.DeleteMessageListener;
 import org.apache.james.mailbox.cassandra.ids.CassandraId;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
 import org.apache.james.mailbox.cassandra.mail.CassandraACLMapper;
@@ -192,9 +193,9 @@ public class CassandraMailboxModule extends AbstractModule {
 
         Multibinder.newSetBinder(binder(), MailboxManagerDefinition.class).addBinding().to(CassandraMailboxManagerDefinition.class);
 
-        Multibinder.newSetBinder(binder(), MailboxListener.GroupMailboxListener.class)
-            .addBinding()
-            .to(MailboxAnnotationListener.class);
+        Multibinder<MailboxListener.GroupMailboxListener> mailboxListeners = Multibinder.newSetBinder(binder(), MailboxListener.GroupMailboxListener.class);
+        mailboxListeners.addBinding().to(MailboxAnnotationListener.class);
+        mailboxListeners.addBinding().to(DeleteMessageListener.class);
 
         bind(MailboxManager.class).annotatedWith(Names.named(MAILBOXMANAGER_NAME)).to(MailboxManager.class);
     }

--- a/server/container/util/src/main/java/org/apache/james/util/FunctionalUtils.java
+++ b/server/container/util/src/main/java/org/apache/james/util/FunctionalUtils.java
@@ -19,6 +19,7 @@
 package org.apache.james.util;
 
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
@@ -35,6 +36,10 @@ public class FunctionalUtils {
             runnable.run();
             return argument;
         };
+    }
+
+    public static Function<Boolean, Boolean> negate() {
+        return b -> !b;
     }
 
     public static Predicate<Boolean> identityPredicate() {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/DefaultMailboxesProvisioner.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/DefaultMailboxesProvisioner.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.jmap.http;
 
+import static org.apache.james.util.FunctionalUtils.negate;
+
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -80,7 +82,7 @@ class DefaultMailboxesProvisioner {
     private Mono<Boolean> mailboxDoesntExist(MailboxPath mailboxPath, MailboxSession session) {
         try {
             return Mono.from(mailboxManager.mailboxExists(mailboxPath, session))
-                .map(x -> !x);
+                .map(negate());
         } catch (MailboxException e) {
             throw new RuntimeException(e);
         }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueView.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.queue.rabbitmq.view.cassandra;
 
+import static org.apache.james.util.FunctionalUtils.negate;
+
 import javax.inject.Inject;
 
 import org.apache.james.queue.api.ManageableMailQueue;
@@ -125,6 +127,6 @@ public class CassandraMailQueueView implements MailQueueView {
     @Override
     public Mono<Boolean> isPresent(EnqueueId id) {
         return cassandraMailQueueMailDelete.isDeleted(id, mailQueueName)
-                .map(bool -> !bool);
+                .map(negate());
     }
 }

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAO.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/DeletedMailsDAO.java
@@ -26,6 +26,7 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.DeletedMailTable.ENQUEUE_ID;
 import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.DeletedMailTable.QUEUE_NAME;
 import static org.apache.james.queue.rabbitmq.view.cassandra.CassandraMailQueueViewModule.DeletedMailTable.TABLE_NAME;
+import static org.apache.james.util.FunctionalUtils.negate;
 
 import javax.inject.Inject;
 
@@ -79,6 +80,6 @@ public class DeletedMailsDAO {
 
     Mono<Boolean> isStillEnqueued(MailQueueName mailQueueName, EnqueueId enqueueId) {
         return isDeleted(mailQueueName, enqueueId)
-            .map(b -> !b);
+            .map(negate());
     }
 }

--- a/src/adr/0029-Cassandra-mailbox-deletion-cleanup.md
+++ b/src/adr/0029-Cassandra-mailbox-deletion-cleanup.md
@@ -1,0 +1,44 @@
+# 29. Cassandra mailbox deletion cleanup
+
+Date: 2020-04-12
+
+## Status
+
+Accepted (lazy consensus)
+
+## Context
+
+Cassandra is used within distributed James product to hold messages and mailboxes metadata.
+
+Cassandra holds the following tables:
+ - mailboxPathV2 + mailbox allowing to retrieve mailboxes informations
+ - acl + UserMailboxACL hold denormalized information
+ - messageIdTable & imapUidTable allow to retrieve mailbox context information
+ - messageV2 table holds message metadata
+ - attachmentV2 holds attachments for messages
+ - References to these attachments are contained within the attachmentOwner and attachmentMessageId tables
+ 
+Currently, the deletion only deletes the first level of metadata. Lower level metadata stay unreachable. The data looks 
+deleted but references are actually still present.
+
+Concretely:
+ - Upon mailbox deletion, only mailboxPathV2 & mailbox content is deleted. messageIdTable, imapUidTable, messageV2, 
+ attachmentV2 & attachmentMessageId metadata are left undeleted.
+ - Upon mailbox deletion, acl + UserMailboxACL are not deleted.
+ - Upon message deletion, only messageIdTable & imapUidTable content are deleted. messageV2, attachmentV2 & 
+ attachmentMessageId metadata are left undeleted.
+
+This jeopardize efforts to regain disk space and privacy, for example through blobStore garbage collection.
+
+## Decision
+
+We need to cleanup Cassandra metadata. They can be retrieved from dandling metadata after the delete operation had been 
+conducted out. We need to delete the lower levels first so that upon failures undeleted metadata can still be reached.
+
+This cleanup is not needed for strict correctness from a MailboxManager point of view thus it could be carried out 
+asynchronously, via mailbox listeners so that it can be retried.
+
+## Consequences
+
+Mailbox listener failures lead to eventBus retrying their execution, we need to ensure the result of the deletion to be 
+idempotent. 


### PR DESCRIPTION
Cassandra is used within distributed James product to hold messages and mailboxes metadata.

Cassandra holds the following tables:
 - mailboxPathV2 + mailbox allowing to retrieve mailboxes informations
 - acl + UserMailboxACL holds denormalized information
 - messageIdTable & imapUidTable allows to retrieve mailbox context information
 - messageV2 table holds message matadata
 - attachmentV2 holds attachment for messages
 - References to these attachments are contained within the attachmentOwner and attachmentMessageId tables
 
Currently, the deletion only deletes the first level of metadata. Lower level metadata stay unreachable. The data looks 
deleted but references are actually still present.

Concretely:
 - Upon mailbox deletion, only mailboxPathV2 & mailbox content is deleted. messageIdTable, imapUidTable, messageV2, 
 attachmentV2 & attachmentMessageId metadata is left undeleted.
 - Upon mailbox deletion, acl + UserMailboxACL is not deleted.
 - Upon message deletion, only messageIdTable & imapUidTable content is deleted. messageV2, attachmentV2 & 
 attachmentMessageId metadata is left undeleted.

This jeopardize efforts to regain disk space and privacy, for example through blobStore garbage collection.

## Decision

We need to cleanup Cassandra metadata. They can be retrieved from dandling metadata after the delete operation had been 
conducted out. We need to delete the lower levels first so that upon failures undeleted metadata can still be reached.

This cleanup is not needed for strict correctness from a MailboxManager point of view thus it could be carried out 
asynchronously, via mailbox listeners so that it can be retried.

## Consequences

Mailbox listener failures leads to eventBus retrying their execution, we need to ensure the result of the deletion to be 
idempotent. This might have consequences on the blobStore garbage collection design.