### PR TITLE
JAMES-2629 Use a future supplier in CassandraAsyncExecutor

### DIFF
--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/utils/CassandraAsyncExecutor.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/utils/CassandraAsyncExecutor.java
@@ -45,9 +45,9 @@ public class CassandraAsyncExecutor {
     }
 
     public Mono<ResultSet> execute(Statement statement) {
-        return Mono.defer(() -> Mono.fromFuture(FutureConverter
+        return Mono.fromFuture(() -> FutureConverter
                 .toCompletableFuture(session.executeAsync(statement)))
-                .publishOn(Schedulers.elastic()));
+                .publishOn(Schedulers.elastic());
     }
 
     public Mono<Boolean> executeReturnApplied(Statement statement) {


### PR DESCRIPTION
This allows getting rid of a Mono::defer call