### PR TITLE
JAMES-3142 API Segragation: UnitializedEventBus // EventBus

### DIFF
--- a/examples/custom-listeners/src/main/java/org/apache/james/examples/custom/listeners/SetCustomFlagOnBigMessages.java
+++ b/examples/custom-listeners/src/main/java/org/apache/james/examples/custom/listeners/SetCustomFlagOnBigMessages.java
@@ -35,6 +35,8 @@ import org.apache.james.mailbox.model.MessageRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Preconditions;
+
 /**
  * A Listener to determine the size of added messages.
  *
@@ -58,6 +60,7 @@ class SetCustomFlagOnBigMessages implements MailboxListener.GroupMailboxListener
 
     @Inject
     SetCustomFlagOnBigMessages(MailboxManager mailboxManager) {
+        Preconditions.checkNotNull(mailboxManager);
         this.mailboxManager = mailboxManager;
     }
 

--- a/examples/custom-listeners/src/test/java/org/apache/james/examples/custom/listeners/SetCustomFlagOnBigMessagesTest.java
+++ b/examples/custom-listeners/src/test/java/org/apache/james/examples/custom/listeners/SetCustomFlagOnBigMessagesTest.java
@@ -57,7 +57,6 @@ class SetCustomFlagOnBigMessagesTest {
     private static final Event.EventId RANDOM_EVENT_ID = Event.EventId.random();
     private static final MailboxPath INBOX_PATH = MailboxPath.inbox(USER);
 
-    private SetCustomFlagOnBigMessages testee;
     private MessageManager inboxMessageManager;
     private MailboxId inboxId;
     private MailboxSession mailboxSession;
@@ -65,15 +64,14 @@ class SetCustomFlagOnBigMessagesTest {
 
     @BeforeEach
     void beforeEach() throws Exception {
-        InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultResources();
+        InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultBuilder()
+            .registerListener((manager, messageIdManager) -> new SetCustomFlagOnBigMessages(manager))
+            .build();
+
         mailboxManager = resources.getMailboxManager();
         mailboxSession = MailboxSessionUtil.create(USER);
         inboxId = mailboxManager.createMailbox(INBOX_PATH, mailboxSession).get();
         inboxMessageManager = mailboxManager.getMailbox(inboxId, mailboxSession);
-
-        testee = new SetCustomFlagOnBigMessages(mailboxManager);
-
-        resources.getEventBus().register(testee);
     }
 
     @Test
@@ -138,7 +136,7 @@ class SetCustomFlagOnBigMessagesTest {
             .addMetaData(oneMBMetaData)
             .build();
 
-        testee.event(eventWithAFakeMessageSize);
+        new SetCustomFlagOnBigMessages(mailboxManager).event(eventWithAFakeMessageSize);
 
         assertThat(getMessageFlags(composedIdOfSmallMessage.getUid()))
             .allSatisfy(flags -> assertThat(flags.contains(BIG_MESSAGE)).isTrue());

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/events/EventBus.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/events/EventBus.java
@@ -19,8 +19,13 @@
 
 package org.apache.james.mailbox.events;
 
+import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 
+import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Mono;
@@ -46,7 +51,7 @@ public interface EventBus {
 
     Registration register(MailboxListener listener, RegistrationKey key);
 
-    Registration register(MailboxListener listener, Group group) throws GroupAlreadyRegistered;
+    void initialize(Map<Group, MailboxListener> listeners) throws GroupsAlreadyRegistered;
 
     Mono<Void> dispatch(Event event, Set<RegistrationKey> key);
 
@@ -56,7 +61,28 @@ public interface EventBus {
         return dispatch(event, ImmutableSet.of(key));
     }
 
-    default Registration register(MailboxListener.GroupMailboxListener groupMailboxListener) {
-        return register(groupMailboxListener, groupMailboxListener.getDefaultGroup());
+    /**
+     * @throws GroupsAlreadyRegistered when any initialize method had already been called
+     */
+    default void initialize(MailboxListener listener, Group group) throws GroupsAlreadyRegistered {
+        initialize(ImmutableMap.of(group, listener));
+    }
+
+    /**
+     * @throws GroupsAlreadyRegistered when any initialize method had already been called
+     */
+    default void initialize(MailboxListener.GroupMailboxListener... groupMailboxListeners) throws GroupsAlreadyRegistered {
+        initialize(ImmutableList.copyOf(groupMailboxListeners));
+    }
+
+    /**
+     * @throws GroupsAlreadyRegistered when any initialize method had already been called
+     */
+    default void initialize(Collection<MailboxListener.GroupMailboxListener> groupMailboxListeners) throws GroupsAlreadyRegistered {
+        Map<Group, MailboxListener> collect = groupMailboxListeners.stream()
+            .collect(Guavate.toImmutableMap(
+                MailboxListener.GroupMailboxListener::getDefaultGroup,
+                MailboxListener.class::cast));
+        initialize(collect);
     }
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/events/EventBus.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/events/EventBus.java
@@ -19,13 +19,8 @@
 
 package org.apache.james.mailbox.events;
 
-import java.util.Collection;
-import java.util.Map;
 import java.util.Set;
 
-import com.github.steveash.guavate.Guavate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Mono;
@@ -51,38 +46,11 @@ public interface EventBus {
 
     Registration register(MailboxListener listener, RegistrationKey key);
 
-    void initialize(Map<Group, MailboxListener> listeners) throws GroupsAlreadyRegistered;
-
     Mono<Void> dispatch(Event event, Set<RegistrationKey> key);
 
     Mono<Void> reDeliver(Group group, Event event);
 
     default Mono<Void> dispatch(Event event, RegistrationKey key) {
         return dispatch(event, ImmutableSet.of(key));
-    }
-
-    /**
-     * @throws GroupsAlreadyRegistered when any initialize method had already been called
-     */
-    default void initialize(MailboxListener listener, Group group) throws GroupsAlreadyRegistered {
-        initialize(ImmutableMap.of(group, listener));
-    }
-
-    /**
-     * @throws GroupsAlreadyRegistered when any initialize method had already been called
-     */
-    default void initialize(MailboxListener.GroupMailboxListener... groupMailboxListeners) throws GroupsAlreadyRegistered {
-        initialize(ImmutableList.copyOf(groupMailboxListeners));
-    }
-
-    /**
-     * @throws GroupsAlreadyRegistered when any initialize method had already been called
-     */
-    default void initialize(Collection<MailboxListener.GroupMailboxListener> groupMailboxListeners) throws GroupsAlreadyRegistered {
-        Map<Group, MailboxListener> collect = groupMailboxListeners.stream()
-            .collect(Guavate.toImmutableMap(
-                MailboxListener.GroupMailboxListener::getDefaultGroup,
-                MailboxListener.class::cast));
-        initialize(collect);
     }
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/events/GroupsAlreadyRegistered.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/events/GroupsAlreadyRegistered.java
@@ -19,15 +19,6 @@
 
 package org.apache.james.mailbox.events;
 
-public class GroupAlreadyRegistered extends RuntimeException {
-    private final Group group;
+public class GroupsAlreadyRegistered extends RuntimeException {
 
-    public GroupAlreadyRegistered(Group group) {
-        super(group.asString() + " is already Registered and thus can not be used.");
-        this.group = group;
-    }
-
-    public Group getGroup() {
-        return group;
-    }
 }

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/events/UninitializedEventBus.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/events/UninitializedEventBus.java
@@ -1,0 +1,56 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.events;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public interface UninitializedEventBus {
+    EventBus initialize(Map<Group, MailboxListener> listeners) throws GroupsAlreadyRegistered;
+
+    /**
+     * @throws GroupsAlreadyRegistered when any initialize method had already been called
+     */
+    default EventBus initialize(MailboxListener listener, Group group) throws GroupsAlreadyRegistered {
+        return initialize(ImmutableMap.of(group, listener));
+    }
+
+    /**
+     * @throws GroupsAlreadyRegistered when any initialize method had already been called
+     */
+    default EventBus initialize(MailboxListener.GroupMailboxListener... groupMailboxListeners) throws GroupsAlreadyRegistered {
+        return initialize(ImmutableList.copyOf(groupMailboxListeners));
+    }
+
+    /**
+     * @throws GroupsAlreadyRegistered when any initialize method had already been called
+     */
+    default EventBus initialize(Collection<MailboxListener.GroupMailboxListener> groupMailboxListeners) throws GroupsAlreadyRegistered {
+        Map<Group, MailboxListener> collect = groupMailboxListeners.stream()
+            .collect(Guavate.toImmutableMap(
+                MailboxListener.GroupMailboxListener::getDefaultGroup,
+                MailboxListener.class::cast));
+        return initialize(collect);
+    }
+}

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -120,9 +120,9 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
     protected abstract T provideMailboxManager();
 
-    protected abstract EventBus retrieveEventBus(T mailboxManager);
-
     protected abstract T provideMailboxManager(MailboxListener.GroupMailboxListener mailboxListener);
+
+    protected abstract EventBus retrieveEventBus(T mailboxManager);
 
     protected Set<PreDeletionHook> preDeletionHooks() {
         return ImmutableSet.of(preDeletionHook1, preDeletionHook2);

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -122,6 +122,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
     protected abstract EventBus retrieveEventBus(T mailboxManager);
 
+    protected abstract T provideMailboxManager(MailboxListener.GroupMailboxListener mailboxListener);
+
     protected Set<PreDeletionHook> preDeletionHooks() {
         return ImmutableSet.of(preDeletionHook1, preDeletionHook2);
     }
@@ -708,16 +710,15 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @BeforeEach
         void setUp() throws Exception {
+            groupListener = new EventCollector();
+            mailboxManager = provideMailboxManager(groupListener);
             session = mailboxManager.createSystemSession(USER_1);
             inbox = MailboxPath.inbox(session);
             newPath = MailboxPath.forUser(USER_1, "specialMailbox");
 
             listener = new EventCollector();
-            groupListener = new EventCollector();
             inboxId = mailboxManager.createMailbox(inbox, session).get();
             inboxManager = mailboxManager.getMailbox(inbox, session);
-
-            retrieveEventBus(mailboxManager).register(groupListener);
         }
 
         @Test
@@ -758,6 +759,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
 
         @Test
         void createMailboxShouldFireMailboxAddedEvent() throws Exception {
+            groupListener.reset(); //needed as setUp did lead to events being dispatched
+
             Optional<MailboxId> newId = mailboxManager.createMailbox(newPath, session);
 
             assertThat(groupListener.getEvents())

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/ErrorHandlingContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/ErrorHandlingContract.java
@@ -98,7 +98,7 @@ interface ErrorHandlingContract extends EventBusContract {
             .doCallRealMethod()
             .when(eventCollector).event(EVENT);
 
-        eventBus().register(eventCollector, GROUP_A);
+        eventBus().initialize(eventCollector, GROUP_A);
         eventBus().dispatch(EVENT, NO_KEYS).block();
 
         getSpeedProfile().shortWaitCondition()
@@ -120,7 +120,7 @@ interface ErrorHandlingContract extends EventBusContract {
             .doCallRealMethod()
             .when(eventCollector).event(EVENT);
 
-        eventBus().register(eventCollector, GROUP_A);
+        eventBus().initialize(eventCollector, GROUP_A);
         eventBus().dispatch(EVENT, NO_KEYS).block();
 
         getSpeedProfile().longWaitCondition()
@@ -144,7 +144,7 @@ interface ErrorHandlingContract extends EventBusContract {
             .doCallRealMethod()
             .when(eventCollector).event(EVENT);
 
-        eventBus().register(eventCollector, GROUP_A);
+        eventBus().initialize(eventCollector, GROUP_A);
         eventBus().dispatch(EVENT, NO_KEYS).block();
 
         TimeUnit.SECONDS.sleep(1);
@@ -156,7 +156,7 @@ interface ErrorHandlingContract extends EventBusContract {
     default void exceedingMaxRetriesShouldStopConsumingFailedEvent() throws Exception {
         ThrowingListener throwingListener = throwingListener();
 
-        eventBus().register(throwingListener, GROUP_A);
+        eventBus().initialize(throwingListener, GROUP_A);
         eventBus().dispatch(EVENT, NO_KEYS).block();
 
         Thread.sleep(getSpeedProfile().getLongWaitTime().toMillis());
@@ -171,7 +171,7 @@ interface ErrorHandlingContract extends EventBusContract {
     default void retriesBackOffShouldDelayByExponentialGrowth() throws Exception {
         ThrowingListener throwingListener = throwingListener();
 
-        eventBus().register(throwingListener, GROUP_A);
+        eventBus().initialize(throwingListener, GROUP_A);
         eventBus().dispatch(EVENT, NO_KEYS).block();
 
         Thread.sleep(getSpeedProfile().getLongWaitTime().toMillis());
@@ -209,7 +209,7 @@ interface ErrorHandlingContract extends EventBusContract {
             }
         };
 
-        eventBus().register(listener, GROUP_A);
+        eventBus().initialize(listener, GROUP_A);
         eventBus().dispatch(EVENT, NO_KEYS).block();
 
         getSpeedProfile().shortWaitCondition().until(successfulRetry::get);
@@ -252,7 +252,7 @@ interface ErrorHandlingContract extends EventBusContract {
             .doCallRealMethod()
             .when(eventCollector).event(EVENT);
 
-        eventBus().register(eventCollector, new EventBusTestFixture.GroupA());
+        eventBus().initialize(eventCollector, new EventBusTestFixture.GroupA());
         eventBus().dispatch(EVENT, NO_KEYS).block();
 
         getSpeedProfile().shortWaitCondition()
@@ -278,7 +278,7 @@ interface ErrorHandlingContract extends EventBusContract {
             .doCallRealMethod()
             .when(eventCollector).event(EVENT);
 
-        eventBus().register(eventCollector, GROUP_A);
+        eventBus().initialize(eventCollector, GROUP_A);
         eventBus().dispatch(EVENT, NO_KEYS).block();
 
         getSpeedProfile().longWaitCondition()
@@ -307,7 +307,7 @@ interface ErrorHandlingContract extends EventBusContract {
             .doCallRealMethod()
             .when(eventCollector).event(EVENT);
 
-        eventBus().register(eventCollector, GROUP_A);
+        eventBus().initialize(eventCollector, GROUP_A);
         eventBus().reDeliver(GROUP_A, EVENT).block();
 
         getSpeedProfile().longWaitCondition()
@@ -339,7 +339,7 @@ interface ErrorHandlingContract extends EventBusContract {
             .doCallRealMethod()
             .when(eventCollector).event(EVENT);
 
-        eventBus().register(eventCollector, GROUP_A);
+        eventBus().initialize(eventCollector, GROUP_A);
         eventBus().reDeliver(GROUP_A, EVENT).block();
 
         getSpeedProfile().longWaitCondition()
@@ -351,7 +351,7 @@ interface ErrorHandlingContract extends EventBusContract {
         EventCollector eventCollector = eventCollector();
         EventCollector eventCollector2 = eventCollector();
 
-        eventBus().register(eventCollector, GROUP_A);
+        eventBus().initialize(eventCollector, GROUP_A);
         eventBus().register(eventCollector2, KEY_1);
         eventBus().reDeliver(GROUP_A, EVENT).block();
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/EventBusConcurrentTestContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/EventBusConcurrentTestContract.java
@@ -37,6 +37,7 @@ import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 public interface EventBusConcurrentTestContract {
@@ -68,9 +69,10 @@ public interface EventBusConcurrentTestContract {
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener2 = newCountingListener();
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener3 = newCountingListener();
 
-            eventBus().register(countingListener1, new EventBusTestFixture.GroupA());
-            eventBus().register(countingListener2, new EventBusTestFixture.GroupB());
-            eventBus().register(countingListener3, new EventBusTestFixture.GroupC());
+            eventBus().initialize(ImmutableMap.of(
+                new GroupTest.GroupA(), countingListener1,
+                new GroupTest.GroupB(), countingListener2,
+                new GroupTest.GroupC(), countingListener3));
             int totalGlobalRegistrations = 3; // GroupA + GroupB + GroupC
 
             ConcurrentTestRunner.builder()
@@ -113,9 +115,10 @@ public interface EventBusConcurrentTestContract {
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener2 = newCountingListener();
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener3 = newCountingListener();
 
-            eventBus().register(countingListener1, new EventBusTestFixture.GroupA());
-            eventBus().register(countingListener2, new EventBusTestFixture.GroupB());
-            eventBus().register(countingListener3, new EventBusTestFixture.GroupC());
+            eventBus().initialize(ImmutableMap.of(
+                new GroupTest.GroupA(), countingListener1,
+                new GroupTest.GroupB(), countingListener2,
+                new GroupTest.GroupC(), countingListener3));
 
             int totalGlobalRegistrations = 3; // GroupA + GroupB + GroupC
             int totalEventDeliveredGlobally = totalGlobalRegistrations * TOTAL_DISPATCH_OPERATIONS;
@@ -148,13 +151,15 @@ public interface EventBusConcurrentTestContract {
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener2 = newCountingListener();
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener3 = newCountingListener();
 
-            eventBus().register(countingListener1, new EventBusTestFixture.GroupA());
-            eventBus().register(countingListener2, new EventBusTestFixture.GroupB());
-            eventBus().register(countingListener3, new EventBusTestFixture.GroupC());
+            eventBus().initialize(ImmutableMap.of(
+                new GroupTest.GroupA(), countingListener1,
+                new GroupTest.GroupB(), countingListener2,
+                new GroupTest.GroupC(), countingListener3));
 
-            eventBus2().register(countingListener1, new EventBusTestFixture.GroupA());
-            eventBus2().register(countingListener2, new EventBusTestFixture.GroupB());
-            eventBus2().register(countingListener3, new EventBusTestFixture.GroupC());
+            eventBus2().initialize(ImmutableMap.of(
+                new GroupTest.GroupA(), countingListener1,
+                new GroupTest.GroupB(), countingListener2,
+                new GroupTest.GroupC(), countingListener3));
 
             int totalGlobalRegistrations = 3; // GroupA + GroupB + GroupC
 
@@ -203,9 +208,10 @@ public interface EventBusConcurrentTestContract {
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener2 = newCountingListener();
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener3 = newCountingListener();
 
-            eventBus2().register(countingListener1, GROUP_A);
-            eventBus2().register(countingListener2, new EventBusTestFixture.GroupB());
-            eventBus2().register(countingListener3, new EventBusTestFixture.GroupC());
+            eventBus2().initialize(ImmutableMap.of(
+                GROUP_A, countingListener1,
+                new EventBusTestFixture.GroupB(), countingListener2,
+                new EventBusTestFixture.GroupC(), countingListener3));
             int totalGlobalRegistrations = 3; // GroupA + GroupB + GroupC
             int totalEventDeliveredGlobally = totalGlobalRegistrations * TOTAL_DISPATCH_OPERATIONS;
 

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/EventBusConcurrentTestContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/EventBusConcurrentTestContract.java
@@ -69,14 +69,14 @@ public interface EventBusConcurrentTestContract {
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener2 = newCountingListener();
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener3 = newCountingListener();
 
-            eventBus().initialize(ImmutableMap.of(
+            EventBus eventBus = eventBus().initialize(ImmutableMap.of(
                 new GroupTest.GroupA(), countingListener1,
                 new GroupTest.GroupB(), countingListener2,
                 new GroupTest.GroupC(), countingListener3));
             int totalGlobalRegistrations = 3; // GroupA + GroupB + GroupC
 
             ConcurrentTestRunner.builder()
-                .operation((threadNumber, operationNumber) -> eventBus().dispatch(EVENT, NO_KEYS).block())
+                .operation((threadNumber, operationNumber) -> eventBus.dispatch(EVENT, NO_KEYS).block())
                 .threadCount(THREAD_COUNT)
                 .operationCount(OPERATION_COUNT)
                 .runSuccessfullyWithin(FIVE_SECONDS);
@@ -91,15 +91,16 @@ public interface EventBusConcurrentTestContract {
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener1 = newCountingListener();
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener2 = newCountingListener();
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener3 = newCountingListener();
-            eventBus().register(countingListener1, KEY_1);
-            eventBus().register(countingListener2, KEY_2);
-            eventBus().register(countingListener3, KEY_3);
+            EventBus eventBus = eventBus().initialize();
+            eventBus.register(countingListener1, KEY_1);
+            eventBus.register(countingListener2, KEY_2);
+            eventBus.register(countingListener3, KEY_3);
 
             int totalKeyListenerRegistrations = 3; // KEY1 + KEY2 + KEY3
             int totalEventBus = 1;
 
             ConcurrentTestRunner.builder()
-                .operation((threadNumber, operationNumber) -> eventBus().dispatch(EVENT, ALL_KEYS).block())
+                .operation((threadNumber, operationNumber) -> eventBus.dispatch(EVENT, ALL_KEYS).block())
                 .threadCount(THREAD_COUNT)
                 .operationCount(OPERATION_COUNT)
                 .runSuccessfullyWithin(FIVE_SECONDS);
@@ -115,7 +116,7 @@ public interface EventBusConcurrentTestContract {
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener2 = newCountingListener();
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener3 = newCountingListener();
 
-            eventBus().initialize(ImmutableMap.of(
+            EventBus eventBus = eventBus().initialize(ImmutableMap.of(
                 new GroupTest.GroupA(), countingListener1,
                 new GroupTest.GroupB(), countingListener2,
                 new GroupTest.GroupC(), countingListener3));
@@ -123,14 +124,14 @@ public interface EventBusConcurrentTestContract {
             int totalGlobalRegistrations = 3; // GroupA + GroupB + GroupC
             int totalEventDeliveredGlobally = totalGlobalRegistrations * TOTAL_DISPATCH_OPERATIONS;
 
-            eventBus().register(countingListener1, KEY_1);
-            eventBus().register(countingListener2, KEY_2);
-            eventBus().register(countingListener3, KEY_3);
+            eventBus.register(countingListener1, KEY_1);
+            eventBus.register(countingListener2, KEY_2);
+            eventBus.register(countingListener3, KEY_3);
             int totalKeyListenerRegistrations = 3; // KEY1 + KEY2 + KEY3
             int totalEventDeliveredByKeys = totalKeyListenerRegistrations * TOTAL_DISPATCH_OPERATIONS;
 
             ConcurrentTestRunner.builder()
-                .operation((threadNumber, operationNumber) -> eventBus().dispatch(EVENT, ALL_KEYS).block())
+                .operation((threadNumber, operationNumber) -> eventBus.dispatch(EVENT, ALL_KEYS).block())
                 .threadCount(THREAD_COUNT)
                 .operationCount(OPERATION_COUNT)
                 .runSuccessfullyWithin(FIVE_SECONDS);
@@ -143,7 +144,7 @@ public interface EventBusConcurrentTestContract {
 
     interface MultiEventBusConcurrentContract extends EventBusContract.MultipleEventBusContract {
 
-        EventBus eventBus3();
+        UninitializedEventBus eventBus3();
 
         @Test
         default void concurrentDispatchGroupShouldDeliverAllEventsToListenersWithMultipleEventBus() throws Exception {
@@ -151,12 +152,12 @@ public interface EventBusConcurrentTestContract {
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener2 = newCountingListener();
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener3 = newCountingListener();
 
-            eventBus().initialize(ImmutableMap.of(
+            EventBus eventBus = eventBus().initialize(ImmutableMap.of(
                 new GroupTest.GroupA(), countingListener1,
                 new GroupTest.GroupB(), countingListener2,
                 new GroupTest.GroupC(), countingListener3));
 
-            eventBus2().initialize(ImmutableMap.of(
+            EventBus eventBus2 = eventBus2().initialize(ImmutableMap.of(
                 new GroupTest.GroupA(), countingListener1,
                 new GroupTest.GroupB(), countingListener2,
                 new GroupTest.GroupC(), countingListener3));
@@ -164,7 +165,7 @@ public interface EventBusConcurrentTestContract {
             int totalGlobalRegistrations = 3; // GroupA + GroupB + GroupC
 
             ConcurrentTestRunner.builder()
-                .operation((threadNumber, operationNumber) -> eventBus().dispatch(EVENT, NO_KEYS).block())
+                .operation((threadNumber, operationNumber) -> eventBus.dispatch(EVENT, NO_KEYS).block())
                 .threadCount(THREAD_COUNT)
                 .operationCount(OPERATION_COUNT)
                 .runSuccessfullyWithin(FIVE_SECONDS);
@@ -179,20 +180,22 @@ public interface EventBusConcurrentTestContract {
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener1 = newCountingListener();
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener2 = newCountingListener();
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener3 = newCountingListener();
+            EventBus eventBus = eventBus().initialize();
+            EventBus eventBus2 = eventBus2().initialize();
 
-            eventBus().register(countingListener1, KEY_1);
-            eventBus().register(countingListener2, KEY_2);
-            eventBus().register(countingListener3, KEY_3);
+            eventBus.register(countingListener1, KEY_1);
+            eventBus.register(countingListener2, KEY_2);
+            eventBus.register(countingListener3, KEY_3);
 
-            eventBus2().register(countingListener1, KEY_1);
-            eventBus2().register(countingListener2, KEY_2);
-            eventBus2().register(countingListener3, KEY_3);
+            eventBus2.register(countingListener1, KEY_1);
+            eventBus2.register(countingListener2, KEY_2);
+            eventBus2.register(countingListener3, KEY_3);
 
             int totalKeyListenerRegistrations = 3; // KEY1 + KEY2 + KEY3
             int totalEventBus = 2; // eventBus1 + eventBus2
 
             ConcurrentTestRunner.builder()
-                .operation((threadNumber, operationNumber) -> eventBus().dispatch(EVENT, ALL_KEYS).block())
+                .operation((threadNumber, operationNumber) -> eventBus.dispatch(EVENT, ALL_KEYS).block())
                 .threadCount(THREAD_COUNT)
                 .operationCount(OPERATION_COUNT)
                 .runSuccessfullyWithin(FIVE_SECONDS);
@@ -207,29 +210,31 @@ public interface EventBusConcurrentTestContract {
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener1 = newCountingListener();
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener2 = newCountingListener();
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener3 = newCountingListener();
-
-            eventBus2().initialize(ImmutableMap.of(
+            EventBus eventBus = eventBus().initialize();
+            EventBus eventBus2 =  eventBus2().initialize(ImmutableMap.of(
                 GROUP_A, countingListener1,
                 new EventBusTestFixture.GroupB(), countingListener2,
                 new EventBusTestFixture.GroupC(), countingListener3));
+            EventBus eventBus3 = eventBus3().initialize();
+
             int totalGlobalRegistrations = 3; // GroupA + GroupB + GroupC
             int totalEventDeliveredGlobally = totalGlobalRegistrations * TOTAL_DISPATCH_OPERATIONS;
 
-            eventBus().register(countingListener1, KEY_1);
-            eventBus().register(countingListener2, KEY_2);
+            eventBus.register(countingListener1, KEY_1);
+            eventBus.register(countingListener2, KEY_2);
 
-            eventBus2().register(countingListener1, KEY_1);
-            eventBus2().register(countingListener2, KEY_2);
+            eventBus2.register(countingListener1, KEY_1);
+            eventBus2.register(countingListener2, KEY_2);
 
-            eventBus3().register(countingListener3, KEY_1);
-            eventBus3().register(countingListener3, KEY_2);
+            eventBus3.register(countingListener3, KEY_1);
+            eventBus3.register(countingListener3, KEY_2);
 
             int totalKeyListenerRegistrations = 2; // KEY1 + KEY2
             int totalEventBus = 3; // eventBus1 + eventBus2 + eventBus3
             int totalEventDeliveredByKeys = totalKeyListenerRegistrations * totalEventBus * TOTAL_DISPATCH_OPERATIONS;
 
             ConcurrentTestRunner.builder()
-                .operation((threadNumber, operationNumber) -> eventBus().dispatch(EVENT, ALL_KEYS).block())
+                .operation((threadNumber, operationNumber) -> eventBus.dispatch(EVENT, ALL_KEYS).block())
                 .threadCount(THREAD_COUNT)
                 .operationCount(OPERATION_COUNT)
                 .runSuccessfullyWithin(FIVE_SECONDS);

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/EventBusContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/EventBusContract.java
@@ -61,8 +61,8 @@ public interface EventBusContract {
 
     interface MultipleEventBusContract extends EventBusContract {
 
-        EventBus eventBus2();
+        UninitializedEventBus eventBus2();
     }
 
-    EventBus eventBus();
+    UninitializedEventBus eventBus();
 }

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/KeyContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/KeyContract.java
@@ -56,6 +56,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+
 import reactor.core.scheduler.Schedulers;
 
 public interface KeyContract extends EventBusContract {
@@ -68,7 +69,8 @@ public interface KeyContract extends EventBusContract {
             AtomicInteger finishedExecutions = new AtomicInteger(0);
             AtomicBoolean rateExceeded = new AtomicBoolean(false);
 
-            eventBus().register(event -> {
+            EventBus eventBus = eventBus().initialize();
+            eventBus.register(event -> {
                 if (nbCalls.get() - finishedExecutions.get() > EventBus.EXECUTION_RATE) {
                     rateExceeded.set(true);
                 }
@@ -79,7 +81,7 @@ public interface KeyContract extends EventBusContract {
             }, KEY_1);
 
             IntStream.range(0, eventCount)
-                .forEach(i -> eventBus().dispatch(EVENT, KEY_1).block());
+                .forEach(i -> eventBus.dispatch(EVENT, KEY_1).block());
 
             getSpeedProfile().shortWaitCondition().atMost(org.awaitility.Duration.TEN_MINUTES)
                 .untilAsserted(() -> assertThat(finishedExecutions.get()).isEqualTo(eventCount));
@@ -88,23 +90,24 @@ public interface KeyContract extends EventBusContract {
 
         @Test
         default void notificationShouldDeliverASingleEventToAllListenersAtTheSameTime() {
+            EventBus eventBus = eventBus().initialize();
             CountDownLatch countDownLatch = new CountDownLatch(1);
             try {
                 ConcurrentLinkedQueue<String> threads = new ConcurrentLinkedQueue<>();
-                eventBus().register(event -> {
+                eventBus.register(event -> {
                     threads.add(Thread.currentThread().getName());
                     countDownLatch.await();
                 }, KEY_1);
-                eventBus().register(event -> {
+                eventBus.register(event -> {
                     threads.add(Thread.currentThread().getName());
                     countDownLatch.await();
                 }, KEY_1);
-                eventBus().register(event -> {
+                eventBus.register(event -> {
                     threads.add(Thread.currentThread().getName());
                     countDownLatch.await();
                 }, KEY_1);
 
-                eventBus().dispatch(EVENT, KEY_1).subscribeOn(Schedulers.elastic()).subscribe();
+                eventBus.dispatch(EVENT, KEY_1).subscribeOn(Schedulers.elastic()).subscribe();
 
 
                 getSpeedProfile().shortWaitCondition().atMost(org.awaitility.Duration.TEN_SECONDS)
@@ -119,12 +122,13 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void registeredListenersShouldNotReceiveNoopEvents() throws Exception {
             MailboxListener listener = newListener();
+            EventBus eventBus = eventBus().initialize();
 
-            eventBus().register(listener, KEY_1);
+            eventBus.register(listener, KEY_1);
 
             Username bob = Username.of("bob");
             MailboxListener.Added noopEvent = new MailboxListener.Added(MailboxSession.SessionId.of(18), bob, MailboxPath.forUser(bob, "mailbox"), TestId.of(58), ImmutableSortedMap.of(), Event.EventId.random());
-            eventBus().dispatch(noopEvent, KEY_1).block();
+            eventBus.dispatch(noopEvent, KEY_1).block();
 
             verify(listener, after(FIVE_HUNDRED_MS.toMillis()).never())
                 .event(any());
@@ -133,10 +137,11 @@ public interface KeyContract extends EventBusContract {
        @Test
         default void registeredListenersShouldReceiveOnlyHandledEvents() throws Exception {
             MailboxListener listener = newListener();
+           EventBus eventBus = eventBus().initialize();
 
-            eventBus().register(listener, KEY_1);
+            eventBus.register(listener, KEY_1);
 
-            eventBus().dispatch(EVENT_UNSUPPORTED_BY_LISTENER, KEY_1).block();
+            eventBus.dispatch(EVENT_UNSUPPORTED_BY_LISTENER, KEY_1).block();
 
             verify(listener, after(FIVE_HUNDRED_MS.toMillis()).never())
                 .event(any());
@@ -145,20 +150,22 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void dispatchShouldNotThrowWhenARegisteredListenerFails() throws Exception {
             MailboxListener listener = newListener();
+            EventBus eventBus = eventBus().initialize();
             doThrow(new RuntimeException()).when(listener).event(any());
 
-            eventBus().register(listener, KEY_1);
+            eventBus.register(listener, KEY_1);
 
-            assertThatCode(() -> eventBus().dispatch(EVENT, NO_KEYS).block())
+            assertThatCode(() -> eventBus.dispatch(EVENT, NO_KEYS).block())
                 .doesNotThrowAnyException();
         }
 
         @Test
         default void dispatchShouldNotNotifyRegisteredListenerWhenEmptyKeySet() throws Exception {
             MailboxListener listener = newListener();
-            eventBus().register(listener, KEY_1);
+            EventBus eventBus = eventBus().initialize();
+            eventBus.register(listener, KEY_1);
 
-            eventBus().dispatch(EVENT, NO_KEYS).block();
+            eventBus.dispatch(EVENT, NO_KEYS).block();
 
             verify(listener, after(FIVE_HUNDRED_MS.toMillis()).never())
                 .event(any());
@@ -167,9 +174,10 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void dispatchShouldNotNotifyListenerRegisteredOnOtherKeys() throws Exception {
             MailboxListener listener = newListener();
-            eventBus().register(listener, KEY_1);
+            EventBus eventBus = eventBus().initialize();
+            eventBus.register(listener, KEY_1);
 
-            eventBus().dispatch(EVENT, ImmutableSet.of(KEY_2)).block();
+            eventBus.dispatch(EVENT, ImmutableSet.of(KEY_2)).block();
 
             verify(listener, after(FIVE_HUNDRED_MS.toMillis()).never())
                 .event(any());
@@ -178,9 +186,10 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void dispatchShouldNotifyRegisteredListeners() throws Exception {
             MailboxListener listener = newListener();
-            eventBus().register(listener, KEY_1);
+            EventBus eventBus = eventBus().initialize();
+            eventBus.register(listener, KEY_1);
 
-            eventBus().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
+            eventBus.dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
             verify(listener, timeout(ONE_SECOND.toMillis()).times(1)).event(any());
         }
@@ -188,9 +197,10 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void dispatchShouldNotifyLocalRegisteredListenerWithoutDelay() throws Exception {
             MailboxListener listener = newListener();
-            eventBus().register(listener, KEY_1);
+            EventBus eventBus = eventBus().initialize();
+            eventBus.register(listener, KEY_1);
 
-            eventBus().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
+            eventBus.dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
             verify(listener, times(1)).event(any());
         }
@@ -199,10 +209,11 @@ public interface KeyContract extends EventBusContract {
         default void dispatchShouldNotifyOnlyRegisteredListener() throws Exception {
             MailboxListener listener = newListener();
             MailboxListener listener2 = newListener();
-            eventBus().register(listener, KEY_1);
-            eventBus().register(listener2, KEY_2);
+            EventBus eventBus = eventBus().initialize();
+            eventBus.register(listener, KEY_1);
+            eventBus.register(listener2, KEY_2);
 
-            eventBus().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
+            eventBus.dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
             verify(listener, timeout(ONE_SECOND.toMillis()).times(1)).event(any());
             verify(listener2, after(FIVE_HUNDRED_MS.toMillis()).never())
@@ -213,10 +224,11 @@ public interface KeyContract extends EventBusContract {
         default void dispatchShouldNotifyAllListenersRegisteredOnAKey() throws Exception {
             MailboxListener listener = newListener();
             MailboxListener listener2 = newListener();
-            eventBus().register(listener, KEY_1);
-            eventBus().register(listener2, KEY_1);
+            EventBus eventBus = eventBus().initialize();
+            eventBus.register(listener, KEY_1);
+            eventBus.register(listener2, KEY_1);
 
-            eventBus().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
+            eventBus.dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
             verify(listener, timeout(ONE_SECOND.toMillis()).times(1)).event(any());
             verify(listener2, timeout(ONE_SECOND.toMillis()).times(1)).event(any());
@@ -225,10 +237,11 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void registerShouldAllowDuplicatedRegistration() throws Exception {
             MailboxListener listener = newListener();
-            eventBus().register(listener, KEY_1);
-            eventBus().register(listener, KEY_1);
+            EventBus eventBus = eventBus().initialize();
+            eventBus.register(listener, KEY_1);
+            eventBus.register(listener, KEY_1);
 
-            eventBus().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
+            eventBus.dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
             verify(listener, timeout(ONE_SECOND.toMillis()).times(1)).event(any());
         }
@@ -236,10 +249,11 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void unregisterShouldRemoveDoubleRegisteredListener() throws Exception {
             MailboxListener listener = newListener();
-            eventBus().register(listener, KEY_1);
-            eventBus().register(listener, KEY_1).unregister();
+            EventBus eventBus = eventBus().initialize();
+            eventBus.register(listener, KEY_1);
+            eventBus.register(listener, KEY_1).unregister();
 
-            eventBus().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
+            eventBus.dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
             verify(listener, after(FIVE_HUNDRED_MS.toMillis()).never())
                 .event(any());
@@ -248,10 +262,11 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void registerShouldNotDispatchPastEvents() throws Exception {
             MailboxListener listener = newListener();
+            EventBus eventBus = eventBus().initialize();
 
-            eventBus().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
+            eventBus.dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
-            eventBus().register(listener, KEY_1);
+            eventBus.register(listener, KEY_1);
 
             verify(listener, after(FIVE_HUNDRED_MS.toMillis()).never())
                 .event(any());
@@ -260,11 +275,12 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void callingAllUnregisterMethodShouldUnregisterTheListener() throws Exception {
             MailboxListener listener = newListener();
-            Registration registration = eventBus().register(listener, KEY_1);
-            eventBus().register(listener, KEY_1).unregister();
+            EventBus eventBus = eventBus().initialize();
+            Registration registration = eventBus.register(listener, KEY_1);
+            eventBus.register(listener, KEY_1).unregister();
             registration.unregister();
 
-            eventBus().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
+            eventBus.dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
             verify(listener, after(FIVE_HUNDRED_MS.toMillis()).never())
                 .event(any());
@@ -273,10 +289,11 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void unregisterShouldHaveNotNotifyWhenCalledOnDifferentKeys() throws Exception {
             MailboxListener listener = newListener();
-            eventBus().register(listener, KEY_1);
-            eventBus().register(listener, KEY_2).unregister();
+            EventBus eventBus = eventBus().initialize();
+            eventBus.register(listener, KEY_1);
+            eventBus.register(listener, KEY_2).unregister();
 
-            eventBus().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
+            eventBus.dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
             verify(listener, timeout(ONE_SECOND.toMillis()).times(1)).event(any());
         }
@@ -284,8 +301,9 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void unregisterShouldBeIdempotentForKeyRegistrations() {
             MailboxListener listener = newListener();
+            EventBus eventBus = eventBus().initialize();
 
-            Registration registration = eventBus().register(listener, KEY_1);
+            Registration registration = eventBus.register(listener, KEY_1);
             registration.unregister();
 
             assertThatCode(registration::unregister)
@@ -295,9 +313,10 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void dispatchShouldAcceptSeveralKeys() throws Exception {
             MailboxListener listener = newListener();
-            eventBus().register(listener, KEY_1);
+            EventBus eventBus = eventBus().initialize();
+            eventBus.register(listener, KEY_1);
 
-            eventBus().dispatch(EVENT, ImmutableSet.of(KEY_1, KEY_2)).block();
+            eventBus.dispatch(EVENT, ImmutableSet.of(KEY_1, KEY_2)).block();
 
             verify(listener, timeout(ONE_SECOND.toMillis()).times(1)).event(any());
         }
@@ -305,10 +324,11 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void dispatchShouldCallListenerOnceWhenSeveralKeysMatching() throws Exception {
             MailboxListener listener = newListener();
-            eventBus().register(listener, KEY_1);
-            eventBus().register(listener, KEY_2);
+            EventBus eventBus = eventBus().initialize();
+            eventBus.register(listener, KEY_1);
+            eventBus.register(listener, KEY_2);
 
-            eventBus().dispatch(EVENT, ImmutableSet.of(KEY_1, KEY_2)).block();
+            eventBus.dispatch(EVENT, ImmutableSet.of(KEY_1, KEY_2)).block();
 
             verify(listener, timeout(ONE_SECOND.toMillis()).times(1)).event(any());
         }
@@ -316,9 +336,10 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void dispatchShouldNotNotifyUnregisteredListener() throws Exception {
             MailboxListener listener = newListener();
-            eventBus().register(listener, KEY_1).unregister();
+            EventBus eventBus = eventBus().initialize();
+            eventBus.register(listener, KEY_1).unregister();
 
-            eventBus().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
+            eventBus.dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
             verify(listener, after(FIVE_HUNDRED_MS.toMillis()).never())
                 .event(any());
@@ -329,9 +350,10 @@ public interface KeyContract extends EventBusContract {
         default void dispatchShouldNotifyAsynchronousListener() throws Exception {
             MailboxListener listener = newListener();
             when(listener.getExecutionMode()).thenReturn(MailboxListener.ExecutionMode.ASYNCHRONOUS);
-            eventBus().register(listener, KEY_1);
+            EventBus eventBus = eventBus().initialize();
+            eventBus.register(listener, KEY_1);
 
-            eventBus().dispatch(EVENT, KEY_1).block();
+            eventBus.dispatch(EVENT, KEY_1).block();
 
             verify(listener, after(FIVE_HUNDRED_MS.toMillis())).event(EVENT);
         }
@@ -339,6 +361,7 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void dispatchShouldNotBlockAsynchronousListener() throws Exception {
             MailboxListener listener = newListener();
+            EventBus eventBus = eventBus().initialize();
             when(listener.getExecutionMode()).thenReturn(MailboxListener.ExecutionMode.ASYNCHRONOUS);
             CountDownLatch latch = new CountDownLatch(1);
             doAnswer(invocation -> {
@@ -348,7 +371,7 @@ public interface KeyContract extends EventBusContract {
 
             assertTimeout(Duration.ofSeconds(2),
                 () -> {
-                    eventBus().dispatch(EVENT, NO_KEYS).block();
+                    eventBus.dispatch(EVENT, NO_KEYS).block();
                     latch.countDown();
                 });
         }
@@ -356,10 +379,12 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void failingRegisteredListenersShouldNotAbortRegisteredDelivery() {
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution listener = new EventBusTestFixture.EventMatcherThrowingListener(ImmutableSet.of(EVENT));
-            eventBus().register(listener, KEY_1);
 
-            eventBus().dispatch(EVENT, KEY_1).block();
-            eventBus().dispatch(EVENT_2, KEY_1).block();
+            EventBus eventBus = eventBus().initialize();
+            eventBus.register(listener, KEY_1);
+
+            eventBus.dispatch(EVENT, KEY_1).block();
+            eventBus.dispatch(EVENT_2, KEY_1).block();
 
             getSpeedProfile().shortWaitCondition()
                 .untilAsserted(() -> assertThat(listener.numberOfEventCalls()).isEqualTo(1));
@@ -368,15 +393,16 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void allRegisteredListenersShouldBeExecutedWhenARegisteredListenerFails() throws Exception {
             MailboxListener listener = newListener();
+            EventBus eventBus = eventBus().initialize();
 
             MailboxListener failingListener = mock(MailboxListener.class);
             when(failingListener.getExecutionMode()).thenReturn(MailboxListener.ExecutionMode.SYNCHRONOUS);
             doThrow(new RuntimeException()).when(failingListener).event(any());
 
-            eventBus().register(failingListener, KEY_1);
-            eventBus().register(listener, KEY_1);
+            eventBus.register(failingListener, KEY_1);
+            eventBus.register(listener, KEY_1);
 
-            eventBus().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
+            eventBus.dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
             verify(listener, timeout(ONE_SECOND.toMillis()).times(1)).event(any());
         }
@@ -387,10 +413,11 @@ public interface KeyContract extends EventBusContract {
         @Test
         default void crossEventBusRegistrationShouldBeAllowed() throws Exception {
             MailboxListener mailboxListener = newListener();
+            EventBus eventBus = eventBus().initialize();
 
-            eventBus().register(mailboxListener, KEY_1);
+            eventBus.register(mailboxListener, KEY_1);
 
-            eventBus2().dispatch(EVENT, KEY_1).block();
+            eventBus2().initialize().dispatch(EVENT, KEY_1).block();
 
             verify(mailboxListener, timeout(ONE_SECOND.toMillis()).times(1)).event(any());
         }
@@ -399,9 +426,9 @@ public interface KeyContract extends EventBusContract {
         default void unregisteredDistantListenersShouldNotBeNotified() throws Exception {
             MailboxListener mailboxListener = newListener();
 
-            eventBus().register(mailboxListener, KEY_1).unregister();
+            eventBus().initialize().register(mailboxListener, KEY_1).unregister();
 
-            eventBus2().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
+            eventBus2().initialize().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
             verify(mailboxListener, after(FIVE_HUNDRED_MS.toMillis()).never())
                 .event(any());
@@ -411,11 +438,13 @@ public interface KeyContract extends EventBusContract {
         default void allRegisteredListenersShouldBeDispatched() throws Exception {
             MailboxListener mailboxListener1 = newListener();
             MailboxListener mailboxListener2 = newListener();
+            EventBus eventBus = eventBus().initialize();
+            EventBus eventBus2 = eventBus2().initialize();
 
-            eventBus().register(mailboxListener1, KEY_1);
-            eventBus2().register(mailboxListener2, KEY_1);
+            eventBus.register(mailboxListener1, KEY_1);
+            eventBus2.register(mailboxListener2, KEY_1);
 
-            eventBus2().dispatch(EVENT, KEY_1).block();
+            eventBus2.dispatch(EVENT, KEY_1).block();
 
             verify(mailboxListener1, timeout(ONE_SECOND.toMillis()).times(1)).event(any());
             verify(mailboxListener2, timeout(ONE_SECOND.toMillis()).times(1)).event(any());
@@ -425,9 +454,9 @@ public interface KeyContract extends EventBusContract {
         default void registerShouldNotDispatchPastEventsInDistributedContext() throws Exception {
             MailboxListener listener = newListener();
 
-            eventBus2().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
+            eventBus2().initialize().dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
-            eventBus().register(listener, KEY_1);
+            eventBus().initialize().register(listener, KEY_1);
 
             verify(listener, after(FIVE_HUNDRED_MS.toMillis()).never())
                 .event(any());
@@ -437,11 +466,13 @@ public interface KeyContract extends EventBusContract {
         default void localDispatchedListenersShouldBeDispatchedWithoutDelay() throws Exception {
             MailboxListener mailboxListener1 = newListener();
             MailboxListener mailboxListener2 = newListener();
+            EventBus eventBus = eventBus().initialize();
+            EventBus eventBus2 = eventBus2().initialize();
 
-            eventBus().register(mailboxListener1, KEY_1);
-            eventBus2().register(mailboxListener2, KEY_1);
+            eventBus.register(mailboxListener1, KEY_1);
+            eventBus2.register(mailboxListener2, KEY_1);
 
-            eventBus2().dispatch(EVENT, KEY_1).block();
+            eventBus2.dispatch(EVENT, KEY_1).block();
 
             verify(mailboxListener2, times(1)).event(any());
             verify(mailboxListener1, timeout(ONE_SECOND.toMillis()).times(1)).event(any());

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/util/EventCollector.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/util/EventCollector.java
@@ -54,4 +54,8 @@ public class EventCollector implements MailboxListener.GroupMailboxListener {
         events.add(event);
     }
 
+    public void reset() {
+        events.clear();
+    }
+
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxManager.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxManager.java
@@ -27,7 +27,7 @@ import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxPathLocker;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.SessionProvider;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.store.MailboxManagerConfiguration;
@@ -59,7 +59,7 @@ public class CassandraMailboxManager extends StoreMailboxManager {
     @Inject
     public CassandraMailboxManager(CassandraMailboxSessionMapperFactory mapperFactory, SessionProvider sessionProvider,
                                    MailboxPathLocker locker, MessageParser messageParser,
-                                   MessageId.Factory messageIdFactory, EventBus eventBus,
+                                   MessageId.Factory messageIdFactory, EventBusSupplier eventBus,
                                    StoreMailboxAnnotationManager annotationManager, StoreRightManager storeRightManager,
                                    QuotaComponents quotaComponents, MessageSearchIndex index,
                                    MailboxManagerConfiguration configuration,
@@ -94,7 +94,7 @@ public class CassandraMailboxManager extends StoreMailboxManager {
     protected StoreMessageManager createMessageManager(Mailbox mailboxRow, MailboxSession session) {
         return new CassandraMessageManager(mapperFactory,
             getMessageSearchIndex(),
-            getEventBus(),
+            getEventBus().get(),
             this.locker,
             mailboxRow,
             getQuotaComponents().getQuotaManager(),

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraCombinationManagerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraCombinationManagerTest.java
@@ -21,6 +21,7 @@ package org.apache.james.mailbox.cassandra;
 
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.mailbox.cassandra.mail.MailboxAggregateModule;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.events.EventBusTestFixture;
 import org.apache.james.mailbox.events.InVMEventBus;
 import org.apache.james.mailbox.events.MemoryEventDeadLetters;
@@ -38,7 +39,10 @@ class CassandraCombinationManagerTest extends AbstractCombinationManagerTest {
     @Override
     public CombinationManagerTestSystem createTestingData() {
         InVMEventBus eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, new MemoryEventDeadLetters());
-        return CassandraCombinationManagerTestSystem.createTestingData(cassandraCluster.getCassandraCluster(), new NoQuotaManager(), eventBus);
+        EventBusSupplier eventBusSupplier = new EventBusSupplier(eventBus);
+        CombinationManagerTestSystem testingData = CassandraCombinationManagerTestSystem.createTestingData(cassandraCluster.getCassandraCluster(), new NoQuotaManager(), eventBusSupplier);
+        eventBusSupplier.initialize();
+        return testingData;
     }
     
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraCombinationManagerTestSystem.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraCombinationManagerTestSystem.java
@@ -20,11 +20,10 @@
 package org.apache.james.mailbox.cassandra;
 
 import org.apache.james.backends.cassandra.CassandraCluster;
-import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.MessageManager;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.MailboxNotFoundException;
 import org.apache.james.mailbox.model.Mailbox;
@@ -32,21 +31,22 @@ import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.quota.QuotaManager;
 import org.apache.james.mailbox.store.CombinationManagerTestSystem;
 import org.apache.james.mailbox.store.PreDeletionHooks;
+import org.apache.james.mailbox.store.StoreMailboxManager;
 
 public class CassandraCombinationManagerTestSystem extends CombinationManagerTestSystem {
 
     private final CassandraMailboxSessionMapperFactory mapperFactory;
     private final CassandraMailboxManager cassandraMailboxManager;
 
-    public static CombinationManagerTestSystem createTestingData(CassandraCluster cassandra, QuotaManager quotaManager, EventBus eventBus) {
+    public static CombinationManagerTestSystem createTestingData(CassandraCluster cassandra, QuotaManager quotaManager, EventBusSupplier eventBus) {
         CassandraMailboxSessionMapperFactory mapperFactory = CassandraTestSystemFixture.createMapperFactory(cassandra);
 
         return new CassandraCombinationManagerTestSystem(CassandraTestSystemFixture.createMessageIdManager(mapperFactory, quotaManager, eventBus, PreDeletionHooks.NO_PRE_DELETION_HOOK),
             mapperFactory,
-            CassandraTestSystemFixture.createMailboxManager(mapperFactory));
+            CassandraTestSystemFixture.createMailboxManager(mapperFactory, eventBus));
     }
 
-    private CassandraCombinationManagerTestSystem(MessageIdManager messageIdManager, CassandraMailboxSessionMapperFactory mapperFactory, MailboxManager cassandraMailboxManager) {
+    private CassandraCombinationManagerTestSystem(MessageIdManager messageIdManager, CassandraMailboxSessionMapperFactory mapperFactory, StoreMailboxManager cassandraMailboxManager) {
         super(cassandraMailboxManager, messageIdManager);
         this.mapperFactory = mapperFactory;
         this.cassandraMailboxManager = (CassandraMailboxManager) cassandraMailboxManager;

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerConsistencyTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerConsistencyTest.java
@@ -27,6 +27,7 @@ import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.cassandra.mail.MailboxAggregateModule;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.search.MailboxQuery;
@@ -41,6 +42,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.github.fge.lambdas.Throwing;
 import com.github.fge.lambdas.runnable.ThrowingRunnable;
+import com.google.common.collect.ImmutableList;
 
 class CassandraMailboxManagerConsistencyTest {
 
@@ -48,6 +50,7 @@ class CassandraMailboxManagerConsistencyTest {
     private static final String INBOX = "INBOX";
     private static final String INBOX_RENAMED = "INBOX_RENAMED";
     private static final int TRY_COUNT_BEFORE_FAILURE = 6;
+    public static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENER = ImmutableList.of();
 
     @RegisterExtension
     static CassandraClusterExtension cassandra = new CassandraClusterExtension(MailboxAggregateModule.MODULE_WITH_QUOTA);
@@ -63,7 +66,8 @@ class CassandraMailboxManagerConsistencyTest {
     void setUp(CassandraCluster cassandra) {
         testee = CassandraMailboxManagerProvider.provideMailboxManager(
             cassandra,
-            PreDeletionHooks.NO_PRE_DELETION_HOOK);
+            PreDeletionHooks.NO_PRE_DELETION_HOOK,
+            NO_ADDITIONAL_LISTENER);
 
         mailboxSession = testee.createSystemSession(USER);
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerProvider.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerProvider.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mailbox.cassandra;
 
+import java.util.List;
+
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.mailbox.acl.GroupMembershipResolver;
 import org.apache.james.mailbox.acl.MailboxACLResolver;
@@ -32,6 +34,7 @@ import org.apache.james.mailbox.cassandra.quota.CassandraPerUserMaxQuotaDao;
 import org.apache.james.mailbox.cassandra.quota.CassandraPerUserMaxQuotaManager;
 import org.apache.james.mailbox.events.EventBusTestFixture;
 import org.apache.james.mailbox.events.InVMEventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.events.MemoryEventDeadLetters;
 import org.apache.james.mailbox.events.delivery.InVmEventDelivery;
 import org.apache.james.mailbox.model.MessageId;
@@ -56,26 +59,29 @@ import org.apache.james.mailbox.store.search.SimpleMessageSearchIndex;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
 
 import com.datastax.driver.core.Session;
+import com.google.common.collect.ImmutableList;
 
 public class CassandraMailboxManagerProvider {
     private static final int LIMIT_ANNOTATIONS = 3;
     private static final int LIMIT_ANNOTATION_SIZE = 30;
 
     public static CassandraMailboxManager provideMailboxManager(CassandraCluster cassandra,
-                                                                PreDeletionHooks preDeletionHooks) {
+                                                                PreDeletionHooks preDeletionHooks,
+                                                                List<MailboxListener.GroupMailboxListener> additionalListeners) {
         CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
 
         CassandraMailboxSessionMapperFactory mapperFactory = TestCassandraMailboxSessionMapperFactory.forTests(
             cassandra,
             messageIdFactory);
 
-        return provideMailboxManager(cassandra.getConf(), preDeletionHooks, mapperFactory, messageIdFactory);
+        return provideMailboxManager(cassandra.getConf(), preDeletionHooks, mapperFactory, messageIdFactory, additionalListeners);
     }
 
     private static CassandraMailboxManager provideMailboxManager(Session session,
-                                                                PreDeletionHooks preDeletionHooks,
-                                                                CassandraMailboxSessionMapperFactory mapperFactory,
-                                                                MessageId.Factory messageIdFactory) {
+                                                                 PreDeletionHooks preDeletionHooks,
+                                                                 CassandraMailboxSessionMapperFactory mapperFactory,
+                                                                 MessageId.Factory messageIdFactory,
+                                                                 List<MailboxListener.GroupMailboxListener> additionalListeners) {
         MailboxACLResolver aclResolver = new UnionMailboxACLResolver();
         GroupMembershipResolver groupMembershipResolver = new SimpleGroupMembershipResolver();
         MessageParser messageParser = new MessageParser();
@@ -103,8 +109,11 @@ public class CassandraMailboxManagerProvider {
             messageParser, messageIdFactory, eventBus, annotationManager, storeRightManager,
             quotaComponents, index, MailboxManagerConfiguration.DEFAULT, preDeletionHooks);
 
-        eventBus.register(quotaUpdater);
-        eventBus.register(new MailboxAnnotationListener(mapperFactory, sessionProvider));
+        eventBus.initialize(ImmutableList.<MailboxListener.GroupMailboxListener>builder()
+                .add(quotaUpdater)
+                .add(new MailboxAnnotationListener(mapperFactory, sessionProvider))
+                .addAll(additionalListeners)
+                .build());
 
         return manager;
     }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerStressTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerStressTest.java
@@ -45,7 +45,7 @@ class CassandraMailboxManagerStressTest implements MailboxManagerStressContract<
 
     @Override
     public EventBus retrieveEventBus() {
-        return mailboxManager.getEventBus();
+        return mailboxManager.getEventBus().get();
     }
 
     @BeforeEach

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerStressTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerStressTest.java
@@ -23,11 +23,15 @@ import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.mailbox.MailboxManagerStressContract;
 import org.apache.james.mailbox.cassandra.mail.MailboxAggregateModule;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.store.PreDeletionHooks;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.google.common.collect.ImmutableList;
+
 class CassandraMailboxManagerStressTest implements MailboxManagerStressContract<CassandraMailboxManager> {
+    private static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENERS = ImmutableList.of();
 
     @RegisterExtension
     static CassandraClusterExtension cassandra = new CassandraClusterExtension(MailboxAggregateModule.MODULE_WITH_QUOTA);
@@ -48,6 +52,7 @@ class CassandraMailboxManagerStressTest implements MailboxManagerStressContract<
     void setUp() {
         this.mailboxManager = CassandraMailboxManagerProvider.provideMailboxManager(
             cassandra.getCassandraCluster(),
-            PreDeletionHooks.NO_PRE_DELETION_HOOK);
+            PreDeletionHooks.NO_PRE_DELETION_HOOK,
+            NO_ADDITIONAL_LISTENERS);
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerTest.java
@@ -53,6 +53,6 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
 
     @Override
     protected EventBus retrieveEventBus(CassandraMailboxManager mailboxManager) {
-        return mailboxManager.getEventBus();
+        return mailboxManager.getEventBus().get();
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerTest.java
@@ -22,11 +22,16 @@ import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.mailbox.MailboxManagerTest;
 import org.apache.james.mailbox.cassandra.mail.MailboxAggregateModule;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.store.PreDeletionHooks;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.google.common.collect.ImmutableList;
+
 public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMailboxManager> {
+    private static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENERS = ImmutableList.of();
+
     @RegisterExtension
     static CassandraClusterExtension cassandra = new CassandraClusterExtension(MailboxAggregateModule.MODULE_WITH_QUOTA);
 
@@ -34,7 +39,16 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
     protected CassandraMailboxManager provideMailboxManager() {
         return CassandraMailboxManagerProvider.provideMailboxManager(
             cassandra.getCassandraCluster(),
-            new PreDeletionHooks(preDeletionHooks(), new RecordingMetricFactory()));
+            new PreDeletionHooks(preDeletionHooks(), new RecordingMetricFactory()),
+            NO_ADDITIONAL_LISTENERS);
+    }
+
+    @Override
+    protected CassandraMailboxManager provideMailboxManager(MailboxListener.GroupMailboxListener listener) {
+        return CassandraMailboxManagerProvider.provideMailboxManager(
+            cassandra.getCassandraCluster(),
+            new PreDeletionHooks(preDeletionHooks(), new RecordingMetricFactory()),
+            ImmutableList.of(listener));
     }
 
     @Override

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerSideEffectTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerSideEffectTest.java
@@ -23,7 +23,8 @@ import java.util.Set;
 
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.mailbox.cassandra.mail.MailboxAggregateModule;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
+import org.apache.james.mailbox.events.UninitializedEventBus;
 import org.apache.james.mailbox.extension.PreDeletionHook;
 import org.apache.james.mailbox.quota.QuotaManager;
 import org.apache.james.mailbox.store.AbstractMessageIdManagerSideEffectTest;
@@ -36,7 +37,10 @@ class CassandraMessageIdManagerSideEffectTest extends AbstractMessageIdManagerSi
     static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(MailboxAggregateModule.MODULE);
 
     @Override
-    protected MessageIdManagerTestSystem createTestSystem(QuotaManager quotaManager, EventBus eventBus, Set<PreDeletionHook> preDeletionHooks) {
-        return CassandraMessageIdManagerTestSystem.createTestingData(cassandraCluster.getCassandraCluster(), quotaManager, eventBus, preDeletionHooks);
+    protected MessageIdManagerTestSystem createTestSystem(QuotaManager quotaManager, UninitializedEventBus eventBus, Set<PreDeletionHook> preDeletionHooks) throws Exception {
+        EventBusSupplier eventBusSupplier = new EventBusSupplier(eventBus);
+        eventBusSupplier.initialize();
+        return CassandraMessageIdManagerTestSystem.createTestingData(cassandraCluster.getCassandraCluster(), quotaManager,
+            eventBusSupplier, preDeletionHooks);
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerStorageTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerStorageTest.java
@@ -21,6 +21,7 @@ package org.apache.james.mailbox.cassandra;
 
 import org.apache.james.backends.cassandra.CassandraClusterExtension;
 import org.apache.james.mailbox.cassandra.mail.MailboxAggregateModule;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.events.EventBusTestFixture;
 import org.apache.james.mailbox.events.InVMEventBus;
 import org.apache.james.mailbox.events.MemoryEventDeadLetters;
@@ -39,6 +40,8 @@ class CassandraMessageIdManagerStorageTest extends AbstractMessageIdManagerStora
     @Override
     protected MessageIdManagerTestSystem createTestingData() {
         InVMEventBus eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, new MemoryEventDeadLetters());
-        return CassandraMessageIdManagerTestSystem.createTestingData(cassandraCluster.getCassandraCluster(), new NoQuotaManager(), eventBus, PreDeletionHook.NO_PRE_DELETION_HOOK);
+        EventBusSupplier eventBusSupplier = new EventBusSupplier(eventBus);
+        eventBusSupplier.initialize();
+        return CassandraMessageIdManagerTestSystem.createTestingData(cassandraCluster.getCassandraCluster(), new NoQuotaManager(), eventBusSupplier, PreDeletionHook.NO_PRE_DELETION_HOOK);
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerTestSystem.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerTestSystem.java
@@ -29,6 +29,7 @@ import org.apache.james.mailbox.quota.CurrentQuotaManager;
 import org.apache.james.mailbox.quota.QuotaManager;
 import org.apache.james.mailbox.store.MessageIdManagerTestSystem;
 import org.apache.james.mailbox.store.PreDeletionHooks;
+import org.apache.james.mailbox.store.event.MailboxAnnotationListener;
 import org.apache.james.mailbox.store.quota.ListeningCurrentQuotaUpdater;
 import org.apache.james.mailbox.store.quota.StoreCurrentQuotaManager;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
@@ -39,10 +40,14 @@ class CassandraMessageIdManagerTestSystem {
                                                         Set<PreDeletionHook> preDeletionHooks) {
         CassandraMailboxSessionMapperFactory mapperFactory = CassandraTestSystemFixture.createMapperFactory(cassandra);
 
+        CassandraMailboxManager mailboxManager = CassandraTestSystemFixture.createMailboxManager(mapperFactory);
+
+        mailboxManager.getEventBus().initialize(new MailboxAnnotationListener(mapperFactory, mailboxManager));
+
         return new MessageIdManagerTestSystem(CassandraTestSystemFixture.createMessageIdManager(mapperFactory, quotaManager, eventBus, new PreDeletionHooks(preDeletionHooks, new RecordingMetricFactory())),
             new CassandraMessageId.Factory(),
             mapperFactory,
-            CassandraTestSystemFixture.createMailboxManager(mapperFactory)) {
+            mailboxManager) {
         };
     }
 
@@ -53,7 +58,11 @@ class CassandraMessageIdManagerTestSystem {
         ListeningCurrentQuotaUpdater listeningCurrentQuotaUpdater = new ListeningCurrentQuotaUpdater(
             (StoreCurrentQuotaManager) currentQuotaManager,
             mailboxManager.getQuotaComponents().getQuotaRootResolver(), mailboxManager.getEventBus(), quotaManager);
-        mailboxManager.getEventBus().register(listeningCurrentQuotaUpdater);
+
+        mailboxManager.getEventBus().initialize(
+            listeningCurrentQuotaUpdater,
+            new MailboxAnnotationListener(mapperFactory, mailboxManager));
+
         return new MessageIdManagerTestSystem(CassandraTestSystemFixture.createMessageIdManager(mapperFactory, quotaManager, mailboxManager.getEventBus(),
             PreDeletionHooks.NO_PRE_DELETION_HOOK),
             new CassandraMessageId.Factory(),

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerTestSystem.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMessageIdManagerTestSystem.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 import org.apache.james.backends.cassandra.CassandraCluster;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.extension.PreDeletionHook;
 import org.apache.james.mailbox.quota.CurrentQuotaManager;
 import org.apache.james.mailbox.quota.QuotaManager;
@@ -36,7 +36,7 @@ import org.apache.james.metrics.tests.RecordingMetricFactory;
 
 class CassandraMessageIdManagerTestSystem {
 
-    static MessageIdManagerTestSystem createTestingData(CassandraCluster cassandra, QuotaManager quotaManager, EventBus eventBus,
+    static MessageIdManagerTestSystem createTestingData(CassandraCluster cassandra, QuotaManager quotaManager, EventBusSupplier eventBus,
                                                         Set<PreDeletionHook> preDeletionHooks) {
         CassandraMailboxSessionMapperFactory mapperFactory = CassandraTestSystemFixture.createMapperFactory(cassandra);
 
@@ -63,8 +63,8 @@ class CassandraMessageIdManagerTestSystem {
             listeningCurrentQuotaUpdater,
             new MailboxAnnotationListener(mapperFactory, mailboxManager));
 
-        return new MessageIdManagerTestSystem(CassandraTestSystemFixture.createMessageIdManager(mapperFactory, quotaManager, mailboxManager.getEventBus(),
-            PreDeletionHooks.NO_PRE_DELETION_HOOK),
+        return new MessageIdManagerTestSystem(
+            CassandraTestSystemFixture.createMessageIdManager(mapperFactory, quotaManager, mailboxManager.getEventBus(), PreDeletionHooks.NO_PRE_DELETION_HOOK),
             new CassandraMessageId.Factory(),
             mapperFactory,
             mailboxManager);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraTestSystemFixture.java
@@ -73,18 +73,18 @@ class CassandraTestSystemFixture {
 
         QuotaComponents quotaComponents = QuotaComponents.disabled(sessionProvider, mapperFactory);
         MessageSearchIndex index = new SimpleMessageSearchIndex(mapperFactory, mapperFactory, new DefaultTextExtractor());
-        CassandraMailboxManager cassandraMailboxManager = new CassandraMailboxManager(mapperFactory, sessionProvider,
+
+        return new CassandraMailboxManager(mapperFactory, sessionProvider,
             new NoMailboxPathLocker(), new MessageParser(), new CassandraMessageId.Factory(),
             eventBus, annotationManager, storeRightManager, quotaComponents, index, MailboxManagerConfiguration.DEFAULT, PreDeletionHooks.NO_PRE_DELETION_HOOK);
-
-        eventBus.register(new MailboxAnnotationListener(mapperFactory, sessionProvider));
-
-        return cassandraMailboxManager;
     }
 
     static StoreMessageIdManager createMessageIdManager(CassandraMailboxSessionMapperFactory mapperFactory, QuotaManager quotaManager, EventBus eventBus,
                                                         PreDeletionHooks preDeletionHooks) {
         CassandraMailboxManager mailboxManager = createMailboxManager(mapperFactory);
+
+        mailboxManager.getEventBus().initialize(new MailboxAnnotationListener(mapperFactory, mailboxManager));
+
         return new StoreMessageIdManager(
             mailboxManager,
             mapperFactory,

--- a/mailbox/event/event-memory/src/main/java/org/apache/james/mailbox/events/InVMEventBus.java
+++ b/mailbox/event/event-memory/src/main/java/org/apache/james/mailbox/events/InVMEventBus.java
@@ -39,7 +39,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
-public class InVMEventBus implements EventBus {
+public class InVMEventBus implements EventBus, UninitializedEventBus {
 
     private final Multimap<RegistrationKey, MailboxListener> registrations;
     private final ConcurrentHashMap<Group, MailboxListener> groups;
@@ -65,13 +65,14 @@ public class InVMEventBus implements EventBus {
     }
 
     @Override
-    public void initialize(Map<Group, MailboxListener> listeners) throws GroupsAlreadyRegistered {
+    public InVMEventBus initialize(Map<Group, MailboxListener> listeners) throws GroupsAlreadyRegistered {
         synchronized (groups) {
             if (initialized) {
                 throw new GroupsAlreadyRegistered();
             }
             groups.putAll(listeners);
             initialized = true;
+            return this;
         }
     }
 

--- a/mailbox/event/event-memory/src/test/java/org/apache/james/mailbox/events/InVMEventBusTest.java
+++ b/mailbox/event/event-memory/src/test/java/org/apache/james/mailbox/events/InVMEventBusTest.java
@@ -42,7 +42,7 @@ public class InVMEventBusTest implements KeyContract.SingleEventBusKeyContract, 
     }
 
     @Override
-    public EventBus eventBus() {
+    public UninitializedEventBus eventBus() {
         return eventBus;
     }
 

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupRegistrationHandler.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupRegistrationHandler.java
@@ -58,11 +58,11 @@ class GroupRegistrationHandler {
         groupRegistrations.values().forEach(GroupRegistration::unregister);
     }
 
-    Registration register(MailboxListener listener, Group group) {
-        return groupRegistrations
+    void register(MailboxListener listener, Group group) {
+        groupRegistrations
             .compute(group, (groupToRegister, oldGroupRegistration) -> {
                 if (oldGroupRegistration != null) {
-                    throw new GroupAlreadyRegistered(group);
+                    throw new GroupsAlreadyRegistered();
                 }
                 return newGroupRegistration(listener, groupToRegister);
             })

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/RabbitMQEventBus.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/RabbitMQEventBus.java
@@ -37,7 +37,7 @@ import com.google.common.collect.ImmutableSet;
 import reactor.core.publisher.Mono;
 import reactor.rabbitmq.Sender;
 
-public class RabbitMQEventBus implements EventBus, Startable {
+public class RabbitMQEventBus implements EventBus, UninitializedEventBus, Startable {
     private static final Set<RegistrationKey> NO_KEY = ImmutableSet.of();
     private static final String NOT_RUNNING_ERROR_MESSAGE = "Event Bus is not running";
     static final String MAILBOX_EVENT = "mailboxEvent";
@@ -130,13 +130,14 @@ public class RabbitMQEventBus implements EventBus, Startable {
     }
 
     @Override
-    public void initialize(Map<Group, MailboxListener> listeners) throws GroupsAlreadyRegistered {
+    public RabbitMQEventBus initialize(Map<Group, MailboxListener> listeners) throws GroupsAlreadyRegistered {
         Preconditions.checkState(isRunning, NOT_RUNNING_ERROR_MESSAGE);
         if (groupsInitialized) {
             throw new GroupsAlreadyRegistered();
         }
         listeners.forEach((group, listener) -> groupRegistrationHandler.register(listener, group));
         groupsInitialized = true;
+        return this;
     }
 
     @Override

--- a/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusTest.java
+++ b/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusTest.java
@@ -181,7 +181,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
     void registerGroupShouldCreateRetryExchange() throws Exception {
         MailboxListener listener = newListener();
         EventBusTestFixture.GroupA registeredGroup = new EventBusTestFixture.GroupA();
-        eventBus.register(listener, registeredGroup);
+        eventBus.initialize(listener, registeredGroup);
 
         GroupConsumerRetry.RetryExchangeName retryExchangeName = GroupConsumerRetry.RetryExchangeName.of(registeredGroup);
         assertThat(rabbitMQExtension.managementAPI().listExchanges())
@@ -199,7 +199,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
         @Test
         void rabbitMQEventBusShouldHandleBulksGracefully() throws Exception {
             EventBusTestFixture.MailboxListenerCountingSuccessfulExecution countingListener1 = newCountingListener();
-            eventBus().register(countingListener1, new EventBusTestFixture.GroupA());
+            eventBus().initialize(countingListener1, new EventBusTestFixture.GroupA());
             int totalGlobalRegistrations = 1; // GroupA
 
             int threadCount = 10;
@@ -251,9 +251,9 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
             doAnswer(callEventAndSleepForever).when(eventBusListener).event(any());
             doAnswer(callEventAndSleepForever).when(eventBus2Listener).event(any());
 
-            eventBus.register(eventBusListener, GROUP_A);
-            eventBus2.register(eventBus2Listener, GROUP_A);
-            eventBus3.register(eventBus3Listener, GROUP_A);
+            eventBus.initialize(eventBusListener, GROUP_A);
+            eventBus2.initialize(eventBus2Listener, GROUP_A);
+            eventBus3.initialize(eventBus3Listener, GROUP_A);
 
             eventBus.dispatch(EVENT, NO_KEYS).block();
             getSpeedProfile().shortWaitCondition()
@@ -354,7 +354,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
                 void dispatchShouldWorkAfterNetworkIssuesForOldRegistration() {
                     rabbitMQEventBusWithNetWorkIssue.start();
                     MailboxListener listener = newListener();
-                    rabbitMQEventBusWithNetWorkIssue.register(listener, GROUP_A);
+                    rabbitMQEventBusWithNetWorkIssue.initialize(listener, GROUP_A);
 
                     rabbitMQNetWorkIssueExtension.getRabbitMQ().pause();
 
@@ -402,7 +402,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
             void dispatchShouldWorkAfterRestartForOldRegistration() throws Exception {
                 eventBus.start();
                 MailboxListener listener = newListener();
-                eventBus.register(listener, GROUP_A);
+                eventBus.initialize(listener, GROUP_A);
 
                 rabbitMQExtension.getRabbitMQ().restart();
 
@@ -417,7 +417,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
 
                 rabbitMQExtension.getRabbitMQ().restart();
 
-                eventBus.register(listener, GROUP_A);
+                eventBus.initialize(listener, GROUP_A);
 
                 eventBus.dispatch(EVENT, NO_KEYS).block();
 
@@ -429,7 +429,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
             void redeliverShouldWorkAfterRestartForOldRegistration() throws Exception {
                 eventBus.start();
                 MailboxListener listener = newListener();
-                eventBus.register(listener, GROUP_A);
+                eventBus.initialize(listener, GROUP_A);
 
                 rabbitMQExtension.getRabbitMQ().restart();
 
@@ -444,7 +444,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
 
                 rabbitMQExtension.getRabbitMQ().restart();
 
-                eventBus.register(listener, GROUP_A);
+                eventBus.initialize(listener, GROUP_A);
 
                 eventBus.reDeliver(GROUP_A, EVENT).block();
                 assertThatListenerReceiveOneEvent(listener);
@@ -503,7 +503,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
 
                 rabbitMQExtension.getRabbitMQ().unpause();
 
-                eventBus.register(listener, GROUP_A);
+                eventBus.initialize(listener, GROUP_A);
                 eventBus.dispatch(EVENT, NO_KEYS).block();
                 assertThatListenerReceiveOneEvent(listener);
             }
@@ -520,7 +520,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
 
                 rabbitMQExtension.getRabbitMQ().unpause();
 
-                eventBus.register(listener, GROUP_A);
+                eventBus.initialize(listener, GROUP_A);
                 eventBus.reDeliver(GROUP_A, EVENT).block();
                 assertThatListenerReceiveOneEvent(listener);
             }
@@ -575,7 +575,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
             @Test
             void stopShouldNotDeleteGroupRegistrationWorkQueue() {
                 eventBus.start();
-                eventBus.register(mock(MailboxListener.class), GROUP_A);
+                eventBus.initialize(mock(MailboxListener.class), GROUP_A);
                 eventBus.stop();
 
                 assertThat(rabbitManagementAPI.listQueues())
@@ -601,7 +601,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
                 eventBus.start();
 
                 MailboxListenerCountingSuccessfulExecution listener = new MailboxListenerCountingSuccessfulExecution();
-                eventBus.register(listener, GROUP_A);
+                eventBus.initialize(listener, GROUP_A);
 
                 try (Closeable closeable = ConcurrentTestRunner.builder()
                     .operation((threadNumber, step) -> eventBus.dispatch(EVENT, KEY_1).block())
@@ -667,7 +667,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
 
             @Test
             void multipleEventBusStopShouldNotDeleteGroupRegistrationWorkQueue() {
-                eventBus.register(mock(MailboxListener.class), GROUP_A);
+                eventBus.initialize(mock(MailboxListener.class), GROUP_A);
 
                 eventBus.stop();
                 eventBus2.stop();
@@ -696,8 +696,8 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
                 eventBus2.start();
 
                 MailboxListenerCountingSuccessfulExecution listener = new MailboxListenerCountingSuccessfulExecution();
-                eventBus.register(listener, GROUP_A);
-                eventBus2.register(listener, GROUP_A);
+                eventBus.initialize(listener, GROUP_A);
+                eventBus2.initialize(listener, GROUP_A);
 
                 try (Closeable closeable = ConcurrentTestRunner.builder()
                     .operation((threadNumber, step) -> eventBus.dispatch(EVENT, KEY_1).block())

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/JPAMailboxManager.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/JPAMailboxManager.java
@@ -22,7 +22,7 @@ import java.util.EnumSet;
 
 import org.apache.james.mailbox.MailboxPathLocker;
 import org.apache.james.mailbox.SessionProvider;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.store.MailboxManagerConfiguration;
 import org.apache.james.mailbox.store.PreDeletionHooks;
@@ -48,7 +48,7 @@ public abstract class JPAMailboxManager extends StoreMailboxManager {
                              MailboxPathLocker locker,
                              MessageParser messageParser,
                              MessageId.Factory messageIdFactory,
-                             EventBus eventBus,
+                             EventBusSupplier eventBus,
                              StoreMailboxAnnotationManager annotationManager,
                              StoreRightManager storeRightManager,
                              QuotaComponents quotaComponents,

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/openjpa/OpenJPAMailboxManager.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/openjpa/OpenJPAMailboxManager.java
@@ -23,7 +23,7 @@ import javax.inject.Inject;
 
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.SessionProvider;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.jpa.JPAMailboxManager;
 import org.apache.james.mailbox.jpa.JPAMailboxSessionMapperFactory;
 import org.apache.james.mailbox.jpa.openjpa.OpenJPAMessageManager.AdvancedFeature;
@@ -48,7 +48,7 @@ public class OpenJPAMailboxManager extends JPAMailboxManager {
                                  SessionProvider sessionProvider,
                                  MessageParser messageParser,
                                  MessageId.Factory messageIdFactory,
-                                 EventBus eventBus,
+                                 EventBusSupplier eventBus,
                                  StoreMailboxAnnotationManager annotationManager,
                                  StoreRightManager storeRightManager,
                                  QuotaComponents quotaComponents,
@@ -66,7 +66,7 @@ public class OpenJPAMailboxManager extends JPAMailboxManager {
     protected StoreMessageManager createMessageManager(Mailbox mailboxRow, MailboxSession session) {
         return new OpenJPAMessageManager(getMapperFactory(),
             getMessageSearchIndex(),
-            getEventBus(),
+            getEventBus().get(),
             getLocker(),
             mailboxRow,
             getAdvancedFeature(),

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxManagerTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxManagerTest.java
@@ -52,10 +52,7 @@ class JPAMailboxManagerTest extends MailboxManagerTest<OpenJPAMailboxManager> {
 
     @Override
     protected OpenJPAMailboxManager provideMailboxManager(MailboxListener.GroupMailboxListener mailboxListener) {
-        if (!openJPAMailboxManager.isPresent()) {
-            openJPAMailboxManager = Optional.of(JpaMailboxManagerProvider.provideMailboxManager(JPA_TEST_CLUSTER, ImmutableList.of(mailboxListener)));
-        }
-        return openJPAMailboxManager.get();
+        return JpaMailboxManagerProvider.provideMailboxManager(JPA_TEST_CLUSTER, ImmutableList.of(mailboxListener));
     }
 
     @AfterEach
@@ -72,6 +69,6 @@ class JPAMailboxManagerTest extends MailboxManagerTest<OpenJPAMailboxManager> {
 
     @Override
     protected EventBus retrieveEventBus(OpenJPAMailboxManager mailboxManager) {
-        return mailboxManager.getEventBus();
+        return mailboxManager.getEventBus().get();
     }
 }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxManagerTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JPAMailboxManagerTest.java
@@ -23,13 +23,18 @@ import java.util.Optional;
 import org.apache.james.backends.jpa.JpaTestCluster;
 import org.apache.james.mailbox.MailboxManagerTest;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.jpa.openjpa.OpenJPAMailboxManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableList;
+
 class JPAMailboxManagerTest extends MailboxManagerTest<OpenJPAMailboxManager> {
+
+    public static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENERS = ImmutableList.of();
 
     @Disabled("JPAMailboxManager is using DefaultMessageId which doesn't support full feature of a messageId, which is an essential" +
         " element of the Vault")
@@ -42,8 +47,13 @@ class JPAMailboxManagerTest extends MailboxManagerTest<OpenJPAMailboxManager> {
     
     @Override
     protected OpenJPAMailboxManager provideMailboxManager() {
+        return JpaMailboxManagerProvider.provideMailboxManager(JPA_TEST_CLUSTER, NO_ADDITIONAL_LISTENERS);
+    }
+
+    @Override
+    protected OpenJPAMailboxManager provideMailboxManager(MailboxListener.GroupMailboxListener mailboxListener) {
         if (!openJPAMailboxManager.isPresent()) {
-            openJPAMailboxManager = Optional.of(JpaMailboxManagerProvider.provideMailboxManager(JPA_TEST_CLUSTER));
+            openJPAMailboxManager = Optional.of(JpaMailboxManagerProvider.provideMailboxManager(JPA_TEST_CLUSTER, ImmutableList.of(mailboxListener)));
         }
         return openJPAMailboxManager.get();
     }

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JpaMailboxManagerStressTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JpaMailboxManagerStressTest.java
@@ -45,7 +45,7 @@ class JpaMailboxManagerStressTest implements MailboxManagerStressContract<OpenJP
 
     @Override
     public EventBus retrieveEventBus() {
-        return getManager().getEventBus();
+        return getManager().getEventBus().get();
     }
 
     @BeforeEach

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JpaMailboxManagerStressTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/JpaMailboxManagerStressTest.java
@@ -24,13 +24,18 @@ import java.util.Optional;
 import org.apache.james.backends.jpa.JpaTestCluster;
 import org.apache.james.mailbox.MailboxManagerStressContract;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.jpa.openjpa.OpenJPAMailboxManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
+import com.google.common.collect.ImmutableList;
+
 class JpaMailboxManagerStressTest implements MailboxManagerStressContract<OpenJPAMailboxManager> {
 
     static final JpaTestCluster JPA_TEST_CLUSTER = JpaTestCluster.create(JPAMailboxFixture.MAILBOX_PERSISTANCE_CLASSES);
+    static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENERS = ImmutableList.of();
+
     Optional<OpenJPAMailboxManager> openJPAMailboxManager = Optional.empty();
 
     @Override
@@ -46,7 +51,7 @@ class JpaMailboxManagerStressTest implements MailboxManagerStressContract<OpenJP
     @BeforeEach
     void setUp() {
         if (!openJPAMailboxManager.isPresent()) {
-            openJPAMailboxManager = Optional.of(JpaMailboxManagerProvider.provideMailboxManager(JPA_TEST_CLUSTER));
+            openJPAMailboxManager = Optional.of(JpaMailboxManagerProvider.provideMailboxManager(JPA_TEST_CLUSTER, NO_ADDITIONAL_LISTENERS));
         }
     }
 

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/DomainUserMaildirMailboxManagerStressTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/DomainUserMaildirMailboxManagerStressTest.java
@@ -23,12 +23,17 @@ import java.io.File;
 
 import org.apache.james.mailbox.MailboxManagerStressContract;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
+import com.google.common.collect.ImmutableList;
+
 class DomainUserMaildirMailboxManagerStressTest implements MailboxManagerStressContract<StoreMailboxManager> {
+    private static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENERS = ImmutableList.of();
+
     @TempDir
     File tmpFolder;
 
@@ -46,6 +51,6 @@ class DomainUserMaildirMailboxManagerStressTest implements MailboxManagerStressC
 
     @BeforeEach
     void setUp() throws MailboxException {
-        this.mailboxManager = MaildirMailboxManagerProvider.createMailboxManager("/%domain/%user", tmpFolder);
+        this.mailboxManager = MaildirMailboxManagerProvider.createMailboxManager("/%domain/%user", tmpFolder, NO_ADDITIONAL_LISTENERS);
     }
 }

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/DomainUserMaildirMailboxManagerTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/DomainUserMaildirMailboxManagerTest.java
@@ -110,7 +110,7 @@ class DomainUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreMailbo
 
     @Override
     protected EventBus retrieveEventBus(StoreMailboxManager mailboxManager) {
-        return mailboxManager.getEventBus();
+        return mailboxManager.getEventBus().get();
     }
 
 

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/DomainUserMaildirMailboxManagerTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/DomainUserMaildirMailboxManagerTest.java
@@ -21,13 +21,17 @@ package org.apache.james.mailbox.maildir;
 import org.apache.james.junit.TemporaryFolderExtension;
 import org.apache.james.mailbox.MailboxManagerTest;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.google.common.collect.ImmutableList;
+
 class DomainUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreMailboxManager> {
+    private static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENERS = ImmutableList.of();
 
     @Disabled("Maildir is using DefaultMessageId which doesn't support full feature of a messageId, which is an essential" +
         " element of the Vault")
@@ -87,7 +91,18 @@ class DomainUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreMailbo
     @Override
     protected StoreMailboxManager provideMailboxManager() {
         try {
-            return MaildirMailboxManagerProvider.createMailboxManager("/%domain/%user", temporaryFolder.getTemporaryFolder().getTempDir());
+            return MaildirMailboxManagerProvider.createMailboxManager("/%domain/%user",
+                temporaryFolder.getTemporaryFolder().getTempDir(), NO_ADDITIONAL_LISTENERS);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected StoreMailboxManager provideMailboxManager(MailboxListener.GroupMailboxListener mailboxListener) {
+        try {
+            return MaildirMailboxManagerProvider.createMailboxManager("/%fulluser",
+                temporaryFolder.getTemporaryFolder().getTempDir(), ImmutableList.of(mailboxListener));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerStressTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerStressTest.java
@@ -46,7 +46,7 @@ class FullUserMaildirMailboxManagerStressTest implements MailboxManagerStressCon
 
     @Override
     public EventBus retrieveEventBus() {
-        return mailboxManager.getEventBus();
+        return mailboxManager.getEventBus().get();
     }
 
     @BeforeEach

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerStressTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerStressTest.java
@@ -23,12 +23,17 @@ import java.io.File;
 
 import org.apache.james.mailbox.MailboxManagerStressContract;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
+import com.google.common.collect.ImmutableList;
+
 class FullUserMaildirMailboxManagerStressTest implements MailboxManagerStressContract<StoreMailboxManager> {
+    private static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENERS = ImmutableList.of();
+
     @TempDir
     File tmpFolder;
 
@@ -46,6 +51,6 @@ class FullUserMaildirMailboxManagerStressTest implements MailboxManagerStressCon
 
     @BeforeEach
     void setUp() throws MailboxException {
-        this.mailboxManager = MaildirMailboxManagerProvider.createMailboxManager("/%fulluser", tmpFolder);
+        this.mailboxManager = MaildirMailboxManagerProvider.createMailboxManager("/%fulluser", tmpFolder, NO_ADDITIONAL_LISTENERS);
     }
 }

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerTest.java
@@ -21,12 +21,16 @@ package org.apache.james.mailbox.maildir;
 import org.apache.james.junit.TemporaryFolderExtension;
 import org.apache.james.mailbox.MailboxManagerTest;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.google.common.collect.ImmutableList;
+
 class FullUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreMailboxManager> {
+    private static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENERS = ImmutableList.of();
 
     @Disabled("Maildir is using DefaultMessageId which doesn't support full feature of a messageId, which is an essential" +
         " element of the Vault")
@@ -40,7 +44,17 @@ class FullUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreMailboxM
     @Override
     protected StoreMailboxManager provideMailboxManager() {
         try {
-            return MaildirMailboxManagerProvider.createMailboxManager("/%fulluser", temporaryFolder.getTemporaryFolder().getTempDir());
+            return MaildirMailboxManagerProvider.createMailboxManager("/%fulluser", temporaryFolder.getTemporaryFolder().getTempDir(), NO_ADDITIONAL_LISTENERS);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected StoreMailboxManager provideMailboxManager(MailboxListener.GroupMailboxListener mailboxListener) {
+        try {
+            return MaildirMailboxManagerProvider.createMailboxManager("/%fulluser",
+                temporaryFolder.getTemporaryFolder().getTempDir(), ImmutableList.of(mailboxListener));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/FullUserMaildirMailboxManagerTest.java
@@ -62,6 +62,6 @@ class FullUserMaildirMailboxManagerTest extends MailboxManagerTest<StoreMailboxM
 
     @Override
     protected EventBus retrieveEventBus(StoreMailboxManager mailboxManager) {
-        return mailboxManager.getEventBus();
+        return mailboxManager.getEventBus().get();
     }
 }

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/MaildirMailboxManagerProvider.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/MaildirMailboxManagerProvider.java
@@ -25,6 +25,7 @@ import org.apache.james.mailbox.acl.GroupMembershipResolver;
 import org.apache.james.mailbox.acl.MailboxACLResolver;
 import org.apache.james.mailbox.acl.SimpleGroupMembershipResolver;
 import org.apache.james.mailbox.acl.UnionMailboxACLResolver;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.events.EventBusTestFixture;
 import org.apache.james.mailbox.events.InVMEventBus;
 import org.apache.james.mailbox.events.MailboxListener;
@@ -60,7 +61,8 @@ public class MaildirMailboxManagerProvider {
         MessageParser messageParser = new MessageParser();
 
         InVMEventBus eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, new MemoryEventDeadLetters());
-        StoreRightManager storeRightManager = new StoreRightManager(mf, aclResolver, groupMembershipResolver, eventBus);
+        EventBusSupplier eventBusSupplier = new EventBusSupplier(eventBus);
+        StoreRightManager storeRightManager = new StoreRightManager(mf, aclResolver, groupMembershipResolver, eventBusSupplier);
 
         Authenticator noAuthenticator = null;
         Authorizator noAuthorizator = null;
@@ -71,10 +73,10 @@ public class MaildirMailboxManagerProvider {
         MessageSearchIndex index = new SimpleMessageSearchIndex(mf, mf, new DefaultTextExtractor());
 
         StoreMailboxManager manager = new StoreMailboxManager(mf, sessionProvider, new JVMMailboxPathLocker(),
-            messageParser, new DefaultMessageId.Factory(), annotationManager, eventBus, storeRightManager,
+            messageParser, new DefaultMessageId.Factory(), annotationManager, eventBusSupplier, storeRightManager,
             quotaComponents, index, MailboxManagerConfiguration.DEFAULT, PreDeletionHooks.NO_PRE_DELETION_HOOK);
 
-        eventBus.initialize(listeners);
+        eventBusSupplier.initialize(listeners);
 
         return manager;
     }

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/MaildirMailboxManagerProvider.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/MaildirMailboxManagerProvider.java
@@ -27,6 +27,7 @@ import org.apache.james.mailbox.acl.SimpleGroupMembershipResolver;
 import org.apache.james.mailbox.acl.UnionMailboxACLResolver;
 import org.apache.james.mailbox.events.EventBusTestFixture;
 import org.apache.james.mailbox.events.InVMEventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.events.MemoryEventDeadLetters;
 import org.apache.james.mailbox.events.delivery.InVmEventDelivery;
 import org.apache.james.mailbox.store.Authenticator;
@@ -46,9 +47,11 @@ import org.apache.james.mailbox.store.search.MessageSearchIndex;
 import org.apache.james.mailbox.store.search.SimpleMessageSearchIndex;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
 
+import com.google.common.collect.ImmutableList;
+
 public class MaildirMailboxManagerProvider {
 
-    public static StoreMailboxManager createMailboxManager(String configuration, File tempFile) {
+    public static StoreMailboxManager createMailboxManager(String configuration, File tempFile, ImmutableList<MailboxListener.GroupMailboxListener> listeners) {
         MaildirStore store = new MaildirStore(tempFile.getPath() + configuration, new JVMMailboxPathLocker());
         MaildirMailboxSessionMapperFactory mf = new MaildirMailboxSessionMapperFactory(store);
 
@@ -70,6 +73,8 @@ public class MaildirMailboxManagerProvider {
         StoreMailboxManager manager = new StoreMailboxManager(mf, sessionProvider, new JVMMailboxPathLocker(),
             messageParser, new DefaultMessageId.Factory(), annotationManager, eventBus, storeRightManager,
             quotaComponents, index, MailboxManagerConfiguration.DEFAULT, PreDeletionHooks.NO_PRE_DELETION_HOOK);
+
+        eventBus.initialize(listeners);
 
         return manager;
     }

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/UserMaildirMailboxManagerStressTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/UserMaildirMailboxManagerStressTest.java
@@ -23,12 +23,17 @@ import java.io.File;
 
 import org.apache.james.mailbox.MailboxManagerStressContract;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.store.StoreMailboxManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
+import com.google.common.collect.ImmutableList;
+
 class UserMaildirMailboxManagerStressTest implements MailboxManagerStressContract<StoreMailboxManager> {
+    private static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_LISTENERS = ImmutableList.of();
+
     @TempDir
     File tmpFolder;
 
@@ -46,6 +51,6 @@ class UserMaildirMailboxManagerStressTest implements MailboxManagerStressContrac
 
     @BeforeEach
     void setUp() throws MailboxException {
-        this.mailboxManager = MaildirMailboxManagerProvider.createMailboxManager("/%user", tmpFolder);
+        this.mailboxManager = MaildirMailboxManagerProvider.createMailboxManager("/%user", tmpFolder, NO_ADDITIONAL_LISTENERS);
     }
 }

--- a/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/UserMaildirMailboxManagerStressTest.java
+++ b/mailbox/maildir/src/test/java/org/apache/james/mailbox/maildir/UserMaildirMailboxManagerStressTest.java
@@ -46,7 +46,7 @@ class UserMaildirMailboxManagerStressTest implements MailboxManagerStressContrac
 
     @Override
     public EventBus retrieveEventBus() {
-        return mailboxManager.getEventBus();
+        return mailboxManager.getEventBus().get();
     }
 
     @BeforeEach

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/InMemoryMailboxManager.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/InMemoryMailboxManager.java
@@ -26,7 +26,7 @@ import javax.inject.Inject;
 import org.apache.james.mailbox.MailboxPathLocker;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.SessionProvider;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.store.MailboxManagerConfiguration;
@@ -39,6 +39,8 @@ import org.apache.james.mailbox.store.StoreRightManager;
 import org.apache.james.mailbox.store.mail.model.impl.MessageParser;
 import org.apache.james.mailbox.store.quota.QuotaComponents;
 import org.apache.james.mailbox.store.search.MessageSearchIndex;
+
+import com.google.common.annotations.VisibleForTesting;
 
 public class InMemoryMailboxManager extends StoreMailboxManager {
 
@@ -53,7 +55,7 @@ public class InMemoryMailboxManager extends StoreMailboxManager {
     @Inject
     public InMemoryMailboxManager(MailboxSessionMapperFactory mailboxSessionMapperFactory, SessionProvider sessionProvider,
                                   MailboxPathLocker locker, MessageParser messageParser, MessageId.Factory messageIdFactory,
-                                  EventBus eventBus,
+                                  EventBusSupplier eventBus,
                                   StoreMailboxAnnotationManager annotationManager,
                                   StoreRightManager storeRightManager,
                                   QuotaComponents quotaComponents,
@@ -74,11 +76,12 @@ public class InMemoryMailboxManager extends StoreMailboxManager {
         return MESSAGE_CAPABILITIES;
     }
 
+    @VisibleForTesting
     @Override
-    protected StoreMessageManager createMessageManager(Mailbox mailbox, MailboxSession session) {
+    public StoreMessageManager createMessageManager(Mailbox mailbox, MailboxSession session) {
         return new InMemoryMessageManager(getMapperFactory(),
             getMessageSearchIndex(),
-            getEventBus(),
+            getEventBus().get(),
             getLocker(),
             mailbox,
             getQuotaComponents().getQuotaManager(),

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/InMemoryCombinationManagerTestSystem.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/InMemoryCombinationManagerTestSystem.java
@@ -18,22 +18,20 @@
  ****************************************************************/
 package org.apache.james.mailbox.inmemory;
 
-import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxPath;
-import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.store.CombinationManagerTestSystem;
 
 public class InMemoryCombinationManagerTestSystem extends CombinationManagerTestSystem {
     private final InMemoryMailboxManager inMemoryMailboxManager;
 
-    public InMemoryCombinationManagerTestSystem(MailboxManager mailboxManager, MessageIdManager messageIdManager) {
+    public InMemoryCombinationManagerTestSystem(InMemoryMailboxManager mailboxManager, MessageIdManager messageIdManager) {
         super(mailboxManager, messageIdManager);
-        this.inMemoryMailboxManager = (InMemoryMailboxManager)mailboxManager;
+        this.inMemoryMailboxManager = mailboxManager;
     }
 
     @Override

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/MemoryMailboxManagerProvider.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/MemoryMailboxManagerProvider.java
@@ -21,6 +21,7 @@ package org.apache.james.mailbox.inmemory;
 
 import java.util.Set;
 
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.extension.PreDeletionHook;
 import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
 
@@ -38,6 +39,21 @@ public class MemoryMailboxManagerProvider {
             .scanningSearchIndex()
             .preDeletionHooks(preDeletionHooks)
             .storeQuotaManager()
+            .build()
+            .getMailboxManager();
+    }
+
+    public static InMemoryMailboxManager provideMailboxManager(Set<PreDeletionHook> preDeletionHooks, MailboxListener.GroupMailboxListener listener) {
+        return InMemoryIntegrationResources.builder()
+            .preProvisionnedFakeAuthenticator()
+            .fakeAuthorizator()
+            .inVmEventBus()
+            .annotationLimits(LIMIT_ANNOTATIONS, LIMIT_ANNOTATION_SIZE)
+            .defaultMessageParser()
+            .scanningSearchIndex()
+            .preDeletionHooks(preDeletionHooks)
+            .storeQuotaManager()
+            .registerListener((any, any2) -> listener)
             .build()
             .getMailboxManager();
     }

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/MemoryMailboxManagerStressTest.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/MemoryMailboxManagerStressTest.java
@@ -35,7 +35,7 @@ class MemoryMailboxManagerStressTest implements MailboxManagerStressContract<InM
 
     @Override
     public EventBus retrieveEventBus() {
-        return mailboxManager.getEventBus();
+        return mailboxManager.getEventBus().get();
     }
 
     @BeforeEach

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/MemoryMailboxManagerTest.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/MemoryMailboxManagerTest.java
@@ -23,8 +23,6 @@ import org.apache.james.mailbox.MailboxManagerTest;
 import org.apache.james.mailbox.events.EventBus;
 import org.apache.james.mailbox.events.MailboxListener;
 
-import com.google.common.collect.ImmutableList;
-
 class MemoryMailboxManagerTest extends MailboxManagerTest<InMemoryMailboxManager> {
 
     @Override
@@ -34,7 +32,7 @@ class MemoryMailboxManagerTest extends MailboxManagerTest<InMemoryMailboxManager
 
     @Override
     protected EventBus retrieveEventBus(InMemoryMailboxManager mailboxManager) {
-        return mailboxManager.getEventBus();
+        return mailboxManager.getEventBus().get();
     }
 
     @Override

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/MemoryMailboxManagerTest.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/MemoryMailboxManagerTest.java
@@ -21,6 +21,9 @@ package org.apache.james.mailbox.inmemory;
 
 import org.apache.james.mailbox.MailboxManagerTest;
 import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.MailboxListener;
+
+import com.google.common.collect.ImmutableList;
 
 class MemoryMailboxManagerTest extends MailboxManagerTest<InMemoryMailboxManager> {
 
@@ -32,5 +35,10 @@ class MemoryMailboxManagerTest extends MailboxManagerTest<InMemoryMailboxManager
     @Override
     protected EventBus retrieveEventBus(InMemoryMailboxManager mailboxManager) {
         return mailboxManager.getEventBus();
+    }
+
+    @Override
+    protected InMemoryMailboxManager provideMailboxManager(MailboxListener.GroupMailboxListener mailboxListener) {
+        return MemoryMailboxManagerProvider.provideMailboxManager(preDeletionHooks(), mailboxListener);
     }
 }

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/manager/InMemoryIntegrationResources.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/manager/InMemoryIntegrationResources.java
@@ -357,11 +357,13 @@ public class InMemoryIntegrationResources implements IntegrationResources<StoreM
                 quotaManager,
                 quotaRootResolver,
                 manager.getPreDeletionHooks());
+            groupListenerFactory.build().forEach(groupListenerRegistrer -> groupListenerRegistrer.accept(manager, messageIdManager));
 
-            eventBus.register(listeningCurrentQuotaUpdater);
-            eventBus.register(new MailboxAnnotationListener(mailboxSessionMapperFactory, sessionProvider));
-            groupListenerFactory.build().forEach(c -> c.accept(manager, messageIdManager));
-            listenersToBeRegistered.build().forEach(eventBus::register);
+            eventBus.initialize(ImmutableList.<MailboxListener.GroupMailboxListener>builder()
+                .addAll(listenersToBeRegistered.build())
+                .add(listeningCurrentQuotaUpdater)
+                .add(new MailboxAnnotationListener(mailboxSessionMapperFactory, sessionProvider))
+                .build());
 
             return new InMemoryIntegrationResources(manager, storeRightManager, messageIdFactory, currentQuotaManager,
                 quotaRootResolver, maxQuotaManager, quotaManager, index, eventBus, messageIdManager);

--- a/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/manager/InMemoryMessageIdManagerSideEffectTest.java
+++ b/mailbox/memory/src/test/java/org/apache/james/mailbox/inmemory/manager/InMemoryMessageIdManagerSideEffectTest.java
@@ -21,7 +21,7 @@ package org.apache.james.mailbox.inmemory.manager;
 
 import java.util.Set;
 
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.UninitializedEventBus;
 import org.apache.james.mailbox.extension.PreDeletionHook;
 import org.apache.james.mailbox.inmemory.InMemoryMessageId;
 import org.apache.james.mailbox.quota.QuotaManager;
@@ -31,7 +31,7 @@ import org.apache.james.mailbox.store.MessageIdManagerTestSystem;
 class InMemoryMessageIdManagerSideEffectTest extends AbstractMessageIdManagerSideEffectTest {
 
     @Override
-    protected MessageIdManagerTestSystem createTestSystem(QuotaManager quotaManager, EventBus eventBus, Set<PreDeletionHook> preDeletionHooks) {
+    protected MessageIdManagerTestSystem createTestSystem(QuotaManager quotaManager, UninitializedEventBus eventBus, Set<PreDeletionHook> preDeletionHooks) {
         InMemoryMessageId.Factory messageIdFactory = new InMemoryMessageId.Factory();
 
         InMemoryIntegrationResources resources = InMemoryIntegrationResources.builder()

--- a/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdListenersTestSystem.java
+++ b/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdListenersTestSystem.java
@@ -53,7 +53,7 @@ class QuotaThresholdListenersTestSystem {
         QuotaThresholdCrossingListener thresholdCrossingListener =
             new QuotaThresholdCrossingListener(mailetContext, MemoryUsersRepository.withVirtualHosting(NO_DOMAIN_LIST), fileSystem, eventStore, configuration);
 
-        eventBus.register(thresholdCrossingListener);
+        eventBus.initialize(thresholdCrossingListener);
     }
 
     void event(Event event) {

--- a/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdListenersTestSystem.java
+++ b/mailbox/plugin/quota-mailing/src/test/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdListenersTestSystem.java
@@ -28,6 +28,7 @@ import org.apache.james.mailbox.events.EventBusTestFixture;
 import org.apache.james.mailbox.events.InVMEventBus;
 import org.apache.james.mailbox.events.MemoryEventDeadLetters;
 import org.apache.james.mailbox.events.RegistrationKey;
+import org.apache.james.mailbox.events.UninitializedEventBus;
 import org.apache.james.mailbox.events.delivery.InVmEventDelivery;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.quota.mailing.QuotaMailingListenerConfiguration;
@@ -46,14 +47,14 @@ class QuotaThresholdListenersTestSystem {
     private final EventBus eventBus;
 
     QuotaThresholdListenersTestSystem(MailetContext mailetContext, EventStore eventStore, QuotaMailingListenerConfiguration configuration) throws MailboxException {
-        eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, new MemoryEventDeadLetters());
+        UninitializedEventBus uninitializedEventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, new MemoryEventDeadLetters());
 
         FileSystem fileSystem = new FileSystemImpl(new JamesServerResourceLoader("."));
 
         QuotaThresholdCrossingListener thresholdCrossingListener =
             new QuotaThresholdCrossingListener(mailetContext, MemoryUsersRepository.withVirtualHosting(NO_DOMAIN_LIST), fileSystem, eventStore, configuration);
 
-        eventBus.initialize(thresholdCrossingListener);
+        eventBus = uninitializedEventBus.initialize(thresholdCrossingListener);
     }
 
     void event(Event event) {

--- a/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/ElasticSearchQuotaSearchTestSystemExtension.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/ElasticSearchQuotaSearchTestSystemExtension.java
@@ -60,7 +60,7 @@ public class ElasticSearchQuotaSearchTestSystemExtension implements ParameterRes
                 elasticSearch.configuration());
 
             InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultBuilder()
-                .registerListener((m, m2) -> new ElasticSearchQuotaMailboxListener(
+                .registerListener((manager, messageIdManager) -> new ElasticSearchQuotaMailboxListener(
                     new ElasticSearchIndexer(client,
                         QuotaRatioElasticSearchConstants.DEFAULT_QUOTA_RATIO_WRITE_ALIAS),
                     new QuotaRatioToElasticSearchJson(),

--- a/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/ElasticSearchQuotaSearchTestSystemExtension.java
+++ b/mailbox/plugin/quota-search-elasticsearch/src/test/java/org/apache/james/quota/search/elasticsearch/ElasticSearchQuotaSearchTestSystemExtension.java
@@ -59,19 +59,17 @@ public class ElasticSearchQuotaSearchTestSystemExtension implements ParameterRes
                 elasticSearch.clientProvider().get(),
                 elasticSearch.configuration());
 
-            InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultResources();
+            InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultBuilder()
+                .registerListener((m, m2) -> new ElasticSearchQuotaMailboxListener(
+                    new ElasticSearchIndexer(client,
+                        QuotaRatioElasticSearchConstants.DEFAULT_QUOTA_RATIO_WRITE_ALIAS),
+                    new QuotaRatioToElasticSearchJson(),
+                    new UserRoutingKeyFactory()))
+                .build();
 
             DNSService dnsService = mock(DNSService.class);
             MemoryDomainList domainList = new MemoryDomainList(dnsService);
             MemoryUsersRepository usersRepository = MemoryUsersRepository.withVirtualHosting(domainList);
-
-            ElasticSearchQuotaMailboxListener listener = new ElasticSearchQuotaMailboxListener(
-                new ElasticSearchIndexer(client,
-                    QuotaRatioElasticSearchConstants.DEFAULT_QUOTA_RATIO_WRITE_ALIAS),
-                new QuotaRatioToElasticSearchJson(),
-                new UserRoutingKeyFactory());
-
-            resources.getMailboxManager().getEventBus().register(listener);
 
             QuotaComponents quotaComponents = resources.getMailboxManager().getQuotaComponents();
 

--- a/mailbox/spring/src/main/java/org/apache/james/mailbox/spring/MailboxInitializer.java
+++ b/mailbox/spring/src/main/java/org/apache/james/mailbox/spring/MailboxInitializer.java
@@ -23,7 +23,7 @@ import javax.inject.Inject;
 
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.SessionProvider;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.store.MailboxSessionMapperFactory;
 import org.apache.james.mailbox.store.event.MailboxAnnotationListener;
@@ -36,14 +36,14 @@ import com.google.common.collect.ImmutableList;
 
 public class MailboxInitializer {
     private final SessionProvider sessionProvider;
-    private final EventBus eventBus;
+    private final EventBusSupplier eventBus;
     private final MessageSearchIndex messageSearchIndex;
     private final QuotaUpdater quotaUpdater;
     private final MailboxManager mailboxManager;
     private final MailboxSessionMapperFactory mapperFactory;
 
     @Inject
-    public MailboxInitializer(SessionProvider sessionProvider, EventBus eventBus, MessageSearchIndex messageSearchIndex, QuotaUpdater quotaUpdater, MailboxManager mailboxManager, MailboxSessionMapperFactory mapperFactory) {
+    public MailboxInitializer(SessionProvider sessionProvider, EventBusSupplier eventBus, MessageSearchIndex messageSearchIndex, QuotaUpdater quotaUpdater, MailboxManager mailboxManager, MailboxSessionMapperFactory mapperFactory) {
         this.sessionProvider = sessionProvider;
         this.eventBus = eventBus;
         this.messageSearchIndex = messageSearchIndex;

--- a/mailbox/spring/src/main/resources/META-INF/spring/event-system.xml
+++ b/mailbox/spring/src/main/resources/META-INF/spring/event-system.xml
@@ -25,12 +25,15 @@
           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
-    <bean id="event-bus" class="org.apache.james.mailbox.events.InVMEventBus" lazy-init="true">
+    <bean id="in-vm-event-bus" class="org.apache.james.mailbox.events.InVMEventBus" lazy-init="true">
         <constructor-arg index="0" ref="event-delivery"/>
         <constructor-arg index="1">
             <util:constant static-field="org.apache.james.mailbox.events.RetryBackoffConfiguration.DEFAULT"/>
         </constructor-arg>
         <constructor-arg index="2" ref="event-deadletters"/>
+    </bean>
+    <bean id="event-bus" class="org.apache.james.mailbox.events.EventBusSupplier" lazy-init="true">
+        <constructor-arg index="0" ref="in-vm-event-bus"/>
     </bean>
     <bean id="event-delivery" class="org.apache.james.mailbox.events.delivery.InVmEventDelivery" lazy-init="true">
         <constructor-arg index="0" ref="metricFactory"/>

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreRightManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreRightManager.java
@@ -32,7 +32,7 @@ import org.apache.james.mailbox.RightManager;
 import org.apache.james.mailbox.acl.ACLDiff;
 import org.apache.james.mailbox.acl.GroupMembershipResolver;
 import org.apache.james.mailbox.acl.MailboxACLResolver;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.events.MailboxIdRegistrationKey;
 import org.apache.james.mailbox.exception.DifferentDomainException;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -56,7 +56,7 @@ import com.google.common.collect.ImmutableMap;
 public class StoreRightManager implements RightManager {
     public static final boolean GROUP_FOLDER = true;
 
-    private final EventBus eventBus;
+    private final EventBusSupplier eventBus;
     private final MailboxSessionMapperFactory mailboxSessionMapperFactory;
     private final MailboxACLResolver aclResolver;
     private final GroupMembershipResolver groupMembershipResolver;
@@ -65,7 +65,7 @@ public class StoreRightManager implements RightManager {
     public StoreRightManager(MailboxSessionMapperFactory mailboxSessionMapperFactory,
                              MailboxACLResolver aclResolver,
                              GroupMembershipResolver groupMembershipResolver,
-                             EventBus eventBus) {
+                             EventBusSupplier eventBus) {
         this.mailboxSessionMapperFactory = mailboxSessionMapperFactory;
         this.aclResolver = aclResolver;
         this.groupMembershipResolver = groupMembershipResolver;
@@ -140,7 +140,7 @@ public class StoreRightManager implements RightManager {
         Mailbox mailbox = mapper.findMailboxByPathBlocking(mailboxPath);
         ACLDiff aclDiff = mapper.updateACL(mailbox, mailboxACLCommand);
 
-        eventBus.dispatch(EventFactory.aclUpdated()
+        eventBus.get().dispatch(EventFactory.aclUpdated()
             .randomEventId()
             .mailboxSession(session)
             .mailbox(mailbox)
@@ -225,7 +225,7 @@ public class StoreRightManager implements RightManager {
     private void setRights(MailboxACL mailboxACL, MailboxMapper mapper, Mailbox mailbox, MailboxSession session) throws MailboxException {
         ACLDiff aclDiff = mapper.setACL(mailbox, mailboxACL);
 
-        eventBus.dispatch(EventFactory.aclUpdated()
+        eventBus.get().dispatch(EventFactory.aclUpdated()
             .randomEventId()
             .mailboxSession(session)
             .mailbox(mailbox)

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/ListeningCurrentQuotaUpdater.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/quota/ListeningCurrentQuotaUpdater.java
@@ -26,7 +26,7 @@ import javax.inject.Inject;
 import org.apache.james.core.quota.QuotaCountUsage;
 import org.apache.james.core.quota.QuotaSizeUsage;
 import org.apache.james.mailbox.events.Event;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.events.Group;
 import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.events.RegistrationKey;
@@ -50,11 +50,11 @@ public class ListeningCurrentQuotaUpdater implements MailboxListener.GroupMailbo
 
     private final StoreCurrentQuotaManager currentQuotaManager;
     private final QuotaRootResolver quotaRootResolver;
-    private final EventBus eventBus;
+    private final EventBusSupplier eventBus;
     private final QuotaManager quotaManager;
 
     @Inject
-    public ListeningCurrentQuotaUpdater(StoreCurrentQuotaManager currentQuotaManager, QuotaRootResolver quotaRootResolver, EventBus eventBus, QuotaManager quotaManager) {
+    public ListeningCurrentQuotaUpdater(StoreCurrentQuotaManager currentQuotaManager, QuotaRootResolver quotaRootResolver, EventBusSupplier eventBus, QuotaManager quotaManager) {
         this.currentQuotaManager = currentQuotaManager;
         this.quotaRootResolver = quotaRootResolver;
         this.eventBus = eventBus;
@@ -91,7 +91,7 @@ public class ListeningCurrentQuotaUpdater implements MailboxListener.GroupMailbo
         computeQuotaOperation(expunged, quotaRoot).ifPresent(Throwing.<QuotaOperation>consumer(quotaOperation -> {
             currentQuotaManager.decrease(quotaOperation);
 
-            eventBus.dispatch(
+            eventBus.get().dispatch(
                 EventFactory.quotaUpdated()
                     .randomEventId()
                     .user(expunged.getUsername())
@@ -109,7 +109,7 @@ public class ListeningCurrentQuotaUpdater implements MailboxListener.GroupMailbo
         computeQuotaOperation(added, quotaRoot).ifPresent(Throwing.<QuotaOperation>consumer(quotaOperation -> {
             currentQuotaManager.increase(quotaOperation);
 
-            eventBus.dispatch(
+            eventBus.get().dispatch(
                 EventFactory.quotaUpdated()
                     .randomEventId()
                     .user(added.getUsername())

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerSideEffectTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerSideEffectTest.java
@@ -46,13 +46,13 @@ import org.apache.james.mailbox.MessageManager.FlagsUpdateMode;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.MetadataWithMailboxId;
 import org.apache.james.mailbox.ModSeq;
-import org.apache.james.mailbox.events.EventBus;
 import org.apache.james.mailbox.events.EventBusTestFixture;
 import org.apache.james.mailbox.events.InVMEventBus;
 import org.apache.james.mailbox.events.MailboxIdRegistrationKey;
 import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.events.MemoryEventDeadLetters;
 import org.apache.james.mailbox.events.MessageMoveEvent;
+import org.apache.james.mailbox.events.UninitializedEventBus;
 import org.apache.james.mailbox.events.delivery.InVmEventDelivery;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.OverQuotaException;
@@ -100,11 +100,11 @@ public abstract class AbstractMessageIdManagerSideEffectTest {
     private QuotaManager quotaManager;
     private MessageIdManagerTestSystem testingData;
     private EventCollector eventCollector;
-    private EventBus eventBus;
+    private InVMEventBus eventBus;
     private PreDeletionHook preDeletionHook1;
     private PreDeletionHook preDeletionHook2;
 
-    protected abstract MessageIdManagerTestSystem createTestSystem(QuotaManager quotaManager, EventBus eventBus, Set<PreDeletionHook> preDeletionHooks) throws Exception;
+    protected abstract MessageIdManagerTestSystem createTestSystem(QuotaManager quotaManager, UninitializedEventBus eventBus, Set<PreDeletionHook> preDeletionHooks) throws Exception;
 
     @BeforeEach
     void setUp() throws Exception {

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/CombinationManagerTestSystem.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/CombinationManagerTestSystem.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.mailbox.store;
 
-import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.MessageManager;
@@ -28,15 +27,15 @@ import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxPath;
 
 public abstract class CombinationManagerTestSystem {
-    private final MailboxManager mailboxManager;
+    private final StoreMailboxManager mailboxManager;
     private final MessageIdManager messageIdManager;
 
-    public CombinationManagerTestSystem(MailboxManager mailboxManager, MessageIdManager messageIdManager) {
+    public CombinationManagerTestSystem(StoreMailboxManager mailboxManager, MessageIdManager messageIdManager) {
         this.messageIdManager = messageIdManager;
         this.mailboxManager = mailboxManager;
     }
 
-    public MailboxManager getMailboxManager() {
+    public StoreMailboxManager getMailboxManager() {
         return mailboxManager;
     }
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/MessageIdManagerTestSystem.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/MessageIdManagerTestSystem.java
@@ -87,7 +87,7 @@ public class MessageIdManagerTestSystem {
             Mailbox mailbox = mapperFactory.getMailboxMapper(mailboxSession).findMailboxById(mailboxId);
             MailboxMessage message = createMessage(mailboxId, flags, messageId, uid);
             mapperFactory.getMessageMapper(mailboxSession).add(mailbox, message);
-            mailboxManager.getEventBus().dispatch(EventFactory.added()
+            mailboxManager.getEventBus().get().dispatch(EventFactory.added()
                 .randomEventId()
                 .mailboxSession(mailboxSession)
                 .mailbox(mailbox)

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxManagerTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxManagerTest.java
@@ -31,6 +31,7 @@ import org.apache.james.mailbox.MailboxSessionUtil;
 import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.acl.SimpleGroupMembershipResolver;
 import org.apache.james.mailbox.acl.UnionMailboxACLResolver;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.events.EventBusTestFixture;
 import org.apache.james.mailbox.events.InVMEventBus;
 import org.apache.james.mailbox.events.MemoryEventDeadLetters;
@@ -89,9 +90,10 @@ class StoreMailboxManagerTest {
         authenticator.addUser(ADMIN, ADMIN_PASSWORD);
 
         InVMEventBus eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, new MemoryEventDeadLetters());
+        EventBusSupplier eventBusSupplier = new EventBusSupplier(eventBus);
 
         StoreRightManager storeRightManager = new StoreRightManager(mockedMapperFactory, new UnionMailboxACLResolver(),
-                                                                    new SimpleGroupMembershipResolver(), eventBus);
+                                                                    new SimpleGroupMembershipResolver(), eventBusSupplier);
 
         StoreMailboxAnnotationManager annotationManager = new StoreMailboxAnnotationManager(mockedMapperFactory, storeRightManager);
         SessionProviderImpl sessionProvider = new SessionProviderImpl(authenticator, FakeAuthorizator.forUserAndAdmin(ADMIN, CURRENT_USER));
@@ -100,8 +102,9 @@ class StoreMailboxManagerTest {
 
         storeMailboxManager = new StoreMailboxManager(mockedMapperFactory, sessionProvider,
                 new JVMMailboxPathLocker(), new MessageParser(), messageIdFactory,
-                annotationManager, eventBus, storeRightManager, quotaComponents, index, MailboxManagerConfiguration.DEFAULT,
+                annotationManager, eventBusSupplier, storeRightManager, quotaComponents, index, MailboxManagerConfiguration.DEFAULT,
                 PreDeletionHooks.NO_PRE_DELETION_HOOK);
+        eventBusSupplier.initialize();
     }
 
     @Test

--- a/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/CassandraReIndexerImplTest.java
+++ b/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/CassandraReIndexerImplTest.java
@@ -36,6 +36,7 @@ import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.cassandra.CassandraMailboxManager;
 import org.apache.james.mailbox.cassandra.CassandraMailboxManagerProvider;
 import org.apache.james.mailbox.cassandra.mail.MailboxAggregateModule;
+import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.indexer.ReIndexer;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxId;
@@ -50,10 +51,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 
 public class CassandraReIndexerImplTest {
     private static final Username USERNAME = Username.of("benwa@apache.org");
     public static final MailboxPath INBOX = MailboxPath.inbox(USERNAME);
+    private static final ImmutableList<MailboxListener.GroupMailboxListener> NO_ADDITIONAL_MAILBOX_LISTENERS = ImmutableList.of();
+
     private CassandraMailboxManager mailboxManager;
     private ListeningMessageSearchIndex messageSearchIndex;
 
@@ -64,7 +68,7 @@ public class CassandraReIndexerImplTest {
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
-        mailboxManager = CassandraMailboxManagerProvider.provideMailboxManager(cassandra, PreDeletionHooks.NO_PRE_DELETION_HOOK);
+        mailboxManager = CassandraMailboxManagerProvider.provideMailboxManager(cassandra, PreDeletionHooks.NO_PRE_DELETION_HOOK, NO_ADDITIONAL_MAILBOX_LISTENERS);
         MailboxSessionMapperFactory mailboxSessionMapperFactory = mailboxManager.getMapperFactory();
         messageSearchIndex = mock(ListeningMessageSearchIndex.class);
         reIndexer = new ReIndexerImpl(new ReIndexerPerformer(mailboxManager, messageSearchIndex, mailboxSessionMapperFactory),

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
@@ -115,7 +115,7 @@ public class CassandraHostSystem extends JamesImapHostSystem {
             new JVMMailboxPathLocker(), new MessageParser(), messageIdFactory,
             eventBus, annotationManager, storeRightManager, quotaComponents, index, MailboxManagerConfiguration.DEFAULT, PreDeletionHooks.NO_PRE_DELETION_HOOK);
 
-        eventBus.register(quotaUpdater);
+        eventBus.initialize(quotaUpdater);
 
         SubscriptionManager subscriptionManager = new StoreSubscriptionManager(mapperFactory);
 

--- a/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/host/InMemoryHostSystem.java
+++ b/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/host/InMemoryHostSystem.java
@@ -64,7 +64,8 @@ public class InMemoryHostSystem extends JamesImapHostSystem {
         this.mailboxManager = resources.getMailboxManager();
         this.perUserMaxQuotaManager = resources.getMaxQuotaManager();
 
-        ImapProcessor defaultImapProcessorFactory = DefaultImapProcessorFactory.createDefaultProcessor(mailboxManager,  mailboxManager.getEventBus(), new StoreSubscriptionManager(mailboxManager.getMapperFactory()),
+        ImapProcessor defaultImapProcessorFactory = DefaultImapProcessorFactory.createDefaultProcessor(mailboxManager,
+            mailboxManager.getEventBus(), new StoreSubscriptionManager(mailboxManager.getMapperFactory()),
             mailboxManager.getQuotaComponents().getQuotaManager(), mailboxManager.getQuotaComponents().getQuotaRootResolver(), new DefaultMetricFactory());
 
         configure(new DefaultImapDecoderFactory().buildImapDecoder(),

--- a/mpt/impl/imap-mailbox/jpa/src/test/java/org/apache/james/mpt/imapmailbox/jpa/host/JPAHostSystem.java
+++ b/mpt/impl/imap-mailbox/jpa/src/test/java/org/apache/james/mpt/imapmailbox/jpa/host/JPAHostSystem.java
@@ -118,8 +118,8 @@ public class JPAHostSystem extends JamesImapHostSystem {
         mailboxManager = new OpenJPAMailboxManager(mapperFactory, sessionProvider, messageParser, new DefaultMessageId.Factory(),
             eventBus, annotationManager, storeRightManager, quotaComponents, index);
 
-        eventBus.register(quotaUpdater);
-        eventBus.register(new MailboxAnnotationListener(mapperFactory, sessionProvider));
+        eventBus.initialize(quotaUpdater,
+            new MailboxAnnotationListener(mapperFactory, sessionProvider));
 
         SubscriptionManager subscriptionManager = new StoreSubscriptionManager(mapperFactory);
         

--- a/mpt/impl/imap-mailbox/rabbitmq/src/test/java/org/apache/james/mpt/imapmailbox/rabbitmq/host/RabbitMQEventBusHostSystem.java
+++ b/mpt/impl/imap-mailbox/rabbitmq/src/test/java/org/apache/james/mpt/imapmailbox/rabbitmq/host/RabbitMQEventBusHostSystem.java
@@ -93,7 +93,7 @@ public class RabbitMQEventBusHostSystem extends JamesImapHostSystem {
         ImapProcessor defaultImapProcessorFactory =
             DefaultImapProcessorFactory.createDefaultProcessor(
                 resources.getMailboxManager(),
-                eventBus,
+                resources.getMailboxManager().getEventBus(),
                 new StoreSubscriptionManager(resources.getMailboxManager().getMapperFactory()),
                 resources.getQuotaManager(),
                 resources.getDefaultUserQuotaRootResolver(),

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/AbstractSelectionProcessor.java
@@ -49,7 +49,7 @@ import org.apache.james.mailbox.MessageManager.MetaData;
 import org.apache.james.mailbox.MessageManager.MetaData.FetchGroup;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.ModSeq;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.MailboxNotFoundException;
 import org.apache.james.mailbox.exception.MessageRangeException;
@@ -68,10 +68,11 @@ abstract class AbstractSelectionProcessor<R extends AbstractMailboxSelectionRequ
 
     private final StatusResponseFactory statusResponseFactory;
     private final boolean openReadOnly;
-    private final EventBus eventBus;
+    private final EventBusSupplier eventBus;
     
-    public AbstractSelectionProcessor(Class<R> acceptableClass, ImapProcessor next, MailboxManager mailboxManager, StatusResponseFactory statusResponseFactory, boolean openReadOnly,
-                                      MetricFactory metricFactory, EventBus eventBus) {
+    public AbstractSelectionProcessor(Class<R> acceptableClass, ImapProcessor next, MailboxManager mailboxManager,
+                                      StatusResponseFactory statusResponseFactory, boolean openReadOnly,
+                                      MetricFactory metricFactory, EventBusSupplier eventBus) {
         super(acceptableClass, next, mailboxManager, statusResponseFactory, metricFactory);
         this.statusResponseFactory = statusResponseFactory;
         this.openReadOnly = openReadOnly;
@@ -399,7 +400,7 @@ abstract class AbstractSelectionProcessor<R extends AbstractMailboxSelectionRequ
             if (currentMailbox != null) {
                 getStatusResponseFactory().untaggedOk(HumanReadableText.QRESYNC_CLOSED, ResponseCode.closed());
             }
-            session.selected(new SelectedMailboxImpl(getMailboxManager(), eventBus, session, mailbox));
+            session.selected(new SelectedMailboxImpl(getMailboxManager(), eventBus.get(), session, mailbox));
 
             sessionMailbox = session.getSelected();
             

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/DefaultProcessorChain.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/DefaultProcessorChain.java
@@ -25,7 +25,7 @@ import org.apache.james.imap.api.process.MailboxTyper;
 import org.apache.james.imap.processor.fetch.FetchProcessor;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.SubscriptionManager;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.quota.QuotaManager;
 import org.apache.james.mailbox.quota.QuotaRootResolver;
 import org.apache.james.metrics.api.MetricFactory;
@@ -37,7 +37,7 @@ public class DefaultProcessorChain {
 
     public static ImapProcessor createDefaultChain(ImapProcessor chainEndProcessor,
                                                    MailboxManager mailboxManager,
-                                                   EventBus eventBus,
+                                                   EventBusSupplier eventBus,
                                                    SubscriptionManager subscriptionManager,
                                                    StatusResponseFactory statusResponseFactory,
                                                    MailboxTyper mailboxTyper,

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/ExamineProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/ExamineProcessor.java
@@ -27,13 +27,13 @@ import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.message.request.ExamineRequest;
 import org.apache.james.mailbox.MailboxManager;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.util.MDCBuilder;
 
 public class ExamineProcessor extends AbstractSelectionProcessor<ExamineRequest> {
 
-    public ExamineProcessor(ImapProcessor next, MailboxManager mailboxManager, EventBus eventBus, StatusResponseFactory statusResponseFactory,
+    public ExamineProcessor(ImapProcessor next, MailboxManager mailboxManager, EventBusSupplier eventBus, StatusResponseFactory statusResponseFactory,
                             MetricFactory metricFactory) {
         super(ExamineRequest.class, next, mailboxManager, statusResponseFactory, true, metricFactory, eventBus);
     }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/IdleProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/IdleProcessor.java
@@ -43,7 +43,7 @@ import org.apache.james.imap.message.request.IdleRequest;
 import org.apache.james.imap.message.response.ContinuationResponse;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.events.Event;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.events.MailboxIdRegistrationKey;
 import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.events.Registration;
@@ -58,13 +58,13 @@ public class IdleProcessor extends AbstractMailboxProcessor<IdleRequest> impleme
     public static final int DEFAULT_SCHEDULED_POOL_CORE_SIZE = 5;
     private static final String DONE = "DONE";
 
-    private final EventBus eventBus;
+    private final EventBusSupplier eventBus;
     private TimeUnit heartbeatIntervalUnit;
     private long heartbeatInterval;
     private boolean enableIdle;
     private ScheduledExecutorService heartbeatExecutor;
 
-    public IdleProcessor(ImapProcessor next, MailboxManager mailboxManager, EventBus eventBus, StatusResponseFactory factory,
+    public IdleProcessor(ImapProcessor next, MailboxManager mailboxManager, EventBusSupplier eventBus, StatusResponseFactory factory,
             MetricFactory metricFactory) {
         super(IdleRequest.class, next, mailboxManager, factory, metricFactory);
         this.eventBus = eventBus;
@@ -88,7 +88,7 @@ public class IdleProcessor extends AbstractMailboxProcessor<IdleRequest> impleme
         SelectedMailbox sm = session.getSelected();
         Registration registration;
         if (sm != null) {
-            registration = eventBus.register(new IdleMailboxListener(session, responder), new MailboxIdRegistrationKey(sm.getMailboxId()));
+            registration = eventBus.get().register(new IdleMailboxListener(session, responder), new MailboxIdRegistrationKey(sm.getMailboxId()));
         } else {
             registration = null;
         }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/SelectProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/SelectProcessor.java
@@ -27,13 +27,13 @@ import org.apache.james.imap.api.message.response.StatusResponseFactory;
 import org.apache.james.imap.api.process.ImapProcessor;
 import org.apache.james.imap.message.request.SelectRequest;
 import org.apache.james.mailbox.MailboxManager;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.util.MDCBuilder;
 
 public class SelectProcessor extends AbstractSelectionProcessor<SelectRequest> {
 
-    public SelectProcessor(ImapProcessor next, MailboxManager mailboxManager, EventBus eventBus, StatusResponseFactory statusResponseFactory,
+    public SelectProcessor(ImapProcessor next, MailboxManager mailboxManager, EventBusSupplier eventBus, StatusResponseFactory statusResponseFactory,
                            MetricFactory metricFactory) {
         super(SelectRequest.class, next, mailboxManager, statusResponseFactory, false, metricFactory, eventBus);
     }

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/main/DefaultImapProcessorFactory.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/main/DefaultImapProcessorFactory.java
@@ -28,20 +28,20 @@ import org.apache.james.imap.processor.base.ImapResponseMessageProcessor;
 import org.apache.james.imap.processor.base.UnknownRequestProcessor;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.SubscriptionManager;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.quota.QuotaManager;
 import org.apache.james.mailbox.quota.QuotaRootResolver;
 import org.apache.james.metrics.api.MetricFactory;
 
 public class DefaultImapProcessorFactory {
 
-    public static ImapProcessor createDefaultProcessor(MailboxManager mailboxManager, EventBus eventBus, SubscriptionManager subscriptionManager, QuotaManager quotaManager, QuotaRootResolver quotaRootResolver,
+    public static ImapProcessor createDefaultProcessor(MailboxManager mailboxManager, EventBusSupplier eventBus, SubscriptionManager subscriptionManager, QuotaManager quotaManager, QuotaRootResolver quotaRootResolver,
             MetricFactory metricFactory) {
         return createXListSupportingProcessor(mailboxManager, eventBus, subscriptionManager, null, quotaManager, quotaRootResolver, metricFactory);
     }
 
     public static ImapProcessor createXListSupportingProcessor(MailboxManager mailboxManager,
-                                                               EventBus eventBus, SubscriptionManager subscriptionManager,
+                                                               EventBusSupplier eventBus, SubscriptionManager subscriptionManager,
                                                                MailboxTyper mailboxTyper, QuotaManager quotaManager, QuotaRootResolver quotaRootResolver, MetricFactory metricFactory) {
 
         StatusResponseFactory statusResponseFactory = new UnpooledStatusResponseFactory();

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/event/RabbitMQEventBusModule.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/event/RabbitMQEventBusModule.java
@@ -20,11 +20,11 @@
 package org.apache.james.modules.event;
 
 import org.apache.james.event.json.EventSerializer;
-import org.apache.james.mailbox.events.EventBus;
 import org.apache.james.mailbox.events.MailboxIdRegistrationKey;
 import org.apache.james.mailbox.events.RabbitMQEventBus;
 import org.apache.james.mailbox.events.RegistrationKey;
 import org.apache.james.mailbox.events.RetryBackoffConfiguration;
+import org.apache.james.mailbox.events.UninitializedEventBus;
 import org.apache.james.utils.InitializationOperation;
 import org.apache.james.utils.InitilizationOperationBuilder;
 
@@ -40,7 +40,7 @@ public class RabbitMQEventBusModule extends AbstractModule {
         bind(EventSerializer.class).in(Scopes.SINGLETON);
 
         bind(RabbitMQEventBus.class).in(Scopes.SINGLETON);
-        bind(EventBus.class).to(RabbitMQEventBus.class);
+        bind(UninitializedEventBus.class).to(RabbitMQEventBus.class);
 
         Multibinder.newSetBinder(binder(), RegistrationKey.Factory.class)
             .addBinding().to(MailboxIdRegistrationKey.Factory.class);

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/DefaultEventModule.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/DefaultEventModule.java
@@ -20,10 +20,11 @@
 package org.apache.james.modules.mailbox;
 
 import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.events.InVMEventBus;
 import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.events.RetryBackoffConfiguration;
+import org.apache.james.mailbox.events.UninitializedEventBus;
 import org.apache.james.mailbox.events.delivery.EventDelivery;
 import org.apache.james.mailbox.events.delivery.InVmEventDelivery;
 import org.apache.james.modules.EventDeadLettersProbe;
@@ -46,11 +47,12 @@ public class DefaultEventModule extends AbstractModule {
         bind(MailboxListenersLoaderImpl.class).in(Scopes.SINGLETON);
         bind(InVmEventDelivery.class).in(Scopes.SINGLETON);
         bind(InVMEventBus.class).in(Scopes.SINGLETON);
+        bind(EventBusSupplier.class).in(Scopes.SINGLETON);
 
         Multibinder.newSetBinder(binder(), GuiceProbe.class).addBinding().to(EventDeadLettersProbe.class);
         bind(MailboxListenersLoader.class).to(MailboxListenersLoaderImpl.class);
         bind(EventDelivery.class).to(InVmEventDelivery.class);
-        bind(EventBus.class).to(InVMEventBus.class);
+        bind(UninitializedEventBus.class).to(InVMEventBus.class);
 
         bind(RetryBackoffConfiguration.class).toInstance(RetryBackoffConfiguration.DEFAULT);
 

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenersLoader.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenersLoader.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.modules.mailbox;
 
+import java.util.Map;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.mailbox.events.Group;
 import org.apache.james.mailbox.events.MailboxListener;
@@ -25,5 +27,5 @@ import org.apache.james.mailbox.events.MailboxListener;
 public interface MailboxListenersLoader {
     Pair<Group, MailboxListener> createListener(ListenerConfiguration configuration);
 
-    void register(Pair<Group, MailboxListener> listener);
+    void register(Map<Group, MailboxListener> listeners);
 }

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenersLoader.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenersLoader.java
@@ -21,11 +21,12 @@ package org.apache.james.modules.mailbox;
 import java.util.Map;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.james.mailbox.events.EventBus;
 import org.apache.james.mailbox.events.Group;
 import org.apache.james.mailbox.events.MailboxListener;
 
 public interface MailboxListenersLoader {
     Pair<Group, MailboxListener> createListener(ListenerConfiguration configuration);
 
-    void register(Map<Group, MailboxListener> listeners);
+    EventBus register(Map<Group, MailboxListener> listeners);
 }

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenersLoaderImpl.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/mailbox/MailboxListenersLoaderImpl.java
@@ -64,7 +64,8 @@ public class MailboxListenersLoaderImpl implements Configurable, MailboxListener
         ImmutableMap<Group, MailboxListener.GroupMailboxListener> guiceListenersAsMap = guiceDefinedListeners.stream()
             .collect(Guavate.toImmutableMap(MailboxListener.GroupMailboxListener::getDefaultGroup));
 
-        ImmutableMap<Group, MailboxListener> registeredListenersAsMap = listenersConfiguration.getListenersConfiguration().stream()
+        ImmutableMap<Group, MailboxListener> registeredListenersAsMap = listenersConfiguration.getListenersConfiguration()
+            .stream()
             .map(this::createListener)
             .collect(Guavate.toImmutableMap(
                 Pair::getLeft,
@@ -78,7 +79,7 @@ public class MailboxListenersLoaderImpl implements Configurable, MailboxListener
 
     @Override
     public void register(Map<Group, MailboxListener> listeners) {
-        listeners.forEach((key, value) -> eventBus.register(value, key));
+        eventBus.initialize(listeners);
     }
 
     @Override

--- a/server/container/guice/mailbox/src/test/java/org/apache/james/modules/mailbox/MailboxListenersLoaderImplTest.java
+++ b/server/container/guice/mailbox/src/test/java/org/apache/james/modules/mailbox/MailboxListenersLoaderImplTest.java
@@ -33,6 +33,7 @@ import org.apache.commons.configuration2.XMLConfiguration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.filesystem.api.FileSystem;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.events.EventBusTestFixture;
 import org.apache.james.mailbox.events.GenericGroup;
 import org.apache.james.mailbox.events.Group;
@@ -63,7 +64,7 @@ class MailboxListenersLoaderImplTest {
         eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, new MemoryEventDeadLetters());
 
         GuiceGenericLoader genericLoader = GuiceGenericLoader.forTesting(new ExtendedClassLoader(fileSystem));
-        testee = new MailboxListenersLoaderImpl(new MailboxListenerFactory(genericLoader), eventBus, ImmutableSet.of());
+        testee = new MailboxListenersLoaderImpl(new MailboxListenerFactory(genericLoader), new EventBusSupplier(eventBus), ImmutableSet.of());
     }
 
     @Test

--- a/server/container/guice/protocols/imap/src/main/java/org/apache/james/modules/protocols/IMAPServerModule.java
+++ b/server/container/guice/protocols/imap/src/main/java/org/apache/james/modules/protocols/IMAPServerModule.java
@@ -28,7 +28,7 @@ import org.apache.james.imapserver.netty.IMAPServerFactory;
 import org.apache.james.imapserver.netty.OioIMAPServerFactory;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.SubscriptionManager;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.quota.QuotaManager;
 import org.apache.james.mailbox.quota.QuotaRootResolver;
 import org.apache.james.metrics.api.MetricFactory;
@@ -57,7 +57,7 @@ public class IMAPServerModule extends AbstractModule {
     @Provides
     ImapProcessor provideImapProcessor(
             MailboxManager mailboxManager,
-            EventBus eventBus,
+            EventBusSupplier eventBus,
             SubscriptionManager subscriptionManager,
             QuotaManager quotaManager,
             QuotaRootResolver quotaRootResolver,

--- a/server/container/guice/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/JmapGuiceProbe.java
+++ b/server/container/guice/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/JmapGuiceProbe.java
@@ -35,6 +35,7 @@ import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageIdManager;
 import org.apache.james.mailbox.events.EventBus;
 import org.apache.james.mailbox.events.MailboxListener;
+import org.apache.james.mailbox.events.RegistrationKey;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageId;
@@ -66,8 +67,8 @@ public class JmapGuiceProbe implements GuiceProbe {
         return jmapServer.getPort();
     }
 
-    public void addMailboxListener(MailboxListener.GroupMailboxListener listener) {
-        eventBus.register(listener);
+    public void addMailboxListener(MailboxListener listener, RegistrationKey registrationKey) {
+        eventBus.register(listener, registrationKey);
     }
 
     public void modifyVacation(AccountId accountId, VacationPatch vacationPatch) {

--- a/server/container/guice/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/JmapGuiceProbe.java
+++ b/server/container/guice/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/JmapGuiceProbe.java
@@ -33,7 +33,7 @@ import org.apache.james.jmap.api.vacation.VacationRepository;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.MessageIdManager;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.events.RegistrationKey;
 import org.apache.james.mailbox.exception.MailboxException;
@@ -50,11 +50,12 @@ public class JmapGuiceProbe implements GuiceProbe {
     private final JMAPServer jmapServer;
     private final MessageIdManager messageIdManager;
     private final MailboxManager mailboxManager;
-    private final EventBus eventBus;
+    private final EventBusSupplier eventBus;
     private final MessageFastViewProjection messageFastViewProjection;
 
     @Inject
-    private JmapGuiceProbe(VacationRepository vacationRepository, JMAPServer jmapServer, MessageIdManager messageIdManager, MailboxManager mailboxManager, EventBus eventBus, MessageFastViewProjection messageFastViewProjection) {
+    private JmapGuiceProbe(VacationRepository vacationRepository, JMAPServer jmapServer, MessageIdManager messageIdManager,
+                           MailboxManager mailboxManager, EventBusSupplier eventBus, MessageFastViewProjection messageFastViewProjection) {
         this.vacationRepository = vacationRepository;
         this.jmapServer = jmapServer;
         this.messageIdManager = messageIdManager;
@@ -68,7 +69,7 @@ public class JmapGuiceProbe implements GuiceProbe {
     }
 
     public void addMailboxListener(MailboxListener listener, RegistrationKey registrationKey) {
-        eventBus.register(listener, registrationKey);
+        eventBus.get().register(listener, registrationKey);
     }
 
     public void modifyVacation(AccountId accountId, VacationPatch vacationPatch) {

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMessagesMethodTest.java
@@ -66,7 +66,6 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -90,6 +89,7 @@ import org.apache.james.mailbox.DefaultMailboxes;
 import org.apache.james.mailbox.FlagsBuilder;
 import org.apache.james.mailbox.Role;
 import org.apache.james.mailbox.events.Event;
+import org.apache.james.mailbox.events.MailboxIdRegistrationKey;
 import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.Attachment;
@@ -132,6 +132,7 @@ import org.junit.experimental.categories.Category;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
+
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.filter.log.LogDetail;
@@ -2463,7 +2464,9 @@ public abstract class SetMessagesMethodTest {
             "]";
 
         EventCollector eventCollector = new EventCollector();
-        jmapServer.getProbe(JmapGuiceProbe.class).addMailboxListener(eventCollector);
+        jmapServer.getProbe(JmapGuiceProbe.class).addMailboxListener(eventCollector,
+            new MailboxIdRegistrationKey(jmapServer.getProbe(MailboxProbeImpl.class)
+                .getMailboxId(MailboxConstants.USER_NAMESPACE, USERNAME.asString(), DefaultMailboxes.OUTBOX)));
 
         String messageId = with()
             .header("Authorization", accessToken.asString())

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/event/PropagateLookupRightListenerTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/event/PropagateLookupRightListenerTest.java
@@ -58,7 +58,6 @@ public class PropagateLookupRightListenerTest {
 
     private StoreRightManager storeRightManager;
     private StoreMailboxManager storeMailboxManager;
-    private PropagateLookupRightListener testee;
 
     private MailboxSession mailboxSession = MailboxSessionUtil.create(OWNER_USER);
 
@@ -73,13 +72,12 @@ public class PropagateLookupRightListenerTest {
 
     @Before
     public void setup() throws Exception {
-        InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultResources();
+        InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultBuilder()
+            .registerListener((manager, messageIdManager) -> new PropagateLookupRightListener(manager, manager))
+            .build();
         storeMailboxManager = resources.getMailboxManager();
         storeRightManager = resources.getStoreRightManager();
         mailboxMapper = storeMailboxManager.getMapperFactory();
-
-        testee = new PropagateLookupRightListener(storeRightManager, storeMailboxManager);
-        storeMailboxManager.getEventBus().register(testee);
 
         parentMailboxId = storeMailboxManager.createMailbox(PARENT_MAILBOX, mailboxSession).get();
         parentMailboxId1 = storeMailboxManager.createMailbox(PARENT_MAILBOX1, mailboxSession).get();
@@ -98,7 +96,9 @@ public class PropagateLookupRightListenerTest {
 
     @Test
     public void getExecutionModeShouldReturnAsynchronous() throws Exception {
-        assertThat(testee.getExecutionMode()).isEqualTo(MailboxListener.ExecutionMode.SYNCHRONOUS);
+        assertThat(new PropagateLookupRightListener(storeRightManager, storeMailboxManager)
+            .getExecutionMode())
+            .isEqualTo(MailboxListener.ExecutionMode.SYNCHRONOUS);
     }
 
     @Test

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/EventDeadLettersRedeliverService.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/EventDeadLettersRedeliverService.java
@@ -22,7 +22,7 @@ package org.apache.james.webadmin.service;
 import javax.inject.Inject;
 
 import org.apache.james.mailbox.events.Event;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.events.EventDeadLetters;
 import org.apache.james.mailbox.events.Group;
 import org.apache.james.task.Task;
@@ -38,12 +38,12 @@ public class EventDeadLettersRedeliverService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EventDeadLettersRedeliverService.class);
 
-    private final EventBus eventBus;
+    private final EventBusSupplier eventBus;
     private final EventDeadLetters deadLetters;
 
     @Inject
     @VisibleForTesting
-    public EventDeadLettersRedeliverService(EventBus eventBus, EventDeadLetters deadLetters) {
+    public EventDeadLettersRedeliverService(EventBusSupplier eventBus, EventDeadLetters deadLetters) {
         this.eventBus = eventBus;
         this.deadLetters = deadLetters;
     }
@@ -54,7 +54,7 @@ public class EventDeadLettersRedeliverService {
     }
 
     private Mono<Task.Result> redeliverGroupEvents(Group group, Event event, EventDeadLetters.InsertionId insertionId) {
-        return eventBus.reDeliver(group, event)
+        return eventBus.get().reDeliver(group, event)
             .then(deadLetters.remove(group, insertionId))
             .thenReturn(Task.Result.COMPLETED)
             .onErrorResume(e -> {

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/ElasticSearchQuotaSearchExtension.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/ElasticSearchQuotaSearchExtension.java
@@ -67,7 +67,6 @@ public class ElasticSearchQuotaSearchExtension implements ParameterResolver, Bef
                     .addHost(elasticSearch.getHttpHost())
                     .build());
 
-            InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultResources();
 
 
             DNSService dnsService = mock(DNSService.class);
@@ -79,7 +78,9 @@ public class ElasticSearchQuotaSearchExtension implements ParameterResolver, Bef
                 new QuotaRatioToElasticSearchJson(),
                 new UserRoutingKeyFactory());
 
-            resources.getMailboxManager().getEventBus().register(listener);
+            InMemoryIntegrationResources resources = InMemoryIntegrationResources.defaultBuilder()
+                .registerListener((manager, messageIdManager) -> listener)
+                .build();
 
             QuotaComponents quotaComponents = resources.getMailboxManager().getQuotaComponents();
 

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
@@ -67,6 +67,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -384,8 +385,8 @@ class EventDeadLettersRoutesTest {
             eventCollectorB = new EventCollector();
             groupA = new EventBusTestFixture.GroupA();
             groupB = new EventBusTestFixture.GroupB();
-            eventBus.register(eventCollectorA, groupA);
-            eventBus.register(eventCollectorB, groupB);
+            eventBus.initialize(ImmutableMap.of(groupA, eventCollectorA,
+                groupB, eventCollectorB));
         }
 
         @Test
@@ -572,7 +573,7 @@ class EventDeadLettersRoutesTest {
         void nestedBeforeEach() {
             eventCollector = new EventCollector();
             groupA = new EventBusTestFixture.GroupA();
-            eventBus.register(eventCollector, groupA);
+            eventBus.initialize(eventCollector, groupA);
         }
 
         @Test
@@ -792,7 +793,7 @@ class EventDeadLettersRoutesTest {
         void nestedBeforeEach() {
             eventCollector = new EventCollector();
             groupA = new EventBusTestFixture.GroupA();
-            eventBus.register(eventCollector, groupA);
+            eventBus.initialize(eventCollector, groupA);
         }
 
         @Test

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/EventDeadLettersRoutesTest.java
@@ -35,7 +35,7 @@ import org.apache.james.core.Username;
 import org.apache.james.event.json.EventSerializer;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.events.Event;
-import org.apache.james.mailbox.events.EventBus;
+import org.apache.james.mailbox.events.EventBusSupplier;
 import org.apache.james.mailbox.events.EventBusTestFixture;
 import org.apache.james.mailbox.events.EventDeadLetters;
 import org.apache.james.mailbox.events.Group;
@@ -109,7 +109,7 @@ class EventDeadLettersRoutesTest {
 
     private WebAdminServer webAdminServer;
     private EventDeadLetters deadLetters;
-    private EventBus eventBus;
+    private EventBusSupplier eventBus;
     private MemoryTaskManager taskManager;
 
     @BeforeEach
@@ -117,7 +117,8 @@ class EventDeadLettersRoutesTest {
         deadLetters = new MemoryEventDeadLetters();
         JsonTransformer jsonTransformer = new JsonTransformer();
         EventSerializer eventSerializer = new EventSerializer(new InMemoryId.Factory(), new InMemoryMessageId.Factory(), new DefaultUserQuotaRootResolver.DefaultQuotaRootDeserializer());
-        eventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), RetryBackoffConfiguration.DEFAULT, deadLetters);
+        InVMEventBus inVMEventBus = new InVMEventBus(new InVmEventDelivery(new RecordingMetricFactory()), RetryBackoffConfiguration.DEFAULT, deadLetters);
+        eventBus = new EventBusSupplier(inVMEventBus);
         EventDeadLettersRedeliverService redeliverService = new EventDeadLettersRedeliverService(eventBus, deadLetters);
         EventDeadLettersService service = new EventDeadLettersService(redeliverService, deadLetters);
 


### PR DESCRIPTION
Points to work on:

We have dependencies loops: some listeners requires either  managers that themselves requires an event bus that requires the listeners for its initialisation.

Guice handling of this dependency loop is straightforward.

However for unit tests this is tricky to deal with and I experimented several strategies:

 - The **evil** MagicEventBus** interface holding both initialized & uninitialized EventBus

This simplifies test setup a lot and avoids sistematic wrapping.

Then the unitialiazeed event bus and the event bus are the same object, we can pass the unitialized event bus, then later initialize it.

This limits the refactoring benefits however calls to MagicEventBus api can be tracked. We can rely on the API split where we need (eg in guice) while skipping it where it hurts (unit tests + spring). However theeventBus implementation cannot be split.

 - Spring compatibility strategy relies on inVm event but to be implementing both

 - the alternative to the evil **MagicEventBus** would be systematic wrapping  of object taking a eventBus to kill dependencies loop. In short: manual re-implementation of Guice dependency loop killing. That is what I implemented in "InMemoryIntegrationResources".

A third alternative could be to rely on guice for initializing these test systems.

-------------------------------------

Follow up to this work:

 - this is not simple to split `EventBus` and `UninitializedEventBus` APIs.
     - Thus we might want to accept https://github.com/linagora/james-project/pull/3279 as an intermediate implementation stage
     - We need to discuss which one of the three strategies to adopt above.
     - Note that these strategies could be composed: eg start with the magic API solution (which makes segragation effective in production code) then enact the wrapping/guice-for-testing strategy

Also we might want to measure the payoff of such a refactoring over https://github.com/linagora/james-project/pull/327

As there is no silver bullet this need discussion!