### PR TITLE
JAMES-3409 Denormalize UidValidity as part of MailboxPath projection

### DIFF
--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionManager.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionManager.java
@@ -36,7 +36,7 @@ import reactor.core.publisher.Mono;
 
 public class CassandraSchemaVersionManager {
     public static final SchemaVersion MIN_VERSION = new SchemaVersion(5);
-    public static final SchemaVersion MAX_VERSION = new SchemaVersion(7);
+    public static final SchemaVersion MAX_VERSION = new SchemaVersion(8);
     public static final SchemaVersion DEFAULT_VERSION = MIN_VERSION;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CassandraSchemaVersionManager.class);

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
@@ -41,6 +41,7 @@ import org.apache.james.mailbox.cassandra.mail.CassandraMailboxDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxMapper;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathDAOImpl;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathV2DAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathV3DAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxRecentsDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
@@ -81,6 +82,7 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
     private final CassandraMailboxDAO mailboxDAO;
     private final CassandraMailboxPathDAOImpl mailboxPathDAO;
     private final CassandraMailboxPathV2DAO mailboxPathV2DAO;
+    private final CassandraMailboxPathV3DAO mailboxPathV3DAO;
     private final CassandraFirstUnseenDAO firstUnseenDAO;
     private final CassandraApplicableFlagDAO applicableFlagDAO;
     private final CassandraAttachmentDAOV2 attachmentDAOV2;
@@ -99,7 +101,7 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
                                                 CassandraMessageDAO messageDAO,
                                                 CassandraMessageIdDAO messageIdDAO, CassandraMessageIdToImapUidDAO imapUidDAO,
                                                 CassandraMailboxCounterDAO mailboxCounterDAO, CassandraMailboxRecentsDAO mailboxRecentsDAO, CassandraMailboxDAO mailboxDAO,
-                                                CassandraMailboxPathDAOImpl mailboxPathDAO, CassandraMailboxPathV2DAO mailboxPathV2DAO, CassandraFirstUnseenDAO firstUnseenDAO, CassandraApplicableFlagDAO applicableFlagDAO,
+                                                CassandraMailboxPathDAOImpl mailboxPathDAO, CassandraMailboxPathV2DAO mailboxPathV2DAO, CassandraMailboxPathV3DAO mailboxPathV3DAO, CassandraFirstUnseenDAO firstUnseenDAO, CassandraApplicableFlagDAO applicableFlagDAO,
                                                 CassandraAttachmentDAOV2 attachmentDAOV2, CassandraDeletedMessageDAO deletedMessageDAO,
                                                 BlobStore blobStore, CassandraAttachmentMessageIdDAO attachmentMessageIdDAO,
                                                 CassandraAttachmentOwnerDAO ownerDAO, CassandraACLMapper aclMapper,
@@ -117,6 +119,7 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
         this.mailboxDAO = mailboxDAO;
         this.mailboxPathDAO = mailboxPathDAO;
         this.mailboxPathV2DAO = mailboxPathV2DAO;
+        this.mailboxPathV3DAO = mailboxPathV3DAO;
         this.firstUnseenDAO = firstUnseenDAO;
         this.attachmentDAOV2 = attachmentDAOV2;
         this.deletedMessageDAO = deletedMessageDAO;
@@ -165,7 +168,7 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
 
     @Override
     public MailboxMapper createMailboxMapper(MailboxSession mailboxSession) {
-        return new CassandraMailboxMapper(mailboxDAO, mailboxPathDAO, mailboxPathV2DAO, userMailboxRightsDAO, aclMapper, versionManager);
+        return new CassandraMailboxMapper(mailboxDAO, mailboxPathDAO, mailboxPathV2DAO, mailboxPathV3DAO, userMailboxRightsDAO, aclMapper, versionManager);
     }
 
     @Override

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapper.java
@@ -57,11 +57,12 @@ public class CassandraMailboxMapper implements MailboxMapper {
     private static final int MAX_RETRY = 5;
     private static final Duration MIN_RETRY_BACKOFF = Duration.ofMillis(10);
     private static final Duration MAX_RETRY_BACKOFF = Duration.ofMillis(1000);
-    private static final SchemaVersion MAILBOX_PATH_V_2_MIGRATION_PERFORMED_VERSION = new SchemaVersion(6);
+    private static final SchemaVersion MAILBOX_PATH_V_3_MIGRATION_PERFORMED_VERSION = new SchemaVersion(8);
 
     private final CassandraMailboxDAO mailboxDAO;
     private final CassandraMailboxPathDAOImpl mailboxPathDAO;
     private final CassandraMailboxPathV2DAO mailboxPathV2DAO;
+    private final CassandraMailboxPathV3DAO mailboxPathV3DAO;
     private final CassandraACLMapper cassandraACLMapper;
     private final CassandraUserMailboxRightsDAO userMailboxRightsDAO;
     private final CassandraSchemaVersionManager versionManager;
@@ -70,19 +71,21 @@ public class CassandraMailboxMapper implements MailboxMapper {
     public CassandraMailboxMapper(CassandraMailboxDAO mailboxDAO,
                                   CassandraMailboxPathDAOImpl mailboxPathDAO,
                                   CassandraMailboxPathV2DAO mailboxPathV2DAO,
+                                  CassandraMailboxPathV3DAO mailboxPathV3DAO,
                                   CassandraUserMailboxRightsDAO userMailboxRightsDAO,
                                   CassandraACLMapper aclMapper,
                                   CassandraSchemaVersionManager versionManager) {
         this.mailboxDAO = mailboxDAO;
         this.mailboxPathDAO = mailboxPathDAO;
         this.mailboxPathV2DAO = mailboxPathV2DAO;
+        this.mailboxPathV3DAO = mailboxPathV3DAO;
         this.userMailboxRightsDAO = userMailboxRightsDAO;
         this.cassandraACLMapper = aclMapper;
         this.versionManager = versionManager;
     }
 
-    private Mono<Boolean> needMailboxPathV1Support() {
-        return versionManager.isBefore(MAILBOX_PATH_V_2_MIGRATION_PERFORMED_VERSION);
+    private Mono<Boolean> needMailboxPathPreviousVersionsSupport() {
+        return versionManager.isBefore(MAILBOX_PATH_V_3_MIGRATION_PERFORMED_VERSION);
     }
 
     @Override
@@ -94,51 +97,62 @@ public class CassandraMailboxMapper implements MailboxMapper {
     }
 
     private Flux<Void> deletePath(Mailbox mailbox) {
-        return needMailboxPathV1Support()
+        return needMailboxPathPreviousVersionsSupport()
             .flatMapMany(needSupport -> {
                 if (needSupport) {
                     return Flux.merge(
                         mailboxPathDAO.delete(mailbox.generateAssociatedPath()),
-                        mailboxPathV2DAO.delete(mailbox.generateAssociatedPath()));
+                        mailboxPathV2DAO.delete(mailbox.generateAssociatedPath()),
+                        mailboxPathV3DAO.delete(mailbox.generateAssociatedPath()));
                 }
-                return Flux.from(mailboxPathV2DAO.delete(mailbox.generateAssociatedPath()));
+                return Flux.from(mailboxPathV3DAO.delete(mailbox.generateAssociatedPath()));
             });
     }
 
     @Override
     public Mono<Mailbox> findMailboxByPath(MailboxPath path) {
-        return mailboxPathV2DAO.retrieveId(path)
-            .map(CassandraIdAndPath::getCassandraId)
-            .flatMap(this::retrieveMailbox)
-            .switchIfEmpty(fromPreviousTable(path));
+        return mailboxPathV3DAO.retrieve(path)
+            .switchIfEmpty(fromPreviousTable(path))
+            .flatMap(this::addAcl);
+    }
+
+    private Mono<Mailbox> addAcl(Mailbox mailbox) {
+        CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
+        return cassandraACLMapper.getACL(mailboxId)
+            .map(acl -> {
+                mailbox.setACL(acl);
+                return mailbox;
+            })
+            .switchIfEmpty(Mono.just(mailbox));
     }
 
     @Override
     public Mono<Boolean> pathExists(MailboxPath mailboxName) {
-        return mailboxPathV2DAO.retrieveId(mailboxName)
-            .switchIfEmpty(mailboxPathDAO.retrieveId(mailboxName))
+        return mailboxPathV3DAO.retrieve(mailboxName)
+            .switchIfEmpty(fromPreviousTable(mailboxName))
             .hasElement();
     }
 
     private Mono<Mailbox> fromPreviousTable(MailboxPath path) {
-        return mailboxPathDAO.retrieveId(path)
+        return mailboxPathV2DAO.retrieveId(path)
+            .switchIfEmpty(mailboxPathDAO.retrieveId(path))
             .map(CassandraIdAndPath::getCassandraId)
             .flatMap(this::retrieveMailbox)
             .flatMap(this::migrate);
     }
 
     private Mono<Mailbox> migrate(Mailbox mailbox) {
-        CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
-        return mailboxPathV2DAO.save(mailbox.generateAssociatedPath(), mailboxId)
+        return mailboxPathV3DAO.save(mailbox)
             .flatMap(success -> deleteIfSuccess(mailbox, success))
             .thenReturn(mailbox);
     }
 
     private Mono<Void> deleteIfSuccess(Mailbox mailbox, boolean success) {
         if (success) {
-            return mailboxPathDAO.delete(mailbox.generateAssociatedPath());
+            return mailboxPathDAO.delete(mailbox.generateAssociatedPath())
+                .then(mailboxPathV2DAO.delete(mailbox.generateAssociatedPath()));
         }
-        LOGGER.info("Concurrent execution lead to data race while migrating {} to 'mailboxPathV2DAO'.",
+        LOGGER.info("Concurrent execution lead to data race while migrating {} to 'mailboxPathV3DAO'.",
             mailbox.generateAssociatedPath());
         return Mono.empty();
     }
@@ -172,20 +186,24 @@ public class CassandraMailboxMapper implements MailboxMapper {
         String fixedNamespace = query.getFixedNamespace();
         Username fixedUser = query.getFixedUser();
 
-        return listPaths(fixedNamespace, fixedUser)
-            .filter(idAndPath -> query.isPathMatch(idAndPath.getMailboxPath()))
-            .distinct(CassandraIdAndPath::getMailboxPath)
-            .concatMap(this::retrieveMailbox);
+        return listMailboxes(fixedNamespace, fixedUser)
+            .filter(mailbox -> query.isPathMatch(mailbox.generateAssociatedPath()))
+            .distinct(Mailbox::generateAssociatedPath)
+            .flatMap(this::addAcl);
     }
 
-    private Flux<CassandraIdAndPath> listPaths(String fixedNamespace, Username fixedUser) {
-        return needMailboxPathV1Support()
+    private Flux<Mailbox> listMailboxes(String fixedNamespace, Username fixedUser) {
+        return needMailboxPathPreviousVersionsSupport()
             .flatMapMany(needSupport -> {
                 if (needSupport) {
-                    return Flux.concat(mailboxPathV2DAO.listUserMailboxes(fixedNamespace, fixedUser),
-                        mailboxPathDAO.listUserMailboxes(fixedNamespace, fixedUser));
+                    return Flux.concat(
+                        mailboxPathV3DAO.listUserMailboxes(fixedNamespace, fixedUser),
+                        Flux.concat(
+                                mailboxPathV2DAO.listUserMailboxes(fixedNamespace, fixedUser),
+                                mailboxPathDAO.listUserMailboxes(fixedNamespace, fixedUser))
+                            .flatMap(this::retrieveMailbox));
                 }
-                return mailboxPathV2DAO.listUserMailboxes(fixedNamespace, fixedUser);
+                return mailboxPathV3DAO.listUserMailboxes(fixedNamespace, fixedUser);
             });
     }
 
@@ -200,7 +218,7 @@ public class CassandraMailboxMapper implements MailboxMapper {
         CassandraId cassandraId = CassandraId.timeBased();
         Mailbox mailbox = new Mailbox(mailboxPath, uidValidity, cassandraId);
 
-        return mailboxPathV2DAO.save(mailbox.generateAssociatedPath(), cassandraId)
+        return mailboxPathV3DAO.save(mailbox)
             .filter(isCreated -> isCreated)
             .flatMap(mailboxHasCreated -> persistMailboxEntity(mailbox)
                 .thenReturn(mailbox))
@@ -220,7 +238,7 @@ public class CassandraMailboxMapper implements MailboxMapper {
 
     private Mono<Boolean> tryRename(Mailbox cassandraMailbox, CassandraId cassandraId) {
         return mailboxDAO.retrieveMailbox(cassandraId)
-            .flatMap(mailbox -> mailboxPathV2DAO.save(cassandraMailbox.generateAssociatedPath(), cassandraId)
+            .flatMap(mailbox -> mailboxPathV3DAO.save(cassandraMailbox)
                 .filter(isCreated -> isCreated)
                 .flatMap(mailboxHasCreated -> deletePreviousMailboxPathReference(mailbox.generateAssociatedPath())
                     .then(persistMailboxEntity(cassandraMailbox))
@@ -235,21 +253,19 @@ public class CassandraMailboxMapper implements MailboxMapper {
     }
 
     private Mono<Void> deletePreviousMailboxPathReference(MailboxPath mailboxPath) {
-        return mailboxPathV2DAO.delete(mailboxPath)
+        return mailboxPathV3DAO.delete(mailboxPath)
             .retryWhen(Retry.backoff(MAX_RETRY, MIN_RETRY_BACKOFF).maxBackoff(MAX_RETRY_BACKOFF));
     }
 
     @Override
     public Mono<Boolean> hasChildren(Mailbox mailbox, char delimiter) {
-        return Flux.merge(
-                mailboxPathDAO.listUserMailboxes(mailbox.getNamespace(), mailbox.getUser()),
-                mailboxPathV2DAO.listUserMailboxes(mailbox.getNamespace(), mailbox.getUser()))
+        return listMailboxes(mailbox.getNamespace(), mailbox.getUser())
             .filter(idAndPath -> isPathChildOfMailbox(idAndPath, mailbox, delimiter))
             .hasElements();
     }
 
-    private boolean isPathChildOfMailbox(CassandraIdAndPath idAndPath, Mailbox mailbox, char delimiter) {
-        return idAndPath.getMailboxPath().getName().startsWith(mailbox.getName() + String.valueOf(delimiter));
+    private boolean isPathChildOfMailbox(Mailbox candidate, Mailbox mailbox, char delimiter) {
+        return candidate.generateAssociatedPath().getName().startsWith(mailbox.getName() + delimiter);
     }
 
     @Override

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxPathV3DAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxPathV3DAO.java
@@ -1,0 +1,215 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static org.apache.james.mailbox.cassandra.GhostMailbox.TYPE;
+import static org.apache.james.mailbox.cassandra.table.CassandraMailboxPathV3Table.FIELDS;
+import static org.apache.james.mailbox.cassandra.table.CassandraMailboxPathV3Table.MAILBOX_ID;
+import static org.apache.james.mailbox.cassandra.table.CassandraMailboxPathV3Table.MAILBOX_NAME;
+import static org.apache.james.mailbox.cassandra.table.CassandraMailboxPathV3Table.NAMESPACE;
+import static org.apache.james.mailbox.cassandra.table.CassandraMailboxPathV3Table.TABLE_NAME;
+import static org.apache.james.mailbox.cassandra.table.CassandraMailboxPathV3Table.UIDVALIDITY;
+import static org.apache.james.mailbox.cassandra.table.CassandraMailboxPathV3Table.USER;
+
+import javax.inject.Inject;
+
+import org.apache.james.backends.cassandra.init.configuration.CassandraConsistenciesConfiguration;
+import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
+import org.apache.james.backends.cassandra.utils.CassandraUtils;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.cassandra.GhostMailbox;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.UidValidity;
+import org.apache.james.util.FunctionalUtils;
+import org.apache.james.util.ReactorUtils;
+
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class CassandraMailboxPathV3DAO {
+    private final CassandraAsyncExecutor cassandraAsyncExecutor;
+    private final CassandraUtils cassandraUtils;
+    private final PreparedStatement delete;
+    private final PreparedStatement insert;
+    private final PreparedStatement select;
+    private final PreparedStatement selectUser;
+    private final PreparedStatement selectAll;
+    private final ConsistencyLevel consistencyLevel;
+
+    @Inject
+    public CassandraMailboxPathV3DAO(Session session, CassandraUtils cassandraUtils,
+                                     CassandraConsistenciesConfiguration consistenciesConfiguration) {
+        this.cassandraAsyncExecutor = new CassandraAsyncExecutor(session);
+        this.consistencyLevel = consistenciesConfiguration.getLightweightTransaction();
+        this.cassandraUtils = cassandraUtils;
+        this.insert = prepareInsert(session);
+        this.delete = prepareDelete(session);
+        this.select = prepareSelect(session);
+        this.selectUser = prepareSelectUser(session);
+        this.selectAll = prepareSelectAll(session);
+    }
+
+    private PreparedStatement prepareDelete(Session session) {
+        return session.prepare(QueryBuilder.delete()
+            .from(TABLE_NAME)
+            .where(eq(NAMESPACE, bindMarker(NAMESPACE)))
+            .and(eq(USER, bindMarker(USER)))
+            .and(eq(MAILBOX_NAME, bindMarker(MAILBOX_NAME)))
+            .ifExists());
+    }
+
+    private PreparedStatement prepareInsert(Session session) {
+        return session.prepare(insertInto(TABLE_NAME)
+            .value(NAMESPACE, bindMarker(NAMESPACE))
+            .value(USER, bindMarker(USER))
+            .value(MAILBOX_NAME, bindMarker(MAILBOX_NAME))
+            .value(MAILBOX_ID, bindMarker(MAILBOX_ID))
+            .value(UIDVALIDITY, bindMarker(UIDVALIDITY))
+            .ifNotExists());
+    }
+
+    private PreparedStatement prepareSelect(Session session) {
+        return session.prepare(select(FIELDS)
+            .from(TABLE_NAME)
+            .where(eq(NAMESPACE, bindMarker(NAMESPACE)))
+            .and(eq(USER, bindMarker(USER)))
+            .and(eq(MAILBOX_NAME, bindMarker(MAILBOX_NAME))));
+    }
+
+    private PreparedStatement prepareSelectUser(Session session) {
+        return session.prepare(select(FIELDS)
+            .from(TABLE_NAME)
+            .where(eq(NAMESPACE, bindMarker(NAMESPACE)))
+            .and(eq(USER, bindMarker(USER))));
+    }
+
+    private PreparedStatement prepareSelectAll(Session session) {
+        return session.prepare(select(FIELDS)
+            .from(TABLE_NAME));
+    }
+
+    public Mono<Mailbox> retrieve(MailboxPath mailboxPath) {
+        return cassandraAsyncExecutor.executeSingleRow(
+            select.bind()
+                .setString(NAMESPACE, mailboxPath.getNamespace())
+                .setString(USER, sanitizeUser(mailboxPath.getUser()))
+                .setString(MAILBOX_NAME, mailboxPath.getName())
+                .setConsistencyLevel(consistencyLevel))
+            .map(this::fromRowToCassandraIdAndPath)
+            .map(FunctionalUtils.toFunction(this::logGhostMailboxSuccess))
+            .switchIfEmpty(ReactorUtils.executeAndEmpty(() -> logGhostMailboxFailure(mailboxPath)));
+    }
+
+    public Flux<Mailbox> listUserMailboxes(String namespace, Username user) {
+        return cassandraAsyncExecutor.execute(
+            selectUser.bind()
+                .setString(NAMESPACE, namespace)
+                .setString(USER, sanitizeUser(user))
+                .setConsistencyLevel(consistencyLevel))
+            .flatMapMany(cassandraUtils::convertToFlux)
+            .map(this::fromRowToCassandraIdAndPath)
+            .map(FunctionalUtils.toFunction(this::logReadSuccess));
+    }
+
+    public Flux<Mailbox> listAll() {
+        return cassandraAsyncExecutor.execute(
+            selectAll.bind())
+            .flatMapMany(cassandraUtils::convertToFlux)
+            .map(this::fromRowToCassandraIdAndPath)
+            .map(FunctionalUtils.toFunction(this::logReadSuccess));
+    }
+
+    /**
+     * See https://issues.apache.org/jira/browse/MAILBOX-322 to read about the Ghost mailbox bug.
+     *
+     * A missed read on an existing mailbox is the cause of the ghost mailbox bug. Here we log missing reads. Successful
+     * reads and write operations are also added in order to allow audit in order to know if the mailbox existed.
+     */
+    public void logGhostMailboxSuccess(Mailbox value) {
+        logReadSuccess(value);
+    }
+
+    public void logGhostMailboxFailure(MailboxPath mailboxPath) {
+        GhostMailbox.logger()
+                .addField(GhostMailbox.MAILBOX_NAME, mailboxPath)
+                .addField(TYPE, "readMiss")
+                .log(logger -> logger.debug("Read mailbox missed"));
+    }
+
+    /**
+     * See https://issues.apache.org/jira/browse/MAILBOX-322 to read about the Ghost mailbox bug.
+     *
+     * Read success allows to know if a mailbox existed before (mailbox write history might be older than this log introduction
+     * or log history might have been dropped)
+     */
+    private void logReadSuccess(Mailbox mailbox) {
+        GhostMailbox.logger()
+            .addField(GhostMailbox.MAILBOX_NAME, mailbox.generateAssociatedPath())
+            .addField(TYPE, "readSuccess")
+            .addField(GhostMailbox.MAILBOX_ID, mailbox.getMailboxId())
+            .log(logger -> logger.debug("Read mailbox succeeded"));
+    }
+
+    private Mailbox fromRowToCassandraIdAndPath(Row row) {
+        return new Mailbox(
+            new MailboxPath(row.getString(NAMESPACE),
+                Username.of(row.getString(USER)),
+                row.getString(MAILBOX_NAME)),
+            UidValidity.of(row.getLong(UIDVALIDITY)),
+            CassandraId.of(row.getUUID(MAILBOX_ID)));
+    }
+
+    public Mono<Boolean> save(Mailbox mailbox) {
+        CassandraId id = (CassandraId) mailbox.getMailboxId();
+
+        return cassandraAsyncExecutor.executeReturnApplied(insert.bind()
+            .setString(NAMESPACE, mailbox.getNamespace())
+            .setString(USER, sanitizeUser(mailbox.getUser()))
+            .setLong(UIDVALIDITY, mailbox.getUidValidity().asLong())
+            .setString(MAILBOX_NAME, mailbox.getName())
+            .setUUID(MAILBOX_ID, id.asUuid()));
+    }
+
+    public Mono<Void> delete(MailboxPath mailboxPath) {
+        return cassandraAsyncExecutor.executeVoid(delete.bind()
+            .setString(NAMESPACE, mailboxPath.getNamespace())
+            .setString(USER, sanitizeUser(mailboxPath.getUser()))
+            .setString(MAILBOX_NAME, mailboxPath.getName()));
+    }
+
+    private String sanitizeUser(Username user) {
+        if (user == null) {
+            return "";
+        }
+        return user.asString();
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/MailboxPathV3Migration.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/MailboxPathV3Migration.java
@@ -1,0 +1,139 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.migration;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.apache.james.backends.cassandra.migration.Migration;
+import org.apache.james.mailbox.cassandra.mail.CassandraIdAndPath;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathV2DAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathV3DAO;
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.task.TaskType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import reactor.core.publisher.Mono;
+
+public class MailboxPathV3Migration implements Migration {
+
+    static class MailboxPathV3MigrationTask implements Task {
+        private final MailboxPathV3Migration migration;
+
+        MailboxPathV3MigrationTask(MailboxPathV3Migration migration) {
+            this.migration = migration;
+        }
+
+        @Override
+        public Result run() throws InterruptedException {
+            return migration.runTask();
+        }
+
+        @Override
+        public TaskType type() {
+            return TYPE;
+        }
+
+        @Override
+        public Optional<TaskExecutionDetails.AdditionalInformation> details() {
+            return Optional.of(migration.getAdditionalInformation());
+        }
+    }
+
+    public static class AdditionalInformation implements TaskExecutionDetails.AdditionalInformation {
+        private final long remainingCount;
+        private final long initialCount;
+        private final Instant timestamp;
+
+        public AdditionalInformation(long remainingCount, long initialCount, Instant timestamp) {
+            this.remainingCount = remainingCount;
+            this.initialCount = initialCount;
+            this.timestamp = timestamp;
+        }
+
+        public long getRemainingCount() {
+            return remainingCount;
+        }
+
+        public long getInitialCount() {
+            return initialCount;
+        }
+
+        @Override
+        public Instant timestamp() {
+            return timestamp;
+        }
+    }
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(MailboxPathV3Migration.class);
+    public static final TaskType TYPE = TaskType.of("cassandra-mailbox-path-v3-migration");
+    private final CassandraMailboxPathV2DAO daoV2;
+    private final CassandraMailboxPathV3DAO daoV3;
+    private final CassandraMailboxDAO mailboxDAO;
+    private final long initialCount;
+
+    @Inject
+    public MailboxPathV3Migration(CassandraMailboxPathV2DAO daoV2, CassandraMailboxPathV3DAO daoV3, CassandraMailboxDAO mailboxDAO) {
+        this.daoV2 = daoV2;
+        this.daoV3 = daoV3;
+        this.mailboxDAO = mailboxDAO;
+        this.initialCount = getCurrentCount();
+    }
+
+    @Override
+    public void apply() {
+        daoV2.listAll()
+            .flatMap(this::migrate)
+            .doOnError(t -> LOGGER.error("Error while performing migration", t))
+            .blockLast();
+    }
+
+    private Mono<Void> migrate(CassandraIdAndPath idAndPath) {
+        return mailboxDAO.retrieveMailbox(idAndPath.getCassandraId())
+            .flatMap(mailbox -> daoV3.save(mailbox)
+                .then(daoV2.delete(mailbox.generateAssociatedPath())))
+            .onErrorResume(error -> handleErrorMigrate(idAndPath, error))
+            .then();
+    }
+
+    private Mono<Void> handleErrorMigrate(CassandraIdAndPath idAndPath, Throwable throwable) {
+        LOGGER.error("Error while performing migration for path {}", idAndPath.getMailboxPath(), throwable);
+        return Mono.empty();
+    }
+
+    @Override
+    public Task asTask() {
+        return new MailboxPathV3MigrationTask(this);
+    }
+
+    AdditionalInformation getAdditionalInformation() {
+        return new AdditionalInformation(getCurrentCount(), initialCount, Clock.systemUTC().instant());
+    }
+
+    private Long getCurrentCount() {
+        return daoV2.listAll().count().block();
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/MailboxPathV3MigrationTaskAdditionalInformationDTO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/MailboxPathV3MigrationTaskAdditionalInformationDTO.java
@@ -1,0 +1,89 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.migration;
+
+import java.time.Instant;
+
+import org.apache.james.json.DTOModule;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MailboxPathV3MigrationTaskAdditionalInformationDTO implements AdditionalInformationDTO {
+
+    private static MailboxPathV3MigrationTaskAdditionalInformationDTO fromDomainObject(MailboxPathV3Migration.AdditionalInformation additionalInformation, String type) {
+        return new MailboxPathV3MigrationTaskAdditionalInformationDTO(
+            type,
+            additionalInformation.getRemainingCount(),
+            additionalInformation.getInitialCount(),
+            additionalInformation.timestamp()
+        );
+    }
+
+    public static final AdditionalInformationDTOModule<MailboxPathV3Migration.AdditionalInformation, MailboxPathV3MigrationTaskAdditionalInformationDTO> MODULE =
+        DTOModule
+            .forDomainObject(MailboxPathV3Migration.AdditionalInformation.class)
+            .convertToDTO(MailboxPathV3MigrationTaskAdditionalInformationDTO.class)
+            .toDomainObjectConverter(MailboxPathV3MigrationTaskAdditionalInformationDTO::toDomainObject)
+            .toDTOConverter(MailboxPathV3MigrationTaskAdditionalInformationDTO::fromDomainObject)
+            .typeName(MailboxPathV3Migration.TYPE.asString())
+            .withFactory(AdditionalInformationDTOModule::new);
+
+    private final String type;
+    private final long remainingCount;
+    private final long initialCount;
+    private final Instant timestamp;
+
+    public MailboxPathV3MigrationTaskAdditionalInformationDTO(@JsonProperty("type") String type,
+                                                              @JsonProperty("remainingCount") long remainingCount,
+                                                              @JsonProperty("initialCount") long initialCount,
+                                                              @JsonProperty("timestamp") Instant timestamp) {
+        this.type = type;
+        this.remainingCount = remainingCount;
+        this.initialCount = initialCount;
+        this.timestamp = timestamp;
+    }
+
+    public long getRemainingCount() {
+        return remainingCount;
+    }
+
+    public long getInitialCount() {
+        return initialCount;
+    }
+
+    @Override
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    private MailboxPathV3Migration.AdditionalInformation toDomainObject() {
+        return new MailboxPathV3Migration.AdditionalInformation(
+            remainingCount,
+            initialCount,
+            timestamp);
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/MailboxPathV3MigrationTaskDTO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/MailboxPathV3MigrationTaskDTO.java
@@ -1,0 +1,59 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.migration;
+
+import java.util.function.Function;
+
+import org.apache.james.json.DTOModule;
+import org.apache.james.server.task.json.dto.TaskDTO;
+import org.apache.james.server.task.json.dto.TaskDTOModule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MailboxPathV3MigrationTaskDTO implements TaskDTO {
+
+    private static MailboxPathV3MigrationTaskDTO fromDomainObject(MailboxPathV3Migration.MailboxPathV3MigrationTask task, String type) {
+        return new MailboxPathV3MigrationTaskDTO(type);
+    }
+
+    public static final Function<MailboxPathV3Migration, TaskDTOModule<MailboxPathV3Migration.MailboxPathV3MigrationTask, MailboxPathV3MigrationTaskDTO>> MODULE = (migration) ->
+        DTOModule
+            .forDomainObject(MailboxPathV3Migration.MailboxPathV3MigrationTask.class)
+            .convertToDTO(MailboxPathV3MigrationTaskDTO.class)
+            .toDomainObjectConverter(dto -> dto.toDomainObject(migration))
+            .toDTOConverter(MailboxPathV3MigrationTaskDTO::fromDomainObject)
+            .typeName(MailboxPathV3Migration.TYPE.asString())
+            .withFactory(TaskDTOModule::new);
+
+    private final String type;
+
+    public MailboxPathV3MigrationTaskDTO(@JsonProperty("type") String type) {
+        this.type = type;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    private MailboxPathV3Migration.MailboxPathV3MigrationTask toDomainObject(MailboxPathV3Migration migration) {
+        return new MailboxPathV3Migration.MailboxPathV3MigrationTask(migration);
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/ConflictingEntry.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/ConflictingEntry.java
@@ -21,7 +21,6 @@ package org.apache.james.mailbox.cassandra.mail.task;
 
 import java.util.Objects;
 
-import org.apache.james.mailbox.cassandra.mail.CassandraIdAndPath;
 import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
@@ -96,8 +95,8 @@ public class ConflictingEntry {
         interface RequireMailboxPathDaoEntry {
             ConflictingEntry mailboxPathDaoEntry(DaoEntry daoEntry);
 
-            default ConflictingEntry mailboxPathDaoEntry(CassandraIdAndPath mailbox) {
-                return mailboxPathDaoEntry(mailbox.getMailboxPath(), mailbox.getCassandraId());
+            default ConflictingEntry mailboxPathDaoEntry(Mailbox mailbox) {
+                return mailboxPathDaoEntry(mailbox.generateAssociatedPath(), mailbox.getMailboxId());
             }
 
             default ConflictingEntry mailboxPathDaoEntry(MailboxPath path, MailboxId id) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/MailboxMergingTaskRunner.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/MailboxMergingTaskRunner.java
@@ -28,7 +28,6 @@ import org.apache.james.mailbox.cassandra.ids.CassandraId;
 import org.apache.james.mailbox.cassandra.mail.CassandraACLMapper;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraUserMailboxRightsDAO;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.ComposedMessageId;
 import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
@@ -51,17 +50,15 @@ public class MailboxMergingTaskRunner {
     private final StoreMessageIdManager messageIdManager;
     private final CassandraMessageIdDAO cassandraMessageIdDAO;
     private final CassandraMailboxDAO mailboxDAO;
-    private final CassandraUserMailboxRightsDAO rightsDAO;
     private final CassandraACLMapper cassandraACLMapper;
     private final MailboxSession mailboxSession;
 
     @Inject
-    public MailboxMergingTaskRunner(MailboxManager mailboxManager, StoreMessageIdManager messageIdManager, CassandraMessageIdDAO cassandraMessageIdDAO, CassandraMailboxDAO mailboxDAO, CassandraUserMailboxRightsDAO rightsDAO, CassandraACLMapper cassandraACLMapper) throws MailboxException {
+    public MailboxMergingTaskRunner(MailboxManager mailboxManager, StoreMessageIdManager messageIdManager, CassandraMessageIdDAO cassandraMessageIdDAO, CassandraMailboxDAO mailboxDAO, CassandraACLMapper cassandraACLMapper) {
         this.mailboxSession = mailboxManager.createSystemSession(Username.of("task"));
         this.messageIdManager = messageIdManager;
         this.cassandraMessageIdDAO = cassandraMessageIdDAO;
         this.mailboxDAO = mailboxDAO;
-        this.rightsDAO = rightsDAO;
         this.cassandraACLMapper = cassandraACLMapper;
     }
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraMailboxModule.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/modules/CassandraMailboxModule.java
@@ -27,6 +27,7 @@ import org.apache.james.backends.cassandra.components.CassandraModule;
 import org.apache.james.backends.cassandra.utils.CassandraConstants;
 import org.apache.james.mailbox.cassandra.table.CassandraMailboxPathTable;
 import org.apache.james.mailbox.cassandra.table.CassandraMailboxPathV2Table;
+import org.apache.james.mailbox.cassandra.table.CassandraMailboxPathV3Table;
 import org.apache.james.mailbox.cassandra.table.CassandraMailboxTable;
 
 import com.datastax.driver.core.schemabuilder.SchemaBuilder;
@@ -68,5 +69,17 @@ public interface CassandraMailboxModule {
             .addPartitionKey(CassandraMailboxPathV2Table.USER, text())
             .addClusteringColumn(CassandraMailboxPathV2Table.MAILBOX_NAME, text())
             .addColumn(CassandraMailboxPathV2Table.MAILBOX_ID, timeuuid()))
+        .table(CassandraMailboxPathV3Table.TABLE_NAME)
+        .comment("Denormalisation table. Allow to retrieve mailboxes belonging to a certain user. This is a " +
+            "LIST optimisation.")
+        .options(options -> options
+            .caching(SchemaBuilder.KeyCaching.ALL,
+                SchemaBuilder.rows(CassandraConstants.DEFAULT_CACHED_ROW_PER_PARTITION)))
+        .statement(statement -> statement
+            .addPartitionKey(CassandraMailboxPathV3Table.NAMESPACE, text())
+            .addPartitionKey(CassandraMailboxPathV3Table.USER, text())
+            .addClusteringColumn(CassandraMailboxPathV3Table.MAILBOX_NAME, text())
+            .addColumn(CassandraMailboxPathV3Table.MAILBOX_ID, timeuuid())
+            .addColumn(CassandraMailboxPathV3Table.UIDVALIDITY, bigint()))
         .build();
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/table/CassandraMailboxPathV3Table.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/table/CassandraMailboxPathV3Table.java
@@ -1,0 +1,37 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.table;
+
+public interface CassandraMailboxPathV3Table {
+
+    String TABLE_NAME = "mailboxPathV3";
+
+    String NAMESPACE = "namespace";
+
+    String USER = "user";
+
+    String MAILBOX_NAME = "mailboxName";
+
+    String MAILBOX_ID = "mailboxId";
+    String UIDVALIDITY = "uidvalidity";
+
+    String[] FIELDS = { NAMESPACE, USER, MAILBOX_NAME, MAILBOX_ID, UIDVALIDITY};
+
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerConsistencyTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerConsistencyTest.java
@@ -424,7 +424,7 @@ class CassandraMailboxManagerConsistencyTest {
 
                 cassandra.getConf().registerScenario(fail()
                     .times(TRY_COUNT_BEFORE_FAILURE)
-                    .whenQueryStartsWith("DELETE FROM mailboxPathV2"));
+                    .whenQueryStartsWith("DELETE FROM mailboxPathV3"));
 
                 doQuietly(() -> testee.deleteMailbox(inboxPath, mailboxSession));
 
@@ -448,7 +448,7 @@ class CassandraMailboxManagerConsistencyTest {
 
                 cassandra.getConf().registerScenario(fail()
                     .times(TRY_COUNT_BEFORE_FAILURE)
-                    .whenQueryStartsWith("DELETE FROM mailboxPathV2"));
+                    .whenQueryStartsWith("DELETE FROM mailboxPathV3"));
 
                 doQuietly(() -> testee.deleteMailbox(inboxId, mailboxSession));
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerConsistencyTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerConsistencyTest.java
@@ -79,6 +79,7 @@ class CassandraMailboxManagerConsistencyTest {
     @Nested
     class FailuresDuringCreation {
 
+        @Disabled("oups")
         @Test
         void createMailboxShouldBeConsistentWhenMailboxDaoFails(CassandraCluster cassandra) {
             cassandra.getConf().registerScenario(fail()
@@ -101,7 +102,7 @@ class CassandraMailboxManagerConsistencyTest {
         void createMailboxShouldBeConsistentWhenMailboxPathDaoFails(CassandraCluster cassandra) {
             cassandra.getConf().registerScenario(fail()
                 .times(TRY_COUNT_BEFORE_FAILURE)
-                .whenQueryStartsWith("INSERT INTO mailboxPathV2"));
+                .whenQueryStartsWith("INSERT INTO mailboxPathV3"));
 
             doQuietly(() -> testee.createMailbox(inboxPath, mailboxSession));
 
@@ -132,7 +133,7 @@ class CassandraMailboxManagerConsistencyTest {
         void createMailboxAfterAFailedCreationShouldCreateTheMailboxWhenMailboxPathDaoFails(CassandraCluster cassandra) throws Exception {
             cassandra.getConf().registerScenario(fail()
                 .times(TRY_COUNT_BEFORE_FAILURE)
-                .whenQueryStartsWith("INSERT INTO mailboxPathV2"));
+                .whenQueryStartsWith("INSERT INTO mailboxPathV3"));
 
             doQuietly(() -> testee.createMailbox(inboxPath, mailboxSession));
 
@@ -199,6 +200,7 @@ class CassandraMailboxManagerConsistencyTest {
     @Nested
     class FailuresDuringRenaming {
 
+        @Disabled("oups")
         @Test
         void renameShouldBeConsistentWhenMailboxDaoFails(CassandraCluster cassandra) throws Exception {
             MailboxId inboxId = testee.createMailbox(inboxPath, mailboxSession)
@@ -230,7 +232,7 @@ class CassandraMailboxManagerConsistencyTest {
 
             cassandra.getConf().registerScenario(fail()
                 .times(TRY_COUNT_BEFORE_FAILURE)
-                .whenQueryStartsWith("INSERT INTO mailboxPathV2"));
+                .whenQueryStartsWith("INSERT INTO mailboxPathV3"));
 
             doQuietly(() -> testee.renameMailbox(inboxPath, inboxPathRenamed, mailboxSession));
 
@@ -287,7 +289,7 @@ class CassandraMailboxManagerConsistencyTest {
 
             cassandra.getConf().registerScenario(fail()
                 .times(TRY_COUNT_BEFORE_FAILURE)
-                .whenQueryStartsWith("INSERT INTO mailboxPathV2"));
+                .whenQueryStartsWith("INSERT INTO mailboxPathV3"));
 
             doQuietly(() -> testee.renameMailbox(inboxPath, inboxPathRenamed, mailboxSession));
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerConsistencyTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerConsistencyTest.java
@@ -79,7 +79,7 @@ class CassandraMailboxManagerConsistencyTest {
     @Nested
     class FailuresDuringCreation {
 
-        @Disabled("oups")
+        @Disabled("For performance reasons we don't validate path reads against mailbox table")
         @Test
         void createMailboxShouldBeConsistentWhenMailboxDaoFails(CassandraCluster cassandra) {
             cassandra.getConf().registerScenario(fail()
@@ -200,7 +200,7 @@ class CassandraMailboxManagerConsistencyTest {
     @Nested
     class FailuresDuringRenaming {
 
-        @Disabled("oups")
+        @Disabled("For performance reasons we don't validate path reads against mailbox table")
         @Test
         void renameShouldBeConsistentWhenMailboxDaoFails(CassandraCluster cassandra) throws Exception {
             MailboxId inboxId = testee.createMailbox(inboxPath, mailboxSession)
@@ -633,7 +633,7 @@ class CassandraMailboxManagerConsistencyTest {
 
                 cassandra.getConf().registerScenario(fail()
                     .times(TRY_COUNT_BEFORE_FAILURE)
-                    .whenQueryStartsWith("DELETE FROM mailboxPathV2"));
+                    .whenQueryStartsWith("DELETE FROM mailboxPathV3"));
 
                 doQuietly(() -> testee.deleteMailbox(inboxPath, mailboxSession));
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraSubscriptionManagerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraSubscriptionManagerTest.java
@@ -37,6 +37,7 @@ import org.apache.james.mailbox.cassandra.mail.CassandraMailboxCounterDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathDAOImpl;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathV2DAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathV3DAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxRecentsDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
@@ -74,6 +75,7 @@ class CassandraSubscriptionManagerTest implements SubscriptionManagerContract {
         CassandraMailboxDAO mailboxDAO = null;
         CassandraMailboxPathDAOImpl mailboxPathDAO = null;
         CassandraMailboxPathV2DAO mailboxPathV2DAO = null;
+        CassandraMailboxPathV3DAO mailboxPathV3DAO = null;
         CassandraFirstUnseenDAO firstUnseenDAO = null;
         CassandraApplicableFlagDAO applicableFlagDAO = null;
         CassandraDeletedMessageDAO deletedMessageDAO = null;
@@ -100,6 +102,7 @@ class CassandraSubscriptionManagerTest implements SubscriptionManagerContract {
                 mailboxDAO,
                 mailboxPathDAO,
                 mailboxPathV2DAO,
+                mailboxPathV3DAO,
                 firstUnseenDAO,
                 applicableFlagDAO,
                 attachmentDAOV2,

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperTest.java
@@ -103,6 +103,11 @@ class CassandraMailboxMapperTest {
             CassandraConfiguration.DEFAULT_CONFIGURATION,
             cassandraCluster.getCassandraConsistenciesConfiguration());
         versionDAO = new CassandraSchemaVersionDAO(cassandra.getConf());
+
+        versionDAO.truncateVersion()
+            .then(versionDAO.updateVersion(new SchemaVersion(7)))
+            .block();
+
         testee = new CassandraMailboxMapper(
             mailboxDAO,
             mailboxPathDAO,
@@ -830,8 +835,6 @@ class CassandraMailboxMapperTest {
 
     @Test
     void findMailboxWithPathLikeShouldReturnMailboxesWhenExistsInV1Table() {
-        versionDAO.updateVersion(new SchemaVersion(7)).block();
-
         mailboxDAO.save(MAILBOX)
             .block();
         mailboxPathDAO.save(MAILBOX_PATH, MAILBOX_ID)
@@ -850,8 +853,6 @@ class CassandraMailboxMapperTest {
 
     @Test
     void findMailboxWithPathLikeShouldReturnMailboxesWhenExistsInBothTables() {
-        versionDAO.updateVersion(new SchemaVersion(7)).block();
-
         mailboxDAO.save(MAILBOX)
             .block();
         mailboxPathDAO.save(MAILBOX_PATH, MAILBOX_ID)
@@ -872,8 +873,6 @@ class CassandraMailboxMapperTest {
 
     @Test
     void findMailboxWithPathLikeShouldReturnMailboxesWhenExistsInV2Table() {
-        versionDAO.updateVersion(new SchemaVersion(7)).block();
-
         mailboxDAO.save(MAILBOX)
             .block();
         mailboxPathV2DAO.save(MAILBOX_PATH, MAILBOX_ID)
@@ -911,8 +910,6 @@ class CassandraMailboxMapperTest {
 
     @Test
     void hasChildrenShouldReturnChildWhenExistsInV1Table() {
-        versionDAO.updateVersion(new SchemaVersion(7)).block();
-
         mailboxDAO.save(MAILBOX)
             .block();
         mailboxPathDAO.save(MAILBOX_PATH, MAILBOX_ID)
@@ -932,8 +929,6 @@ class CassandraMailboxMapperTest {
 
     @Test
     void hasChildrenShouldReturnChildWhenExistsInBothTables() {
-        versionDAO.updateVersion(new SchemaVersion(7)).block();
-
         mailboxDAO.save(MAILBOX)
             .block();
         mailboxPathDAO.save(MAILBOX_PATH, MAILBOX_ID)
@@ -955,8 +950,6 @@ class CassandraMailboxMapperTest {
 
     @Test
     void hasChildrenShouldReturnChildWhenExistsInV2Table() {
-        versionDAO.updateVersion(new SchemaVersion(7)).block();
-
         mailboxDAO.save(MAILBOX)
             .block();
         mailboxPathV2DAO.save(MAILBOX_PATH, MAILBOX_ID)
@@ -995,8 +988,6 @@ class CassandraMailboxMapperTest {
 
     @Test
     void findMailboxWithPathLikeShouldRemoveDuplicatesAndKeepV3() {
-        versionDAO.updateVersion(new SchemaVersion(7)).block();
-
         mailboxDAO.save(MAILBOX).block();
         mailboxPathV3DAO.save(MAILBOX).block();
 

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxMapperTest.java
@@ -36,6 +36,7 @@ import org.apache.james.backends.cassandra.utils.CassandraUtils;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionDAO;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManager;
 import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.backends.cassandra.versions.SchemaVersion;
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.cassandra.ids.CassandraId;
 import org.apache.james.mailbox.cassandra.modules.CassandraAclModule;
@@ -84,7 +85,9 @@ class CassandraMailboxMapperTest {
     private CassandraMailboxDAO mailboxDAO;
     private CassandraMailboxPathDAOImpl mailboxPathDAO;
     private CassandraMailboxPathV2DAO mailboxPathV2DAO;
+    private CassandraMailboxPathV3DAO mailboxPathV3DAO;
     private CassandraMailboxMapper testee;
+    private CassandraSchemaVersionDAO versionDAO;
 
     @BeforeEach
     void setUp() {
@@ -92,19 +95,22 @@ class CassandraMailboxMapperTest {
         mailboxDAO = new CassandraMailboxDAO(cassandra.getConf(), cassandra.getTypesProvider(), cassandraCluster.getCassandraConsistenciesConfiguration());
         mailboxPathDAO = new CassandraMailboxPathDAOImpl(cassandra.getConf(), cassandra.getTypesProvider(), cassandraCluster.getCassandraConsistenciesConfiguration());
         mailboxPathV2DAO = new CassandraMailboxPathV2DAO(cassandra.getConf(), CassandraUtils.WITH_DEFAULT_CONFIGURATION, cassandraCluster.getCassandraConsistenciesConfiguration());
+        mailboxPathV3DAO = new CassandraMailboxPathV3DAO(cassandra.getConf(), CassandraUtils.WITH_DEFAULT_CONFIGURATION, cassandraCluster.getCassandraConsistenciesConfiguration());
         CassandraUserMailboxRightsDAO userMailboxRightsDAO = new CassandraUserMailboxRightsDAO(cassandra.getConf(), CassandraUtils.WITH_DEFAULT_CONFIGURATION);
         CassandraACLMapper aclMapper = new CassandraACLMapper(
             cassandra.getConf(),
             new CassandraUserMailboxRightsDAO(cassandra.getConf(), CassandraUtils.WITH_DEFAULT_CONFIGURATION),
             CassandraConfiguration.DEFAULT_CONFIGURATION,
             cassandraCluster.getCassandraConsistenciesConfiguration());
+        versionDAO = new CassandraSchemaVersionDAO(cassandra.getConf());
         testee = new CassandraMailboxMapper(
             mailboxDAO,
             mailboxPathDAO,
             mailboxPathV2DAO,
+            mailboxPathV3DAO,
             userMailboxRightsDAO,
             aclMapper,
-            new CassandraSchemaVersionManager(new CassandraSchemaVersionDAO(cassandra.getConf())));
+            new CassandraSchemaVersionManager(versionDAO));
     }
 
     @Nested
@@ -242,6 +248,9 @@ class CassandraMailboxMapperTest {
             }
         }
 
+        @Disabled("In order to be more performant mailboxPath V3 table includes the UID_VALIDITY." +
+            "Reading paths no longer requires reading the mailbox by id but this of course has a " +
+            "consistency cost.")
         @Test
         void createShouldBeConsistentWhenFailToPersistMailbox(CassandraCluster cassandra) {
             cassandra.getConf()
@@ -348,7 +357,7 @@ class CassandraMailboxMapperTest {
             cassandra.getConf()
                 .registerScenario(fail()
                     .times(TRY_COUNT_BEFORE_FAILURE)
-                    .whenQueryStartsWith("DELETE FROM mailboxPathV2 WHERE namespace=:namespace AND user=:user AND mailboxName=:mailboxName IF EXISTS;"));
+                    .whenQueryStartsWith("DELETE FROM mailboxPathV3 WHERE namespace=:namespace AND user=:user AND mailboxName=:mailboxName IF EXISTS;"));
 
             doQuietly(() -> testee.rename(inboxRenamed).block());
 
@@ -377,7 +386,7 @@ class CassandraMailboxMapperTest {
             cassandra.getConf()
                 .registerScenario(fail()
                     .times(TRY_COUNT_BEFORE_FAILURE)
-                    .whenQueryStartsWith("DELETE FROM mailboxPathV2 WHERE namespace=:namespace AND user=:user AND mailboxName=:mailboxName IF EXISTS;"));
+                    .whenQueryStartsWith("DELETE FROM mailboxPathV3 WHERE namespace=:namespace AND user=:user AND mailboxName=:mailboxName IF EXISTS;"));
 
             doQuietly(() -> testee.rename(inboxRenamed).block());
 
@@ -399,7 +408,7 @@ class CassandraMailboxMapperTest {
             cassandra.getConf()
                 .registerScenario(fail()
                     .times(TRY_COUNT_BEFORE_FAILURE)
-                    .whenQueryStartsWith("DELETE FROM mailboxPathV2 WHERE namespace=:namespace AND user=:user AND mailboxName=:mailboxName IF EXISTS;"));
+                    .whenQueryStartsWith("DELETE FROM mailboxPathV3 WHERE namespace=:namespace AND user=:user AND mailboxName=:mailboxName IF EXISTS;"));
 
             doQuietly(() -> testee.rename(inboxRenamed).block());
 
@@ -450,7 +459,7 @@ class CassandraMailboxMapperTest {
             CassandraId inboxId = (CassandraId) inbox.getMailboxId();
             // simulate mailbox old data has not been migrated to v2
             mailboxPathDAO.save(inboxPath, inboxId).block();
-            mailboxPathV2DAO.delete(inboxPath).block();
+            mailboxPathV3DAO.delete(inboxPath).block();
 
             // on current v2 generation, save a new mailbox with the exactly name
             // => two mailboxes with same name but different ids
@@ -598,7 +607,7 @@ class CassandraMailboxMapperTest {
             cassandra.getConf()
                 .registerScenario(fail()
                     .times(TRY_COUNT_BEFORE_FAILURE)
-                    .whenQueryStartsWith("DELETE FROM mailboxPathV2 WHERE namespace=:namespace AND user=:user AND mailboxName=:mailboxName IF EXISTS;"));
+                    .whenQueryStartsWith("DELETE FROM mailboxPathV3 WHERE namespace=:namespace AND user=:user AND mailboxName=:mailboxName IF EXISTS;"));
 
             doQuietly(() -> testee.rename(inboxRenamed).block());
 
@@ -651,7 +660,7 @@ class CassandraMailboxMapperTest {
         assertThatThrownBy(() -> testee.rename(newMailbox).block())
             .isInstanceOf(TooLongMailboxNameException.class);
 
-        assertThat(mailboxPathV2DAO.retrieveId(MAILBOX_PATH).blockOptional())
+        assertThat(mailboxPathV3DAO.retrieve(MAILBOX_PATH).blockOptional())
             .isPresent();
     }
 
@@ -686,6 +695,36 @@ class CassandraMailboxMapperTest {
     }
 
     @Test
+    void deleteShouldDeleteMailboxAndMailboxPathFromV3Table() {
+        mailboxDAO.save(MAILBOX)
+            .block();
+        mailboxPathV3DAO.save(MAILBOX)
+            .block();
+
+        testee.delete(MAILBOX).block();
+
+        assertThat(testee.findMailboxByPath(MAILBOX_PATH).blockOptional())
+            .isEmpty();
+    }
+
+    @Test
+    void deleteShouldDeleteMailboxAndMailboxPathFromAllTables() {
+        mailboxDAO.save(MAILBOX)
+            .block();
+        mailboxPathDAO.save(MAILBOX_PATH, MAILBOX_ID)
+            .block();
+        mailboxPathV2DAO.save(MAILBOX_PATH, MAILBOX_ID)
+            .block();
+        mailboxPathV3DAO.save(MAILBOX)
+            .block();
+
+        testee.delete(MAILBOX).block();
+
+        assertThat(testee.findMailboxByPath(MAILBOX_PATH).blockOptional())
+            .isEmpty();
+    }
+
+    @Test
     void findMailboxByPathShouldReturnMailboxWhenExistsInV1Table() {
         mailboxDAO.save(MAILBOX)
             .block();
@@ -710,12 +749,10 @@ class CassandraMailboxMapperTest {
     }
 
     @Test
-    void findMailboxByPathShouldReturnMailboxWhenExistsInBothTables() {
+    void findMailboxByPathShouldReturnMailboxWhenExistsInV3Table() {
         mailboxDAO.save(MAILBOX)
             .block();
-        mailboxPathDAO.save(MAILBOX_PATH, MAILBOX_ID)
-            .block();
-        mailboxPathV2DAO.save(MAILBOX_PATH, MAILBOX_ID)
+        mailboxPathV3DAO.save(MAILBOX)
             .block();
 
         Mailbox mailbox = testee.findMailboxByPath(MAILBOX_PATH).block();
@@ -724,12 +761,30 @@ class CassandraMailboxMapperTest {
     }
 
     @Test
-    void deleteShouldRemoveMailboxWhenInBothTables() {
+    void findMailboxByPathShouldReturnMailboxWhenExistsInAllTables() {
         mailboxDAO.save(MAILBOX)
             .block();
         mailboxPathDAO.save(MAILBOX_PATH, MAILBOX_ID)
             .block();
         mailboxPathV2DAO.save(MAILBOX_PATH, MAILBOX_ID)
+            .block();
+        mailboxPathV3DAO.save(MAILBOX)
+            .block();
+
+        Mailbox mailbox = testee.findMailboxByPath(MAILBOX_PATH).block();
+
+        assertThat(mailbox.generateAssociatedPath()).isEqualTo(MAILBOX_PATH);
+    }
+
+    @Test
+    void deleteShouldRemoveMailboxWhenInAllTables() {
+        mailboxDAO.save(MAILBOX)
+            .block();
+        mailboxPathDAO.save(MAILBOX_PATH, MAILBOX_ID)
+            .block();
+        mailboxPathV2DAO.save(MAILBOX_PATH, MAILBOX_ID)
+            .block();
+        mailboxPathV3DAO.save(MAILBOX)
             .block();
 
         testee.delete(MAILBOX).block();
@@ -775,6 +830,8 @@ class CassandraMailboxMapperTest {
 
     @Test
     void findMailboxWithPathLikeShouldReturnMailboxesWhenExistsInV1Table() {
+        versionDAO.updateVersion(new SchemaVersion(7)).block();
+
         mailboxDAO.save(MAILBOX)
             .block();
         mailboxPathDAO.save(MAILBOX_PATH, MAILBOX_ID)
@@ -793,6 +850,8 @@ class CassandraMailboxMapperTest {
 
     @Test
     void findMailboxWithPathLikeShouldReturnMailboxesWhenExistsInBothTables() {
+        versionDAO.updateVersion(new SchemaVersion(7)).block();
+
         mailboxDAO.save(MAILBOX)
             .block();
         mailboxPathDAO.save(MAILBOX_PATH, MAILBOX_ID)
@@ -813,6 +872,8 @@ class CassandraMailboxMapperTest {
 
     @Test
     void findMailboxWithPathLikeShouldReturnMailboxesWhenExistsInV2Table() {
+        versionDAO.updateVersion(new SchemaVersion(7)).block();
+
         mailboxDAO.save(MAILBOX)
             .block();
         mailboxPathV2DAO.save(MAILBOX_PATH, MAILBOX_ID)
@@ -830,7 +891,28 @@ class CassandraMailboxMapperTest {
     }
 
     @Test
+    void findMailboxWithPathLikeShouldReturnMailboxesWhenExistsInV3Table() {
+        mailboxDAO.save(MAILBOX)
+            .block();
+        mailboxPathV3DAO.save(MAILBOX)
+            .block();
+
+        List<Mailbox> mailboxes = testee.findMailboxWithPathLike(MailboxQuery.builder()
+            .privateNamespace()
+            .username(USER)
+            .expression(Wildcard.INSTANCE)
+            .build()
+            .asUserBound())
+            .collectList()
+            .block();
+
+        assertThat(mailboxes).containsOnly(MAILBOX);
+    }
+
+    @Test
     void hasChildrenShouldReturnChildWhenExistsInV1Table() {
+        versionDAO.updateVersion(new SchemaVersion(7)).block();
+
         mailboxDAO.save(MAILBOX)
             .block();
         mailboxPathDAO.save(MAILBOX_PATH, MAILBOX_ID)
@@ -850,6 +932,8 @@ class CassandraMailboxMapperTest {
 
     @Test
     void hasChildrenShouldReturnChildWhenExistsInBothTables() {
+        versionDAO.updateVersion(new SchemaVersion(7)).block();
+
         mailboxDAO.save(MAILBOX)
             .block();
         mailboxPathDAO.save(MAILBOX_PATH, MAILBOX_ID)
@@ -871,6 +955,8 @@ class CassandraMailboxMapperTest {
 
     @Test
     void hasChildrenShouldReturnChildWhenExistsInV2Table() {
+        versionDAO.updateVersion(new SchemaVersion(7)).block();
+
         mailboxDAO.save(MAILBOX)
             .block();
         mailboxPathV2DAO.save(MAILBOX_PATH, MAILBOX_ID)
@@ -889,9 +975,30 @@ class CassandraMailboxMapperTest {
     }
 
     @Test
-    void findMailboxWithPathLikeShouldRemoveDuplicatesAndKeepV2() {
+    void hasChildrenShouldReturnChildWhenExistsInV3Table() {
+        mailboxDAO.save(MAILBOX)
+            .block();
+        mailboxPathV3DAO.save(MAILBOX)
+            .block();
+        CassandraId childMailboxId = CassandraId.timeBased();
+        MailboxPath childMailboxPath = MailboxPath.forUser(USER, "name.child");
+        Mailbox childMailbox = new Mailbox(childMailboxPath, UID_VALIDITY, childMailboxId);
+        mailboxDAO.save(childMailbox)
+            .block();
+        mailboxPathV3DAO.save(childMailbox)
+            .block();
+
+        boolean hasChildren = testee.hasChildren(MAILBOX, '.').block();
+
+        assertThat(hasChildren).isTrue();
+    }
+
+    @Test
+    void findMailboxWithPathLikeShouldRemoveDuplicatesAndKeepV3() {
+        versionDAO.updateVersion(new SchemaVersion(7)).block();
+
         mailboxDAO.save(MAILBOX).block();
-        mailboxPathV2DAO.save(MAILBOX_PATH, MAILBOX_ID).block();
+        mailboxPathV3DAO.save(MAILBOX).block();
 
         mailboxDAO.save(MAILBOX_BIS).block();
         mailboxPathDAO.save(MAILBOX_PATH, MAILBOX_ID_2).block();

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxPathV3DAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxPathV3DAOTest.java
@@ -1,0 +1,153 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ * http://www.apache.org/licenses/LICENSE-2.0                   *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail;
+
+import static org.apache.james.mailbox.cassandra.mail.MailboxFixture.MAILBOX_1;
+import static org.apache.james.mailbox.cassandra.mail.MailboxFixture.MAILBOX_2;
+import static org.apache.james.mailbox.cassandra.mail.MailboxFixture.MAILBOX_3;
+import static org.apache.james.mailbox.cassandra.mail.MailboxFixture.USER_INBOX_MAILBOXPATH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.utils.CassandraUtils;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.mailbox.cassandra.modules.CassandraMailboxModule;
+import org.apache.james.mailbox.model.Mailbox;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class CassandraMailboxPathV3DAOTest {
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(CassandraModule.aggregateModules(
+        CassandraMailboxModule.MODULE, CassandraSchemaVersionModule.MODULE));
+
+    CassandraMailboxPathV3DAO testee;
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandra) {
+        testee = new CassandraMailboxPathV3DAO(
+            cassandra.getConf(),
+            CassandraUtils.WITH_DEFAULT_CONFIGURATION,
+            cassandraCluster.getCassandraConsistenciesConfiguration());
+    }
+
+    @Test
+    void cassandraIdAndPathShouldRespectBeanContract() {
+        EqualsVerifier.forClass(CassandraIdAndPath.class).verify();
+    }
+
+    @Test
+    void saveShouldInsertNewEntry() {
+        assertThat(testee.save(MAILBOX_1).block()).isTrue();
+
+        assertThat(testee.retrieve(USER_INBOX_MAILBOXPATH).blockOptional())
+            .contains(MAILBOX_1);
+    }
+
+    @Test
+    void saveOnSecondShouldBeFalse() {
+        assertThat(testee.save(MAILBOX_1).block()).isTrue();
+        assertThat(testee.save(MAILBOX_1).block()).isFalse();
+    }
+
+    @Test
+    void retrieveIdShouldReturnEmptyWhenEmptyData() {
+        assertThat(testee.retrieve(USER_INBOX_MAILBOXPATH).blockOptional())
+            .isEmpty();
+    }
+
+    @Test
+    void retrieveIdShouldReturnStoredData() {
+        testee.save(MAILBOX_1).block();
+
+        assertThat(testee.retrieve(USER_INBOX_MAILBOXPATH).blockOptional())
+            .contains(MAILBOX_1);
+    }
+
+    @Test
+    void getUserMailboxesShouldReturnAllMailboxesOfUser() {
+        testee.save(MAILBOX_1).block();
+        testee.save(MAILBOX_2).block();
+        testee.save(MAILBOX_3).block();
+
+        List<Mailbox> cassandraIds = testee
+            .listUserMailboxes(USER_INBOX_MAILBOXPATH.getNamespace(), USER_INBOX_MAILBOXPATH.getUser())
+            .collectList()
+            .block();
+
+        assertThat(cassandraIds)
+            .hasSize(2)
+            .containsOnly(MAILBOX_1, MAILBOX_2);
+    }
+
+    @Test
+    void deleteShouldNotThrowWhenEmpty() {
+        testee.delete(USER_INBOX_MAILBOXPATH).block();
+    }
+
+    @Test
+    void deleteShouldDeleteTheExistingMailboxId() {
+        testee.save(MAILBOX_1).block();
+
+        testee.delete(USER_INBOX_MAILBOXPATH).block();
+
+        assertThat(testee.retrieve(USER_INBOX_MAILBOXPATH).blockOptional())
+            .isEmpty();
+    }
+
+    @Test
+    void listAllShouldBeEmptyByDefault() {
+        assertThat(testee.listAll().collectList().block()).isEmpty();
+    }
+
+    @Test
+    void listAllShouldContainAddedEntry() {
+        testee.save(MAILBOX_1).block();
+
+        assertThat(testee.listAll().collectList().block())
+            .containsExactlyInAnyOrder(MAILBOX_1);
+    }
+
+    @Test
+    void listAllShouldNotContainDeletedEntry() {
+        testee.save(MAILBOX_1).block();
+
+        testee.delete(USER_INBOX_MAILBOXPATH).block();
+
+        assertThat(testee.listAll().collectList().block())
+            .isEmpty();
+    }
+
+    @Test
+    void listAllShouldContainAddedEntries() {
+        testee.save(MAILBOX_1).block();
+        testee.save(MAILBOX_3).block();
+
+        assertThat(testee.listAll().collectList().block())
+            .containsExactlyInAnyOrder(MAILBOX_1, MAILBOX_3);
+    }
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/MailboxFixture.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/MailboxFixture.java
@@ -21,7 +21,9 @@ package org.apache.james.mailbox.cassandra.mail;
 
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.model.Mailbox;
 import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.UidValidity;
 
 public interface MailboxFixture {
     Username USER = Username.of("user");
@@ -34,4 +36,8 @@ public interface MailboxFixture {
     MailboxPath USER_OUTBOX_MAILBOXPATH = MailboxPath.forUser(USER, "OUTBOX");
     MailboxPath OTHER_USER_MAILBOXPATH = MailboxPath.forUser(OTHER_USER, "INBOX");
     CassandraIdAndPath INBOX_ID_AND_PATH = new CassandraIdAndPath(INBOX_ID, USER_INBOX_MAILBOXPATH);
+
+    Mailbox MAILBOX_1 = new Mailbox(USER_INBOX_MAILBOXPATH, UidValidity.of(42), INBOX_ID);
+    Mailbox MAILBOX_2 = new Mailbox(USER_OUTBOX_MAILBOXPATH, UidValidity.of(43), OUTBOX_ID);
+    Mailbox MAILBOX_3 = new Mailbox(OTHER_USER_MAILBOXPATH, UidValidity.of(44), otherMailboxId);
 }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/MailboxPathV3MigrationTaskSerializationTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/MailboxPathV3MigrationTaskSerializationTest.java
@@ -1,0 +1,52 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.migration;
+
+import static org.mockito.Mockito.mock;
+
+import java.time.Instant;
+
+import org.apache.james.JsonSerializationVerifier;
+import org.junit.jupiter.api.Test;
+
+class MailboxPathV3MigrationTaskSerializationTest {
+    private static final Instant TIMESTAMP = Instant.parse("2018-11-13T12:00:55Z");
+    private static final MailboxPathV3Migration MIGRATION = mock(MailboxPathV3Migration.class);
+    private static final MailboxPathV3Migration.MailboxPathV3MigrationTask TASK = new MailboxPathV3Migration.MailboxPathV3MigrationTask(MIGRATION);
+    private static final String SERIALIZED_TASK = "{\"type\": \"cassandra-mailbox-path-v3-migration\"}";
+    private static final MailboxPathV3Migration.AdditionalInformation DETAILS = new MailboxPathV3Migration.AdditionalInformation(42L, 10, TIMESTAMP);
+    private static final String SERIALIZED_ADDITIONAL_INFORMATION = "{\"type\": \"cassandra-mailbox-path-v3-migration\", \"remainingCount\":42,\"initialCount\":10, \"timestamp\":\"2018-11-13T12:00:55Z\"}";
+
+    @Test
+    void taskShouldBeSerializable() throws Exception {
+        JsonSerializationVerifier.dtoModule(MailboxPathV3MigrationTaskDTO.MODULE.apply(MIGRATION))
+            .bean(TASK)
+            .json(SERIALIZED_TASK)
+            .verify();
+    }
+
+    @Test
+    void additionalInformationShouldBeSerializable() throws Exception {
+        JsonSerializationVerifier.dtoModule(MailboxPathV3MigrationTaskAdditionalInformationDTO.MODULE)
+            .bean(DETAILS)
+            .json(SERIALIZED_ADDITIONAL_INFORMATION)
+            .verify();
+    }
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/MailboxPathV3MigrationTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/MailboxPathV3MigrationTest.java
@@ -1,0 +1,100 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.migration;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.utils.CassandraUtils;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathDAOImpl;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathV2DAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathV3DAO;
+import org.apache.james.mailbox.cassandra.modules.CassandraAclModule;
+import org.apache.james.mailbox.cassandra.modules.CassandraMailboxModule;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.UidValidity;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class MailboxPathV3MigrationTest {
+
+    private static final MailboxPath MAILBOX_PATH_1 = MailboxPath.forUser(Username.of("bob"), "Important");
+    private static final UidValidity UID_VALIDITY_1 = UidValidity.of(452);
+    private static final CassandraId MAILBOX_ID_1 = CassandraId.timeBased();
+    private static final Mailbox MAILBOX = new Mailbox(MAILBOX_PATH_1, UID_VALIDITY_1, MAILBOX_ID_1);
+
+
+    public static final CassandraModule MODULES = CassandraModule.aggregateModules(
+            CassandraMailboxModule.MODULE,
+            CassandraAclModule.MODULE,
+            CassandraSchemaVersionModule.MODULE);
+
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(MODULES);
+
+    private CassandraMailboxPathDAOImpl daoV1;
+    private CassandraMailboxPathV2DAO daoV2;
+    private CassandraMailboxPathV3DAO daoV3;
+    private CassandraMailboxDAO mailboxDAO;
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandra) {
+        daoV1 = new CassandraMailboxPathDAOImpl(
+            cassandra.getConf(),
+            cassandra.getTypesProvider(),
+            CassandraUtils.WITH_DEFAULT_CONFIGURATION,
+            cassandraCluster.getCassandraConsistenciesConfiguration());
+        daoV2 = new CassandraMailboxPathV2DAO(
+            cassandra.getConf(),
+            CassandraUtils.WITH_DEFAULT_CONFIGURATION,
+            cassandraCluster.getCassandraConsistenciesConfiguration());
+        daoV3 = new CassandraMailboxPathV3DAO(
+            cassandra.getConf(),
+            CassandraUtils.WITH_DEFAULT_CONFIGURATION,
+            cassandraCluster.getCassandraConsistenciesConfiguration());
+
+        mailboxDAO = new CassandraMailboxDAO(
+            cassandra.getConf(),
+            cassandra.getTypesProvider(),
+            cassandraCluster.getCassandraConsistenciesConfiguration());
+    }
+
+    @Test
+    void migrationTaskShouldMoveDataToMostRecentDao() {
+        daoV2.save(MAILBOX_PATH_1, MAILBOX_ID_1).block();
+        mailboxDAO.save(MAILBOX).block();
+
+        new MailboxPathV3Migration(daoV2, daoV3, mailboxDAO).apply();
+
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(daoV1.retrieveId(MAILBOX_PATH_1).blockOptional()).isEmpty();
+        softly.assertThat(daoV2.retrieveId(MAILBOX_PATH_1).blockOptional()).isEmpty();
+        softly.assertThat(daoV3.retrieve(MAILBOX_PATH_1).blockOptional())
+            .contains(MAILBOX);
+        softly.assertAll();
+    }
+}

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraMailboxModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/mailbox/CassandraMailboxModule.java
@@ -53,6 +53,7 @@ import org.apache.james.mailbox.cassandra.mail.CassandraMailboxDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxMapper;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathDAOImpl;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathV2DAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathV3DAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxRecentsDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
@@ -121,6 +122,7 @@ public class CassandraMailboxModule extends AbstractModule {
         bind(CassandraMailboxDAO.class).in(Scopes.SINGLETON);
         bind(CassandraMailboxPathDAOImpl.class).in(Scopes.SINGLETON);
         bind(CassandraMailboxPathV2DAO.class).in(Scopes.SINGLETON);
+        bind(CassandraMailboxPathV3DAO.class).in(Scopes.SINGLETON);
         bind(CassandraMailboxRecentsDAO.class).in(Scopes.SINGLETON);
         bind(CassandraMessageDAO.class).in(Scopes.SINGLETON);
         bind(CassandraMessageIdDAO.class).in(Scopes.SINGLETON);

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/webadmin/CassandraRoutesModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/webadmin/CassandraRoutesModule.java
@@ -26,6 +26,7 @@ import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionManage
 import org.apache.james.backends.cassandra.versions.SchemaTransition;
 import org.apache.james.backends.cassandra.versions.SchemaVersion;
 import org.apache.james.mailbox.cassandra.mail.migration.MailboxPathV2Migration;
+import org.apache.james.mailbox.cassandra.mail.migration.MailboxPathV3Migration;
 import org.apache.james.rrt.cassandra.migration.MappingsSourcesMigration;
 import org.apache.james.webadmin.Routes;
 import org.apache.james.webadmin.routes.CassandraMailboxMergingRoutes;
@@ -40,6 +41,7 @@ import com.google.inject.name.Names;
 public class CassandraRoutesModule extends AbstractModule {
     private static final SchemaTransition FROM_V5_TO_V6 = SchemaTransition.to(new SchemaVersion(6));
     private static final SchemaTransition FROM_V6_TO_V7 = SchemaTransition.to(new SchemaVersion(7));
+    private static final SchemaTransition FROM_V7_TO_V8 = SchemaTransition.to(new SchemaVersion(8));
 
     @Override
     protected void configure() {
@@ -57,6 +59,7 @@ public class CassandraRoutesModule extends AbstractModule {
         MapBinder<SchemaTransition, Migration> allMigrationClazzBinder = MapBinder.newMapBinder(binder(), SchemaTransition.class, Migration.class);
         allMigrationClazzBinder.addBinding(FROM_V5_TO_V6).to(MailboxPathV2Migration.class);
         allMigrationClazzBinder.addBinding(FROM_V6_TO_V7).to(MappingsSourcesMigration.class);
+        allMigrationClazzBinder.addBinding(FROM_V7_TO_V8).to(MailboxPathV3Migration.class);
 
         bind(SchemaVersion.class)
             .annotatedWith(Names.named(CassandraMigrationService.LATEST_VERSION))

--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/FixingGhostMailboxTest.java
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/FixingGhostMailboxTest.java
@@ -59,7 +59,7 @@ import org.apache.james.jmap.draft.JmapGuiceProbe;
 import org.apache.james.junit.categories.BasicFeature;
 import org.apache.james.mailbox.MessageManager.AppendCommand;
 import org.apache.james.mailbox.cassandra.mail.task.MailboxMergingTask;
-import org.apache.james.mailbox.cassandra.table.CassandraMailboxPathV2Table;
+import org.apache.james.mailbox.cassandra.table.CassandraMailboxPathV3Table;
 import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.model.ComposedMessageId;
 import org.apache.james.mailbox.model.MailboxACL;
@@ -182,10 +182,10 @@ class FixingGhostMailboxTest {
         testExtension.await();
 
         // Simulate ghost mailbox bug
-        session.execute(delete().from(CassandraMailboxPathV2Table.TABLE_NAME)
-            .where(eq(CassandraMailboxPathV2Table.NAMESPACE, MailboxConstants.USER_NAMESPACE))
-            .and(eq(CassandraMailboxPathV2Table.USER, ALICE))
-            .and(eq(CassandraMailboxPathV2Table.MAILBOX_NAME, MailboxConstants.INBOX)));
+        session.execute(delete().from(CassandraMailboxPathV3Table.TABLE_NAME)
+            .where(eq(CassandraMailboxPathV3Table.NAMESPACE, MailboxConstants.USER_NAMESPACE))
+            .and(eq(CassandraMailboxPathV3Table.USER, ALICE))
+            .and(eq(CassandraMailboxPathV3Table.MAILBOX_NAME, MailboxConstants.INBOX)));
 
         // trigger provisioning
         given()


### PR DESCRIPTION
## Why?

Current read pattern is:

 - list the paths from the mailboxPath table
 - Then read mailbox from mailbox table. Each mailbox is held on a separate primary key.
 - Then read the ACLs (per mailbox primary key)
 - Then read the mailbox counters (per mailbox primary key)

With https://www.datastax.com/blog/2015/02/basic-rules-cassandra-data-modeling in mind, we should minimize the number of primary keys reads. This is achievable by fully denormalizing the mailbox table, so that reading the mailboxPath table is enough for building the mailbox.

The new read pattern then become:

 - list the paths from the mailboxPath table
 - Then read the ACLs (per mailbox primary key)
 - Then read the mailbox counters (per mailbox primary key)

By decreasing by 33% the amount of primary key reads, we of course expect to unlock some performance enhancements.

## How

- Add the UID_VALIDITY metadata as part of a new mailboxV3 table
- Implement live & batch migration for this new table. Migrated data can skip reads to old DAOs.

## Results

GetMailboxes unlocks a x3 performance improvment.

Scenario played: 15 minutes inboxhomeloadingsimulation with 4500 users per hour (to not overwhelm swift)

Before:

![Capture d’écran de 2020-07-30 09-51-27](https://user-images.githubusercontent.com/6928740/88874909-598c4800-d24a-11ea-9e90-2533a06f5c71.png)

After:

![Capture d’écran de 2020-07-31 10-58-11](https://user-images.githubusercontent.com/6928740/88998775-01724600-d31d-11ea-96fe-d8f71adabb27.png)



Performance enhancements will also be noticeable on some IMAP commands as well (eg IMAP LIST)