### PR TITLE
JAMES-3170 POC CassandraBlobStoreCache circuit breaking

### DIFF
--- a/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/blob.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/blob.properties
@@ -36,6 +36,12 @@ cache.enable=false
 # Units: bytes, Kib, MiB, GiB, TiB
 # cache.sizeThresholdInBytes=8 KiB
 
+# Circuit breaking based on in flight request count at the driver level
+# Above a threshold of in flight requests, the Cassandra server is considered overwhelmed
+# In a self-healing effort, we stop submitting requests to the cache in order to recover.
+# Optional, defaults to 256
+# cache.inFlightRequests.threshold=256
+
 
 # ============================================== ObjectStorage ============================================
 

--- a/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/blob.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/blob.properties
@@ -30,6 +30,12 @@ cache.enable=false
 # Units: bytes, Kib, MiB, GiB, TiB
 # cache.sizeThresholdInBytes=8 KiB
 
+# Circuit breaking based on in flight request count at the driver level
+# Above a threshold of in flight requests, the Cassandra server is considered overwhelmed
+# In a self-healing effort, we stop submitting requests to the cache in order to recover.
+# Optional, defaults to 256
+# cache.inFlightRequests.threshold=256
+
 # ========================================= Hybrid BlobStore ======================================
 # hybrid is using both objectstorage for unfrequently read or big blobs & cassandra for small, often read blobs
 # Size threshold for considering a blob as 'big', causing it to be saved in the low cost blobStore

--- a/src/site/xdoc/server/config-blobstore.xml
+++ b/src/site/xdoc/server/config-blobstore.xml
@@ -77,6 +77,13 @@
                         Supported units: bytes, Kib, MiB, GiB, TiB
                         Maximum size of stored objects expressed in bytes.</dd>
                 </dl>
+                <dl>
+                    <dt><strong>cache.inFlightRequests.threshold</strong></dt>
+                    <dd>DEFAULT: 256, Circuit breaking based on in flight request count at the driver level.
+                        Above a threshold of in flight requests, the Cassandra server is considered overwhelmed
+                        In a self-healing effort, we stop submitting requests to the cache in order to recover.
+                        </dd>
+                </dl>
             </subsection>
 
             <subsection name="Hybrid BlobStore size threshold (deprecated)">


### PR DESCRIPTION
Upon IMAP fetch on header to get `Messsage-Id` header on a large message range, Cassandra throughtput is not high enough to keep up with 200 messages batches.

It highlights that despite high Cassandra usage we keep on using the BlobStore cache.

We overwhelm the Cassandra cluster with a feature that is not required for correctness.

A better behavior would be to abandon BlobStore caching from a given Cassandra occupation ratio in order to preserve Cassandra. This results in a degraded mode, where we read all from the Object storage.