### PR TITLE
JAMES-3265 Fasten fetching all flags

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
@@ -323,7 +323,7 @@ public interface MessageManager {
      */
     MessageResultIterator getMessages(MessageRange set, FetchGroup fetchGroup, MailboxSession mailboxSession) throws MailboxException;
 
-    Publisher<ComposedMessageIdWithMetaData> getFlags(MessageRange set, MailboxSession session);
+    Publisher<ComposedMessageIdWithMetaData> listMessagesMetadata(MessageRange set, MailboxSession session);
 
     /**
      * Return the underlying {@link Mailbox}

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MessageManager.java
@@ -39,6 +39,7 @@ import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.UnsupportedCriteriaException;
 import org.apache.james.mailbox.exception.UnsupportedRightException;
 import org.apache.james.mailbox.model.ComposedMessageId;
+import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.FetchGroup;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxACL;
@@ -53,6 +54,7 @@ import org.apache.james.mailbox.model.SearchQuery;
 import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mime4j.dom.Message;
 import org.apache.james.mime4j.message.DefaultMessageWriter;
+import org.reactivestreams.Publisher;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -320,6 +322,8 @@ public interface MessageManager {
      * @return MessageResult with the fields defined by FetchGroup
      */
     MessageResultIterator getMessages(MessageRange set, FetchGroup fetchGroup, MailboxSession mailboxSession) throws MailboxException;
+
+    Publisher<ComposedMessageIdWithMetaData> getFlags(MessageRange set, MailboxSession session);
 
     /**
      * Return the underlying {@link Mailbox}

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -19,6 +19,7 @@
 package org.apache.james.mailbox;
 
 import static org.apache.james.mailbox.MailboxManager.RenameOption.RENAME_SUBSCRIPTIONS;
+import static org.apache.james.mailbox.MessageManager.FlagsUpdateMode.REPLACE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -63,6 +64,7 @@ import org.apache.james.mailbox.exception.TooLongMailboxNameException;
 import org.apache.james.mailbox.extension.PreDeletionHook;
 import org.apache.james.mailbox.mock.DataProvisioner;
 import org.apache.james.mailbox.model.ComposedMessageId;
+import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.FetchGroup;
 import org.apache.james.mailbox.model.MailboxACL;
 import org.apache.james.mailbox.model.MailboxAnnotation;
@@ -2662,6 +2664,60 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
             MailboxPath inbox = MailboxPath.inbox(session);
             mailboxManager.createMailbox(inbox, session).get();
             inboxManager = mailboxManager.getMailbox(inbox, session);
+        }
+
+        @Test
+        void listMessagesMetadataShouldReturnEmptyWhenNoMessages() {
+            assertThat(Flux.from(inboxManager.listMessagesMetadata(MessageRange.all(), session))
+                .collectList().block())
+                .isEmpty();
+        }
+
+        @Test
+        void listMessagesMetadataShouldReturnAppendedMessage() throws Exception {
+            Flags flags = new Flags(Flags.Flag.DELETED);
+            ComposedMessageId composeId = inboxManager.appendMessage(AppendCommand.builder()
+                .withFlags(flags)
+                .build(ClassLoaderUtils.getSystemResourceAsSharedStream("eml/twoAttachmentsApi.eml")), session).getId();
+
+            assertThat(Flux.from(inboxManager.listMessagesMetadata(MessageRange.all(), session))
+                    .collectList().block())
+                .hasSize(1)
+                .allSatisfy(ids -> SoftAssertions.assertSoftly(softly -> {
+                    softly.assertThat(ids.getComposedMessageId()).isEqualTo(composeId);
+                    softly.assertThat(ids.getFlags()).isEqualTo(flags);
+                }));
+        }
+
+        @Test
+        void listMessagesMetadataShouldReturnUpdatedMessage() throws Exception {
+            Flags flags = new Flags(Flags.Flag.SEEN);
+            ComposedMessageId composeId = inboxManager.appendMessage(AppendCommand.builder()
+                .withFlags(new Flags(Flags.Flag.DELETED))
+                .build(ClassLoaderUtils.getSystemResourceAsSharedStream("eml/twoAttachmentsApi.eml")), session).getId();
+
+            inboxManager.setFlags(flags, REPLACE, MessageRange.all(), session);
+
+            assertThat(Flux.from(inboxManager.listMessagesMetadata(MessageRange.all(), session))
+                    .collectList().block())
+                .hasSize(1)
+                .allSatisfy(ids -> SoftAssertions.assertSoftly(softly -> {
+                    softly.assertThat(ids.getComposedMessageId()).isEqualTo(composeId);
+                    softly.assertThat(ids.getFlags()).isEqualTo(flags);
+                }));
+        }
+
+        @Test
+        void listMessagesMetadataShouldNotReturnDeletedMessage() throws Exception {
+            inboxManager.appendMessage(AppendCommand.builder()
+                .withFlags(new Flags(Flags.Flag.DELETED))
+                .build(ClassLoaderUtils.getSystemResourceAsSharedStream("eml/twoAttachmentsApi.eml")), session).getId();
+
+            inboxManager.expunge(MessageRange.all(), session);
+
+            assertThat(Flux.from(inboxManager.listMessagesMetadata(MessageRange.all(), session))
+                    .collectList().block())
+                .isEmpty();
         }
 
         @Test

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/MailboxManagerTest.java
@@ -2684,7 +2684,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
                     .collectList().block())
                 .hasSize(1)
                 .allSatisfy(ids -> SoftAssertions.assertSoftly(softly -> {
-                    softly.assertThat(ids.getComposedMessageId()).isEqualTo(composeId);
+                    softly.assertThat(ids.getComposedMessageId().getMailboxId()).isEqualTo(composeId.getMailboxId());
+                    softly.assertThat(ids.getComposedMessageId().getUid()).isEqualTo(composeId.getUid());
                     softly.assertThat(ids.getFlags()).isEqualTo(flags);
                 }));
         }
@@ -2702,7 +2703,8 @@ public abstract class MailboxManagerTest<T extends MailboxManager> {
                     .collectList().block())
                 .hasSize(1)
                 .allSatisfy(ids -> SoftAssertions.assertSoftly(softly -> {
-                    softly.assertThat(ids.getComposedMessageId()).isEqualTo(composeId);
+                    softly.assertThat(ids.getComposedMessageId().getMailboxId()).isEqualTo(composeId.getMailboxId());
+                    softly.assertThat(ids.getComposedMessageId().getUid()).isEqualTo(composeId.getUid());
                     softly.assertThat(ids.getFlags()).isEqualTo(flags);
                 }));
         }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -174,6 +174,12 @@ public class CassandraMessageMapper implements MessageMapper {
     }
 
     @Override
+    public Flux<ComposedMessageIdWithMetaData> getFlags(Mailbox mailbox, MessageRange set) {
+        CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
+        return messageIdDAO.retrieveMessages(mailboxId, set, Limit.unlimited());
+    }
+
+    @Override
     public Flux<MailboxMessage> findInMailboxReactive(Mailbox mailbox, MessageRange messageRange, FetchType ftype, int limitAsInt) {
         CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -174,7 +174,7 @@ public class CassandraMessageMapper implements MessageMapper {
     }
 
     @Override
-    public Flux<ComposedMessageIdWithMetaData> getFlags(Mailbox mailbox, MessageRange set) {
+    public Flux<ComposedMessageIdWithMetaData> listMessagesMetadata(Mailbox mailbox, MessageRange set) {
         CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
         return messageIdDAO.retrieveMessages(mailboxId, set, Limit.unlimited());
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -60,6 +60,7 @@ import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.ReadOnlyException;
 import org.apache.james.mailbox.exception.UnsupportedRightException;
 import org.apache.james.mailbox.model.ComposedMessageId;
+import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.FetchGroup;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxACL;
@@ -97,6 +98,7 @@ import org.apache.james.util.IteratorWrapper;
 import org.apache.james.util.io.BodyOffsetInputStream;
 import org.apache.james.util.io.InputStreamConsummer;
 import org.apache.james.util.streams.Iterators;
+import org.reactivestreams.Publisher;
 
 import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
@@ -649,6 +651,12 @@ public class StoreMessageManager implements MessageManager {
     public MessageResultIterator getMessages(MessageRange set, FetchGroup fetchGroup, MailboxSession mailboxSession) throws MailboxException {
         final MessageMapper messageMapper = mapperFactory.getMessageMapper(mailboxSession);
         return new StoreMessageResultIterator(messageMapper, mailbox, set, batchSizes, fetchGroup);
+    }
+
+    @Override
+    public Publisher<ComposedMessageIdWithMetaData> getFlags(MessageRange set, MailboxSession session) {
+        MessageMapper messageMapper = mapperFactory.getMessageMapper(session);
+        return messageMapper.getFlags(mailbox, set);
     }
 
     /**

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -654,9 +654,9 @@ public class StoreMessageManager implements MessageManager {
     }
 
     @Override
-    public Publisher<ComposedMessageIdWithMetaData> getFlags(MessageRange set, MailboxSession session) {
+    public Publisher<ComposedMessageIdWithMetaData> listMessagesMetadata(MessageRange set, MailboxSession session) {
         MessageMapper messageMapper = mapperFactory.getMessageMapper(session);
-        return messageMapper.getFlags(mailbox, set);
+        return messageMapper.listMessagesMetadata(mailbox, set);
     }
 
     /**

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
@@ -69,20 +69,14 @@ public interface MessageMapper extends Mapper {
             throws MailboxException;
 
     default Flux<ComposedMessageIdWithMetaData> listMessagesMetadata(Mailbox mailbox, MessageRange set) {
-        try {
-            Iterator<MailboxMessage> messages = findInMailbox(mailbox, set, FetchType.Metadata, UNLIMITED);
-
-            return Iterators.toFlux(messages)
-                .map(message -> new ComposedMessageIdWithMetaData(
-                    new ComposedMessageId(
-                        message.getMailboxId(),
-                        message.getMessageId(),
-                        message.getUid()),
-                    message.createFlags(),
-                    message.getModSeq()));
-        } catch (MailboxException e) {
-            return Flux.error(e);
-        }
+        return findInMailboxReactive(mailbox, set, FetchType.Metadata, UNLIMITED)
+            .map(message -> new ComposedMessageIdWithMetaData(
+                new ComposedMessageId(
+                    message.getMailboxId(),
+                    message.getMessageId(),
+                    message.getUid()),
+                message.createFlags(),
+                message.getModSeq()));
     }
 
     default Flux<MailboxMessage> findInMailboxReactive(Mailbox mailbox, MessageRange set, FetchType type, int limit) {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
@@ -31,6 +31,8 @@ import org.apache.james.mailbox.MessageManager.FlagsUpdateMode;
 import org.apache.james.mailbox.MessageUid;
 import org.apache.james.mailbox.ModSeq;
 import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.ComposedMessageId;
+import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MessageMetaData;
@@ -52,6 +54,7 @@ import reactor.core.publisher.Mono;
  * to the end of the request.
  */
 public interface MessageMapper extends Mapper {
+    int UNLIMITED = -1;
 
     /**
      * Return a {@link Iterator} which holds the messages for the given criterias
@@ -64,6 +67,23 @@ public interface MessageMapper extends Mapper {
      */
     Iterator<MailboxMessage> findInMailbox(Mailbox mailbox, MessageRange set, FetchType type, int limit)
             throws MailboxException;
+
+    default Flux<ComposedMessageIdWithMetaData> getFlags(Mailbox mailbox, MessageRange set) {
+        try {
+            Iterator<MailboxMessage> messages = findInMailbox(mailbox, set, FetchType.Metadata, UNLIMITED);
+
+            return Iterators.toFlux(messages)
+                .map(message -> new ComposedMessageIdWithMetaData(
+                    new ComposedMessageId(
+                        message.getMailboxId(),
+                        message.getMessageId(),
+                        message.getUid()),
+                    message.createFlags(),
+                    message.getModSeq()));
+        } catch (MailboxException e) {
+            return Flux.error(e);
+        }
+    }
 
     default Flux<MailboxMessage> findInMailboxReactive(Mailbox mailbox, MessageRange set, FetchType type, int limit) {
         try {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MessageMapper.java
@@ -68,7 +68,7 @@ public interface MessageMapper extends Mapper {
     Iterator<MailboxMessage> findInMailbox(Mailbox mailbox, MessageRange set, FetchType type, int limit)
             throws MailboxException;
 
-    default Flux<ComposedMessageIdWithMetaData> getFlags(Mailbox mailbox, MessageRange set) {
+    default Flux<ComposedMessageIdWithMetaData> listMessagesMetadata(Mailbox mailbox, MessageRange set) {
         try {
             Iterator<MailboxMessage> messages = findInMailbox(mailbox, set, FetchType.Metadata, UNLIMITED);
 

--- a/protocols/imap/src/main/java/org/apache/james/imap/api/message/FetchData.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/api/message/FetchData.java
@@ -142,6 +142,16 @@ public class FetchData {
         return vanished;
     }
 
+    public boolean isOnlyFlags() {
+        return bodyElements.isEmpty()
+            && itemToFetch.stream()
+            .filter(item -> item != Item.FLAGS)
+            .filter(item -> item != Item.UID)
+            .filter(item -> item != Item.MODSEQ)
+            .findAny()
+            .isEmpty();
+    }
+
     @Override
     public final int hashCode() {
         return Objects.hash(itemToFetch, bodyElements, setSeen, changedSince);

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchProcessor.java
@@ -145,7 +145,7 @@ public class FetchProcessor extends AbstractMailboxProcessor<FetchRequest> {
 
         for (MessageRange range : ranges) {
             if (fetch.isOnlyFlags()) {
-                processFlagsRange(session, mailbox, fetch, mailboxSession, responder, builder, range);
+                processMessageRangeForFlags(session, mailbox, fetch, mailboxSession, responder, builder, range);
             } else {
                 processMessageRange(session, mailbox, fetch, useUids, mailboxSession, responder, builder, resultToFetch, range);
             }
@@ -153,8 +153,8 @@ public class FetchProcessor extends AbstractMailboxProcessor<FetchRequest> {
 
     }
 
-    private void processFlagsRange(ImapSession session, MessageManager mailbox, FetchData fetch, MailboxSession mailboxSession, Responder responder, FetchResponseBuilder builder, MessageRange range) {
-        Iterator<ComposedMessageIdWithMetaData> results = Flux.from(mailbox.getFlags(range, mailboxSession))
+    private void processMessageRangeForFlags(ImapSession session, MessageManager mailbox, FetchData fetch, MailboxSession mailboxSession, Responder responder, FetchResponseBuilder builder, MessageRange range) {
+        Iterator<ComposedMessageIdWithMetaData> results = Flux.from(mailbox.listMessagesMetadata(range, mailboxSession))
             .filter(ids -> !fetch.contains(Item.MODSEQ) || ids.getModSeq().asLong() > fetch.getChangedSince())
             .toStream()
             .iterator();

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/fetch/FetchProcessor.java
@@ -21,6 +21,7 @@ package org.apache.james.imap.processor.fetch;
 
 import java.io.Closeable;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 import org.apache.james.imap.api.ImapConstants;
@@ -41,6 +42,7 @@ import org.apache.james.mailbox.MessageManager;
 import org.apache.james.mailbox.MessageManager.MailboxMetaData;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.exception.MessageRangeException;
+import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.FetchGroup;
 import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.MessageResult;
@@ -49,6 +51,8 @@ import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.util.MDCBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import reactor.core.publisher.Flux;
 
 public class FetchProcessor extends AbstractMailboxProcessor<FetchRequest> {
     private static final Logger LOGGER = LoggerFactory.getLogger(FetchProcessor.class);
@@ -140,37 +144,71 @@ public class FetchProcessor extends AbstractMailboxProcessor<FetchRequest> {
         FetchGroup resultToFetch = FetchDataConverter.getFetchGroup(fetch);
 
         for (MessageRange range : ranges) {
-            MessageResultIterator messages = mailbox.getMessages(range, resultToFetch, mailboxSession);
-            while (messages.hasNext()) {
-                final MessageResult result = messages.next();
-
-                //skip unchanged messages - this should be filtered at the mailbox level to take advantage of indexes
-                if (fetch.contains(Item.MODSEQ) && result.getModSeq().asLong() <= fetch.getChangedSince()) {
-                    continue;
-                }
-
-                try {
-                    final FetchResponse response = builder.build(fetch, result, mailbox, session, useUids);
-                    responder.respond(response);
-                } catch (MessageRangeException e) {
-                    // we can't for whatever reason find the message so
-                    // just skip it and log it to debug
-                    LOGGER.debug("Unable to find message with uid {}", result.getUid(), e);
-                } catch (MailboxException e) {
-                    // we can't for whatever reason find parse all requested parts of the message. This may because it was deleted while try to access the parts.
-                    // So we just skip it 
-                    //
-                    // See IMAP-347
-                    LOGGER.error("Unable to fetch message with uid {}, so skip it", result.getUid(), e);
-                }
-            }
-
-            // Throw the exception if we received one
-            if (messages.getException() != null) {
-                throw messages.getException();
+            if (fetch.isOnlyFlags()) {
+                processFlagsRange(session, mailbox, fetch, mailboxSession, responder, builder, range);
+            } else {
+                processMessageRange(session, mailbox, fetch, useUids, mailboxSession, responder, builder, resultToFetch, range);
             }
         }
 
+    }
+
+    private void processFlagsRange(ImapSession session, MessageManager mailbox, FetchData fetch, MailboxSession mailboxSession, Responder responder, FetchResponseBuilder builder, MessageRange range) {
+        Iterator<ComposedMessageIdWithMetaData> results = Flux.from(mailbox.getFlags(range, mailboxSession))
+            .filter(ids -> !fetch.contains(Item.MODSEQ) || ids.getModSeq().asLong() > fetch.getChangedSince())
+            .toStream()
+            .iterator();
+
+        while (results.hasNext()) {
+            ComposedMessageIdWithMetaData result = results.next();
+
+            try {
+                final FetchResponse response = builder.build(fetch, result, mailbox, session);
+                responder.respond(response);
+            } catch (MessageRangeException e) {
+                // we can't for whatever reason find the message so
+                // just skip it and log it to debug
+                LOGGER.debug("Unable to find message with uid {}", result.getComposedMessageId().getUid(), e);
+            } catch (MailboxException e) {
+                // we can't for whatever reason find parse all requested parts of the message. This may because it was deleted while try to access the parts.
+                // So we just skip it
+                //
+                // See IMAP-347
+                LOGGER.error("Unable to fetch message with uid {}, so skip it", result.getComposedMessageId().getUid(), e);
+            }
+        }
+    }
+
+    private void processMessageRange(ImapSession session, MessageManager mailbox, FetchData fetch, boolean useUids, MailboxSession mailboxSession, Responder responder, FetchResponseBuilder builder, FetchGroup resultToFetch, MessageRange range) throws MailboxException {
+        MessageResultIterator messages = mailbox.getMessages(range, resultToFetch, mailboxSession);
+        while (messages.hasNext()) {
+            final MessageResult result = messages.next();
+
+            //skip unchanged messages - this should be filtered at the mailbox level to take advantage of indexes
+            if (fetch.contains(Item.MODSEQ) && result.getModSeq().asLong() <= fetch.getChangedSince()) {
+                continue;
+            }
+
+            try {
+                final FetchResponse response = builder.build(fetch, result, mailbox, session, useUids);
+                responder.respond(response);
+            } catch (MessageRangeException e) {
+                // we can't for whatever reason find the message so
+                // just skip it and log it to debug
+                LOGGER.debug("Unable to find message with uid {}", result.getUid(), e);
+            } catch (MailboxException e) {
+                // we can't for whatever reason find parse all requested parts of the message. This may because it was deleted while try to access the parts.
+                // So we just skip it
+                //
+                // See IMAP-347
+                LOGGER.error("Unable to fetch message with uid {}, so skip it", result.getUid(), e);
+            }
+        }
+
+        // Throw the exception if we received one
+        if (messages.getException() != null) {
+            throw messages.getException();
+        }
     }
 
 


### PR DESCRIPTION
As we disabled buggy CONDSTORE extension upon reconnection, TBird has no
choice than to do a full scan of all uid & flags to resync.

This operation is costly.

On top of the Cassandra backend, 99+% of the time is spent reading the
messagev2 table that is not needed for this Fetch request, effectively
slowing down the request.

By adding a method allowing to retrieve ComposedMessageIdWithMetaDatas for
a range in a given mailbox on top of the MessageManager, we allow
significant performance enhancement for IMAP on top of the Cassandra backend.