### PR TITLE
Fasten JMAP  uploads

### DIFF
--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/StreamCompatibleBlobPutter.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/StreamCompatibleBlobPutter.java
@@ -75,7 +75,9 @@ public class StreamCompatibleBlobPutter implements BlobPutter {
     private BlobId updateBlobId(ObjectStorageBucketName bucketName, String from, BlobId to) {
         String bucketNameAsString = bucketName.asString();
         blobStore.copyBlob(bucketNameAsString, from, bucketNameAsString, to.asString(), CopyOptions.NONE);
-        blobStore.removeBlob(bucketNameAsString, from);
+        Mono.fromRunnable(() -> blobStore.removeBlob(bucketNameAsString, from))
+            .subscribeOn(Schedulers.elastic())
+            .subscribe();
         return to;
     }
 

--- a/server/container/util/src/main/java/org/apache/james/util/ReactorUtils.java
+++ b/server/container/util/src/main/java/org/apache/james/util/ReactorUtils.java
@@ -85,15 +85,15 @@ public class ReactorUtils {
     }
 
     public static InputStream toInputStream(Flux<ByteBuffer> byteArrays) {
-        int prefect = 1;
-        return toInputStream(byteArrays, prefect);
+        int prefetch = 1;
+        return toInputStream(byteArrays, prefetch);
     }
 
 
-    public static InputStream toInputStream(Flux<ByteBuffer> byteArrays, int prefect) {
-        Preconditions.checkArgument(prefect > 0, "'prefetch' needs to be strictly positive");
+    public static InputStream toInputStream(Flux<ByteBuffer> byteArrays, int prefetch) {
+        Preconditions.checkArgument(prefetch > 0, "'prefetch' needs to be strictly positive");
 
-        return new StreamInputStream(byteArrays.toIterable(prefect).iterator());
+        return new StreamInputStream(byteArrays.toIterable(prefetch).iterator());
     }
 
     public static Flux<ByteBuffer> toChunks(InputStream inputStream, int bufferSize) {

--- a/server/container/util/src/main/java/org/apache/james/util/ReactorUtils.java
+++ b/server/container/util/src/main/java/org/apache/james/util/ReactorUtils.java
@@ -45,6 +45,7 @@ public class ReactorUtils {
     public static final String MDC_KEY_PREFIX = "MDC-";
 
     private static final Duration DELAY = Duration.ZERO;
+    private static final int BATCH_SIZE = 4;
 
     public static <T, U> RequiresQuantity<T, U> throttle() {
         return elements -> duration -> operation -> {
@@ -84,7 +85,15 @@ public class ReactorUtils {
     }
 
     public static InputStream toInputStream(Flux<ByteBuffer> byteArrays) {
-        return new StreamInputStream(byteArrays.toIterable(1).iterator());
+        int prefect = 1;
+        return toInputStream(byteArrays, prefect);
+    }
+
+
+    public static InputStream toInputStream(Flux<ByteBuffer> byteArrays, int prefect) {
+        Preconditions.checkArgument(prefect > 0, "'prefetch' needs to be strictly positive");
+
+        return new StreamInputStream(byteArrays.toIterable(prefect).iterator());
     }
 
     public static Flux<ByteBuffer> toChunks(InputStream inputStream, int bufferSize) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/UploadRoutes.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/UploadRoutes.java
@@ -114,8 +114,8 @@ public class UploadRoutes implements JMAPRoutes {
     }
 
     private Mono<Void> post(HttpServerRequest request, HttpServerResponse response, ContentType contentType, MailboxSession session) {
-        int prefect = 4;
-        InputStream content = ReactorUtils.toInputStream(request.receive().asByteBuffer().subscribeOn(Schedulers.elastic()), prefect);
+        int prefetch = 4;
+        InputStream content = ReactorUtils.toInputStream(request.receive().asByteBuffer().subscribeOn(Schedulers.elastic()), prefetch);
         return Mono.from(metricFactory.decoratePublisherWithTimerMetric("JMAP-upload-post",
             handle(contentType, content, session, response)));
     }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/UploadRoutes.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/UploadRoutes.java
@@ -114,7 +114,8 @@ public class UploadRoutes implements JMAPRoutes {
     }
 
     private Mono<Void> post(HttpServerRequest request, HttpServerResponse response, ContentType contentType, MailboxSession session) {
-        InputStream content = ReactorUtils.toInputStream(request.receive().asByteBuffer().subscribeOn(Schedulers.elastic()));
+        int prefect = 4;
+        InputStream content = ReactorUtils.toInputStream(request.receive().asByteBuffer().subscribeOn(Schedulers.elastic()), prefect);
         return Mono.from(metricFactory.decoratePublisherWithTimerMetric("JMAP-upload-post",
             handle(contentType, content, session, response)));
     }


### PR DESCRIPTION
Rationals:

 - I encountered some JMAP uploads slow traces (22s). While it can result from a slow client, further evaluation led me to think the data are lazily fetched, resulting in unecessary, blocking, network roundtrips between James and the clients.

```
Transaction type: Web
Transaction name: /upload
Start: 2020-06-29 5:04:50.834 am (+07:00)
Duration: 28,426.1 milliseconds
```

The following code changes highlights my findings.

Here is the queries for the above request:

![Capture d’écran de 2020-06-29 13-07-23](https://user-images.githubusercontent.com/6928740/85979310-6975f980-ba0a-11ea-8eea-8daa4eee7876.png)

And a flame graph supporting the clame (disclaimer: causality is not correlation...)

![Capture d’écran de 2020-06-29 13-07-19](https://user-images.githubusercontent.com/6928740/85979379-92968a00-ba0a-11ea-94b4-2910768d5372.png)

Also, temporary blob deletion can be done asynchronously...

