### PR TITLE
JAMES-3277 JMAP Rely on MessageManager::setFlags to optimize massive …

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/MailboxManager.java
@@ -289,6 +289,8 @@ public interface MailboxManager extends RequestAware, RightManager, MailboxAnnot
      */
     List<MessageRange> moveMessages(MessageRange set, MailboxPath from, MailboxPath to, MailboxSession session) throws MailboxException;
 
+    List<MessageRange> moveMessages(MessageRange set, MailboxId from, MailboxId to, MailboxSession session) throws MailboxException;
+
     enum MailboxSearchFetchType {
         Minimal,
         Counters

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -623,6 +623,14 @@ public class StoreMailboxManager implements MailboxManager {
     }
 
     @Override
+    public List<MessageRange> moveMessages(MessageRange set, MailboxId from, MailboxId to, MailboxSession session) throws MailboxException {
+        StoreMessageManager toMailbox = (StoreMessageManager) getMailbox(to, session);
+        StoreMessageManager fromMailbox = (StoreMessageManager) getMailbox(from, session);
+
+        return configuration.getMoveBatcher().batchMessages(set, messageRange -> fromMailbox.moveTo(messageRange, toMailbox, session));
+    }
+
+    @Override
     public Flux<MailboxMetaData> search(MailboxQuery expression, MailboxSearchFetchType fetchType, MailboxSession session) {
         Mono<List<Mailbox>> mailboxesMono = searchMailboxes(expression, session, Right.Lookup).collectList();
 

--- a/server/container/util/src/main/java/org/apache/james/util/StreamUtils.java
+++ b/server/container/util/src/main/java/org/apache/james/util/StreamUtils.java
@@ -59,6 +59,12 @@ public class StreamUtils {
         return streams.flatMap(Function.identity());
     }
 
+    public static <T> boolean isSingleValued(Stream<T> stream) {
+        return stream.distinct()
+            .limit(2)
+            .count() == 1;
+    }
+
     @SafeVarargs
     public static <T> Stream<T> flatten(Stream<T>... streams) {
         return flatten(Arrays.stream(streams));

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMessagesMethodTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMessagesMethodTest.java
@@ -1130,6 +1130,80 @@ public abstract class SetMessagesMethodTest {
             .body(FIRST_MAILBOX + ".unreadMessages", equalTo(0));
     }
 
+    @Test
+    public void massiveMessageMoveShouldBeApplied() throws MailboxException {
+        mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME.asString(), "mailbox");
+        mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME.asString(), DefaultMailboxes.DRAFTS);
+        mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME.asString(), DefaultMailboxes.OUTBOX);
+        mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME.asString(), DefaultMailboxes.SENT);
+        MailboxId mailboxId = mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME.asString(), DefaultMailboxes.TRASH);
+        mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, USERNAME.asString(), DefaultMailboxes.SPAM);
+
+        ComposedMessageId message1 = mailboxProbe.appendMessage(USERNAME.asString(), USER_MAILBOX,
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
+        ComposedMessageId message2 = mailboxProbe.appendMessage(USERNAME.asString(), USER_MAILBOX,
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
+        ComposedMessageId message3 = mailboxProbe.appendMessage(USERNAME.asString(), USER_MAILBOX,
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags(Flags.Flag.SEEN));
+        ComposedMessageId message4 = mailboxProbe.appendMessage(USERNAME.asString(), USER_MAILBOX,
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
+        ComposedMessageId message5 = mailboxProbe.appendMessage(USERNAME.asString(), USER_MAILBOX,
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags(Flags.Flag.ANSWERED));
+        ComposedMessageId message6 = mailboxProbe.appendMessage(USERNAME.asString(), USER_MAILBOX,
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
+        ComposedMessageId message7 = mailboxProbe.appendMessage(USERNAME.asString(), USER_MAILBOX,
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
+        ComposedMessageId message8 = mailboxProbe.appendMessage(USERNAME.asString(), USER_MAILBOX,
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
+        ComposedMessageId message9 = mailboxProbe.appendMessage(USERNAME.asString(), USER_MAILBOX,
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags(Flags.Flag.SEEN));
+        ComposedMessageId message10 = mailboxProbe.appendMessage(USERNAME.asString(), USER_MAILBOX,
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
+        ComposedMessageId message11 = mailboxProbe.appendMessage(USERNAME.asString(), USER_MAILBOX,
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags(Flags.Flag.ANSWERED));
+        ComposedMessageId message12 = mailboxProbe.appendMessage(USERNAME.asString(), USER_MAILBOX,
+            new ByteArrayInputStream("Subject: test\r\n\r\ntestmail".getBytes(StandardCharsets.UTF_8)), new Date(), false, new Flags());
+
+        String serializedMessageId1 = message1.getMessageId().serialize();
+        String serializedMessageId2 = message2.getMessageId().serialize();
+        String serializedMessageId3 = message3.getMessageId().serialize();
+        String serializedMessageId4 = message4.getMessageId().serialize();
+        String serializedMessageId5 = message5.getMessageId().serialize();
+        String serializedMessageId6 = message6.getMessageId().serialize();
+        String serializedMessageId7 = message7.getMessageId().serialize();
+        String serializedMessageId8 = message8.getMessageId().serialize();
+        String serializedMessageId9 = message9.getMessageId().serialize();
+        String serializedMessageId10 = message10.getMessageId().serialize();
+        String serializedMessageId11 = message11.getMessageId().serialize();
+        String serializedMessageId12 = message12.getMessageId().serialize();
+
+        // When
+        given()
+            .header("Authorization", accessToken.asString())
+            .body(String.format("[[\"setMessages\", {\"update\": {" +
+                    "  \"%s\" : { \"mailboxIds\": [" + mailboxId.serialize() + "]}, " +
+                    "  \"%s\" : { \"mailboxIds\": [" + mailboxId.serialize() + "]}, " +
+                    "  \"%s\" : { \"mailboxIds\": [" + mailboxId.serialize() + "]}, " +
+                    "  \"%s\" : { \"mailboxIds\": [" + mailboxId.serialize() + "]}, " +
+                    "  \"%s\" : { \"mailboxIds\": [" + mailboxId.serialize() + "]}, " +
+                    "  \"%s\" : { \"mailboxIds\": [" + mailboxId.serialize() + "]}, " +
+                    "  \"%s\" : { \"mailboxIds\": [" + mailboxId.serialize() + "]}, " +
+                    "  \"%s\" : { \"mailboxIds\": [" + mailboxId.serialize() + "]}, " +
+                    "  \"%s\" : { \"mailboxIds\": [" + mailboxId.serialize() + "]}, " +
+                    "  \"%s\" : { \"mailboxIds\": [" + mailboxId.serialize() + "]}, " +
+                    "  \"%s\" : { \"mailboxIds\": [" + mailboxId.serialize() + "]}, " +
+                    "  \"%s\" : { \"mailboxIds\": [" + mailboxId.serialize() + "]} " +
+                    "} }, \"#0\"]]", serializedMessageId1, serializedMessageId2, serializedMessageId3,
+                serializedMessageId4, serializedMessageId5, serializedMessageId6,
+                serializedMessageId7, serializedMessageId8, serializedMessageId9,
+                serializedMessageId10, serializedMessageId11, serializedMessageId12))
+            .when()
+            .post("/jmap")
+            // Then
+            .then()
+            .log().ifValidationFails().body(ARGUMENTS + ".updated", hasSize(12));
+    }
+
     @Category(BasicFeature.class)
     @Test
     public void sendingAMailShouldLeadToAppropriateMailboxCountersOnSent() {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/UpdateMessagePatch.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/UpdateMessagePatch.java
@@ -21,6 +21,7 @@ package org.apache.james.jmap.draft.model;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -139,6 +140,10 @@ public class UpdateMessagePatch {
         return !oldKeywords.isPresent() && !keywords.isPresent();
     }
 
+    public boolean isOnlyAFlagUpdate() {
+        return !mailboxIds.isPresent() && (oldKeywords.isPresent() || keywords.isPresent());
+    }
+
     public ImmutableList<ValidationResult> getValidationErrors() {
         return validationErrors;
     }
@@ -153,6 +158,24 @@ public class UpdateMessagePatch {
             .orElse(keywords
                 .map(keyword -> keyword.asFlagsWithRecentAndDeletedFrom(currentFlags))
                 .orElse(currentFlags));
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof UpdateMessagePatch) {
+            UpdateMessagePatch that = (UpdateMessagePatch) o;
+
+            return Objects.equals(this.mailboxIds, that.mailboxIds)
+                && Objects.equals(this.keywords, that.keywords)
+                && Objects.equals(this.oldKeywords, that.oldKeywords)
+                && Objects.equals(this.validationErrors, that.validationErrors);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(mailboxIds, keywords, oldKeywords, validationErrors);
     }
 
     @Override

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/UpdateMessagePatch.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/UpdateMessagePatch.java
@@ -144,6 +144,12 @@ public class UpdateMessagePatch {
         return !mailboxIds.isPresent() && (oldKeywords.isPresent() || keywords.isPresent());
     }
 
+    public boolean isOnlyAMove() {
+        return mailboxIds.map(list -> list.size() == 1).orElse(false)
+            && oldKeywords.isEmpty()
+            && keywords.isEmpty();
+    }
+
     public ImmutableList<ValidationResult> getValidationErrors() {
         return validationErrors;
     }

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/SetMessagesUpdateProcessorTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/methods/SetMessagesUpdateProcessorTest.java
@@ -178,8 +178,10 @@ public class SetMessagesUpdateProcessorTest {
         referenceUpdater = new ReferenceUpdater(mockMessageIdManager, mockedMailboxManager);
 
         UpdateMessagePatchConverter updateMessagePatchConverter = null;
+        MailboxManager mailboxManager = null;
         sut = new SetMessagesUpdateProcessor(updateMessagePatchConverter,
             messageIdManager,
+            mailboxManager,
             fakeSystemMailboxesProvider,
             mockedMailboxIdFactory,
             messageSender,
@@ -234,8 +236,10 @@ public class SetMessagesUpdateProcessorTest {
                 .thenReturn(mockInvalidPatch);
 
 
+        MailboxManager mailboxManager = null;
         SetMessagesUpdateProcessor sut = new SetMessagesUpdateProcessor(mockConverter,
             mockMessageIdManager,
+            mailboxManager,
             fakeSystemMailboxesProvider,
             mockedMailboxIdFactory,
             messageSender,


### PR DESCRIPTION
…flags updates (Draft)

We notice that many slow traces at the JMAP level are flag updates, generating a high count of Cassandra queries.

By grouping the update we enable to share modseq allocation, and counter updates, reducing drastically query count.

Furthermore parallelism with a flag update stage is unlocked, significantly fasting the request up.

Query count before: 10m+9 (6 message => 69 queries, 9 messages => 99 queries, 12 messages => 129 queries)
Query count after: 4m+16 (6 message => 40 queries, 9 messages => 52 queries, 9 messages => 64 queries)

TODO:
 - [x] Implement this also on top of RFC-8621
 - [x] Experiment with "move" usage to see if it is relevant.