### PR TITLE
[CI_ONLY] Disable mvn tests for checking deployment tests

### DIFF
--- a/dockerfiles/compilation/java-11/compile.sh
+++ b/dockerfiles/compilation/java-11/compile.sh
@@ -62,7 +62,7 @@ git checkout $SHA1
 if [ "$SKIPTESTS" = "skipTests" ]; then
    mvn package -DskipTests ${MVN_ADDITIONAL_ARG_LINE}
 else
-   mvn package ${MVN_ADDITIONAL_ARG_LINE}
+   mvn package -DskipTests ${MVN_ADDITIONAL_ARG_LINE}
 fi
 
 # download glowroot jar


### PR DESCRIPTION
Just a quick way to check our deployment tests are still working, until we find something better...