### PR TITLE
[NO_REVIEW] [CI] JAMES-3253 Remove Log warning for remoteDelivery configuration in def…

### DIFF
--- a/dockerfiles/packaging/guice/cassandra/package/etc/james/templates/mailetcontainer.xml
+++ b/dockerfiles/packaging/guice/cassandra/package/etc/james/templates/mailetcontainer.xml
@@ -87,7 +87,7 @@
             <mailet match="All" class="RemoteDelivery">
                 <outgoingQueue>outgoing</outgoingQueue>
                 <delayTime>5000, 100000, 500000</delayTime>
-                <maxRetries>25</maxRetries>
+                <maxRetries>3</maxRetries>
                 <maxDnsProblemRetries>0</maxDnsProblemRetries>
                 <deliveryThreads>10</deliveryThreads>
                 <sendpartial>true</sendpartial>

--- a/examples/custom-mailets/src/main/resources/mailetcontainer.xml
+++ b/examples/custom-mailets/src/main/resources/mailetcontainer.xml
@@ -101,7 +101,7 @@
             <mailet match="All" class="RemoteDelivery">
                 <outgoingQueue>outgoing</outgoingQueue>
                 <delayTime>5000, 100000, 500000</delayTime>
-                <maxRetries>25</maxRetries>
+                <maxRetries>3</maxRetries>
                 <maxDnsProblemRetries>0</maxDnsProblemRetries>
                 <deliveryThreads>10</deliveryThreads>
                 <sendpartial>true</sendpartial>

--- a/server/container/guice/jpa-guice/src/main/resources/defaultMailetContainer.xml
+++ b/server/container/guice/jpa-guice/src/main/resources/defaultMailetContainer.xml
@@ -49,6 +49,7 @@
         <mailet match="SMTPAuthSuccessful" class="RemoteDelivery">
             <outgoingQueue>outgoing</outgoingQueue>
             <delayTime>5000, 100000, 500000</delayTime>
+            <maxRetries>3</maxRetries>
             <maxDnsProblemRetries>0</maxDnsProblemRetries>
             <deliveryThreads>10</deliveryThreads>
             <sendpartial>true</sendpartial>

--- a/server/container/guice/jpa-guice/src/main/resources/defaultMailetContainer.xml
+++ b/server/container/guice/jpa-guice/src/main/resources/defaultMailetContainer.xml
@@ -49,7 +49,6 @@
         <mailet match="SMTPAuthSuccessful" class="RemoteDelivery">
             <outgoingQueue>outgoing</outgoingQueue>
             <delayTime>5000, 100000, 500000</delayTime>
-            <maxRetries>25</maxRetries>
             <maxDnsProblemRetries>0</maxDnsProblemRetries>
             <deliveryThreads>10</deliveryThreads>
             <sendpartial>true</sendpartial>

--- a/server/container/guice/jpa-smtp-common/src/main/resources/defaultMailetContainer.xml
+++ b/server/container/guice/jpa-smtp-common/src/main/resources/defaultMailetContainer.xml
@@ -43,7 +43,7 @@
         <mailet match="SMTPAuthSuccessful" class="RemoteDelivery">
             <outgoingQueue>outgoing</outgoingQueue>
             <delayTime>5000, 100000, 500000</delayTime>
-            <maxRetries>25</maxRetries>
+            <maxRetries>3</maxRetries>
             <maxDnsProblemRetries>0</maxDnsProblemRetries>
             <deliveryThreads>10</deliveryThreads>
             <sendpartial>true</sendpartial>

--- a/server/container/guice/jpa-smtp-mariadb/sample-configuration/mailetcontainer.xml
+++ b/server/container/guice/jpa-smtp-mariadb/sample-configuration/mailetcontainer.xml
@@ -63,7 +63,7 @@
             <mailet match="relay-allowed" class="RemoteDelivery">
                 <outgoingQueue>outgoing</outgoingQueue>
                 <delayTime>5000, 100000, 500000</delayTime>
-                <maxRetries>25</maxRetries>
+                <maxRetries>3</maxRetries>
                 <maxDnsProblemRetries>0</maxDnsProblemRetries>
                 <deliveryThreads>10</deliveryThreads>
                 <sendpartial>true</sendpartial>

--- a/server/container/guice/protocols/jmap/src/main/resources/defaultJmapMailetContainer.xml
+++ b/server/container/guice/protocols/jmap/src/main/resources/defaultJmapMailetContainer.xml
@@ -65,7 +65,7 @@
         <mailet match="All" class="RemoteDelivery">
             <outgoingQueue>outgoing</outgoingQueue>
             <delayTime>5000, 100000, 23*500000</delayTime>
-            <maxRetries>25</maxRetries>
+            <maxRetries>3</maxRetries>
             <maxDnsProblemRetries>0</maxDnsProblemRetries>
             <deliveryThreads>10</deliveryThreads>
             <sendpartial>true</sendpartial>

--- a/server/mailet/mailetcontainer-api/src/main/resources/mailetcontainer.xml
+++ b/server/mailet/mailetcontainer-api/src/main/resources/mailetcontainer.xml
@@ -63,7 +63,7 @@
         <delayTime>2 hours</delayTime>
         <delayTime>3 hours</delayTime>
         <delayTime>6 hours</delayTime>
-        <maxRetries>25</maxRetries>
+        <maxRetries>6</maxRetries>
         <maxDnsProblemRetries>0</maxDnsProblemRetries>
         <deliveryThreads>10</deliveryThreads>
         <sendpartial>true</sendpartial>


### PR DESCRIPTION
…aultMailetContainer.xml for JPA Guice

This file is relied upon when configuration file is missing