### PR TITLE
JAMES-3364 DeletedMessageVault: deleting many messages dead-locks

### DIFF
--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/DeletedMessageVaultHook.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/DeletedMessageVaultHook.java
@@ -146,19 +146,13 @@ public class DeletedMessageVaultHook implements PreDeletionHook {
     private Flux<DeletedMessageMailboxContext> groupMetadataByOwnerAndMessageId(DeleteOperation deleteOperation) {
         return Flux.fromIterable(deleteOperation.getDeletionMetadataList())
             .groupBy(MetadataWithMailboxId::getMailboxId)
-            .flatMap(this::addOwnerToMetadata)
-            .groupBy(this::toMessageIdUserPair)
-            .flatMap(groupFlux -> groupFlux.reduce(DeletedMessageMailboxContext::combine));
+            .flatMap(this::addOwnerToMetadata);
     }
 
     private Flux<DeletedMessageMailboxContext> addOwnerToMetadata(GroupedFlux<MailboxId, MetadataWithMailboxId> groupedFlux) {
         return retrieveMailboxUser(groupedFlux.key())
             .flatMapMany(owner -> groupedFlux.map(metadata ->
                 new DeletedMessageMailboxContext(metadata.getMessageMetaData().getMessageId(), owner, ImmutableList.of(metadata.getMailboxId()))));
-    }
-
-    private Pair<MessageId, Username> toMessageIdUserPair(DeletedMessageMailboxContext deletedMessageMetadata) {
-        return Pair.of(deletedMessageMetadata.getMessageId(), deletedMessageMetadata.getOwner());
     }
 
     private Mono<Username> retrieveMailboxUser(MailboxId mailboxId) {

--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/DeletedMessageVaultHook.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/DeletedMessageVaultHook.java
@@ -50,19 +50,6 @@ import reactor.core.publisher.Mono;
 
 public class DeletedMessageVaultHook implements PreDeletionHook {
     static class DeletedMessageMailboxContext {
-        private static DeletedMessageMailboxContext combine(DeletedMessageMailboxContext first, DeletedMessageMailboxContext second) {
-            Preconditions.checkArgument(first.messageId.equals(second.getMessageId()));
-            Preconditions.checkArgument(first.owner.equals(second.getOwner()));
-
-            return new DeletedMessageMailboxContext(
-                first.messageId,
-                first.owner,
-                ImmutableList.<MailboxId>builder()
-                    .addAll(first.ownerMailboxes)
-                    .addAll(second.ownerMailboxes)
-                    .build());
-        }
-
         private final MessageId messageId;
         private final Username owner;
         private final List<MailboxId> ownerMailboxes;

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageVaultHookTest.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageVaultHookTest.java
@@ -167,7 +167,7 @@ class DeletedMessageVaultHookTest {
     }
 
     @Test
-    void deletingManyMessagesSHouldSucceed() throws Exception {
+    void deletingManyMessagesShouldSucceed() throws Exception {
         MailboxId aliceMailbox = mailboxManager.createMailbox(MAILBOX_ALICE_ONE, aliceSession).get();
         MessageManager messageManager = mailboxManager.getMailbox(aliceMailbox, aliceSession);
 

--- a/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageVaultHookTest.java
+++ b/mailbox/plugin/deleted-messages-vault/src/test/java/org/apache/james/vault/DeletedMessageVaultHookTest.java
@@ -23,11 +23,13 @@ import static org.apache.james.vault.DeletedMessageFixture.DELETION_DATE;
 import static org.apache.james.vault.DeletedMessageFixture.DELIVERY_DATE;
 import static org.apache.james.vault.DeletedMessageFixture.INTERNAL_DATE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import org.apache.james.blob.api.HashBlobId;
 import org.apache.james.blob.memory.MemoryDumbBlobStore;
@@ -58,6 +60,7 @@ import org.apache.james.vault.search.Query;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.github.fge.lambdas.Throwing;
 import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
@@ -161,6 +164,19 @@ class DeletedMessageVaultHookTest {
         DeletedMessage deletedMessage = buildDeletedMessage(ImmutableList.of(aliceMailbox), messageId, ALICE, messageSize);
         assertThat(Flux.from(messageVault.search(ALICE, Query.ALL)).blockFirst())
             .isEqualTo(deletedMessage);
+    }
+
+    @Test
+    void deletingManyMessagesSHouldSucceed() throws Exception {
+        MailboxId aliceMailbox = mailboxManager.createMailbox(MAILBOX_ALICE_ONE, aliceSession).get();
+        MessageManager messageManager = mailboxManager.getMailbox(aliceMailbox, aliceSession);
+
+        ImmutableList<MessageId> ids = IntStream.range(0, 1000)
+            .mapToObj(Throwing.intFunction(i -> appendMessage(messageManager).getMessageId()))
+            .collect(Guavate.toImmutableList());
+
+        assertThatCode(() -> messageIdManager.delete(ids, aliceSession))
+            .doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION


== Symptoms

When deleting ~1000 messages at once with the deletedMessage vault enabled, the deletion dead-locks and never completes.

== Fix

The deleted message vault goup bys deleted entries when retrieving the username associated with a mailbox (performance purposes) then groups the mailboxIds together for a given messageId.

These too groupBys steps proved to be failing.

Getting read of the second groupbys eventually solve the dead lock issues.

Drawback: if a message is referenced in several mailboxes at once, we expect it to be inserted several time in the (indempotent) deleted message vault, leading to a performance penalty. However this is a rare unexpected corner case, and it looks like premature optimization.
