### PR TITLE
POC Backpressure aware execution rate for the eventBus

### DIFF
--- a/mailbox/event/event-rabbitmq/pom.xml
+++ b/mailbox/event/event-rabbitmq/pom.xml
@@ -81,6 +81,11 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>metrics-dropwizard</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>metrics-tests</artifactId>
             <scope>test</scope>
         </dependency>

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/EventDispatcher.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/EventDispatcher.java
@@ -113,6 +113,7 @@ public class EventDispatcher {
                     MDCBuilder.create()
                         .addContext(EventBus.StructuredLoggingFields.REGISTRATION_KEY, registrationKey),
                     event)
+            .then()
             .onErrorResume(e -> {
                 structuredLogger(event, ImmutableSet.of(registrationKey))
                     .log(logger -> logger.error("Exception happens when dispatching event", e));

--- a/metrics/metrics-api/src/main/java/org/apache/james/metrics/api/TimeMetric.java
+++ b/metrics/metrics-api/src/main/java/org/apache/james/metrics/api/TimeMetric.java
@@ -27,6 +27,10 @@ public interface TimeMetric {
 
         Duration elasped();
 
+        boolean exceedP99();
+
+        boolean exceedP50();
+
         ExecutionResult logWhenExceedP99(Duration thresholdInNanoSeconds);
     }
 

--- a/metrics/metrics-logger/src/main/java/org/apache/james/metrics/logger/DefaultTimeMetric.java
+++ b/metrics/metrics-logger/src/main/java/org/apache/james/metrics/logger/DefaultTimeMetric.java
@@ -39,6 +39,16 @@ public class DefaultTimeMetric implements TimeMetric {
         }
 
         @Override
+        public boolean exceedP99() {
+            return false;
+        }
+
+        @Override
+        public boolean exceedP50() {
+            return false;
+        }
+
+        @Override
         public ExecutionResult logWhenExceedP99(Duration thresholdInNanoSeconds) {
             return this;
         }

--- a/metrics/metrics-tests/src/main/java/org/apache/james/metrics/tests/RecordingTimeMetric.java
+++ b/metrics/metrics-tests/src/main/java/org/apache/james/metrics/tests/RecordingTimeMetric.java
@@ -36,6 +36,18 @@ public class RecordingTimeMetric implements TimeMetric {
         }
 
         @Override
+        public boolean exceedP99() {
+            return false;
+        }
+
+        @Override
+        public boolean exceedP50() {
+            return false;
+        }
+
+        @Override
+
+
         public Duration elasped() {
             return elasped;
         }


### PR DESCRIPTION
The idea is to use metrics (p50 and p99) as a feedback for
the execution rate:

 - Handle a maximum on EXECUTION_RATE requests at the same time
 - Slow down when p99 is exceeded (minimum of 1)
 - Speed up when execution rate is below p50

This aims at avoiding overwhelming the downstream system

![Capture d’écran de 2020-07-15 12-01-32](https://user-images.githubusercontent.com/6928740/87505486-2b780700-c693-11ea-8f59-a0dfed75bb28.png)
