### PR TITLE
JAMES-3320: Expose supported private extension in Session object

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/SessionRoutesContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/SessionRoutesContract.scala
@@ -52,7 +52,9 @@ object SessionRoutesContract {
                          |      "maxSizeAttachmentsPerEmail" : 20000000,
                          |      "emailQuerySortOptions" : [ "receivedAt", "cc", "from", "to", "subject", "size", "sentAt", "hasKeyword", "uid", "Id" ],
                          |      "mayCreateTopLevelMailbox" : true
-                         |    }
+                         |    },
+                         |    "urn:apache:james:params:jmap:mail:quota": {},
+                         |    "urn:apache:james:params:jmap:mail:shares": {}
                          |  },
                          |  "accounts" : {
                          |    "0fe275bf13ff761407c17f64b1dfae2f4b3186feea223d7267b79f873a105401" : {
@@ -77,7 +79,9 @@ object SessionRoutesContract {
                          |          "maxSizeAttachmentsPerEmail" : 20000000,
                          |          "emailQuerySortOptions" : [ "receivedAt", "cc", "from", "to", "subject", "size", "sentAt", "hasKeyword", "uid", "Id" ],
                          |          "mayCreateTopLevelMailbox" : true
-                         |        }
+                         |        },
+                         |        "urn:apache:james:params:jmap:mail:quota": {},
+                         |        "urn:apache:james:params:jmap:mail:shares": {}
                          |      }
                          |    }
                          |  },

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/Serializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/Serializer.scala
@@ -249,8 +249,15 @@ class Serializer @Inject() (mailboxIdFactory: MailboxId.Factory) {
       })
     }
 
-  private def mailboxWritesWithFilteredProperties(properties: Option[Properties], capabilities: Set[CapabilityIdentifier]): Writes[Mailbox] = {
-    mailboxWrites(Mailbox.propertiesFiltered(properties, capabilities))
+  private def mailboxWritesWithFilteredProperties(properties: Option[Properties], capabilities: immutable.Set[CapabilityIdentifier]): Writes[Mailbox] = {
+    val propertiesForCapabitilites: immutable.Map[CapabilityIdentifier, immutable.Set[String]] = Map(
+      CapabilityIdentifier.JAMES_QUOTA -> Set("quotas"),
+      CapabilityIdentifier.JAMES_SHARES -> Set("namespace", "rights")
+    )
+    val propertiesToHide = propertiesForCapabitilites.filterNot(entry => capabilities.contains(entry._1))
+      .flatMap(_._2)
+      .toSet
+    mailboxWrites(propertiesToHide)
   }
 
   private implicit def jsErrorWrites: Writes[JsError] = Json.writes[JsError]

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/Serializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/Serializer.scala
@@ -34,7 +34,7 @@ import org.apache.james.mailbox.model.{MailboxACL, MailboxId}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
-import scala.collection.{immutable, Seq => LegacySeq}
+import scala.collection.{Seq => LegacySeq}
 import scala.util.Try
 
 class Serializer @Inject() (mailboxIdFactory: MailboxId.Factory) {
@@ -249,15 +249,8 @@ class Serializer @Inject() (mailboxIdFactory: MailboxId.Factory) {
       })
     }
 
-  private def mailboxWritesWithFilteredProperties(properties: Option[Properties], capabilities: immutable.Set[CapabilityIdentifier]): Writes[Mailbox] = {
-    val propertiesForCapabitilites: immutable.Map[CapabilityIdentifier, immutable.Set[String]] = Map(
-      CapabilityIdentifier.JAMES_QUOTA -> Set("quotas"),
-      CapabilityIdentifier.JAMES_SHARES -> Set("namespace", "rights")
-    )
-    val propertiesToHide = propertiesForCapabitilites.filterNot(entry => capabilities.contains(entry._1))
-      .flatMap(_._2)
-      .toSet
-    mailboxWrites(propertiesToHide)
+  private def mailboxWritesWithFilteredProperties(properties: Option[Properties], capabilities: Set[CapabilityIdentifier]): Writes[Mailbox] = {
+    mailboxWrites(Mailbox.propertiesFiltered(properties, capabilities))
   }
 
   private implicit def jsErrorWrites: Writes[JsError] = Json.writes[JsError]

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/Serializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/Serializer.scala
@@ -93,8 +93,8 @@ class Serializer @Inject() (mailboxIdFactory: MailboxId.Factory) {
   private implicit val urlWrites: Writes[URL] = url => JsString(url.toString)
   private implicit val coreCapabilityWrites: Writes[CoreCapabilityProperties] = Json.writes[CoreCapabilityProperties]
   private implicit val mailCapabilityWrites: Writes[MailCapabilityProperties] = Json.writes[MailCapabilityProperties]
-  private implicit val quotaCapabilityWrites: Writes[MailQuotaProperties] = Json.writes[MailQuotaProperties]
-  private implicit val shareCapabilityWrites: Writes[MailSharesProperties] = Json.writes[MailSharesProperties]
+
+  private implicit val shareCapabilityWrites: Writes[MailSharesProperties] = Json.valueWrites[MailSharesProperties]
 
   private implicit def setCapabilityWrites(implicit corePropertiesWriter: Writes[CoreCapabilityProperties],
                                            mailCapabilityWrites: Writes[MailCapabilityProperties],
@@ -116,10 +116,6 @@ class Serializer @Inject() (mailboxIdFactory: MailboxId.Factory) {
       })
     }
 
-  private implicit val capabilitiesWrites: Writes[Capabilities] = capabilities => setCapabilityWrites.writes(
-    Set(capabilities.coreCapability, capabilities.mailCapability, capabilities.mailQuotaCapability, capabilities.mailSharesCapability
-  ))
-
   private implicit val accountIdWrites: Format[AccountId] = Json.valueFormat[AccountId]
   private implicit def identifierMapWrite[Any](implicit idWriter: Writes[AccountId]): Writes[immutable.Map[CapabilityIdentifier, Any]] =
     (m: immutable.Map[CapabilityIdentifier, Any]) => {
@@ -131,17 +127,9 @@ class Serializer @Inject() (mailboxIdFactory: MailboxId.Factory) {
 
   private implicit val isPersonalFormat: Format[IsPersonal] = Json.valueFormat[IsPersonal]
   private implicit val isReadOnlyFormat: Format[IsReadOnly] = Json.valueFormat[IsReadOnly]
-  private implicit val accountWrites: Writes[Account] = (
-      (JsPath \ Account.NAME).write[Username] and
-      (JsPath \ Account.IS_PERSONAL).write[IsPersonal] and
-      (JsPath \ Account.IS_READ_ONLY).write[IsReadOnly] and
-      (JsPath \ Account.ACCOUNT_CAPABILITIES).write[immutable.Set[_ <: Capability]]
-    ) (unlift(Account.unapplyIgnoreAccountId))
 
   private implicit def accountListWrites(implicit accountWrites: Writes[Account]): Writes[List[Account]] =
     (list: List[Account]) => JsObject(list.map(account => (account.accountId.id.value, accountWrites.writes(account))))
-
-  private implicit val sessionWrites: Writes[Session] = Json.writes[Session]
 
   private implicit val mailboxIdWrites: Writes[MailboxId] = mailboxId => JsString(mailboxId.serialize)
   private implicit val mailboxIdReads: Reads[MailboxId] = {
@@ -197,29 +185,43 @@ class Serializer @Inject() (mailboxIdFactory: MailboxId.Factory) {
   private implicit val quotaValueWrites: Writes[Value] = Json.writes[Value]
 
 
-  private implicit def quotaMapWrites(implicit valueWriter: Writes[Value]): Writes[immutable.Map[Quotas.Type, Value]] =
+  private implicit val quotaMapWrites: Writes[immutable.Map[Quotas.Type, Value]] =
     (m: immutable.Map[Quotas.Type, Value]) => {
       m.foldLeft(JsObject.empty)((jsObject, kv) => {
         val (quotaType: Quotas.Type, value: Value) = kv
-        jsObject.+(quotaType.toString, valueWriter.writes(value))
+        jsObject.+(quotaType.toString, quotaValueWrites.writes(value))
       })
     }
 
-  private implicit def quotaWrites(implicit quotaWriter: Writes[immutable.Map[Quotas.Type, Value]]): Writes[Quota] = {
-    implicit val write: Writes[immutable.Map[Quotas.Type, Value]] = quotaWriter
-    Json.valueWrites[Quota]
-  }
+  private implicit val quotaWrites: Writes[Quota] = Json.valueWrites[Quota]
 
-  private implicit def quotasMapWrites(implicit quotaWriter: Writes[Quota]): Writes[immutable.Map[QuotaId, Quota]] =
+  private implicit val quotasMapWrites: Writes[immutable.Map[QuotaId, Quota]] =
     (m: immutable.Map[QuotaId, Quota]) => {
       m.foldLeft(JsObject.empty)((jsObject, kv) => {
         val (quotaId: QuotaId, quota: Quota) = kv
-        jsObject.+(quotaId.getName, quotaWriter.writes(quota))
+        jsObject.+(quotaId.getName, quotaWrites.writes(quota))
       })
     }
 
-  implicit def mailboxWrites(properties: Set[String]): Writes[Mailbox] = Json.writes[Mailbox]
-    .transform((o: JsObject) => JsObject(o.fields.filter(entry => properties.contains(entry._1))))
+  private implicit val quotasWrite: Writes[Quotas] = Json.valueWrites[Quotas]
+
+  private implicit val quotaCapabilityWrites: Writes[MailQuotaProperties] = Json.valueWrites[MailQuotaProperties]
+
+  private implicit val capabilitiesWrites: Writes[Capabilities] = capabilities => setCapabilityWrites.writes(
+    Set(capabilities.coreCapability, capabilities.mailCapability, capabilities.mailQuotaCapability, capabilities.mailSharesCapability
+    ))
+
+  private implicit def accountWrites(implicit setCapabilityWrites: Writes[Set[_ <: Capability]]): Writes[Account] = (
+    (JsPath \ Account.NAME).write[Username] and
+      (JsPath \ Account.IS_PERSONAL).write[IsPersonal] and
+      (JsPath \ Account.IS_READ_ONLY).write[IsReadOnly] and
+      (JsPath \ Account.ACCOUNT_CAPABILITIES).write[immutable.Set[_ <: Capability]]
+    ) (unlift(Account.unapplyIgnoreAccountId))
+
+  private implicit def sessionWrites(implicit accountWrites: Writes[Account], capabilitiesWrites: Writes[Capabilities]): Writes[Session] = Json.writes[Session]
+
+  implicit def mailboxWrites(propertiesToHide: immutable.Set[String]): Writes[Mailbox] = Json.writes[Mailbox]
+    .transform((o: JsObject) => JsObject(o.fields.filterNot(entry => propertiesToHide.contains(entry._1))))
 
   private implicit val idsRead: Reads[Ids] = Json.valueReads[Ids]
   private implicit val propertiesRead: Reads[Properties] = Json.valueReads[Properties]

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/Serializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/Serializer.scala
@@ -34,7 +34,7 @@ import org.apache.james.mailbox.model.{MailboxACL, MailboxId}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
-import scala.collection.{Seq => LegacySeq}
+import scala.collection.{immutable, Seq => LegacySeq}
 import scala.util.Try
 
 class Serializer @Inject() (mailboxIdFactory: MailboxId.Factory) {
@@ -43,15 +43,15 @@ class Serializer @Inject() (mailboxIdFactory: MailboxId.Factory) {
   private implicit val serverIdFormat: Format[ServerId] = Json.valueFormat[ServerId]
   private implicit val createdIdsFormat: Format[CreatedIds] = Json.valueFormat[CreatedIds]
 
-  private implicit def createdIdsIdWrites(implicit serverIdWriter: Writes[ServerId]): Writes[Map[ClientId, ServerId]] =
-    (ids: Map[ClientId, ServerId]) => {
+  private implicit def createdIdsIdWrites(implicit serverIdWriter: Writes[ServerId]): Writes[immutable.Map[ClientId, ServerId]] =
+    (ids: immutable.Map[ClientId, ServerId]) => {
       ids.foldLeft(JsObject.empty)((jsObject, kv) => {
         val (clientId: ClientId, serverId: ServerId) = kv
         jsObject.+(clientId.value.value, serverIdWriter.writes(serverId))
       })
     }
 
-  private implicit def createdIdsIdRead(implicit serverIdReader: Reads[ServerId]): Reads[Map[ClientId, ServerId]] =
+  private implicit def createdIdsIdRead(implicit serverIdReader: Reads[ServerId]): Reads[immutable.Map[ClientId, ServerId]] =
     Reads.mapReads[ClientId, ServerId] {
       clientIdString => Json.fromJson[ClientId](JsString(clientIdString))
     }
@@ -93,26 +93,36 @@ class Serializer @Inject() (mailboxIdFactory: MailboxId.Factory) {
   private implicit val urlWrites: Writes[URL] = url => JsString(url.toString)
   private implicit val coreCapabilityWrites: Writes[CoreCapabilityProperties] = Json.writes[CoreCapabilityProperties]
   private implicit val mailCapabilityWrites: Writes[MailCapabilityProperties] = Json.writes[MailCapabilityProperties]
+  private implicit val quotaCapabilityWrites: Writes[MailQuotaProperties] = Json.writes[MailQuotaProperties]
+  private implicit val shareCapabilityWrites: Writes[MailSharesProperties] = Json.writes[MailSharesProperties]
 
   private implicit def setCapabilityWrites(implicit corePropertiesWriter: Writes[CoreCapabilityProperties],
-                                   mailCapabilityWrites: Writes[MailCapabilityProperties]): Writes[Set[_ <: Capability]] =
+                                           mailCapabilityWrites: Writes[MailCapabilityProperties],
+                                           quotaPropertiesWrites: Writes[MailQuotaProperties],
+                                           sharesPropertiesWrites: Writes[MailSharesProperties]): Writes[Set[_ <: Capability]] =
     (set: Set[_ <: Capability]) => {
       set.foldLeft(JsObject.empty)((jsObject, capability) => {
         capability match {
-          case capability: CoreCapability => (
-            jsObject.+(capability.identifier.value, corePropertiesWriter.writes(capability.properties)))
-          case capability: MailCapability => (
-            jsObject.+(capability.identifier.value, mailCapabilityWrites.writes(capability.properties)))
+          case capability: CoreCapability =>
+            jsObject.+(capability.identifier.value, corePropertiesWriter.writes(capability.properties))
+          case capability: MailCapability =>
+            jsObject.+(capability.identifier.value, mailCapabilityWrites.writes(capability.properties))
+          case capability: MailQuotaCapability =>
+            jsObject.+(capability.identifier.value, quotaPropertiesWrites.writes(capability.properties))
+          case capability: MailSharesCapability =>
+            jsObject.+(capability.identifier.value, sharesPropertiesWrites.writes(capability.properties))
           case _ => jsObject
         }
       })
     }
 
-  private implicit val capabilitiesWrites: Writes[Capabilities] = capabilities => setCapabilityWrites.writes(Set(capabilities.coreCapability, capabilities.mailCapability))
+  private implicit val capabilitiesWrites: Writes[Capabilities] = capabilities => setCapabilityWrites.writes(
+    Set(capabilities.coreCapability, capabilities.mailCapability, capabilities.mailQuotaCapability, capabilities.mailSharesCapability
+  ))
 
   private implicit val accountIdWrites: Format[AccountId] = Json.valueFormat[AccountId]
-  private implicit def identifierMapWrite[Any](implicit idWriter: Writes[AccountId]): Writes[Map[CapabilityIdentifier, Any]] =
-    (m: Map[CapabilityIdentifier, Any]) => {
+  private implicit def identifierMapWrite[Any](implicit idWriter: Writes[AccountId]): Writes[immutable.Map[CapabilityIdentifier, Any]] =
+    (m: immutable.Map[CapabilityIdentifier, Any]) => {
       m.foldLeft(JsObject.empty)((jsObject, kv) => {
         val (identifier: CapabilityIdentifier, id: AccountId) = kv
         jsObject.+(identifier.value, idWriter.writes(id))
@@ -125,7 +135,7 @@ class Serializer @Inject() (mailboxIdFactory: MailboxId.Factory) {
       (JsPath \ Account.NAME).write[Username] and
       (JsPath \ Account.IS_PERSONAL).write[IsPersonal] and
       (JsPath \ Account.IS_READ_ONLY).write[IsReadOnly] and
-      (JsPath \ Account.ACCOUNT_CAPABILITIES).write[Set[_ <: Capability]]
+      (JsPath \ Account.ACCOUNT_CAPABILITIES).write[immutable.Set[_ <: Capability]]
     ) (unlift(Account.unapplyIgnoreAccountId))
 
   private implicit def accountListWrites(implicit accountWrites: Writes[Account]): Writes[List[Account]] =
@@ -166,35 +176,42 @@ class Serializer @Inject() (mailboxIdFactory: MailboxId.Factory) {
   private implicit val mailboxACLWrites: Writes[MailboxACL.Right] = right => JsString(right.asCharacter.toString)
 
   private implicit val rightWrites: Writes[Right] = Json.valueWrites[Right]
-  private implicit val rightsWrites: Writes[Rights] = Json.valueWrites[Rights]
 
-  private implicit def rightsMapWrites(implicit rightWriter: Writes[Seq[Right]]): Writes[Map[Username, Seq[Right]]] =
-    (m: Map[Username, Seq[Right]]) => {
+  private implicit def rightsMapWrites(implicit rightWriter: Writes[immutable.Set[Right]]): Writes[immutable.Map[Username, immutable.Set[Right]]] =
+    (m: immutable.Map[Username, immutable.Set[Right]]) => {
       m.foldLeft(JsObject.empty)((jsObject, kv) => {
-        val (username: Username, rights: Seq[Right]) = kv
+        val (username: Username, rights: immutable.Set[Right]) = kv
         jsObject.+(username.asString, rightWriter.writes(rights))
       })
     }
+
+  private implicit def rightsWrite(implicit rightWrite: Writes[immutable.Map[Username, immutable.Set[Right]]]): Writes[Rights] = {
+    implicit val write = rightWrite
+    Json.writes[Rights]
+  }
 
   private implicit val domainWrites: Writes[Domain] = domain => JsString(domain.asString)
   private implicit val quotaRootWrites: Writes[QuotaRoot] = Json.writes[QuotaRoot]
   private implicit val quotaIdWrites: Writes[QuotaId] = Json.valueWrites[QuotaId]
 
   private implicit val quotaValueWrites: Writes[Value] = Json.writes[Value]
-  private implicit val quotaWrites: Writes[Quota] = Json.valueWrites[Quota]
 
-  private implicit def quotaMapWrites(implicit valueWriter: Writes[Value]): Writes[Map[Quotas.Type, Value]] =
-    (m: Map[Quotas.Type, Value]) => {
+
+  private implicit def quotaMapWrites(implicit valueWriter: Writes[Value]): Writes[immutable.Map[Quotas.Type, Value]] =
+    (m: immutable.Map[Quotas.Type, Value]) => {
       m.foldLeft(JsObject.empty)((jsObject, kv) => {
         val (quotaType: Quotas.Type, value: Value) = kv
         jsObject.+(quotaType.toString, valueWriter.writes(value))
       })
     }
 
-  private implicit val quotasWrites: Writes[Quotas] = Json.valueWrites[Quotas]
+  private implicit def quotaWrites(implicit quotaWriter: Writes[immutable.Map[Quotas.Type, Value]]): Writes[Quota] = {
+    implicit val write: Writes[immutable.Map[Quotas.Type, Value]] = quotaWriter
+    Json.valueWrites[Quota]
+  }
 
-  private implicit def quotasMapWrites(implicit quotaWriter: Writes[Quota]): Writes[Map[QuotaId, Quota]] =
-    (m: Map[QuotaId, Quota]) => {
+  private implicit def quotasMapWrites(implicit quotaWriter: Writes[Quota]): Writes[immutable.Map[QuotaId, Quota]] =
+    (m: immutable.Map[QuotaId, Quota]) => {
       m.foldLeft(JsObject.empty)((jsObject, kv) => {
         val (quotaId: QuotaId, quota: Quota) = kv
         jsObject.+(quotaId.getName, quotaWriter.writes(quota))

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/Mailbox.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/Mailbox.scala
@@ -156,7 +156,8 @@ object Mailbox {
       CapabilityIdentifier.JAMES_SHARES -> Set("namespace", "rights")
     )
 
-    val propertiesToHide = propertiesForCapabilities.filterNot(entry => allowedCapabilities.contains(entry._1))
+    val propertiesToHide = propertiesForCapabilities
+      .filterNot(entry => allowedCapabilities.contains(entry._1))
       .flatMap(_._2)
       .toSet
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/Quotas.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/Quotas.scala
@@ -23,6 +23,7 @@ import org.apache.james.core.Domain
 import org.apache.james.jmap.model.UnsignedInt.UnsignedInt
 import org.apache.james.mailbox.model.{QuotaRoot => ModelQuotaRoot}
 
+import scala.collection.immutable
 import scala.compat.java8.OptionConverters._
 
 object QuotaRoot{
@@ -52,11 +53,11 @@ case class QuotaId(quotaRoot: QuotaRoot) extends AnyVal {
 }
 
 object Quota {
-  def from(quota: Map[Quotas.Type, Value]) = new Quota(quota)
+  def from(quota: immutable.Map[Quotas.Type, Value]) = new Quota(quota)
 }
 
-case class Quota(quota: Map[Quotas.Type, Value]) extends AnyVal
+case class Quota(quota: immutable.Map[Quotas.Type, Value]) extends AnyVal
 
 case class Value(used: UnsignedInt, max: Option[UnsignedInt])
 
-case class Quotas(quotas: Map[QuotaId, Quota]) extends AnyVal
+case class Quotas(quotas: immutable.Map[QuotaId, Quota]) extends AnyVal

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/Capabilities.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/Capabilities.scala
@@ -19,6 +19,7 @@
 package org.apache.james.jmap.model
 
 import eu.timepit.refined.auto._
+import org.apache.james.jmap.mail.Quotas
 
 object DefaultCapabilities {
   val CORE_CAPABILITY = CoreCapability(
@@ -43,9 +44,11 @@ object DefaultCapabilities {
     )
   )
 
-  val SUPPORTED = Capabilities(CORE_CAPABILITY, MAIL_CAPABILITY)
+  val MAIL_QUOTA_CAPABILITY = MailQuotaCapability(properties = MailQuotaProperties(Quotas(Map.empty)))
+  val MAIL_SHARE_CAPABILITY = MailSharesCapability(properties = MailSharesProperties(Map.empty))
+  val SUPPORTED = Capabilities(CORE_CAPABILITY, MAIL_CAPABILITY, MAIL_QUOTA_CAPABILITY, MAIL_SHARE_CAPABILITY)
 }
 
-case class Capabilities(coreCapability: CoreCapability, mailCapability: MailCapability) {
-  def toSet : Set[Capability] = Set(coreCapability, mailCapability)
+case class Capabilities(coreCapability: CoreCapability, mailCapability: MailCapability, mailQuotaCapability: MailQuotaCapability, mailSharesCapability: MailSharesCapability) {
+  def toSet : Set[Capability] = Set(coreCapability, mailCapability, mailQuotaCapability, mailSharesCapability)
 }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/Capability.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/Capability.scala
@@ -23,10 +23,13 @@ import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
 import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.string.Uri
-import org.apache.james.jmap.model.CapabilityIdentifier.{CapabilityIdentifier, JMAP_CORE, JMAP_MAIL}
+import org.apache.james.jmap.mail.{Quotas, Rights}
+import org.apache.james.jmap.model.CapabilityIdentifier.{CapabilityIdentifier, JAMES_QUOTA, JAMES_SHARES, JMAP_CORE, JMAP_MAIL}
 import org.apache.james.jmap.model.CoreCapabilityProperties.CollationAlgorithm
 import org.apache.james.jmap.model.MailCapability.EmailQuerySortOption
 import org.apache.james.jmap.model.UnsignedInt.UnsignedInt
+
+import scala.collection.immutable
 
 object CapabilityIdentifier {
   type CapabilityIdentifier = String Refined Uri
@@ -87,5 +90,21 @@ final case class MailCapabilityProperties(maxMailboxesPerEmail: MaxMailboxesPerE
                                           maxSizeAttachmentsPerEmail: MaxSizeAttachmentsPerEmail,
                                           emailQuerySortOptions: List[EmailQuerySortOption],
                                           mayCreateTopLevelMailbox: MayCreateTopLevelMailbox) extends CapabilityProperties {
+}
+
+final case class MailQuotaProperties(value: Quotas) extends CapabilityProperties {
+}
+
+final case class MailQuotaCapability(properties: MailQuotaProperties,
+                                identifier: CapabilityIdentifier = JAMES_QUOTA) extends Capability {
+
+}
+
+final case class MailSharesProperties(value: immutable.Map[String, String]) extends CapabilityProperties {
+}
+
+final case class MailSharesCapability(properties: MailSharesProperties,
+                                identifier: CapabilityIdentifier = JAMES_SHARES) extends Capability {
+
 }
 

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/json/Fixture.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/json/Fixture.scala
@@ -67,7 +67,9 @@ object Fixture {
                          |      "maxSizeAttachmentsPerEmail" : 20000000,
                          |      "emailQuerySortOptions" : [ "receivedAt", "cc", "from", "to", "subject", "size", "sentAt", "hasKeyword", "uid", "Id" ],
                          |      "mayCreateTopLevelMailbox" : true
-                         |    }
+                         |    },
+                         |    "urn:apache:james:params:jmap:mail:quota": {},
+                         |    "urn:apache:james:params:jmap:mail:shares": {}
                          |  },
                          |  "accounts" : {
                          |    "0fe275bf13ff761407c17f64b1dfae2f4b3186feea223d7267b79f873a105401" : {
@@ -98,7 +100,9 @@ object Fixture {
                          |  },
                          |  "primaryAccounts" : {
                          |    "urn:ietf:params:jmap:core" : "0fe275bf13ff761407c17f64b1dfae2f4b3186feea223d7267b79f873a105401",
-                         |    "urn:ietf:params:jmap:mail" : "0fe275bf13ff761407c17f64b1dfae2f4b3186feea223d7267b79f873a105401"
+                         |    "urn:ietf:params:jmap:mail" : "0fe275bf13ff761407c17f64b1dfae2f4b3186feea223d7267b79f873a105401",
+                         |    "urn:apache:james:params:jmap:mail:quota": "0fe275bf13ff761407c17f64b1dfae2f4b3186feea223d7267b79f873a105401",
+                         |    "urn:apache:james:params:jmap:mail:shares": "0fe275bf13ff761407c17f64b1dfae2f4b3186feea223d7267b79f873a105401"
                          |  },
                          |  "username" : "bob@james.org",
                          |  "apiUrl" : "http://this-url-is-hardcoded.org/jmap",

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/json/Fixture.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/json/Fixture.scala
@@ -94,7 +94,9 @@ object Fixture {
                          |          "maxSizeAttachmentsPerEmail" : 20000000,
                          |          "emailQuerySortOptions" : [ "receivedAt", "cc", "from", "to", "subject", "size", "sentAt", "hasKeyword", "uid", "Id" ],
                          |          "mayCreateTopLevelMailbox" : true
-                         |        }
+                         |        },
+                         |        "urn:apache:james:params:jmap:mail:quota": {},
+                         |        "urn:apache:james:params:jmap:mail:shares": {}
                          |      }
                          |    }
                          |  },

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/json/MailboxSerializationTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/json/MailboxSerializationTest.scala
@@ -130,7 +130,8 @@ class MailboxSerializationTest extends AnyWordSpec with Matchers {
           |}""".stripMargin
 
       val serializer = new Serializer(new TestId.Factory)
-      assertThatJson(Json.stringify(serializer.serialize(MAILBOX)(serializer.mailboxWrites(Mailbox.allProperties)))).isEqualTo(expectedJson)
+      val actual: String = Json.stringify(serializer.serialize(MAILBOX)(serializer.mailboxWrites(Mailbox.allProperties)))
+      assertThatJson(actual).isEqualTo(expectedJson)
     }
   }
 }

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/json/SessionSerializationTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/json/SessionSerializationTest.scala
@@ -24,13 +24,13 @@ import java.net.URL
 import eu.timepit.refined.auto._
 import org.apache.james.core.Username
 import org.apache.james.jmap.json.SessionSerializationTest.SESSION
+import org.apache.james.jmap.mail.Quotas
 import org.apache.james.jmap.model.CapabilityIdentifier.CapabilityIdentifier
 import org.apache.james.jmap.model.CoreCapabilityProperties.CollationAlgorithm
 import org.apache.james.jmap.model.MailCapability.EmailQuerySortOption
 import org.apache.james.jmap.model.State.State
 import org.apache.james.jmap.model._
 import org.apache.james.mailbox.model.TestId
-import org.apache.mailet.Mail
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json.Json
@@ -80,8 +80,8 @@ object SessionSerializationTest {
     emailQuerySortOptions = EMAIL_QUERY_SORT_OPTIONS,
     mayCreateTopLevelMailbox = MAY_CREATE_TOP_LEVEL_MAILBOX))
 
-  private val MAIL_QUOTA_CAPABILITY: MailQuotaCapability = MailQuotaCapability(properties = MailQuotaProperties())
-  private val MAIL_SHARE_CAPABILITY: MailSharesCapability = MailSharesCapability(properties = MailSharesProperties())
+  private val MAIL_QUOTA_CAPABILITY: MailQuotaCapability = MailQuotaCapability(properties = MailQuotaProperties(Quotas(Map.empty)))
+  private val MAIL_SHARE_CAPABILITY: MailSharesCapability = MailSharesCapability(properties = MailSharesProperties(Map.empty))
   private val CAPABILITIES = Capabilities(CORE_CAPABILITY, MAIL_CAPABILITY, MAIL_QUOTA_CAPABILITY, MAIL_SHARE_CAPABILITY)
 
   private val IS_PERSONAL : IsPersonal = IsPersonal(true)
@@ -151,7 +151,9 @@ class SessionSerializationTest extends AnyWordSpec with Matchers {
           |      "maxSizeAttachmentsPerEmail": 890099,
           |      "emailQuerySortOptions": ["size"],
           |      "mayCreateTopLevelMailbox": true
-          |    }
+          |    },
+          |    "urn:apache:james:params:jmap:mail:quota":{},
+          |    "urn:apache:james:params:jmap:mail:shares":{}
           |  },
           |  "accounts": {
           |    "807a5306ccb4527af7790a0f9b48a776514bdbfba064e355461a76bcffbf2c90": {

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/json/SessionSerializationTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/json/SessionSerializationTest.scala
@@ -30,6 +30,7 @@ import org.apache.james.jmap.model.MailCapability.EmailQuerySortOption
 import org.apache.james.jmap.model.State.State
 import org.apache.james.jmap.model._
 import org.apache.james.mailbox.model.TestId
+import org.apache.mailet.Mail
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json.Json
@@ -79,7 +80,9 @@ object SessionSerializationTest {
     emailQuerySortOptions = EMAIL_QUERY_SORT_OPTIONS,
     mayCreateTopLevelMailbox = MAY_CREATE_TOP_LEVEL_MAILBOX))
 
-  private val CAPABILITIES = Capabilities(CORE_CAPABILITY, MAIL_CAPABILITY)
+  private val MAIL_QUOTA_CAPABILITY: MailQuotaCapability = MailQuotaCapability(properties = MailQuotaProperties())
+  private val MAIL_SHARE_CAPABILITY: MailSharesCapability = MailSharesCapability(properties = MailSharesProperties())
+  private val CAPABILITIES = Capabilities(CORE_CAPABILITY, MAIL_CAPABILITY, MAIL_QUOTA_CAPABILITY, MAIL_SHARE_CAPABILITY)
 
   private val IS_PERSONAL : IsPersonal = IsPersonal(true)
   private val IS_NOT_PERSONAL : IsPersonal = IsPersonal(false)

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPServer.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/JMAPServer.java
@@ -78,6 +78,7 @@ public class JMAPServer implements Startable {
         try {
             return jmapRoutesHandlers.stream()
                 .flatMap(jmapRoutesHandler -> jmapRoutesHandler.routes(versionParser.parseRequestVersionHeader(request)))
+
                 .filter(jmapRoute -> jmapRoute.matches(request))
                 .map(JMAPRoute::getAction)
                 .findFirst()


### PR DESCRIPTION
When a user get a session object, urn:apache:james:params:jmap:mail:quota and urn:apache:james:params:jmap:mail:shares shoud appear next to urn:ietf:params:jmap:core and urn:ietf:params:jmap:mail