### PR TITLE
[Security fix] Upgrade org.apache.ant:ant from 1.10.6 to 1.10.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2281,7 +2281,7 @@
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
-                <version>1.10.6</version>
+                <version>1.10.8</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.ant</groupId>


### PR DESCRIPTION
=> https://github.com/linagora/james-project/network/alert/pom.xml/org.apache.ant:ant/open

CVE-2020-1945
moderate severity
Vulnerable versions: >= 1.10.0, < 1.10.8
Patched version: 1.10.8

Apache Ant 1.1 to 1.9.14 and 1.10.0 to 1.10.7 uses the default temporary directory identified by the Java system property java.io.tmpdir for several tasks and may thus leak sensitive information. The fixcrlf and replaceregexp tasks also copy files from the temporary directory back into the build tree allowing an attacker to inject modified source files into the build process.