### PR TITLE
Update RabbitMQConnectionFactory.java

### DIFF
--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConnectionFactory.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/RabbitMQConnectionFactory.java
@@ -50,6 +50,10 @@ public class RabbitMQConnectionFactory {
             connectionFactory.setChannelRpcTimeout(rabbitMQConfiguration.getChannelRpcTimeoutInMs());
             connectionFactory.setConnectionTimeout(rabbitMQConfiguration.getConnectionTimeoutInMs());
             connectionFactory.setNetworkRecoveryInterval(rabbitMQConfiguration.getNetworkRecoveryIntervalInMs());
+
+            connectionFactory.setUsername(rabbitMQConfiguration.getManagementCredentials().getUser());
+            connectionFactory.setPassword(String.valueOf(rabbitMQConfiguration.getManagementCredentials().getPassword()));
+
             return connectionFactory;
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
when rabbitmq change guest's password, it cannot be connected and will throw exception:
An unexpected connection driver error occured (Exception message: Socket closed)
so we should set username and password here to make it work correctly