### PR TITLE
JAMES-2991 All group listeners should specify their interesting events

### DIFF
--- a/mailbox/plugin/quota-mailing/src/main/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdCrossingListener.java
+++ b/mailbox/plugin/quota-mailing/src/main/java/org/apache/james/mailbox/quota/mailing/listeners/QuotaThresholdCrossingListener.java
@@ -74,6 +74,10 @@ public class QuotaThresholdCrossingListener implements MailboxListener.ReactiveG
         return GROUP;
     }
 
+    @Override
+    public boolean isHandling(Event event) {
+        return event instanceof QuotaUsageUpdatedEvent;
+    }
 
     @Override
     public Publisher<Void> reactiveEvent(Event event) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/event/ComputeMessageFastViewProjectionListener.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/event/ComputeMessageFastViewProjectionListener.java
@@ -79,6 +79,11 @@ public class ComputeMessageFastViewProjectionListener implements MailboxListener
         return Mono.empty();
     }
 
+    @Override
+    public boolean isHandling(Event event) {
+        return event instanceof Added;
+    }
+
     private Mono<Void> handleAddedEvent(Added addedEvent, MailboxSession session) {
         return Flux.from(messageIdManager.getMessagesReactive(addedEvent.getMessageIds(), FetchGroup.FULL_CONTENT, session))
             .flatMap(Throwing.function(messageResult -> Mono.fromCallable(

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/event/PropagateLookupRightListener.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/event/PropagateLookupRightListener.java
@@ -76,6 +76,11 @@ public class PropagateLookupRightListener implements MailboxListener.GroupMailbo
         }
     }
 
+    @Override
+    public boolean isHandling(Event event) {
+        return event instanceof MailboxACLUpdated || event instanceof MailboxRenamed;
+    }
+
     private MailboxSession createMailboxSession(Event event) throws MailboxException {
         return mailboxManager.createSystemSession(event.getUsername());
     }


### PR DESCRIPTION
This avoids sending them all events and thus reduces RabbitMQ traffic.