### PR TITLE
JAMES-3143 Fix unstable Consistency integration test

### DIFF
--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/ConsistencyTasksIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/ConsistencyTasksIntegrationTest.java
@@ -266,7 +266,7 @@ class ConsistencyTasksIntegrationTest {
 
         Awaitility.await()
             .untilAsserted(() -> assertThat(server.getProbe(MailRepositoryProbeImpl.class)
-                .getRepositoryMailCount(MailRepositoryUrl.from("cassandra://var/mail/error/"))).isEqualTo(1));
+                .getRepositoryMailCount(MailRepositoryUrl.from("cassandra://var/mail/error/"))).isGreaterThanOrEqualTo(1));
 
         server.getProbe(TestingSessionProbe.class)
             .getTestingSession().registerScenario(executeNormally()


### PR DESCRIPTION
When sending a mails, localDelivery fails. A bounce is generated for the
sender, who is local, thus localDelivery fails again.

The time window during which only one email processing had been failing
is thus short, we should await that "at least once email delivery" had
been failing.