### PR TITLE
J3295 atmost matcher config

### DIFF
--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/AtMost.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/AtMost.java
@@ -80,7 +80,7 @@ public class AtMost extends GenericMatcher {
         atMostExecutions = parseAttributeValue(conditions);
     }
 
-    private AttributeName parseAttribute(List<String> conditions){
+    private AttributeName parseAttribute(List<String> conditions) {
         switch (conditions.size()) {
             case ONLY_CONDITION_VALUE:
                 return AT_MOST_EXECUTIONS;

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/AtMost.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/AtMost.java
@@ -87,7 +87,7 @@ public class AtMost extends GenericMatcher {
             case CONDITION_NAME_AND_VALUE:
                 return AttributeName.of(conditions.get(0));
             default:
-                throw new IllegalArgumentException("MatcherConfiguration format should follow: 'name:value'");
+                throw new IllegalArgumentException("MatcherConfiguration format should follow: 'name:value' or 'value'");
         }
     }
 
@@ -98,7 +98,7 @@ public class AtMost extends GenericMatcher {
             case CONDITION_NAME_AND_VALUE:
                 return MailetUtil.getInitParameterAsStrictlyPositiveInteger(conditions.get(1));
             default:
-                throw new IllegalArgumentException("MatcherConfiguration format should follow: 'name:value'");
+                throw new IllegalArgumentException("MatcherConfiguration format should follow: 'name:value' or 'value'");
         }
     }
 

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/AtMost.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/AtMost.java
@@ -20,10 +20,12 @@
 package org.apache.james.transport.matchers;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 import javax.mail.MessagingException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.james.core.MailAddress;
 import org.apache.mailet.Attribute;
 import org.apache.mailet.AttributeName;
@@ -33,39 +35,99 @@ import org.apache.mailet.Mail;
 import org.apache.mailet.base.GenericMatcher;
 import org.apache.mailet.base.MailetUtil;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 
 /**
+<<<<<<< 2ac2f1c25f5911ee496ecf17224c763445337601
  * Checks that a mail did at most X executions on a specific operation.
  *
  * If no executions have been performed previously, it sets up an attribute `AT_MOST_EXECUTIONS`
  * in the mail that will be incremented every time the check succeeds.
+=======
+ * <p>Checks that a mail did at most X retries on a specific operation</p>
  *
- * The check fails when the defined X limit is reached.
+ * <p> If no retries have been performed previously for Y attribute, it'll be sets up.</p>
+ * <p> In the mail, every time the check was succeeds, counter of it will be increment by one.
+ * The check fails when the defined X limit is reached.</p>
+>>>>>>> j3295: handle configuration AtMostMatcher with differents config
  *
+ * <ul>
+ * <li>X - count of how many times a specific operation retried</li>
+ * <li>Y - name of attribute represented for specific operation retried, default value is: <i>AT_MOST_TRIES</i></li>
+ * </ul>
+ *
+<<<<<<< 2ac2f1c25f5911ee496ecf17224c763445337601
  * <p>The example below will match a mail with at most 3 executions on the mailet</p>
+=======
+ * <p>The example below will match mail with at most 3 tries on the mailet
+ * with attribute name <i>AT_MOST_TRIES</i></p>
+>>>>>>> j3295: handle configuration AtMostMatcher with differents config
  *
  * <pre><code>
- * &lt;mailet match=&quot;AtMost=3&quot; class=&quot;&lt;any-class&gt;&quot;&gt;
+ * &lt;mailet match=&quot;AtMost=AT_MOST_TRIES:3&quot; class=&quot;&lt;any-class&gt;&quot;&gt;
  * &lt;/mailet&gt;
  * </code></pre>
  */
 public class AtMost extends GenericMatcher {
+<<<<<<< 2ac2f1c25f5911ee496ecf17224c763445337601
     static final AttributeName AT_MOST_EXECUTIONS = AttributeName.of("AT_MOST_EXECUTIONS");
     private Integer atMostExecutions;
 
     @Override
     public void init() throws MessagingException {
         this.atMostExecutions = MailetUtil.getInitParameterAsStrictlyPositiveInteger(getCondition());
+=======
+    static final AttributeName AT_MOST_TRIES = AttributeName.of("AT_MOST_TRIES");
+    private static final String CONDITION_SEPARATOR = ":";
+    private static final int ONLY_CONDITION_VALUE = 1;
+    private static final int CONDITION_NAME_AND_VALUE = 2;
+
+    private Attribute condition;
+
+    @Override
+    public void init() throws MessagingException {
+        String conditionConfig = getMatcherConfig().getCondition();
+        Preconditions.checkArgument(StringUtils.isNotBlank(conditionConfig), "MatcherConfiguration is mandatory!");
+        Preconditions.checkArgument(!conditionConfig.startsWith(CONDITION_SEPARATOR),
+            "MatcherConfiguration can not start with '%s'", CONDITION_SEPARATOR);
+
+        List<String> conditions = Splitter.on(CONDITION_SEPARATOR).splitToList(conditionConfig);
+        condition = parseAttribute(conditions);
+    }
+
+    private Attribute parseAttribute(List<String> conditions) throws MessagingException {
+        switch (conditions.size()) {
+            case ONLY_CONDITION_VALUE:
+                return new Attribute(AT_MOST_TRIES,
+                    AttributeValue.of(MailetUtil.getInitParameterAsStrictlyPositiveInteger(conditions.get(0))));
+
+            case CONDITION_NAME_AND_VALUE:
+                return new Attribute(AttributeName.of(conditions.get(0)),
+                    AttributeValue.of(MailetUtil.getInitParameterAsStrictlyPositiveInteger(conditions.get(1))));
+
+            default:
+                throw new IllegalArgumentException("MatcherConfiguration format should follow: 'value:name'");
+        }
+>>>>>>> j3295: handle configuration AtMostMatcher with differents config
     }
 
     @Override
     public Collection<MailAddress> match(Mail mail) throws MessagingException {
+<<<<<<< 2ac2f1c25f5911ee496ecf17224c763445337601
         return AttributeUtils.getValueAndCastFromMail(mail, AT_MOST_EXECUTIONS, Integer.class)
             .or(() -> Optional.of(0))
             .filter(executions -> executions < atMostExecutions)
             .map(executions -> {
                 mail.setAttribute(new Attribute(AT_MOST_EXECUTIONS, AttributeValue.of(executions + 1)));
+=======
+        return AttributeUtils.getValueAndCastFromMail(mail, condition.getName(), Integer.class)
+            .or(() -> Optional.of(0))
+            .filter(retries -> retries < condition.getValue().valueAs(Integer.class).get())
+            .map(retries -> {
+                mail.setAttribute(new Attribute(condition.getName(), AttributeValue.of(retries + 1)));
+>>>>>>> j3295: handle configuration AtMostMatcher with differents config
                 return mail.getRecipients();
             })
             .orElse(ImmutableList.of());

--- a/mailet/standard/src/main/java/org/apache/james/transport/matchers/AtMost.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/matchers/AtMost.java
@@ -42,8 +42,8 @@ import com.google.common.collect.ImmutableList;
 /**
  * Checks that a mail did at most X executions on a specific operation.
  *
- * <p> If no executions have been performed previously for Y attribute, it will be sets up.</p>
- * <p> In the mail, every time the check was succeeds, its counter will be incremented by one.
+ * <p> If no executions have been performed previously for Y attribute, it will be set up.</p>
+ * <p> In the mail, every time the check succeeds, its counter will be incremented by one.
  * The check fails when the defined X limit is reached.</p>
  *
  * <ul>

--- a/mailet/standard/src/test/java/org/apache/james/transport/matchers/AtMostTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/matchers/AtMostTest.java
@@ -66,16 +66,11 @@ class AtMostTest {
 
     @Nested
     class WrongConditionConfigurationTest {
-        private static final String NO_VALUE_MATCHER = "NoValueMatcher";
-        private static final String RETRY_WITHOUT_CONDITION_NAME = ":3";
-        private static final String RETRY_WITHOUT_CONDITION_VALUE = "randomName:";
-        private static final String RETRY_WITH_SPACE_IN_CONDITION = "  :  ";
-
         @Test
         void shouldThrowWhenMatchersConfigWithOutConditionValue() {
             assertThatThrownBy(() -> new AtMost().init(FakeMatcherConfig.builder()
-                .matcherName(NO_VALUE_MATCHER)
-                .condition(RETRY_WITHOUT_CONDITION_VALUE)
+                .matcherName("NoValueMatcher")
+                .condition("randomName:")
                 .build()))
                 .isInstanceOf(MessagingException.class);
         }
@@ -83,7 +78,7 @@ class AtMostTest {
         @Test
         void shouldThrowWhenMatchersConfigWithConditionValueAsWord() {
             assertThatThrownBy(() -> new AtMost().init(FakeMatcherConfig.builder()
-                .matcherName(NO_VALUE_MATCHER)
+                .matcherName("NoValueMatcher")
                 .condition("value")
                 .build()))
                 .isInstanceOf(MessagingException.class);
@@ -92,7 +87,7 @@ class AtMostTest {
         @Test
         void shouldThrowWhenMatchersConfigWithNegativeConditionValue() {
             assertThatThrownBy(() -> new AtMost().init(FakeMatcherConfig.builder()
-                .matcherName(NO_VALUE_MATCHER)
+                .matcherName("NoValueMatcher")
                 .condition("-87")
                 .build()))
                 .isInstanceOf(MessagingException.class);
@@ -101,8 +96,8 @@ class AtMostTest {
         @Test
         void shouldThrowWhenMatchersConfigWithoutConditionValue() {
             assertThatThrownBy(() -> new AtMost().init(FakeMatcherConfig.builder()
-                .matcherName(NO_VALUE_MATCHER)
-                .condition(RETRY_WITHOUT_CONDITION_VALUE)
+                .matcherName("NoValueMatcher")
+                .condition("randomName:")
                 .build()))
                 .isInstanceOf(MessagingException.class);
         }
@@ -110,8 +105,8 @@ class AtMostTest {
         @Test
         void shouldThrowWhenMatchersConfigWithoutConditionName() {
             assertThatThrownBy(() -> new AtMost().init(FakeMatcherConfig.builder()
-                .matcherName(NO_VALUE_MATCHER)
-                .condition(RETRY_WITHOUT_CONDITION_NAME)
+                .matcherName("NoValueMatcher")
+                .condition(":3")
                 .build()))
                 .isInstanceOf(IllegalArgumentException.class);
         }
@@ -119,8 +114,8 @@ class AtMostTest {
         @Test
         void shouldThrowWhenMatchersConfigNameAsSpace() {
             assertThatThrownBy(() -> new AtMost().init(FakeMatcherConfig.builder()
-                .matcherName(NO_VALUE_MATCHER)
-                .condition(RETRY_WITH_SPACE_IN_CONDITION)
+                .matcherName("NoValueMatcher")
+                .condition("  :  ")
                 .build()))
                 .isInstanceOf(MessagingException.class);
         }
@@ -128,10 +123,6 @@ class AtMostTest {
 
     @Nested
     class MultiplesMatcherConfigurationTest {
-        private static final String MULTIPLE_MATCHERS = "MultipleMatchers";
-        private static final String RETRY_3_TIMES = "randomName:3";
-        private static final String RETRY_5_TIMES = "randomName:5";
-
         private AtMost multipleMatchers;
 
         @BeforeEach
@@ -140,15 +131,15 @@ class AtMostTest {
             multipleMatchers.init(
                 FakeMatcherConfig.builder()
                     .matcherName("MultipleMatchers")
-                    .condition(RETRY_3_TIMES)
-                    .condition(RETRY_5_TIMES)
+                    .condition("randomName:3")
+                    .condition("randomName:5")
                     .build());
         }
 
         @Test
         void matchersShouldMatchWhenNoRetries() throws MessagingException {
             Mail mail = createMail();
-            mail.setAttribute(new Attribute(AttributeName.of(MULTIPLE_MATCHERS), AttributeValue.of(0)));
+            mail.setAttribute(new Attribute(AttributeName.of("MultipleMatchers"), AttributeValue.of(0)));
 
             Collection<MailAddress> actual = multipleMatchers.match(mail);
 
@@ -158,7 +149,7 @@ class AtMostTest {
         @Test
         void matchersShouldStopWhenAMatcherReachedLimit() throws MessagingException {
             Mail mail = createMail();
-            mail.setAttribute(new Attribute(AttributeName.of(MULTIPLE_MATCHERS), AttributeValue.of(3)));
+            mail.setAttribute(new Attribute(AttributeName.of("MultipleMatchers"), AttributeValue.of(3)));
 
             Collection<MailAddress> actual = multipleMatchers.match(mail);
 

--- a/mailet/standard/src/test/java/org/apache/james/transport/matchers/AtMostTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/matchers/AtMostTest.java
@@ -159,13 +159,18 @@ class AtMostTest {
         }
 
         @Test
-        void matchersShouldMatchWhenLimitNotReached() throws MessagingException {
-            Mail mail = createMail();
-            mail.setAttribute(new Attribute(AttributeName.of("AtMost3"), AttributeValue.of(2)));
+        void matchersShouldStopWhenAMatcherReachedLimit() throws MessagingException {
+            Mail mail1 = createMail();
 
-            Collection<MailAddress> actual = atMost2.match(mail);
-
-            assertThat(actual).containsOnly(RECIPIENT1);
+            SoftAssertions.assertSoftly(Throwing.consumer(
+                softly -> {
+                    softly.assertThat(atMost2.match(mail1)).containsOnly(RECIPIENT1);
+                    softly.assertThat(atMost2.match(mail1)).containsOnly(RECIPIENT1);
+                    softly.assertThat(atMost2.match(mail1)).isEmpty();
+                    softly.assertThat(atMost3.match(mail1)).containsOnly(RECIPIENT1);
+                    softly.assertThat(atMost3.match(mail1)).containsOnly(RECIPIENT1);
+                    softly.assertThat(atMost3.match(mail1)).isEmpty();
+                }));
         }
     }
 

--- a/mailet/standard/src/test/java/org/apache/james/transport/matchers/AtMostTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/matchers/AtMostTest.java
@@ -85,15 +85,6 @@ class AtMostTest {
         }
 
         @Test
-        void shouldThrowWhenMatchersConfigWithNegativeConditionValue() {
-            assertThatThrownBy(() -> new AtMost().init(FakeMatcherConfig.builder()
-                    .matcherName("NoValueMatcher")
-                    .condition("-87")
-                    .build()))
-                .isInstanceOf(MessagingException.class);
-        }
-
-        @Test
         void shouldThrowWhenMatchersConfigWithoutConditionName() {
             assertThatThrownBy(() -> new AtMost().init(FakeMatcherConfig.builder()
                     .matcherName("NoValueMatcher")
@@ -120,17 +111,6 @@ class AtMostTest {
 
             assertThatThrownBy(() -> matcher.init(matcherConfig))
                 .isInstanceOf(IllegalArgumentException.class);
-        }
-
-        @Test
-        void shouldThrowWithInvalidCondition() {
-            FakeMatcherConfig matcherConfig = FakeMatcherConfig.builder()
-                .matcherName("AtMost")
-                .condition("invalid")
-                .build();
-
-            assertThatThrownBy(() -> matcher.init(matcherConfig))
-                .isInstanceOf(MessagingException.class);
         }
 
         @Test
@@ -176,21 +156,6 @@ class AtMostTest {
                     .matcherName("AtMost")
                     .condition("AtMost3:2")
                     .build());
-        }
-
-        @Test
-        void matchersShouldStopWhenAMatcherReachedLimit() throws MessagingException {
-            Mail mail1 = createMail();
-
-            SoftAssertions.assertSoftly(Throwing.consumer(
-                softly -> {
-                    softly.assertThat(atMost2.match(mail1)).containsOnly(RECIPIENT1);
-                    softly.assertThat(atMost2.match(mail1)).containsOnly(RECIPIENT1);
-                    softly.assertThat(atMost2.match(mail1)).isEmpty();
-                    softly.assertThat(atMost3.match(mail1)).containsOnly(RECIPIENT1);
-                    softly.assertThat(atMost3.match(mail1)).containsOnly(RECIPIENT1);
-                    softly.assertThat(atMost3.match(mail1)).isEmpty();
-                }));
         }
 
         @Test

--- a/mailet/standard/src/test/java/org/apache/james/transport/matchers/AtMostTest.java
+++ b/mailet/standard/src/test/java/org/apache/james/transport/matchers/AtMostTest.java
@@ -67,155 +67,50 @@ class AtMostTest {
     @Nested
     class InvalidConditionConfigurationTest {
         @Test
-        void shouldThrowWhenMatchersConfigWithOutConditionValue() {
+        void shouldThrowWhenMatchersConfigWithoutConditionValue() {
             assertThatThrownBy(() -> new AtMost().init(FakeMatcherConfig.builder()
-                .matcherName("NoValueMatcher")
-                .condition("randomName:")
-                .build()))
+                    .matcherName("NoValueMatcher")
+                    .condition("randomName:")
+                    .build()))
                 .isInstanceOf(MessagingException.class);
         }
 
         @Test
         void shouldThrowWhenMatchersConfigWithInvalidConditionValue() {
             assertThatThrownBy(() -> new AtMost().init(FakeMatcherConfig.builder()
-                .matcherName("NoValueMatcher")
-                .condition("value")
-                .build()))
+                    .matcherName("NoValueMatcher")
+                    .condition("value")
+                    .build()))
                 .isInstanceOf(MessagingException.class);
         }
 
         @Test
         void shouldThrowWhenMatchersConfigWithNegativeConditionValue() {
             assertThatThrownBy(() -> new AtMost().init(FakeMatcherConfig.builder()
-                .matcherName("NoValueMatcher")
-                .condition("-87")
-                .build()))
+                    .matcherName("NoValueMatcher")
+                    .condition("-87")
+                    .build()))
                 .isInstanceOf(MessagingException.class);
         }
 
         @Test
-        void shouldThrowWhenMatchersConfigWithOutConditionName() {
+        void shouldThrowWhenMatchersConfigWithoutConditionName() {
             assertThatThrownBy(() -> new AtMost().init(FakeMatcherConfig.builder()
-                .matcherName("NoValueMatcher")
-                .condition(":3")
-                .build()))
+                    .matcherName("NoValueMatcher")
+                    .condition(":3")
+                    .build()))
                 .isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
         void shouldThrowWhenMatchersConfigNameAsSpace() {
             assertThatThrownBy(() -> new AtMost().init(FakeMatcherConfig.builder()
-                .matcherName("NoValueMatcher")
-                .condition("  :  ")
-                .build()))
+                    .matcherName("NoValueMatcher")
+                    .condition("  :  ")
+                    .build()))
                 .isInstanceOf(MessagingException.class);
         }
-    }
 
-    @Nested
-    class MultipleMatchersConfigurationTest {
-        private AtMost atMost3;
-        private AtMost atMost5;
-
-        @BeforeEach
-        void setup() throws MessagingException {
-            this.atMost3 = new AtMost();
-            atMost3.init(
-                FakeMatcherConfig.builder()
-                    .matcherName("AtMost")
-                    .condition("AtMost:3")
-                    .build());
-
-            this.atMost5 = new AtMost();
-            atMost5.init(
-                FakeMatcherConfig.builder()
-                    .matcherName("AtMost")
-                    .condition("AtMost:5")
-                    .build());
-        }
-
-        @Test
-        void matchersShouldMatchWhenNoRetries() throws MessagingException {
-            Mail mail = createMail();
-            mail.setAttribute(new Attribute(AttributeName.of("AtMost"), AttributeValue.of(1)));
-
-            SoftAssertions.assertSoftly(Throwing.consumer(
-                softly -> {
-                    softly.assertThat(atMost3.match(mail)).contains(RECIPIENT1);
-                    softly.assertThat(atMost3.match(mail)).containsOnly(RECIPIENT1);
-                    softly.assertThat(atMost3.match(mail)).isEmpty();
-                    softly.assertThat(atMost5.match(mail)).containsOnly(RECIPIENT1);
-                    softly.assertThat(atMost5.match(mail)).containsOnly(RECIPIENT1);
-                    softly.assertThat(atMost5.match(mail)).isEmpty();
-                }));
-        }
-
-        @Test
-        void matchersShouldStopWhenAMatcherReachedLimit() throws MessagingException {
-            Mail mail = createMail();
-            mail.setAttribute(new Attribute(AttributeName.of("AtMost"), AttributeValue.of(2)));
-
-            SoftAssertions.assertSoftly(Throwing.consumer(
-                softly -> {
-                    softly.assertThat(atMost3.match(mail)).containsOnly(RECIPIENT1);
-                    softly.assertThat(atMost3.match(mail)).isEmpty();
-                    softly.assertThat(atMost5.match(mail)).containsOnly(RECIPIENT1);
-                    softly.assertThat(atMost5.match(mail)).containsOnly(RECIPIENT1);
-                    softly.assertThat(atMost5.match(mail)).isEmpty();
-                }));
-        }
-
-        @Test
-        void matchersShouldMatchWhenLimitNotReached() throws MessagingException {
-            Mail mail = createMail();
-            mail.setAttribute(new Attribute(AttributeName.of("AtMost"), AttributeValue.of(2)));
-
-            Collection<MailAddress> actual = atMost3.match(mail);
-
-            assertThat(actual).containsOnly(RECIPIENT1);
-        }
-    }
-
-    @Nested
-    class SingleMatcherConfigurationTest {
-        @Test
-        void shouldMatchWhenAttributeNotSet() throws MessagingException {
-            Mail mail = createMail();
-
-            Collection<MailAddress> actual = matcher.match(mail);
-
-            assertThat(actual).containsOnly(RECIPIENT1);
-        }
-
-        @Test
-        void shouldMatchWhenNoRetries() throws MessagingException {
-            Mail mail = createMail();
-            mail.setAttribute(new Attribute(AT_MOST_TRIES, AttributeValue.of(0)));
-
-            Collection<MailAddress> actual = matcher.match(mail);
-
-            assertThat(actual).containsOnly(RECIPIENT1);
-        }
-
-        @Test
-        void shouldNotMatchWhenOverAtMost() throws MessagingException {
-            Mail mail = createMail();
-            mail.setAttribute(new Attribute(AT_MOST_TRIES, AttributeValue.of(3)));
-
-            Collection<MailAddress> actual = matcher.match(mail);
-
-            assertThat(actual).isEmpty();
-        }
-
-        @Test
-        void shouldNotMatchWhenEqualToAtMost() throws MessagingException {
-            Mail mail = createMail();
-            mail.setAttribute(new Attribute(AT_MOST_TRIES, AttributeValue.of(2)));
-
-            Collection<MailAddress> actual = matcher.match(mail);
-
-            assertThat(actual).isEmpty();
-        }
 
         @Test
         void shouldThrowWithEmptyCondition() {
@@ -258,6 +153,96 @@ class AtMostTest {
 
             assertThatThrownBy(() -> matcher.init(matcherConfig))
                 .isInstanceOf(MessagingException.class);
+        }
+    }
+
+    @Nested
+    class MultipleMatchersConfigurationTest {
+        private AtMost atMost2;
+        private AtMost atMost3;
+
+        @BeforeEach
+        void setup() throws MessagingException {
+            this.atMost2 = new AtMost();
+            atMost2.init(
+                FakeMatcherConfig.builder()
+                    .matcherName("AtMost")
+                    .condition("AtMost2:2")
+                    .build());
+
+            this.atMost3 = new AtMost();
+            atMost3.init(
+                FakeMatcherConfig.builder()
+                    .matcherName("AtMost")
+                    .condition("AtMost3:2")
+                    .build());
+        }
+
+        @Test
+        void matchersShouldStopWhenAMatcherReachedLimit() throws MessagingException {
+            Mail mail1 = createMail();
+
+            SoftAssertions.assertSoftly(Throwing.consumer(
+                softly -> {
+                    softly.assertThat(atMost2.match(mail1)).containsOnly(RECIPIENT1);
+                    softly.assertThat(atMost2.match(mail1)).containsOnly(RECIPIENT1);
+                    softly.assertThat(atMost2.match(mail1)).isEmpty();
+                    softly.assertThat(atMost3.match(mail1)).containsOnly(RECIPIENT1);
+                    softly.assertThat(atMost3.match(mail1)).containsOnly(RECIPIENT1);
+                    softly.assertThat(atMost3.match(mail1)).isEmpty();
+                }));
+        }
+
+        @Test
+        void matchersShouldMatchWhenLimitNotReached() throws MessagingException {
+            Mail mail = createMail();
+            mail.setAttribute(new Attribute(AttributeName.of("AtMost3"), AttributeValue.of(2)));
+
+            Collection<MailAddress> actual = atMost2.match(mail);
+
+            assertThat(actual).containsOnly(RECIPIENT1);
+        }
+    }
+
+    @Nested
+    class SingleMatcherConfigurationTest {
+        @Test
+        void shouldMatchWhenAttributeNotSet() throws MessagingException {
+            Mail mail = createMail();
+
+            Collection<MailAddress> actual = matcher.match(mail);
+
+            assertThat(actual).containsOnly(RECIPIENT1);
+        }
+
+        @Test
+        void shouldMatchWhenNoRetries() throws MessagingException {
+            Mail mail = createMail();
+            mail.setAttribute(new Attribute(AT_MOST_EXECUTIONS, AttributeValue.of(0)));
+
+            Collection<MailAddress> actual = matcher.match(mail);
+
+            assertThat(actual).containsOnly(RECIPIENT1);
+        }
+
+        @Test
+        void shouldNotMatchWhenOverAtMost() throws MessagingException {
+            Mail mail = createMail();
+            mail.setAttribute(new Attribute(AT_MOST_EXECUTIONS, AttributeValue.of(3)));
+
+            Collection<MailAddress> actual = matcher.match(mail);
+
+            assertThat(actual).isEmpty();
+        }
+
+        @Test
+        void shouldNotMatchWhenEqualToAtMost() throws MessagingException {
+            Mail mail = createMail();
+            mail.setAttribute(new Attribute(AT_MOST_EXECUTIONS, AttributeValue.of(2)));
+
+            Collection<MailAddress> actual = matcher.match(mail);
+
+            assertThat(actual).isEmpty();
         }
 
         @Test

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/RemoteDeliveryErrorHandlingTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/RemoteDeliveryErrorHandlingTest.java
@@ -98,7 +98,7 @@ public class RemoteDeliveryErrorHandlingTest {
                     .addMailet(BCC_STRIPPER)
                     .addMailet(MailetConfiguration.builder()
                         .mailet(RemoteDelivery.class)
-                        .addProperty("maxRetries", "1")
+                        .addProperty("maxRetries", "2")
                         .addProperty("delayTime", "0")
                         .addProperty("bounceProcessor", "remote-delivery-error")
                         .matcher(AtMost.class)
@@ -107,6 +107,7 @@ public class RemoteDeliveryErrorHandlingTest {
                         .matcher(All.class)
                         .mailet(ToRepository.class)
                         .addProperty("repositoryPath", REMOTE_DELIVERY_PERMANENT_ERROR_REPOSITORY.asString())))
+
                 .putProcessor(ProcessorConfiguration.builder()
                     .state("remote-delivery-error")
                     .addMailet(MailetConfiguration.builder()

--- a/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/RemoteDeliveryErrorHandlingTest.java
+++ b/server/mailet/integration-testing/src/test/java/org/apache/james/transport/mailets/RemoteDeliveryErrorHandlingTest.java
@@ -98,7 +98,7 @@ public class RemoteDeliveryErrorHandlingTest {
                     .addMailet(BCC_STRIPPER)
                     .addMailet(MailetConfiguration.builder()
                         .mailet(RemoteDelivery.class)
-                        .addProperty("maxRetries", "2")
+                        .addProperty("maxRetries", "1")
                         .addProperty("delayTime", "0")
                         .addProperty("bounceProcessor", "remote-delivery-error")
                         .matcher(AtMost.class)
@@ -107,7 +107,6 @@ public class RemoteDeliveryErrorHandlingTest {
                         .matcher(All.class)
                         .mailet(ToRepository.class)
                         .addProperty("repositoryPath", REMOTE_DELIVERY_PERMANENT_ERROR_REPOSITORY.asString())))
-
                 .putProcessor(ProcessorConfiguration.builder()
                     .state("remote-delivery-error")
                     .addMailet(MailetConfiguration.builder()


### PR DESCRIPTION
The idea was:
As this matcher can be used several time within the mailet container, we need to be able to specify the name of the attribute used to count retries (optional). 
Proposed syntax:
```
<mailet matcher="AtMost=5:myAttribute" class="..."> 
    ... 
</mailet>
```