### PR TITLE
JAMES-3357 Mailbox/set creation response needs to display extension p…

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
@@ -311,6 +311,79 @@ trait MailboxSetMethodContract {
   }
 
   @Test
+  def createSHouldNotReturnSubscribeWhenSpecified(server: GuiceJamesServer): Unit = {
+    val request =
+      """
+        |{
+        |   "using": [ "urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail" ],
+        |   "methodCalls": [
+        |       [
+        |           "Mailbox/set",
+        |           {
+        |                "accountId": "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6",
+        |                "create": {
+        |                    "C42": {
+        |                      "name": "myMailbox",
+        |                      "isSubscribed": true
+        |                    }
+        |                }
+        |           },
+        |    "c1"
+        |       ]
+        |   ]
+        |}
+        |""".stripMargin
+
+    val response = `given`
+      .header(ACCEPT.toString, ACCEPT_RFC8621_VERSION_HEADER)
+      .body(request)
+    .when
+      .post
+    .`then`
+      .log().ifValidationFails()
+      .statusCode(SC_OK)
+      .contentType(JSON)
+      .extract
+      .body
+      .asString
+
+    val mailboxId: String = server.getProbe(classOf[MailboxProbeImpl])
+      .getMailboxId("#private", BOB.asString(), "myMailbox")
+      .serialize()
+
+    assertThatJson(response).isEqualTo(
+      s"""{
+         |	"sessionState": "75128aab4b1b",
+         |	"methodResponses": [
+         |		["Mailbox/set", {
+         |			"accountId": "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6",
+         |			"newState": "000001",
+         |			"created": {
+         |				"C42": {
+         |					"id": "${mailboxId}",
+         |					"totalEmails": 0,
+         |					"unreadEmails": 0,
+         |					"totalThreads": 0,
+         |					"unreadThreads": 0,
+         |					"myRights": {
+         |						"mayReadItems": true,
+         |						"mayAddItems": true,
+         |						"mayRemoveItems": true,
+         |						"maySetSeen": true,
+         |						"maySetKeywords": true,
+         |						"mayCreateChild": true,
+         |						"mayRename": true,
+         |						"mayDelete": true,
+         |						"maySubmit": true
+         |					}
+         |				}
+         |			}
+         |		}, "c1"]
+         |	]
+         |}""".stripMargin)
+  }
+
+  @Test
   def mailboxSetShouldNotSubscribeMailboxWhenRequired(server: GuiceJamesServer): Unit = {
     val request =
       """

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxSetMethodContract.scala
@@ -361,6 +361,7 @@ trait MailboxSetMethodContract {
          |			"created": {
          |				"C42": {
          |					"id": "${mailboxId}",
+         |          "sortOrder":1000,
          |					"totalEmails": 0,
          |					"unreadEmails": 0,
          |					"totalThreads": 0,
@@ -1034,6 +1035,7 @@ trait MailboxSetMethodContract {
          |      "created": {
          |        "C42": {
          |          "id": "$mailboxId",
+         |          "sortOrder":1000,
          |          "isSubscribed":true,
          |          "myRights":{"mayAddItems":true,"mayCreateChild":true,"mayDelete":true,"mayReadItems":true,"mayRemoveItems":true,"mayRename":true,"maySetKeywords":true,"maySetSeen":true,"maySubmit":true},
          |          "totalEmails":0,

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/MailboxSet.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/MailboxSet.scala
@@ -134,7 +134,7 @@ case class MailboxCreationResponse(id: MailboxId,
                                    unreadThreads: UnreadThreads,
                                    myRights: MailboxRights,
                                    quotas: Option[Quotas],
-                                   isSubscribed: IsSubscribed)
+                                   isSubscribed: Option[IsSubscribed])
 
 object MailboxSetResponse {
   def empty: MailboxUpdateResponse = MailboxUpdateResponse(JsObject(Map[String, JsValue]()))

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/MailboxSet.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/MailboxSet.scala
@@ -110,7 +110,7 @@ case class MailboxSetError(`type`: SetErrorType, description: Option[SetErrorDes
 
 
 object MailboxCreationResponse {
-  def allProperties: Set[String] = Set("id", "role", "totalEmails", "unreadEmails",
+  def allProperties: Set[String] = Set("id", "sortOrder", "role", "totalEmails", "unreadEmails",
     "totalThreads", "unreadThreads", "myRights", "isSubscribed", "quotas")
 
   def propertiesFiltered(allowedCapabilities : Set[CapabilityIdentifier]) : Set[String] = {

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/MailboxSet.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/MailboxSet.scala
@@ -29,8 +29,9 @@ import eu.timepit.refined.string.StartsWith
 import org.apache.james.jmap.mail.MailboxName.MailboxName
 import org.apache.james.jmap.mail.MailboxPatchObject.MailboxPatchObjectKey
 import org.apache.james.jmap.mail.MailboxSetRequest.{MailboxCreationId, UnparsedMailboxId}
-import org.apache.james.jmap.model.AccountId
+import org.apache.james.jmap.model.CapabilityIdentifier.CapabilityIdentifier
 import org.apache.james.jmap.model.State.State
+import org.apache.james.jmap.model.{AccountId, CapabilityIdentifier}
 import org.apache.james.mailbox.Role
 import org.apache.james.mailbox.model.MailboxId
 import play.api.libs.json.{JsObject, JsString, JsValue}
@@ -107,19 +108,33 @@ object MailboxSetError {
 
 case class MailboxSetError(`type`: SetErrorType, description: Option[SetErrorDescription], properties: Option[Properties])
 
+
+object MailboxCreationResponse {
+  def allProperties: Set[String] = Set("id", "role", "totalEmails", "unreadEmails",
+    "totalThreads", "unreadThreads", "myRights", "isSubscribed", "quotas")
+
+  def propertiesFiltered(allowedCapabilities : Set[CapabilityIdentifier]) : Set[String] = {
+    val propertiesForCapabilities: Map[CapabilityIdentifier, Set[String]] = Map(
+      CapabilityIdentifier.JAMES_QUOTA -> Set("quotas"))
+
+    val propertiesToHide = propertiesForCapabilities.filterNot(entry => allowedCapabilities.contains(entry._1))
+      .flatMap(_._2)
+      .toSet
+
+    allProperties -- propertiesToHide
+  }
+}
+
 case class MailboxCreationResponse(id: MailboxId,
-                                   role: Option[Role],//TODO see if we need to return this, if a role is set by the server during creation
+                                   role: Option[Role],
                                    sortOrder: SortOrder,
                                    totalEmails: TotalEmails,
                                    unreadEmails: UnreadEmails,
                                    totalThreads: TotalThreads,
                                    unreadThreads: UnreadThreads,
                                    myRights: MailboxRights,
-                                   rights: Option[Rights],//TODO display only if RightsExtension and if some rights are set by the server during creation
-                                   namespace: Option[MailboxNamespace], //TODO display only if RightsExtension
-                                   quotas: Option[Quotas],//TODO display only if QuotasExtension
-                                   isSubscribed: IsSubscribed
-                                  )
+                                   quotas: Option[Quotas],
+                                   isSubscribed: IsSubscribed)
 
 object MailboxSetResponse {
   def empty: MailboxUpdateResponse = MailboxUpdateResponse(JsObject(Map[String, JsValue]()))

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetMethod.scala
@@ -28,6 +28,7 @@ import org.apache.james.jmap.model.CapabilityIdentifier.CapabilityIdentifier
 import org.apache.james.jmap.model.Invocation.{Arguments, MethodName}
 import org.apache.james.jmap.model.{ClientId, Id, Invocation, ServerId, State}
 import org.apache.james.jmap.routes.ProcessingContext
+import org.apache.james.jmap.utils.quotas.QuotaLoaderWithPreloadedDefaultFactory
 import org.apache.james.mailbox.MailboxManager.RenameOption
 import org.apache.james.mailbox.exception.{InsufficientRightsException, MailboxExistsException, MailboxNameException, MailboxNotFoundException}
 import org.apache.james.mailbox.model.{FetchGroup, MailboxId, MailboxPath, MessageRange}
@@ -48,7 +49,7 @@ case class MailboxCreationParseException(mailboxSetError: MailboxSetError) exten
 sealed trait CreationResult {
   def mailboxCreationId: MailboxCreationId
 }
-case class CreationSuccess(mailboxCreationId: MailboxCreationId, mailboxId: MailboxId) extends CreationResult
+case class CreationSuccess(mailboxCreationId: MailboxCreationId, mailboxCreationResponse: MailboxCreationResponse) extends CreationResult
 case class CreationFailure(mailboxCreationId: MailboxCreationId, exception: Exception) extends CreationResult {
   def asMailboxSetError: MailboxSetError = exception match {
     case e: MailboxNotFoundException => MailboxSetError.invalidArgument(Some(SetErrorDescription(e.getMessage)), Some(Properties(List("parentId"))))
@@ -62,25 +63,11 @@ case class CreationFailure(mailboxCreationId: MailboxCreationId, exception: Exce
 case class CreationResults(created: Seq[CreationResult]) {
   def retrieveCreated: Map[MailboxCreationId, MailboxCreationResponse] = created
     .flatMap(result => result match {
-      case success: CreationSuccess => Some(success.mailboxCreationId, success.mailboxId)
+      case success: CreationSuccess => Some(success.mailboxCreationId, success.mailboxCreationResponse)
       case _ => None
     })
     .toMap
-    .map(creation => (creation._1, toCreationResponse(creation._2)))
-
-  private def toCreationResponse(mailboxId: MailboxId): MailboxCreationResponse = MailboxCreationResponse(
-    id = mailboxId,
-    role = None,
-    sortOrder = SortOrder.defaultSortOrder,
-    totalEmails = TotalEmails(0L),
-    unreadEmails = UnreadEmails(0L),
-    totalThreads = TotalThreads(0L),
-    unreadThreads = UnreadThreads(0L),
-    myRights = MailboxRights.FULL,
-    rights = None,
-    namespace = None,
-    quotas = None,
-    isSubscribed = IsSubscribed(true))
+    .map(creation => (creation._1, creation._2))
 
   def retrieveErrors: Map[MailboxCreationId, MailboxSetError] = created
     .flatMap(result => result match {
@@ -147,6 +134,7 @@ class MailboxSetMethod @Inject()(serializer: Serializer,
                                  mailboxManager: MailboxManager,
                                  subscriptionManager: SubscriptionManager,
                                  mailboxIdFactory: MailboxId.Factory,
+                                 quotaFactory : QuotaLoaderWithPreloadedDefaultFactory,
                                  metricFactory: MetricFactory) extends Method {
   override val methodName: MethodName = MethodName("Mailbox/set")
 
@@ -158,7 +146,7 @@ class MailboxSetMethod @Inject()(serializer: Serializer,
             creationResults <- createMailboxes(mailboxSession, mailboxSetRequest, processingContext)
             deletionResults <- deleteMailboxes(mailboxSession, mailboxSetRequest, processingContext)
             updateResults <- updateMailboxes(mailboxSession, mailboxSetRequest, processingContext)
-          } yield createResponse(invocation, mailboxSetRequest, creationResults, deletionResults, updateResults)
+          } yield createResponse(capabilities, invocation, mailboxSetRequest, creationResults, deletionResults, updateResults)
         }))
   }
 
@@ -296,9 +284,9 @@ class MailboxSetMethod @Inject()(serializer: Serializer,
           path = path,
           mailboxCreationRequest = mailboxCreationRequest)))
       .fold(e => CreationFailure(mailboxCreationId, e),
-        mailboxId => {
-          recordCreationIdInProcessingContext(mailboxCreationId, processingContext, mailboxId)
-          CreationSuccess(mailboxCreationId, mailboxId)
+        creationResponse => {
+          recordCreationIdInProcessingContext(mailboxCreationId, processingContext, creationResponse.id)
+          CreationSuccess(mailboxCreationId, creationResponse)
         })
   }
 
@@ -318,7 +306,7 @@ class MailboxSetMethod @Inject()(serializer: Serializer,
 
   private def createMailbox(mailboxSession: MailboxSession,
                             path: MailboxPath,
-                            mailboxCreationRequest: MailboxCreationRequest): Either[Exception, MailboxId] = {
+                            mailboxCreationRequest: MailboxCreationRequest): Either[Exception, MailboxCreationResponse] = {
     try {
       //can safely do a get as the Optional is empty only if the mailbox name is empty which is forbidden by the type constraint on MailboxName
       val mailboxId = mailboxManager.createMailbox(path, mailboxSession).get()
@@ -330,7 +318,21 @@ class MailboxSetMethod @Inject()(serializer: Serializer,
       mailboxCreationRequest.rights
           .foreach(rights => mailboxManager.setRights(mailboxId, rights.toMailboxAcl.asJava, mailboxSession))
 
-      Right(mailboxId)
+      val quotas = quotaFactory.loadFor(mailboxSession)
+        .flatMap(quotaLoader => quotaLoader.getQuotas(path))
+        .block()
+
+      Right(MailboxCreationResponse(
+        id = mailboxId,
+        sortOrder = SortOrder.defaultSortOrder,
+        role = None,
+        totalEmails = TotalEmails(0L),
+        unreadEmails = UnreadEmails(0L),
+        totalThreads = TotalThreads(0L),
+        unreadThreads = UnreadThreads(0L),
+        myRights = MailboxRights.FULL,
+        quotas = Some(quotas),
+        isSubscribed = IsSubscribed(true)))
     } catch {
       case error: Exception => Left(error)
     }
@@ -366,7 +368,8 @@ class MailboxSetMethod @Inject()(serializer: Serializer,
       case e: Exception => Left(e)
     }
 
-  private def createResponse(invocation: Invocation,
+  private def createResponse(capabilities: Set[CapabilityIdentifier],
+                             invocation: Invocation,
                              mailboxSetRequest: MailboxSetRequest,
                              creationResults: CreationResults,
                              deletionResults: DeletionResults,
@@ -383,7 +386,7 @@ class MailboxSetMethod @Inject()(serializer: Serializer,
       notDestroyed = Some(deletionResults.retrieveErrors).filter(_.nonEmpty))
     
     Invocation(methodName,
-      Arguments(serializer.serialize(response).as[JsObject]),
+      Arguments(serializer.serialize(response, capabilities).as[JsObject]),
       invocation.methodCallId)
   }
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxSetMethod.scala
@@ -311,7 +311,8 @@ class MailboxSetMethod @Inject()(serializer: Serializer,
       //can safely do a get as the Optional is empty only if the mailbox name is empty which is forbidden by the type constraint on MailboxName
       val mailboxId = mailboxManager.createMailbox(path, mailboxSession).get()
 
-      if (mailboxCreationRequest.isSubscribed.getOrElse(IsSubscribed(true)).value) {
+      val defaultSubscribed = IsSubscribed(true)
+      if (mailboxCreationRequest.isSubscribed.getOrElse(defaultSubscribed).value) {
         subscriptionManager.subscribe(mailboxSession, path.getName)
       }
 
@@ -332,7 +333,11 @@ class MailboxSetMethod @Inject()(serializer: Serializer,
         unreadThreads = UnreadThreads(0L),
         myRights = MailboxRights.FULL,
         quotas = Some(quotas),
-        isSubscribed = IsSubscribed(true)))
+        isSubscribed =  if (mailboxCreationRequest.isSubscribed.isEmpty) {
+          Some(defaultSubscribed)
+        } else {
+          None
+        }))
     } catch {
       case error: Exception => Left(error)
     }


### PR DESCRIPTION
…roperties

Note that rights are explicitly specified by the client, or empty, thus never needs to be returned.

Roles also always are empty as the user cannot create system mailboxes, that are automatically provisionned.