### PR TITLE
 JAMES-3318 BlobStoreDeletedMessageVault should use DumbBlobStore for effective deletion

### DIFF
--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageVaultHookTest.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageVaultHookTest.java
@@ -30,7 +30,7 @@ import java.time.ZoneOffset;
 import java.util.List;
 
 import org.apache.james.blob.api.HashBlobId;
-import org.apache.james.blob.memory.MemoryBlobStoreFactory;
+import org.apache.james.blob.memory.MemoryDumbBlobStore;
 import org.apache.james.core.MailAddress;
 import org.apache.james.core.MaybeSender;
 import org.apache.james.core.Username;
@@ -50,6 +50,7 @@ import org.apache.james.mailbox.model.MessageRange;
 import org.apache.james.mailbox.model.SearchQuery;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.apache.james.mime4j.dom.Message;
+import org.apache.james.server.blob.deduplication.BlobStoreFactory;
 import org.apache.james.vault.blob.BlobStoreDeletedMessageVault;
 import org.apache.james.vault.blob.BucketNameGenerator;
 import org.apache.james.vault.memory.metadata.MemoryDeletedMessageMetadataVault;
@@ -108,11 +109,13 @@ class DeletedMessageVaultHookTest {
     @BeforeEach
     void setUp() throws Exception {
         clock = Clock.fixed(DELETION_DATE.toInstant(), ZoneOffset.UTC);
+        MemoryDumbBlobStore dumbBlobStore = new MemoryDumbBlobStore();
         messageVault = new BlobStoreDeletedMessageVault(new RecordingMetricFactory(), new MemoryDeletedMessageMetadataVault(),
-            MemoryBlobStoreFactory.builder()
+            BlobStoreFactory.builder()
+                .dumbBlobStore(dumbBlobStore)
                 .blobIdFactory(new HashBlobId.Factory())
                 .defaultBucketName()
-                .passthrough(), new BucketNameGenerator(clock), clock,
+                .passthrough(), dumbBlobStore, new BucketNameGenerator(clock), clock,
             RetentionConfiguration.DEFAULT);
 
         DeletedMessageConverter deletedMessageConverter = new DeletedMessageConverter();

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVaultTest.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVaultTest.java
@@ -40,8 +40,9 @@ import java.time.ZonedDateTime;
 
 import org.apache.james.blob.api.BucketName;
 import org.apache.james.blob.api.HashBlobId;
-import org.apache.james.blob.memory.MemoryBlobStoreFactory;
+import org.apache.james.blob.memory.MemoryDumbBlobStore;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
+import org.apache.james.server.blob.deduplication.BlobStoreFactory;
 import org.apache.james.utils.UpdatableTickingClock;
 import org.apache.james.vault.DeletedMessageVault;
 import org.apache.james.vault.DeletedMessageVaultContract;
@@ -63,12 +64,14 @@ class BlobStoreDeletedMessageVaultTest implements DeletedMessageVaultContract, D
     void setUp() {
         clock = new UpdatableTickingClock(NOW.toInstant());
         metricFactory = new RecordingMetricFactory();
+        MemoryDumbBlobStore dumbBlobStore = new MemoryDumbBlobStore();
         messageVault = new BlobStoreDeletedMessageVault(metricFactory, new MemoryDeletedMessageMetadataVault(),
-            MemoryBlobStoreFactory.builder()
+            BlobStoreFactory.builder()
+                .dumbBlobStore(dumbBlobStore)
                 .blobIdFactory(new HashBlobId.Factory())
                 .defaultBucketName()
                 .passthrough(),
-            new BucketNameGenerator(clock), clock, RetentionConfiguration.DEFAULT);
+            dumbBlobStore, new BucketNameGenerator(clock), clock, RetentionConfiguration.DEFAULT);
     }
 
     @Override

--- a/server/blob/blob-api/src/test/java/org/apache/james/blob/api/BlobStoreContract.java
+++ b/server/blob/blob-api/src/test/java/org/apache/james/blob/api/BlobStoreContract.java
@@ -39,7 +39,7 @@ import com.google.common.base.Strings;
 
 import reactor.core.publisher.Mono;
 
-public interface BlobStoreContract extends DeleteBlobStoreContract, BucketBlobStoreContract {
+public interface BlobStoreContract extends BucketBlobStoreContract {
 
     static Stream<Arguments> storagePolicies() {
         return Stream.of(

--- a/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraPassTroughBlobStoreTest.java
+++ b/server/blob/blob-cassandra/src/test/java/org/apache/james/blob/cassandra/CassandraPassTroughBlobStoreTest.java
@@ -27,13 +27,14 @@ import org.apache.james.backends.cassandra.init.configuration.CassandraConfigura
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
 import org.apache.james.blob.api.BucketName;
+import org.apache.james.blob.api.DeleteBlobStoreContract;
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.MetricableBlobStore;
 import org.apache.james.server.blob.deduplication.BlobStoreFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class CassandraPassTroughBlobStoreTest implements CassandraBlobStoreContract {
+public class CassandraPassTroughBlobStoreTest implements DeleteBlobStoreContract, CassandraBlobStoreContract {
     @RegisterExtension
     static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(CassandraBlobModule.MODULE);
 

--- a/server/blob/blob-memory/src/test/java/org/apache/james/blob/memory/MemoryBlobStorePassThroughTest.java
+++ b/server/blob/blob-memory/src/test/java/org/apache/james/blob/memory/MemoryBlobStorePassThroughTest.java
@@ -21,12 +21,13 @@ package org.apache.james.blob.memory;
 
 import org.apache.james.blob.api.BlobId;
 import org.apache.james.blob.api.BlobStore;
+import org.apache.james.blob.api.DeleteBlobStoreContract;
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.api.MetricableBlobStore;
 import org.apache.james.blob.api.MetricableBlobStoreContract;
 import org.junit.jupiter.api.BeforeEach;
 
-public class MemoryBlobStorePassThroughTest implements MetricableBlobStoreContract {
+public class MemoryBlobStorePassThroughTest implements DeleteBlobStoreContract, MetricableBlobStoreContract {
 
     private static final HashBlobId.Factory BLOB_ID_FACTORY = new HashBlobId.Factory();
     private BlobStore blobStore;

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobStore.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobStore.java
@@ -214,4 +214,11 @@ public class ObjectStorageBlobStore implements BlobStore {
         return Mono.<Void>fromRunnable(() -> blobStore.removeBlob(resolvedBucketName.asString(), blobId.asString()))
             .subscribeOn(Schedulers.elastic());
     }
+
+    // Workaround while waiting for DumbBlobStore extraction
+    public Mono<Void> deleteEffectively(BucketName bucketName, BlobId blobId) {
+        ObjectStorageBucketName resolvedBucketName = bucketNameResolver.resolve(bucketName);
+        return Mono.<Void>fromRunnable(() -> blobStore.removeBlob(resolvedBucketName.asString(), blobId.asString()))
+            .subscribeOn(Schedulers.elastic());
+    }
 }

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobStore.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobStore.java
@@ -210,9 +210,7 @@ public class ObjectStorageBlobStore implements BlobStore {
 
     @Override
     public Mono<Void> delete(BucketName bucketName, BlobId blobId) {
-        ObjectStorageBucketName resolvedBucketName = bucketNameResolver.resolve(bucketName);
-        return Mono.<Void>fromRunnable(() -> blobStore.removeBlob(resolvedBucketName.asString(), blobId.asString()))
-            .subscribeOn(Schedulers.elastic());
+        return Mono.empty();
     }
 
     // Workaround while waiting for DumbBlobStore extraction

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobStoreAWSCryptoTest.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobStoreAWSCryptoTest.java
@@ -35,7 +35,6 @@ import org.apache.james.blob.objectstorage.crypto.CryptoConfig;
 import org.apache.james.blob.objectstorage.swift.Credentials;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(DockerAwsS3Extension.class)
@@ -86,17 +85,5 @@ public class ObjectStorageBlobStoreAWSCryptoTest implements MetricableBlobStoreC
     @Override
     public BlobId.Factory blobIdFactory() {
         return BLOB_ID_FACTORY;
-    }
-
-    @Override
-    @Disabled("JAMES-2829 Unstable with scality/S3 impl")
-    public void readShouldNotReadPartiallyWhenDeletingConcurrentlyBigBlob() {
-
-    }
-
-    @Override
-    @Disabled("JAMES-2838 Unstable with scality/S3 impl")
-    public void readBytesShouldNotReadPartiallyWhenDeletingConcurrentlyBigBlob() {
-
     }
 }

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobStoreAWSNamespaceTest.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobStoreAWSNamespaceTest.java
@@ -34,7 +34,6 @@ import org.apache.james.blob.objectstorage.aws.DockerAwsS3Container;
 import org.apache.james.blob.objectstorage.aws.DockerAwsS3Extension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(DockerAwsS3Extension.class)
@@ -79,18 +78,6 @@ public class ObjectStorageBlobStoreAWSNamespaceTest implements MetricableBlobSto
     @Override
     public BlobId.Factory blobIdFactory() {
         return new HashBlobId.Factory();
-    }
-
-    @Override
-    @Disabled("JAMES-2829 Unstable with scality/S3 impl")
-    public void readShouldNotReadPartiallyWhenDeletingConcurrentlyBigBlob() {
-
-    }
-
-    @Override
-    @Disabled("JAMES-2838 Unstable with scality/S3 impl")
-    public void readBytesShouldNotReadPartiallyWhenDeletingConcurrentlyBigBlob() {
-
     }
 }
 

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobStoreAWSPrefixAndNamespaceTest.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobStoreAWSPrefixAndNamespaceTest.java
@@ -34,7 +34,6 @@ import org.apache.james.blob.objectstorage.aws.DockerAwsS3Container;
 import org.apache.james.blob.objectstorage.aws.DockerAwsS3Extension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(DockerAwsS3Extension.class)
@@ -80,18 +79,6 @@ public class ObjectStorageBlobStoreAWSPrefixAndNamespaceTest implements Metricab
     @Override
     public BlobId.Factory blobIdFactory() {
         return new HashBlobId.Factory();
-    }
-
-    @Override
-    @Disabled("JAMES-2829 Unstable with scality/S3 impl")
-    public void readShouldNotReadPartiallyWhenDeletingConcurrentlyBigBlob() {
-
-    }
-
-    @Override
-    @Disabled("JAMES-2838 Unstable with scality/S3 impl")
-    public void readBytesShouldNotReadPartiallyWhenDeletingConcurrentlyBigBlob() {
-
     }
 }
 

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobStoreAWSPrefixTest.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobStoreAWSPrefixTest.java
@@ -33,7 +33,6 @@ import org.apache.james.blob.objectstorage.aws.DockerAwsS3Container;
 import org.apache.james.blob.objectstorage.aws.DockerAwsS3Extension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(DockerAwsS3Extension.class)
@@ -78,18 +77,6 @@ public class ObjectStorageBlobStoreAWSPrefixTest implements MetricableBlobStoreC
     @Override
     public BlobId.Factory blobIdFactory() {
         return new HashBlobId.Factory();
-    }
-
-    @Override
-    @Disabled("JAMES-2829 Unstable with scality/S3 impl")
-    public void readShouldNotReadPartiallyWhenDeletingConcurrentlyBigBlob() {
-
-    }
-
-    @Override
-    @Disabled("JAMES-2838 Unstable with scality/S3 impl")
-    public void readBytesShouldNotReadPartiallyWhenDeletingConcurrentlyBigBlob() {
-
     }
 }
 

--- a/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobStoreAWSTest.java
+++ b/server/blob/blob-objectstorage/src/test/java/org/apache/james/blob/objectstorage/ObjectStorageBlobStoreAWSTest.java
@@ -33,7 +33,6 @@ import org.apache.james.blob.objectstorage.aws.DockerAwsS3Container;
 import org.apache.james.blob.objectstorage.aws.DockerAwsS3Extension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(DockerAwsS3Extension.class)
@@ -78,17 +77,5 @@ public class ObjectStorageBlobStoreAWSTest implements MetricableBlobStoreContrac
     @Override
     public BlobId.Factory blobIdFactory() {
         return BLOB_ID_FACTORY;
-    }
-
-    @Override
-    @Disabled("JAMES-2829 Unstable with scality/S3 impl")
-    public void readShouldNotReadPartiallyWhenDeletingConcurrentlyBigBlob() {
-
-    }
-
-    @Override
-    @Disabled("JAMES-2838 Unstable with scality/S3 impl")
-    public void readBytesShouldNotReadPartiallyWhenDeletingConcurrentlyBigBlob() {
-
     }
 }

--- a/server/blob/blob-storage-strategy/src/main/scala/org/apache/james/server/blob/deduplication/DeDuplicationBlobStore.scala
+++ b/server/blob/blob-storage-strategy/src/main/scala/org/apache/james/server/blob/deduplication/DeDuplicationBlobStore.scala
@@ -95,6 +95,6 @@ class DeDuplicationBlobStore @Inject()(dumbBlobStore: DumbBlobStore,
     Preconditions.checkNotNull(bucketName)
     Preconditions.checkNotNull(blobId)
 
-    dumbBlobStore.delete(bucketName, blobId)
+    SMono.empty
   }
 }

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/blobstore/BlobStoreModulesChooser.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/blobstore/BlobStoreModulesChooser.java
@@ -54,6 +54,7 @@ public class BlobStoreModulesChooser {
         @Override
         protected void configure() {
             install(new ObjectStorageDependenciesModule());
+            bind(DumbBlobStore.class).to(NoopDumbBlobStore.class);
             bind(BlobStore.class)
                 .annotatedWith(Names.named(CachedBlobStore.BACKEND))
                 .to(ObjectStorageBlobStore.class);

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/blobstore/NoopDumbBlobStore.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/blobstore/NoopDumbBlobStore.java
@@ -1,0 +1,83 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.blobstore;
+
+import java.io.InputStream;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.james.blob.api.BlobId;
+import org.apache.james.blob.api.BucketName;
+import org.apache.james.blob.api.DumbBlobStore;
+import org.apache.james.blob.api.ObjectNotFoundException;
+import org.apache.james.blob.api.ObjectStoreIOException;
+import org.apache.james.blob.objectstorage.ObjectStorageBlobStore;
+import org.reactivestreams.Publisher;
+
+import com.google.common.io.ByteSource;
+
+
+/**
+ * This class is a workaround while waiting for a real DumbBlobStore to be extracted from ObjectStorageBlobStore
+ */
+public class NoopDumbBlobStore implements DumbBlobStore {
+    private final ObjectStorageBlobStore objectStorageBlobStore;
+
+    @Inject
+    public NoopDumbBlobStore(ObjectStorageBlobStore objectStorageBlobStore) {
+        this.objectStorageBlobStore = objectStorageBlobStore;
+    }
+
+    @Override
+    public InputStream read(BucketName bucketName, BlobId blobId) throws ObjectStoreIOException, ObjectNotFoundException {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public Publisher<byte[]> readBytes(BucketName bucketName, BlobId blobId) {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public Publisher<Void> save(BucketName bucketName, BlobId blobId, byte[] data) {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public Publisher<Void> save(BucketName bucketName, BlobId blobId, InputStream inputStream) {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public Publisher<Void> save(BucketName bucketName, BlobId blobId, ByteSource content) {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public Publisher<Void> delete(BucketName bucketName, BlobId blobId) {
+        return objectStorageBlobStore.deleteEffectively(bucketName, blobId);
+    }
+
+    @Override
+    public Publisher<Void> deleteBucket(BucketName bucketName) {
+        throw new NotImplementedException("Not implemented");
+    }
+}


### PR DESCRIPTION
I found a workaround to mitigate the fact that ObjectStorage don't have a DumbBlobStore 'yet' (namely write a "temporary" DumbBlobStore implementing only delete by basing itself on the BlobStore - reversing the dependency).

This unlock work on effective deletion.