### PR TITLE
JAMES-3295 Matcher for permanent error SMTP code

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/Bouncer.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/Bouncer.java
@@ -24,6 +24,7 @@ import java.io.StringWriter;
 import java.net.ConnectException;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.util.Optional;
 
 import javax.mail.MessagingException;
 import javax.mail.SendFailedException;
@@ -41,6 +42,7 @@ public class Bouncer {
     private static final Logger LOGGER = LoggerFactory.getLogger(Bouncer.class);
 
     public static final AttributeName DELIVERY_ERROR = AttributeName.of("delivery-error");
+    public static final AttributeName DELIVERY_ERROR_CODE = AttributeName.of("delivery-error-code");
     private final RemoteDeliveryConfiguration configuration;
     private final MailetContext mailetContext;
 
@@ -54,6 +56,7 @@ public class Bouncer {
             LOGGER.debug("Null Sender: no bounce will be generated for {}", mail.getName());
         } else {
             if (configuration.getBounceProcessor() != null) {
+                computeErrorCode(ex).ifPresent(mail::setAttribute);
                 mail.setAttribute(new Attribute(DELIVERY_ERROR, AttributeValue.of(getErrorMsg(ex))));
                 try {
                     mailetContext.sendMail(mail, configuration.getBounceProcessor());
@@ -66,6 +69,14 @@ public class Bouncer {
         }
     }
 
+    private Optional<Attribute> computeErrorCode(Exception ex) {
+        return Optional.ofNullable(ex)
+            .filter(e -> e instanceof MessagingException)
+            .map(MessagingException.class::cast)
+            .map(EnhancedMessagingException::new)
+            .flatMap(EnhancedMessagingException::getReturnCode)
+            .map(code -> new Attribute(DELIVERY_ERROR_CODE, AttributeValue.of(code)));
+    }
 
     private void bounceWithMailetContext(Mail mail, Exception ex) {
         LOGGER.debug("Sending failure message {}", mail.getName());
@@ -115,7 +126,7 @@ public class Bouncer {
     }
 
     private String sanitizeExceptionMessage(Exception e) {
-        if (e.getMessage() == null) {
+        if (e == null || e.getMessage() == null) {
             return "null";
         } else {
             return e.getMessage().trim();

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/RemoteDeliveryFailedWithSMTPCode.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/matchers/RemoteDeliveryFailedWithSMTPCode.java
@@ -1,0 +1,59 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.matchers;
+
+import static org.apache.james.transport.mailets.remote.delivery.Bouncer.DELIVERY_ERROR_CODE;
+
+import java.util.Collection;
+
+import javax.mail.MessagingException;
+
+import org.apache.james.core.MailAddress;
+import org.apache.mailet.AttributeUtils;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMatcher;
+import org.apache.mailet.base.MailetUtil;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * <p>
+ * Checks the SMTP error code attached to remote delivery failures 
+ * </p>
+ */
+public class RemoteDeliveryFailedWithSMTPCode extends GenericMatcher {
+
+    private Integer errorCode;
+
+    @Override
+    public void init() throws MessagingException {
+        this.errorCode = MailetUtil.getInitParameterAsStrictlyPositiveInteger(getCondition());
+        Preconditions.checkArgument(errorCode >= 101 && errorCode <= 554, "Invalid SMTP code");
+    }
+
+    @Override
+    public Collection<MailAddress> match(Mail mail) {
+        return AttributeUtils.getValueAndCastFromMail(mail, DELIVERY_ERROR_CODE, Integer.class)
+            .filter(errorCode::equals)
+            .map(any -> mail.getRecipients())
+            .orElse(ImmutableList.of());
+    }
+}

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/matchers/RemoteDeliveryFailedWithSMTPCodeTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/matchers/RemoteDeliveryFailedWithSMTPCodeTest.java
@@ -1,0 +1,173 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.matchers;
+
+import static org.apache.james.transport.mailets.remote.delivery.Bouncer.DELIVERY_ERROR_CODE;
+import static org.apache.mailet.base.MailAddressFixture.RECIPIENT1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Collection;
+
+import javax.mail.MessagingException;
+
+import org.apache.james.core.MailAddress;
+import org.apache.mailet.Attribute;
+import org.apache.mailet.AttributeValue;
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.test.FakeMail;
+import org.apache.mailet.base.test.FakeMatcherConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class RemoteDeliveryFailedWithSMTPCodeTest {
+
+    private static final String CONDITION = "521";
+    public static final int SMTP_ERROR_CODE_521 = 521;
+
+    private RemoteDeliveryFailedWithSMTPCode testee;
+
+    private Mail createMail() throws MessagingException {
+        return FakeMail.builder()
+            .name("test-message")
+            .recipient(RECIPIENT1)
+            .build();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        testee = new RemoteDeliveryFailedWithSMTPCode();
+
+        FakeMatcherConfig matcherConfig = FakeMatcherConfig.builder()
+            .matcherName("RemoteDeliveryFailedWithSMTPCode")
+            .condition(CONDITION)
+            .build();
+
+        testee.init(matcherConfig);
+    }
+
+    @Test
+    void shouldMatchWhenErrorCodeIsEqual() throws Exception {
+        Mail mail = createMail();
+        mail.setAttribute(new Attribute(DELIVERY_ERROR_CODE, AttributeValue.of(SMTP_ERROR_CODE_521)));
+
+        Collection<MailAddress> actual = testee.match(mail);
+
+        assertThat(actual).containsOnly(RECIPIENT1);
+    }
+
+    @Test
+    void shouldNotMatchWhenErrorCodeIsNotEqual() throws Exception {
+        Mail mail = createMail();
+        mail.setAttribute(new Attribute(DELIVERY_ERROR_CODE, AttributeValue.of(522)));
+
+        Collection<MailAddress> actual = testee.match(mail);
+
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenErrorCodeIsMissing() throws Exception {
+        Mail mail = createMail();
+
+        Collection<MailAddress> actual = testee.match(mail);
+
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchWhenErrorCodeIsInvalid() throws Exception {
+        Mail mail = createMail();
+        mail.setAttribute(new Attribute(DELIVERY_ERROR_CODE, AttributeValue.of("abc")));
+
+        Collection<MailAddress> actual = testee.match(mail);
+
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    void shouldThrowWhenConditionIsEmpty() {
+        FakeMatcherConfig matcherConfig = FakeMatcherConfig.builder()
+            .matcherName("RemoteDeliveryFailedWithSMTPCode")
+            .build();
+
+        assertThatThrownBy(() -> testee.init(matcherConfig))
+            .isInstanceOf(MessagingException.class);
+    }
+
+    @Test
+    void shouldThrowWhenConditionIsInvalid() {
+        FakeMatcherConfig matcherConfig = FakeMatcherConfig.builder()
+            .matcherName("RemoteDeliveryFailedWithSMTPCode")
+            .condition("abc")
+            .build();
+
+        assertThatThrownBy(() -> testee.init(matcherConfig))
+            .isInstanceOf(MessagingException.class);
+    }
+
+    @Test
+    void shouldThrowWhenConditionIsNegative() {
+        FakeMatcherConfig matcherConfig = FakeMatcherConfig.builder()
+            .matcherName("RemoteDeliveryFailedWithSMTPCode")
+            .condition("-1")
+            .build();
+
+        assertThatThrownBy(() -> testee.init(matcherConfig))
+            .isInstanceOf(MessagingException.class);
+    }
+
+    @Test
+    void shouldThrowWhenConditionIsZero() {
+        FakeMatcherConfig matcherConfig = FakeMatcherConfig.builder()
+            .matcherName("RemoteDeliveryFailedWithSMTPCode")
+            .condition("0")
+            .build();
+
+        assertThatThrownBy(() -> testee.init(matcherConfig))
+            .isInstanceOf(MessagingException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"99", "555"})
+    void shouldThrowWhenInvalidErrorCode(String condition) {
+        FakeMatcherConfig matcherConfig = FakeMatcherConfig.builder()
+            .matcherName("RemoteDeliveryFailedWithSMTPCode")
+            .condition(condition)
+            .build();
+
+        assertThatThrownBy(() -> testee.init(matcherConfig))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"101", "554"})
+    void shouldNotThrowWhenValidErrorCode(String condition) {
+        FakeMatcherConfig matcherConfig = FakeMatcherConfig.builder()
+            .matcherName("RemoteDeliveryFailedWithSMTPCode")
+            .condition(condition)
+            .build();
+
+        assertThatCode(() -> testee.init(matcherConfig)).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
Missing matchers for generic temporary/permanent errors & rebase on https://github.com/linagora/james-project/pull/3543 for integration tests.