### PR TITLE
JAMES-3265 Reduce statement count upon CassandraMessageMapper::delete & Flags updates

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraIndexTableHandler.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraIndexTableHandler.java
@@ -19,15 +19,23 @@
 
 package org.apache.james.mailbox.cassandra.mail;
 
+import java.util.Collection;
+import java.util.List;
+
 import javax.inject.Inject;
 import javax.mail.Flags;
 
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.cassandra.ids.CassandraId;
 import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
+import org.apache.james.mailbox.model.MailboxCounters;
+import org.apache.james.mailbox.model.MessageMetaData;
 import org.apache.james.mailbox.model.UpdatedFlags;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
+import org.apache.james.util.streams.Iterators;
 
+import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import reactor.core.publisher.Flux;
@@ -61,9 +69,37 @@ public class CassandraIndexTableHandler {
         return Flux.mergeDelayError(Queues.XS_BUFFER_SIZE,
                 updateFirstUnseenOnDelete(mailboxId, composedMessageIdWithMetaData.getFlags(), composedMessageIdWithMetaData.getComposedMessageId().getUid()),
                 mailboxRecentDAO.removeFromRecent(mailboxId, composedMessageIdWithMetaData.getComposedMessageId().getUid()),
-                deletedMessageDAO.removeDeleted(mailboxId, uid),
+                updateDeletedMessageProjectionOnDelete(mailboxId, uid, composedMessageIdWithMetaData.getFlags()),
                 decrementCountersOnDelete(mailboxId, composedMessageIdWithMetaData.getFlags()))
             .then();
+    }
+
+    public Mono<Void> updateIndexOnDelete(CassandraId mailboxId, Collection<MessageMetaData> metaData) {
+        return Flux.mergeDelayError(Queues.XS_BUFFER_SIZE,
+                Flux.fromIterable(metaData)
+                    .flatMap(message -> updateFirstUnseenOnDelete(mailboxId, message.getFlags(), message.getUid())),
+                Flux.fromIterable(metaData)
+                    .flatMap(message -> updateRecentOnDelete(mailboxId, message.getUid(), message.getFlags())),
+                Flux.fromIterable(metaData)
+                    .flatMap(message -> updateDeletedMessageProjectionOnDelete(mailboxId, message.getUid(), message.getFlags())),
+                decrementCountersOnDelete(mailboxId, metaData))
+            .then();
+    }
+
+    private Mono<Void> updateRecentOnDelete(CassandraId mailboxId, MessageUid uid, Flags flags) {
+        if (flags.contains(Flags.Flag.RECENT)) {
+            return mailboxRecentDAO.removeFromRecent(mailboxId, uid);
+        }
+
+        return Mono.empty();
+    }
+
+    private Mono<Void> updateDeletedMessageProjectionOnDelete(CassandraId mailboxId, MessageUid uid, Flags flags) {
+        if (flags.contains(Flags.Flag.DELETED)) {
+            return deletedMessageDAO.removeDeleted(mailboxId, uid);
+        }
+
+        return Mono.empty();
     }
 
     public Mono<Void> updateIndexOnAdd(MailboxMessage message, CassandraId mailboxId) {
@@ -79,12 +115,29 @@ public class CassandraIndexTableHandler {
     }
 
     public Mono<Void> updateIndexOnFlagsUpdate(CassandraId mailboxId, UpdatedFlags updatedFlags) {
+        return updateIndexOnFlagsUpdate(mailboxId, ImmutableList.of(updatedFlags));
+    }
+
+    public Mono<Void> updateIndexOnFlagsUpdate(CassandraId mailboxId, List<UpdatedFlags> updatedFlags) {
         return Flux.mergeDelayError(Queues.XS_BUFFER_SIZE,
                 manageUnseenMessageCountsOnFlagsUpdate(mailboxId, updatedFlags),
                 manageRecentOnFlagsUpdate(mailboxId, updatedFlags),
                 updateFirstUnseenOnFlagsUpdate(mailboxId, updatedFlags),
-                applicableFlagDAO.updateApplicableFlags(mailboxId, ImmutableSet.copyOf(updatedFlags.userFlagIterator())),
+                manageApplicableFlagsOnFlagsUpdate(mailboxId, updatedFlags),
                 updateDeletedOnFlagsUpdate(mailboxId, updatedFlags))
+            .then();
+    }
+
+    private Mono<Void> manageApplicableFlagsOnFlagsUpdate(CassandraId mailboxId, List<UpdatedFlags> updatedFlags) {
+        return applicableFlagDAO.updateApplicableFlags(mailboxId,
+            updatedFlags.stream()
+                .flatMap(flags -> Iterators.toStream(flags.userFlagIterator()))
+                .collect(Guavate.toImmutableSet()));
+    }
+
+    private Mono<Void> updateDeletedOnFlagsUpdate(CassandraId mailboxId, List<UpdatedFlags> updatedFlags) {
+        return Flux.fromIterable(updatedFlags)
+            .concatMap(flags -> updateDeletedOnFlagsUpdate(mailboxId, flags))
             .then();
     }
 
@@ -105,6 +158,19 @@ public class CassandraIndexTableHandler {
         return mailboxCounterDAO.decrementUnseenAndCount(mailboxId);
     }
 
+    private Mono<Void> decrementCountersOnDelete(CassandraId mailboxId, Collection<MessageMetaData> metaData) {
+        long seenCount = metaData.stream()
+            .map(MessageMetaData::getFlags)
+            .filter(flags -> flags.contains(Flags.Flag.SEEN))
+            .count();
+
+        return mailboxCounterDAO.remove(MailboxCounters.builder()
+            .mailboxId(mailboxId)
+            .count(metaData.size())
+            .unseen(seenCount)
+            .build());
+    }
+
     private Mono<Void> incrementCountersOnSave(CassandraId mailboxId, Flags flags) {
         if (flags.contains(Flags.Flag.SEEN)) {
             return mailboxCounterDAO.incrementCount(mailboxId);
@@ -119,14 +185,33 @@ public class CassandraIndexTableHandler {
         return Mono.empty();
     }
 
-    private Mono<Void> manageUnseenMessageCountsOnFlagsUpdate(CassandraId mailboxId, UpdatedFlags updatedFlags) {
-        if (updatedFlags.isModifiedToUnset(Flags.Flag.SEEN)) {
-            return mailboxCounterDAO.incrementUnseen(mailboxId);
-        }
-        if (updatedFlags.isModifiedToSet(Flags.Flag.SEEN)) {
-            return mailboxCounterDAO.decrementUnseen(mailboxId);
+    private Mono<Void> manageUnseenMessageCountsOnFlagsUpdate(CassandraId mailboxId,  List<UpdatedFlags> updatedFlags) {
+        int sum = updatedFlags.stream()
+            .mapToInt(flags -> {
+                if (flags.isModifiedToUnset(Flags.Flag.SEEN)) {
+                    return 1;
+                }
+                if (flags.isModifiedToSet(Flags.Flag.SEEN)) {
+                    return -1;
+                }
+                return 0;
+            })
+            .sum();
+
+        if (sum != 0) {
+            return mailboxCounterDAO.add(MailboxCounters.builder()
+                .mailboxId(mailboxId)
+                .count(0)
+                .unseen(sum)
+                .build());
         }
         return Mono.empty();
+    }
+
+    private Mono<Void> manageRecentOnFlagsUpdate(CassandraId mailboxId, List<UpdatedFlags> updatedFlags) {
+        return Flux.fromIterable(updatedFlags)
+            .concatMap(flags -> manageRecentOnFlagsUpdate(mailboxId, flags))
+            .then();
     }
 
     private Mono<Void> manageRecentOnFlagsUpdate(CassandraId mailboxId, UpdatedFlags updatedFlags) {
@@ -159,6 +244,12 @@ public class CassandraIndexTableHandler {
             return Mono.empty();
         }
         return firstUnseenDAO.removeUnread(mailboxId, uid);
+    }
+
+    private Mono<Void> updateFirstUnseenOnFlagsUpdate(CassandraId mailboxId, List<UpdatedFlags> updatedFlags) {
+        return Flux.fromIterable(updatedFlags)
+            .concatMap(flags -> updateFirstUnseenOnFlagsUpdate(mailboxId, flags))
+            .then();
     }
 
     private Mono<Void> updateFirstUnseenOnFlagsUpdate(CassandraId mailboxId, UpdatedFlags updatedFlags) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxCounterDAO.java
@@ -136,7 +136,7 @@ public class CassandraMailboxCounterDAO {
             .build();
     }
 
-    private Mono<Void> add(MailboxCounters counters) {
+    public Mono<Void> add(MailboxCounters counters) {
         CassandraId mailboxId = (CassandraId) counters.getMailboxId();
         return cassandraAsyncExecutor.executeVoid(
             bindWithMailbox(mailboxId, addToCounters)
@@ -144,7 +144,7 @@ public class CassandraMailboxCounterDAO {
                 .setLong(UNSEEN, counters.getUnseen()));
     }
 
-    private Mono<Void> remove(MailboxCounters counters) {
+    public Mono<Void> remove(MailboxCounters counters) {
         CassandraId mailboxId = (CassandraId) counters.getMailboxId();
         return cassandraAsyncExecutor.executeVoid(
             bindWithMailbox(mailboxId, removeToCounters)

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -325,9 +325,9 @@ public class CassandraMessageMapper implements MessageMapper {
     }
 
     private Mono<FlagsUpdateStageResult> runUpdateStage(CassandraId mailboxId, Flux<ComposedMessageIdWithMetaData> toBeUpdated, FlagsUpdateCalculator flagsUpdateCalculator) {
-        Mono<ModSeq> newModSeq = computeNewModSeq(mailboxId);
-        return toBeUpdated
-            .concatMap(metadata -> newModSeq.flatMap(modSeq -> tryFlagsUpdate(flagsUpdateCalculator, modSeq, metadata)))
+        return computeNewModSeq(mailboxId)
+            .flatMapMany(newModSeq -> toBeUpdated
+            .concatMap(metadata -> tryFlagsUpdate(flagsUpdateCalculator, newModSeq, metadata)))
             .reduce(FlagsUpdateStageResult.none(), FlagsUpdateStageResult::merge)
             .flatMap(result -> updateIndexesForUpdatesResult(mailboxId, result));
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -63,6 +63,7 @@ import com.google.common.collect.ImmutableList;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import reactor.util.retry.Retry;
 
 public class CassandraMessageMapper implements MessageMapper {
@@ -138,25 +139,30 @@ public class CassandraMessageMapper implements MessageMapper {
 
     @Override
     public void delete(Mailbox mailbox, MailboxMessage message) {
-        deleteAsFuture(message)
+        ComposedMessageIdWithMetaData metaData = message.getComposedMessageIdWithMetaData();
+
+        deleteAndHandleIndexUpdates(metaData)
             .block();
     }
 
-    private Mono<Void> deleteAsFuture(MailboxMessage message) {
-        ComposedMessageIdWithMetaData composedMessageIdWithMetaData = message.getComposedMessageIdWithMetaData();
+    private Mono<Void> deleteAndHandleIndexUpdates(ComposedMessageIdWithMetaData composedMessageIdWithMetaData) {
+        ComposedMessageId composedMessageId = composedMessageIdWithMetaData.getComposedMessageId();
+        CassandraId mailboxId = (CassandraId) composedMessageId.getMailboxId();
 
-        return deleteUsingMailboxId(composedMessageIdWithMetaData);
+        return delete(composedMessageIdWithMetaData)
+             .then(indexTableHandler.updateIndexOnDelete(composedMessageIdWithMetaData, mailboxId));
     }
 
-    private Mono<Void> deleteUsingMailboxId(ComposedMessageIdWithMetaData composedMessageIdWithMetaData) {
+    private Mono<Void> delete(ComposedMessageIdWithMetaData composedMessageIdWithMetaData) {
         ComposedMessageId composedMessageId = composedMessageIdWithMetaData.getComposedMessageId();
         CassandraMessageId messageId = (CassandraMessageId) composedMessageId.getMessageId();
         CassandraId mailboxId = (CassandraId) composedMessageId.getMailboxId();
         MessageUid uid = composedMessageId.getUid();
+
         return Flux.merge(
                 imapUidDAO.delete(messageId, mailboxId),
                 messageIdDAO.delete(mailboxId, uid))
-            .then(indexTableHandler.updateIndexOnDelete(composedMessageIdWithMetaData, mailboxId));
+                .then();
     }
 
     @Override
@@ -210,25 +216,20 @@ public class CassandraMessageMapper implements MessageMapper {
     public Map<MessageUid, MessageMetaData> deleteMessages(Mailbox mailbox, List<MessageUid> uids) {
         CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
 
-        return Flux.fromStream(uids.stream())
-            .flatMap(messageUid -> expungeOne(mailboxId, messageUid), cassandraConfiguration.getExpungeChunkSize())
-            .collect(Guavate.<SimpleMailboxMessage, MessageUid, MessageMetaData>toImmutableMap(MailboxMessage::getUid, MailboxMessage::metaData))
+        return Flux.fromIterable(MessageRange.toRanges(uids))
+            .concatMap(range -> messageIdDAO.retrieveMessages(mailboxId, range, Limit.unlimited()))
+            .flatMap(this::expungeOne, cassandraConfiguration.getExpungeChunkSize())
+            .collect(Guavate.toImmutableMap(MailboxMessage::getUid, MailboxMessage::metaData))
+            .flatMap(messageMap -> indexTableHandler.updateIndexOnDelete(mailboxId, messageMap.values())
+                .thenReturn(messageMap))
+            .subscribeOn(Schedulers.elastic())
             .block();
     }
 
-    private Mono<SimpleMailboxMessage> expungeOne(CassandraId mailboxId, MessageUid messageUid) {
-        return retrieveComposedId(mailboxId, messageUid)
-            .flatMap(idWithMetadata -> deleteUsingMailboxId(idWithMetadata).thenReturn(idWithMetadata))
-            .flatMap(idWithMetadata -> messageDAO.retrieveMessage(idWithMetadata, FetchType.Metadata)
-                .map(pair -> pair.toMailboxMessage(idWithMetadata, ImmutableList.of())));
-    }
-
-    private Mono<ComposedMessageIdWithMetaData> retrieveComposedId(CassandraId mailboxId, MessageUid uid) {
-        return messageIdDAO.retrieve(mailboxId, uid)
-            .handle((t, sink) ->
-                t.ifPresentOrElse(
-                    sink::next,
-                    () -> LOGGER.warn("Could not retrieve message {} {}", mailboxId, uid)));
+    private Mono<SimpleMailboxMessage> expungeOne(ComposedMessageIdWithMetaData metaData) {
+        return delete(metaData)
+            .then(messageDAO.retrieveMessage(metaData, FetchType.Metadata)
+                .map(pair -> pair.toMailboxMessage(metaData, ImmutableList.of())));
     }
 
     @Override
@@ -236,7 +237,7 @@ public class CassandraMessageMapper implements MessageMapper {
         ComposedMessageIdWithMetaData composedMessageIdWithMetaData = original.getComposedMessageIdWithMetaData();
 
         MessageMetaData messageMetaData = copy(destinationMailbox, original);
-        deleteUsingMailboxId(composedMessageIdWithMetaData).block();
+        deleteAndHandleIndexUpdates(composedMessageIdWithMetaData).block();
 
         return messageMetaData;
     }
@@ -338,14 +339,12 @@ public class CassandraMessageMapper implements MessageMapper {
     }
 
     private Mono<FlagsUpdateStageResult> updateIndexesForUpdatesResult(CassandraId mailboxId, FlagsUpdateStageResult result) {
-        return Flux.fromIterable(result.getSucceeded())
-            .flatMap(Throwing
-                .function((UpdatedFlags updatedFlags) -> indexTableHandler.updateIndexOnFlagsUpdate(mailboxId, updatedFlags))
-                .fallbackTo(failedIndex -> {
-                    LOGGER.error("Could not update flag indexes for mailboxId {} UID {}. This will lead to inconsistencies across Cassandra tables", mailboxId, failedIndex.getUid());
-                    return Mono.empty();
-                }))
-            .then(Mono.just(result));
+        return indexTableHandler.updateIndexOnFlagsUpdate(mailboxId, result.getSucceeded())
+            .onErrorResume(e -> {
+                LOGGER.error("Could not update flag indexes for mailboxId {}. This will lead to inconsistencies across Cassandra tables", mailboxId, e);
+                return Mono.empty();
+            })
+            .thenReturn(result);
     }
 
     @Override

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraIndexTableHandlerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraIndexTableHandlerTest.java
@@ -286,7 +286,7 @@ class CassandraIndexTableHandlerTest {
 
         testee.updateIndexOnDelete(new ComposedMessageIdWithMetaData(
                 new ComposedMessageId(MAILBOX_ID, CASSANDRA_MESSAGE_ID, MESSAGE_UID),
-                new Flags(),
+                new Flags(Flags.Flag.DELETED),
                 MODSEQ),
             MAILBOX_ID).block();
 


### PR DESCRIPTION
This effectively optimizes IMAP EXPUNGE & STORE operations, dramatically limit counter writes,
and should prevent unneeded large tombstones ranges creations for deletedMessages and recentMessages projections.

