### PR TITLE
JAMES-3172 SerialTaskManagerWorker cancelation is not immediate

### DIFF
--- a/server/task/task-memory/src/test/java/org/apache/james/task/SerialTaskManagerWorkerTest.java
+++ b/server/task/task-memory/src/test/java/org/apache/james/task/SerialTaskManagerWorkerTest.java
@@ -225,6 +225,10 @@ class SerialTaskManagerWorkerTest {
 
         resultMono.block(Duration.ofSeconds(10));
 
+        // Due to the use of signals, cancellation cannot be instantaneous
+        // Let a grace period for the cancellation to complete to increase test stability
+        Thread.sleep(50);
+
         verify(listener, atLeastOnce()).cancelled(id, Optional.empty());
         verifyNoMoreInteractions(listener);
     }


### PR DESCRIPTION
The uses of signals can not be expected to be immediate. Thus
`theWorkerShouldCancelAnInProgressTask` test was failing as the
cancellation could be repeated after the mock check, eventually
failing the test.

This effectively solves the instability noticed on `theWorkerShouldCancelAnInProgressTask`