### PR TITLE
[REFACTORING] Allow a build variable for demo image

### DIFF
--- a/dockerfiles/run/guice/provisioned/Dockerfile
+++ b/dockerfiles/run/guice/provisioned/Dockerfile
@@ -2,7 +2,8 @@
 #
 # VERSION	1.0
 
-FROM linagora/james-jpa-guice:james-project-3.4.0
+ARG BASE_IMAGE=linagora/james-jpa-guice:james-project-3.4.0
+FROM ${BASE_IMAGE}
 
 # Install git
 RUN apt-get update


### PR DESCRIPTION
This enables to use a build time variable when builing this image:

```
docker build --build-arg BASE_IMAGE=XXX .
```

Currently, we need to alter a copy of the dockerfile in order to
customize the from image...

```
sh "cd dockerfiles/run/guice/provisioned; cp Dockerfile NewDockerfile; sed -i -- 's,linagora/james-jpa-guice,${images.jamesJPA},g' NewDockerfile"

sh "cd dockerfiles/run/guice/provisioned; docker build --tag=${images.jamesDemoForTesting} -f NewDockerfile ."
```

We can thus significantly simplify the testing pipeline.