### PR TITLE
JAMES-3393 Build stability fix build failing on deployment test

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -57,7 +57,6 @@ import org.apache.james.util.streams.Limit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.fge.lambdas.Throwing;
 import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 import javax.mail.Flags;
 import javax.mail.Flags.Flag;
@@ -262,8 +263,9 @@ public class CassandraMessageMapper implements MessageMapper {
         CassandraId mailboxId = (CassandraId) mailbox.getMailboxId();
 
         return block(addUidAndModseq(message, mailboxId)
-            .flatMap(Throwing.function(messageWithUidAndModSeq -> save(mailbox, messageWithUidAndModSeq)
-                .thenReturn(messageWithUidAndModSeq)))
+            .flatMap(messageWithUidAndModSeq -> Mono.fromCallable(() -> save(mailbox, messageWithUidAndModSeq))
+                .flatMap(Function.identity())
+                .thenReturn(messageWithUidAndModSeq))
             .map(MailboxMessage::metaData));
     }
 


### PR DESCRIPTION


When deleting a mailbox.
If an error happen during reading one of its message, the whole process fails.
In order to make it more resilient we should retry the operation.

This would fix the current build instability on the deployment tests.
