### PR TITLE
JAMES-3149 Avoid some Reactor::subscribeOn calls

### DIFF
--- a/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/ReactorElasticSearchClient.java
+++ b/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/ReactorElasticSearchClient.java
@@ -154,7 +154,7 @@ public class ReactorElasticSearchClient implements AutoCloseable {
 
     private static <T> Mono<T> toReactor(Consumer<ActionListener<T>> async) {
         return Mono.<T>create(sink -> async.accept(getListener(sink)))
-            .subscribeOn(Schedulers.elastic());
+            .publishOn(Schedulers.elastic());
     }
 
     private static <T> ActionListener<T> getListener(MonoSink<T> sink) {

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/events/GroupContract.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/events/GroupContract.java
@@ -56,6 +56,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+
 import reactor.core.scheduler.Schedulers;
 
 public interface GroupContract {
@@ -158,7 +159,9 @@ public interface GroupContract {
             AtomicBoolean successfulRetry = new AtomicBoolean(false);
             MailboxListener listener = event -> {
                 if (event.getEventId().equals(EVENT_ID)) {
-                    eventBus().dispatch(EVENT_2, NO_KEYS).block();
+                    eventBus().dispatch(EVENT_2, NO_KEYS)
+                        .subscribeOn(Schedulers.elastic())
+                        .block();
                     successfulRetry.set(true);
                 }
             };

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageIdManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageIdManager.java
@@ -80,6 +80,7 @@ import com.google.common.collect.Sets;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 public class StoreMessageIdManager implements MessageIdManager {
 
@@ -235,6 +236,7 @@ public class StoreMessageIdManager implements MessageIdManager {
                 new MailboxIdRegistrationKey(metadataWithMailboxId.getMailboxId())))
                 .sneakyThrow())
             .then()
+            .subscribeOn(Schedulers.elastic())
             .block();
     }
 
@@ -305,6 +307,7 @@ public class StoreMessageIdManager implements MessageIdManager {
             messageMoves.impactedMailboxIds()
                 .map(MailboxIdRegistrationKey::new)
                 .collect(Guavate.toImmutableSet()))
+            .subscribeOn(Schedulers.elastic())
             .block();
     }
 
@@ -322,6 +325,7 @@ public class StoreMessageIdManager implements MessageIdManager {
                 .addMetaData(eventPayload)
                 .build(),
                 new MailboxIdRegistrationKey(mailboxId))
+            .subscribeOn(Schedulers.elastic())
             .block();
         }
     }
@@ -331,12 +335,13 @@ public class StoreMessageIdManager implements MessageIdManager {
             Mailbox mailbox = mailboxSessionMapperFactory.getMailboxMapper(mailboxSession).findMailboxById(mailboxId);
 
             eventBus.dispatch(EventFactory.flagsUpdated()
-                .randomEventId()
-                .mailboxSession(mailboxSession)
-                .mailbox(mailbox)
-                .updatedFlags(updatedFlags)
-                .build(),
+                    .randomEventId()
+                    .mailboxSession(mailboxSession)
+                    .mailbox(mailbox)
+                    .updatedFlags(updatedFlags)
+                    .build(),
                 new MailboxIdRegistrationKey(mailboxId))
+                .subscribeOn(Schedulers.elastic())
                 .block();
         }
     }
@@ -393,12 +398,13 @@ public class StoreMessageIdManager implements MessageIdManager {
             save(messageIdMapper, copy);
 
             eventBus.dispatch(EventFactory.added()
-                .randomEventId()
-                .mailboxSession(mailboxSession)
-                .mailbox(mailboxMapper.findMailboxById(mailboxId))
-                .addMetaData(copy.metaData())
-                .build(),
-                new MailboxIdRegistrationKey(mailboxId))
+                    .randomEventId()
+                    .mailboxSession(mailboxSession)
+                    .mailbox(mailboxMapper.findMailboxById(mailboxId))
+                    .addMetaData(copy.metaData())
+                    .build(),
+                    new MailboxIdRegistrationKey(mailboxId))
+                .subscribeOn(Schedulers.elastic())
                 .block();
         }
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -289,6 +289,7 @@ public class StoreMessageManager implements MessageManager {
                 .metaData(ImmutableSortedMap.copyOf(deletedMessages))
                 .build(),
             new MailboxIdRegistrationKey(mailbox.getMailboxId()))
+            .subscribeOn(Schedulers.elastic())
             .block();
     }
 
@@ -437,12 +438,12 @@ public class StoreMessageManager implements MessageManager {
                 Mailbox mailbox = getMailboxEntity();
 
                 eventBus.dispatch(EventFactory.added()
-                    .randomEventId()
-                    .mailboxSession(mailboxSession)
-                    .mailbox(mailbox)
-                    .addMetaData(data.getLeft())
-                    .build(),
-                    new MailboxIdRegistrationKey(mailbox.getMailboxId()))
+                        .randomEventId()
+                        .mailboxSession(mailboxSession)
+                        .mailbox(mailbox)
+                        .addMetaData(data.getLeft())
+                        .build(),
+                        new MailboxIdRegistrationKey(mailbox.getMailboxId()))
                     .subscribeOn(Schedulers.elastic())
                     .block();
                 MessageMetaData messageMetaData = data.getLeft();
@@ -592,12 +593,13 @@ public class StoreMessageManager implements MessageManager {
         List<UpdatedFlags> updatedFlags = Iterators.toStream(it).collect(Guavate.toImmutableList());
 
         eventBus.dispatch(EventFactory.flagsUpdated()
-            .randomEventId()
-            .mailboxSession(mailboxSession)
-            .mailbox(getMailboxEntity())
-            .updatedFlags(updatedFlags)
-            .build(),
-            new MailboxIdRegistrationKey(mailbox.getMailboxId()))
+                .randomEventId()
+                .mailboxSession(mailboxSession)
+                .mailbox(getMailboxEntity())
+                .updatedFlags(updatedFlags)
+                .build(),
+                new MailboxIdRegistrationKey(mailbox.getMailboxId()))
+            .subscribeOn(Schedulers.elastic())
             .block();
 
         return updatedFlags.stream().collect(Guavate.toImmutableMap(
@@ -759,6 +761,7 @@ public class StoreMessageManager implements MessageManager {
                     .messageId(messageIds.build())
                     .build(),
                 messageMoves.impactedMailboxIds().map(MailboxIdRegistrationKey::new).collect(Guavate.toImmutableSet())))
+            .subscribeOn(Schedulers.elastic())
             .blockLast();
 
         return copiedUids;
@@ -800,6 +803,7 @@ public class StoreMessageManager implements MessageManager {
                     .session(session)
                     .build(),
                 messageMoves.impactedMailboxIds().map(MailboxIdRegistrationKey::new).collect(Guavate.toImmutableSet())))
+            .subscribeOn(Schedulers.elastic())
             .blockLast();
 
         return moveUids;

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreRightManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreRightManager.java
@@ -54,6 +54,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 public class StoreRightManager implements RightManager {
     public static final boolean GROUP_FOLDER = true;
@@ -156,6 +157,7 @@ public class StoreRightManager implements RightManager {
             .aclDiff(aclDiff)
             .build(),
             new MailboxIdRegistrationKey(mailbox.getMailboxId()))
+            .subscribeOn(Schedulers.elastic())
             .block();
     }
 
@@ -241,6 +243,7 @@ public class StoreRightManager implements RightManager {
             .aclDiff(aclDiff)
             .build(),
             new MailboxIdRegistrationKey(mailbox.getMailboxId()))
+            .subscribeOn(Schedulers.elastic())
             .block();
     }
 

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueBrowser.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/view/cassandra/CassandraMailQueueBrowser.java
@@ -47,7 +47,6 @@ import com.google.common.base.Preconditions;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 public class CassandraMailQueueBrowser {
 
@@ -110,8 +109,7 @@ public class CassandraMailQueueBrowser {
     Flux<EnqueuedItemWithSlicingContext> browseReferences(MailQueueName queueName) {
         return browseStartDao.findBrowseStart(queueName)
             .flatMapMany(this::allSlicesStartingAt)
-            .flatMapSequential(slice -> browseSlice(queueName, slice))
-            .subscribeOn(Schedulers.elastic());
+            .flatMapSequential(slice -> browseSlice(queueName, slice));
     }
 
     private Mono<Mail> toMailFuture(EnqueuedItemWithSlicingContext enqueuedItemWithSlicingContext) {


### PR DESCRIPTION
Flux::subscribeOn documents: 

```
Typically used for slow publisher e.g., blocking IO, fast consumer(s) scenarios.
```

I believe that, in addition to limiting block calls, we should also try pushing subscribeOn calls at the edges of our reactive code.