### PR TITLE
James 3200 - Fix typos in MDN parser

### DIFF
--- a/mdn/src/main/java/org/apache/james/mdn/MDNReportParser.java
+++ b/mdn/src/main/java/org/apache/james/mdn/MDNReportParser.java
@@ -190,7 +190,7 @@ public class MDNReportParser {
             return Sequence(
                 "\\",
                 FirstOf(
-                    Ch((char)0xd0),
+                    Ch((char)0),
                     obsCtext(),
                     lf(),
                     cr()));

--- a/mdn/src/main/java/org/apache/james/mdn/MDNReportParser.java
+++ b/mdn/src/main/java/org/apache/james/mdn/MDNReportParser.java
@@ -260,9 +260,26 @@ public class MDNReportParser {
             return Ch((char)0x22);
         }
 
+        //   obs-qtext       =   obs-NO-WS-CTL
+        Rule obsQtext() {
+            return obsNoWsCtl();
+        }
+
+        /*   qtext           =   %d33 /             ; Printable US-ASCII
+                                 %d35-91 /          ;  characters not including
+                                 %d93-126 /         ;  "\" or the quote character
+                                 obs-qtext  */
+        Rule qtext() {
+            return FirstOf(
+                (char)33,
+                CharRange((char)35, (char)91),
+                CharRange((char)93, (char)126),
+                obsQtext());
+        }
+
         //   qcontent        =   qtext / quoted-pair
         Rule qcontent() {
-            return FirstOf(qcontent(), quotedPair());
+            return FirstOf(qtext(), quotedPair());
         }
 
         //   domain          =   dot-atom / domain-literal / obs-domain


### PR DESCRIPTION
Some rules were mistyped in the parser, here is a fix.

I tried to introduce some tests to show the error, but as it concerns some obsolete rules it's pretty hard to find reliable example, so I stuck with the current test suite.