### PR TITLE
JAMES-2725 Specify length when available when uploading blobs to AWS

### DIFF
--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/BlobPutter.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/BlobPutter.java
@@ -20,6 +20,7 @@
 package org.apache.james.blob.objectstorage;
 
 import java.io.Closeable;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.apache.james.blob.api.BlobId;
@@ -39,7 +40,7 @@ import reactor.core.publisher.Mono;
 
 public interface BlobPutter extends Closeable {
 
-    Mono<Void> putDirectly(ObjectStorageBucketName bucketName, Blob blob);
+    Mono<Void> putDirectly(ObjectStorageBucketName bucketName, Blob blob, Optional<Long> length);
 
     Mono<BlobId> putAndComputeId(ObjectStorageBucketName bucketName, Blob initialBlob, Supplier<BlobId> blobIdSupplier);
 }

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobStore.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/ObjectStorageBlobStore.java
@@ -105,12 +105,13 @@ public class ObjectStorageBlobStore implements BlobStore {
             .flatMap(blobId -> {
                 Payload payload = payloadCodec.write(data);
 
+                Long length = payload.getLength().orElse(Long.valueOf(data.length));
                 Blob blob = blobStore.blobBuilder(blobId.asString())
                     .payload(payload.getPayload())
-                    .contentLength(payload.getLength().orElse(Long.valueOf(data.length)))
+                    .contentLength(length)
                     .build();
 
-                return blobPutter.putDirectly(resolvedBucketName, blob)
+                return blobPutter.putDirectly(resolvedBucketName, blob, Optional.of(length))
                     .thenReturn(blobId);
             });
     }

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/StreamCompatibleBlobPutter.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/StreamCompatibleBlobPutter.java
@@ -51,7 +51,7 @@ public class StreamCompatibleBlobPutter implements BlobPutter {
     }
 
     @Override
-    public Mono<Void> putDirectly(ObjectStorageBucketName bucketName, Blob blob) {
+    public Mono<Void> putDirectly(ObjectStorageBucketName bucketName, Blob blob, Optional<Long> length) {
         return Mono.fromRunnable(() -> blobStore.putBlob(bucketName.asString(), blob))
             .publishOn(Schedulers.elastic())
             .retryWhen(Retry
@@ -67,7 +67,7 @@ public class StreamCompatibleBlobPutter implements BlobPutter {
 
     @Override
     public Mono<BlobId> putAndComputeId(ObjectStorageBucketName bucketName, Blob initialBlob, Supplier<BlobId> blobIdSupplier) {
-        return putDirectly(bucketName, initialBlob)
+        return putDirectly(bucketName, initialBlob, Optional.empty())
             .then(Mono.fromCallable(blobIdSupplier::get))
             .map(blobId -> updateBlobId(bucketName, initialBlob.getMetadata().getName(), blobId));
     }

--- a/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/aws/AwsS3ObjectStorage.java
+++ b/server/blob/blob-objectstorage/src/main/java/org/apache/james/blob/objectstorage/aws/AwsS3ObjectStorage.java
@@ -146,8 +146,8 @@ public class AwsS3ObjectStorage {
         }
 
         @Override
-        public Mono<Void> putDirectly(ObjectStorageBucketName bucketName, Blob blob) {
-            return putWithRetry(bucketName, () -> uploadByBlob(bucketName, blob));
+        public Mono<Void> putDirectly(ObjectStorageBucketName bucketName, Blob blob, Optional<Long> length) {
+            return putWithRetry(bucketName, () -> uploadByBlob(bucketName, blob, length));
         }
 
         @Override
@@ -191,12 +191,14 @@ public class AwsS3ObjectStorage {
             upload(request);
         }
 
-        private void uploadByBlob(ObjectStorageBucketName bucketName, Blob blob) throws InterruptedException, IOException {
+        private void uploadByBlob(ObjectStorageBucketName bucketName, Blob blob, Optional<Long> length) throws InterruptedException, IOException {
             try (InputStream payload = blob.getPayload().openStream()) {
+                ObjectMetadata objectMetadata = new ObjectMetadata();
+                length.ifPresent(objectMetadata::setContentLength);
                 PutObjectRequest request = new PutObjectRequest(bucketName.asString(),
                     blob.getMetadata().getName(),
                     payload,
-                    new ObjectMetadata());
+                    objectMetadata);
 
                 upload(request);
             }


### PR DESCRIPTION
Otherwise we get these worrying blobs:

```
[WARN ] c.a.s.s.AmazonS3Client - No content length specified for stream data.  Stream contents will be buffered in memory and could result in out of memory errors.
```

Cc @rouazana 