### PR TITLE
JAMES-3384 email query unsupported params

### DIFF
--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailQueryMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailQueryMethodContract.scala
@@ -870,7 +870,12 @@ trait EmailQueryMethodContract {
   @ParameterizedTest
   @ValueSource(strings = Array(
     "allInThreadHaveKeyword",
-    "someInThreadHaveKeyword"
+    "someInThreadHaveKeyword",
+    "size",
+    "from",
+    "to",
+    "subject",
+    "hasKeyword"
   ))
   def listMailsShouldReturnUnsupportedSortWhenPropertyFieldInComparatorIsValidButUnsupported(unsupported: String): Unit = {
     val request =

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailQueryMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailQueryMethodContract.scala
@@ -1014,6 +1014,82 @@ trait EmailQueryMethodContract {
   }
 
   @Test
+  def listMailsShouldReturnInvalidArgumentsWhenAnchorParameterIsPresent(): Unit = {
+    val request =
+      s"""{
+         |  "using": [
+         |    "urn:ietf:params:jmap:core",
+         |    "urn:ietf:params:jmap:mail"],
+         |  "methodCalls": [[
+         |    "Email/query",
+         |    {
+         |      "accountId": "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6",
+         |      "anchor": "123"
+         |    },
+         |    "c1"]]
+         |}""".stripMargin
+
+    val response = `given`
+      .header(ACCEPT.toString, ACCEPT_RFC8621_VERSION_HEADER)
+      .body(request)
+    .when
+      .post
+    .`then`
+      .statusCode(SC_OK)
+      .contentType(JSON)
+      .extract
+      .body
+      .asString
+
+    assertThatJson(response)
+      .inPath("$.methodResponses[0][1]")
+      .isEqualTo(s"""
+       {
+          "type": "invalidArguments",
+          "description": "The following parameter anchor is syntactically valid, but is not supported by the server."
+       }
+       """)
+  }
+
+  @Test
+  def listMailsShouldReturnInvalidArgumentsWhenAnchorOffsetParameterIsPresent(): Unit = {
+    val request =
+      s"""{
+         |  "using": [
+         |    "urn:ietf:params:jmap:core",
+         |    "urn:ietf:params:jmap:mail"],
+         |  "methodCalls": [[
+         |    "Email/query",
+         |    {
+         |      "accountId": "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6",
+         |      "anchorOffset": 0
+         |    },
+         |    "c1"]]
+         |}""".stripMargin
+
+    val response = `given`
+      .header(ACCEPT.toString, ACCEPT_RFC8621_VERSION_HEADER)
+      .body(request)
+    .when
+      .post
+    .`then`
+      .statusCode(SC_OK)
+      .contentType(JSON)
+      .extract
+      .body
+      .asString
+
+    assertThatJson(response)
+      .inPath("$.methodResponses[0][1]")
+      .isEqualTo(s"""
+       {
+          "type": "invalidArguments",
+          "description": "The following parameter anchorOffset is syntactically valid, but is not supported by the server."
+       }
+       """)
+  }
+
+  @Test
   def shouldReturnIllegalArgumentErrorForAnUnknownSpecificUserMailboxes(server: GuiceJamesServer): Unit = {
     val message: Message = Message.Builder
       .of

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/EmailQuerySerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/EmailQuerySerializer.scala
@@ -20,7 +20,7 @@
 package org.apache.james.jmap.json
 
 import javax.inject.Inject
-import org.apache.james.jmap.mail.{Collation, Comparator, EmailQueryRequest, EmailQueryResponse, FilterCondition, HasAttachment, IsAscending, ReceivedAtSortProperty, SortProperty}
+import org.apache.james.jmap.mail.{AllInThreadHaveKeywordSortProperty, Collation, Comparator, EmailQueryRequest, EmailQueryResponse, FilterCondition, HasAttachment, IsAscending, ReceivedAtSortProperty, SomeInThreadHaveKeywordSortProperty, SortProperty}
 import org.apache.james.jmap.model.{AccountId, CanCalculateChanges, Keyword, LimitUnparsed, PositionUnparsed, QueryState}
 import org.apache.james.mailbox.model.{MailboxId, MessageId}
 import play.api.libs.json._
@@ -59,6 +59,8 @@ class EmailQuerySerializer @Inject()(mailboxIdFactory: MailboxId.Factory) {
 
   private implicit val sortPropertyReads: Reads[SortProperty] = {
     case JsString("receivedAt") => JsSuccess(ReceivedAtSortProperty)
+    case JsString("allInThreadHaveKeyword") => JsSuccess(AllInThreadHaveKeywordSortProperty)
+    case JsString("someInThreadHaveKeyword") => JsSuccess(SomeInThreadHaveKeywordSortProperty)
     case JsString(others) => JsError(s"'$others' is not a supported sort property")
     case _ => JsError(s"Expecting a JsString to represent a sort property")
   }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/EmailQuerySerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/EmailQuerySerializer.scala
@@ -20,7 +20,7 @@
 package org.apache.james.jmap.json
 
 import javax.inject.Inject
-import org.apache.james.jmap.mail.{AllInThreadHaveKeywordSortProperty, Anchor, AnchorOffset, CollapseThreads, Collation, Comparator, EmailQueryRequest, EmailQueryResponse, FilterCondition, FromSortProperty, HasAttachment, HasKeywordSortProperty, IsAscending, ReceivedAtSortProperty, SizeSortProperty, SomeInThreadHaveKeywordSortProperty, SortProperty, SubjectSortProperty, ToSortProperty}
+import org.apache.james.jmap.mail.{AllInThreadHaveKeywordSortProperty, Anchor, AnchorOffset, Bcc, Body, Cc, CollapseThreads, Collation, Comparator, EmailQueryRequest, EmailQueryResponse, FilterCondition, From, FromSortProperty, HasAttachment, HasKeywordSortProperty, Header, IsAscending, ReceivedAtSortProperty, SizeSortProperty, SomeInThreadHaveKeywordSortProperty, SortProperty, Subject, SubjectSortProperty, Text, To, ToSortProperty}
 import org.apache.james.jmap.model.{AccountId, CanCalculateChanges, Keyword, LimitUnparsed, PositionUnparsed, QueryState}
 import org.apache.james.mailbox.model.{MailboxId, MessageId}
 import play.api.libs.json._
@@ -49,6 +49,14 @@ class EmailQuerySerializer @Inject()(mailboxIdFactory: MailboxId.Factory) {
     case _ => JsError("Expecting keywords to be represented by a JsString")
   }
   private implicit val hasAttachmentReads: Reads[HasAttachment] = Json.valueReads[HasAttachment]
+  private implicit val textReads: Reads[Text] = Json.valueReads[Text]
+  private implicit val fromReads: Reads[From] = Json.valueReads[From]
+  private implicit val toReads: Reads[To] = Json.valueReads[To]
+  private implicit val ccReads: Reads[Cc] = Json.valueReads[Cc]
+  private implicit val bccReads: Reads[Bcc] = Json.valueReads[Bcc]
+  private implicit val subjectReads: Reads[Subject] = Json.valueReads[Subject]
+  private implicit val headerReads: Reads[Header] = Json.valueReads[Header]
+  private implicit val bodyReads: Reads[Body] = Json.valueReads[Body]
   private implicit val filterConditionReads: Reads[FilterCondition] = Json.reads[FilterCondition]
   private implicit val limitUnparsedReads: Reads[LimitUnparsed] = Json.valueReads[LimitUnparsed]
   private implicit val CanCalculateChangesFormat: Format[CanCalculateChanges] = Json.valueFormat[CanCalculateChanges]

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/EmailQuerySerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/EmailQuerySerializer.scala
@@ -20,7 +20,7 @@
 package org.apache.james.jmap.json
 
 import javax.inject.Inject
-import org.apache.james.jmap.mail.{AllInThreadHaveKeywordSortProperty, CollapseThreads, Collation, Comparator, EmailQueryRequest, EmailQueryResponse, FilterCondition, HasAttachment, IsAscending, ReceivedAtSortProperty, SomeInThreadHaveKeywordSortProperty, SortProperty}
+import org.apache.james.jmap.mail.{AllInThreadHaveKeywordSortProperty, Anchor, AnchorOffset, CollapseThreads, Collation, Comparator, EmailQueryRequest, EmailQueryResponse, FilterCondition, HasAttachment, IsAscending, ReceivedAtSortProperty, SomeInThreadHaveKeywordSortProperty, SortProperty}
 import org.apache.james.jmap.model.{AccountId, CanCalculateChanges, Keyword, LimitUnparsed, PositionUnparsed, QueryState}
 import org.apache.james.mailbox.model.{MailboxId, MessageId}
 import play.api.libs.json._
@@ -72,6 +72,8 @@ class EmailQuerySerializer @Inject()(mailboxIdFactory: MailboxId.Factory) {
   private implicit val collationFormat: Format[Collation] = Json.valueFormat[Collation]
   private implicit val comparatorFormat: Format[Comparator] = Json.format[Comparator]
   private implicit val collapseThreadsReads: Reads[CollapseThreads] = Json.valueReads[CollapseThreads]
+  private implicit val anchorReads: Reads[Anchor] = Json.valueReads[Anchor]
+  private implicit val anchorOffsetReads: Reads[AnchorOffset] = Json.valueReads[AnchorOffset]
 
   private implicit val emailQueryRequestReads: Reads[EmailQueryRequest] = Json.reads[EmailQueryRequest]
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/EmailQuerySerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/EmailQuerySerializer.scala
@@ -20,7 +20,7 @@
 package org.apache.james.jmap.json
 
 import javax.inject.Inject
-import org.apache.james.jmap.mail.{AllInThreadHaveKeywordSortProperty, Anchor, AnchorOffset, CollapseThreads, Collation, Comparator, EmailQueryRequest, EmailQueryResponse, FilterCondition, HasAttachment, IsAscending, ReceivedAtSortProperty, SomeInThreadHaveKeywordSortProperty, SortProperty}
+import org.apache.james.jmap.mail.{AllInThreadHaveKeywordSortProperty, Anchor, AnchorOffset, CollapseThreads, Collation, Comparator, EmailQueryRequest, EmailQueryResponse, FilterCondition, FromSortProperty, HasAttachment, HasKeywordSortProperty, IsAscending, ReceivedAtSortProperty, SizeSortProperty, SomeInThreadHaveKeywordSortProperty, SortProperty, SubjectSortProperty, ToSortProperty}
 import org.apache.james.jmap.model.{AccountId, CanCalculateChanges, Keyword, LimitUnparsed, PositionUnparsed, QueryState}
 import org.apache.james.mailbox.model.{MailboxId, MessageId}
 import play.api.libs.json._
@@ -61,6 +61,11 @@ class EmailQuerySerializer @Inject()(mailboxIdFactory: MailboxId.Factory) {
     case JsString("receivedAt") => JsSuccess(ReceivedAtSortProperty)
     case JsString("allInThreadHaveKeyword") => JsSuccess(AllInThreadHaveKeywordSortProperty)
     case JsString("someInThreadHaveKeyword") => JsSuccess(SomeInThreadHaveKeywordSortProperty)
+    case JsString("size") => JsSuccess(SizeSortProperty)
+    case JsString("from") => JsSuccess(FromSortProperty)
+    case JsString("to") => JsSuccess(ToSortProperty)
+    case JsString("subject") => JsSuccess(SubjectSortProperty)
+    case JsString("hasKeyword") => JsSuccess(HasKeywordSortProperty)
     case JsString(others) => JsError(s"'$others' is not a supported sort property")
     case _ => JsError(s"Expecting a JsString to represent a sort property")
   }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/EmailQuerySerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/EmailQuerySerializer.scala
@@ -20,7 +20,7 @@
 package org.apache.james.jmap.json
 
 import javax.inject.Inject
-import org.apache.james.jmap.mail.{AllInThreadHaveKeywordSortProperty, Collation, Comparator, EmailQueryRequest, EmailQueryResponse, FilterCondition, HasAttachment, IsAscending, ReceivedAtSortProperty, SomeInThreadHaveKeywordSortProperty, SortProperty}
+import org.apache.james.jmap.mail.{AllInThreadHaveKeywordSortProperty, CollapseThreads, Collation, Comparator, EmailQueryRequest, EmailQueryResponse, FilterCondition, HasAttachment, IsAscending, ReceivedAtSortProperty, SomeInThreadHaveKeywordSortProperty, SortProperty}
 import org.apache.james.jmap.model.{AccountId, CanCalculateChanges, Keyword, LimitUnparsed, PositionUnparsed, QueryState}
 import org.apache.james.mailbox.model.{MailboxId, MessageId}
 import play.api.libs.json._
@@ -71,6 +71,7 @@ class EmailQuerySerializer @Inject()(mailboxIdFactory: MailboxId.Factory) {
   private implicit val isAscendingFormat: Format[IsAscending] = Json.valueFormat[IsAscending]
   private implicit val collationFormat: Format[Collation] = Json.valueFormat[Collation]
   private implicit val comparatorFormat: Format[Comparator] = Json.format[Comparator]
+  private implicit val collapseThreadsReads: Reads[CollapseThreads] = Json.valueReads[CollapseThreads]
 
   private implicit val emailQueryRequestReads: Reads[EmailQueryRequest] = Json.reads[EmailQueryRequest]
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailQuery.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailQuery.scala
@@ -31,6 +31,14 @@ case class UnsupportedSortException(unsupportedSort: String) extends Unsupported
 case class UnsupportedFilterException(unsupportedFilter: String) extends UnsupportedOperationException
 case class UnsupportedRequestParameterException(unsupportedParam: String) extends UnsupportedOperationException
 
+case class Text(value: String) extends AnyVal
+case class From(value: String) extends AnyVal
+case class To(value: String) extends AnyVal
+case class Cc(value: String) extends AnyVal
+case class Bcc(value: String) extends AnyVal
+case class Body(value: String) extends AnyVal
+case class Header(value: String) extends AnyVal
+
 case class FilterCondition(inMailbox: Option[MailboxId],
                            inMailboxOtherThan: Option[Seq[MailboxId]],
                            before: Option[UTCDate],
@@ -42,7 +50,15 @@ case class FilterCondition(inMailbox: Option[MailboxId],
                            hasAttachment: Option[HasAttachment],
                            allInThreadHaveKeyword: Option[Keyword],
                            someInThreadHaveKeyword: Option[Keyword],
-                           noneInThreadHaveKeyword: Option[Keyword])
+                           noneInThreadHaveKeyword: Option[Keyword],
+                           text: Option[Text],
+                           from: Option[From],
+                           to: Option[To],
+                           cc: Option[Cc],
+                           bcc: Option[Bcc],
+                           subject: Option[Subject],
+                           header: Option[Set[Header]],
+                           body: Option[Body])
 
 case class EmailQueryRequest(accountId: AccountId,
                              position: Option[PositionUnparsed],

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailQuery.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailQuery.scala
@@ -63,9 +63,23 @@ case object ReceivedAtSortProperty extends SortProperty {
 case object AllInThreadHaveKeywordSortProperty extends SortProperty {
   override def toSortClause: Either[UnsupportedSortException, SortClause] = Left(UnsupportedSortException("allInThreadHaveKeyword"))
 }
-
 case object SomeInThreadHaveKeywordSortProperty extends SortProperty {
   override def toSortClause: Either[UnsupportedSortException, SortClause] = Left(UnsupportedSortException("someInThreadHaveKeyword"))
+}
+case object SizeSortProperty extends SortProperty {
+  override def toSortClause: Either[UnsupportedSortException, SortClause] = Left(UnsupportedSortException("size"))
+}
+case object FromSortProperty extends SortProperty {
+  override def toSortClause: Either[UnsupportedSortException, SortClause] = Left(UnsupportedSortException("from"))
+}
+case object ToSortProperty extends SortProperty {
+  override def toSortClause: Either[UnsupportedSortException, SortClause] = Left(UnsupportedSortException("to"))
+}
+case object SubjectSortProperty extends SortProperty {
+  override def toSortClause: Either[UnsupportedSortException, SortClause] = Left(UnsupportedSortException("subject"))
+}
+case object HasKeywordSortProperty extends SortProperty {
+  override def toSortClause: Either[UnsupportedSortException, SortClause] = Left(UnsupportedSortException("hasKeyword"))
 }
 
 object IsAscending {

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailQuery.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailQuery.scala
@@ -29,6 +29,7 @@ import org.apache.james.mailbox.model.{MailboxId, MessageId, SearchQuery}
 
 case class UnsupportedSortException(unsupportedSort: String) extends UnsupportedOperationException
 case class UnsupportedFilterException(unsupportedFilter: String) extends UnsupportedOperationException
+case class UnsupportedRequestParameterException(unsupportedParam: String) extends UnsupportedOperationException
 
 case class FilterCondition(inMailbox: Option[MailboxId],
                            inMailboxOtherThan: Option[Seq[MailboxId]],
@@ -48,7 +49,9 @@ case class EmailQueryRequest(accountId: AccountId,
                              limit: Option[LimitUnparsed],
                              filter: Option[FilterCondition],
                              comparator: Option[Set[Comparator]],
-                             collapseThreads: Option[CollapseThreads])
+                             collapseThreads: Option[CollapseThreads],
+                             anchor: Option[Anchor],
+                             anchorOffset: Option[AnchorOffset])
 
 sealed trait SortProperty {
   def toSortClause: Either[UnsupportedSortException, SortClause]
@@ -93,6 +96,8 @@ case class Comparator(property: SortProperty,
 }
 
 case class CollapseThreads(value: Boolean) extends AnyVal
+case class Anchor(value: String) extends AnyVal
+case class AnchorOffset(value: Int) extends AnyVal
 
 case class EmailQueryResponse(accountId: AccountId,
                               queryState: QueryState,

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailQuery.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailQuery.scala
@@ -39,7 +39,12 @@ case class FilterCondition(inMailbox: Option[MailboxId],
                            maxSize: Option[Size],
                            hasAttachment: Option[HasAttachment])
 
-case class EmailQueryRequest(accountId: AccountId, position: Option[PositionUnparsed], limit: Option[LimitUnparsed], filter: Option[FilterCondition], comparator: Option[Set[Comparator]])
+case class EmailQueryRequest(accountId: AccountId,
+                             position: Option[PositionUnparsed],
+                             limit: Option[LimitUnparsed],
+                             filter: Option[FilterCondition],
+                             comparator: Option[Set[Comparator]],
+                             collapseThreads: Option[CollapseThreads])
 
 sealed trait SortProperty {
   def toSortClause: Either[UnsupportedSortException, SortClause]
@@ -82,6 +87,8 @@ case class Comparator(property: SortProperty,
       sortClause <- property.toSortClause
     } yield new SearchQuery.Sort(sortClause, isAscending.getOrElse(ASCENDING).toSortOrder)
 }
+
+case class CollapseThreads(value: Boolean) extends AnyVal
 
 case class EmailQueryResponse(accountId: AccountId,
                               queryState: QueryState,

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailQuery.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/EmailQuery.scala
@@ -28,6 +28,7 @@ import org.apache.james.mailbox.model.SearchQuery.Sort.SortClause
 import org.apache.james.mailbox.model.{MailboxId, MessageId, SearchQuery}
 
 case class UnsupportedSortException(unsupportedSort: String) extends UnsupportedOperationException
+case class UnsupportedFilterException(unsupportedFilter: String) extends UnsupportedOperationException
 
 case class FilterCondition(inMailbox: Option[MailboxId],
                            inMailboxOtherThan: Option[Seq[MailboxId]],
@@ -37,7 +38,10 @@ case class FilterCondition(inMailbox: Option[MailboxId],
                            notKeyword: Option[Keyword],
                            minSize: Option[Size],
                            maxSize: Option[Size],
-                           hasAttachment: Option[HasAttachment])
+                           hasAttachment: Option[HasAttachment],
+                           allInThreadHaveKeyword: Option[Keyword],
+                           someInThreadHaveKeyword: Option[Keyword],
+                           noneInThreadHaveKeyword: Option[Keyword])
 
 case class EmailQueryRequest(accountId: AccountId,
                              position: Option[PositionUnparsed],

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/Invocation.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/Invocation.scala
@@ -73,4 +73,8 @@ object ErrorCode {
   case object UnsupportedSort extends ErrorCode {
     override def code: String = "unsupportedSort"
   }
+
+  case object UnsupportedFilter extends ErrorCode {
+    override def code: String = "unsupportedFilter"
+  }
 }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/Invocation.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/Invocation.scala
@@ -69,4 +69,8 @@ object ErrorCode {
   case object InvalidResultReference extends ErrorCode {
     override def code: String = "invalidResultReference"
   }
+
+  case object UnsupportedSort extends ErrorCode {
+    override def code: String = "unsupportedSort"
+  }
 }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/utils/search/MailboxFilter.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/utils/search/MailboxFilter.scala
@@ -61,7 +61,8 @@ object MailboxFilter {
   object QueryFilter {
     def buildQuery(request: EmailQueryRequest): Either[UnsupportedFilterException, SearchQuery.Builder] = {
       List(ReceivedBefore, ReceivedAfter, HasAttachment, HasKeyWord, NotKeyWord, MinSize, MaxSize,
-           AllInThreadHaveKeyword, NoneInThreadHaveKeyword, SomeInThreadHaveKeyword)
+           AllInThreadHaveKeyword, NoneInThreadHaveKeyword, SomeInThreadHaveKeyword, Text, From,
+           To, Cc, Bcc, Subject, Header, Body)
         .foldLeftM(new SearchQuery.Builder())((builder, filter) => filter.toQuery(builder, request))
     }
   }
@@ -160,6 +161,62 @@ object MailboxFilter {
     override def toQuery(builder: SearchQuery.Builder, request: EmailQueryRequest): Either[UnsupportedFilterException, SearchQuery.Builder] =
       request.filter.flatMap(_.someInThreadHaveKeyword) match {
         case Some(_) => Left(UnsupportedFilterException("someInThreadHaveKeyword"))
+        case None => Right(builder)
+      }
+  }
+  case object Text extends QueryFilter {
+    override def toQuery(builder: SearchQuery.Builder, request: EmailQueryRequest): Either[UnsupportedFilterException, SearchQuery.Builder] =
+      request.filter.flatMap(_.text) match {
+        case Some(_) => Left(UnsupportedFilterException("text"))
+        case None => Right(builder)
+      }
+  }
+  case object From extends QueryFilter {
+    override def toQuery(builder: SearchQuery.Builder, request: EmailQueryRequest): Either[UnsupportedFilterException, SearchQuery.Builder] =
+      request.filter.flatMap(_.from) match {
+        case Some(_) => Left(UnsupportedFilterException("from"))
+        case None => Right(builder)
+      }
+  }
+  case object To extends QueryFilter {
+    override def toQuery(builder: SearchQuery.Builder, request: EmailQueryRequest): Either[UnsupportedFilterException, SearchQuery.Builder] =
+      request.filter.flatMap(_.to) match {
+        case Some(_) => Left(UnsupportedFilterException("to"))
+        case None => Right(builder)
+      }
+  }
+  case object Cc extends QueryFilter {
+    override def toQuery(builder: SearchQuery.Builder, request: EmailQueryRequest): Either[UnsupportedFilterException, SearchQuery.Builder] =
+      request.filter.flatMap(_.cc) match {
+        case Some(_) => Left(UnsupportedFilterException("cc"))
+        case None => Right(builder)
+      }
+  }
+  case object Bcc extends QueryFilter {
+    override def toQuery(builder: SearchQuery.Builder, request: EmailQueryRequest): Either[UnsupportedFilterException, SearchQuery.Builder] =
+      request.filter.flatMap(_.bcc) match {
+        case Some(_) => Left(UnsupportedFilterException("bcc"))
+        case None => Right(builder)
+      }
+  }
+  case object Subject extends QueryFilter {
+    override def toQuery(builder: SearchQuery.Builder, request: EmailQueryRequest): Either[UnsupportedFilterException, SearchQuery.Builder] =
+      request.filter.flatMap(_.subject) match {
+        case Some(_) => Left(UnsupportedFilterException("subject"))
+        case None => Right(builder)
+      }
+  }
+  case object Header extends QueryFilter {
+    override def toQuery(builder: SearchQuery.Builder, request: EmailQueryRequest): Either[UnsupportedFilterException, SearchQuery.Builder] =
+      request.filter.flatMap(_.header) match {
+        case Some(_) => Left(UnsupportedFilterException("header"))
+        case None => Right(builder)
+      }
+  }
+  case object Body extends QueryFilter {
+    override def toQuery(builder: SearchQuery.Builder, request: EmailQueryRequest): Either[UnsupportedFilterException, SearchQuery.Builder] =
+      request.filter.flatMap(_.body) match {
+        case Some(_) => Left(UnsupportedFilterException("body"))
         case None => Right(builder)
       }
   }


### PR DESCRIPTION
Managing in this PR:
* collapseThreads param does noop
* use of `allInThreadHaveKeyword` and `someInThreadHaveKeyword` in sort generates an `unsuportedSort` error method 
* use of `allInThreadHaveKeyword`, `someInThreadHaveKeyword` and `noneInThreadHaveKeyword` in filter generates an `unsupportedFilter` error method
* Anchor/AnchorOffset are not supported as request params

Remaining:
* Unknown filter should return an error => in an other PR, it sounds quite tricky with the current code, and it's not part of this task initially