### PR TITLE
JAMES-3402 JMAP MDN messages should have a Date header

### DIFF
--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/JmapMDN.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/JmapMDN.java
@@ -20,6 +20,7 @@
 package org.apache.james.jmap.draft.model;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -152,6 +153,7 @@ public class JmapMDN {
             .setTo(getSenderAddress(originalMessage))
             .setFrom(username.asString())
             .setSubject(subject)
+            .setDate(new Date())
             .setMessageId(MimeUtil.createUniqueMessageId(username.getDomainPart().map(Domain::name).orElse(null)))
             .build();
     }

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/JmapMDNTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/JmapMDNTest.java
@@ -151,6 +151,23 @@ public class JmapMDNTest {
     }
 
     @Test
+    public void generateMDNMessageShouldPositionDateHeader() throws Exception {
+        String senderAddress = "sender@local";
+        Message originMessage = Message.Builder.of()
+            .setMessageId("45554@local.com")
+            .setFrom(senderAddress)
+            .setBody("body", StandardCharsets.UTF_8)
+            .addField(new RawField(JmapMDN.RETURN_PATH, "<" + senderAddress + ">"))
+            .addField(new RawField(JmapMDN.DISPOSITION_NOTIFICATION_TO, "<" + senderAddress + ">"))
+            .build();
+
+        assertThat(
+            MDN.generateMDNMessage(originMessage, MAILBOX_SESSION)
+                .getDate())
+            .isNotNull();
+    }
+
+    @Test
     public void generateMDNMessageShouldFailOnMissingDisposition() throws Exception {
         String senderAddress = "sender@local";
         Message originMessage = Message.Builder.of()


### PR DESCRIPTION
Missing date headers is misleading, and leads to wrong message ordering, eg in thunderbird.