### PR TITLE
POC Override Cassandra driver queue size to 0 for Cassandra cache

### DIFF
--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/ResilientClusterProvider.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/ResilientClusterProvider.java
@@ -50,7 +50,7 @@ public class ResilientClusterProvider implements Provider<Cluster> {
 
     @VisibleForTesting
     @Inject
-    ResilientClusterProvider(ClusterConfiguration configuration) {
+    public ResilientClusterProvider(ClusterConfiguration configuration) {
         Duration waitDelay = Duration.ofMillis(configuration.getMinDelay());
         cluster = Mono.fromCallable(getClusterRetryCallable(configuration))
             .doOnError(e -> LOGGER.warn("Error establishing Cassandra connection. Next retry scheduled in {} ms", waitDelay, e))

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/configuration/ClusterConfiguration.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/configuration/ClusterConfiguration.java
@@ -36,6 +36,21 @@ import com.google.common.collect.ImmutableList;
 public class ClusterConfiguration {
 
     public static class Builder {
+        public static Builder from(ClusterConfiguration clusterConfiguration) {
+            return builder()
+                .hosts(clusterConfiguration.getHosts())
+                .createKeyspace(clusterConfiguration.shouldCreateKeyspace())
+                .minDelay(clusterConfiguration.getMinDelay())
+                .maxRetry(clusterConfiguration.getMaxRetry())
+                .poolingOptions(clusterConfiguration.getPoolingOptions())
+                .queryLoggerConfiguration(clusterConfiguration.getQueryLoggerConfiguration())
+                .readTimeoutMillis(clusterConfiguration.getReadTimeoutMillis())
+                .connectTimeoutMillis(clusterConfiguration.getConnectTimeoutMillis())
+                .useSsl(clusterConfiguration.useSsl())
+                .username(clusterConfiguration.getUsername())
+                .password(clusterConfiguration.getPassword());
+        }
+
         private ImmutableList.Builder<Host> hosts;
         private boolean createKeyspace;
         private Optional<Integer> minDelay;
@@ -82,6 +97,11 @@ public class ClusterConfiguration {
             return this;
         }
 
+        public Builder createKeyspace(boolean createKeyspace) {
+            this.createKeyspace = createKeyspace;
+            return this;
+        }
+
         public Builder minDelay(Optional<Integer> minDelay) {
             this.minDelay = minDelay;
             return this;
@@ -101,7 +121,11 @@ public class ClusterConfiguration {
         }
 
         public Builder queryLoggerConfiguration(QueryLoggerConfiguration queryLoggerConfiguration) {
-            this.queryLoggerConfiguration = Optional.of(queryLoggerConfiguration);
+            return queryLoggerConfiguration(Optional.of(queryLoggerConfiguration));
+        }
+
+        public Builder queryLoggerConfiguration(Optional<QueryLoggerConfiguration> queryLoggerConfiguration) {
+            this.queryLoggerConfiguration = queryLoggerConfiguration;
             return this;
         }
 

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraCacheSessionModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraCacheSessionModule.java
@@ -19,16 +19,24 @@
 
 package org.apache.james.modules.mailbox;
 
+import java.io.FileNotFoundException;
 import java.util.Set;
 
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.init.KeyspaceFactory;
+import org.apache.james.backends.cassandra.init.ResilientClusterProvider;
 import org.apache.james.backends.cassandra.init.SessionWithInitializedTablesFactory;
 import org.apache.james.backends.cassandra.init.configuration.ClusterConfiguration;
 import org.apache.james.backends.cassandra.init.configuration.InjectionNames;
 import org.apache.james.backends.cassandra.init.configuration.KeyspaceConfiguration;
+import org.apache.james.util.Host;
+import org.apache.james.utils.PropertiesProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.PoolingOptions;
 import com.datastax.driver.core.Session;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
@@ -40,6 +48,13 @@ import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 
 public class CassandraCacheSessionModule extends AbstractModule {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CassandraSessionModule.class);
+
+    private static final String LOCALHOST = "127.0.0.1";
+    private static final String CASSANDRA_FILE_NAME = "cassandra";
+    private static final int CASSANDRA_PORT = 9042;
+
     @Override
     protected void configure() {
         bind(InitializedCacheCluster.class).in(Scopes.SINGLETON);
@@ -62,6 +77,33 @@ public class CassandraCacheSessionModule extends AbstractModule {
         return new SessionWithInitializedTablesFactory(keyspaceConfiguration, cluster.cluster, module).get();
     }
 
+    @Singleton
+    @Named(InjectionNames.CACHE)
+    @Provides
+    Cluster provideCluster(@Named(InjectionNames.CACHE) ClusterConfiguration clusterConfiguration) {
+        PoolingOptions cachingPoolingOptions = clusterConfiguration.getPoolingOptions()
+            .orElse(new PoolingOptions());
+        cachingPoolingOptions.setMaxQueueSize(0);
+
+        return new ResilientClusterProvider(ClusterConfiguration.Builder.from(clusterConfiguration)
+            .poolingOptions(cachingPoolingOptions)
+            .build())
+            .get();
+    }
+
+    @Provides
+    @Named(InjectionNames.CACHE)
+    @Singleton
+    ClusterConfiguration provideClusterConfiguration(PropertiesProvider propertiesProvider) throws ConfigurationException {
+        try {
+            return ClusterConfiguration.from(propertiesProvider.getConfiguration(CASSANDRA_FILE_NAME));
+        } catch (FileNotFoundException e) {
+            return ClusterConfiguration.builder()
+                .host(Host.from(LOCALHOST, CASSANDRA_PORT))
+                .build();
+        }
+    }
+
     @Named(InjectionNames.CACHE)
     @Provides
     @Singleton
@@ -73,7 +115,7 @@ public class CassandraCacheSessionModule extends AbstractModule {
         private final Cluster cluster;
 
         @Inject
-        private InitializedCacheCluster(Cluster cluster, ClusterConfiguration clusterConfiguration, KeyspacesConfiguration keyspacesConfiguration) {
+        private InitializedCacheCluster(@Named(InjectionNames.CACHE) Cluster cluster, ClusterConfiguration clusterConfiguration, KeyspacesConfiguration keyspacesConfiguration) {
             this.cluster = cluster;
 
             if (clusterConfiguration.shouldCreateKeyspace()) {


### PR DESCRIPTION
If the request cannot be executed straight away, we rather not execute it at all.

This is an agressive alternative to https://github.com/linagora/james-project/pull/3467