### PR TITLE
JAMES-3308 RabbitMQTerminationSubscriberTest should be thread safe

### DIFF
--- a/server/task/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/RabbitMQTerminationSubscriberTest.java
+++ b/server/task/task-distributed/src/test/java/org/apache/james/task/eventsourcing/distributed/RabbitMQTerminationSubscriberTest.java
@@ -31,8 +31,10 @@ import static org.awaitility.Duration.TEN_SECONDS;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.IntStream;
 
 import org.apache.james.backends.rabbitmq.RabbitMQExtension;
@@ -123,12 +125,11 @@ class RabbitMQTerminationSubscriberTest implements TerminationSubscriberContract
 
         sendEvents(subscriber1, COMPLETED_EVENT);
 
-        List<Event> receivedEventsFirst = new ArrayList<>();
+        Collection<Event> receivedEventsFirst = new ConcurrentLinkedQueue<>();
         firstListener.subscribe(receivedEventsFirst::add);
 
         await().atMost(ONE_MINUTE).untilAsserted(() ->
-            SoftAssertions.assertSoftly(soft -> {
-                assertThat(receivedEventsFirst).containsExactly(COMPLETED_EVENT);
-            }));
+            SoftAssertions.assertSoftly(soft ->
+                assertThat(receivedEventsFirst).containsExactly(COMPLETED_EVENT)));
     }
 }


### PR DESCRIPTION
We should enforce the use of thread safe collections to prevent unlikely runtime failures
(ConcurrentModificationException)