### PR TITLE
JAMES-3380 use non am/pm dependent hour format

### DIFF
--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/MessageSearches.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/search/MessageSearches.java
@@ -635,20 +635,20 @@ public class MessageSearches implements Iterable<SimpleMessageSearchIndex.Search
 
     private SimpleDateFormat createFormat(DateResolution dateResolution) {
         switch (dateResolution) {
-        case Year:
-            return new SimpleDateFormat("yyyy");
-        case Month:
-            return new SimpleDateFormat("yyyyMM");
-        case Day:
-            return new SimpleDateFormat("yyyyMMdd");
-        case Hour:
-            return new SimpleDateFormat("yyyyMMddhh");
-        case Minute:
-            return new SimpleDateFormat("yyyyMMddhhmm");
-        case Second:
-            return new SimpleDateFormat("yyyyMMddhhmmss");
-        default:
-            return new SimpleDateFormat("yyyyMMddhhmmssSSS");
+            case Year:
+                return new SimpleDateFormat("yyyy");
+            case Month:
+                return new SimpleDateFormat("yyyyMM");
+            case Day:
+                return new SimpleDateFormat("yyyyMMdd");
+            case Hour:
+                return new SimpleDateFormat("yyyyMMddkk");
+            case Minute:
+                return new SimpleDateFormat("yyyyMMddkkmm");
+            case Second:
+                return new SimpleDateFormat("yyyyMMddkkmmss");
+            default:
+                return new SimpleDateFormat("yyyyMMddkkmmssSSS");
         }
     }
 


### PR DESCRIPTION


The date format used to compare the date in order to sort them, used 'hh' in the date format to represent the hour instead of 'kk'.
https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html
So one date in the afternoon could not be compared with a date in the morning.

This leads to error in the memory implementation. And some flacky test passing at certain hours but not others...
