### PR TITLE
JAMES−2290 Fix unstable test: DiscreteDistributionTest.partitionShoul…

### DIFF
--- a/server/testing/src/main/java/org/apache/james/utils/DiscreteDistribution.java
+++ b/server/testing/src/main/java/org/apache/james/utils/DiscreteDistribution.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import org.apache.commons.math3.distribution.EnumeratedDistribution;
+import org.apache.commons.math3.random.MersenneTwister;
 import org.apache.commons.math3.util.Pair;
 
 import com.github.steveash.guavate.Guavate;
@@ -66,7 +67,7 @@ public class DiscreteDistribution<T> {
     private final EnumeratedDistribution<T> enumeratedDistribution;
 
     private DiscreteDistribution(List<DistributionEntry<T>> distribution) {
-        enumeratedDistribution = new EnumeratedDistribution<>(distribution.stream()
+        enumeratedDistribution = new EnumeratedDistribution<>(new MersenneTwister(), distribution.stream()
             .map(DistributionEntry::toPair)
             .collect(Guavate.toImmutableList()));
     }

--- a/server/testing/src/test/java/org/apache/james/utils/DiscreteDistributionTest.java
+++ b/server/testing/src/test/java/org/apache/james/utils/DiscreteDistributionTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.ImmutableList;
 
 class DiscreteDistributionTest {
+    public static final Offset<Long> OFFSET = Offset.offset(10_000L);
 
     @Test
     void createShouldNotSupportNegativeDistribution() {
@@ -84,7 +85,8 @@ class DiscreteDistributionTest {
 
         Map<String, Long> experimentOutcome = testee.generateRandomStream().limit(1_000_000)
             .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
-        assertThat(experimentOutcome.get("a")).isCloseTo(experimentOutcome.get("b"), Offset.offset(5_000L));
+        assertThat(experimentOutcome.get("a"))
+            .isCloseTo(experimentOutcome.get("b"), OFFSET);
     }
 
     @Test
@@ -96,7 +98,8 @@ class DiscreteDistributionTest {
 
         Map<String, Long> experimentOutcome = testee.generateRandomStream().limit(1_000_000)
             .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
-        assertThat(experimentOutcome.get("a")).isCloseTo(experimentOutcome.get("b") * 2, Offset.offset(5_000L));
+        assertThat(experimentOutcome.get("a"))
+            .isCloseTo(experimentOutcome.get("b") * 2, OFFSET);
     }
 
     @Test
@@ -109,7 +112,8 @@ class DiscreteDistributionTest {
 
         Map<String, Long> experimentOutcome = testee.generateRandomStream().limit(1_000_000)
             .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
-        assertThat(experimentOutcome.get("a")).isCloseTo(experimentOutcome.get("b") * 2, Offset.offset(5_000L));
+        assertThat(experimentOutcome.get("a"))
+            .isCloseTo(experimentOutcome.get("b") * 2, OFFSET);
     }
 
 }


### PR DESCRIPTION
…dSupportDuplicatedDistributionEntry

We encountered the following failure:

```
[ERROR]   DiscreteDistributionTest.partitionShouldSupportDuplicatedDistributionEntry:112
Expecting:
   <668532L>
 to be close to:
   <662936L>
 by less than <5000L> but difference was <5596L>.
 (a difference of exactly <5000L> being considered valid)
```

A difference of 10.000 seems reasonable too and more unlikely to break.