### PR TITLE
Jenkins stress tests updates

### DIFF
--- a/JenkinsfileStressTests.groovy
+++ b/JenkinsfileStressTests.groovy
@@ -64,10 +64,24 @@ pipeline {
                                 case "reference":
                                     sh "cd /srv && sudo btrfs subvolume snapshot bench-snapshot-s3 bench-running-docker"
                                     sh 'docker run -d --name=cassandra -p 9042:9042 -v /srv/bench-running-docker/cassandra:/var/lib/cassandra cassandra:3.11.3'
+
+                                    sh 'sleep 10'
+
                                     sh 'docker run -d --name=elasticsearch -p 9200:9200 -v /srv/bench-running-docker/elasticsearch:/usr/share/elasticsearch/data  --env "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:6.3.2'
+
+                                    sh 'sleep 10'
+
                                     sh 'docker run -d --name=tika apache/tika:1.24'
+
+                                    sh 'sleep 10'
+
                                     sh 'docker run -d --name=s3 --env "REMOTE_MANAGEMENT_DISABLE=1" --env "SCALITY_ACCESS_KEY_ID=accessKey1" --env "SCALITY_SECRET_ACCESS_KEY=secretKey1" -v /srv/bench-running-docker/s3/localData:/usr/src/app/localData -v /srv/bench-running-docker/s3/localMetadata:/usr/src/app/localMetadata zenko/cloudserver:8.2.6'
+
+                                    sh 'sleep 10'
+
                                     sh 'docker run -d --name=rabbitmq -p 15672:15672 -p 5672:5672 rabbitmq:3.8.1-management'
+
+                                    sh 'sleep 10'
 
                                     sh 'docker run -d --hostname HOSTNAME -p 25:25 -p 1080:80 -p 8000:8000 -p 110:110 -p 143:143 -p 465:465 -p 587:587 -p 993:993 --link cassandra:cassandra --link rabbitmq:rabbitmq --link elasticsearch:elasticsearch --link tika:tika --link s3:s3.docker.test --name james_run -t james_run'
                                     break

--- a/JenkinsfileStressTests.groovy
+++ b/JenkinsfileStressTests.groovy
@@ -119,6 +119,13 @@ pipeline {
                                     sh "docker exec james_run ${jamesCliWithOptions} adduser user${n}@open-paas.org secret"
                                 }
                             }
+                            if (params.PROFILE == "reference") {
+                                // Sometimes Zenko fails at starting correctly with provisioning.
+                                // There is a timeout when it tries to connect to metadata service.
+                                // Maybe too much metadata to charge? It seems a restart helps with this for now
+                                sh "docker restart s3"
+                                sh 'sleep 5'
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
After noticing a problem with Zenko/cloudserver on the provisioning, I added more time between image runs and a restart for zenko/cloudserver.

Opened an issue on their forum regarding this with more details: https://forum.zenko.io/t/error-when-starting-zenko-cloudserver-with-mounted-data/779