### PR TITLE
JAMES-3263 Optimize RecipientRewriteTable::getMappingsForType

### DIFF
--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
@@ -30,7 +30,6 @@ import org.apache.james.rrt.lib.Mappings;
 import org.apache.james.rrt.lib.MappingsImpl;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 
 /**
  * Interface which should be implemented of classes which map recipients.
@@ -148,12 +147,12 @@ public interface RecipientRewriteTable {
     }
 
     default Stream<Mapping> getMappingsForType(Mapping.Type type) throws RecipientRewriteTableException {
-        return ImmutableSet.copyOf(getAllMappings()
+        return getAllMappings()
             .values().stream()
             .map(mappings -> mappings.select(type))
-            .reduce(Mappings::union)
-            .orElse(MappingsImpl.empty()))
-            .stream();
+            .reduce(MappingsImpl.builder(), MappingsImpl.Builder::addAll, (builder1, builder2) -> builder1.addAll(builder2.build()))
+            .build()
+            .asStream();
     }
 
 }

--- a/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
+++ b/server/data/data-api/src/main/java/org/apache/james/rrt/api/RecipientRewriteTable.java
@@ -152,7 +152,8 @@ public interface RecipientRewriteTable {
             .map(mappings -> mappings.select(type))
             .reduce(MappingsImpl.builder(), MappingsImpl.Builder::addAll, (builder1, builder2) -> builder1.addAll(builder2.build()))
             .build()
-            .asStream();
+            .asStream()
+            .distinct();
     }
 
 }


### PR DESCRIPTION
The heavy use of intermediate objects did lead to unoptimized execution.

This change-set unlocks a x100 performance improvement for memory micro benchmarks with 10.000 entries.

Here is the micro benchmark code snipset:

```
    @Test
    public void test() throws Exception {
        AbstractRecipientRewriteTable recipientRewriteTable = getRecipientRewriteTable();
        IntStream.range(0, 10000)
            .forEach(Throwing.intConsumer(i -> recipientRewriteTable
                .addMapping(
                    MappingSource.fromUser("bob" + i, SUPPORTED_DOMAIN),
                    Mapping.alias("bob-alias" + i + "@" + SUPPORTED_DOMAIN))));
        for (int i = 0; i < 10; i++) {
            System.out.println("Warmup " + i);
            recipientRewriteTable.getMappingsForType(Mapping.Type.Alias).collect(Guavate.toImmutableList());
        }
        for (int i = 0; i < 10; i++) {
            Stopwatch started = Stopwatch.createStarted();
            recipientRewriteTable.getMappingsForType(Mapping.Type.Alias).collect(Guavate.toImmutableList());
            System.out.println(started.elapsed(TimeUnit.MILLISECONDS));
        }
    }
```