### PR TITLE
JAMES-3430 Restructure Cassandra mailbox message properties storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - JAMES-3263 Optimize RecipientRewriteTable::getMappingsForType
 - JAMES-3176 Rewritte MDN parsing with Parboiled scala (avoid asm library dependency clash within the Distributed Server)
 - JAMES-3194 Rely on DTOConverter in TaskRoute
+- JAMES-3430 Restructure message properties storage within Cassandra Mailbox. See upgrade instructions.
 
 ### Deprecated
 - HybridBlobStore. This will be removed after 3.6.0 release. Introduced to fasten small blob access, its usage could be

--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionManager.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/versions/CassandraSchemaVersionManager.java
@@ -36,7 +36,7 @@ import reactor.core.publisher.Mono;
 
 public class CassandraSchemaVersionManager {
     public static final SchemaVersion MIN_VERSION = new SchemaVersion(5);
-    public static final SchemaVersion MAX_VERSION = new SchemaVersion(8);
+    public static final SchemaVersion MAX_VERSION = new SchemaVersion(9);
     public static final SchemaVersion DEFAULT_VERSION = MIN_VERSION;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CassandraSchemaVersionManager.class);

--- a/docs/modules/servers/pages/distributed/operate/cassandra-migration.adoc
+++ b/docs/modules/servers/pages/distributed/operate/cassandra-migration.adoc
@@ -23,5 +23,7 @@ to mailboxPathV2 table relying on a composite primary key.
 handy for things like mail aliases (I want to list aliases rewritting things to bob). Without this projection table being available,
 (ie we rely on schema version 6 or less) such information is obtained through a full table scan, unoptimized. From schema version 7,
 the optimized projection can safely be used.
+* *From V7 to V8* : Add UID_VALIDITY to mailboxPath table in order not to mandate mailbox table reads.
+* *From V8 to V9* : Adopt a more compact representation for message properties.
 
 The xref:distributed/operate/guide.adoc#_updating_cassandra_schema_version[Operator guide] further details the migration process.

--- a/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxMessageFixture.java
+++ b/mailbox/backup/src/test/java/org/apache/james/mailbox/backup/MailboxMessageFixture.java
@@ -130,7 +130,7 @@ public interface MailboxMessageFixture {
         .internalDate(new Date(DATE_1.toEpochSecond()))
         .bodyStartOctet(0)
         .flags(flags1)
-        .propertyBuilder(new PropertyBuilder())
+        .properties(new PropertyBuilder())
         .mailboxId(MAILBOX_ID_1)
         .build();
 
@@ -142,7 +142,7 @@ public interface MailboxMessageFixture {
         .internalDate(new Date(DATE_1.toEpochSecond()))
         .bodyStartOctet(0)
         .flags(flags1)
-        .propertyBuilder(new PropertyBuilder())
+        .properties(new PropertyBuilder())
         .mailboxId(MAILBOX_ID_11)
         .build();
 
@@ -154,7 +154,7 @@ public interface MailboxMessageFixture {
         .internalDate(new Date(DATE_2.toEpochSecond()))
         .bodyStartOctet(0)
         .flags(new Flags())
-        .propertyBuilder(new PropertyBuilder())
+        .properties(new PropertyBuilder())
         .mailboxId(MAILBOX_ID_1)
         .build();
 }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/CassandraMailboxSessionMapperFactory.java
@@ -44,6 +44,7 @@ import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathV2DAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathV3DAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxRecentsDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAOV3;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdMapper;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdToImapUidDAO;
@@ -75,6 +76,7 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
     private final CassandraUidProvider uidProvider;
     private final CassandraModSeqProvider modSeqProvider;
     private final CassandraMessageDAO messageDAO;
+    private final CassandraMessageDAOV3 messageDAOV3;
     private final CassandraMessageIdDAO messageIdDAO;
     private final CassandraMessageIdToImapUidDAO imapUidDAO;
     private final CassandraMailboxCounterDAO mailboxCounterDAO;
@@ -101,7 +103,7 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
     @Inject
     public CassandraMailboxSessionMapperFactory(CassandraUidProvider uidProvider, CassandraModSeqProvider modSeqProvider, Session session,
                                                 CassandraMessageDAO messageDAO,
-                                                CassandraMessageIdDAO messageIdDAO, CassandraMessageIdToImapUidDAO imapUidDAO,
+                                                CassandraMessageDAOV3 messageDAOV3, CassandraMessageIdDAO messageIdDAO, CassandraMessageIdToImapUidDAO imapUidDAO,
                                                 CassandraMailboxCounterDAO mailboxCounterDAO, CassandraMailboxRecentsDAO mailboxRecentsDAO, CassandraMailboxDAO mailboxDAO,
                                                 CassandraMailboxPathDAOImpl mailboxPathDAO, CassandraMailboxPathV2DAO mailboxPathV2DAO, CassandraMailboxPathV3DAO mailboxPathV3DAO, CassandraFirstUnseenDAO firstUnseenDAO, CassandraApplicableFlagDAO applicableFlagDAO,
                                                 CassandraAttachmentDAOV2 attachmentDAOV2, CassandraDeletedMessageDAO deletedMessageDAO,
@@ -115,6 +117,7 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
         this.modSeqProvider = modSeqProvider;
         this.session = session;
         this.messageDAO = messageDAO;
+        this.messageDAOV3 = messageDAOV3;
         this.messageIdDAO = messageIdDAO;
         this.imapUidDAO = imapUidDAO;
         this.mailboxCounterDAO = mailboxCounterDAO;
@@ -151,6 +154,7 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
                                           modSeqProvider,
                                           createAttachmentMapper(mailboxSession),
                                           messageDAO,
+                                          messageDAOV3,
                                           messageIdDAO,
                                           imapUidDAO,
                                           mailboxCounterDAO,
@@ -166,7 +170,7 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
     public MessageIdMapper createMessageIdMapper(MailboxSession mailboxSession) {
         return new CassandraMessageIdMapper(getMailboxMapper(mailboxSession), mailboxDAO,
                 createAttachmentMapper(mailboxSession),
-                imapUidDAO, messageIdDAO, messageDAO, indexTableHandler, modSeqProvider,
+                imapUidDAO, messageIdDAO, messageDAO, messageDAOV3, indexTableHandler, modSeqProvider,
                 cassandraConfiguration);
     }
 
@@ -211,7 +215,7 @@ public class CassandraMailboxSessionMapperFactory extends MailboxSessionMapperFa
     }
 
     public DeleteMessageListener deleteMessageListener() {
-        return new DeleteMessageListener(imapUidDAO, messageIdDAO, messageDAO, attachmentDAOV2, ownerDAO,
+        return new DeleteMessageListener(imapUidDAO, messageIdDAO, messageDAO, messageDAOV3, attachmentDAOV2, ownerDAO,
             attachmentMessageIdDAO, aclMapper, userMailboxRightsDAO, applicableFlagDAO, firstUnseenDAO, deletedMessageDAO,
             mailboxCounterDAO, mailboxRecentsDAO, blobStore);
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
@@ -192,7 +192,9 @@ public class CassandraMessageDAO {
     }
 
     private List<UDTValue> buildPropertiesUdt(MailboxMessage message) {
-        return message.getProperties().stream()
+        return message.getProperties()
+            .toProperties()
+            .stream()
             .map(property -> typesProvider.getDefinedUserType(PROPERTIES)
                 .newValue()
                 .setString(Properties.NAMESPACE, property.getNamespace())
@@ -236,19 +238,19 @@ public class CassandraMessageDAO {
                 row.getLong(FULL_CONTENT_OCTETS),
                 row.getInt(BODY_START_OCTET),
                 new SharedByteArrayInputStream(content),
-                getPropertyBuilder(row),
+                getProperties(row),
                 getAttachments(row).collect(Guavate.toImmutableList()),
                 headerId,
                 bodyId));
     }
 
-    private PropertyBuilder getPropertyBuilder(Row row) {
+    private org.apache.james.mailbox.store.mail.model.impl.Properties getProperties(Row row) {
         PropertyBuilder property = new PropertyBuilder(
             row.getList(PROPERTIES, UDTValue.class).stream()
                 .map(this::toProperty)
                 .collect(Collectors.toList()));
         property.setTextualLineCount(row.getLong(TEXTUAL_LINE_COUNT));
-        return property;
+        return property.build();
     }
 
     private Property toProperty(UDTValue udtValue) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
@@ -61,6 +61,7 @@ import org.apache.james.mailbox.model.AttachmentId;
 import org.apache.james.mailbox.model.Cid;
 import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
+import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.Property;
@@ -78,6 +79,7 @@ import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Bytes;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 
@@ -92,7 +94,9 @@ public class CassandraMessageDAO {
     private final PreparedStatement insert;
     private final PreparedStatement delete;
     private final PreparedStatement select;
+    private final PreparedStatement selectAll;
     private final Cid.CidParser cidParser;
+    private final CassandraMessageId.Factory messageIdFactory;
     private final ConsistencyLevel consistencyLevel;
 
     @Inject
@@ -100,8 +104,10 @@ public class CassandraMessageDAO {
                                CassandraTypesProvider typesProvider,
                                BlobStore blobStore,
                                BlobId.Factory blobIdFactory,
+                               CassandraMessageId.Factory messageIdFactory,
                                CassandraConsistenciesConfiguration consistenciesConfiguration) {
         this.cassandraAsyncExecutor = new CassandraAsyncExecutor(session);
+        this.messageIdFactory = messageIdFactory;
         this.consistencyLevel = consistenciesConfiguration.getRegular();
         this.typesProvider = typesProvider;
         this.blobStore = blobStore;
@@ -110,6 +116,7 @@ public class CassandraMessageDAO {
         this.insert = prepareInsert(session);
         this.delete = prepareDelete(session);
         this.select = prepareSelect(session);
+        this.selectAll = prepareSelectAll(session);
         this.cidParser = Cid.parser().relaxed();
     }
 
@@ -117,6 +124,11 @@ public class CassandraMessageDAO {
         return session.prepare(select()
             .from(TABLE_NAME)
             .where(eq(MESSAGE_ID, bindMarker(MESSAGE_ID))));
+    }
+
+    private PreparedStatement prepareSelectAll(Session session) {
+        return session.prepare(select()
+            .from(TABLE_NAME));
     }
 
     private PreparedStatement prepareInsert(Session session) {
@@ -137,6 +149,11 @@ public class CassandraMessageDAO {
         return session.prepare(QueryBuilder.delete()
             .from(TABLE_NAME)
             .where(eq(MESSAGE_ID, bindMarker(MESSAGE_ID))));
+    }
+
+    public Flux<MessageRepresentation> list() {
+        return cassandraAsyncExecutor.executeRows(selectAll.bind())
+            .map(this::message);
     }
 
     public Mono<Void> save(MailboxMessage message) throws MailboxException {
@@ -242,6 +259,23 @@ public class CassandraMessageDAO {
                 getAttachments(row).collect(Guavate.toImmutableList()),
                 headerId,
                 bodyId));
+    }
+
+    private MessageRepresentation message(Row row) {
+        BlobId headerId = retrieveBlobId(HEADER_CONTENT, row);
+        BlobId bodyId = retrieveBlobId(BODY_CONTENT, row);
+        CassandraMessageId messageId = messageIdFactory.of(row.getUUID(MESSAGE_ID));
+
+        return new MessageRepresentation(
+                messageId,
+                row.getTimestamp(INTERNAL_DATE),
+                row.getLong(FULL_CONTENT_OCTETS),
+                row.getInt(BODY_START_OCTET),
+                new SharedByteArrayInputStream(EMPTY_BYTE_ARRAY),
+                getProperties(row),
+                getAttachments(row).collect(Guavate.toImmutableList()),
+                headerId,
+                bodyId);
     }
 
     private org.apache.james.mailbox.store.mail.model.impl.Properties getProperties(Row row) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAO.java
@@ -61,7 +61,6 @@ import org.apache.james.mailbox.model.AttachmentId;
 import org.apache.james.mailbox.model.Cid;
 import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
-import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.Property;

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3.java
@@ -1,0 +1,329 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static org.apache.james.blob.api.BlobStore.StoragePolicy.LOW_COST;
+import static org.apache.james.blob.api.BlobStore.StoragePolicy.SIZE_BASED;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageIds.MESSAGE_ID;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.ATTACHMENTS;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.BODY_CONTENT;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.BODY_OCTECTS;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.BODY_START_OCTET;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.FULL_CONTENT_OCTETS;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.HEADER_CONTENT;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.INTERNAL_DATE;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.Properties.CONTENT_DESCRIPTION;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.Properties.CONTENT_DISPOSITION_PARAMETERS;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.Properties.CONTENT_DISPOSITION_TYPE;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.Properties.CONTENT_ID;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.Properties.CONTENT_LANGUAGE;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.Properties.CONTENT_LOCATION;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.Properties.CONTENT_MD5;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.Properties.CONTENT_TRANSFER_ENCODING;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.Properties.CONTENT_TYPE_PARAMETERS;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.Properties.MEDIA_TYPE;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.Properties.SUB_TYPE;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.TABLE_NAME;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.TEXTUAL_LINE_COUNT;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import javax.inject.Inject;
+import javax.mail.util.SharedByteArrayInputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.james.backends.cassandra.init.CassandraTypesProvider;
+import org.apache.james.backends.cassandra.init.configuration.CassandraConsistenciesConfiguration;
+import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
+import org.apache.james.blob.api.BlobId;
+import org.apache.james.blob.api.BlobStore;
+import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.cassandra.table.CassandraMessageV3Table.Attachments;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.AttachmentId;
+import org.apache.james.mailbox.model.Cid;
+import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
+import org.apache.james.mailbox.model.MessageAttachmentMetadata;
+import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
+import org.apache.james.mailbox.store.mail.model.MailboxMessage;
+import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.UDTValue;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Bytes;
+
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
+
+public class CassandraMessageDAOV3 {
+    public static final long DEFAULT_LONG_VALUE = 0L;
+    private static final byte[] EMPTY_BYTE_ARRAY = {};
+
+    private final CassandraAsyncExecutor cassandraAsyncExecutor;
+    private final CassandraTypesProvider typesProvider;
+    private final BlobStore blobStore;
+    private final BlobId.Factory blobIdFactory;
+    private final PreparedStatement insert;
+    private final PreparedStatement delete;
+    private final PreparedStatement select;
+    private final Cid.CidParser cidParser;
+    private final ConsistencyLevel consistencyLevel;
+
+    @Inject
+    public CassandraMessageDAOV3(Session session, CassandraTypesProvider typesProvider, BlobStore blobStore,
+                                 BlobId.Factory blobIdFactory,
+                                 CassandraConsistenciesConfiguration consistenciesConfiguration) {
+        this.cassandraAsyncExecutor = new CassandraAsyncExecutor(session);
+        this.consistencyLevel = consistenciesConfiguration.getRegular();
+        this.typesProvider = typesProvider;
+        this.blobStore = blobStore;
+        this.blobIdFactory = blobIdFactory;
+
+        this.insert = prepareInsert(session);
+        this.delete = prepareDelete(session);
+        this.select = prepareSelect(session);
+        this.cidParser = Cid.parser().relaxed();
+    }
+
+    private PreparedStatement prepareSelect(Session session) {
+        return session.prepare(select()
+            .from(TABLE_NAME)
+            .where(eq(MESSAGE_ID, bindMarker(MESSAGE_ID))));
+    }
+
+    private PreparedStatement prepareInsert(Session session) {
+        return session.prepare(insertInto(TABLE_NAME)
+            .value(MESSAGE_ID, bindMarker(MESSAGE_ID))
+            .value(INTERNAL_DATE, bindMarker(INTERNAL_DATE))
+            .value(BODY_START_OCTET, bindMarker(BODY_START_OCTET))
+            .value(FULL_CONTENT_OCTETS, bindMarker(FULL_CONTENT_OCTETS))
+            .value(BODY_OCTECTS, bindMarker(BODY_OCTECTS))
+            .value(BODY_CONTENT, bindMarker(BODY_CONTENT))
+            .value(HEADER_CONTENT, bindMarker(HEADER_CONTENT))
+            .value(CONTENT_DESCRIPTION, bindMarker(CONTENT_DESCRIPTION))
+            .value(CONTENT_DISPOSITION_TYPE, bindMarker(CONTENT_DISPOSITION_TYPE))
+            .value(MEDIA_TYPE, bindMarker(MEDIA_TYPE))
+            .value(SUB_TYPE, bindMarker(SUB_TYPE))
+            .value(CONTENT_ID, bindMarker(CONTENT_ID))
+            .value(CONTENT_MD5, bindMarker(CONTENT_MD5))
+            .value(CONTENT_TRANSFER_ENCODING, bindMarker(CONTENT_TRANSFER_ENCODING))
+            .value(CONTENT_LOCATION, bindMarker(CONTENT_LOCATION))
+            .value(CONTENT_LANGUAGE, bindMarker(CONTENT_LANGUAGE))
+            .value(CONTENT_DISPOSITION_PARAMETERS, bindMarker(CONTENT_DISPOSITION_PARAMETERS))
+            .value(CONTENT_TYPE_PARAMETERS, bindMarker(CONTENT_TYPE_PARAMETERS))
+            .value(TEXTUAL_LINE_COUNT, bindMarker(TEXTUAL_LINE_COUNT))
+            .value(ATTACHMENTS, bindMarker(ATTACHMENTS)));
+    }
+
+    private PreparedStatement prepareDelete(Session session) {
+        return session.prepare(QueryBuilder.delete()
+            .from(TABLE_NAME)
+            .where(eq(MESSAGE_ID, bindMarker(MESSAGE_ID))));
+    }
+
+    public Mono<Void> save(MailboxMessage message) throws MailboxException {
+        return saveContent(message)
+            .flatMap(pair -> cassandraAsyncExecutor.executeVoid(boundWriteStatement(message, pair)));
+    }
+
+    private Mono<Tuple2<BlobId, BlobId>> saveContent(MailboxMessage message) throws MailboxException {
+        try {
+            byte[] headerContent = IOUtils.toByteArray(message.getHeaderContent());
+            byte[] bodyContent = IOUtils.toByteArray(message.getBodyContent());
+
+            Mono<BlobId> bodyFuture = Mono.from(blobStore.save(blobStore.getDefaultBucketName(), bodyContent, LOW_COST));
+            Mono<BlobId> headerFuture = Mono.from(blobStore.save(blobStore.getDefaultBucketName(), headerContent, SIZE_BASED));
+
+            return headerFuture.zipWith(bodyFuture);
+        } catch (IOException e) {
+            throw new MailboxException("Error saving mail content", e);
+        }
+    }
+
+    private BoundStatement boundWriteStatement(MailboxMessage message, Tuple2<BlobId, BlobId> pair) {
+        CassandraMessageId messageId = (CassandraMessageId) message.getMessageId();
+        PropertyBuilder propertyBuilder = new PropertyBuilder(message.getProperties());
+        return insert.bind()
+            .setUUID(MESSAGE_ID, messageId.get())
+            .setTimestamp(INTERNAL_DATE, message.getInternalDate())
+            .setInt(BODY_START_OCTET, (int) (message.getHeaderOctets()))
+            .setLong(FULL_CONTENT_OCTETS, message.getFullContentOctets())
+            .setLong(BODY_OCTECTS, message.getBodyOctets())
+            .setString(BODY_CONTENT, pair.getT2().asString())
+            .setString(HEADER_CONTENT, pair.getT1().asString())
+            .setLong(TEXTUAL_LINE_COUNT, Optional.ofNullable(message.getTextualLineCount()).orElse(DEFAULT_LONG_VALUE))
+            .setString(CONTENT_DESCRIPTION, propertyBuilder.getContentDescription())
+            .setString(CONTENT_DISPOSITION_TYPE, propertyBuilder.getContentDispositionType())
+            .setString(MEDIA_TYPE, propertyBuilder.getMediaType())
+            .setString(SUB_TYPE, propertyBuilder.getSubType())
+            .setString(CONTENT_ID, propertyBuilder.getContentID())
+            .setString(CONTENT_MD5, propertyBuilder.getContentMD5())
+            .setString(CONTENT_TRANSFER_ENCODING, propertyBuilder.getContentTransferEncoding())
+            .setString(CONTENT_LOCATION, propertyBuilder.getContentLocation())
+            .setList(CONTENT_LANGUAGE, propertyBuilder.getContentLanguage())
+            .setMap(CONTENT_DISPOSITION_PARAMETERS, propertyBuilder.getContentDispositionParameters())
+            .setMap(CONTENT_TYPE_PARAMETERS, propertyBuilder.getContentTypeParameters())
+            .setList(ATTACHMENTS, buildAttachmentUdt(message));
+    }
+
+    private ImmutableList<UDTValue> buildAttachmentUdt(MailboxMessage message) {
+        return message.getAttachments().stream()
+            .map(this::toUDT)
+            .collect(Guavate.toImmutableList());
+    }
+
+    private UDTValue toUDT(MessageAttachmentMetadata messageAttachment) {
+        UDTValue result = typesProvider.getDefinedUserType(ATTACHMENTS)
+            .newValue()
+            .setString(Attachments.ID, messageAttachment.getAttachmentId().getId())
+            .setBool(Attachments.IS_INLINE, messageAttachment.isInline());
+        messageAttachment.getName()
+            .ifPresent(name -> result.setString(Attachments.NAME, name));
+        messageAttachment.getCid()
+            .ifPresent(cid -> result.setString(Attachments.CID, cid.getValue()));
+        return result;
+    }
+
+    public Mono<MessageRepresentation> retrieveMessage(ComposedMessageIdWithMetaData id, FetchType fetchType) {
+        CassandraMessageId cassandraMessageId = (CassandraMessageId) id.getComposedMessageId().getMessageId();
+        return retrieveMessage(cassandraMessageId, fetchType);
+    }
+
+    public Mono<MessageRepresentation> retrieveMessage(CassandraMessageId cassandraMessageId, FetchType fetchType) {
+        return retrieveRow(cassandraMessageId)
+                .flatMap(resultSet -> message(resultSet, cassandraMessageId, fetchType));
+    }
+
+    private Mono<ResultSet> retrieveRow(CassandraMessageId messageId) {
+        return cassandraAsyncExecutor.execute(select
+            .bind()
+            .setUUID(MESSAGE_ID, messageId.get())
+            .setConsistencyLevel(consistencyLevel));
+    }
+
+    private Mono<MessageRepresentation>
+    message(ResultSet rows, CassandraMessageId cassandraMessageId, FetchType fetchType) {
+        if (rows.isExhausted()) {
+            return Mono.empty();
+        }
+
+        Row row = rows.one();
+        BlobId headerId = retrieveBlobId(HEADER_CONTENT, row);
+        BlobId bodyId = retrieveBlobId(BODY_CONTENT, row);
+        int bodyStartOctet = row.getInt(BODY_START_OCTET);
+
+        return buildContentRetriever(fetchType, headerId, bodyId, bodyStartOctet).map(content ->
+            new MessageRepresentation(
+                cassandraMessageId,
+                row.getTimestamp(INTERNAL_DATE),
+                row.getLong(FULL_CONTENT_OCTETS),
+                row.getInt(BODY_START_OCTET),
+                new SharedByteArrayInputStream(content),
+                getPropertyBuilder(row),
+                getAttachments(row).collect(Guavate.toImmutableList()),
+                headerId,
+                bodyId));
+    }
+
+    private PropertyBuilder getPropertyBuilder(Row row) {
+        PropertyBuilder property = new PropertyBuilder();
+        property.setContentDescription(row.getString(CONTENT_DESCRIPTION));
+        property.setContentDispositionType(row.getString(CONTENT_DISPOSITION_TYPE));
+        property.setMediaType(row.getString(MEDIA_TYPE));
+        property.setSubType(row.getString(SUB_TYPE));
+        property.setContentID(row.getString(CONTENT_ID));
+        property.setContentMD5(row.getString(CONTENT_MD5));
+        property.setContentTransferEncoding(row.getString(CONTENT_TRANSFER_ENCODING));
+        property.setContentLocation(row.getString(CONTENT_LOCATION));
+        property.setContentLanguage(row.getList(CONTENT_LANGUAGE, String.class));
+        property.setContentDispositionParameters(row.getMap(CONTENT_DISPOSITION_PARAMETERS, String.class, String.class));
+        property.setContentTypeParameters(row.getMap(CONTENT_TYPE_PARAMETERS, String.class, String.class));
+        property.setTextualLineCount(row.getLong(TEXTUAL_LINE_COUNT));
+        return property;
+    }
+
+    private Stream<MessageAttachmentRepresentation> getAttachments(Row row) {
+        List<UDTValue> udtValues = row.getList(ATTACHMENTS, UDTValue.class);
+        return attachmentByIds(udtValues);
+    }
+
+    private Stream<MessageAttachmentRepresentation> attachmentByIds(List<UDTValue> udtValues) {
+        return udtValues.stream()
+            .map(this::messageAttachmentByIdFrom);
+    }
+
+    private MessageAttachmentRepresentation messageAttachmentByIdFrom(UDTValue udtValue) {
+        return MessageAttachmentRepresentation.builder()
+            .attachmentId(AttachmentId.from(udtValue.getString(Attachments.ID)))
+            .name(udtValue.getString(Attachments.NAME))
+            .cid(cidParser.parse(udtValue.getString(Attachments.CID)))
+            .isInline(udtValue.getBool(Attachments.IS_INLINE))
+            .build();
+    }
+
+    public Mono<Void> delete(CassandraMessageId messageId) {
+        return cassandraAsyncExecutor.executeVoid(delete.bind()
+            .setUUID(MESSAGE_ID, messageId.get()));
+    }
+
+    private Mono<byte[]> buildContentRetriever(FetchType fetchType, BlobId headerId, BlobId bodyId, int bodyStartOctet) {
+        switch (fetchType) {
+            case Full:
+                return getFullContent(headerId, bodyId);
+            case Headers:
+                return getContent(headerId);
+            case Body:
+                return getContent(bodyId)
+                    .map(data -> Bytes.concat(new byte[bodyStartOctet], data));
+            case Metadata:
+                return Mono.just(EMPTY_BYTE_ARRAY);
+            default:
+                throw new RuntimeException("Unknown FetchType " + fetchType);
+        }
+    }
+
+    private Mono<byte[]> getFullContent(BlobId headerId, BlobId bodyId) {
+        return getContent(headerId)
+            .zipWith(getContent(bodyId), Bytes::concat);
+    }
+
+    private Mono<byte[]> getContent(BlobId blobId) {
+        return Mono.from(blobStore.readBytes(blobStore.getDefaultBucketName(), blobId));
+    }
+
+    private BlobId retrieveBlobId(String field, Row row) {
+        return blobIdFactory.from(row.getString(field));
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/MessageRepresentation.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/MessageRepresentation.java
@@ -35,19 +35,19 @@ public class MessageRepresentation {
     private final MessageId messageId;
     private final Date internalDate;
     private final Long size;
-    private final Integer bodySize;
+    private final Integer bodyStartOctet;
     private final SharedByteArrayInputStream content;
     private final Properties properties;
     private final List<MessageAttachmentRepresentation> attachments;
     private final BlobId headerId;
     private final BlobId bodyId;
 
-    public MessageRepresentation(MessageId messageId, Date internalDate, Long size, Integer bodySize, SharedByteArrayInputStream content,
+    public MessageRepresentation(MessageId messageId, Date internalDate, Long size, Integer bodyStartOctet, SharedByteArrayInputStream content,
                                  Properties properties, List<MessageAttachmentRepresentation> attachments, BlobId headerId, BlobId bodyId) {
         this.messageId = messageId;
         this.internalDate = internalDate;
         this.size = size;
-        this.bodySize = bodySize;
+        this.bodyStartOctet = bodyStartOctet;
         this.content = content;
         this.properties = properties;
         this.attachments = attachments;
@@ -62,13 +62,25 @@ public class MessageRepresentation {
             .uid(metadata.getComposedMessageId().getUid())
             .modseq(metadata.getModSeq())
             .internalDate(internalDate)
-            .bodyStartOctet(bodySize)
+            .bodyStartOctet(bodyStartOctet)
             .size(size)
             .content(content)
             .flags(metadata.getFlags())
             .properties(properties)
             .addAttachments(attachments)
             .build();
+    }
+
+    public Date getInternalDate() {
+        return internalDate;
+    }
+
+    public Long getSize() {
+        return size;
+    }
+
+    public Integer getBodyStartOctet() {
+        return bodyStartOctet;
     }
 
     public MessageId getMessageId() {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/MessageRepresentation.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/MessageRepresentation.java
@@ -28,7 +28,7 @@ import org.apache.james.blob.api.BlobId;
 import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
-import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
+import org.apache.james.mailbox.store.mail.model.impl.Properties;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 
 public class MessageRepresentation {
@@ -37,19 +37,19 @@ public class MessageRepresentation {
     private final Long size;
     private final Integer bodySize;
     private final SharedByteArrayInputStream content;
-    private final PropertyBuilder propertyBuilder;
+    private final Properties properties;
     private final List<MessageAttachmentRepresentation> attachments;
     private final BlobId headerId;
     private final BlobId bodyId;
 
     public MessageRepresentation(MessageId messageId, Date internalDate, Long size, Integer bodySize, SharedByteArrayInputStream content,
-                                 PropertyBuilder propertyBuilder, List<MessageAttachmentRepresentation> attachments, BlobId headerId, BlobId bodyId) {
+                                 Properties properties, List<MessageAttachmentRepresentation> attachments, BlobId headerId, BlobId bodyId) {
         this.messageId = messageId;
         this.internalDate = internalDate;
         this.size = size;
         this.bodySize = bodySize;
         this.content = content;
-        this.propertyBuilder = propertyBuilder;
+        this.properties = properties;
         this.attachments = attachments;
         this.headerId = headerId;
         this.bodyId = bodyId;
@@ -66,7 +66,7 @@ public class MessageRepresentation {
             .size(size)
             .content(content)
             .flags(metadata.getFlags())
-            .propertyBuilder(propertyBuilder)
+            .properties(properties)
             .addAttachments(attachments)
             .build();
     }
@@ -79,8 +79,8 @@ public class MessageRepresentation {
         return content;
     }
 
-    public PropertyBuilder getPropertyBuilder() {
-        return propertyBuilder;
+    public Properties getProperties() {
+        return properties;
     }
 
     public List<MessageAttachmentRepresentation> getAttachments() {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/MessageV3Migration.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/MessageV3Migration.java
@@ -1,0 +1,119 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.migration;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.apache.james.backends.cassandra.migration.Migration;
+import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAOV3;
+import org.apache.james.mailbox.cassandra.mail.MessageRepresentation;
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.task.TaskType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import reactor.core.publisher.Mono;
+
+public class MessageV3Migration implements Migration {
+    private static final int CONCURRENCY = 50;
+
+    static class MessageV3MigrationTask implements Task {
+        private final MessageV3Migration migration;
+
+        MessageV3MigrationTask(MessageV3Migration migration) {
+            this.migration = migration;
+        }
+
+        @Override
+        public Result run() throws InterruptedException {
+            return migration.runTask();
+        }
+
+        @Override
+        public TaskType type() {
+            return TYPE;
+        }
+
+        @Override
+        public Optional<TaskExecutionDetails.AdditionalInformation> details() {
+            return Optional.of(migration.getAdditionalInformation());
+        }
+    }
+
+    public static class AdditionalInformation implements TaskExecutionDetails.AdditionalInformation {
+        private final Instant timestamp;
+
+        public AdditionalInformation(Instant timestamp) {
+            this.timestamp = timestamp;
+        }
+
+        @Override
+        public Instant timestamp() {
+            return timestamp;
+        }
+    }
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(MessageV3Migration.class);
+    public static final TaskType TYPE = TaskType.of("cassandra-message-v3-migration");
+    private final CassandraMessageDAO daoV2;
+    private final CassandraMessageDAOV3 daoV3;
+
+    @Inject
+    public MessageV3Migration(CassandraMessageDAO daoV2, CassandraMessageDAOV3 daoV3) {
+        this.daoV2 = daoV2;
+        this.daoV3 = daoV3;
+    }
+
+    @Override
+    public void apply() {
+        daoV2.list()
+            .flatMap(this::migrate, CONCURRENCY)
+            .doOnError(t -> LOGGER.error("Error while performing migration", t))
+            .blockLast();
+    }
+
+    private Mono<Void> migrate(MessageRepresentation messageRepresentation) {
+        return daoV3.save(messageRepresentation)
+            .then(daoV2.delete((CassandraMessageId) messageRepresentation.getMessageId()))
+            .onErrorResume(error -> handleErrorMigrate(messageRepresentation, error))
+            .then();
+    }
+
+    private Mono<Void> handleErrorMigrate(MessageRepresentation messageRepresentation, Throwable throwable) {
+        LOGGER.error("Error while performing migration for {}", messageRepresentation.getMessageId(), throwable);
+        return Mono.empty();
+    }
+
+    @Override
+    public Task asTask() {
+        return new MessageV3MigrationTask(this);
+    }
+
+    AdditionalInformation getAdditionalInformation() {
+        return new AdditionalInformation(Clock.systemUTC().instant());
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/MessageV3MigrationTaskAdditionalInformationDTO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/MessageV3MigrationTaskAdditionalInformationDTO.java
@@ -1,0 +1,69 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.migration;
+
+import java.time.Instant;
+
+import org.apache.james.json.DTOModule;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MessageV3MigrationTaskAdditionalInformationDTO implements AdditionalInformationDTO {
+    private static MessageV3MigrationTaskAdditionalInformationDTO fromDomainObject(MessageV3Migration.AdditionalInformation additionalInformation, String type) {
+        return new MessageV3MigrationTaskAdditionalInformationDTO(
+            type,
+            additionalInformation.timestamp()
+        );
+    }
+
+    public static final AdditionalInformationDTOModule<MessageV3Migration.AdditionalInformation, MessageV3MigrationTaskAdditionalInformationDTO> MODULE =
+        DTOModule
+            .forDomainObject(MessageV3Migration.AdditionalInformation.class)
+            .convertToDTO(MessageV3MigrationTaskAdditionalInformationDTO.class)
+            .toDomainObjectConverter(MessageV3MigrationTaskAdditionalInformationDTO::toDomainObject)
+            .toDTOConverter(MessageV3MigrationTaskAdditionalInformationDTO::fromDomainObject)
+            .typeName(MessageV3Migration.TYPE.asString())
+            .withFactory(AdditionalInformationDTOModule::new);
+
+    private final String type;
+    private final Instant timestamp;
+
+    public MessageV3MigrationTaskAdditionalInformationDTO(@JsonProperty("type") String type,
+                                                          @JsonProperty("timestamp") Instant timestamp) {
+        this.type = type;
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    private MessageV3Migration.AdditionalInformation toDomainObject() {
+        return new MessageV3Migration.AdditionalInformation(timestamp);
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/MessageV3MigrationTaskDTO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/migration/MessageV3MigrationTaskDTO.java
@@ -1,0 +1,59 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.migration;
+
+import java.util.function.Function;
+
+import org.apache.james.json.DTOModule;
+import org.apache.james.server.task.json.dto.TaskDTO;
+import org.apache.james.server.task.json.dto.TaskDTOModule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MessageV3MigrationTaskDTO implements TaskDTO {
+
+    private static MessageV3MigrationTaskDTO fromDomainObject(MessageV3Migration.MessageV3MigrationTask task, String type) {
+        return new MessageV3MigrationTaskDTO(type);
+    }
+
+    public static final Function<MessageV3Migration, TaskDTOModule<MessageV3Migration.MessageV3MigrationTask, MessageV3MigrationTaskDTO>> MODULE = (migration) ->
+        DTOModule
+            .forDomainObject(MessageV3Migration.MessageV3MigrationTask.class)
+            .convertToDTO(MessageV3MigrationTaskDTO.class)
+            .toDomainObjectConverter(dto -> dto.toDomainObject(migration))
+            .toDTOConverter(MessageV3MigrationTaskDTO::fromDomainObject)
+            .typeName(MessageV3Migration.TYPE.asString())
+            .withFactory(TaskDTOModule::new);
+
+    private final String type;
+
+    public MessageV3MigrationTaskDTO(@JsonProperty("type") String type) {
+        this.type = type;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    private MessageV3Migration.MessageV3MigrationTask toDomainObject(MessageV3Migration migration) {
+        return new MessageV3Migration.MessageV3MigrationTask(migration);
+    }
+}

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/table/CassandraMessageV3Table.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/table/CassandraMessageV3Table.java
@@ -1,0 +1,55 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.table;
+
+public interface CassandraMessageV3Table {
+
+    String TABLE_NAME = "messageV3";
+    String INTERNAL_DATE = "internalDate";
+    String BODY_START_OCTET = "bodyStartOctet";
+    String FULL_CONTENT_OCTETS = "fullContentOctets";
+    String BODY_OCTECTS = "bodyOctets";
+    String TEXTUAL_LINE_COUNT = "textualLineCount";
+    String BODY_CONTENT = "bodyContent";
+    String HEADER_CONTENT = "headerContent";
+    String ATTACHMENTS = "attachments";
+
+    interface Properties {
+        String MEDIA_TYPE = "mediaType";
+        String SUB_TYPE = "subType";
+        String CONTENT_ID = "contentId";
+        String CONTENT_LOCATION = "contentLocation";
+        String CONTENT_DESCRIPTION = "contentDescription";
+        String CONTENT_TRANSFER_ENCODING = "contentTransferEncoding";
+        String CONTENT_DISPOSITION_TYPE = "contentDispositionType";
+        String CONTENT_DISPOSITION_PARAMETERS = "contentDispositionParameters";
+        String CONTENT_TYPE_PARAMETERS = "contentTypeParameters";
+        String CONTENT_MD5 = "contentMd5";
+        String CONTENT_LANGUAGE = "contentLanguage";
+    }
+
+    interface Attachments {
+        String ID = "id";
+        String NAME = "name";
+        String CID = "cid";
+        String IS_INLINE = "isInline";
+    }
+
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraMailboxManagerTest.java
@@ -53,7 +53,7 @@ import org.apache.james.mailbox.cassandra.mail.CassandraDeletedMessageDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraFirstUnseenDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxCounterDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxRecentsDAO;
-import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAOV3;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdToImapUidDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraUserMailboxRightsDAO;
@@ -820,8 +820,8 @@ public class CassandraMailboxManagerTest extends MailboxManagerTest<CassandraMai
                 new CassandraMessageId.Factory());
         }
 
-        private CassandraMessageDAO messageDAO(CassandraCluster cassandraCluster) {
-            return new CassandraMessageDAO(
+        private CassandraMessageDAOV3 messageDAO(CassandraCluster cassandraCluster) {
+            return new CassandraMessageDAOV3(
                 cassandraCluster.getConf(),
                 cassandraCluster.getTypesProvider(),
                 mock(BlobStore.class),

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraSubscriptionManagerTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/CassandraSubscriptionManagerTest.java
@@ -40,6 +40,7 @@ import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathV2DAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxPathV3DAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMailboxRecentsDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAOV3;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdToImapUidDAO;
 import org.apache.james.mailbox.cassandra.mail.CassandraModSeqProvider;
@@ -70,6 +71,7 @@ class CassandraSubscriptionManagerTest implements SubscriptionManagerContract {
     void setUp() {
         CassandraMessageIdToImapUidDAO imapUidDAO = null;
         CassandraMessageDAO messageDAO = null;
+        CassandraMessageDAOV3 messageDAOV3 = null;
         CassandraMessageIdDAO messageIdDAO = null;
         CassandraMailboxCounterDAO mailboxCounterDAO = null;
         CassandraMailboxRecentsDAO mailboxRecentsDAO = null;
@@ -97,6 +99,7 @@ class CassandraSubscriptionManagerTest implements SubscriptionManagerContract {
                 modSeqProvider,
                 cassandraCluster.getCassandraCluster().getConf(),
                 messageDAO,
+                messageDAOV3,
                 messageIdDAO,
                 imapUidDAO,
                 mailboxCounterDAO,

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOTest.java
@@ -112,7 +112,7 @@ class CassandraMessageDAOTest {
         MessageRepresentation attachmentRepresentation =
             toMessage(testee.retrieveMessage(messageIdWithMetadata, MessageMapper.FetchType.Metadata));
 
-        assertThat(attachmentRepresentation.getPropertyBuilder().getTextualLineCount())
+        assertThat(attachmentRepresentation.getProperties().getTextualLineCount())
             .isEqualTo(0L);
     }
 
@@ -128,7 +128,7 @@ class CassandraMessageDAOTest {
         MessageRepresentation attachmentRepresentation =
             toMessage(testee.retrieveMessage(messageIdWithMetadata, MessageMapper.FetchType.Metadata));
 
-        assertThat(attachmentRepresentation.getPropertyBuilder().getTextualLineCount()).isEqualTo(textualLineCount);
+        assertThat(attachmentRepresentation.getProperties().getTextualLineCount()).isEqualTo(textualLineCount);
     }
 
     @Test
@@ -183,7 +183,7 @@ class CassandraMessageDAOTest {
             .size(content.length())
             .content(new SharedByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)))
             .flags(new Flags())
-            .propertyBuilder(propertyBuilder)
+            .properties(propertyBuilder.build())
             .addAttachments(attachments)
             .build();
     }

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOTest.java
@@ -94,6 +94,7 @@ class CassandraMessageDAOTest {
             cassandra.getTypesProvider(),
             blobStore,
             blobIdFactory,
+            messageIdFactory,
             cassandraCluster.getCassandraConsistenciesConfiguration());
 
         messageIdWithMetadata = ComposedMessageIdWithMetaData.builder()

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3Test.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageDAOV3Test.java
@@ -1,0 +1,194 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.mailbox.cassandra.mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+
+import javax.mail.Flags;
+import javax.mail.util.SharedByteArrayInputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.blob.api.BlobStore;
+import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.cassandra.CassandraBlobModule;
+import org.apache.james.blob.cassandra.CassandraBlobStoreFactory;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.ModSeq;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.cassandra.modules.CassandraMessageModule;
+import org.apache.james.mailbox.model.ComposedMessageId;
+import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
+import org.apache.james.mailbox.model.MessageAttachmentMetadata;
+import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.store.mail.MessageMapper;
+import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Bytes;
+
+import reactor.core.publisher.Mono;
+
+class CassandraMessageDAOV3Test {
+    private static final int BODY_START = 16;
+    private static final CassandraId MAILBOX_ID = CassandraId.timeBased();
+    private static final String CONTENT = "Subject: Test7 \n\nBody7\n.\n";
+    private static final MessageUid messageUid = MessageUid.of(1);
+    private static final List<MessageAttachmentMetadata> NO_ATTACHMENT = ImmutableList.of();
+
+    public static final CassandraModule MODULES = CassandraModule.aggregateModules(
+            CassandraMessageModule.MODULE,
+            CassandraBlobModule.MODULE,
+            CassandraSchemaVersionModule.MODULE);
+
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(
+            MODULES);
+
+    private CassandraMessageDAOV3 testee;
+
+    private SimpleMailboxMessage message;
+    private CassandraMessageId messageId;
+    private ComposedMessageIdWithMetaData messageIdWithMetadata;
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandra) {
+        CassandraMessageId.Factory messageIdFactory = new CassandraMessageId.Factory();
+        messageId = messageIdFactory.generate();
+        BlobStore blobStore = CassandraBlobStoreFactory.forTesting(cassandra.getConf())
+            .passthrough();
+        HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
+        testee = new CassandraMessageDAOV3(
+            cassandra.getConf(),
+            cassandra.getTypesProvider(),
+            blobStore,
+            blobIdFactory,
+            cassandraCluster.getCassandraConsistenciesConfiguration());
+
+        messageIdWithMetadata = ComposedMessageIdWithMetaData.builder()
+                .composedMessageId(new ComposedMessageId(MAILBOX_ID, messageId, messageUid))
+                .flags(new Flags())
+                .modSeq(ModSeq.of(1))
+                .build();
+    }
+
+    @Test
+    void saveShouldSaveNullValueForTextualLineCountAsZero() throws Exception {
+        message = createMessage(messageId, CONTENT, BODY_START, new PropertyBuilder(), NO_ATTACHMENT);
+
+        testee.save(message).block();
+
+        MessageRepresentation attachmentRepresentation =
+            toMessage(testee.retrieveMessage(messageIdWithMetadata, MessageMapper.FetchType.Metadata));
+
+        assertThat(attachmentRepresentation.getProperties().getTextualLineCount())
+            .isEqualTo(0L);
+    }
+
+    @Test
+    void saveShouldSaveTextualLineCount() throws Exception {
+        long textualLineCount = 10L;
+        PropertyBuilder propertyBuilder = new PropertyBuilder();
+        propertyBuilder.setTextualLineCount(textualLineCount);
+        message = createMessage(messageId, CONTENT, BODY_START, propertyBuilder, NO_ATTACHMENT);
+
+        testee.save(message).block();
+
+        MessageRepresentation attachmentRepresentation =
+            toMessage(testee.retrieveMessage(messageIdWithMetadata, MessageMapper.FetchType.Metadata));
+
+        assertThat(attachmentRepresentation.getProperties().getTextualLineCount()).isEqualTo(textualLineCount);
+    }
+
+    @Test
+    void saveShouldStoreMessageWithFullContent() throws Exception {
+        message = createMessage(messageId, CONTENT, BODY_START, new PropertyBuilder(), NO_ATTACHMENT);
+
+        testee.save(message).block();
+
+        MessageRepresentation attachmentRepresentation =
+            toMessage(testee.retrieveMessage(messageIdWithMetadata, MessageMapper.FetchType.Full));
+
+        assertThat(IOUtils.toString(attachmentRepresentation.getContent(), StandardCharsets.UTF_8))
+            .isEqualTo(CONTENT);
+    }
+
+    @Test
+    void saveShouldStoreMessageWithBodyContent() throws Exception {
+        message = createMessage(messageId, CONTENT, BODY_START, new PropertyBuilder(), NO_ATTACHMENT);
+
+        testee.save(message).block();
+
+        MessageRepresentation attachmentRepresentation =
+            toMessage(testee.retrieveMessage(messageIdWithMetadata, MessageMapper.FetchType.Body));
+
+        byte[] expected = Bytes.concat(
+            new byte[BODY_START],
+            CONTENT.substring(BODY_START).getBytes(StandardCharsets.UTF_8));
+        assertThat(IOUtils.toString(attachmentRepresentation.getContent(), StandardCharsets.UTF_8))
+            .isEqualTo(IOUtils.toString(new ByteArrayInputStream(expected), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void saveShouldStoreMessageWithHeaderContent() throws Exception {
+        message = createMessage(messageId, CONTENT, BODY_START, new PropertyBuilder(), NO_ATTACHMENT);
+
+        testee.save(message).block();
+
+        MessageRepresentation attachmentRepresentation =
+            toMessage(testee.retrieveMessage(messageIdWithMetadata, MessageMapper.FetchType.Headers));
+
+        assertThat(IOUtils.toString(attachmentRepresentation.getContent(), StandardCharsets.UTF_8))
+            .isEqualTo(CONTENT.substring(0, BODY_START));
+    }
+
+    private SimpleMailboxMessage createMessage(MessageId messageId, String content, int bodyStart, PropertyBuilder propertyBuilder, Collection<MessageAttachmentMetadata> attachments) {
+        return SimpleMailboxMessage.builder()
+            .messageId(messageId)
+            .mailboxId(MAILBOX_ID)
+            .uid(messageUid)
+            .internalDate(new Date())
+            .bodyStartOctet(bodyStart)
+            .size(content.length())
+            .content(new SharedByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)))
+            .flags(new Flags())
+            .properties(propertyBuilder)
+            .addAttachments(attachments)
+            .build();
+    }
+
+    private MessageRepresentation toMessage(Mono<MessageRepresentation> read) {
+        return read.blockOptional()
+            .orElseThrow(() -> new IllegalStateException("Collection is not supposed to be empty"));
+    }
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapperTest.java
@@ -122,7 +122,7 @@ class CassandraMessageIdMapperTest extends MessageIdMapperTest {
             cassandra.getConf()
                 .registerScenario(fail()
                     .forever()
-                    .whenQueryStartsWith("INSERT INTO messageV2 (messageId,internalDate,bodyStartOctet,fullContentOctets,bodyOctets,bodyContent,headerContent,properties,textualLineCount,attachments)"));
+                    .whenQueryStartsWith("INSERT INTO messageV3"));
 
             try {
                 message1.setUid(mapperProvider.generateMessageUid());

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapperTest.java
@@ -198,7 +198,7 @@ class CassandraMessageMapperTest extends MessageMapperTest {
 
 
             assertThat(statementRecorder.listExecutedStatements(Selector.preparedStatement(
-                "SELECT * FROM messageV2 WHERE messageId=:messageId;")))
+                "SELECT * FROM messageV3 WHERE messageId=:messageId;")))
                 .hasSize(limit);
         }
 
@@ -228,7 +228,7 @@ class CassandraMessageMapperTest extends MessageMapperTest {
             cassandra.getConf()
                 .registerScenario(fail()
                     .forever()
-                    .whenQueryStartsWith("INSERT INTO messageV2 (messageId,internalDate,bodyStartOctet,fullContentOctets,bodyOctets,bodyContent,headerContent,properties,textualLineCount,attachments)"));
+                    .whenQueryStartsWith("INSERT INTO messageV3"));
 
             try {
                 messageMapper.add(benwaInboxMailbox, message1);

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/MessageV3MigrationTaskSerializationTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/MessageV3MigrationTaskSerializationTest.java
@@ -1,0 +1,52 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.migration;
+
+import static org.mockito.Mockito.mock;
+
+import java.time.Instant;
+
+import org.apache.james.JsonSerializationVerifier;
+import org.junit.jupiter.api.Test;
+
+class MessageV3MigrationTaskSerializationTest {
+    private static final Instant TIMESTAMP = Instant.parse("2018-11-13T12:00:55Z");
+    private static final MessageV3Migration MIGRATION = mock(MessageV3Migration.class);
+    private static final MessageV3Migration.MessageV3MigrationTask TASK = new MessageV3Migration.MessageV3MigrationTask(MIGRATION);
+    private static final String SERIALIZED_TASK = "{\"type\": \"cassandra-message-v3-migration\"}";
+    private static final MessageV3Migration.AdditionalInformation DETAILS = new MessageV3Migration.AdditionalInformation(TIMESTAMP);
+    private static final String SERIALIZED_ADDITIONAL_INFORMATION = "{\"type\": \"cassandra-message-v3-migration\", \"timestamp\":\"2018-11-13T12:00:55Z\"}";
+
+    @Test
+    void taskShouldBeSerializable() throws Exception {
+        JsonSerializationVerifier.dtoModule(MessageV3MigrationTaskDTO.MODULE.apply(MIGRATION))
+            .bean(TASK)
+            .json(SERIALIZED_TASK)
+            .verify();
+    }
+
+    @Test
+    void additionalInformationShouldBeSerializable() throws Exception {
+        JsonSerializationVerifier.dtoModule(MessageV3MigrationTaskAdditionalInformationDTO.MODULE)
+            .bean(DETAILS)
+            .json(SERIALIZED_ADDITIONAL_INFORMATION)
+            .verify();
+    }
+}

--- a/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/MessageV3MigrationTest.java
+++ b/mailbox/cassandra/src/test/java/org/apache/james/mailbox/cassandra/mail/migration/MessageV3MigrationTest.java
@@ -1,0 +1,137 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.mailbox.cassandra.mail.migration;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.List;
+
+import javax.mail.Flags;
+import javax.mail.util.SharedByteArrayInputStream;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.blob.api.BlobStore;
+import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.cassandra.CassandraBlobModule;
+import org.apache.james.blob.cassandra.CassandraBlobStoreFactory;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAO;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAOV3;
+import org.apache.james.mailbox.cassandra.modules.CassandraMessageModule;
+import org.apache.james.mailbox.model.MessageAttachmentMetadata;
+import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.store.mail.MessageMapper;
+import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableList;
+
+class MessageV3MigrationTest {
+    private static final int BODY_START = 16;
+    private static final CassandraId MAILBOX_ID = CassandraId.timeBased();
+    private static final String CONTENT = "Subject: Test7 \n\nBody7\n.\n";
+    private static final MessageUid messageUid = MessageUid.of(1);
+    private static final List<MessageAttachmentMetadata> NO_ATTACHMENT = ImmutableList.of();
+
+    public static final CassandraModule MODULES = CassandraModule.aggregateModules(
+        CassandraMessageModule.MODULE,
+        CassandraBlobModule.MODULE,
+        CassandraSchemaVersionModule.MODULE);
+
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(MODULES);
+
+    private CassandraMessageDAO daoV2;
+    private CassandraMessageDAOV3 daoV3;
+    private CassandraMessageId.Factory messageIdFactory;
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandra) {
+        BlobStore blobStore = CassandraBlobStoreFactory.forTesting(cassandra.getConf())
+            .passthrough();
+        HashBlobId.Factory blobIdFactory = new HashBlobId.Factory();
+        daoV2 = new CassandraMessageDAO(
+            cassandra.getConf(),
+            cassandra.getTypesProvider(),
+            blobStore,
+            blobIdFactory,
+            new CassandraMessageId.Factory(),
+            cassandraCluster.getCassandraConsistenciesConfiguration());
+        daoV3 = new CassandraMessageDAOV3(
+            cassandra.getConf(),
+            cassandra.getTypesProvider(),
+            blobStore,
+            blobIdFactory,
+            cassandraCluster.getCassandraConsistenciesConfiguration());
+        messageIdFactory = new CassandraMessageId.Factory();
+    }
+
+    @Test
+    void migrationTaskShouldMoveDataToMostRecentDao() throws Exception{
+        SimpleMailboxMessage message1 = createMessage(messageIdFactory.generate());
+        SimpleMailboxMessage message2 = createMessage(messageIdFactory.generate());
+        SimpleMailboxMessage message3 = createMessage(messageIdFactory.generate());
+        SimpleMailboxMessage message4 = createMessage(messageIdFactory.generate());
+
+        daoV2.save(message1).block();
+        daoV2.save(message2).block();
+        daoV2.save(message3).block();
+        daoV2.save(message4).block();
+
+        new MessageV3Migration(daoV2, daoV3).apply();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(daoV3.retrieveMessage((CassandraMessageId) message1.getMessageId(), MessageMapper.FetchType.Metadata).block().getMessageId())
+                .isEqualTo(message1.getMessageId());
+            softly.assertThat(daoV3.retrieveMessage((CassandraMessageId) message2.getMessageId(), MessageMapper.FetchType.Metadata).block().getMessageId())
+                .isEqualTo(message2.getMessageId());
+            softly.assertThat(daoV3.retrieveMessage((CassandraMessageId) message3.getMessageId(), MessageMapper.FetchType.Metadata).block().getMessageId())
+                .isEqualTo(message3.getMessageId());
+            softly.assertThat(daoV3.retrieveMessage((CassandraMessageId) message4.getMessageId(), MessageMapper.FetchType.Metadata).block().getMessageId())
+                .isEqualTo(message4.getMessageId());
+
+            softly.assertThat(daoV2.list().collectList().block()).isEmpty();
+        });
+    }
+
+    private SimpleMailboxMessage createMessage(MessageId messageId) {
+        return SimpleMailboxMessage.builder()
+            .messageId(messageId)
+            .mailboxId(MAILBOX_ID)
+            .uid(messageUid)
+            .internalDate(new Date())
+            .bodyStartOctet(MessageV3MigrationTest.BODY_START)
+            .size(MessageV3MigrationTest.CONTENT.length())
+            .content(new SharedByteArrayInputStream(MessageV3MigrationTest.CONTENT.getBytes(StandardCharsets.UTF_8)))
+            .flags(new Flags())
+            .properties(new PropertyBuilder().build())
+            .addAttachments(NO_ATTACHMENT)
+            .build();
+    }
+}

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndexTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/events/ElasticSearchListeningMessageSearchIndexTest.java
@@ -109,7 +109,7 @@ class ElasticSearchListeningMessageSearchIndexTest {
         .internalDate(new Date(1433628000000L))
         .size(SIZE)
         .content(new SharedByteArrayInputStream("message".getBytes(StandardCharsets.UTF_8)))
-        .propertyBuilder(new PropertyBuilder())
+        .properties(new PropertyBuilder())
         .modseq(MOD_SEQ);
 
     static final SimpleMailboxMessage MESSAGE_1 = MESSAGE_BUILDER.messageId(MESSAGE_ID_1)

--- a/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/MessageToElasticSearchJsonTest.java
+++ b/mailbox/elasticsearch/src/test/java/org/apache/james/mailbox/elasticsearch/json/MessageToElasticSearchJsonTest.java
@@ -100,7 +100,7 @@ class MessageToElasticSearchJsonTest {
                 BODY_START_OCTET,
                 ClassLoaderUtils.getSystemResourceAsSharedStream("eml/spamMail.eml"),
                 new Flags(),
-                propertyBuilder,
+                propertyBuilder.build(),
                 MAILBOX_ID);
         spamMail.setUid(UID);
         spamMail.setModSeq(MOD_SEQ);
@@ -120,7 +120,7 @@ class MessageToElasticSearchJsonTest {
                 BODY_START_OCTET,
                 ClassLoaderUtils.getSystemResourceAsSharedStream("eml/invalidCharset.eml"),
                 new Flags(),
-                propertyBuilder,
+                propertyBuilder.build(),
                 MAILBOX_ID);
         spamMail.setUid(UID);
         spamMail.setModSeq(MOD_SEQ);
@@ -142,7 +142,7 @@ class MessageToElasticSearchJsonTest {
                 BODY_START_OCTET,
                 ClassLoaderUtils.getSystemResourceAsSharedStream("eml/htmlMail.eml"),
                 new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("social", "pocket-money").build(),
-                propertyBuilder,
+                propertyBuilder.build(),
                 MAILBOX_ID);
         htmlMail.setModSeq(MOD_SEQ);
         htmlMail.setUid(UID);
@@ -162,7 +162,7 @@ class MessageToElasticSearchJsonTest {
                 BODY_START_OCTET,
                 ClassLoaderUtils.getSystemResourceAsSharedStream("eml/pgpSignedMail.eml"),
                 new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("debian", "security").build(),
-                propertyBuilder,
+                propertyBuilder.build(),
                 MAILBOX_ID);
         pgpSignedMail.setModSeq(MOD_SEQ);
         pgpSignedMail.setUid(UID);
@@ -182,7 +182,7 @@ class MessageToElasticSearchJsonTest {
                 BODY_START_OCTET,
                 ClassLoaderUtils.getSystemResourceAsSharedStream("eml/mail.eml"),
                 new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("debian", "security").build(),
-                propertyBuilder,
+                propertyBuilder.build(),
                 MAILBOX_ID);
         mail.setModSeq(MOD_SEQ);
         mail.setUid(UID);
@@ -203,7 +203,7 @@ class MessageToElasticSearchJsonTest {
                 BODY_START_OCTET,
                 ClassLoaderUtils.getSystemResourceAsSharedStream("eml/recursiveMail.eml"),
                 new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("debian", "security").build(),
-                propertyBuilder,
+                propertyBuilder.build(),
                 MAILBOX_ID);
         recursiveMail.setModSeq(MOD_SEQ);
         recursiveMail.setUid(UID);
@@ -223,7 +223,7 @@ class MessageToElasticSearchJsonTest {
                 BODY_START_OCTET,
                 ClassLoaderUtils.getSystemResourceAsSharedStream("eml/recursiveMail.eml"),
                 new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("debian", "security").build(),
-                propertyBuilder,
+                propertyBuilder.build(),
                 MAILBOX_ID);
         mailWithNoInternalDate.setModSeq(MOD_SEQ);
         mailWithNoInternalDate.setUid(UID);
@@ -242,7 +242,7 @@ class MessageToElasticSearchJsonTest {
                 BODY_START_OCTET,
                 ClassLoaderUtils.getSystemResourceAsSharedStream("eml/recursiveMail.eml"),
                 new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("debian", "security").build(),
-                propertyBuilder,
+                propertyBuilder.build(),
                 MAILBOX_ID);
         mailWithNoInternalDate.setModSeq(MOD_SEQ);
         mailWithNoInternalDate.setUid(UID);
@@ -270,7 +270,7 @@ class MessageToElasticSearchJsonTest {
                 BODY_START_OCTET,
                 ClassLoaderUtils.getSystemResourceAsSharedStream("eml/recursiveMail.eml"),
                 new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("debian", "security").build(),
-                propertyBuilder,
+                propertyBuilder.build(),
                 MAILBOX_ID);
         mailWithNoInternalDate.setModSeq(MOD_SEQ);
         mailWithNoInternalDate.setUid(UID);
@@ -299,7 +299,7 @@ class MessageToElasticSearchJsonTest {
             BODY_START_OCTET,
             ClassLoaderUtils.getSystemResourceAsSharedStream("eml/recursiveMail.eml"),
             new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("debian", "security").build(),
-            propertyBuilder,
+            propertyBuilder.build(),
             null);
         mailWithNoMailboxId.setModSeq(MOD_SEQ);
         mailWithNoMailboxId.setUid(UID);
@@ -351,7 +351,7 @@ class MessageToElasticSearchJsonTest {
             BODY_START_OCTET,
             ClassLoaderUtils.getSystemResourceAsSharedStream("eml/nonTextual.eml"),
             new Flags(),
-            propertyBuilder,
+            propertyBuilder.build(),
             MAILBOX_ID);
         spamMail.setUid(UID);
         spamMail.setModSeq(MOD_SEQ);
@@ -371,7 +371,7 @@ class MessageToElasticSearchJsonTest {
             BODY_START_OCTET,
             ClassLoaderUtils.getSystemResourceAsSharedStream("eml/emailWithNonIndexableAttachment.eml"),
             new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("debian", "security").build(),
-            propertyBuilder,
+            propertyBuilder.build(),
             MAILBOX_ID);
         message.setModSeq(MOD_SEQ);
         message.setUid(UID);
@@ -399,7 +399,7 @@ class MessageToElasticSearchJsonTest {
             BODY_START_OCTET,
             ClassLoaderUtils.getSystemResourceAsSharedStream("eml/emailWithNonIndexableAttachment.eml"),
             new FlagsBuilder().add(Flags.Flag.DELETED, Flags.Flag.SEEN).add("debian", "security").build(),
-            propertyBuilder,
+            propertyBuilder.build(),
             MAILBOX_ID);
         message.setModSeq(MOD_SEQ);
         message.setUid(UID);

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/AbstractJPAMailboxMessage.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/AbstractJPAMailboxMessage.java
@@ -260,7 +260,7 @@ public abstract class AbstractJPAMailboxMessage implements MailboxMessage {
         this.mediaType = properties.getMediaType();
         this.subType = properties.getSubType();
         final List<Property> propertiesAsList = properties.toProperties();
-        this.properties = new ArrayList<>(this.properties.size());
+        this.properties = new ArrayList<>(propertiesAsList.size());
         int order = 0;
         for (Property property : propertiesAsList) {
             this.properties.add(new JPAProperty(property, order++));

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/AbstractJPAMailboxMessage.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/model/openjpa/AbstractJPAMailboxMessage.java
@@ -61,6 +61,7 @@ import org.apache.james.mailbox.store.mail.model.FlagsFactory;
 import org.apache.james.mailbox.store.mail.model.MailboxMessage;
 import org.apache.james.mailbox.store.mail.model.Property;
 import org.apache.james.mailbox.store.mail.model.impl.MessageParser;
+import org.apache.james.mailbox.store.mail.model.impl.Properties;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 import org.apache.openjpa.persistence.jdbc.ElementJoinColumn;
 import org.apache.openjpa.persistence.jdbc.ElementJoinColumns;
@@ -254,13 +255,14 @@ public abstract class AbstractJPAMailboxMessage implements MailboxMessage {
         setFlags(flags);
         this.contentOctets = contentOctets;
         this.bodyStartOctet = bodyStartOctet;
-        this.textualLineCount = propertyBuilder.getTextualLineCount();
-        this.mediaType = propertyBuilder.getMediaType();
-        this.subType = propertyBuilder.getSubType();
-        final List<Property> properties = propertyBuilder.toProperties();
-        this.properties = new ArrayList<>(properties.size());
+        Properties properties = propertyBuilder.build();
+        this.textualLineCount = properties.getTextualLineCount();
+        this.mediaType = properties.getMediaType();
+        this.subType = properties.getSubType();
+        final List<Property> propertiesAsList = properties.toProperties();
+        this.properties = new ArrayList<>(this.properties.size());
         int order = 0;
-        for (Property property : properties) {
+        for (Property property : propertiesAsList) {
             this.properties.add(new JPAProperty(property, order++));
         }
 
@@ -296,11 +298,10 @@ public abstract class AbstractJPAMailboxMessage implements MailboxMessage {
         this.bodyStartOctet = (int) (original.getFullContentOctets() - original.getBodyOctets());
         this.internalDate = original.getInternalDate();
 
-        PropertyBuilder pBuilder = new PropertyBuilder(original.getProperties());
         this.textualLineCount = original.getTextualLineCount();
         this.mediaType = original.getMediaType();
         this.subType = original.getSubType();
-        final List<Property> properties = pBuilder.toProperties();
+        final List<Property> properties = original.getProperties().toProperties();
         this.properties = new ArrayList<>(properties.size());
         int order = 0;
         for (Property property : properties) {
@@ -360,10 +361,11 @@ public abstract class AbstractJPAMailboxMessage implements MailboxMessage {
      * @return unmodifiable list of meta-data, not null
      */
     @Override
-    public List<Property> getProperties() {
-        return properties.stream()
+    public Properties getProperties() {
+        return new PropertyBuilder(properties.stream()
             .map(JPAProperty::toProperty)
-            .collect(Guavate.toImmutableList());
+            .collect(Guavate.toImmutableList()))
+            .build();
     }
 
     @Override

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/MessageUtilsTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/MessageUtilsTest.java
@@ -63,7 +63,7 @@ class MessageUtilsTest {
         MockitoAnnotations.initMocks(this);
         messageUtils = new MessageUtils(uidProvider, modSeqProvider);
         message = new SimpleMailboxMessage(MESSAGE_ID, new Date(), CONTENT.length(), BODY_START,
-            new SharedByteArrayInputStream(CONTENT.getBytes()), new Flags(), new PropertyBuilder(), mailbox.getMailboxId());
+            new SharedByteArrayInputStream(CONTENT.getBytes()), new Flags(), new PropertyBuilder().build(), mailbox.getMailboxId());
     }
     
     @Test

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/model/MaildirMessage.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/model/MaildirMessage.java
@@ -37,8 +37,8 @@ import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.model.ParsedAttachment;
 import org.apache.james.mailbox.store.mail.model.DefaultMessageId;
 import org.apache.james.mailbox.store.mail.model.Message;
-import org.apache.james.mailbox.store.mail.model.Property;
 import org.apache.james.mailbox.store.mail.model.impl.MessageParser;
+import org.apache.james.mailbox.store.mail.model.impl.Properties;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 import org.apache.james.mailbox.store.streaming.CountingInputStream;
 import org.apache.james.mime4j.MimeException;
@@ -185,13 +185,13 @@ public class MaildirMessage implements Message {
     @Override
     public String getMediaType() {
         parseMessage();
-        return propertyBuilder.getMediaType();
+        return propertyBuilder.build().getMediaType();
     }
 
     @Override
     public String getSubType() {
         parseMessage();
-        return propertyBuilder.getSubType();
+        return propertyBuilder.build().getSubType();
     }
 
     @Override
@@ -221,13 +221,13 @@ public class MaildirMessage implements Message {
     @Override
     public Long getTextualLineCount() {
         parseMessage();
-        return propertyBuilder.getTextualLineCount();
+        return propertyBuilder.build().getTextualLineCount();
     }
 
     @Override
-    public List<Property> getProperties() {
+    public Properties getProperties() {
         parseMessage();
-        return propertyBuilder.toProperties();
+        return propertyBuilder.build();
     }
 
     @Override

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/model/MaildirMessage.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/model/MaildirMessage.java
@@ -118,10 +118,6 @@ public class MaildirMessage implements Message {
                 propertyBuilder.setCharset(codeset);
             }
 
-            final String boundary = descriptor.getBoundary();
-            if (boundary != null) {
-                propertyBuilder.setBoundary(boundary);
-            }
             if ("text".equalsIgnoreCase(mediaType)) {
                 long lines = -1;
                 try (CountingInputStream bodyStream = new CountingInputStream(parser.getInputStream())) {

--- a/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
+++ b/mailbox/plugin/spamassassin/src/test/java/org/apache/james/mailbox/spamassassin/SpamAssassinListenerTest.java
@@ -271,7 +271,7 @@ class SpamAssassinListenerTest {
         int bodyStartOctet = 25;
         byte[] content = "Subject: test\r\n\r\nBody\r\n".getBytes(StandardCharsets.UTF_8);
         SimpleMailboxMessage message = new SimpleMailboxMessage(MESSAGE_ID, new Date(),
-            size, bodyStartOctet, new SharedByteArrayInputStream(content), new Flags(), new PropertyBuilder(),
+            size, bodyStartOctet, new SharedByteArrayInputStream(content), new Flags(), new PropertyBuilder().build(),
             mailbox.getMailboxId());
         MessageMetaData messageMetaData = mapperFactory.createMessageMapper(null).add(mailbox, message);
         message.setUid(messageMetaData.getUid());

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/LazyMimeDescriptor.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/LazyMimeDescriptor.java
@@ -32,6 +32,7 @@ import org.apache.james.mailbox.model.Header;
 import org.apache.james.mailbox.model.MessageResult;
 import org.apache.james.mailbox.model.MimeDescriptor;
 import org.apache.james.mailbox.store.mail.model.Message;
+import org.apache.james.mailbox.store.mail.model.impl.Properties;
 import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
 
 /**
@@ -42,7 +43,7 @@ public class LazyMimeDescriptor implements MimeDescriptor {
 
     private final Message message;
     private final MessageResult result;
-    private PropertyBuilder pbuilder;
+    private Properties properties;
     
     public LazyMimeDescriptor(MessageResult result, Message message) {
         this.message = message;
@@ -151,11 +152,11 @@ public class LazyMimeDescriptor implements MimeDescriptor {
      * 
      * @return pbuilder
      */
-    private PropertyBuilder getPropertyBuilder() {
-        if (pbuilder == null) {
-            pbuilder = new PropertyBuilder(message.getProperties());
+    private Properties getPropertyBuilder() {
+        if (properties == null) {
+            properties = message.getProperties();
         }
-        return pbuilder;
+        return properties;
     }
     
 }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageFactory.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/MessageFactory.java
@@ -43,7 +43,7 @@ public interface MessageFactory<T extends MailboxMessage> {
         public SimpleMailboxMessage createMessage(MessageId messageId, Mailbox mailbox, Date internalDate, int size,
                                             int bodyStartOctet, SharedInputStream content, Flags flags,
                                             PropertyBuilder propertyBuilder, List<MessageAttachmentMetadata> attachments) {
-            return new SimpleMailboxMessage(messageId, internalDate, size, bodyStartOctet, content, flags, propertyBuilder,
+            return new SimpleMailboxMessage(messageId, internalDate, size, bodyStartOctet, content, flags, propertyBuilder.build(),
                 mailbox.getMailboxId(), attachments);
         }
     }

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -478,10 +478,6 @@ public class StoreMessageManager implements MessageManager {
         } else {
             propertyBuilder.setCharset(codeset);
         }
-        final String boundary = descriptor.getBoundary();
-        if (boundary != null) {
-            propertyBuilder.setBoundary(boundary);
-        }
         return propertyBuilder;
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/DelegatingMailboxMessage.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/DelegatingMailboxMessage.java
@@ -27,6 +27,7 @@ import javax.mail.Flags;
 
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.store.mail.model.impl.Properties;
 
 public abstract class DelegatingMailboxMessage implements MailboxMessage {
 
@@ -77,7 +78,7 @@ public abstract class DelegatingMailboxMessage implements MailboxMessage {
     }
 
     @Override
-    public List<Property> getProperties() {
+    public Properties getProperties() {
         return message.getProperties();
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/Message.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/Message.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.store.mail.model.impl.Properties;
 
 public interface Message {
 
@@ -96,11 +97,11 @@ public interface Message {
     /**
      * Gets a read-only list of meta-data properties.
      * For properties with multiple values, this list will contain
-     * several enteries with the same namespace and local name.
+     * several entries with the same namespace and local name.
      *
      * @return unmodifiable list of meta-data, not null
      */
-    List<Property> getProperties();
+    Properties getProperties();
     
     /**
      * Return the list of attachments

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/StandardNames.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/StandardNames.java
@@ -94,12 +94,6 @@ public class StandardNames {
     public static final String MIME_CONTENT_TYPE_PARAMETER_CHARSET_NAME = "charset";
     
     /**
-     * Namespace for <a href='http://www.faqs.org/rfcs/rfc2045.html'>MIME</a> Content-Type
-     * "boundary" parameter.
-     */
-    public static final String MIME_CONTENT_TYPE_PARAMETER_BOUNDARY_NAME = "boundary";
-    
-    /**
      * Namespace for <a href='http://www.faqs.org/rfcs/rfc2045.html'>MIME</a> mime type properties.
      * A distinct namespace is required to distinguish these properties from the Content-Type
      * parameters.

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/Properties.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/Properties.java
@@ -1,0 +1,261 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.mailbox.store.mail.model.impl;
+
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_DESCRIPTION_NAME;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_DESCRIPTION_SPACE;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_DISPOSITION_PARAMETER_SPACE;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_DISPOSITION_SPACE;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_DISPOSITION_TYPE_NAME;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_ID_NAME;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_ID_SPACE;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_LANGUAGE_NAME;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_LANGUAGE_SPACE;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_LOCATION_NAME;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_LOCATION_SPACE;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_MD5_NAME;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_MD5_SPACE;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TRANSFER_ENCODING_NAME;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TRANSFER_ENCODING_SPACE;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TYPE_PARAMETER_BOUNDARY_NAME;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TYPE_PARAMETER_CHARSET_NAME;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TYPE_PARAMETER_SPACE;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_MEDIA_TYPE_NAME;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_MIME_TYPE_SPACE;
+import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_SUB_TYPE_NAME;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.james.mailbox.store.mail.model.Property;
+
+import com.github.steveash.guavate.Guavate;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+
+public class Properties {
+    private Long textualLineCount;
+    private final ImmutableList<Property> properties;
+
+    public Properties(List<Property> props, Long textualLineCount) {
+        this.textualLineCount = textualLineCount;
+        this.properties = ImmutableList.copyOf(props);
+    }
+
+    /**
+     * Gets the number of CRLF in a textual document.
+     * @return CRLF count when document is textual,
+     * null otherwise
+     */
+    public Long getTextualLineCount() {
+        return textualLineCount;
+    }
+    
+    /**
+     * Gets the first value with the given name.
+     * Used to retrieve values with a single value.
+     * @param namespace not null
+     * @param localName not null
+     * @return value, 
+     * or null when no property has the given name and namespace
+     */
+    private String getFirstValue(String namespace, String localName) {
+        return properties.stream()
+            .filter(property -> property.isNamed(namespace, localName))
+            .findFirst()
+            .map(Property::getValue)
+            .orElse(null);
+    }
+    
+    /**
+     * Lists all values for a property.
+     * @param namespace not null
+     * @param localName not null
+     * @return not null
+     */
+    private List<String> getValues(String namespace, String localName) {
+        return properties.stream()
+            .filter(property -> property.isNamed(namespace, localName))
+            .map(Property::getValue)
+            .collect(Guavate.toImmutableList());
+    }
+
+    
+    /**
+     * Maps properties in the given namespace.
+     * @param namespace not null
+     * @return values indexed by local name
+     */
+    private SortedMap<String,String> getProperties(String namespace) {
+        final SortedMap<String, String> parameters = new TreeMap<>();
+        for (Property property : properties) {
+            if (property.isInSpace(namespace)) {
+                parameters.put(property.getLocalName(), property.getValue());
+            }
+        }
+        return parameters;
+    }
+    
+    /**
+     * Gets the top level MIME content media type.
+     * 
+     * @return top level MIME content media type, or null if default
+     */
+    public String getMediaType() {
+        return getFirstValue(MIME_MIME_TYPE_SPACE, MIME_MEDIA_TYPE_NAME);
+    }
+
+    /**
+     * Gets the MIME content subtype.
+     * 
+     * @return the MIME content subtype, or null if default
+     */
+    public String getSubType() {
+        return getFirstValue(MIME_MIME_TYPE_SPACE, MIME_SUB_TYPE_NAME);
+    }
+
+    
+    /**
+     * Gets the MIME Content-ID.
+     * 
+     * @return the MIME content subtype, or null if default
+     */
+    public String getContentID() {
+        return getFirstValue(MIME_CONTENT_ID_SPACE, MIME_CONTENT_ID_NAME);
+    }
+    
+    /**
+     * Gets the MIME Content-Description.
+     * 
+     * @return the MIME Content-Description, 
+     * or null if this meta data is not present
+     */
+    public String getContentDescription() {
+        return getFirstValue(MIME_CONTENT_DESCRIPTION_SPACE, MIME_CONTENT_DESCRIPTION_NAME);
+    }
+    
+    /**
+     * Gets the MIME Content-Transfer-Encoding.
+     * 
+     * @return the MIME Content-Transfer-Encoding, 
+     * or null if this meta data is not present
+     */
+    public String getContentTransferEncoding() {
+        return getFirstValue(MIME_CONTENT_TRANSFER_ENCODING_SPACE, MIME_CONTENT_TRANSFER_ENCODING_NAME);
+    }
+
+    
+    /**
+     * Gets the RFC2557 Content-Location.
+     * 
+     * @return the RFC2557 Content-Location, 
+     * or null if this meta data is not present
+     */
+    public String getContentLocation() {
+        return getFirstValue(MIME_CONTENT_LOCATION_SPACE, MIME_CONTENT_LOCATION_NAME);
+    }
+    
+    /**
+     * Gets the RFC2183 Content-Disposition disposition-type.
+     * 
+     * @return the RFC2183 Content-Disposition, 
+     * or null if this meta data is not present
+     */
+    public String getContentDispositionType() {
+        return getFirstValue(MIME_CONTENT_DISPOSITION_SPACE, MIME_CONTENT_DISPOSITION_TYPE_NAME);
+    }
+    
+    /**
+     * Gets RFC2183 Content-Disposition parameters.
+     * @return parameter values indexed by lower case local names 
+     */
+    public Map<String,String> getContentDispositionParameters() {
+        return getProperties(MIME_CONTENT_DISPOSITION_PARAMETER_SPACE);
+    }
+    
+    /**
+     * Gets RFC2045 Content-Type parameters.
+     * @return parameter values indexed by lower case local names 
+     */
+    public Map<String,String> getContentTypeParameters() {
+        return getProperties(MIME_CONTENT_TYPE_PARAMETER_SPACE);
+    }
+    
+    /**
+     * Gets the RFC1864 Content-MD5.
+     * 
+     * @return the RFC1864 Content-MD5, 
+     * or null if this meta data is not present
+     */
+    public String getContentMD5() {
+        return getFirstValue(MIME_CONTENT_MD5_SPACE, MIME_CONTENT_MD5_NAME);
+    }
+    
+    /**
+     * Gets the RFC2045 Content-Type "charset" parameter.
+     * 
+     * @return the RFC2045 Content-Type "charset" parameter, 
+     * or null if this meta data is not present
+     */
+    public String getCharset() {
+        return getFirstValue(MIME_CONTENT_TYPE_PARAMETER_SPACE, MIME_CONTENT_TYPE_PARAMETER_CHARSET_NAME);
+    }
+
+    
+    /**
+     * Gets the RFC2045 Content-Type "boundary" parameter.
+     * 
+     * @return the RFC2045 Content-Type "boundary" parameter, 
+     * or null if this meta data is not present
+     */
+    public String getBoundary() {
+        return getFirstValue(MIME_CONTENT_TYPE_PARAMETER_SPACE, MIME_CONTENT_TYPE_PARAMETER_BOUNDARY_NAME);
+    }
+    
+    /**
+     * Gets the RFC1766 Content-Language.
+     * 
+     * @return list of parsed langauge tags from the RFC1766 Content-Language, 
+     * possibly empty
+     */
+    public List<String> getContentLanguage() {
+        return getValues(MIME_CONTENT_LANGUAGE_SPACE, MIME_CONTENT_LANGUAGE_NAME);
+    }
+
+    public List<Property> toProperties() {
+        return new ArrayList<>(properties);
+    }
+
+    /**
+     * Constructs a <code>String</code> with all attributes
+     * in name = value format.
+     *
+     * @return a <code>String</code> representation 
+     * of this object.
+     */
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("textualLineCount", textualLineCount)
+            .add("properties", properties)
+            .toString();
+    }
+}

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/Properties.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/Properties.java
@@ -41,6 +41,7 @@ import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_SUB_T
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -220,6 +221,22 @@ public class Properties {
 
     public List<Property> toProperties() {
         return new ArrayList<>(properties);
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof Properties) {
+            Properties that = (Properties) o;
+
+            return Objects.equals(this.textualLineCount, that.textualLineCount)
+                && Objects.equals(this.properties, that.properties);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(textualLineCount, properties);
     }
 
     /**

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/Properties.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/Properties.java
@@ -33,7 +33,6 @@ import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTE
 import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_MD5_SPACE;
 import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TRANSFER_ENCODING_NAME;
 import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TRANSFER_ENCODING_SPACE;
-import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TYPE_PARAMETER_CHARSET_NAME;
 import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TYPE_PARAMETER_SPACE;
 import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_MEDIA_TYPE_NAME;
 import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_MIME_TYPE_SPACE;
@@ -207,16 +206,6 @@ public class Properties {
      */
     public String getContentMD5() {
         return getFirstValue(MIME_CONTENT_MD5_SPACE, MIME_CONTENT_MD5_NAME);
-    }
-    
-    /**
-     * Gets the RFC2045 Content-Type "charset" parameter.
-     * 
-     * @return the RFC2045 Content-Type "charset" parameter, 
-     * or null if this meta data is not present
-     */
-    public String getCharset() {
-        return getFirstValue(MIME_CONTENT_TYPE_PARAMETER_SPACE, MIME_CONTENT_TYPE_PARAMETER_CHARSET_NAME);
     }
     
     /**

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/Properties.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/Properties.java
@@ -33,7 +33,6 @@ import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTE
 import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_MD5_SPACE;
 import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TRANSFER_ENCODING_NAME;
 import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TRANSFER_ENCODING_SPACE;
-import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TYPE_PARAMETER_BOUNDARY_NAME;
 import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TYPE_PARAMETER_CHARSET_NAME;
 import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TYPE_PARAMETER_SPACE;
 import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_MEDIA_TYPE_NAME;
@@ -218,17 +217,6 @@ public class Properties {
      */
     public String getCharset() {
         return getFirstValue(MIME_CONTENT_TYPE_PARAMETER_SPACE, MIME_CONTENT_TYPE_PARAMETER_CHARSET_NAME);
-    }
-
-    
-    /**
-     * Gets the RFC2045 Content-Type "boundary" parameter.
-     * 
-     * @return the RFC2045 Content-Type "boundary" parameter, 
-     * or null if this meta data is not present
-     */
-    public String getBoundary() {
-        return getFirstValue(MIME_CONTENT_TYPE_PARAMETER_SPACE, MIME_CONTENT_TYPE_PARAMETER_BOUNDARY_NAME);
     }
     
     /**

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/PropertyBuilder.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/PropertyBuilder.java
@@ -44,12 +44,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 import org.apache.james.mailbox.store.mail.model.Property;
-
-import com.github.steveash.guavate.Guavate;
 
 /**
  * Builds properties
@@ -90,35 +86,7 @@ public class PropertyBuilder {
     public void setTextualLineCount(Long textualLineCount) {
         this.textualLineCount = textualLineCount;
     }
-    
-    /**
-     * Gets the first value with the given name.
-     * Used to retrieve values with a single value.
-     * @param namespace not null
-     * @param localName not null
-     * @return value, 
-     * or null when no property has the given name and namespace
-     */
-    public String getFirstValue(String namespace, String localName) {
-        return properties.stream()
-            .filter(property -> property.isNamed(namespace, localName))
-            .findFirst()
-            .map(Property::getValue)
-            .orElse(null);
-    }
-    
-    /**
-     * Lists all values for a property.
-     * @param namespace not null
-     * @param localName not null
-     * @return not null
-     */
-    public List<String> getValues(String namespace, String localName) {
-        return properties.stream()
-            .filter(property -> property.isNamed(namespace, localName))
-            .map(Property::getValue)
-            .collect(Guavate.toImmutableList());
-    }
+
     
     /**
      * Sets a property allowing only a single value.
@@ -126,7 +94,7 @@ public class PropertyBuilder {
      * @param localName not null
      * @param value null to remove property
      */
-    public void setProperty(String namespace, String localName, String value) {
+    private void setProperty(String namespace, String localName, String value) {
         properties.removeIf(property -> property.isNamed(namespace, localName));
         
         if (value != null) {
@@ -140,7 +108,7 @@ public class PropertyBuilder {
      * @param localName not null
      * @param values null to remove property
      */
-    public void setProperty(String namespace, String localName, List<String> values) {
+    private void setProperty(String namespace, String localName, List<String> values) {
         properties.removeIf(property -> property.isNamed(namespace, localName));
         if (values != null) {
             for (String value:values) {
@@ -150,41 +118,17 @@ public class PropertyBuilder {
     }
     
     /**
-     * Maps properties in the given namespace.
-     * @param namespace not null
-     * @return values indexed by local name
-     */
-    public SortedMap<String,String> getProperties(String namespace) {
-        final SortedMap<String, String> parameters = new TreeMap<>();
-        for (Property property : properties) {
-            if (property.isInSpace(namespace)) {
-                parameters.put(property.getLocalName(), property.getValue());
-            }
-        }
-        return parameters;
-    }
-    
-    /**
      * Sets properties in the given namespace from the map.
      * Existing properties in the namespace will be removed.
      * All local names will be converted to lower case.
      * @param namespace not null
      * @param valuesByLocalName not null
      */
-    public void setProperties(String namespace, Map<String,String> valuesByLocalName) {
+    private void setProperties(String namespace, Map<String,String> valuesByLocalName) {
         properties.removeIf(property -> property.isInSpace(namespace));
         for (Map.Entry<String, String> valueByLocalName:valuesByLocalName.entrySet()) {
             properties.add(new Property(namespace, valueByLocalName.getKey().toLowerCase(Locale.US), valueByLocalName.getValue()));
         }
-    }
-    
-    /**
-     * Gets the top level MIME content media type.
-     * 
-     * @return top level MIME content media type, or null if default
-     */
-    public String getMediaType() {
-        return getFirstValue(MIME_MIME_TYPE_SPACE, MIME_MEDIA_TYPE_NAME);
     }
     
     /**
@@ -195,15 +139,6 @@ public class PropertyBuilder {
      */
     public void setMediaType(String value) {
         setProperty(MIME_MIME_TYPE_SPACE, MIME_MEDIA_TYPE_NAME, value);
-    }
-
-    /**
-     * Gets the MIME content subtype.
-     * 
-     * @return the MIME content subtype, or null if default
-     */
-    public String getSubType() {
-        return getFirstValue(MIME_MIME_TYPE_SPACE, MIME_SUB_TYPE_NAME);
     }
     
     /**
@@ -217,15 +152,6 @@ public class PropertyBuilder {
     }
     
     /**
-     * Gets the MIME Content-ID.
-     * 
-     * @return the MIME content subtype, or null if default
-     */
-    public String getContentID() {
-        return getFirstValue(MIME_CONTENT_ID_SPACE, MIME_CONTENT_ID_NAME);
-    }
-    
-    /**
      * Sets MIME Content-ID.
      * 
      * @param value the MIME content subtype, 
@@ -233,16 +159,6 @@ public class PropertyBuilder {
      */
     public void setContentID(String value) {
         setProperty(MIME_CONTENT_ID_SPACE, MIME_CONTENT_ID_NAME, value);
-    }
-    
-    /**
-     * Gets the MIME Content-Description.
-     * 
-     * @return the MIME Content-Description, 
-     * or null if this meta data is not present
-     */
-    public String getContentDescription() {
-        return getFirstValue(MIME_CONTENT_DESCRIPTION_SPACE, MIME_CONTENT_DESCRIPTION_NAME);
     }
     
     /**
@@ -256,16 +172,6 @@ public class PropertyBuilder {
     }
     
     /**
-     * Gets the MIME Content-Transfer-Encoding.
-     * 
-     * @return the MIME Content-Transfer-Encoding, 
-     * or null if this meta data is not present
-     */
-    public String getContentTransferEncoding() {
-        return getFirstValue(MIME_CONTENT_TRANSFER_ENCODING_SPACE, MIME_CONTENT_TRANSFER_ENCODING_NAME);
-    }
-    
-    /**
      * Sets MIME Content-Transfer-Encoding.
      * 
      * @param value the MIME Content-Transfer-Encoding
@@ -273,16 +179,6 @@ public class PropertyBuilder {
      */
     public void setContentTransferEncoding(String value) {
         setProperty(MIME_CONTENT_TRANSFER_ENCODING_SPACE, MIME_CONTENT_TRANSFER_ENCODING_NAME, value);
-    }
-    
-    /**
-     * Gets the RFC2557 Content-Location.
-     * 
-     * @return the RFC2557 Content-Location, 
-     * or null if this meta data is not present
-     */
-    public String getContentLocation() {
-        return getFirstValue(MIME_CONTENT_LOCATION_SPACE, MIME_CONTENT_LOCATION_NAME);
     }
     
     /**
@@ -306,24 +202,6 @@ public class PropertyBuilder {
     }
     
     /**
-     * Gets the RFC2183 Content-Disposition disposition-type.
-     * 
-     * @return the RFC2183 Content-Disposition, 
-     * or null if this meta data is not present
-     */
-    public String getContentDispositionType() {
-        return getFirstValue(MIME_CONTENT_DISPOSITION_SPACE, MIME_CONTENT_DISPOSITION_TYPE_NAME);
-    }
-    
-    /**
-     * Gets RFC2183 Content-Disposition parameters.
-     * @return parameter values indexed by lower case local names 
-     */
-    public Map<String,String> getContentDispositionParameters() {
-        return getProperties(MIME_CONTENT_DISPOSITION_PARAMETER_SPACE);
-    }
-    
-    /**
      * Sets Content-Disposition parameters.
      * Parameter names will be normalised to lower case.
      * @param valuesByParameterName values indexed by parameter name
@@ -333,30 +211,12 @@ public class PropertyBuilder {
     }
     
     /**
-     * Gets RFC2045 Content-Type parameters.
-     * @return parameter values indexed by lower case local names 
-     */
-    public Map<String,String> getContentTypeParameters() {
-        return getProperties(MIME_CONTENT_TYPE_PARAMETER_SPACE);
-    }
-    
-    /**
      * Sets Content-Type parameters.
      * Parameter names will be normalised to lower case.
      * @param valuesByParameterName values indexed by parameter name
      */
     public void setContentTypeParameters(Map<String,String> valuesByParameterName) {
         setProperties(MIME_CONTENT_TYPE_PARAMETER_SPACE, valuesByParameterName);
-    }
-    
-    /**
-     * Gets the RFC1864 Content-MD5.
-     * 
-     * @return the RFC1864 Content-MD5, 
-     * or null if this meta data is not present
-     */
-    public String getContentMD5() {
-        return getFirstValue(MIME_CONTENT_MD5_SPACE, MIME_CONTENT_MD5_NAME);
     }
     
     /**
@@ -370,16 +230,6 @@ public class PropertyBuilder {
     }
     
     /**
-     * Gets the RFC2045 Content-Type "charset" parameter.
-     * 
-     * @return the RFC2045 Content-Type "charset" parameter, 
-     * or null if this meta data is not present
-     */
-    public String getCharset() {
-        return getFirstValue(MIME_CONTENT_TYPE_PARAMETER_SPACE, MIME_CONTENT_TYPE_PARAMETER_CHARSET_NAME);
-    }
-    
-    /**
      * Sets RFC2045 Content-Type "charset" parameter.
      * 
      * @param value the RFC2045 Content-Type "charset" parameter
@@ -390,16 +240,6 @@ public class PropertyBuilder {
     }
     
     /**
-     * Gets the RFC2045 Content-Type "boundary" parameter.
-     * 
-     * @return the RFC2045 Content-Type "boundary" parameter, 
-     * or null if this meta data is not present
-     */
-    public String getBoundary() {
-        return getFirstValue(MIME_CONTENT_TYPE_PARAMETER_SPACE, MIME_CONTENT_TYPE_PARAMETER_BOUNDARY_NAME);
-    }
-    
-    /**
      * Sets RFC2045 Content-Type "boundary" parameter.
      * 
      * @param value the RFC2045 Content-Type "boundary" parameter
@@ -407,16 +247,6 @@ public class PropertyBuilder {
      */
     public void setBoundary(String value) {
         setProperty(MIME_CONTENT_TYPE_PARAMETER_SPACE, MIME_CONTENT_TYPE_PARAMETER_BOUNDARY_NAME, value);
-    }
-    
-    /**
-     * Gets the RFC1766 Content-Language.
-     * 
-     * @return list of parsed langauge tags from the RFC1766 Content-Language, 
-     * possibly empty
-     */
-    public List<String> getContentLanguage() {
-        return getValues(MIME_CONTENT_LANGUAGE_SPACE, MIME_CONTENT_LANGUAGE_NAME);
     }
     
     /**
@@ -435,6 +265,10 @@ public class PropertyBuilder {
      */
     public List<Property> toProperties() {
         return new ArrayList<>(properties);
+    }
+
+    public Properties build() {
+        return new Properties(properties, textualLineCount);
     }
 
     /**

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/PropertyBuilder.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/PropertyBuilder.java
@@ -33,7 +33,6 @@ import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTE
 import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_MD5_SPACE;
 import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TRANSFER_ENCODING_NAME;
 import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TRANSFER_ENCODING_SPACE;
-import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TYPE_PARAMETER_BOUNDARY_NAME;
 import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TYPE_PARAMETER_CHARSET_NAME;
 import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_CONTENT_TYPE_PARAMETER_SPACE;
 import static org.apache.james.mailbox.store.mail.model.StandardNames.MIME_MEDIA_TYPE_NAME;
@@ -237,16 +236,6 @@ public class PropertyBuilder {
      */
     public void setCharset(String value) {
         setProperty(MIME_CONTENT_TYPE_PARAMETER_SPACE, MIME_CONTENT_TYPE_PARAMETER_CHARSET_NAME, value);
-    }
-    
-    /**
-     * Sets RFC2045 Content-Type "boundary" parameter.
-     * 
-     * @param value the RFC2045 Content-Type "boundary" parameter
-     * or null to remove
-     */
-    public void setBoundary(String value) {
-        setProperty(MIME_CONTENT_TYPE_PARAMETER_SPACE, MIME_CONTENT_TYPE_PARAMETER_BOUNDARY_NAME, value);
     }
     
     /**

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMessage.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMessage.java
@@ -28,25 +28,20 @@ import javax.mail.internet.SharedInputStream;
 import org.apache.james.mailbox.model.MessageAttachmentMetadata;
 import org.apache.james.mailbox.model.MessageId;
 import org.apache.james.mailbox.store.mail.model.Message;
-import org.apache.james.mailbox.store.mail.model.Property;
 
 public class SimpleMessage implements Message {
 
     private final MessageId messageId;
-    private final String subType;
-    private final String mediaType;
     private final SharedInputStream content;
     private final int bodyStartOctet;
     private final Date internalDate;
     private final long size;
     private final Long textualLineCount;
-    private final List<Property> properties;
+    private final Properties properties;
     private final List<MessageAttachmentMetadata> attachments;
 
-    public SimpleMessage(MessageId messageId, SharedInputStream content, long size, Date internalDate, String subType, String mediaType, int bodyStartOctet, Long textualLineCount, List<Property> properties, List<MessageAttachmentMetadata> attachments) {
+    public SimpleMessage(MessageId messageId, SharedInputStream content, long size, Date internalDate, int bodyStartOctet, Long textualLineCount, Properties properties, List<MessageAttachmentMetadata> attachments) {
         this.messageId = messageId;
-        this.subType = subType;
-        this.mediaType = mediaType;
         this.content = content;
         this.bodyStartOctet = bodyStartOctet;
         this.internalDate = internalDate;
@@ -73,12 +68,12 @@ public class SimpleMessage implements Message {
 
     @Override
     public String getMediaType() {
-        return mediaType;
+        return properties.getMediaType();
     }
 
     @Override
     public String getSubType() {
-        return subType;
+        return properties.getSubType();
     }
 
     @Override
@@ -116,7 +111,7 @@ public class SimpleMessage implements Message {
     }
 
     @Override
-    public List<Property> getProperties() {
+    public Properties getProperties() {
         return properties;
     }
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/MessageBuilder.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/MessageBuilder.java
@@ -81,7 +81,7 @@ public class MessageBuilder {
     public MailboxMessage build(MessageId messageId) throws Exception {
         byte[] headerContent = getHeaderContent();
         SimpleMailboxMessage mailboxMessage = new SimpleMailboxMessage(messageId, internalDate, size, headerContent.length,
-            new SharedByteArrayInputStream(Bytes.concat(headerContent, body)), flags, new PropertyBuilder(), mailboxId, NO_ATTACHMENTS);
+            new SharedByteArrayInputStream(Bytes.concat(headerContent, body)), flags, new PropertyBuilder().build(), mailboxId, NO_ATTACHMENTS);
         mailboxMessage.setUid(uid);
         return mailboxMessage;
     }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/MessageIdManagerTestSystem.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/MessageIdManagerTestSystem.java
@@ -114,7 +114,7 @@ public class MessageIdManagerTestSystem {
 
     private static MailboxMessage createMessage(MailboxId mailboxId, Flags flags, MessageId messageId, MessageUid uid) {
         MailboxMessage mailboxMessage = new SimpleMailboxMessage(messageId, new Date(), MESSAGE_CONTENT.length, 1256,
-            new SharedByteArrayInputStream(MESSAGE_CONTENT), flags, new PropertyBuilder(), mailboxId);
+            new SharedByteArrayInputStream(MESSAGE_CONTENT), flags, new PropertyBuilder().build(), mailboxId);
         mailboxMessage.setModSeq(MOD_SEQ);
         mailboxMessage.setUid(uid);
         return mailboxMessage;

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxMessageResultIteratorTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/StoreMailboxMessageResultIteratorTest.java
@@ -98,7 +98,7 @@ class StoreMailboxMessageResultIteratorTest {
 
         private SimpleMailboxMessage createMessage(MessageUid uid) {
             SimpleMailboxMessage message = new SimpleMailboxMessage(new DefaultMessageId(), null, 0, 0, new SharedByteArrayInputStream(
-                    "".getBytes()), new Flags(), new PropertyBuilder(), TestId.of(1L));
+                    "".getBytes()), new Flags(), new PropertyBuilder().build(), TestId.of(1L));
             message.setUid(uid);
             return message;
         }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMessageAssertTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMessageAssertTest.java
@@ -90,7 +90,7 @@ class ListMessageAssertTest {
     private MailboxMessage createMailboxMessage(MailboxId mailboxId, MessageId messageId, MessageUid uid, Date internalDate,
                                                 String content, int bodyStart, PropertyBuilder propertyBuilder) {
         SimpleMailboxMessage simpleMailboxMessage = new SimpleMailboxMessage(messageId, internalDate, content.length(),
-            bodyStart, new SharedByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)), new Flags(), propertyBuilder, mailboxId);
+            bodyStart, new SharedByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)), new Flags(), propertyBuilder.build(), mailboxId);
 
         simpleMailboxMessage.setUid(uid);
         simpleMailboxMessage.setModSeq(ModSeq.first());
@@ -103,7 +103,7 @@ class ListMessageAssertTest {
 
     private MailboxMessage createMessage(Mailbox mailbox, MessageId messageId, String content, int bodyStart, PropertyBuilder propertyBuilder) {
         SimpleMailboxMessage simpleMailboxMessage = new SimpleMailboxMessage(messageId, INTERNAL_DATE, content.length(),
-            bodyStart, new SharedByteArrayInputStream(content.getBytes()), new Flags(), propertyBuilder, mailbox.getMailboxId());
+            bodyStart, new SharedByteArrayInputStream(content.getBytes()), new Flags(), propertyBuilder.build(), mailbox.getMailboxId());
 
         simpleMailboxMessage.setUid(MESSAGE_UID);
         return simpleMailboxMessage;

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMessagePropertiesAssertTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/ListMessagePropertiesAssertTest.java
@@ -31,7 +31,7 @@ import com.google.common.collect.ImmutableList;
 
 class ListMessagePropertiesAssertTest {
     static final String OTHER_VALUE = "US-ASCII";
-    static final String OTHER_LOCAL_NAME = StandardNames.MIME_CONTENT_TYPE_PARAMETER_CHARSET_NAME;
+    static final String OTHER_LOCAL_NAME = StandardNames.MIME_CONTENT_MD5_NAME;
     static final String OTHER_NAMESPACE = StandardNames.MIME_CONTENT_TYPE_PARAMETER_SPACE;
     static final String VALUE = "7bit";
     static final String LOCAL_NAME = StandardNames.MIME_CONTENT_TRANSFER_ENCODING_NAME;

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMessageAssertTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MailboxMessageAssertTest.java
@@ -48,11 +48,11 @@ class MailboxMessageAssertTest {
         Date date = new Date();
 
         SimpleMailboxMessage message1 = new SimpleMailboxMessage(MESSAGE_ID, date, headerString.length() + bodyString.length(),
-            headerString.length(), new SharedByteArrayInputStream((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder(), MAILBOX_ID);
+            headerString.length(), new SharedByteArrayInputStream((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder().build(), MAILBOX_ID);
         message1.setUid(UID);
 
         SimpleMailboxMessage message2 = new SimpleMailboxMessage(MESSAGE_ID, date, headerString.length() + bodyString.length(),
-            headerString.length(), new SharedByteArrayInputStream((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder(), MAILBOX_ID);
+            headerString.length(), new SharedByteArrayInputStream((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder().build(), MAILBOX_ID);
         message2.setUid(UID);
 
         MessageAssert.assertThat(message1).isEqualTo(message2, MessageMapper.FetchType.Full);
@@ -65,12 +65,12 @@ class MailboxMessageAssertTest {
         Date date = new Date();
 
         SimpleMailboxMessage message1 = new SimpleMailboxMessage(MESSAGE_ID, date, headerString.length() + bodyString.length(),
-            headerString.length(), new SharedByteArrayInputStream((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder(), MAILBOX_ID);
+            headerString.length(), new SharedByteArrayInputStream((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder().build(), MAILBOX_ID);
         message1.setUid(UID);
 
         bodyString = "work\n.\n";
         SimpleMailboxMessage message2 = new SimpleMailboxMessage(MESSAGE_ID, date, headerString.length() + bodyString.length(),
-            headerString.length(), new SharedByteArrayInputStream((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder(), MAILBOX_ID);
+            headerString.length(), new SharedByteArrayInputStream((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder().build(), MAILBOX_ID);
         message2.setUid(UID);
 
         MessageAssert.assertThat(message1).isEqualTo(message2, MessageMapper.FetchType.Headers);
@@ -83,12 +83,12 @@ class MailboxMessageAssertTest {
         Date date = new Date();
 
         SimpleMailboxMessage message1 = new SimpleMailboxMessage(MESSAGE_ID, date, headerString.length() + bodyString.length(),
-            headerString.length(), new SharedByteArrayInputStream((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder(), MAILBOX_ID);
+            headerString.length(), new SharedByteArrayInputStream((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder().build(), MAILBOX_ID);
         message1.setUid(UID);
 
         bodyString = "work\n.\n";
         SimpleMailboxMessage message2 = new SimpleMailboxMessage(MESSAGE_ID, date, headerString.length() + bodyString.length(),
-            headerString.length(), new SharedByteArrayInputStream((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder(), MAILBOX_ID);
+            headerString.length(), new SharedByteArrayInputStream((headerString + bodyString).getBytes()), new Flags(), new PropertyBuilder().build(), MAILBOX_ID);
         message2.setUid(UID);
 
         assertThatThrownBy(() -> MessageAssert.assertThat(message1).isEqualTo(message2, MessageMapper.FetchType.Body))

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
@@ -992,7 +992,7 @@ public abstract class MessageIdMapperTest {
                 bodyStart, 
                 new SharedByteArrayInputStream(content.getBytes()), 
                 new Flags(), 
-                propertyBuilder, 
+                propertyBuilder.build(),
                 mailbox.getMailboxId());
     }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -800,27 +800,26 @@ public abstract class MessageMapperTest {
         propBuilder.setMediaType("text");
         propBuilder.setSubType("html");
         propBuilder.setTextualLineCount(2L);
-        propBuilder.setProperty(StandardNames.NAMESPACE_RFC_2045, StandardNames.MIME_CONTENT_TRANSFER_ENCODING_NAME, "7bit");
-        propBuilder.setProperty(StandardNames.MIME_CONTENT_TYPE_PARAMETER_SPACE, StandardNames.MIME_CONTENT_TYPE_PARAMETER_CHARSET_NAME, "US-ASCII");
+        propBuilder.setContentTransferEncoding("7bit");
+        propBuilder.setCharset("US-ASCII");
 
         MailboxMessage messageWithProperties = createMessage(benwaWorkMailbox, mapperProvider.generateMessageId(), "Subject: messagePropertiesShouldBeStored \n\nBody\n.\n", BODY_START, propBuilder);
         MessageMetaData messageMetaData = messageMapper.add(benwaInboxMailbox, messageWithProperties);
         MailboxMessage message = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(messageMetaData.getUid()), FetchType.Body, 1).next();
 
-        assertProperties(message.getProperties()).containsOnly(propBuilder.toProperties());
+        assertProperties(message.getProperties().toProperties()).containsOnly(propBuilder.toProperties());
     }
     
     @Test
     void messagePropertiesShouldBeStoredWhenDuplicateEntries() throws Exception {
         PropertyBuilder propBuilder = new PropertyBuilder();
-        propBuilder.setProperty(StandardNames.MIME_CONTENT_LANGUAGE_SPACE, StandardNames.MIME_CONTENT_LANGUAGE_NAME, "us");
-        propBuilder.setProperty(StandardNames.MIME_CONTENT_LANGUAGE_SPACE, StandardNames.MIME_CONTENT_LANGUAGE_NAME, "fr");
+        propBuilder.setContentLanguage(ImmutableList.of("us", "fr"));
 
         MailboxMessage messageWithProperties = createMessage(benwaWorkMailbox, mapperProvider.generateMessageId(), "Subject: messagePropertiesShouldBeStoredWhenDuplicateEntries \n\nBody\n.\n", BODY_START, propBuilder);
         MessageMetaData messageMetaData = messageMapper.add(benwaInboxMailbox, messageWithProperties);
         MailboxMessage message = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(messageMetaData.getUid()), FetchType.Body, 1).next();
 
-        assertProperties(message.getProperties()).containsOnly(propBuilder.toProperties());
+        assertProperties(message.getProperties().toProperties()).containsOnly(propBuilder.toProperties());
     }
 
     @Test
@@ -828,7 +827,7 @@ public abstract class MessageMapperTest {
         MailboxMessage messageWithProperties = createMessage(benwaWorkMailbox, mapperProvider.generateMessageId(), "Subject: messagePropertiesShouldBeStoredWhenNoProperty \n\nBody\n.\n", BODY_START, new PropertyBuilder());
         MessageMetaData messageMetaData = messageMapper.add(benwaInboxMailbox, messageWithProperties);
         MailboxMessage message = messageMapper.findInMailbox(benwaInboxMailbox, MessageRange.one(messageMetaData.getUid()), FetchType.Body, 1).next();
-        assertThat(message.getProperties()).isEmpty();
+        assertThat(message.getProperties().toProperties()).isEmpty();
     }
 
     @Test
@@ -1251,6 +1250,6 @@ public abstract class MessageMapperTest {
     }
     
     private MailboxMessage createMessage(Mailbox mailbox, MessageId messageId, String content, int bodyStart, PropertyBuilder propertyBuilder) {
-        return new SimpleMailboxMessage(messageId, new Date(), content.length(), bodyStart, new SharedByteArrayInputStream(content.getBytes()), new Flags(), propertyBuilder, mailbox.getMailboxId());
+        return new SimpleMailboxMessage(messageId, new Date(), content.length(), bodyStart, new SharedByteArrayInputStream(content.getBytes()), new Flags(), propertyBuilder.build(), mailbox.getMailboxId());
     }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMoveTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMoveTest.java
@@ -143,6 +143,6 @@ public abstract class MessageMoveTest {
     }
     
     private MailboxMessage createMessage(Mailbox mailbox, MessageId messageId, String content, int bodyStart, PropertyBuilder propertyBuilder) {
-        return new SimpleMailboxMessage(messageId, new Date(), content.length(), bodyStart, new SharedByteArrayInputStream(content.getBytes()), new Flags(), propertyBuilder, mailbox.getMailboxId());
+        return new SimpleMailboxMessage(messageId, new Date(), content.length(), bodyStart, new SharedByteArrayInputStream(content.getBytes()), new Flags(), propertyBuilder.build(), mailbox.getMailboxId());
     }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageWithAttachmentMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageWithAttachmentMapperTest.java
@@ -193,10 +193,10 @@ public abstract class MessageWithAttachmentMapperTest {
     }
 
     private SimpleMailboxMessage createMessage(Mailbox mailbox, MessageId messageId, String content, int bodyStart, PropertyBuilder propertyBuilder, List<MessageAttachmentMetadata> attachments) {
-        return new SimpleMailboxMessage(messageId, new Date(), content.length(), bodyStart, new SharedByteArrayInputStream(content.getBytes()), new Flags(), propertyBuilder, mailbox.getMailboxId(), attachments);
+        return new SimpleMailboxMessage(messageId, new Date(), content.length(), bodyStart, new SharedByteArrayInputStream(content.getBytes()), new Flags(), propertyBuilder.build(), mailbox.getMailboxId(), attachments);
     }
 
     private SimpleMailboxMessage createMessage(Mailbox mailbox, MessageId messageId, String content, int bodyStart, PropertyBuilder propertyBuilder) {
-        return new SimpleMailboxMessage(messageId, new Date(), content.length(), bodyStart, new SharedByteArrayInputStream(content.getBytes()), new Flags(), propertyBuilder, mailbox.getMailboxId());
+        return new SimpleMailboxMessage(messageId, new Date(), content.length(), bodyStart, new SharedByteArrayInputStream(content.getBytes()), new Flags(), propertyBuilder.build(), mailbox.getMailboxId());
     }
 }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MetadataMapAssertTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MetadataMapAssertTest.java
@@ -53,7 +53,7 @@ class MetadataMapAssertTest {
     @BeforeEach
     void setUp() {
         message1 = new SimpleMailboxMessage(MESSAGE_ID, DATE, HEADER_STRING.length() + BODY_STRING.length(),
-            HEADER_STRING.length(), new SharedByteArrayInputStream((HEADER_STRING + BODY_STRING).getBytes()), new Flags(), new PropertyBuilder(), MAILBOX_ID);
+            HEADER_STRING.length(), new SharedByteArrayInputStream((HEADER_STRING + BODY_STRING).getBytes()), new Flags(), new PropertyBuilder().build(), MAILBOX_ID);
         message1.setUid(UID);
         message1.setModSeq(MODSEQ);
     }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailboxMessageTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/impl/SimpleMailboxMessageTest.java
@@ -114,7 +114,7 @@ class SimpleMailboxMessageTest {
             BODY_START_OCTET,
             CONTENT_STREAM,
             new Flags(),
-            propertyBuilder,
+            propertyBuilder.build(),
             TEST_ID);
 
         SimpleMailboxMessage copy = SimpleMailboxMessage.copy(TestId.of(1337), original);
@@ -135,7 +135,7 @@ class SimpleMailboxMessageTest {
         return new SimpleMailboxMessage(new DefaultMessageId(), Calendar.getInstance().getTime(),
             content.length(), BODY_START_OCTET, new SharedByteArrayInputStream(
                     content.getBytes(MESSAGE_CHARSET)), new Flags(),
-            new PropertyBuilder(), TEST_ID);
+            new PropertyBuilder().build(), TEST_ID);
     }
 
     @Test
@@ -163,7 +163,7 @@ class SimpleMailboxMessageTest {
             .size(SIZE)
             .content(CONTENT_STREAM)
             .flags(new Flags())
-            .propertyBuilder(new PropertyBuilder())
+            .properties(new PropertyBuilder())
             .build();
     }
 
@@ -195,7 +195,7 @@ class SimpleMailboxMessageTest {
             .size(SIZE)
             .content(CONTENT_STREAM)
             .flags(flags)
-            .propertyBuilder(propertyBuilder)
+            .properties(propertyBuilder)
             .addAttachments(ImmutableList.of(messageAttachment))
             .build();
         String messageContent = IOUtils.toString(message.getFullContent(), StandardCharsets.UTF_8);
@@ -208,7 +208,7 @@ class SimpleMailboxMessageTest {
             soft.assertThat(message.getFullContentOctets()).isEqualTo(SIZE);
             soft.assertThat(messageContent).isEqualTo(MESSAGE_CONTENT);
             soft.assertThat(message.createFlags()).isEqualTo(flags);
-            soft.assertThat(message.getProperties()).isEqualTo(propertyBuilder.toProperties());
+            soft.assertThat(message.getProperties().toProperties()).isEqualTo(propertyBuilder.toProperties());
             soft.assertThat(message.getUid()).isEqualTo(uid);
             soft.assertThat(message.getModSeq()).isEqualTo(modseq);
             soft.assertThat(message.getAttachments()).containsOnly(messageAttachment);
@@ -225,7 +225,7 @@ class SimpleMailboxMessageTest {
                 .size(SIZE)
                 .content(CONTENT_STREAM)
                 .flags(new Flags())
-                .propertyBuilder(new PropertyBuilder())
+                .properties(new PropertyBuilder())
                 .build())
             .isInstanceOf(NullPointerException.class);
     }
@@ -240,7 +240,7 @@ class SimpleMailboxMessageTest {
                 .size(SIZE)
                 .content(CONTENT_STREAM)
                 .flags(new Flags())
-                .propertyBuilder(new PropertyBuilder())
+                .properties(new PropertyBuilder())
                 .build())
             .isInstanceOf(NullPointerException.class);
     }
@@ -254,7 +254,7 @@ class SimpleMailboxMessageTest {
                 .size(SIZE)
                 .content(CONTENT_STREAM)
                 .flags(new Flags())
-                .propertyBuilder(new PropertyBuilder())
+                .properties(new PropertyBuilder())
                 .build())
             .isInstanceOf(NullPointerException.class);
     }
@@ -269,7 +269,7 @@ class SimpleMailboxMessageTest {
                 .size(SIZE)
                 .content(CONTENT_STREAM)
                 .flags(new Flags())
-                .propertyBuilder(new PropertyBuilder())
+                .properties(new PropertyBuilder())
                 .build())
             .isInstanceOf(NullPointerException.class);
     }
@@ -284,7 +284,7 @@ class SimpleMailboxMessageTest {
                 .bodyStartOctet(BODY_START_OCTET)
                 .content(CONTENT_STREAM)
                 .flags(new Flags())
-                .propertyBuilder(new PropertyBuilder())
+                .properties(new PropertyBuilder())
                 .build())
             .isInstanceOf(NullPointerException.class);
     }
@@ -299,7 +299,7 @@ class SimpleMailboxMessageTest {
                 .bodyStartOctet(BODY_START_OCTET)
                 .size(SIZE)
                 .flags(new Flags())
-                .propertyBuilder(new PropertyBuilder())
+                .properties(new PropertyBuilder())
                 .build())
             .isInstanceOf(NullPointerException.class);
     }
@@ -314,7 +314,7 @@ class SimpleMailboxMessageTest {
                 .bodyStartOctet(BODY_START_OCTET)
                 .size(SIZE)
                 .content(CONTENT_STREAM)
-                .propertyBuilder(new PropertyBuilder())
+                .properties(new PropertyBuilder())
                 .build())
             .isInstanceOf(NullPointerException.class);
     }

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/utils/ApplicableFlagCalculatorTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/utils/ApplicableFlagCalculatorTest.java
@@ -105,7 +105,7 @@ class ApplicableFlagCalculatorTest {
         int bodyStart = 10;
 
         return new SimpleMailboxMessage(new DefaultMessageId(), new Date(), content.length(), bodyStart,
-            new SharedByteArrayInputStream(content.getBytes()), messageFlags, new PropertyBuilder(), TestId.of(1));
+            new SharedByteArrayInputStream(content.getBytes()), messageFlags, new PropertyBuilder().build(), TestId.of(1));
     }
 
     private Flags getDefaultApplicableFlag() {

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/ListeningMessageSearchIndexContract.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/ListeningMessageSearchIndexContract.java
@@ -52,7 +52,7 @@ public interface ListeningMessageSearchIndexContract {
         .internalDate(new Date(1433628000000L))
         .size(SIZE)
         .content(new SharedByteArrayInputStream("message".getBytes(StandardCharsets.UTF_8)))
-        .propertyBuilder(new PropertyBuilder())
+        .properties(new PropertyBuilder())
         .modseq(MOD_SEQ);
     
     ListeningMessageSearchIndex testee();

--- a/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/CassandraReIndexerImplTest.java
+++ b/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/CassandraReIndexerImplTest.java
@@ -318,7 +318,7 @@ public class CassandraReIndexerImplTest {
             cassandra.getConf()
                 .registerScenario(fail()
                     .forever()
-                    .whenQueryStartsWith("SELECT * FROM messageV2 WHERE messageId=:messageId;"));
+                    .whenQueryStartsWith("SELECT * FROM messageV3 WHERE messageId=:messageId;"));
 
             Task task = reIndexer.reIndex(ReIndexer.RunningOptions.DEFAULT);
             task.run();

--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/webadmin/CassandraRoutesModule.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/modules/webadmin/CassandraRoutesModule.java
@@ -27,6 +27,7 @@ import org.apache.james.backends.cassandra.versions.SchemaTransition;
 import org.apache.james.backends.cassandra.versions.SchemaVersion;
 import org.apache.james.mailbox.cassandra.mail.migration.MailboxPathV2Migration;
 import org.apache.james.mailbox.cassandra.mail.migration.MailboxPathV3Migration;
+import org.apache.james.mailbox.cassandra.mail.migration.MessageV3Migration;
 import org.apache.james.rrt.cassandra.migration.MappingsSourcesMigration;
 import org.apache.james.webadmin.Routes;
 import org.apache.james.webadmin.routes.CassandraMailboxMergingRoutes;
@@ -42,6 +43,7 @@ public class CassandraRoutesModule extends AbstractModule {
     private static final SchemaTransition FROM_V5_TO_V6 = SchemaTransition.to(new SchemaVersion(6));
     private static final SchemaTransition FROM_V6_TO_V7 = SchemaTransition.to(new SchemaVersion(7));
     private static final SchemaTransition FROM_V7_TO_V8 = SchemaTransition.to(new SchemaVersion(8));
+    private static final SchemaTransition FROM_V8_TO_V9 = SchemaTransition.to(new SchemaVersion(9));
 
     @Override
     protected void configure() {
@@ -60,6 +62,7 @@ public class CassandraRoutesModule extends AbstractModule {
         allMigrationClazzBinder.addBinding(FROM_V5_TO_V6).to(MailboxPathV2Migration.class);
         allMigrationClazzBinder.addBinding(FROM_V6_TO_V7).to(MappingsSourcesMigration.class);
         allMigrationClazzBinder.addBinding(FROM_V7_TO_V8).to(MailboxPathV3Migration.class);
+        allMigrationClazzBinder.addBinding(FROM_V8_TO_V9).to(MessageV3Migration.class);
 
         bind(SchemaVersion.class)
             .annotatedWith(Names.named(CassandraMigrationService.LATEST_VERSION))

--- a/server/container/util/src/main/java/org/apache/james/util/StreamUtils.java
+++ b/server/container/util/src/main/java/org/apache/james/util/StreamUtils.java
@@ -59,6 +59,12 @@ public class StreamUtils {
         return streams.flatMap(Function.identity());
     }
 
+    public static <T> boolean isSingleValued(Stream<T> stream) {
+        return stream.distinct()
+            .limit(2)
+            .count() == 1;
+    }
+
     @SafeVarargs
     public static <T> Stream<T> flatten(Stream<T>... streams) {
         return flatten(Arrays.stream(streams));

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/UpdateMessagePatch.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/UpdateMessagePatch.java
@@ -21,6 +21,7 @@ package org.apache.james.jmap.draft.model;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -139,6 +140,10 @@ public class UpdateMessagePatch {
         return !oldKeywords.isPresent() && !keywords.isPresent();
     }
 
+    public boolean isOnlyAFlagUpdate() {
+        return !mailboxIds.isPresent() && (oldKeywords.isPresent() || keywords.isPresent());
+    }
+
     public ImmutableList<ValidationResult> getValidationErrors() {
         return validationErrors;
     }
@@ -153,6 +158,24 @@ public class UpdateMessagePatch {
             .orElse(keywords
                 .map(keyword -> keyword.asFlagsWithRecentAndDeletedFrom(currentFlags))
                 .orElse(currentFlags));
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof UpdateMessagePatch) {
+            UpdateMessagePatch that = (UpdateMessagePatch) o;
+
+            return Objects.equals(this.mailboxIds, that.mailboxIds)
+                && Objects.equals(this.keywords, that.keywords)
+                && Objects.equals(this.oldKeywords, that.oldKeywords)
+                && Objects.equals(this.validationErrors, that.validationErrors);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(mailboxIds, keywords, oldKeywords, validationErrors);
     }
 
     @Override

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/SetMessagesUpdateProcessorTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/SetMessagesUpdateProcessorTest.java
@@ -178,8 +178,10 @@ public class SetMessagesUpdateProcessorTest {
         referenceUpdater = new ReferenceUpdater(mockMessageIdManager, mockedMailboxManager);
 
         UpdateMessagePatchConverter updateMessagePatchConverter = null;
+        MailboxManager mailboxManager = null;
         sut = new SetMessagesUpdateProcessor(updateMessagePatchConverter,
             messageIdManager,
+            mailboxManager,
             fakeSystemMailboxesProvider,
             mockedMailboxIdFactory,
             messageSender,
@@ -234,8 +236,10 @@ public class SetMessagesUpdateProcessorTest {
                 .thenReturn(mockInvalidPatch);
 
 
+        MailboxManager mailboxManager = null;
         SetMessagesUpdateProcessor sut = new SetMessagesUpdateProcessor(mockConverter,
             mockMessageIdManager,
+            mailboxManager,
             fakeSystemMailboxesProvider,
             mockedMailboxIdFactory,
             messageSender,

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/MailboxesRoutesTest.java
@@ -519,7 +519,7 @@ class MailboxesRoutesTest {
                     .internalDate(new Date(ZonedDateTime.parse("2018-02-15T15:54:02Z").toEpochSecond()))
                     .bodyStartOctet(0)
                     .flags(new Flags("myFlags"))
-                    .propertyBuilder(new PropertyBuilder())
+                    .properties(new PropertyBuilder())
                     .mailboxId(mailboxId)
                     .build();
 
@@ -938,7 +938,7 @@ class MailboxesRoutesTest {
                     .internalDate(new Date(ZonedDateTime.parse("2018-02-15T15:54:02Z").toEpochSecond()))
                     .bodyStartOctet(0)
                     .flags(new Flags("myFlags"))
-                    .propertyBuilder(new PropertyBuilder())
+                    .properties(new PropertyBuilder())
                     .mailboxId(mailboxId)
                     .build();
 

--- a/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/test/java/org/apache/james/webadmin/routes/UserMailboxesRoutesTest.java
@@ -1529,7 +1529,7 @@ class UserMailboxesRoutesTest {
                     .internalDate(new Date(ZonedDateTime.parse("2018-02-15T15:54:02Z").toEpochSecond()))
                     .bodyStartOctet(0)
                     .flags(new Flags("myFlags"))
-                    .propertyBuilder(new PropertyBuilder())
+                    .properties(new PropertyBuilder())
                     .mailboxId(mailboxId)
                     .build();
 

--- a/src/site/xdoc/server/config-cassandra.xml
+++ b/src/site/xdoc/server/config-cassandra.xml
@@ -257,6 +257,18 @@
 
     </subsection>
 
+    <subsection name="From V7 to V8">
+
+      <p>Add UID_VALIDITY to mailboxPath table in order not to mandate mailbox table reads.</p>
+
+    </subsection>
+
+    <subsection name="From V8 to V9">
+
+      <p>Adopt a more compact representation for message properties.</p>
+
+    </subsection>
+
   </section>
 
 </body>

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -20,6 +20,32 @@ Change list:
  - [mailqueue.size.metricsEnabled now defaults to false](#mailqueuesizemetricsenabled-now-defaults-to-false)
  - [LDAP users repository connection pool now defaults to false](#ldap-users-repository-connection-pool-now-defaults-to-false)
  - [Swift support has been dropped](#swift-support-has-been-dropped)
+ - [Cassandra Schema update to V8](#cassandra-schema-update-to-v8)
+ - [Cassandra Schema update to V9](#cassandra-schema-update-to-v9)
+
+### Cassandra Schema update to V9
+
+Date 20/10/2020
+
+JIRA: https://issues.apache.org/jira/browse/JAMES-3430
+
+Concerned product: Distributed James
+
+Adopt a more compact representation for message properties. This improves performance of the Cassandra mailbox.
+
+In order to benefit from this work, you need to [upgrade to the latest schema version](https://github.com/apache/james-project/blob/master/src/site/markdown/server/manage-webadmin.md#upgrading-to-the-latest-version).
+
+### Cassandra Schema update to V8
+
+Date 13/10/2020
+
+JIRA: https://issues.apache.org/jira/browse/JAMES-3409
+
+Concerned product: Distributed James
+
+Add UID_VALIDITY to mailboxPath table in order not to mandate mailbox table reads. This improves performance of the Cassandra mailbox.
+
+In order to benefit from this work, you need to [upgrade to the latest schema version](https://github.com/apache/james-project/blob/master/src/site/markdown/server/manage-webadmin.md#upgrading-to-the-latest-version).
 
 ### Swift support has been dropped
 


### PR DESCRIPTION
Restructure CassandraMessageDAO (and underlying table) to store known properties in a column instead of a UDT list. 

This avoids the use of a collection on a critical table thus should significantly fasten related operations.


|Changeset|space (uncompressed) | space (compressed) |table level latency|
|----------------|-------------------------|----------------------------|----------------------------|
| Before |   1597 bytes / message |266 bytes / message| 0.158 ms |
| After | 310 bytes / message |136 bytes/ message| 0.128 ms |

(using benchmark code reported in https://github.com/linagora/james-project/pull/3925)