### PR TITLE
JAMES-3408 IMAP List not reading counters for Distributed James

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
@@ -289,6 +289,11 @@ public interface MailboxManager extends RequestAware, RightManager, MailboxAnnot
      */
     List<MessageRange> moveMessages(MessageRange set, MailboxPath from, MailboxPath to, MailboxSession session) throws MailboxException;
 
+    enum MailboxSearchFetchType {
+        Minimal,
+        Counters
+    }
+
     /**
      * Searches for mailboxes matching the given query.
      * 
@@ -297,7 +302,11 @@ public interface MailboxManager extends RequestAware, RightManager, MailboxAnnot
      * @param session
      *            the context for this call, not null
      */
-    Flux<MailboxMetaData> search(MailboxQuery expression, MailboxSession session);
+    default Flux<MailboxMetaData> search(MailboxQuery expression, MailboxSession session) {
+        return search(expression, MailboxSearchFetchType.Counters, session);
+    }
+
+    Flux<MailboxMetaData> search(MailboxQuery expression, MailboxSearchFetchType fetchType, MailboxSession session);
 
     /**
      * Searches for messages matching the given query.

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxMetaData.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MailboxMetaData.java
@@ -60,15 +60,6 @@ public class MailboxMetaData implements Comparable<MailboxMetaData> {
         HAS_NO_CHILDREN
     }
 
-    public static MailboxMetaData unselectableMailbox(MailboxPath path, MailboxId mailboxId, char delimiter) {
-        return new MailboxMetaData(path, mailboxId, delimiter, Children.CHILDREN_ALLOWED_BUT_UNKNOWN, Selectability.NONE, new MailboxACL(),
-            MailboxCounters.builder()
-                .mailboxId(mailboxId)
-                .count(0)
-                .unseen(0)
-                .build());
-    }
-
     public static  final Comparator<MailboxMetaData> COMPARATOR = Comparator
         .<MailboxMetaData, Boolean>comparing(metadata -> metadata.getPath().isInbox()).reversed()
         .thenComparing(metadata -> metadata.getPath().getName());

--- a/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/DefaultMailboxBackup.java
+++ b/mailbox/backup/src/main/java/org/apache/james/mailbox/backup/DefaultMailboxBackup.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.mailbox.backup;
 
+import static org.apache.james.mailbox.MailboxManager.MailboxSearchFetchType.Minimal;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -145,7 +147,7 @@ public class DefaultMailboxBackup implements MailboxBackup {
             .privateNamespace()
             .user(session.getUser())
             .build();
-        Stream<MailboxPath> paths = mailboxManager.search(queryUser, session)
+        Stream<MailboxPath> paths = mailboxManager.search(queryUser, Minimal, session)
             .toStream()
             .map(MailboxMetaData::getPath);
         List<MailAccountContent> mailboxes = paths

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -29,6 +29,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -626,36 +627,37 @@ public class StoreMailboxManager implements MailboxManager {
         Mono<List<Mailbox>> mailboxesMono = searchMailboxes(expression, session, Right.Lookup).collectList();
 
         return mailboxesMono
-            .flatMapMany(mailboxes -> {
-                if (fetchType == MailboxSearchFetchType.Counters) {
-                    return withCounters(expression, session, mailboxes);
-                } else {
-                    return withoutCounters(expression, session, mailboxes);
-                }
-            })
+            .flatMapMany(mailboxes -> Flux.fromIterable(mailboxes)
+                .filter(expression::matches)
+                .transform(metadataTransformation(fetchType, session, mailboxes)))
             .sort(MailboxMetaData.COMPARATOR);
     }
 
-    public Flux<MailboxMetaData> withCounters(MailboxQuery expression, MailboxSession session, List<Mailbox> mailboxes) {
+    private Function<Flux<Mailbox>, Flux<MailboxMetaData>> metadataTransformation(MailboxSearchFetchType fetchType, MailboxSession session, List<Mailbox> mailboxes) {
+        if (fetchType == MailboxSearchFetchType.Counters) {
+            return withCounters(session, mailboxes);
+        }
+        return withoutCounters(session, mailboxes);
+    }
+
+    private Function<Flux<Mailbox>, Flux<MailboxMetaData>> withCounters(MailboxSession session, List<Mailbox> mailboxes) {
         MessageMapper messageMapper = mailboxSessionMapperFactory.getMessageMapper(session);
-        return Flux.fromIterable(mailboxes)
-            .filter(expression::matches)
+        return mailboxFlux -> mailboxFlux
             .flatMap(mailbox -> retrieveCounters(messageMapper, mailbox, session)
                 .map(Throwing.<MailboxCounters, MailboxMetaData>function(
                     counters -> toMailboxMetadata(session, mailboxes, mailbox, counters))
                     .sneakyThrow()));
     }
 
-    public Flux<MailboxMetaData> withoutCounters(MailboxQuery expression, MailboxSession session, List<Mailbox> mailboxes) {
-        return Flux.fromIterable(mailboxes)
-            .filter(expression::matches)
-            .map(Throwing.<Mailbox, MailboxMetaData>function(
-                    mailbox -> toMailboxMetadata(session, mailboxes, mailbox,
-                        MailboxCounters.builder()
-                            .mailboxId(mailbox.getMailboxId())
-                            .count(0)
-                            .unseen(0)
-                            .build()))
+    private Function<Flux<Mailbox>, Flux<MailboxMetaData>> withoutCounters(MailboxSession session, List<Mailbox> mailboxes) {
+        return mailboxFlux -> mailboxFlux
+                .map(Throwing.<Mailbox, MailboxMetaData>function(
+                    mailbox -> toMailboxMetadata(session, mailboxes, mailbox, MailboxCounters
+                        .builder()
+                        .mailboxId(mailbox.getMailboxId())
+                        .count(0)
+                        .unseen(0)
+                        .build()))
                     .sneakyThrow());
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/SystemMailboxesProviderImpl.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/SystemMailboxesProviderImpl.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mailbox.store;
 
+import static org.apache.james.mailbox.MailboxManager.MailboxSearchFetchType.Minimal;
+
 import javax.inject.Inject;
 
 import org.apache.james.core.Username;
@@ -73,7 +75,7 @@ public class SystemMailboxesProviderImpl implements SystemMailboxesProvider {
         MailboxQuery mailboxQuery = MailboxQuery.privateMailboxesBuilder(session)
             .expression(new PrefixedWildcard(aRole.getDefaultMailbox()))
             .build();
-        return mailboxManager.search(mailboxQuery, session)
+        return mailboxManager.search(mailboxQuery, Minimal, session)
             .map(MailboxMetaData::getPath)
             .filter(path -> hasRole(aRole, path))
             .map(Throwing.function(loadMailbox).sneakyThrow());

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/SystemMailboxesProviderImplTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/SystemMailboxesProviderImplTest.java
@@ -58,7 +58,7 @@ class SystemMailboxesProviderImplTest {
     void getMailboxByRoleShouldReturnEmptyWhenNoMailbox() throws Exception {
         when(mailboxManager.createSystemSession(MailboxFixture.ALICE)).thenReturn(mailboxSession);
         when(mailboxManager.getMailbox(eq(MailboxFixture.INBOX_ALICE), eq(mailboxSession))).thenThrow(MailboxNotFoundException.class);
-        when(mailboxManager.search(any(), any())).thenReturn(Flux.empty());
+        when(mailboxManager.search(any(), any(), any())).thenReturn(Flux.empty());
 
         assertThat(Flux.from(systemMailboxProvider.getMailboxByRole(Role.INBOX, mailboxSession.getUser())).toStream())
             .isEmpty();

--- a/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
+++ b/mpt/impl/imap-mailbox/cassandra/src/test/java/org/apache/james/mpt/imapmailbox/cassandra/host/CassandraHostSystem.java
@@ -85,6 +85,10 @@ public class CassandraHostSystem extends JamesImapHostSystem {
         this.cassandraHost = cassandraHost;
     }
 
+    public CassandraCluster getCassandra() {
+        return cassandra;
+    }
+
     @Override
     public void beforeTest() throws Exception {
         super.beforeTest();

--- a/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/ListOnly.test
+++ b/mpt/impl/imap-mailbox/core/src/main/resources/org/apache/james/imap/scripts/ListOnly.test
@@ -1,0 +1,85 @@
+################################################################
+# Licensed to the Apache Software Foundation (ASF) under one   #
+# or more contributor license agreements.  See the NOTICE file #
+# distributed with this work for additional information        #
+# regarding copyright ownership.  The ASF licenses this file   #
+# to you under the Apache License, Version 2.0 (the            #
+# "License"); you may not use this file except in compliance   #
+# with the License.  You may obtain a copy of the License at   #
+#                                                              #
+#   http://www.apache.org/licenses/LICENSE-2.0                 #
+#                                                              #
+# Unless required by applicable law or agreed to in writing,   #
+# software distributed under the License is distributed on an  #
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       #
+# KIND, either express or implied.  See the License for the    #
+# specific language governing permissions and limitations      #
+# under the License.                                           #
+################################################################
+# Create a few folders
+C: 10 CREATE listtest
+S: 10 OK CREATE completed.
+C: 11 CREATE listtest.subfolder
+S: 11 OK CREATE completed.
+C: 12 CREATE listtest1
+S: 12 OK CREATE completed.
+C: 13 CREATE listtest1.subfolder1
+S: 13 OK CREATE completed.
+
+# Empty 1st arg searches default context (#mail)
+C: 10 LIST "" listtest
+S: \* LIST \(\\HasChildren\) \"\.\" "listtest"
+S: 10 OK LIST completed.
+
+# % returns all mailboxes matching
+C: a1 LIST "" %
+SUB {
+S: \* LIST \(\\HasChildren\) \"\.\" "listtest"
+S: \* LIST \(\\HasChildren\) \"\.\" "listtest1"
+S: \* LIST \(\\HasNoChildren\) \"\.\" "INBOX"
+}
+S: a1 OK LIST completed.
+C: a2 LIST "" INBOX%
+S: \* LIST \(\\HasNoChildren\) \"\.\" "INBOX"
+S: a2 OK LIST completed.
+C: a3 LIST "" I%
+S: \* LIST \(\\HasNoChildren\) \"\.\" "INBOX"
+S: a3 OK LIST completed.
+C: a4 LIST "" l%
+SUB {
+S: \* LIST \(\\HasChildren\) \"\.\" "listtest"
+S: \* LIST \(\\HasChildren\) \"\.\" "listtest1"
+}
+S: a4 OK LIST completed.
+
+
+# * returns all folders and subfolders
+C: b1 LIST "" *
+SUB {
+S: \* LIST \(\\HasChildren\) \"\.\" "listtest"
+S: \* LIST \(\\HasChildren\) \"\.\" "listtest1"
+S: \* LIST \(\\HasNoChildren\) \"\.\" "listtest.subfolder"
+S: \* LIST \(\\HasNoChildren\) \"\.\" "listtest1.subfolder1"
+S: \* LIST \(\\HasNoChildren\) \"\.\" "INBOX"
+}
+S: b1 OK LIST completed.
+C: b2 LIST "" INBOX*
+S: \* LIST \(\\HasNoChildren\) \"\.\" "INBOX"
+S: b2 OK LIST completed.
+C: b3 LIST "" I*
+S: \* LIST \(\\HasNoChildren\) \"\.\" "INBOX"
+S: b3 OK LIST completed.
+C: b4 LIST "" l*
+SUB {
+S: \* LIST \(\\HasChildren\) \"\.\" "listtest"
+S: \* LIST \(\\HasChildren\) \"\.\" "listtest1"
+S: \* LIST \(\\HasNoChildren\) \"\.\" "listtest.subfolder"
+S: \* LIST \(\\HasNoChildren\) \"\.\" "listtest1.subfolder1"
+}
+S: b4 OK LIST completed.
+
+# List a nonexistent group
+C: a1 LIST "nosuchmailbox" "*"
+S: a1 OK LIST completed.
+C: a1 LIST "" "nosuch*"
+S: a1 OK LIST completed.

--- a/protocols/imap/src/main/java/org/apache/james/imap/processor/ListProcessor.java
+++ b/protocols/imap/src/main/java/org/apache/james/imap/processor/ListProcessor.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.imap.processor;
 
+import static org.apache.james.mailbox.MailboxManager.MailboxSearchFetchType.Minimal;
+
 import java.io.Closeable;
 
 import org.apache.james.imap.api.ImapMessage;
@@ -137,7 +139,7 @@ public class ListProcessor extends AbstractMailboxProcessor<ListRequest> {
                         basePath.getName(),
                         ModifiedUtf7.decodeModifiedUTF7(mailboxName),
                         mailboxSession.getPathDelimiter()))
-                    .build(), mailboxSession)
+                    .build(), Minimal, mailboxSession)
             .doOnNext(metaData -> processResult(responder, isRelative, metaData, getMailboxType(session, metaData.getPath())))
             .then()
             .block();

--- a/server/container/guice/mailbox/src/main/java/org/apache/james/modules/MailboxProbeImpl.java
+++ b/server/container/guice/mailbox/src/main/java/org/apache/james/modules/MailboxProbeImpl.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.modules;
 
+import static org.apache.james.mailbox.MailboxManager.MailboxSearchFetchType.Minimal;
 import static org.apache.james.mailbox.store.MailboxReactorUtils.block;
 
 import java.io.InputStream;
@@ -121,6 +122,7 @@ public class MailboxProbeImpl implements GuiceProbe, MailboxProbe {
             MailboxQuery.privateMailboxesBuilder(session)
                 .expression(Wildcard.INSTANCE)
                 .build(),
+            Minimal,
             session);
     }
 

--- a/server/container/mailbox-jmx/src/main/java/org/apache/james/adapter/mailbox/MailboxManagerManagement.java
+++ b/server/container/mailbox-jmx/src/main/java/org/apache/james/adapter/mailbox/MailboxManagerManagement.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.james.adapter.mailbox;
 
+import static org.apache.james.mailbox.MailboxManager.MailboxSearchFetchType.Minimal;
+
 import java.io.Closeable;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -205,6 +207,7 @@ public class MailboxManagerManagement extends StandardMBean implements MailboxMa
             MailboxQuery.privateMailboxesBuilder(session)
                 .matchesAllMailboxNames()
                 .build(),
+            Minimal,
             session)
             .collect(Guavate.toImmutableList())
             .block();

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RandomStoring.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RandomStoring.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.transport.mailets;
 
+import static org.apache.james.mailbox.MailboxManager.MailboxSearchFetchType.Minimal;
+
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
@@ -116,7 +118,7 @@ public class RandomStoring extends GenericMailet {
         try {
             MailboxSession session = mailboxManager.createSystemSession(username);
             return mailboxManager
-                .search(MailboxQuery.privateMailboxesBuilder(session).build(), session)
+                .search(MailboxQuery.privateMailboxesBuilder(session).build(), Minimal, session)
                 .toStream()
                 .map(metaData -> new ReroutingInfos(metaData.getPath().getName(), username));
         } catch (Exception e) {

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/MailboxFactoryTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/MailboxFactoryTest.java
@@ -178,7 +178,13 @@ public class MailboxFactoryTest {
         mailboxManager.createMailbox(mailboxPath, mailboxSession);
 
         Optional<MailboxId> id = sut.getParentIdFromMailboxPath(mailboxPath,
-            Optional.of(ImmutableList.of(MailboxMetaData.unselectableMailbox(parentMailboxPath, parentId, DELIMITER))),
+            Optional.of(ImmutableList.of(new MailboxMetaData(parentMailboxPath, parentId, DELIMITER,
+                MailboxMetaData.Children.CHILDREN_ALLOWED_BUT_UNKNOWN, MailboxMetaData.Selectability.NONE, new MailboxACL(),
+                MailboxCounters.builder()
+                    .mailboxId(parentId)
+                    .count(0)
+                    .unseen(0)
+                    .build()))),
             mailboxSession);
         assertThat(id).contains(parentId);
     }

--- a/server/protocols/webadmin/webadmin-jmap/src/main/java/org/apache/james/webadmin/data/jmap/MessageFastViewProjectionCorrector.java
+++ b/server/protocols/webadmin/webadmin-jmap/src/main/java/org/apache/james/webadmin/data/jmap/MessageFastViewProjectionCorrector.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.webadmin.data.jmap;
 
+import static org.apache.james.mailbox.MailboxManager.MailboxSearchFetchType.Minimal;
+
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
@@ -225,7 +227,7 @@ public class MessageFastViewProjectionCorrector {
     }
 
     private Flux<MailboxMetaData> listUsersMailboxes(MailboxSession session) {
-        return mailboxManager.search(MailboxQuery.privateMailboxesBuilder(session).build(), session);
+        return mailboxManager.search(MailboxQuery.privateMailboxesBuilder(session).build(), Minimal, session);
     }
 
     private Mono<MessageManager> retrieveMailbox(MailboxSession session, MailboxMetaData mailboxMetadata) {

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/UserMailboxesService.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/UserMailboxesService.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.webadmin.service;
 
+import static org.apache.james.mailbox.MailboxManager.MailboxSearchFetchType.Minimal;
+
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -127,7 +129,7 @@ public class UserMailboxesService {
     private Stream<MailboxMetaData> listUserMailboxes(MailboxSession mailboxSession) throws MailboxException {
         return mailboxManager.search(
             MailboxQuery.privateMailboxesBuilder(mailboxSession).build(),
-            mailboxSession)
+            Minimal, mailboxSession)
             .toStream();
     }
 

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -963,7 +963,7 @@ class UserMailboxesRoutesTest {
             MailboxMetaData metaData = mock(MailboxMetaData.class);
             when(metaData.getPath()).thenReturn(MailboxPath.forUser(USERNAME, MAILBOX_NAME));
             doReturn(Flux.just(metaData))
-                .when(mailboxManager).search(any(MailboxQuery.class), any(MailboxSession.class));
+                .when(mailboxManager).search(any(MailboxQuery.class), any(), any(MailboxSession.class));
             doThrow(new MailboxNotFoundException(MAILBOX_NAME)).when(mailboxManager).deleteMailbox(any(MailboxPath.class), any());
 
             when()
@@ -1011,7 +1011,7 @@ class UserMailboxesRoutesTest {
         @Test
         void deleteShouldReturnOkOnMailboxNotFoundExceptionWhenRemovingMailboxes() throws Exception {
             MailboxId mailboxId = InMemoryId.of(12);
-            when(mailboxManager.search(any(MailboxQuery.class), any()))
+            when(mailboxManager.search(any(MailboxQuery.class), any(), any()))
                 .thenReturn(
                         Flux.just(testMetadata(MailboxPath.forUser(USERNAME, "any"), mailboxId, '.')));
             doThrow(new MailboxNotFoundException("any")).when(mailboxManager).deleteMailbox(any(MailboxPath.class), any());

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -85,6 +85,8 @@ import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
 import org.apache.james.mailbox.model.ComposedMessageId;
 import org.apache.james.mailbox.model.FetchGroup;
 import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxACL;
+import org.apache.james.mailbox.model.MailboxCounters;
 import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxMetaData;
 import org.apache.james.mailbox.model.MailboxPath;
@@ -127,6 +129,15 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 class UserMailboxesRoutesTest {
+    public static MailboxMetaData testMetadata(MailboxPath path, MailboxId mailboxId, char delimiter) {
+        return new MailboxMetaData(path, mailboxId, delimiter, MailboxMetaData.Children.CHILDREN_ALLOWED_BUT_UNKNOWN, MailboxMetaData.Selectability.NONE, new MailboxACL(),
+            MailboxCounters.builder()
+                .mailboxId(mailboxId)
+                .count(0)
+                .unseen(0)
+                .build());
+    }
+
     private static final Username USERNAME = Username.of("username");
     private static final String MAILBOX_NAME = "myMailboxName";
     private static final String MAILBOX_NAME_WITH_DOTS = "my..MailboxName";
@@ -902,7 +913,7 @@ class UserMailboxesRoutesTest {
             when(mailboxManager.search(any(MailboxQuery.class), any()))
                 .thenReturn(
                         Flux.just(
-                                MailboxMetaData.unselectableMailbox(
+                                testMetadata(
                                         MailboxPath.forUser(USERNAME, MAILBOX_NAME), mailboxId, '.')));
             doThrow(new RuntimeException()).when(mailboxManager).deleteMailbox(any(MailboxPath.class), any());
 
@@ -928,7 +939,7 @@ class UserMailboxesRoutesTest {
             when(mailboxManager.search(any(MailboxQuery.class), any()))
                 .thenReturn(
                         Flux.just(
-                                MailboxMetaData.unselectableMailbox(MailboxPath.forUser(USERNAME, MAILBOX_NAME), mailboxId, '.')));
+                            testMetadata(MailboxPath.forUser(USERNAME, MAILBOX_NAME), mailboxId, '.')));
             doThrow(new MailboxException()).when(mailboxManager).deleteMailbox(any(MailboxPath.class), any());
 
             when()
@@ -988,7 +999,7 @@ class UserMailboxesRoutesTest {
             when(mailboxManager.search(any(MailboxQuery.class), any()))
                 .thenReturn(
                         Flux.just(
-                                MailboxMetaData.unselectableMailbox(MailboxPath.forUser(USERNAME, "any"), mailboxId, '.')));
+                            testMetadata(MailboxPath.forUser(USERNAME, "any"), mailboxId, '.')));
             doThrow(new RuntimeException()).when(mailboxManager).deleteMailbox(any(MailboxPath.class), any());
 
             when()
@@ -1002,7 +1013,7 @@ class UserMailboxesRoutesTest {
             MailboxId mailboxId = InMemoryId.of(12);
             when(mailboxManager.search(any(MailboxQuery.class), any()))
                 .thenReturn(
-                        Flux.just(MailboxMetaData.unselectableMailbox(MailboxPath.forUser(USERNAME, "any"), mailboxId, '.')));
+                        Flux.just(testMetadata(MailboxPath.forUser(USERNAME, "any"), mailboxId, '.')));
             doThrow(new MailboxNotFoundException("any")).when(mailboxManager).deleteMailbox(any(MailboxPath.class), any());
 
             when()
@@ -1016,7 +1027,7 @@ class UserMailboxesRoutesTest {
             MailboxId mailboxId = InMemoryId.of(12);
             when(mailboxManager.search(any(MailboxQuery.class), any()))
                 .thenReturn(
-                        Flux.just(MailboxMetaData.unselectableMailbox(MailboxPath.forUser(USERNAME, "any"), mailboxId, '.')));
+                        Flux.just(testMetadata(MailboxPath.forUser(USERNAME, "any"), mailboxId, '.')));
             doThrow(new MailboxException()).when(mailboxManager).deleteMailbox(any(MailboxPath.class), any());
 
             when()


### PR DESCRIPTION
IMAP LIST and many other methods do not need the mailbox counters. Reading them is however a major performance hit,
and accounts for most of Cassandra request time upon IMAP LIST.

This is even more important if (potentially expenssive) read repairs
are performed upon counter reads.

I first tried an alternative: adding an API letting retrieve the counters from a mailbox.
However for safety we want to enforce the right access on the mailbox before disclosing its
counters. But for efficiency, we should not refetch this information.

A pattern would then be "protocol layer first retrieves the mailbox" then "using that mailbox requests
the counters". This would be unsafe as the mailbox object could be crafted in the protocol layers to
cheat the right resolution system.

I came to the conclusion we need two "search mailboxes" methods, one that fetch counters and one that don't.

The smoother way to do that is to follow the already classic FetchType pattern in the StoreMailboxManager.