### PR TITLE
MAILBOX-392 Relax mailbox name constraint regarding '&'

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxPath.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxPath.java
@@ -62,7 +62,7 @@ public class MailboxPath {
         return new MailboxPath(MailboxConstants.USER_NAMESPACE, username, mailboxName);
     }
 
-    private static final String INVALID_CHARS = "%*&#";
+    private static final String INVALID_CHARS = "%*#";
     private static final CharMatcher INVALID_CHARS_MATCHER = CharMatcher.anyOf(INVALID_CHARS);
     // This is the size that all mailbox backend should support
     public  static final int MAX_MAILBOX_NAME_LENGTH = 200;

--- a/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxPathTest.java
+++ b/mailbox/api/src/test/java/org/apache/james/mailbox/model/MailboxPathTest.java
@@ -250,13 +250,6 @@ class MailboxPathTest {
     }
 
     @Test
-    void assertAcceptableShouldThrowOnAnd() {
-        assertThatThrownBy(() -> MailboxPath.forUser(USER, "a&b")
-                .assertAcceptable('.'))
-            .isInstanceOf(MailboxNameException.class);
-    }
-
-    @Test
     void assertAcceptableShouldThrowOnSharp() {
         assertThatThrownBy(() -> MailboxPath.forUser(USER, "a#b")
                 .assertAcceptable('.'))

--- a/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/imapmailbox/suite/Listing.java
+++ b/mpt/impl/imap-mailbox/core/src/main/java/org/apache/james/mpt/imapmailbox/suite/Listing.java
@@ -32,8 +32,8 @@ public abstract class Listing implements ImapTestConstants {
 
     protected abstract ImapHostSystem createImapHostSystem();
     
-    private ImapHostSystem system;
-    private SimpleScriptedTestProtocol simpleScriptedTestProtocol;
+    protected ImapHostSystem system;
+    protected SimpleScriptedTestProtocol simpleScriptedTestProtocol;
 
     @Before
     public void setUp() throws Exception {

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/ListSpecialChar.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/ListSpecialChar.test
@@ -1,0 +1,26 @@
+################################################################
+# Licensed to the Apache Software Foundation (ASF) under one   #
+# or more contributor license agreements.  See the NOTICE file #
+# distributed with this work for additional information        #
+# regarding copyright ownership.  The ASF licenses this file   #
+# to you under the Apache License, Version 2.0 (the            #
+# "License"); you may not use this file except in compliance   #
+# with the License.  You may obtain a copy of the License at   #
+#                                                              #
+#   http://www.apache.org/licenses/LICENSE-2.0                 #
+#                                                              #
+# Unless required by applicable law or agreed to in writing,   #
+# software distributed under the License is distributed on an  #
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       #
+# KIND, either express or implied.  See the License for the    #
+# specific language governing permissions and limitations      #
+# under the License.                                           #
+################################################################
+
+
+C: a3 LIST "" *
+SUB {
+S: \* LIST \(\\HasNoChildren\) \"\.\" \"INBOX\"
+S: \* LIST \(\\HasNoChildren\) \"\.\" \"projects &- abc\"
+}
+S: a3 OK LIST completed.

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/ListSpecialChar.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/ListSpecialChar.test
@@ -22,5 +22,6 @@ C: a3 LIST "" *
 SUB {
 S: \* LIST \(\\HasNoChildren\) \"\.\" \"INBOX\"
 S: \* LIST \(\\HasNoChildren\) \"\.\" \"projects &- abc\"
+S: \* LIST \(\\HasNoChildren\) \"\.\" \"&AOk-valuations\"
 }
 S: a3 OK LIST completed.

--- a/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/InMemoryListingTest.java
+++ b/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/InMemoryListingTest.java
@@ -19,10 +19,14 @@
 
 package org.apache.james.mpt.imapmailbox.inmemory;
 
+import java.util.Locale;
+
+import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mpt.api.ImapHostSystem;
 import org.apache.james.mpt.imapmailbox.inmemory.host.InMemoryHostSystem;
 import org.apache.james.mpt.imapmailbox.suite.Listing;
 import org.junit.Before;
+import org.junit.Test;
 
 public class InMemoryListingTest extends Listing {
 
@@ -40,5 +44,15 @@ public class InMemoryListingTest extends Listing {
     protected ImapHostSystem createImapHostSystem() {
         return system;
     }
-    
+
+
+    @Test
+    public void listShouldUTF7EscapeSpecialChar() throws Exception {
+        system.createMailbox(MailboxPath.forUser(USER, "projects & abc"));
+
+        simpleScriptedTestProtocol
+            .withLocale(Locale.KOREA)
+            .run("ListSpecialChar");
+    }
+
 }

--- a/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/InMemoryListingTest.java
+++ b/mpt/impl/imap-mailbox/inmemory/src/test/java/org/apache/james/mpt/imapmailbox/inmemory/InMemoryListingTest.java
@@ -49,6 +49,7 @@ public class InMemoryListingTest extends Listing {
     @Test
     public void listShouldUTF7EscapeSpecialChar() throws Exception {
         system.createMailbox(MailboxPath.forUser(USER, "projects & abc"));
+        system.createMailbox(MailboxPath.forUser(USER, "évaluations"));
 
         simpleScriptedTestProtocol
             .withLocale(Locale.KOREA)

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -321,7 +321,7 @@ class UserMailboxesRoutesTest {
                 .containsEntry("statusCode", BAD_REQUEST_400)
                 .containsEntry("type", "InvalidArgument")
                 .containsEntry("message", "Attempt to create an invalid mailbox")
-                .containsEntry("details", "#private:username:myMailboxName# contains one of the forbidden characters %*&#");
+                .containsEntry("details", "#private:username:myMailboxName# contains one of the forbidden characters %*#");
         }
 
         @Test
@@ -361,7 +361,7 @@ class UserMailboxesRoutesTest {
                 .containsEntry("statusCode", BAD_REQUEST_400)
                 .containsEntry("type", "InvalidArgument")
                 .containsEntry("message", "Attempt to test existence of an invalid mailbox")
-                .containsEntry("details", "#private:username:myMailboxName* contains one of the forbidden characters %*&#");
+                .containsEntry("details", "#private:username:myMailboxName* contains one of the forbidden characters %*#");
         }
 
         @Test
@@ -416,7 +416,7 @@ class UserMailboxesRoutesTest {
                 .containsEntry("statusCode", BAD_REQUEST_400)
                 .containsEntry("type", "InvalidArgument")
                 .containsEntry("message", "Attempt to test existence of an invalid mailbox")
-                .containsEntry("details", "#private:username:myMailboxName% contains one of the forbidden characters %*&#");
+                .containsEntry("details", "#private:username:myMailboxName% contains one of the forbidden characters %*#");
         }
 
         @Test
@@ -471,7 +471,7 @@ class UserMailboxesRoutesTest {
                 .containsEntry("statusCode", BAD_REQUEST_400)
                 .containsEntry("type", "InvalidArgument")
                 .containsEntry("message", "Attempt to test existence of an invalid mailbox")
-                .containsEntry("details", "#private:username:myMailboxName# contains one of the forbidden characters %*&#");
+                .containsEntry("details", "#private:username:myMailboxName# contains one of the forbidden characters %*#");
         }
 
         @Test
@@ -511,58 +511,28 @@ class UserMailboxesRoutesTest {
         }
 
         @Test
-        void getShouldReturnUserErrorWithInvalidAndMailboxName() throws Exception {
-            Map<String, Object> errors = when()
+        void getShouldReturnNotFoundWithAndMailboxName() throws Exception {
+            when()
                 .get(MAILBOX_NAME + "&")
             .then()
-                .statusCode(BAD_REQUEST_400)
-                .contentType(JSON)
-                .extract()
-                .body()
-                .jsonPath()
-                .getMap(".");
-
-            assertThat(errors)
-                .containsEntry("statusCode", BAD_REQUEST_400)
-                .containsEntry("type", "InvalidArgument")
-                .containsEntry("message", "Attempt to test existence of an invalid mailbox")
-                .containsEntry("details", "#private:username:myMailboxName& contains one of the forbidden characters %*&#");
+                .statusCode(NOT_FOUND_404);
         }
 
         @Test
-        void putShouldReturnUserErrorWithInvalidAndMailboxName() throws Exception {
-            Map<String, Object> errors = when()
+        void putShouldReturnSuccessWithAndMailboxName() throws Exception {
+            when()
                 .put(MAILBOX_NAME + "&")
             .then()
-                .statusCode(BAD_REQUEST_400)
-                .contentType(JSON)
-                .extract()
-                .body()
-                .jsonPath()
-                .getMap(".");
-
-            assertThat(errors)
-                .containsEntry("statusCode", BAD_REQUEST_400)
-                .containsEntry("type", "InvalidArgument")
-                .containsEntry("message", "Attempt to create an invalid mailbox");
+                .statusCode(NO_CONTENT_204);
         }
 
         @Test
-        void deleteShouldReturnUserErrorWithInvalidAndMailboxName() throws Exception {
-            Map<String, Object> errors = when()
+        void deleteShouldReturnSuccessWithAndMailboxName() throws Exception {
+            when()
                 .put(MAILBOX_NAME + "&")
             .then()
-                .statusCode(BAD_REQUEST_400)
-                .contentType(JSON)
-                .extract()
-                .body()
-                .jsonPath()
-                .getMap(".");
-
-            assertThat(errors)
-                .containsEntry("statusCode", BAD_REQUEST_400)
-                .containsEntry("type", "InvalidArgument")
-                .containsEntry("message", "Attempt to create an invalid mailbox");
+                .statusCode(NO_CONTENT_204)
+                .contentType(JSON);
         }
 
         @Test


### PR DESCRIPTION
As per RFC-XXX '&' character can be escaped

```
   In modified UTF-7, printable US-ASCII characters except for "&"
   represent themselves; that is, characters with octet values 0x20-0x25
   and 0x27-0x7e.  The character "&" (0x26) is represented by the two-
   octet sequence "&-".
```

As such, the '&' don't need to be forbidden in mailbox name.

This caused issue during some data migration as the use of & in folder names is popular.