### PR TITLE
JAMES-3058 SolveMailboxInconbsistencies: Flux.merge leads to undeterm…

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesService.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesService.java
@@ -414,7 +414,6 @@ public class SolveMailboxInconsistenciesService {
     private Mono<Inconsistency> detectInconsistency(CassandraIdAndPath pathRegistration) {
         return mailboxDAO.retrieveMailbox(pathRegistration.getCassandraId())
             .map(mailbox -> {
-                System.out.println(pathRegistration + " vs " + mailbox);
                 if (mailbox.generateAssociatedPath().equals(pathRegistration.getMailboxPath())) {
                     return NO_INCONSISTENCY;
                 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesService.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesService.java
@@ -368,7 +368,7 @@ public class SolveMailboxInconsistenciesService {
 
     Mono<Result> fixMailboxInconsistencies(Context context) {
         assertValidVersion();
-        return Flux.merge(
+        return Flux.concat(
                 processMailboxDaoInconsistencies(context),
                 processMailboxPathDaoInconsistencies(context))
             .reduce(Result.COMPLETED, Task::combine);
@@ -414,6 +414,7 @@ public class SolveMailboxInconsistenciesService {
     private Mono<Inconsistency> detectInconsistency(CassandraIdAndPath pathRegistration) {
         return mailboxDAO.retrieveMailbox(pathRegistration.getCassandraId())
             .map(mailbox -> {
+                System.out.println(pathRegistration + " vs " + mailbox);
                 if (mailbox.generateAssociatedPath().equals(pathRegistration.getMailboxPath())) {
                     return NO_INCONSISTENCY;
                 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesServiceTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesServiceTest.java
@@ -202,6 +202,7 @@ class SolveMailboxInconsistenciesServiceTest {
         assertThat(context.snapshot())
             .isEqualTo(Context.builder()
                 .processedMailboxEntries(1)
+                .processedMailboxPathEntries(1)
                 .addFixedInconsistencies(MAILBOX.getMailboxId())
                 .build()
                 .snapshot());
@@ -253,7 +254,7 @@ class SolveMailboxInconsistenciesServiceTest {
         assertThat(context.snapshot())
             .isEqualTo(Context.builder()
                 .processedMailboxEntries(1)
-                .processedMailboxPathEntries(1)
+                .processedMailboxPathEntries(2)
                 .addFixedInconsistencies(CASSANDRA_ID_1)
                 .addConflictingEntry(ConflictingEntry.builder()
                     .mailboxDaoEntry(MAILBOX)


### PR DESCRIPTION
…inistic results

Depending on wether for a given mailbox we fix possible inconsistencies
by path first or by id first, the result won't be the same.

Flux merge interleave publishers leading to such undeterministic results
while Flux.concat avoid such issues.