### PR TITLE
Disable unstable tests that keeps failing recuringly for a long period of time

### DIFF
--- a/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusTest.java
+++ b/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusTest.java
@@ -581,6 +581,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
                 assertThatListenerReceiveOneEvent(listener);
             }
 
+            @Disabled("JAMES-3083 Disable this unstable test")
             @Test
             void dispatchShouldWorkAfterRestartForNewKeyRegistration() throws Exception {
                 eventBus.start();

--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/vault/RabbitMQDeletedMessageVaultIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/vault/RabbitMQDeletedMessageVaultIntegrationTest.java
@@ -23,9 +23,11 @@ import org.apache.james.CassandraExtension;
 import org.apache.james.CassandraRabbitMQJamesConfiguration;
 import org.apache.james.CassandraRabbitMQJamesServerMain;
 import org.apache.james.DockerElasticSearchExtension;
+import org.apache.james.GuiceJamesServer;
 import org.apache.james.JamesServerBuilder;
 import org.apache.james.JamesServerExtension;
 import org.apache.james.SearchConfiguration;
+import org.apache.james.junit.categories.BasicFeature;
 import org.apache.james.modules.AwsS3BlobStoreExtension;
 import org.apache.james.modules.RabbitMQExtension;
 import org.apache.james.modules.TestJMAPServerModule;
@@ -33,6 +35,9 @@ import org.apache.james.modules.blobstore.BlobStoreConfiguration;
 import org.apache.james.modules.vault.TestDeleteMessageVaultPreDeletionHookModule;
 import org.apache.james.webadmin.integration.WebadminIntegrationTestModule;
 import org.apache.james.webadmin.integration.vault.DeletedMessageVaultIntegrationTest;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class RabbitMQDeletedMessageVaultIntegrationTest extends DeletedMessageVaultIntegrationTest {
@@ -61,5 +66,13 @@ class RabbitMQDeletedMessageVaultIntegrationTest extends DeletedMessageVaultInte
     @Override
     protected void awaitSearchUpToDate() {
         ES_EXTENSION.await();
+    }
+
+    @Disabled("JAMES-2688 Unstable test")
+    @Test
+    @Tag(BasicFeature.TAG)
+    @Override
+    public void vaultExportShouldExportZipContainsVaultMessagesToShareeWhenImapDeletedMailbox(GuiceJamesServer jmapServer) {
+
     }
 }

--- a/server/protocols/webadmin-integration-test/webadmin-integration-test-common/src/main/java/org/apache/james/webadmin/integration/vault/DeletedMessageVaultIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/webadmin-integration-test-common/src/main/java/org/apache/james/webadmin/integration/vault/DeletedMessageVaultIntegrationTest.java
@@ -481,7 +481,7 @@ public abstract class DeletedMessageVaultIntegrationTest {
 
     @Tag(BasicFeature.TAG)
     @Test
-    public void vaultExportShouldExportZipContainsVaultMessagesToShareeWhenJmapDeleteMessage() throws Exception {
+    void vaultExportShouldExportZipContainsVaultMessagesToShareeWhenJmapDeleteMessage() throws Exception {
         bartSendMessageToHomer();
         WAIT_TWO_MINUTES.until(() -> listMessageIdsForAccount(homerAccessToken).size() == 1);
         String messageIdOfHomer = listMessageIdsForAccount(homerAccessToken).get(0);

--- a/server/protocols/webadmin-integration-test/webadmin-integration-test-common/src/main/java/org/apache/james/webadmin/integration/vault/DeletedMessageVaultIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/webadmin-integration-test-common/src/main/java/org/apache/james/webadmin/integration/vault/DeletedMessageVaultIntegrationTest.java
@@ -481,7 +481,7 @@ public abstract class DeletedMessageVaultIntegrationTest {
 
     @Tag(BasicFeature.TAG)
     @Test
-    void vaultExportShouldExportZipContainsVaultMessagesToShareeWhenJmapDeleteMessage() throws Exception {
+    public void vaultExportShouldExportZipContainsVaultMessagesToShareeWhenJmapDeleteMessage() throws Exception {
         bartSendMessageToHomer();
         WAIT_TWO_MINUTES.until(() -> listMessageIdsForAccount(homerAccessToken).size() == 1);
         String messageIdOfHomer = listMessageIdsForAccount(homerAccessToken).get(0);
@@ -522,7 +522,7 @@ public abstract class DeletedMessageVaultIntegrationTest {
 
     @Tag(BasicFeature.TAG)
     @Test
-    void vaultExportShouldExportZipContainsVaultMessagesToShareeWhenImapDeletedMailbox(GuiceJamesServer jmapServer) throws Exception {
+    public void vaultExportShouldExportZipContainsVaultMessagesToShareeWhenImapDeletedMailbox(GuiceJamesServer jmapServer) throws Exception {
         bartSendMessageToHomer();
         WAIT_TWO_MINUTES.until(() -> listMessageIdsForAccount(homerAccessToken).size() == 1);
         String messageIdOfHomer = listMessageIdsForAccount(homerAccessToken).get(0);

--- a/server/task/task-memory/src/test/java/org/apache/james/task/eventsourcing/MemoryTerminationSubscriberTest.java
+++ b/server/task/task-memory/src/test/java/org/apache/james/task/eventsourcing/MemoryTerminationSubscriberTest.java
@@ -20,8 +20,18 @@
 
 package org.apache.james.task.eventsourcing;
 
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
 class MemoryTerminationSubscriberTest implements TerminationSubscriberContract {
     public TerminationSubscriber subscriber() {
         return new MemoryTerminationSubscriber();
+    }
+
+    @Disabled("JAMES-2813 This test is unstable")
+    @Override
+    @Test
+    public void dynamicListeningEventsShouldGetOnlyNewEvents() {
+
     }
 }


### PR DESCRIPTION
I had yet another look at them and must admit I completly loose patience here.

The approach I propose is to disable them first not to harm our productivity, then people feeling concerned might want to fix them, and re-enable them in separate PRs.