### PR TITLE
JAMES-3433 Fix blob store cache usage

### DIFF
--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobStore.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/BlobStore.java
@@ -55,5 +55,5 @@ public interface BlobStore {
 
     Publisher<Void> deleteBucket(BucketName bucketName);
 
-    Publisher<Void> delete(BucketName bucketName, BlobId blobId);
+    Publisher<Boolean> delete(BucketName bucketName, BlobId blobId);
 }

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/MetricableBlobStore.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/MetricableBlobStore.java
@@ -70,6 +70,17 @@ public class MetricableBlobStore implements BlobStore {
     }
 
     @Override
+    public Publisher<byte[]> readBytes(BucketName bucketName, BlobId blobId, StoragePolicy storagePolicy) {
+        return metricFactory.decoratePublisherWithTimerMetric(READ_BYTES_TIMER_NAME, blobStoreImpl.readBytes(bucketName, blobId, storagePolicy));
+    }
+
+    @Override
+    public InputStream read(BucketName bucketName, BlobId blobId, StoragePolicy storagePolicy) {
+        return metricFactory
+            .decorateSupplierWithTimerMetric(READ_TIMER_NAME, () -> blobStoreImpl.read(bucketName, blobId, storagePolicy));
+    }
+
+    @Override
     public Publisher<Void> deleteBucket(BucketName bucketName) {
         return metricFactory.decoratePublisherWithTimerMetric(DELETE_BUCKET_TIMER_NAME, blobStoreImpl.deleteBucket(bucketName));
     }

--- a/server/blob/blob-api/src/main/java/org/apache/james/blob/api/MetricableBlobStore.java
+++ b/server/blob/blob-api/src/main/java/org/apache/james/blob/api/MetricableBlobStore.java
@@ -91,7 +91,7 @@ public class MetricableBlobStore implements BlobStore {
     }
 
     @Override
-    public Publisher<Void> delete(BucketName bucketName, BlobId blobId) {
+    public Publisher<Boolean> delete(BucketName bucketName, BlobId blobId) {
         return metricFactory.decoratePublisherWithTimerMetric(DELETE_TIMER_NAME, blobStoreImpl.delete(bucketName, blobId));
     }
 

--- a/server/blob/blob-common/src/main/java/org/apache/james/blob/api/Store.java
+++ b/server/blob/blob-common/src/main/java/org/apache/james/blob/api/Store.java
@@ -108,7 +108,8 @@ public interface Store<T, I> {
         @Override
         public Publisher<Void> delete(I blobIds) {
             return Flux.fromIterable(blobIds.asMap().values())
-                .flatMap(id -> blobStore.delete(blobStore.getDefaultBucketName(), id));
+                .flatMap(id -> blobStore.delete(blobStore.getDefaultBucketName(), id))
+                .then();
         }
     }
 }

--- a/server/blob/blob-storage-strategy/src/main/scala/org/apache/james/server/blob/deduplication/DeDuplicationBlobStore.scala
+++ b/server/blob/blob-storage-strategy/src/main/scala/org/apache/james/server/blob/deduplication/DeDuplicationBlobStore.scala
@@ -91,10 +91,10 @@ class DeDuplicationBlobStore @Inject()(blobStoreDAO: BlobStoreDAO,
     blobStoreDAO.deleteBucket(bucketName)
   }
 
-  override def delete(bucketName: BucketName, blobId: BlobId): Publisher[Void] = {
+  override def delete(bucketName: BucketName, blobId: BlobId): Publisher[java.lang.Boolean] = {
     Preconditions.checkNotNull(bucketName)
     Preconditions.checkNotNull(blobId)
 
-    SMono.empty
+    SMono.just(Boolean.box(false))
   }
 }

--- a/server/blob/blob-storage-strategy/src/main/scala/org/apache/james/server/blob/deduplication/PassThroughBlobStore.scala
+++ b/server/blob/blob-storage-strategy/src/main/scala/org/apache/james/server/blob/deduplication/PassThroughBlobStore.scala
@@ -69,10 +69,11 @@ class PassThroughBlobStore @Inject()(blobStoreDAO: BlobStoreDAO,
     blobStoreDAO.deleteBucket(bucketName)
   }
 
-  override def delete(bucketName: BucketName, blobId: BlobId): Publisher[Void] = {
+  override def delete(bucketName: BucketName, blobId: BlobId): Publisher[java.lang.Boolean] = {
     Preconditions.checkNotNull(bucketName)
     Preconditions.checkNotNull(blobId)
 
-    blobStoreDAO.delete(bucketName, blobId)
+    SMono.fromPublisher(blobStoreDAO.delete(bucketName, blobId))
+      .`then`(SMono.just(Boolean.box(true)))
   }
 }

--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/CassandraCacheQueryTest.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/CassandraCacheQueryTest.java
@@ -1,0 +1,181 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+import org.apache.james.backends.cassandra.StatementRecorder;
+import org.apache.james.backends.cassandra.TestingSession;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.init.SessionWithInitializedTablesFactory;
+import org.apache.james.blob.cassandra.cache.CassandraBlobCacheModule;
+import org.apache.james.core.Domain;
+import org.apache.james.mailbox.DefaultMailboxes;
+import org.apache.james.modules.MailboxProbeImpl;
+import org.apache.james.modules.protocols.ImapGuiceProbe;
+import org.apache.james.modules.protocols.SmtpGuiceProbe;
+import org.apache.james.util.MimeMessageUtil;
+import org.apache.james.util.Port;
+import org.apache.james.utils.DataProbeImpl;
+import org.apache.james.utils.GuiceProbe;
+import org.apache.james.utils.SMTPMessageSender;
+import org.apache.james.utils.SpoolerProbe;
+import org.apache.james.utils.TestIMAPClient;
+import org.apache.mailet.base.test.FakeMail;
+import org.awaitility.Awaitility;
+import org.awaitility.Duration;
+import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.datastax.driver.core.Session;
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Names;
+
+class CassandraCacheQueryTest {
+    private static class TestingSessionProbe implements GuiceProbe {
+        private final TestingSession testingSession;
+
+        @Inject
+        private TestingSessionProbe(TestingSession testingSession) {
+            this.testingSession = testingSession;
+        }
+
+        public TestingSession getTestingSession() {
+            return testingSession;
+        }
+    }
+
+    private static class TestingSessionModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            Multibinder.newSetBinder(binder(), GuiceProbe.class)
+                .addBinding()
+                .to(TestingSessionProbe.class);
+
+            bind(Session.class)
+                .annotatedWith(Names.named("cache"))
+                .to(TestingSession.class);
+            bind(Session.class)
+                .to(TestingSession.class);
+            Multibinder.newSetBinder(binder(), CassandraModule.class).addBinding().toInstance(CassandraBlobCacheModule.MODULE);
+        }
+
+        @Provides
+        @Singleton
+        TestingSession provideSession(SessionWithInitializedTablesFactory factory) {
+            return new TestingSession(factory.get());
+        }
+    }
+
+    @RegisterExtension
+    static JamesServerExtension jamesServerExtension = WithCacheImmutableTest.baseExtensionBuilder()
+        .lifeCycle(JamesServerExtension.Lifecycle.PER_TEST)
+        .overrideServerModule(new TestingSessionModule())
+        .build();
+
+    private static final int MESSAGE_COUNT = 1;
+    private static final String JAMES_SERVER_HOST = "127.0.0.1";
+    private static final String DOMAIN = "apache.org";
+    private static final String JAMES_USER = "james-user@" + DOMAIN;
+    private static final String PASSWORD = "secret";
+    private static final String SENDER = "bob@apache.org";
+    private static final String UNICODE_BODY = "Unicode €uro symbol.";
+    private static final ConditionFactory CALMLY_AWAIT = Awaitility
+        .with().pollInterval(Duration.ONE_HUNDRED_MILLISECONDS)
+        .and().pollDelay(Duration.ONE_HUNDRED_MILLISECONDS)
+        .await();
+
+    private StatementRecorder statementRecorder;
+
+    @BeforeEach
+    void beforeEach(GuiceJamesServer server) throws Exception {
+        this.statementRecorder = new StatementRecorder();
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(JAMES_USER, PASSWORD);
+
+        MailboxProbeImpl mailboxProbe = server.getProbe(MailboxProbeImpl.class);
+        mailboxProbe.createMailbox("#private", JAMES_USER, DefaultMailboxes.INBOX);
+
+        server.getProbe(TestingSessionProbe.class).getTestingSession().printStatements();
+        server.getProbe(TestingSessionProbe.class).getTestingSession().recordStatements(statementRecorder);
+
+        sendAMail(server);
+        readAMail(server);
+    }
+
+    @Test
+    void deDuplicatingBlobStoreShouldNotClearCache() {
+        assertThat(statementRecorder.listExecutedStatements(
+              StatementRecorder.Selector.preparedStatementStartingWith("DELETE FROM blob_cache")))
+            .isEmpty();
+    }
+
+    @Test
+    void cacheShouldBeRead() {
+        assertThat(statementRecorder.listExecutedStatements(
+                StatementRecorder.Selector.preparedStatementStartingWith("SELECT * FROM blob_cache")))
+            .isNotEmpty();
+    }
+
+    private void readAMail(GuiceJamesServer server) throws IOException {
+        try (TestIMAPClient reader = new TestIMAPClient()) {
+            int imapPort = server.getProbe(ImapGuiceProbe.class).getImapPort();
+            reader.connect(JAMES_SERVER_HOST, imapPort)
+                .login(JAMES_USER, PASSWORD)
+                .select(TestIMAPClient.INBOX)
+                .awaitMessageCount(CALMLY_AWAIT, MESSAGE_COUNT);
+
+            assertThat(reader.readFirstMessage())
+                .contains(UNICODE_BODY);
+        }
+    }
+
+    private void sendAMail(GuiceJamesServer server) throws IOException, MessagingException {
+        Port smtpPort = server.getProbe(SmtpGuiceProbe.class).getSmtpPort();
+        try (SMTPMessageSender sender = new SMTPMessageSender(Domain.LOCALHOST.asString())) {
+            sender.connect(JAMES_SERVER_HOST, smtpPort);
+            MimeMessage mimeMessage = MimeMessageUtil.mimeMessageFromStream(
+                ClassLoader.getSystemResourceAsStream("eml/mail-containing-unicode-characters.eml"));
+
+            FakeMail.Builder mail = FakeMail.builder()
+                .name("test-unicode-body")
+                .sender(SENDER)
+                .recipient(JAMES_USER)
+                .mimeMessage(mimeMessage);
+
+            sender.sendMessage(mail);
+        }
+
+        CALMLY_AWAIT.until(() -> server.getProbe(SpoolerProbe.class).processingFinished());
+    }
+
+}

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/ExportService.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/ExportService.java
@@ -139,7 +139,8 @@ public class ExportService {
             .onErrorResume(e -> {
                 LOGGER.error("Error deleting Blob with blobId: {}", blobId.asString(), e);
                 return Mono.empty();
-            });
+            })
+            .then();
     }
 
     private Mono<Void> writeUserMailboxesContent(Username username, PipedOutputStream out) {


### PR DESCRIPTION
 - We were missing a global test enforcing blob store cache usage when configured.

It was a bit tricky as we need extra work to instrument the caching session...

 - I spotted that the MetricableBlobStore did not propagate the read storage strategy ; LOW_COST was assumed, skipping the cache.

 - I also saw the content of the cache was aggressively deleted upon dequeue...