### PR TITLE
JAMES-3432: Limit size attachment

### DIFF
--- a/docs/modules/servers/pages/distributed/configure/jmap.adoc
+++ b/docs/modules/servers/pages/distributed/configure/jmap.adoc
@@ -29,6 +29,12 @@ This should not be the same keystore than the ones used by TLS based protocols.
 | jwt.publickeypem.url
 | Optional. JWT tokens allow request to bypass authentication
 
+| url.prefix
+| Optional. Configuration urlPrefix for JMAP routes.
+
+| upload.max.size
+| Optional. Configuration max size Upload in new JMAP-RFC-8621.
+
 |===
 
 == Wire tapping

--- a/docs/modules/servers/pages/distributed/configure/jmap.adoc
+++ b/docs/modules/servers/pages/distributed/configure/jmap.adoc
@@ -35,7 +35,7 @@ This should not be the same keystore than the ones used by TLS based protocols.
 
 | upload.max.size
 | Optional. Configuration max size Upload in new JMAP-RFC-8621.
-| Default value: 30MB.
+| Default value: 30M. Supported units are B (bytes) K (KB) M (MB) G (GB).
 
 |===
 

--- a/docs/modules/servers/pages/distributed/configure/jmap.adoc
+++ b/docs/modules/servers/pages/distributed/configure/jmap.adoc
@@ -31,9 +31,11 @@ This should not be the same keystore than the ones used by TLS based protocols.
 
 | url.prefix
 | Optional. Configuration urlPrefix for JMAP routes.
+| Default value: http://localhost.
 
 | upload.max.size
 | Optional. Configuration max size Upload in new JMAP-RFC-8621.
+| Default value: 30MB.
 
 |===
 

--- a/server/container/util/src/main/java/org/apache/james/util/Size.java
+++ b/server/container/util/src/main/java/org/apache/james/util/Size.java
@@ -68,7 +68,7 @@ public class Size {
     }
 
     public static Size of(Long value, Unit unit) {
-        Preconditions.checkArgument(value > 0, "Maxsize must be positive");
+        Preconditions.checkArgument(value >= 0, "Maxsize must be positive");
         return new Size(unit, value);
     }
 

--- a/server/container/util/src/main/java/org/apache/james/util/Size.java
+++ b/server/container/util/src/main/java/org/apache/james/util/Size.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.util;
 
+import com.google.common.base.Preconditions;
 import com.google.common.math.LongMath;
 
 /**
@@ -35,7 +36,7 @@ public class Size {
      * supported units : B ( 2^0 ), K ( 2^10 ), M ( 2^20 ), G ( 2^30 )
      * See  RFC822.SIZE
      */
-    private enum Unit {
+    public enum Unit {
         NoUnit,
         B,
         K,
@@ -49,6 +50,8 @@ public class Size {
     Long value;
 
     private Size(Unit unit, Long value) {
+        Preconditions.checkArgument(value > 0, "Maxsize must be positive");
+
         this.unit = unit;
         this.value = value;
     }
@@ -64,6 +67,10 @@ public class Size {
         Unit unit = getUnit(lastChar);
         String argWithoutUnit = removeLastCharIfNeeded(providedLongWithUnitString, unit);
         return new Size(unit, Long.parseLong(argWithoutUnit));
+    }
+
+    public static Size of(Long value, Unit unit) {
+        return new Size(unit, value);
     }
 
     public Unit getUnit() {

--- a/server/container/util/src/main/java/org/apache/james/util/Size.java
+++ b/server/container/util/src/main/java/org/apache/james/util/Size.java
@@ -50,8 +50,6 @@ public class Size {
     Long value;
 
     private Size(Unit unit, Long value) {
-        Preconditions.checkArgument(value > 0, "Maxsize must be positive");
-
         this.unit = unit;
         this.value = value;
     }
@@ -70,6 +68,7 @@ public class Size {
     }
 
     public static Size of(Long value, Unit unit) {
+        Preconditions.checkArgument(value > 0, "Maxsize must be positive");
         return new Size(unit, value);
     }
 

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/UploadContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/UploadContract.scala
@@ -141,28 +141,8 @@ trait UploadContract {
       .body
       .asString
 
-    assertThat(response.contains("Attempt to upload exceed max size"))
-      .isTrue
-  }
-
-  @Test
-  def shouldRejectWhenUploadFilesExceedMaxSize(): Unit = {
-    val response: String = `given`
-      .basePath("")
-      .header(ACCEPT.toString, ACCEPT_RFC8621_VERSION_HEADER)
-      .contentType(ContentType.BINARY)
-      .body(VALID_INPUT_STREAM)
-      .body(VALID_INPUT_STREAM)
-    .when
-      .post(s"/upload/$ACCOUNT_ID/")
-    .`then`
-      .statusCode(SC_BAD_REQUEST)
-      .extract
-      .body
-      .asString
-
-    assertThat(response.contains("Attempt to upload exceed max size"))
-      .isTrue
+    assertThat(response)
+      .contains("Attempt to upload exceed max size")
   }
 
   @Test

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/UploadContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/UploadContract.scala
@@ -24,21 +24,20 @@ import java.nio.charset.StandardCharsets
 import io.netty.handler.codec.http.HttpHeaderNames.ACCEPT
 import io.restassured.RestAssured.{`given`, requestSpecification}
 import io.restassured.http.ContentType
-import net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson
 import org.apache.commons.io.IOUtils
-import org.apache.http.HttpStatus.{SC_CREATED, SC_NOT_FOUND, SC_OK, SC_UNAUTHORIZED}
+import org.apache.http.HttpStatus.{SC_BAD_REQUEST, SC_CREATED, SC_OK, SC_UNAUTHORIZED}
 import org.apache.james.GuiceJamesServer
 import org.apache.james.jmap.http.UserCredential
 import org.apache.james.jmap.rfc8621.contract.Fixture.{ACCEPT_RFC8621_VERSION_HEADER, ACCOUNT_ID, ALICE, ALICE_ACCOUNT_ID, ALICE_PASSWORD, BOB, BOB_PASSWORD, DOMAIN, RFC8621_VERSION_HEADER, _2_DOT_DOMAIN, authScheme, baseRequestSpecBuilder}
 import org.apache.james.jmap.rfc8621.contract.UploadContract.{BIG_INPUT_STREAM, VALID_INPUT_STREAM}
 import org.apache.james.utils.DataProbeImpl
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.{BeforeEach, Disabled, Test}
+import org.junit.jupiter.api.{BeforeEach, Test}
 import play.api.libs.json.{JsString, Json}
 
 object UploadContract {
-  private val BIG_INPUT_STREAM: InputStream = new ByteArrayInputStream("123456789\r\n".repeat(10025).getBytes)
-  private val VALID_INPUT_STREAM: InputStream = new ByteArrayInputStream("123456789\r\n".repeat(1).getBytes)
+  private val BIG_INPUT_STREAM: InputStream = new ByteArrayInputStream("123456789\r\n".repeat(1025).getBytes)
+  private val VALID_INPUT_STREAM: InputStream = new ByteArrayInputStream("123456789\r\n".repeat(29).getBytes)
 }
 
 trait UploadContract {
@@ -128,7 +127,6 @@ trait UploadContract {
   }
 
   @Test
-  @Disabled("JAMES-1788 Upload size limitation needs to be contributed")
   def shouldRejectWhenUploadFileTooBig(): Unit = {
     val response: String = `given`
       .basePath("")
@@ -138,13 +136,33 @@ trait UploadContract {
     .when
       .post(s"/upload/$ACCOUNT_ID/")
     .`then`
-      .statusCode(SC_OK)
+      .statusCode(SC_BAD_REQUEST)
       .extract
       .body
       .asString
 
-    assertThatJson(response)
-      .isEqualTo("Should be error")
+    assertThat(response.equals("Attempt to upload exceed max size"))
+      .isTrue
+  }
+
+  @Test
+  def shouldRejectWhenUploadFilesExceedMaxSize(): Unit = {
+    val response: String = `given`
+      .basePath("")
+      .header(ACCEPT.toString, ACCEPT_RFC8621_VERSION_HEADER)
+      .contentType(ContentType.BINARY)
+      .body(VALID_INPUT_STREAM)
+      .body(VALID_INPUT_STREAM)
+    .when
+      .post(s"/upload/$ACCOUNT_ID/")
+    .`then`
+      .statusCode(SC_BAD_REQUEST)
+      .extract
+      .body
+      .asString
+
+    assertThat(response.equals("Attempt to upload exceed max size"))
+      .isTrue
   }
 
   @Test

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/UploadContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/UploadContract.scala
@@ -36,8 +36,8 @@ import org.junit.jupiter.api.{BeforeEach, Test}
 import play.api.libs.json.{JsString, Json}
 
 object UploadContract {
-  private val BIG_INPUT_STREAM: InputStream = new ByteArrayInputStream("123456789\r\n".repeat(1025).getBytes)
-  private val VALID_INPUT_STREAM: InputStream = new ByteArrayInputStream("123456789\r\n".repeat(29).getBytes)
+  private val BIG_INPUT_STREAM: InputStream = new ByteArrayInputStream("123456789\r\n".repeat(1024 * 1024 * 4).getBytes)
+  private val VALID_INPUT_STREAM: InputStream = new ByteArrayInputStream("123456789\r\n".repeat(1024 * 1024 * 3).getBytes)
 }
 
 trait UploadContract {
@@ -141,7 +141,7 @@ trait UploadContract {
       .body
       .asString
 
-    assertThat(response.equals("Attempt to upload exceed max size"))
+    assertThat(response.contains("Attempt to upload exceed max size"))
       .isTrue
   }
 
@@ -161,7 +161,7 @@ trait UploadContract {
       .body
       .asString
 
-    assertThat(response.equals("Attempt to upload exceed max size"))
+    assertThat(response.contains("Attempt to upload exceed max size"))
       .isTrue
   }
 

--- a/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/resources/jmap.properties
+++ b/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/resources/jmap.properties
@@ -1,2 +1,3 @@
 # Configuration urlPrefix for JMAP routes.
 url.prefix=http://domain.com
+upload.max.size=30

--- a/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/resources/jmap.properties
+++ b/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/resources/jmap.properties
@@ -1,3 +1,3 @@
 # Configuration urlPrefix for JMAP routes.
 url.prefix=http://domain.com
-upload.max.size=30
+upload.max.mb.size=30

--- a/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/resources/jmap.properties
+++ b/server/protocols/jmap-rfc-8621-integration-tests/memory-jmap-rfc-8621-integration-tests/src/test/resources/jmap.properties
@@ -1,3 +1,3 @@
 # Configuration urlPrefix for JMAP routes.
 url.prefix=http://domain.com
-upload.max.mb.size=30
+upload.max.size=30M

--- a/server/protocols/jmap-rfc-8621/pom.xml
+++ b/server/protocols/jmap-rfc-8621/pom.xml
@@ -96,6 +96,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>commons-fileupload</groupId>
+            <artifactId>commons-fileupload</artifactId>
+            <version>1.4</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.dpaukov</groupId>
             <artifactId>combinatoricslib3</artifactId>
             <scope>test</scope>

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/JmapRfc8621Configuration.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/JmapRfc8621Configuration.scala
@@ -22,33 +22,24 @@ package org.apache.james.jmap.model
 import java.net.URL
 
 import org.apache.commons.configuration2.Configuration
-import org.apache.james.util
+import org.apache.james.jmap.model.JmapRfc8621Configuration.UPLOAD_LIMIT_30_MB
 import org.apache.james.util.Size
-
-import scala.util.{Failure, Success, Try}
-
 
 object JmapRfc8621Configuration {
   val LOCALHOST_URL_PREFIX: String = "http://localhost"
-  private def from(urlPrefixString: String): JmapRfc8621Configuration = JmapRfc8621Configuration(urlPrefixString)
-  var LOCALHOST_CONFIGURATION: JmapRfc8621Configuration = from(LOCALHOST_URL_PREFIX)
+  val UPLOAD_LIMIT_30_MB: Size = Size.of(30, Size.Unit.M)
+  val LOCALHOST_CONFIGURATION: JmapRfc8621Configuration = JmapRfc8621Configuration(LOCALHOST_URL_PREFIX, UPLOAD_LIMIT_30_MB)
   val URL_PREFIX_PROPERTIES: String = "url.prefix"
-
   val UPLOAD_LIMIT_PROPERTIES: String = "upload.max.size"
-  val UPLOAD_LIMIT_30_MB: Long = 30 * 1024 * 1024
-  var MAXSIZE_UPLOAD: Option[util.Size] = None
 
   def from(configuration: Configuration): JmapRfc8621Configuration = {
-    MAXSIZE_UPLOAD = Try(Size.parse(configuration.getString(UPLOAD_LIMIT_PROPERTIES))) match {
-      case Success(size: Size) => Some(size)
-      case Failure(_) => None
-    }
-
-    JmapRfc8621Configuration(Option(configuration.getString(URL_PREFIX_PROPERTIES)).getOrElse(LOCALHOST_URL_PREFIX))
+    JmapRfc8621Configuration(
+      urlPrefixString = Option(configuration.getString(URL_PREFIX_PROPERTIES)).getOrElse(LOCALHOST_URL_PREFIX),
+      maxUploadSize = Option(configuration.getString(UPLOAD_LIMIT_PROPERTIES, null)).map(Size.parse).getOrElse(UPLOAD_LIMIT_30_MB))
   }
 }
 
-case class JmapRfc8621Configuration(urlPrefixString: String) {
+case class JmapRfc8621Configuration(urlPrefixString: String, maxUploadSize: Size = UPLOAD_LIMIT_30_MB) {
   val urlPrefix: URL = new URL(urlPrefixString)
   val apiUrl: URL = new URL(s"$urlPrefixString/jmap")
   val downloadUrl: URL = new URL(urlPrefixString + "/download/$accountId/$blobId/?type=$type&name=$name")

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/JmapRfc8621Configuration.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/JmapRfc8621Configuration.scala
@@ -32,12 +32,13 @@ object JmapRfc8621Configuration {
   var LOCALHOST_CONFIGURATION: JmapRfc8621Configuration = from(LOCALHOST_URL_PREFIX)
   val URL_PREFIX_PROPERTIES: String = "url.prefix"
 
-  val UPLOAD_LIMIT_PROPERTIES: String = "upload.max.size"
-  val UPLOAD_LIMIT_DEFAULT: Long = 30 * 1024 * 1024
+  val UPLOAD_LIMIT_PROPERTIES: String = "upload.max.mb.size"
+  val MB: Long =  1024 * 1024
+  val UPLOAD_LIMIT_30_MB: Long = 30
   var MAXSIZE_UPLOAD: Option[Size] = None
 
   def from(configuration: Configuration): JmapRfc8621Configuration = {
-    MAXSIZE_UPLOAD = Some(UploadRoutes.sanitizeSize(configuration.getLong(UPLOAD_LIMIT_PROPERTIES, UPLOAD_LIMIT_DEFAULT)))
+    MAXSIZE_UPLOAD = Some(UploadRoutes.sanitizeSize(configuration.getLong(UPLOAD_LIMIT_PROPERTIES, UPLOAD_LIMIT_30_MB) * MB ))
     JmapRfc8621Configuration(Option(configuration.getString(URL_PREFIX_PROPERTIES)).getOrElse(LOCALHOST_URL_PREFIX))
   }
 }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/JmapRfc8621Configuration.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/JmapRfc8621Configuration.scala
@@ -22,6 +22,9 @@ package org.apache.james.jmap.model
 import java.net.URL
 
 import org.apache.commons.configuration2.Configuration
+import org.apache.james.jmap.routes.UploadRoutes
+import org.apache.james.jmap.routes.UploadRoutes.Size
+
 
 object JmapRfc8621Configuration {
   val LOCALHOST_URL_PREFIX: String = "http://localhost"
@@ -29,8 +32,14 @@ object JmapRfc8621Configuration {
   var LOCALHOST_CONFIGURATION: JmapRfc8621Configuration = from(LOCALHOST_URL_PREFIX)
   val URL_PREFIX_PROPERTIES: String = "url.prefix"
 
-  def from(configuration: Configuration): JmapRfc8621Configuration =
+  val UPLOAD_LIMIT_PROPERTIES: String = "upload.max.size"
+  val UPLOAD_LIMIT_DEFAULT: Long = 30 * 1024 * 1024
+  var MAXSIZE_UPLOAD: Option[Size] = None
+
+  def from(configuration: Configuration): JmapRfc8621Configuration = {
+    MAXSIZE_UPLOAD = Some(UploadRoutes.sanitizeSize(configuration.getLong(UPLOAD_LIMIT_PROPERTIES, UPLOAD_LIMIT_DEFAULT)))
     JmapRfc8621Configuration(Option(configuration.getString(URL_PREFIX_PROPERTIES)).getOrElse(LOCALHOST_URL_PREFIX))
+  }
 }
 
 case class JmapRfc8621Configuration(urlPrefixString: String) {

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/JmapRfc8621Configuration.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/JmapRfc8621Configuration.scala
@@ -22,10 +22,10 @@ package org.apache.james.jmap.model
 import java.net.URL
 
 import org.apache.commons.configuration2.Configuration
-import org.apache.james.jmap.routes.UploadRoutes
-import org.apache.james.jmap.routes.UploadRoutes.Size
 import org.apache.james.util
 import org.apache.james.util.Size
+
+import scala.util.{Failure, Success, Try}
 
 
 object JmapRfc8621Configuration {
@@ -34,12 +34,16 @@ object JmapRfc8621Configuration {
   var LOCALHOST_CONFIGURATION: JmapRfc8621Configuration = from(LOCALHOST_URL_PREFIX)
   val URL_PREFIX_PROPERTIES: String = "url.prefix"
 
-  val UPLOAD_LIMIT_PROPERTIES: String = "upload.max.mb.size"
-  val UPLOAD_LIMIT_30_MB: String = "30M"
+  val UPLOAD_LIMIT_PROPERTIES: String = "upload.max.size"
+  val UPLOAD_LIMIT_30_MB: Long = 30 * 1024 * 1024
   var MAXSIZE_UPLOAD: Option[util.Size] = None
 
   def from(configuration: Configuration): JmapRfc8621Configuration = {
-    MAXSIZE_UPLOAD = Some(Size.parse(configuration.getString(UPLOAD_LIMIT_PROPERTIES, UPLOAD_LIMIT_30_MB)))
+    MAXSIZE_UPLOAD = Try(Size.parse(configuration.getString(UPLOAD_LIMIT_PROPERTIES))) match {
+      case Success(size: Size) => Some(size)
+      case Failure(_) => None
+    }
+
     JmapRfc8621Configuration(Option(configuration.getString(URL_PREFIX_PROPERTIES)).getOrElse(LOCALHOST_URL_PREFIX))
   }
 }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/JmapRfc8621Configuration.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/model/JmapRfc8621Configuration.scala
@@ -24,6 +24,8 @@ import java.net.URL
 import org.apache.commons.configuration2.Configuration
 import org.apache.james.jmap.routes.UploadRoutes
 import org.apache.james.jmap.routes.UploadRoutes.Size
+import org.apache.james.util
+import org.apache.james.util.Size
 
 
 object JmapRfc8621Configuration {
@@ -33,12 +35,11 @@ object JmapRfc8621Configuration {
   val URL_PREFIX_PROPERTIES: String = "url.prefix"
 
   val UPLOAD_LIMIT_PROPERTIES: String = "upload.max.mb.size"
-  val MB: Long =  1024 * 1024
-  val UPLOAD_LIMIT_30_MB: Long = 30
-  var MAXSIZE_UPLOAD: Option[Size] = None
+  val UPLOAD_LIMIT_30_MB: String = "30M"
+  var MAXSIZE_UPLOAD: Option[util.Size] = None
 
   def from(configuration: Configuration): JmapRfc8621Configuration = {
-    MAXSIZE_UPLOAD = Some(UploadRoutes.sanitizeSize(configuration.getLong(UPLOAD_LIMIT_PROPERTIES, UPLOAD_LIMIT_30_MB) * MB ))
+    MAXSIZE_UPLOAD = Some(Size.parse(configuration.getString(UPLOAD_LIMIT_PROPERTIES, UPLOAD_LIMIT_30_MB)))
     JmapRfc8621Configuration(Option(configuration.getString(URL_PREFIX_PROPERTIES)).getOrElse(LOCALHOST_URL_PREFIX))
   }
 }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/UploadRoutes.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/UploadRoutes.scala
@@ -19,14 +19,12 @@
 
 package org.apache.james.jmap.routes
 
-import java.io.{InputStream, PushbackInputStream}
-import java.time.ZonedDateTime
-import java.util
-import java.util.{Arrays, Optional, stream}
+import java.io.{IOException, InputStream, UncheckedIOException}
+import java.util.stream
 import java.util.stream.Stream
 
 import eu.timepit.refined.api.Refined
-import io.netty.handler.codec.http.HttpHeaderNames.{CONTENT_TYPE, LAST_MODIFIED}
+import io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE
 import io.netty.handler.codec.http.HttpResponseStatus.{BAD_REQUEST, CREATED}
 import io.netty.handler.codec.http.HttpMethod
 import javax.inject.{Inject, Named}
@@ -46,7 +44,7 @@ import reactor.netty.http.server.{HttpServerRequest, HttpServerResponse}
 import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric.NonNegative
 import eu.timepit.refined.refineV
-import org.apache.commons.io.IOUtils
+import org.apache.commons.fileupload.util.LimitedInputStream
 import org.apache.james.jmap.exceptions.UnauthorizedException
 import org.apache.james.jmap.json.UploadSerializer
 import org.apache.james.jmap.mail.BlobId
@@ -73,52 +71,6 @@ case class UploadResponse(accountId: AccountId,
                           blobId: BlobId,
                           `type`: ContentType,
                           size: Size)
-
-private object ReadAheadInputStream {
-
-  trait RequireStream {
-    def of(in: InputStream): ReadAheadInputStream.RequireLength
-  }
-
-  trait RequireLength {
-    def length(length: Int): ReadAheadInputStream
-  }
-
-  private def hasMore(stream: PushbackInputStream): Boolean = {
-    val nextByte: Int = stream.read
-    if (nextByte >= 0) {
-      stream.unread(nextByte)
-      true
-    }
-    else false
-  }
-
-  def eager: ReadAheadInputStream.RequireStream = (in: InputStream) => (length: Int) => {
-      def foo(length: Int): ReadAheadInputStream = { //+1 is to evaluate hasMore
-        val stream: PushbackInputStream = new PushbackInputStream(in, length + 1)
-        val bytes: Array[Byte] = new Array[Byte](length)
-        val readByteCount: Int = IOUtils.read(stream, bytes)
-        var firstBytes: Option[Array[Byte]] = null
-        var hasMore: Boolean = false
-        if (readByteCount < 0) {
-          firstBytes = None
-          hasMore = false
-        } else {
-          val readBytes: Array[Byte] = util.Arrays.copyOf(bytes, readByteCount)
-          hasMore = this.hasMore(stream)
-          stream.unread(readBytes)
-          firstBytes = Some(readBytes)
-        }
-        new ReadAheadInputStream(stream, firstBytes, hasMore)
-      }
-
-      foo(length)
-    }
-}
-
-private class ReadAheadInputStream private(val in: PushbackInputStream,
-                                           val firstBytes: Option[Array[Byte]],
-                                           val hasMore: Boolean)
 
 class UploadRoutes @Inject()(@Named(InjectionKeys.RFC_8621) val authenticator: Authenticator,
                              val attachmentManager: AttachmentManager,
@@ -147,7 +99,6 @@ class UploadRoutes @Inject()(@Named(InjectionKeys.RFC_8621) val authenticator: A
           .flatMap(session => post(request, response, ContentType.of(contentType), session))
           .onErrorResume {
             case e: UnauthorizedException => SMono.fromPublisher(handleAuthenticationFailure(response, LOGGER, e))
-            case e: IllegalArgumentException => SMono.fromPublisher(handleIllegalArgumentException(response, e));
             case e: Throwable => SMono.fromPublisher(handleInternalError(response, LOGGER, e))
           }
           .asJava().`then`()
@@ -155,7 +106,7 @@ class UploadRoutes @Inject()(@Named(InjectionKeys.RFC_8621) val authenticator: A
     }
   }
 
-  private def handleIllegalArgumentException(response: HttpServerResponse, e: IllegalArgumentException) = {
+  private def handleUncheckedIOException(response: HttpServerResponse, e: UncheckedIOException) = {
     response.status(BAD_REQUEST).sendString(SMono.just(e.getMessage))
   }
 
@@ -181,20 +132,18 @@ class UploadRoutes @Inject()(@Named(InjectionKeys.RFC_8621) val authenticator: A
 
   def handle(accountId: AccountId, contentType: ContentType, content: InputStream, mailboxSession: MailboxSession, response: HttpServerResponse): SMono[Void] = {
 
-    SMono.fromCallable(() => ReadAheadInputStream.eager.of(content).length(JmapRfc8621Configuration.MAXSIZE_UPLOAD.get.value.toInt))
-      .flatMap(saveFileOrRaiseError(accountId, contentType, mailboxSession))
+    SMono.fromCallable(() => new LimitedInputStream(content, JmapRfc8621Configuration.MAXSIZE_UPLOAD.get.value.toLong) {
+      override def raiseError(max: Long, count: Long): Unit = if (count > max) throw new IOException("Attempt to upload exceed max size")
+    })
+      .flatMap(uploadContent(accountId, contentType, _, mailboxSession))
       .flatMap(uploadResponse => SMono.fromPublisher(response
               .header(CONTENT_TYPE, uploadResponse.`type`.asString())
               .status(CREATED)
               .sendString(SMono.just(serializer.serialize(uploadResponse).toString()))))
+      .onErrorResume {
+        case e: UncheckedIOException => SMono.fromPublisher(handleUncheckedIOException(response, e))
+      }
 
-  }
-
-  private def saveFileOrRaiseError(accountId: AccountId, contentType: ContentType, mailboxSession: MailboxSession): (ReadAheadInputStream) => SMono[UploadResponse] = {
-    readAheadStream => readAheadStream.hasMore match {
-      case false => uploadContent(accountId, contentType, readAheadStream.in, mailboxSession)
-      case true => SMono.raiseError(new IllegalArgumentException("Attempt to upload exceed max size"))
-    }
   }
 
   def uploadContent(accountId: AccountId, contentType: ContentType, inputStream: InputStream, session: MailboxSession): SMono[UploadResponse] =

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/UploadRoutes.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/UploadRoutes.scala
@@ -73,6 +73,7 @@ case class UploadResponse(accountId: AccountId,
                           size: Size)
 
 class UploadRoutes @Inject()(@Named(InjectionKeys.RFC_8621) val authenticator: Authenticator,
+                             val configuration: JmapRfc8621Configuration,
                              val attachmentManager: AttachmentManager,
                              val serializer: UploadSerializer) extends JMAPRoutes {
 
@@ -130,10 +131,7 @@ class UploadRoutes @Inject()(@Named(InjectionKeys.RFC_8621) val authenticator: A
   }
 
   def handle(accountId: AccountId, contentType: ContentType, content: InputStream, mailboxSession: MailboxSession, response: HttpServerResponse): SMono[Void] = {
-    val maxSize: Long = JmapRfc8621Configuration.MAXSIZE_UPLOAD match {
-      case Some(size) => size.asBytes()
-      case _ => JmapRfc8621Configuration.UPLOAD_LIMIT_30_MB
-    }
+    val maxSize: Long = configuration.maxUploadSize.asBytes()
 
     SMono.fromCallable(() => new LimitedInputStream(content, maxSize) {
       override def raiseError(max: Long, count: Long): Unit = if (count > max) {

--- a/src/site/xdoc/server/config-jmap.xml
+++ b/src/site/xdoc/server/config-jmap.xml
@@ -63,7 +63,7 @@
 
                     <dt><strong>upload.max.size</strong></dt>
                     <dd>Optional. Configuration max size Upload in new JMAP-RFC-8621.</dd>
-                    <dd>Default value: 30MB.</dd>
+                    <dd>Default value: 30M. Supported units are B (bytes) K (KB) M (MB) G (GB).</dd>
                 </dl>
 
             </subsection>

--- a/src/site/xdoc/server/config-jmap.xml
+++ b/src/site/xdoc/server/config-jmap.xml
@@ -59,9 +59,11 @@
 
                     <dt><strong>url.prefix</strong></dt>
                     <dd>Optional. Configuration urlPrefix for JMAP routes.</dd>
+                    <dd>Default value: http://localhost.</dd>
 
                     <dt><strong>upload.max.size</strong></dt>
                     <dd>Optional. Configuration max size Upload in new JMAP-RFC-8621.</dd>
+                    <dd>Default value: 30MB.</dd>
                 </dl>
 
             </subsection>

--- a/src/site/xdoc/server/config-jmap.xml
+++ b/src/site/xdoc/server/config-jmap.xml
@@ -56,6 +56,12 @@
 
                     <dt><strong>jwt.publickeypem.url</strong></dt>
                     <dd>Optional. JWT tokens allows request to bypass authentication</dd>
+
+                    <dt><strong>url.prefix</strong></dt>
+                    <dd>Optional. Configuration urlPrefix for JMAP routes.</dd>
+
+                    <dt><strong>upload.max.size</strong></dt>
+                    <dd>Optional. Configuration max size Upload in new JMAP-RFC-8621.</dd>
                 </dl>
 
             </subsection>


### PR DESCRIPTION
IDEAL: 

- Had property to config max_size_upload and default 30MB
- Validate upload file (same code as blobStoreCached)
- Add a case when upload files valid size but not in total size.