### PR TITLE
JAMES-3176 MDN parboiled parser can be a constant

### DIFF
--- a/mdn/src/main/java/org/apache/james/mdn/MDNReportParser.java
+++ b/mdn/src/main/java/org/apache/james/mdn/MDNReportParser.java
@@ -46,6 +46,8 @@ import org.parboiled.support.ParsingResult;
 import com.google.common.annotations.VisibleForTesting;
 
 public class MDNReportParser {
+    private static final Parser PARSER = Parboiled.createParser(Parser.class);
+
     public MDNReportParser() {
     }
 
@@ -54,8 +56,8 @@ public class MDNReportParser {
     }
 
     public Optional<MDNReport> parse(String mdnReport) {
-        Parser parser = Parboiled.createParser(MDNReportParser.Parser.class);
-        ParsingResult<Object> result = new ReportingParseRunner<>(parser.dispositionNotificationContent()).run(mdnReport);
+        ParsingResult<Object> result = new ReportingParseRunner<>(PARSER.dispositionNotificationContent())
+            .run(mdnReport);
         if (result.matched) {
             return Optional.of((MDNReport)result.resultValue);
         }


### PR DESCRIPTION
Instantiation of the parser was performed via reflection upon each MDN
parsing.

The instantiation of the parser generated several exception stack-traces
on one of our running production instance:

```
 java.lang.RuntimeException: Error creating extended parser class: null
	at org.parboiled.Parboiled.createParser(Parboiled.java:58)
	at org.apache.james.mdn.MDNReportParser.parse(MDNReportParser.java:57)
	at org.apache.james.mdn.MDNReportParser.parse(MDNReportParser.java:53)
	at org.apache.james.jmap.mailet.ExtractMDNOriginalJMAPMessageId.parseReport(ExtractMDNOriginalJMAPMessageId.java:120)
[...]
Caused by: java.lang.IllegalArgumentException: null
	at org.objectweb.asm.ClassVisitor.<init>(Unknown Source)
	at org.objectweb.asm.ClassVisitor.<init>(Unknown Source)
	at org.objectweb.asm.tree.ClassNode.<init>(Unknown Source)
	at org.parboiled.transform.ParserClassNode.<init>(ParserClassNode.java:43)
	at org.parboiled.transform.ParserTransformer.extendParserClass(ParserTransformer.java:43)
	at org.parboiled.transform.ParserTransformer.transformParser(ParserTransformer.java:39)
	at org.parboiled.Parboiled.createParser(Parboiled.java:54)
```

Given that a parser only defines a set of rules, and is thus immutable,
we can turn it into a constant, effectively solving our problem.