### PR TITLE
JAMES-3204 Push limit to Cassandra backend when reading messages

### DIFF
--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/CassandraCluster.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/CassandraCluster.java
@@ -18,8 +18,6 @@
  ****************************************************************/
 package org.apache.james.backends.cassandra;
 
-import static org.apache.james.backends.cassandra.Scenario.NOTHING;
-
 import java.util.Optional;
 
 import org.apache.james.backends.cassandra.components.CassandraModule;
@@ -85,7 +83,7 @@ public final class CassandraCluster implements AutoCloseable {
 
     @Override
     public void close() {
-        nonPrivilegedSession.registerScenario(NOTHING);
+        nonPrivilegedSession.resetInstrumentation();
         if (!nonPrivilegedCluster.isClosed()) {
             clearTables();
             closeCluster();

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/CassandraClusterExtension.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/CassandraClusterExtension.java
@@ -76,7 +76,7 @@ public class CassandraClusterExtension implements BeforeAllCallback, BeforeEachC
     @Override
     public void afterEach(ExtensionContext extensionContext) {
         cassandraCluster.clearTables();
-        cassandraCluster.getConf().registerScenario(Scenario.NOTHING);
+        cassandraCluster.getConf().resetInstrumentation();
     }
 
     @Override

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/StatementRecorder.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/StatementRecorder.java
@@ -1,0 +1,46 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.backends.cassandra;
+
+
+import java.util.List;
+
+import com.datastax.driver.core.Statement;
+import com.google.common.collect.ImmutableList;
+
+public class StatementRecorder {
+    private final ImmutableList.Builder<Statement> statements;
+
+    public StatementRecorder() {
+        statements = ImmutableList.builder();
+    }
+
+    void recordStatement(Statement statement) {
+        synchronized (statements) {
+            statements.add(statement);
+        }
+    }
+
+    public List<Statement> listExecutedStatements() {
+        synchronized (statements) {
+            return statements.build();
+        }
+    }
+}

--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/StatementRecorder.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/StatementRecorder.java
@@ -21,26 +21,23 @@ package org.apache.james.backends.cassandra;
 
 
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 import com.datastax.driver.core.Statement;
 import com.google.common.collect.ImmutableList;
 
 public class StatementRecorder {
-    private final ImmutableList.Builder<Statement> statements;
+    private final ConcurrentLinkedDeque statements;
 
     public StatementRecorder() {
-        statements = ImmutableList.builder();
+        statements = new ConcurrentLinkedDeque();
     }
 
     void recordStatement(Statement statement) {
-        synchronized (statements) {
-            statements.add(statement);
-        }
+        statements.add(statement);
     }
 
     public List<Statement> listExecutedStatements() {
-        synchronized (statements) {
-            return statements.build();
-        }
+        return ImmutableList.copyOf(statements);
     }
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/DeleteMessageListener.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/DeleteMessageListener.java
@@ -51,6 +51,7 @@ import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.store.mail.MessageMapper;
+import org.apache.james.util.streams.Limit;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -137,7 +138,7 @@ public class DeleteMessageListener implements MailboxListener.GroupMailboxListen
     }
 
     private Mono<Void> handleMailboxDeletion(CassandraId mailboxId) {
-        return messageIdDAO.retrieveMessages(mailboxId, MessageRange.all())
+        return messageIdDAO.retrieveMessages(mailboxId, MessageRange.all(), Limit.unlimited())
             .map(ComposedMessageIdWithMetaData::getComposedMessageId)
             .concatMap(metadata -> handleMessageDeletionAsPartOfMailboxDeletion((CassandraMessageId) metadata.getMessageId(), mailboxId)
                 .then(imapUidDAO.delete((CassandraMessageId) metadata.getMessageId(), mailboxId))

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAO.java
@@ -57,6 +57,7 @@ import org.apache.james.mailbox.cassandra.ids.CassandraMessageId.Factory;
 import org.apache.james.mailbox.model.ComposedMessageId;
 import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.util.streams.Limit;
 
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Row;
@@ -71,6 +72,7 @@ public class CassandraMessageIdDAO {
 
     private static final String IMAP_UID_GTE = IMAP_UID + "_GTE";
     private static final String IMAP_UID_LTE = IMAP_UID + "_LTE";
+    public static final String LIMIT = "LIMIT_BIND_MARKER";
 
     private final CassandraAsyncExecutor cassandraAsyncExecutor;
     private final Factory messageIdFactory;
@@ -78,8 +80,11 @@ public class CassandraMessageIdDAO {
     private final PreparedStatement insert;
     private final PreparedStatement select;
     private final PreparedStatement selectAllUids;
+    private final PreparedStatement selectAllUidsLimited;
     private final PreparedStatement selectUidGte;
+    private final PreparedStatement selectUidGteLimited;
     private final PreparedStatement selectUidRange;
+    private final PreparedStatement selectUidRangeLimited;
     private final PreparedStatement update;
     private final PreparedStatement listStatement;
 
@@ -92,8 +97,11 @@ public class CassandraMessageIdDAO {
         this.update = prepareUpdate(session);
         this.select = prepareSelect(session);
         this.selectAllUids = prepareSelectAllUids(session);
+        this.selectAllUidsLimited = prepareSelectAllUidsLimited(session);
         this.selectUidGte = prepareSelectUidGte(session);
+        this.selectUidGteLimited = prepareSelectUidGteLimited(session);
         this.selectUidRange = prepareSelectUidRange(session);
+        this.selectUidRangeLimited = prepareSelectUidRangeLimited(session);
         this.listStatement = prepareList(session);
     }
 
@@ -144,8 +152,15 @@ public class CassandraMessageIdDAO {
 
     private PreparedStatement prepareSelectAllUids(Session session) {
         return session.prepare(select(FIELDS)
-                .from(TABLE_NAME)
-                .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID))));
+            .from(TABLE_NAME)
+            .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID))));
+    }
+
+    private PreparedStatement prepareSelectAllUidsLimited(Session session) {
+        return session.prepare(select(FIELDS)
+            .from(TABLE_NAME)
+            .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID)))
+            .limit(bindMarker(LIMIT)));
     }
 
     private PreparedStatement prepareList(Session session) {
@@ -155,17 +170,34 @@ public class CassandraMessageIdDAO {
 
     private PreparedStatement prepareSelectUidGte(Session session) {
         return session.prepare(select(FIELDS)
-                .from(TABLE_NAME)
-                .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID)))
-                .and(gte(IMAP_UID, bindMarker(IMAP_UID))));
+            .from(TABLE_NAME)
+            .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID)))
+            .and(gte(IMAP_UID, bindMarker(IMAP_UID))));
+    }
+
+    private PreparedStatement prepareSelectUidGteLimited(Session session) {
+        return session.prepare(select(FIELDS)
+            .from(TABLE_NAME)
+            .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID)))
+            .and(gte(IMAP_UID, bindMarker(IMAP_UID)))
+            .limit(bindMarker(LIMIT)));
     }
 
     private PreparedStatement prepareSelectUidRange(Session session) {
         return session.prepare(select(FIELDS)
-                .from(TABLE_NAME)
-                .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID)))
-                .and(gte(IMAP_UID, bindMarker(IMAP_UID_GTE)))
-                .and(lte(IMAP_UID, bindMarker(IMAP_UID_LTE))));
+            .from(TABLE_NAME)
+            .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID)))
+            .and(gte(IMAP_UID, bindMarker(IMAP_UID_GTE)))
+            .and(lte(IMAP_UID, bindMarker(IMAP_UID_LTE))));
+    }
+
+    private PreparedStatement prepareSelectUidRangeLimited(Session session) {
+        return session.prepare(select(FIELDS)
+            .from(TABLE_NAME)
+            .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID)))
+            .and(gte(IMAP_UID, bindMarker(IMAP_UID_GTE)))
+            .and(lte(IMAP_UID, bindMarker(IMAP_UID_LTE)))
+            .limit(bindMarker(LIMIT)));
     }
 
     public Mono<Void> delete(CassandraId mailboxId, MessageUid uid) {
@@ -226,8 +258,8 @@ public class CassandraMessageIdDAO {
                 .setLong(IMAP_UID, uid.asLong()));
     }
 
-    public Flux<ComposedMessageIdWithMetaData> retrieveMessages(CassandraId mailboxId, MessageRange set) {
-        return retrieveRows(mailboxId, set)
+    public Flux<ComposedMessageIdWithMetaData> retrieveMessages(CassandraId mailboxId, MessageRange set, Limit limit) {
+        return retrieveRows(mailboxId, set, limit)
             .map(this::fromRowToComposedMessageIdWithFlags);
     }
 
@@ -236,36 +268,51 @@ public class CassandraMessageIdDAO {
             .map(this::fromRowToComposedMessageIdWithFlags);
     }
 
-    private Flux<Row> retrieveRows(CassandraId mailboxId, MessageRange set) {
+    private Flux<Row> retrieveRows(CassandraId mailboxId, MessageRange set, Limit limit) {
         switch (set.getType()) {
         case ALL:
-            return selectAll(mailboxId);
+            return selectAll(mailboxId, limit);
         case FROM:
-            return selectFrom(mailboxId, set.getUidFrom());
+            return selectFrom(mailboxId, set.getUidFrom(), limit);
         case RANGE:
-            return selectRange(mailboxId, set.getUidFrom(), set.getUidTo());
+            return selectRange(mailboxId, set.getUidFrom(), set.getUidTo(), limit);
         case ONE:
             return Flux.concat(selectOneRow(mailboxId, set.getUidFrom()));
         }
         throw new UnsupportedOperationException();
     }
 
-    private Flux<Row> selectAll(CassandraId mailboxId) {
-        return cassandraAsyncExecutor.executeRows(selectAllUids.bind()
-                .setUUID(MAILBOX_ID, mailboxId.asUuid()));
-    }
-
-    private Flux<Row> selectFrom(CassandraId mailboxId, MessageUid uid) {
-        return cassandraAsyncExecutor.executeRows(selectUidGte.bind()
+    private Flux<Row> selectAll(CassandraId mailboxId, Limit limit) {
+        return cassandraAsyncExecutor.executeRows(limit.getLimit()
+            .map(limitAsInt -> selectAllUidsLimited.bind()
                 .setUUID(MAILBOX_ID, mailboxId.asUuid())
-                .setLong(IMAP_UID, uid.asLong()));
+                .setInt(LIMIT, limitAsInt))
+            .orElse(selectAllUids.bind()
+                .setUUID(MAILBOX_ID, mailboxId.asUuid())));
     }
 
-    private Flux<Row> selectRange(CassandraId mailboxId, MessageUid from, MessageUid to) {
-        return cassandraAsyncExecutor.executeRows(selectUidRange.bind()
+    private Flux<Row> selectFrom(CassandraId mailboxId, MessageUid uid, Limit limit) {
+        return cassandraAsyncExecutor.executeRows(limit.getLimit()
+            .map(limitAsInt -> selectUidGteLimited.bind()
+                .setUUID(MAILBOX_ID, mailboxId.asUuid())
+                .setLong(IMAP_UID, uid.asLong())
+                .setInt(LIMIT, limitAsInt))
+            .orElse(selectUidGte.bind()
+                .setUUID(MAILBOX_ID, mailboxId.asUuid())
+                .setLong(IMAP_UID, uid.asLong())));
+    }
+
+    private Flux<Row> selectRange(CassandraId mailboxId, MessageUid from, MessageUid to, Limit limit) {
+        return cassandraAsyncExecutor.executeRows(limit.getLimit()
+            .map(limitAsInt -> selectUidRangeLimited.bind()
                 .setUUID(MAILBOX_ID, mailboxId.asUuid())
                 .setLong(IMAP_UID_GTE, from.asLong())
-                .setLong(IMAP_UID_LTE, to.asLong()));
+                .setLong(IMAP_UID_LTE, to.asLong())
+                .setInt(LIMIT, limitAsInt))
+            .orElse(selectUidRange.bind()
+                .setUUID(MAILBOX_ID, mailboxId.asUuid())
+                .setLong(IMAP_UID_GTE, from.asLong())
+                .setLong(IMAP_UID_LTE, to.asLong())));
     }
 
     private ComposedMessageIdWithMetaData fromRowToComposedMessageIdWithFlags(Row row) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -170,10 +170,8 @@ public class CassandraMessageMapper implements MessageMapper {
     public Flux<MailboxMessage> findInMailboxReactive(Mailbox mailbox, MessageRange messageRange, FetchType ftype, int limit) {
         CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
 
-        return Limit.from(limit).applyOnFlux(
-            messageIdDAO.retrieveMessages(mailboxId, messageRange)
-                .flatMap(id -> retrieveMessage(id, ftype), cassandraConfiguration.getMessageReadChunkSize()))
-            .map(MailboxMessage.class::cast)
+        return Limit.from(limit).applyOnFlux(messageIdDAO.retrieveMessages(mailboxId, messageRange))
+            .flatMap(id -> retrieveMessage(id, ftype), cassandraConfiguration.getMessageReadChunkSize())
             .sort(Comparator.comparing(MailboxMessage::getUid));
     }
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/MailboxMergingTaskRunner.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/MailboxMergingTaskRunner.java
@@ -37,6 +37,7 @@ import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.store.StoreMessageIdManager;
 import org.apache.james.task.Task;
+import org.apache.james.util.streams.Limit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,7 +69,7 @@ public class MailboxMergingTaskRunner {
     }
 
     private Task.Result moveMessages(CassandraId oldMailboxId, CassandraId newMailboxId, MailboxSession session, MailboxMergingTask.Context context) {
-        return cassandraMessageIdDAO.retrieveMessages(oldMailboxId, MessageRange.all())
+        return cassandraMessageIdDAO.retrieveMessages(oldMailboxId, MessageRange.all(), Limit.unlimited())
             .map(ComposedMessageIdWithMetaData::getComposedMessageId)
             .map(messageId -> moveMessage(newMailboxId, messageId, session, context))
             .reduce(Task.Result.COMPLETED, Task::combine)

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersService.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/RecomputeMailboxCountersService.java
@@ -39,6 +39,7 @@ import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.task.Task;
 import org.apache.james.task.Task.Result;
+import org.apache.james.util.streams.Limit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -216,7 +217,7 @@ public class RecomputeMailboxCountersService {
         CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
         Counter counter = new Counter(mailboxId);
 
-        return imapUidToMessageIdDAO.retrieveMessages(mailboxId, MessageRange.all())
+        return imapUidToMessageIdDAO.retrieveMessages(mailboxId, MessageRange.all(), Limit.unlimited())
             .flatMap(message -> latestMetadata(mailboxId, message, options), MESSAGE_CONCURRENCY)
             .doOnNext(counter::process)
             .then(Mono.defer(() -> counterDAO.resetCounters(counter.snapshot())))

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerTest.java
@@ -69,6 +69,7 @@ import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.apache.james.util.ClassLoaderUtils;
 import org.apache.james.util.streams.Iterators;
+import org.apache.james.util.streams.Limit;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -140,7 +141,7 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
                 softly.assertThat(imapUidDAO(cassandraCluster).retrieve(cassandraMessageId, Optional.of(mailboxId)).collectList().block())
                     .isEmpty();
 
-                softly.assertThat(messageIdDAO(cassandraCluster).retrieveMessages(mailboxId, MessageRange.all()).collectList().block())
+                softly.assertThat(messageIdDAO(cassandraCluster).retrieveMessages(mailboxId, MessageRange.all(), Limit.unlimited()).collectList().block())
                     .isEmpty();
 
                 softly.assertThat(attachmentDAO(cassandraCluster).getAttachment(attachmentId).blockOptional())
@@ -179,7 +180,7 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
                 softly.assertThat(imapUidDAO(cassandraCluster).retrieve(cassandraMessageId, Optional.of(mailboxId)).collectList().block())
                     .isEmpty();
 
-                softly.assertThat(messageIdDAO(cassandraCluster).retrieveMessages(mailboxId, MessageRange.all()).collectList().block())
+                softly.assertThat(messageIdDAO(cassandraCluster).retrieveMessages(mailboxId, MessageRange.all(), Limit.unlimited()).collectList().block())
                     .isEmpty();
 
                 softly.assertThat(attachmentDAO(cassandraCluster).getAttachment(attachmentId).blockOptional())
@@ -218,7 +219,7 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
                 softly.assertThat(imapUidDAO(cassandraCluster).retrieve(cassandraMessageId, Optional.of(mailboxId)).collectList().block())
                     .isEmpty();
 
-                softly.assertThat(messageIdDAO(cassandraCluster).retrieveMessages(mailboxId, MessageRange.all()).collectList().block())
+                softly.assertThat(messageIdDAO(cassandraCluster).retrieveMessages(mailboxId, MessageRange.all(), Limit.unlimited()).collectList().block())
                     .isEmpty();
 
                 softly.assertThat(attachmentDAO(cassandraCluster).getAttachment(attachmentId).blockOptional())
@@ -257,7 +258,7 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
                 softly.assertThat(imapUidDAO(cassandraCluster).retrieve(cassandraMessageId, Optional.of(mailboxId)).collectList().block())
                     .isEmpty();
 
-                softly.assertThat(messageIdDAO(cassandraCluster).retrieveMessages(mailboxId, MessageRange.all()).collectList().block())
+                softly.assertThat(messageIdDAO(cassandraCluster).retrieveMessages(mailboxId, MessageRange.all(), Limit.unlimited()).collectList().block())
                     .isEmpty();
 
                 softly.assertThat(attachmentDAO(cassandraCluster).getAttachment(attachmentId).blockOptional())
@@ -296,7 +297,7 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
                 softly.assertThat(imapUidDAO(cassandraCluster).retrieve(cassandraMessageId, Optional.of(mailboxId)).collectList().block())
                     .isEmpty();
 
-                softly.assertThat(messageIdDAO(cassandraCluster).retrieveMessages(mailboxId, MessageRange.all()).collectList().block())
+                softly.assertThat(messageIdDAO(cassandraCluster).retrieveMessages(mailboxId, MessageRange.all(), Limit.unlimited()).collectList().block())
                     .isEmpty();
 
                 softly.assertThat(attachmentDAO(cassandraCluster).getAttachment(attachmentId).blockOptional())
@@ -425,7 +426,7 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
                 softly.assertThat(imapUidDAO(cassandraCluster).retrieve(cassandraMessageId, Optional.of(mailboxId)).collectList().block())
                     .isEmpty();
 
-                softly.assertThat(messageIdDAO(cassandraCluster).retrieveMessages(mailboxId, MessageRange.all()).collectList().block())
+                softly.assertThat(messageIdDAO(cassandraCluster).retrieveMessages(mailboxId, MessageRange.all(), Limit.unlimited()).collectList().block())
                     .isEmpty();
 
                 softly.assertThat(attachmentDAO(cassandraCluster).getAttachment(attachmentId).blockOptional())
@@ -492,7 +493,7 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
                 softly.assertThat(imapUidDAO(cassandraCluster).retrieve(cassandraMessageId, Optional.of(mailboxId)).collectList().block())
                     .isEmpty();
 
-                softly.assertThat(messageIdDAO(cassandraCluster).retrieveMessages(mailboxId, MessageRange.all()).collectList().block())
+                softly.assertThat(messageIdDAO(cassandraCluster).retrieveMessages(mailboxId, MessageRange.all(), Limit.unlimited()).collectList().block())
                     .isEmpty();
 
                 softly.assertThat(attachmentDAO(cassandraCluster).getAttachment(attachmentId).blockOptional())

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAOTest.java
@@ -420,7 +420,7 @@ class CassandraMessageIdDAOTest {
                 .build();
         Flux.merge(testee.insert(composedMessageIdWithMetaData),
                 testee.insert(composedMessageIdWithMetaData2))
-        .blockLast();
+            .blockLast();
 
         assertThat(testee.retrieveMessages(mailboxId, MessageRange.all(), Limit.limit(1)).toIterable())
             .containsOnly(composedMessageIdWithMetaData);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdDAOTest.java
@@ -37,6 +37,7 @@ import org.apache.james.mailbox.cassandra.modules.CassandraMessageModule;
 import org.apache.james.mailbox.model.ComposedMessageId;
 import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.MessageRange;
+import org.apache.james.util.streams.Limit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -395,8 +396,34 @@ class CassandraMessageIdDAOTest {
                 testee.insert(composedMessageIdWithMetaData2))
         .blockLast();
 
-        assertThat(testee.retrieveMessages(mailboxId, MessageRange.all()).toIterable())
+        assertThat(testee.retrieveMessages(mailboxId, MessageRange.all(), Limit.unlimited()).toIterable())
             .containsOnly(composedMessageIdWithMetaData, composedMessageIdWithMetaData2);
+    }
+
+    @Test
+    void retrieveMessagesShouldApplyLimitWhenRangeAll() {
+        CassandraMessageId messageId = messageIdFactory.generate();
+        CassandraMessageId messageId2 = messageIdFactory.generate();
+        CassandraId mailboxId = CassandraId.timeBased();
+        MessageUid messageUid = MessageUid.of(1);
+        MessageUid messageUid2 = MessageUid.of(2);
+
+        ComposedMessageIdWithMetaData composedMessageIdWithMetaData = ComposedMessageIdWithMetaData.builder()
+                .composedMessageId(new ComposedMessageId(mailboxId, messageId, messageUid))
+                .flags(new Flags())
+                .modSeq(ModSeq.of(1))
+                .build();
+        ComposedMessageIdWithMetaData composedMessageIdWithMetaData2 = ComposedMessageIdWithMetaData.builder()
+                .composedMessageId(new ComposedMessageId(mailboxId, messageId2, messageUid2))
+                .flags(new Flags())
+                .modSeq(ModSeq.of(1))
+                .build();
+        Flux.merge(testee.insert(composedMessageIdWithMetaData),
+                testee.insert(composedMessageIdWithMetaData2))
+        .blockLast();
+
+        assertThat(testee.retrieveMessages(mailboxId, MessageRange.all(), Limit.limit(1)).toIterable())
+            .containsOnly(composedMessageIdWithMetaData);
     }
 
     @Test
@@ -429,8 +456,41 @@ class CassandraMessageIdDAOTest {
                 testee.insert(composedMessageIdWithMetaData2))
         .blockLast();
 
-        assertThat(testee.retrieveMessages(mailboxId, MessageRange.from(messageUid2)).toIterable())
+        assertThat(testee.retrieveMessages(mailboxId, MessageRange.from(messageUid2), Limit.unlimited()).toIterable())
             .containsOnly(composedMessageIdWithMetaData, composedMessageIdWithMetaData2);
+    }
+    @Test
+    void retrieveMessagesShouldAppluLimitWhenRangeFrom() {
+        CassandraMessageId messageId = messageIdFactory.generate();
+        CassandraMessageId messageId2 = messageIdFactory.generate();
+        CassandraMessageId messageId3 = messageIdFactory.generate();
+        CassandraId mailboxId = CassandraId.timeBased();
+        MessageUid messageUid = MessageUid.of(1);
+        MessageUid messageUid2 = MessageUid.of(2);
+        MessageUid messageUid3 = MessageUid.of(3);
+
+        ComposedMessageIdWithMetaData composedMessageIdWithMetaData = ComposedMessageIdWithMetaData.builder()
+            .composedMessageId(new ComposedMessageId(mailboxId, messageId2, messageUid2))
+            .flags(new Flags())
+            .modSeq(ModSeq.of(1))
+            .build();
+        ComposedMessageIdWithMetaData composedMessageIdWithMetaData2 = ComposedMessageIdWithMetaData.builder()
+            .composedMessageId(new ComposedMessageId(mailboxId, messageId3, messageUid3))
+            .flags(new Flags())
+            .modSeq(ModSeq.of(1))
+            .build();
+        Flux.merge(testee.insert(
+            ComposedMessageIdWithMetaData.builder()
+                .composedMessageId(new ComposedMessageId(mailboxId, messageId, messageUid))
+                .flags(new Flags())
+                .modSeq(ModSeq.of(1))
+                .build()),
+            testee.insert(composedMessageIdWithMetaData),
+            testee.insert(composedMessageIdWithMetaData2))
+            .blockLast();
+
+        assertThat(testee.retrieveMessages(mailboxId, MessageRange.from(messageUid2), Limit.limit(1)).toIterable())
+            .containsOnly(composedMessageIdWithMetaData);
     }
 
     @Test
@@ -472,8 +532,51 @@ class CassandraMessageIdDAOTest {
                     .build()))
         .blockLast();
 
-        assertThat(testee.retrieveMessages(mailboxId, MessageRange.range(messageUid2, messageUid3)).toIterable())
+        assertThat(testee.retrieveMessages(mailboxId, MessageRange.range(messageUid2, messageUid3), Limit.unlimited()).toIterable())
             .containsOnly(composedMessageIdWithMetaData, composedMessageIdWithMetaData2);
+    }
+
+    @Test
+    void retrieveMessagesShouldApplyLimitWhenRange() {
+        CassandraMessageId messageId = messageIdFactory.generate();
+        CassandraMessageId messageId2 = messageIdFactory.generate();
+        CassandraMessageId messageId3 = messageIdFactory.generate();
+        CassandraMessageId messageId4 = messageIdFactory.generate();
+        CassandraId mailboxId = CassandraId.timeBased();
+        MessageUid messageUid = MessageUid.of(1);
+        MessageUid messageUid2 = MessageUid.of(2);
+        MessageUid messageUid3 = MessageUid.of(3);
+        MessageUid messageUid4 = MessageUid.of(4);
+
+        testee.insert(ComposedMessageIdWithMetaData.builder()
+                .composedMessageId(new ComposedMessageId(mailboxId, messageId, messageUid))
+                .flags(new Flags())
+                .modSeq(ModSeq.of(1))
+            .build())
+            .block();
+
+        ComposedMessageIdWithMetaData composedMessageIdWithMetaData = ComposedMessageIdWithMetaData.builder()
+            .composedMessageId(new ComposedMessageId(mailboxId, messageId2, messageUid2))
+            .flags(new Flags())
+            .modSeq(ModSeq.of(1))
+            .build();
+
+        ComposedMessageIdWithMetaData composedMessageIdWithMetaData2 = ComposedMessageIdWithMetaData.builder()
+            .composedMessageId(new ComposedMessageId(mailboxId, messageId3, messageUid3))
+            .flags(new Flags())
+            .modSeq(ModSeq.of(1))
+            .build();
+        Flux.merge(testee.insert(composedMessageIdWithMetaData),
+            testee.insert(composedMessageIdWithMetaData2),
+            testee.insert(ComposedMessageIdWithMetaData.builder()
+                .composedMessageId(new ComposedMessageId(mailboxId, messageId4, messageUid4))
+                .flags(new Flags())
+                .modSeq(ModSeq.of(1))
+                .build()))
+            .blockLast();
+
+        assertThat(testee.retrieveMessages(mailboxId, MessageRange.range(messageUid2, messageUid3), Limit.limit(1)).toIterable())
+            .containsOnly(composedMessageIdWithMetaData);
     }
 
     @Test
@@ -505,7 +608,7 @@ class CassandraMessageIdDAOTest {
                     .build()))
         .blockLast();
 
-        assertThat(testee.retrieveMessages(mailboxId, MessageRange.one(messageUid2)).toIterable())
+        assertThat(testee.retrieveMessages(mailboxId, MessageRange.one(messageUid2), Limit.unlimited()).toIterable())
             .containsOnly(composedMessageIdWithMetaData);
     }
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapperTest.java
@@ -39,6 +39,7 @@ import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.store.mail.MessageMapper;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.MessageIdMapperTest;
+import org.apache.james.util.streams.Limit;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -103,7 +104,7 @@ class CassandraMessageIdMapperTest extends MessageIdMapperTest {
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
                 softly.assertThat(sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.Metadata))
                     .isEmpty();
-                softly.assertThat(messageIdDAO.retrieveMessages((CassandraId) benwaInboxMailbox.getMailboxId(), MessageRange.all()).collectList().block())
+                softly.assertThat(messageIdDAO.retrieveMessages((CassandraId) benwaInboxMailbox.getMailboxId(), MessageRange.all(), Limit.unlimited()).collectList().block())
                     .isEmpty();
             }));
         }
@@ -127,7 +128,7 @@ class CassandraMessageIdMapperTest extends MessageIdMapperTest {
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
                 softly.assertThat(sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.Metadata))
                     .isEmpty();
-                softly.assertThat(messageIdDAO.retrieveMessages((CassandraId) benwaInboxMailbox.getMailboxId(), MessageRange.all()).collectList().block())
+                softly.assertThat(messageIdDAO.retrieveMessages((CassandraId) benwaInboxMailbox.getMailboxId(), MessageRange.all(), Limit.unlimited()).collectList().block())
                     .isEmpty();
             }));
         }
@@ -151,7 +152,7 @@ class CassandraMessageIdMapperTest extends MessageIdMapperTest {
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
                 softly.assertThat(sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.Metadata))
                     .isEmpty();
-                softly.assertThat(messageIdDAO.retrieveMessages((CassandraId) benwaInboxMailbox.getMailboxId(), MessageRange.all()).collectList().block())
+                softly.assertThat(messageIdDAO.retrieveMessages((CassandraId) benwaInboxMailbox.getMailboxId(), MessageRange.all(), Limit.unlimited()).collectList().block())
                     .isEmpty();
             }));
         }
@@ -175,7 +176,7 @@ class CassandraMessageIdMapperTest extends MessageIdMapperTest {
             SoftAssertions.assertSoftly(Throwing.consumer(softly -> {
                 softly.assertThat(sut.find(ImmutableList.of(message1.getMessageId()), MessageMapper.FetchType.Metadata))
                     .isEmpty();
-                softly.assertThat(messageIdDAO.retrieveMessages((CassandraId) benwaInboxMailbox.getMailboxId(), MessageRange.all()).collectList().block())
+                softly.assertThat(messageIdDAO.retrieveMessages((CassandraId) benwaInboxMailbox.getMailboxId(), MessageRange.all(), Limit.unlimited()).collectList().block())
                     .isEmpty();
             }));
         }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperTest.java
@@ -39,6 +39,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
 import com.datastax.driver.core.BoundStatement;
 import com.github.fge.lambdas.Throwing;
@@ -60,7 +61,7 @@ class CassandraMessageMapperTest extends MessageMapperTest {
         cassandra.getConf().recordStatements(statementRecorder);
 
         int limit = 2;
-        messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.all(), FetchType.Full, limit);
+        ImmutableList.copyOf(messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.all(), FetchType.Full, limit));
 
         assertThat(statementRecorder.listExecutedStatements())
             .filteredOn(statement -> statement instanceof BoundStatement)

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperTest.java
@@ -34,8 +34,8 @@ import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
 import org.apache.james.mailbox.store.mail.model.MapperProvider;
 import org.apache.james.mailbox.store.mail.model.MessageMapperTest;
+import org.apache.james.util.streams.Limit;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -52,7 +52,6 @@ class CassandraMessageMapperTest extends MessageMapperTest {
         return new CassandraMapperProvider(cassandraCluster.getCassandraCluster());
     }
 
-    @Disabled("Currently generates a read to messageV2 per stored message despite the limit")
     @Test
     void findInMailboxLimitShouldLimitProjectionReadCassandraQueries(CassandraCluster cassandra) throws MailboxException {
         saveMessages();
@@ -91,7 +90,7 @@ class CassandraMessageMapperTest extends MessageMapperTest {
                 softly.assertThat(messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.all(), FetchType.Metadata, 1))
                     .toIterable()
                     .isEmpty();
-                softly.assertThat(messageIdDAO.retrieveMessages((CassandraId) benwaInboxMailbox.getMailboxId(), MessageRange.all()).collectList().block())
+                softly.assertThat(messageIdDAO.retrieveMessages((CassandraId) benwaInboxMailbox.getMailboxId(), MessageRange.all(), Limit.unlimited()).collectList().block())
                     .isEmpty();
             }));
         }
@@ -114,7 +113,7 @@ class CassandraMessageMapperTest extends MessageMapperTest {
                 softly.assertThat(messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.all(), FetchType.Metadata, 1))
                     .toIterable()
                     .isEmpty();
-                softly.assertThat(messageIdDAO.retrieveMessages((CassandraId) benwaInboxMailbox.getMailboxId(), MessageRange.all()).collectList().block())
+                softly.assertThat(messageIdDAO.retrieveMessages((CassandraId) benwaInboxMailbox.getMailboxId(), MessageRange.all(), Limit.unlimited()).collectList().block())
                     .isEmpty();
             }));
         }
@@ -137,7 +136,7 @@ class CassandraMessageMapperTest extends MessageMapperTest {
                 softly.assertThat(messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.all(), FetchType.Metadata, 1))
                     .toIterable()
                     .isEmpty();
-                softly.assertThat(messageIdDAO.retrieveMessages((CassandraId) benwaInboxMailbox.getMailboxId(), MessageRange.all()).collectList().block())
+                softly.assertThat(messageIdDAO.retrieveMessages((CassandraId) benwaInboxMailbox.getMailboxId(), MessageRange.all(), Limit.unlimited()).collectList().block())
                     .isEmpty();
             }));
         }
@@ -160,7 +159,7 @@ class CassandraMessageMapperTest extends MessageMapperTest {
                 softly.assertThat(messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.all(), FetchType.Metadata, 1))
                     .toIterable()
                     .isEmpty();
-                softly.assertThat(messageIdDAO.retrieveMessages((CassandraId) benwaInboxMailbox.getMailboxId(), MessageRange.all()).collectList().block())
+                softly.assertThat(messageIdDAO.retrieveMessages((CassandraId) benwaInboxMailbox.getMailboxId(), MessageRange.all(), Limit.unlimited()).collectList().block())
                     .isEmpty();
             }));
         }

--- a/server/container/util/src/main/java/org/apache/james/util/streams/Limit.java
+++ b/server/container/util/src/main/java/org/apache/james/util/streams/Limit.java
@@ -61,6 +61,10 @@ public class Limit {
         return limit;
     }
 
+    public boolean isUnlimited() {
+        return !limit.isPresent();
+    }
+
     public <T> Stream<T> applyOnStream(Stream<T> stream) {
         return limit
             .map(stream::limit)


### PR DESCRIPTION
We noticed some `BusyPool` exceptions filling up the driver queue upon IMAP query (FETCH flags for all the messages in the mailbox).

The MessageManager do batch those reads (by default by 200 for metadata)., wich then call the MessageMapper with this limit.

Some unit tests performed at the Cassandra mailbox level proved the soft filtering did badly applies, and that we were performing uneeded extra reads for the full batch read from the database.

One good mitigation strategy is to push the limit to the Cassandra query, and ensures filtering happens before the extra reads are performed.

https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#take-long- documents that it just don't propagate downstream request once a given amount is reached however it do not ensure any form of backpressure. We might want to further audit our code, looking for similar take mis-usages.
