### PR TITLE
JAMES-3383: Email/Query expose allowed sort in accountCapabilities

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/SessionRoutesContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/SessionRoutesContract.scala
@@ -56,7 +56,7 @@ object SessionRoutesContract {
                          |      "maxMailboxDepth" : null,
                          |      "maxSizeMailboxName" : 200,
                          |      "maxSizeAttachmentsPerEmail" : 20000000,
-                         |      "emailQuerySortOptions" : [ "receivedAt", "cc", "from", "to", "subject", "size", "sentAt", "hasKeyword", "uid", "Id" ],
+                         |      "emailQuerySortOptions" : ["receivedAt", "sentAt"],
                          |      "mayCreateTopLevelMailbox" : true
                          |    },
                          |    "urn:apache:james:params:jmap:mail:quota": {},
@@ -84,7 +84,7 @@ object SessionRoutesContract {
                          |          "maxMailboxDepth" : null,
                          |          "maxSizeMailboxName" : 200,
                          |          "maxSizeAttachmentsPerEmail" : 20000000,
-                         |          "emailQuerySortOptions" : [ "receivedAt", "cc", "from", "to", "subject", "size", "sentAt", "hasKeyword", "uid", "Id" ],
+                         |          "emailQuerySortOptions" : ["receivedAt", "sentAt"],
                          |          "mayCreateTopLevelMailbox" : true
                          |        },
                          |        "urn:apache:james:params:jmap:mail:quota": {},

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/Capabilities.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/Capabilities.scala
@@ -39,7 +39,7 @@ object DefaultCapabilities {
       MaxMailboxDepth(None),
       MaxSizeMailboxName(200L),
       MaxSizeAttachmentsPerEmail(20_000_000L),
-      emailQuerySortOptions = List("receivedAt", "cc", "from", "to", "subject", "size", "sentAt", "hasKeyword", "uid", "Id"),
+      emailQuerySortOptions = List("receivedAt", "sentAt"),
       MayCreateTopLevelMailbox(true)
     )
   )

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/http/SessionRoutesTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/http/SessionRoutesTest.scala
@@ -116,7 +116,7 @@ class SessionRoutesTest extends AnyFlatSpec with BeforeAndAfter with Matchers {
                          |      "maxMailboxDepth" : null,
                          |      "maxSizeMailboxName" : 200,
                          |      "maxSizeAttachmentsPerEmail" : 20000000,
-                         |      "emailQuerySortOptions" : [ "receivedAt", "cc", "from", "to", "subject", "size", "sentAt", "hasKeyword", "uid", "Id" ],
+                         |      "emailQuerySortOptions" : ["receivedAt", "sentAt"],
                          |      "mayCreateTopLevelMailbox" : true
                          |    },
                          |    "urn:apache:james:params:jmap:mail:quota": {},
@@ -144,7 +144,7 @@ class SessionRoutesTest extends AnyFlatSpec with BeforeAndAfter with Matchers {
                          |          "maxMailboxDepth" : null,
                          |          "maxSizeMailboxName" : 200,
                          |          "maxSizeAttachmentsPerEmail" : 20000000,
-                         |          "emailQuerySortOptions" : [ "receivedAt", "cc", "from", "to", "subject", "size", "sentAt", "hasKeyword", "uid", "Id" ],
+                         |          "emailQuerySortOptions" : ["receivedAt", "sentAt"],
                          |          "mayCreateTopLevelMailbox" : true
                          |        },
                          |        "urn:apache:james:params:jmap:mail:quota": {},


### PR DESCRIPTION
The works already done, just need to adjust the supported options for now:
"receivedAt", "sentAt"