### PR TITLE
JAMES-3140 Better handle CassandraModSeqRetries

### DIFF
--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/Scenario.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/Scenario.java
@@ -33,10 +33,16 @@ import com.datastax.driver.core.Statement;
 import com.google.common.base.Preconditions;
 
 public class Scenario {
+    public static class InjectedFailureException extends RuntimeException {
+        public InjectedFailureException() {
+            super("Injected failure");
+        }
+    }
+
     @FunctionalInterface
     interface Behavior {
         Behavior THROW = (session, statement) -> {
-            throw new RuntimeException("Injected failure");
+            throw new InjectedFailureException();
         };
 
         Behavior EXECUTE_NORMALLY = Session::executeAsync;

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/TestingSessionTest.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/TestingSessionTest.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.james.backends.cassandra.Scenario.Barrier;
+import org.apache.james.backends.cassandra.Scenario.InjectedFailureException;
 import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionDAO;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
@@ -89,7 +90,7 @@ class TestingSessionTest {
                 .whenQueryStartsWith("SELECT value FROM schemaVersion;"));
 
         assertThatThrownBy(() -> dao.getCurrentSchemaVersion().block())
-            .isInstanceOf(RuntimeException.class);
+            .isInstanceOf(InjectedFailureException.class);
     }
 
     @Test
@@ -102,7 +103,7 @@ class TestingSessionTest {
         assertThatThrownBy(() -> new CassandraAsyncExecutor(cassandra.getConf())
                 .execute(select(VALUE).from(TABLE_NAME))
                 .block())
-            .isInstanceOf(RuntimeException.class);
+            .isInstanceOf(InjectedFailureException.class);
     }
 
     @Test
@@ -113,7 +114,7 @@ class TestingSessionTest {
                 .forAllQueries());
 
         assertThatThrownBy(() -> dao.getCurrentSchemaVersion().block())
-            .isInstanceOf(RuntimeException.class);
+            .isInstanceOf(InjectedFailureException.class);
     }
 
     @Test
@@ -142,9 +143,9 @@ class TestingSessionTest {
 
         SoftAssertions.assertSoftly(softly -> {
             assertThatThrownBy(() -> dao.getCurrentSchemaVersion().block())
-                .isInstanceOf(RuntimeException.class);
+                .isInstanceOf(InjectedFailureException.class);
             assertThatThrownBy(() -> dao.getCurrentSchemaVersion().block())
-                .isInstanceOf(RuntimeException.class);
+                .isInstanceOf(InjectedFailureException.class);
             assertThatCode(() -> dao.getCurrentSchemaVersion().block())
                 .doesNotThrowAnyException();
         });
@@ -165,7 +166,7 @@ class TestingSessionTest {
             assertThatCode(() -> dao.getCurrentSchemaVersion().block())
                 .doesNotThrowAnyException();
             assertThatThrownBy(() -> dao.getCurrentSchemaVersion().block())
-                .isInstanceOf(RuntimeException.class);
+                .isInstanceOf(InjectedFailureException.class);
             assertThatCode(() -> dao.getCurrentSchemaVersion().block())
                 .doesNotThrowAnyException();
         });
@@ -180,11 +181,11 @@ class TestingSessionTest {
 
         SoftAssertions.assertSoftly(softly -> {
             assertThatThrownBy(() -> dao.getCurrentSchemaVersion().block())
-                .isInstanceOf(RuntimeException.class);
+                .isInstanceOf(InjectedFailureException.class);
             assertThatThrownBy(() -> dao.getCurrentSchemaVersion().block())
-                .isInstanceOf(RuntimeException.class);
+                .isInstanceOf(InjectedFailureException.class);
             assertThatThrownBy(() -> dao.getCurrentSchemaVersion().block())
-                .isInstanceOf(RuntimeException.class);
+                .isInstanceOf(InjectedFailureException.class);
         });
     }
 
@@ -198,7 +199,7 @@ class TestingSessionTest {
         dao.updateVersion(new SchemaVersion(36)).block();
 
         assertThatThrownBy(() -> dao.getCurrentSchemaVersion().block())
-            .isInstanceOf(RuntimeException.class);
+            .isInstanceOf(InjectedFailureException.class);
     }
 
     @Test
@@ -287,6 +288,6 @@ class TestingSessionTest {
         barrier.releaseCaller();
 
         assertThatThrownBy(operation::block)
-            .isInstanceOf(RuntimeException.class);
+            .isInstanceOf(InjectedFailureException.class);
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraModSeqProvider.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraModSeqProvider.java
@@ -178,24 +178,14 @@ public class CassandraModSeqProvider implements ModSeqProvider {
     }
 
     public Mono<ModSeq> nextModSeq(CassandraId mailboxId) {
+        Duration firstBackoff = Duration.ofMillis(10);
+
         return findHighestModSeq(mailboxId)
             .flatMap(maybeHighestModSeq -> maybeHighestModSeq
                         .map(highestModSeq -> tryUpdateModSeq(mailboxId, highestModSeq))
                         .orElseGet(() -> tryInsertModSeq(mailboxId, ModSeq.first())))
-            .switchIfEmpty(handleRetries(mailboxId));
-    }
-
-    private Mono<ModSeq> handleRetries(CassandraId mailboxId) {
-        Duration firstBackoff = Duration.ofMillis(10);
-        return tryFindThenUpdateOnce(mailboxId)
             .single()
             .retryWhen(Retry.backoff(maxModSeqRetries, firstBackoff).scheduler(Schedulers.elastic()));
-    }
-
-    private Mono<ModSeq> tryFindThenUpdateOnce(CassandraId mailboxId) {
-        return Mono.defer(() -> findHighestModSeq(mailboxId)
-            .<ModSeq>handle((t, sink) -> t.ifPresent(sink::next))
-            .flatMap(highestModSeq -> tryUpdateModSeq(mailboxId, highestModSeq)));
     }
 
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraModSeqProvider.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraModSeqProvider.java
@@ -56,7 +56,6 @@ import reactor.util.retry.Retry;
 public class CassandraModSeqProvider implements ModSeqProvider {
 
     public static final String MOD_SEQ_CONDITION = "modSeqCondition";
-    private final long maxModSeqRetries;
 
     public static class ExceptionRelay extends RuntimeException {
         private final MailboxException underlying;
@@ -83,6 +82,7 @@ public class CassandraModSeqProvider implements ModSeqProvider {
     }
 
     private final CassandraAsyncExecutor cassandraAsyncExecutor;
+    private final long maxModSeqRetries;
     private final PreparedStatement select;
     private final PreparedStatement update;
     private final PreparedStatement insert;


### PR DESCRIPTION
Sub-part of https://github.com/linagora/james-project/pull/3319

In an empty modseq, retires did not include the initial row creation, but
only its update.

(Triggered because "100 mail should be well received" runs way faster
with the blob store cache.)

**TODO**

 - [x] Write unit tests for this