### PR TITLE
 JAMES-3305 James do not start if eventBus workQueues don't rely on dead-letter

### DIFF
--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
@@ -37,13 +37,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.fge.lambdas.Throwing;
+import com.google.common.base.Preconditions;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ShutdownSignalException;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SignalType;
 import reactor.core.scheduler.Schedulers;
+import reactor.rabbitmq.BindingSpecification;
 import reactor.rabbitmq.ChannelPool;
+import reactor.rabbitmq.QueueSpecification;
 import reactor.rabbitmq.RabbitFlux;
 import reactor.rabbitmq.Receiver;
 import reactor.rabbitmq.ReceiverOptions;
@@ -234,6 +239,29 @@ public class ReactorRabbitMQChannelPool implements ChannelPool, Startable {
            .channelPool(this)
            .resourceManagementChannelMono(
                connectionMono.map(Throwing.function(Connection::createChannel)).cache()));
+    }
+
+    public Mono<Void> createWorkQueue(QueueSpecification queueSpecification, BindingSpecification bindingSpecification) {
+        Preconditions.checkArgument(queueSpecification.getName() != null, "WorkQueue pattern do not make sense for unamed queues");
+        Preconditions.checkArgument(queueSpecification.getName().equals(bindingSpecification.getQueue()),
+            "Binding needs to be targetting the created queue %s instead of %s",
+            queueSpecification.getName(), bindingSpecification.getQueue());
+
+        return Flux.concat(
+            Mono.using(this::createSender,
+                managementSender -> managementSender.declareQueue(queueSpecification),
+                Sender::close)
+                .onErrorResume(
+                    e -> e instanceof ShutdownSignalException
+                        && e.getMessage().contains("reply-code=406, reply-text=PRECONDITION_FAILED - inequivalent arg 'x-dead-letter-exchange' for queue"),
+                    e -> {
+                        LOGGER.warn("{} already exists without dead-letter setup. Dead lettered messages to it will be lost. " +
+                            "To solve this, re-create the queue with the x-dead-letter-exchange argument set up.",
+                            queueSpecification.getName());
+                        return Mono.empty();
+                    }),
+            sender.bind(bindingSpecification))
+            .then();
     }
 
     private void invalidateObject(Channel channel) {

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
@@ -242,7 +242,7 @@ public class ReactorRabbitMQChannelPool implements ChannelPool, Startable {
     }
 
     public Mono<Void> createWorkQueue(QueueSpecification queueSpecification, BindingSpecification bindingSpecification) {
-        Preconditions.checkArgument(queueSpecification.getName() != null, "WorkQueue pattern do not make sense for unamed queues");
+        Preconditions.checkArgument(queueSpecification.getName() != null, "WorkQueue pattern do not make sense for unnamed queues");
         Preconditions.checkArgument(queueSpecification.getName().equals(bindingSpecification.getQueue()),
             "Binding needs to be targetting the created queue %s instead of %s",
             queueSpecification.getName(), bindingSpecification.getQueue());

--- a/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/NetworkErrorTest.java
+++ b/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/NetworkErrorTest.java
@@ -1,0 +1,87 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.events;
+
+import static org.apache.james.mailbox.events.EventBusTestFixture.EVENT;
+import static org.apache.james.mailbox.events.EventBusTestFixture.GROUP_A;
+import static org.apache.james.mailbox.events.EventBusTestFixture.NO_KEYS;
+import static org.apache.james.mailbox.events.EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION;
+import static org.apache.james.mailbox.events.EventBusTestFixture.newListener;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+
+import org.apache.james.backends.rabbitmq.RabbitMQExtension;
+import org.apache.james.backends.rabbitmq.RabbitMQFixture;
+import org.apache.james.event.json.EventSerializer;
+import org.apache.james.mailbox.model.TestId;
+import org.apache.james.mailbox.model.TestMessageId;
+import org.apache.james.mailbox.store.quota.DefaultUserQuotaRootResolver;
+import org.apache.james.metrics.tests.RecordingMetricFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class NetworkErrorTest {
+    @RegisterExtension
+    static RabbitMQExtension rabbitMQExtension = RabbitMQExtension.singletonRabbitMQ()
+        .isolationPolicy(RabbitMQExtension.IsolationPolicy.WEAK);
+
+    private RabbitMQEventBus eventBus;
+
+    @BeforeEach
+    void setUp() {
+        MemoryEventDeadLetters memoryEventDeadLetters = new MemoryEventDeadLetters();
+
+        TestId.Factory mailboxIdFactory = new TestId.Factory();
+        EventSerializer eventSerializer = new EventSerializer(mailboxIdFactory, new TestMessageId.Factory(), new DefaultUserQuotaRootResolver.DefaultQuotaRootDeserializer());
+        RoutingKeyConverter routingKeyConverter = RoutingKeyConverter.forFactories(new MailboxIdRegistrationKey.Factory(mailboxIdFactory));
+
+        eventBus = new RabbitMQEventBus(rabbitMQExtension.getSender(), rabbitMQExtension.getReceiverProvider(),
+            eventSerializer, RETRY_BACKOFF_CONFIGURATION, routingKeyConverter,
+            memoryEventDeadLetters, new RecordingMetricFactory(), rabbitMQExtension.getRabbitChannelPool());
+
+        eventBus.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        eventBus.stop();
+    }
+
+    @Test
+    void dispatchShouldWorkAfterNetworkIssuesForOldRegistration() {
+        MailboxListener listener = newListener();
+        eventBus.register(listener, GROUP_A);
+
+        rabbitMQExtension.getRabbitMQ().pause();
+
+        assertThatThrownBy(() -> eventBus.dispatch(EVENT, NO_KEYS).block())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Retries exhausted");
+
+        rabbitMQExtension.getRabbitMQ().unpause();
+
+        eventBus.dispatch(EVENT, NO_KEYS).block();
+        RabbitMQFixture.awaitAtMostThirtySeconds
+            .untilAsserted(() -> verify(listener).event(EVENT));
+    }
+
+}

--- a/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusDeadLetterQueueUpgradeTest.java
+++ b/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusDeadLetterQueueUpgradeTest.java
@@ -1,0 +1,87 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.events;
+
+import static org.apache.james.backends.rabbitmq.Constants.AUTO_DELETE;
+import static org.apache.james.backends.rabbitmq.Constants.DURABLE;
+import static org.apache.james.backends.rabbitmq.Constants.EXCLUSIVE;
+import static org.apache.james.mailbox.events.EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.apache.james.backends.rabbitmq.RabbitMQExtension;
+import org.apache.james.event.json.EventSerializer;
+import org.apache.james.mailbox.events.EventBusTestFixture.GroupA;
+import org.apache.james.mailbox.events.GroupRegistration.WorkQueueName;
+import org.apache.james.mailbox.model.TestId;
+import org.apache.james.mailbox.model.TestMessageId;
+import org.apache.james.mailbox.store.quota.DefaultUserQuotaRootResolver;
+import org.apache.james.mailbox.util.EventCollector;
+import org.apache.james.metrics.tests.RecordingMetricFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import reactor.rabbitmq.QueueSpecification;
+
+class RabbitMQEventBusDeadLetterQueueUpgradeTest {
+    @RegisterExtension
+    static RabbitMQExtension rabbitMQExtension = RabbitMQExtension.singletonRabbitMQ()
+        .isolationPolicy(RabbitMQExtension.IsolationPolicy.WEAK);
+
+    private RabbitMQEventBus eventBus;
+
+    @BeforeEach
+    void setUp() {
+        MemoryEventDeadLetters memoryEventDeadLetters = new MemoryEventDeadLetters();
+
+        TestId.Factory mailboxIdFactory = new TestId.Factory();
+        EventSerializer eventSerializer = new EventSerializer(mailboxIdFactory, new TestMessageId.Factory(), new DefaultUserQuotaRootResolver.DefaultQuotaRootDeserializer());
+        RoutingKeyConverter routingKeyConverter = RoutingKeyConverter.forFactories(new MailboxIdRegistrationKey.Factory(mailboxIdFactory));
+
+        eventBus = new RabbitMQEventBus(rabbitMQExtension.getSender(), rabbitMQExtension.getReceiverProvider(),
+            eventSerializer, RETRY_BACKOFF_CONFIGURATION, routingKeyConverter,
+            memoryEventDeadLetters, new RecordingMetricFactory(), rabbitMQExtension.getRabbitChannelPool());
+
+        eventBus.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        eventBus.stop();
+    }
+
+    @Test
+    void eventBusShouldStartWhenDeadLetterUpgradeWasNotPerformed() {
+        GroupA registeredGroup = new GroupA();
+        WorkQueueName workQueueName = WorkQueueName.of(registeredGroup);
+        
+        rabbitMQExtension.getSender()
+            .declareQueue(QueueSpecification.queue(workQueueName.asString())
+                .durable(DURABLE)
+                .exclusive(!EXCLUSIVE)
+                .autoDelete(!AUTO_DELETE))
+            .block();
+
+        assertThatCode(eventBus::start).doesNotThrowAnyException();
+        assertThatCode(() -> eventBus.register(new EventCollector(), registeredGroup)).doesNotThrowAnyException();
+    }
+
+}

--- a/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusTest.java
+++ b/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusTest.java
@@ -154,7 +154,10 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
     }
 
     private RabbitMQEventBus newEventBus(Sender sender, ReceiverProvider receiverProvider) {
-        return new RabbitMQEventBus(sender, receiverProvider, eventSerializer, EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, routingKeyConverter, memoryEventDeadLetters, new RecordingMetricFactory());
+        return new RabbitMQEventBus(sender, receiverProvider, eventSerializer,
+            EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, routingKeyConverter,
+            memoryEventDeadLetters, new RecordingMetricFactory(),
+            rabbitMQExtension.getRabbitChannelPool());
     }
 
     @Override

--- a/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusTest.java
+++ b/mailbox/event/event-rabbitmq/src/test/java/org/apache/james/mailbox/events/RabbitMQEventBusTest.java
@@ -460,24 +460,6 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
                 }
 
                 @Test
-                void dispatchShouldWorkAfterNetworkIssuesForOldRegistration() {
-                    rabbitMQEventBusWithNetWorkIssue.start();
-                    MailboxListener listener = newListener();
-                    rabbitMQEventBusWithNetWorkIssue.register(listener, GROUP_A);
-
-                    rabbitMQNetWorkIssueExtension.getRabbitMQ().pause();
-
-                    assertThatThrownBy(() -> rabbitMQEventBusWithNetWorkIssue.dispatch(EVENT, NO_KEYS).block())
-                        .isInstanceOf(IllegalStateException.class)
-                        .hasMessageContaining("Retries exhausted");
-
-                    rabbitMQNetWorkIssueExtension.getRabbitMQ().unpause();
-
-                    rabbitMQEventBusWithNetWorkIssue.dispatch(EVENT, NO_KEYS).block();
-                    assertThatListenerReceiveOneEvent(listener);
-                }
-
-                @Test
                 void dispatchShouldWorkAfterNetworkIssuesForOldRegistrationAndKey() {
                     rabbitMQEventBusWithNetWorkIssue.start();
                     MailboxListener listener = newListener();

--- a/mpt/impl/imap-mailbox/rabbitmq/src/test/java/org/apache/james/mpt/imapmailbox/rabbitmq/host/RabbitMQEventBusHostSystem.java
+++ b/mpt/impl/imap-mailbox/rabbitmq/src/test/java/org/apache/james/mpt/imapmailbox/rabbitmq/host/RabbitMQEventBusHostSystem.java
@@ -112,7 +112,8 @@ public class RabbitMQEventBusHostSystem extends JamesImapHostSystem {
         RoutingKeyConverter routingKeyConverter = new RoutingKeyConverter(ImmutableSet.of(new MailboxIdRegistrationKey.Factory(mailboxIdFactory)));
         return new RabbitMQEventBus(reactorRabbitMQChannelPool.getSender(), reactorRabbitMQChannelPool::createReceiver,
             eventSerializer, RetryBackoffConfiguration.DEFAULT, routingKeyConverter, new MemoryEventDeadLetters(),
-            new RecordingMetricFactory());
+            new RecordingMetricFactory(),
+            reactorRabbitMQChannelPool);
     }
 
     @Override


### PR DESCRIPTION
Difficulties encountered:

 - The reactive AMQP java client do not allow to see if a queue already exist. We need
 to actually try to create it, and resume the error to handle creation errors.
 - The error causes the entire channel (sender) to be crashed. As such, the potentially
 erroneous createQueue needs to be performed in a separate channel.

Note that we don't have other uses of dead-letter exchanges, eventBus is breaking, but the mailQueue is not.

