### PR TITLE
JAMES-3441 Avoid starting mail spooler when 'threads' = 0 

### DIFF
--- a/docs/modules/servers/pages/distributed/configure/mailetcontainer.adoc
+++ b/docs/modules/servers/pages/distributed/configure/mailetcontainer.adoc
@@ -30,7 +30,8 @@ If this is set to a non-local email address, the mail server
 will still function, but will generate a warning on startup.
 
 | spooler.threads
-| Number of simultaneous threads used to spool the mails.
+| Number of simultaneous threads used to spool the mails. Set to zero, it disables mail processing - use with
+caution.
 
 | spooler.errorRepository
 | Mail repository to store email in after several unrecoverable errors. Mails failing processing, for which

--- a/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/CamelMailetContainerModule.java
+++ b/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/CamelMailetContainerModule.java
@@ -45,6 +45,7 @@ import org.apache.james.mailetcontainer.impl.JamesMailetContext;
 import org.apache.james.mailetcontainer.impl.MatcherMailetPair;
 import org.apache.james.mailetcontainer.impl.camel.CamelCompositeProcessor;
 import org.apache.james.mailetcontainer.impl.camel.CamelMailetProcessor;
+import org.apache.james.mailrepository.api.MailRepositoryStore;
 import org.apache.james.server.core.configuration.ConfigurationProvider;
 import org.apache.james.transport.mailets.RemoveMimeHeader;
 import org.apache.james.transport.matchers.All;
@@ -123,12 +124,19 @@ public class CamelMailetContainerModule extends AbstractModule {
         return camelContext;
     }
 
+    @Provides
+    @Singleton
+    public JamesMailSpooler.Configuration spoolerConfiguration(MailRepositoryStore mailRepositoryStore, ConfigurationProvider configurationProvider) {
+        HierarchicalConfiguration<ImmutableNode> conf = getJamesSpoolerConfiguration(configurationProvider);
+        return JamesMailSpooler.Configuration.from(mailRepositoryStore, conf);
+    }
+
     @ProvidesIntoSet
-    InitializationOperation startSpooler(JamesMailSpooler jamesMailSpooler, ConfigurationProvider configurationProvider) {
+    InitializationOperation startSpooler(JamesMailSpooler jamesMailSpooler, JamesMailSpooler.Configuration configuration) {
         return InitilizationOperationBuilder
             .forClass(JamesMailSpooler.class)
             .init(() -> {
-                jamesMailSpooler.configure(getJamesSpoolerConfiguration(configurationProvider));
+                jamesMailSpooler.configure(configuration);
                 jamesMailSpooler.init();
             });
     }

--- a/server/container/guice/memory-guice/src/test/java/org/apache/james/DisabledSpoolerTest.java
+++ b/server/container/guice/memory-guice/src/test/java/org/apache/james/DisabledSpoolerTest.java
@@ -1,0 +1,84 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import static org.apache.james.jmap.JMAPTestingConstants.ALICE;
+import static org.apache.james.jmap.JMAPTestingConstants.ALICE_PASSWORD;
+import static org.apache.james.jmap.JMAPTestingConstants.BOB;
+import static org.apache.james.jmap.JMAPTestingConstants.BOB_PASSWORD;
+import static org.apache.james.jmap.JMAPTestingConstants.DOMAIN;
+import static org.apache.james.jmap.JMAPTestingConstants.LOCALHOST_IP;
+import static org.apache.james.jmap.draft.JmapJamesServerContract.JAMES_SERVER_HOST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.mailbox.model.MailboxConstants;
+import org.apache.james.mailetcontainer.impl.JamesMailSpooler;
+import org.apache.james.mailrepository.api.MailRepositoryUrl;
+import org.apache.james.modules.TestJMAPServerModule;
+import org.apache.james.modules.protocols.ImapGuiceProbe;
+import org.apache.james.modules.protocols.SmtpGuiceProbe;
+import org.apache.james.utils.DataProbeImpl;
+import org.apache.james.utils.SMTPMessageSender;
+import org.apache.james.utils.TestIMAPClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class DisabledSpoolerTest {
+    private static final String MESSAGE = "Subject: test\r\n" +
+        "\r\n" +
+        "testmail";
+
+    @RegisterExtension
+    static JamesServerExtension jamesServerExtension = new JamesServerBuilder<>(JamesServerBuilder.defaultConfigurationProvider())
+        .server(configuration -> MemoryJamesServerMain.createServer(configuration)
+            .overrideWith(new TestJMAPServerModule())
+            .overrideWith(binder -> binder.bind(JamesMailSpooler.Configuration.class)
+                .toInstance(new JamesMailSpooler.Configuration(0, MailRepositoryUrl.from("memory://repo1")))))
+        .lifeCycle(JamesServerExtension.Lifecycle.PER_CLASS)
+        .build();
+
+    @RegisterExtension
+    SMTPMessageSender smtpMessageSender = new SMTPMessageSender(DOMAIN);
+    @RegisterExtension
+    TestIMAPClient testIMAPClient = new TestIMAPClient();
+
+    @BeforeEach
+    void setUp(GuiceJamesServer guiceJamesServer) throws Exception {
+        DataProbeImpl dataProbe = guiceJamesServer.getProbe(DataProbeImpl.class);
+        dataProbe.fluent()
+            .addDomain(DOMAIN)
+            .addUser(ALICE.asString(), ALICE_PASSWORD)
+            .addUser(BOB.asString(), BOB_PASSWORD);
+    }
+
+    @Test
+    void emailsShouldNotBeDequeuedWhenZeroSpoolerThreads(GuiceJamesServer server) throws Exception {
+        smtpMessageSender.connect(LOCALHOST_IP, server.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .sendMessageWithHeaders(ALICE.asString(), BOB.asString(), MESSAGE);
+
+        Thread.sleep(5000);
+
+        long messageCount = testIMAPClient.connect(JAMES_SERVER_HOST, server.getProbe(ImapGuiceProbe.class).getImapPort())
+            .login(BOB, BOB_PASSWORD)
+            .getMessageCount(MailboxConstants.INBOX);
+        assertThat(messageCount).isEqualTo(0L);
+    }
+}

--- a/server/container/guice/memory-guice/src/test/resources/mailetcontainer.xml
+++ b/server/container/guice/memory-guice/src/test/resources/mailetcontainer.xml
@@ -95,6 +95,7 @@
             <mailet match="All" class="SpamAssassin">
                 <spamdHost>localhost</spamdHost>
                 <spamdPort>783</spamdPort>
+                <onMailetException>ignore</onMailetException>
             </mailet>
             <mailet match="IsMarkedAsSpam" class="WithStorageDirective">
                 <targetFolderName>Spam</targetFolderName>

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailSpooler.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailSpooler.java
@@ -63,6 +63,126 @@ import reactor.core.scheduler.Schedulers;
  * them from the spool when processing is complete.
  */
 public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMBean {
+    private static class Runner {
+        private final AtomicInteger processingActive = new AtomicInteger(0);
+        private final MetricFactory metricFactory;
+        private final MailProcessor mailProcessor;
+        private final MailRepository errorRepository;
+        private final MailRepositoryUrl errorRepositoryURL;
+        private final reactor.core.Disposable disposable;
+        private final MailQueue queue;
+        private final int concurrencyLevel;
+
+        private Runner(MetricFactory metricFactory, MailProcessor mailProcessor, MailRepository errorRepository, MailRepositoryUrl errorRepositoryURL, MailQueue queue, int concurrencyLevel) {
+            this.metricFactory = metricFactory;
+            this.mailProcessor = mailProcessor;
+            this.errorRepository = errorRepository;
+            this.errorRepositoryURL = errorRepositoryURL;
+            this.disposable = run(queue);
+            this.queue = queue;
+            this.concurrencyLevel = concurrencyLevel;
+        }
+
+        private reactor.core.Disposable run(MailQueue queue) {
+            return Flux.from(queue.deQueue())
+                .flatMap(item -> handleOnQueueItem(item).subscribeOn(Schedulers.elastic()), concurrencyLevel)
+                .onErrorContinue((throwable, item) -> LOGGER.error("Exception processing mail while spooling {}", item, throwable))
+                .subscribeOn(Schedulers.elastic())
+                .subscribe();
+        }
+
+        private Mono<Void> handleOnQueueItem(MailQueueItem queueItem) {
+            TimeMetric timeMetric = metricFactory.timer(SPOOL_PROCESSING);
+            return Mono.fromCallable(processingActive::incrementAndGet)
+                .flatMap(ignore -> processMail(queueItem))
+                .doOnSuccess(any -> timeMetric.stopAndPublish().logWhenExceedP99(DEFAULT_100_MS_THRESHOLD))
+                .doOnTerminate(processingActive::decrementAndGet);
+        }
+
+        private Mono<Void> processMail(MailQueueItem queueItem) {
+            return Mono
+                .using(
+                    queueItem::getMail,
+                    mail -> Mono.fromRunnable(() -> performProcessMail(queueItem, mail)),
+                    LifecycleUtil::dispose);
+        }
+
+        private void performProcessMail(MailQueueItem queueItem, Mail mail) {
+            LOGGER.debug("==== Begin processing mail {} ====", mail.getName());
+            try {
+                mailProcessor.service(mail);
+
+                if (Thread.currentThread().isInterrupted()) {
+                    throw new InterruptedException("Thread has been interrupted");
+                }
+                queueItem.done(true);
+            } catch (Exception e) {
+                handleError(queueItem, mail, e);
+            } finally {
+                LOGGER.debug("==== End processing mail {} ====", mail.getName());
+            }
+        }
+
+        private void handleError(MailQueueItem queueItem, Mail mail, Exception processingException) {
+            int failureCount = computeFailureCount(mail);
+
+            try {
+                if (failureCount > MAXIMUM_FAILURE_COUNT) {
+                    LOGGER.error("Failed {} processing {} consecutive times. Abort. Mail is saved in {}", mail.getName(), failureCount, errorRepositoryURL.asString());
+                    storeInErrorRepository(queueItem);
+                } else {
+                    LOGGER.error("Failed {} processing {} consecutive times. Mail is requeued with increased failure count.", mail.getName(), failureCount, processingException);
+                    reEnqueue(queueItem, failureCount);
+                }
+            } catch (Exception nestedE) {
+                LOGGER.error("Could not apply standard error handling for {}, defaulting to nack", mail.getName(), nestedE);
+                nack(queueItem, processingException);
+            }
+        }
+
+        private int computeFailureCount(Mail mail) {
+            Integer previousFailureCount = mail.getAttribute(MAIL_PROCESSING_ERROR_COUNT)
+                .flatMap(attribute -> attribute.getValue().valueAs(Integer.class))
+                .orElse(0);
+            return previousFailureCount + 1;
+        }
+
+        private void reEnqueue(MailQueueItem queueItem, int failureCount) throws MailQueue.MailQueueException {
+            Mail mail = queueItem.getMail();
+            mail.setAttribute(new Attribute(MAIL_PROCESSING_ERROR_COUNT, AttributeValue.of(failureCount)));
+            queue.enQueue(mail);
+            queueItem.done(true);
+        }
+
+        private void storeInErrorRepository(MailQueueItem queueItem) throws MessagingException {
+            errorRepository.store(queueItem.getMail());
+            queueItem.done(true);
+        }
+
+        private void nack(MailQueueItem queueItem, Exception processingException) {
+            try {
+                queueItem.done(false);
+            } catch (MailQueue.MailQueueException ex) {
+                throw new RuntimeException(processingException);
+            }
+        }
+
+        public void dispose() {
+            LOGGER.info("start dispose() ...");
+            disposable.dispose();
+            try {
+                queue.close();
+            } catch (IOException e) {
+                LOGGER.debug("error closing queue", e);
+            }
+            LOGGER.info("thread shutdown completed.");
+        }
+
+        public int getCurrentSpoolCount() {
+            return processingActive.get();
+        }
+    }
+
     private static final Logger LOGGER = LoggerFactory.getLogger(JamesMailSpooler.class);
 
     public static final String SPOOL_PROCESSING = "spoolProcessing";
@@ -74,23 +194,14 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
      * concurrency level to use for dequeuing mails from spool, allows to throttle resources dedicated to that async
      * process.
      */
-    private int concurrencyLevel;
-
-    private final AtomicInteger processingActive = new AtomicInteger(0);
-
     private final MetricFactory metricFactory;
-
-    /**
-     * The mail processor
-     */
     private final MailProcessor mailProcessor;
     private final MailRepositoryStore mailRepositoryStore;
-
     private final MailQueueFactory<?> queueFactory;
+
+    private int concurrencyLevel;
     private MailRepositoryUrl errorRepositoryURL;
-    private MailRepository errorRepository;
-    private reactor.core.Disposable disposable;
-    private MailQueue queue;
+    private Optional<Runner> runner;
 
     @Inject
     public JamesMailSpooler(MetricFactory metricFactory, MailProcessor mailProcessor, MailRepositoryStore mailRepositoryStore, MailQueueFactory<?> queueFactory) {
@@ -118,100 +229,20 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
     public void init() {
         LOGGER.info("init...");
         LOGGER.info("Concurrency level is {}", concurrencyLevel);
-        queue = queueFactory.createQueue(MailQueueFactory.SPOOL, MailQueueFactory.prefetchCount(concurrencyLevel));
-        disposable = run(queue);
+        MailQueue queue = queueFactory.createQueue(MailQueueFactory.SPOOL, MailQueueFactory.prefetchCount(concurrencyLevel));
+        runner = Optional.of(new Runner(metricFactory,
+            mailProcessor, errorRepository(), errorRepositoryURL, queue, concurrencyLevel));
         LOGGER.info("Spooler started");
+    }
+
+    private MailRepository errorRepository() {
         try {
-            this.errorRepository = mailRepositoryStore.select(errorRepositoryURL);
+            return mailRepositoryStore.select(errorRepositoryURL);
         } catch (MailRepositoryStore.MailRepositoryStoreException e) {
             throw new RuntimeException(e);
         }
-
     }
 
-    private reactor.core.Disposable run(MailQueue queue) {
-        return Flux.from(queue.deQueue())
-            .flatMap(item -> handleOnQueueItem(item).subscribeOn(Schedulers.elastic()), concurrencyLevel)
-            .onErrorContinue((throwable, item) -> LOGGER.error("Exception processing mail while spooling {}", item, throwable))
-            .subscribeOn(Schedulers.elastic())
-            .subscribe();
-    }
-
-    private Mono<Void> handleOnQueueItem(MailQueueItem queueItem) {
-        TimeMetric timeMetric = metricFactory.timer(SPOOL_PROCESSING);
-        return Mono.fromCallable(processingActive::incrementAndGet)
-            .flatMap(ignore -> processMail(queueItem))
-            .doOnSuccess(any -> timeMetric.stopAndPublish().logWhenExceedP99(DEFAULT_100_MS_THRESHOLD))
-            .doOnTerminate(processingActive::decrementAndGet);
-    }
-
-    private Mono<Void> processMail(MailQueueItem queueItem) {
-        return Mono
-            .using(
-                queueItem::getMail,
-                mail -> Mono.fromRunnable(() -> performProcessMail(queueItem, mail)),
-                LifecycleUtil::dispose);
-    }
-
-    private void performProcessMail(MailQueueItem queueItem, Mail mail) {
-        LOGGER.debug("==== Begin processing mail {} ====", mail.getName());
-        try {
-            mailProcessor.service(mail);
-
-            if (Thread.currentThread().isInterrupted()) {
-                throw new InterruptedException("Thread has been interrupted");
-            }
-            queueItem.done(true);
-        } catch (Exception e) {
-            handleError(queueItem, mail, e);
-        } finally {
-            LOGGER.debug("==== End processing mail {} ====", mail.getName());
-        }
-    }
-
-    private void handleError(MailQueueItem queueItem, Mail mail, Exception processingException) {
-        int failureCount = computeFailureCount(mail);
-
-        try {
-            if (failureCount > MAXIMUM_FAILURE_COUNT) {
-                LOGGER.error("Failed {} processing {} consecutive times. Abort. Mail is saved in {}", mail.getName(), failureCount, errorRepositoryURL.asString());
-                storeInErrorRepository(queueItem);
-            } else {
-                LOGGER.error("Failed {} processing {} consecutive times. Mail is requeued with increased failure count.", mail.getName(), failureCount, processingException);
-                reEnqueue(queueItem, failureCount);
-            }
-        } catch (Exception nestedE) {
-            LOGGER.error("Could not apply standard error handling for {}, defaulting to nack", mail.getName(), nestedE);
-            nack(queueItem, processingException);
-        }
-    }
-
-    private int computeFailureCount(Mail mail) {
-        Integer previousFailureCount = mail.getAttribute(MAIL_PROCESSING_ERROR_COUNT)
-            .flatMap(attribute -> attribute.getValue().valueAs(Integer.class))
-            .orElse(0);
-        return previousFailureCount + 1;
-    }
-
-    private void reEnqueue(MailQueueItem queueItem, int failureCount) throws MailQueue.MailQueueException {
-        Mail mail = queueItem.getMail();
-        mail.setAttribute(new Attribute(MAIL_PROCESSING_ERROR_COUNT, AttributeValue.of(failureCount)));
-        queue.enQueue(mail);
-        queueItem.done(true);
-    }
-
-    private void storeInErrorRepository(MailQueueItem queueItem) throws MessagingException {
-        errorRepository.store(queueItem.getMail());
-        queueItem.done(true);
-    }
-
-    private void nack(MailQueueItem queueItem, Exception processingException) {
-        try {
-            queueItem.done(false);
-        } catch (MailQueue.MailQueueException ex) {
-            throw new RuntimeException(processingException);
-        }
-    }
 
     /**
      * The dispose operation is called at the end of a components lifecycle.
@@ -224,14 +255,7 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
     @PreDestroy
     @Override
     public void dispose() {
-        LOGGER.info("start dispose() ...");
-        disposable.dispose();
-        try {
-            queue.close();
-        } catch (IOException e) {
-            LOGGER.debug("error closing queue", e);
-        }
-        LOGGER.info("thread shutdown completed.");
+        runner.ifPresent(Runner::dispose);
     }
 
     @Override
@@ -241,6 +265,6 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
 
     @Override
     public int getCurrentSpoolCount() {
-        return processingActive.get();
+        return runner.map(Runner::getCurrentSpoolCount).orElse(0);
     }
 }

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailSpooler.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailSpooler.java
@@ -53,6 +53,7 @@ import org.apache.mailet.Mail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
 import reactor.core.publisher.Flux;
@@ -70,24 +71,24 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
         private final MetricFactory metricFactory;
         private final MailProcessor mailProcessor;
         private final MailRepository errorRepository;
-        private final MailRepositoryUrl errorRepositoryURL;
         private final reactor.core.Disposable disposable;
         private final MailQueue queue;
-        private final int concurrencyLevel;
+        private final Configuration configuration;
 
-        private Runner(MetricFactory metricFactory, MailProcessor mailProcessor, MailRepository errorRepository, MailRepositoryUrl errorRepositoryURL, MailQueue queue, int concurrencyLevel) {
+        private Runner(MetricFactory metricFactory, MailProcessor mailProcessor,
+                       MailRepository errorRepository, MailQueue queue, Configuration configuration) {
             this.metricFactory = metricFactory;
             this.mailProcessor = mailProcessor;
             this.errorRepository = errorRepository;
-            this.errorRepositoryURL = errorRepositoryURL;
-            this.disposable = run(queue);
             this.queue = queue;
-            this.concurrencyLevel = concurrencyLevel;
+            this.configuration = configuration;
+
+            this.disposable = run(queue);
         }
 
         private reactor.core.Disposable run(MailQueue queue) {
             return Flux.from(queue.deQueue())
-                .flatMap(item -> handleOnQueueItem(item).subscribeOn(Schedulers.elastic()), concurrencyLevel)
+                .flatMap(item -> handleOnQueueItem(item).subscribeOn(Schedulers.elastic()), configuration.getConcurrencyLevel())
                 .onErrorContinue((throwable, item) -> LOGGER.error("Exception processing mail while spooling {}", item, throwable))
                 .subscribeOn(Schedulers.elastic())
                 .subscribe();
@@ -130,7 +131,7 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
 
             try {
                 if (failureCount > MAXIMUM_FAILURE_COUNT) {
-                    LOGGER.error("Failed {} processing {} consecutive times. Abort. Mail is saved in {}", mail.getName(), failureCount, errorRepositoryURL.asString());
+                    LOGGER.error("Failed {} processing {} consecutive times. Abort. Mail is saved in {}", mail.getName(), failureCount, configuration.getErrorRepositoryURL().asString());
                     storeInErrorRepository(queueItem);
                 } else {
                     LOGGER.error("Failed {} processing {} consecutive times. Mail is requeued with increased failure count.", mail.getName(), failureCount, processingException);
@@ -185,6 +186,50 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
         }
     }
 
+    public static class Configuration {
+        public static Configuration from(MailRepositoryStore mailRepositoryStore, HierarchicalConfiguration<ImmutableNode> config) {
+            int concurrencyLevel = config.getInt("threads", 100);
+            MailRepositoryUrl errorRepositoryURL = Optional.ofNullable(config.getString("errorRepository", null))
+                .map(MailRepositoryUrl::from)
+                .orElseGet(() -> MailRepositoryUrl.fromPathAndProtocol(
+                    mailRepositoryStore.defaultProtocol()
+                        .orElseThrow(() -> new IllegalStateException("Cannot retrieve mailRepository URL, you need to configure an `errorRepository` property for the spooler.0")),
+                    ERROR_REPOSITORY_PATH));
+
+            return new Configuration(concurrencyLevel, errorRepositoryURL);
+        }
+
+        private final int concurrencyLevel;
+        private final MailRepositoryUrl errorRepositoryURL;
+
+        public Configuration(int concurrencyLevel, MailRepositoryUrl errorRepositoryURL) {
+            Preconditions.checkArgument(concurrencyLevel >= 0, "'threads' needs to be greater than or equal to zero");
+            
+            this.concurrencyLevel = concurrencyLevel;
+            this.errorRepositoryURL = errorRepositoryURL;
+        }
+
+        public int getConcurrencyLevel() {
+            return concurrencyLevel;
+        }
+
+        public boolean isEnabled() {
+            return concurrencyLevel > 0;
+        }
+
+        public MailRepositoryUrl getErrorRepositoryURL() {
+            return errorRepositoryURL;
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                .add("concurrencyLevel", concurrencyLevel)
+                .add("errorRepositoryURL", errorRepositoryURL)
+                .toString();
+        }
+    }
+
     private static final Logger LOGGER = LoggerFactory.getLogger(JamesMailSpooler.class);
 
     public static final String SPOOL_PROCESSING = "spoolProcessing";
@@ -201,8 +246,7 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
     private final MailRepositoryStore mailRepositoryStore;
     private final MailQueueFactory<?> queueFactory;
 
-    private int concurrencyLevel;
-    private MailRepositoryUrl errorRepositoryURL;
+    private Configuration configuration;
     private Optional<Runner> runner;
 
     @Inject
@@ -215,13 +259,11 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
 
     @Override
     public void configure(HierarchicalConfiguration<ImmutableNode> config) {
-        concurrencyLevel = config.getInt("threads", 100);
-        errorRepositoryURL = Optional.ofNullable(config.getString("errorRepository", null))
-            .map(MailRepositoryUrl::from)
-            .orElseGet(() -> MailRepositoryUrl.fromPathAndProtocol(
-                mailRepositoryStore.defaultProtocol()
-                    .orElseThrow(() -> new IllegalStateException("Cannot retrieve mailRepository URL, you need to configure an `errorRepository` property for the spooler.0")),
-                ERROR_REPOSITORY_PATH));
+        configure(Configuration.from(mailRepositoryStore, config));
+    }
+
+    public void configure(Configuration configuration) {
+        this.configuration = configuration;
     }
 
     /**
@@ -229,13 +271,12 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
      */
     @PostConstruct
     public void init() {
-        Preconditions.checkArgument(concurrencyLevel >= 0, "'threads' needs to be greater than or equal to zero");
-        if (concurrencyLevel > 0) {
+        if (configuration.isEnabled()) {
             LOGGER.info("init...");
-            LOGGER.info("Concurrency level is {}", concurrencyLevel);
-            MailQueue queue = queueFactory.createQueue(MailQueueFactory.SPOOL, MailQueueFactory.prefetchCount(concurrencyLevel));
+            LOGGER.info("Concurrency level is {}", configuration.getConcurrencyLevel());
+            MailQueue queue = queueFactory.createQueue(MailQueueFactory.SPOOL, MailQueueFactory.prefetchCount(configuration.getConcurrencyLevel()));
             runner = Optional.of(new Runner(metricFactory,
-                mailProcessor, errorRepository(), errorRepositoryURL, queue, concurrencyLevel));
+                mailProcessor, errorRepository(), queue, configuration));
             LOGGER.info("Spooler started");
         } else {
             LOGGER.info("Spooler had been dis-activated. To enable is set 'threads' count to a value greater than zero");
@@ -244,7 +285,7 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
 
     private MailRepository errorRepository() {
         try {
-            return mailRepositoryStore.select(errorRepositoryURL);
+            return mailRepositoryStore.select(configuration.getErrorRepositoryURL());
         } catch (MailRepositoryStore.MailRepositoryStoreException e) {
             throw new RuntimeException(e);
         }
@@ -267,7 +308,7 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
 
     @Override
     public int getThreadCount() {
-        return concurrencyLevel;
+        return configuration.getConcurrencyLevel();
     }
 
     @Override

--- a/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailSpooler.java
+++ b/server/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailSpooler.java
@@ -279,7 +279,7 @@ public class JamesMailSpooler implements Disposable, Configurable, MailSpoolerMB
                 mailProcessor, errorRepository(), queue, configuration));
             LOGGER.info("Spooler started");
         } else {
-            LOGGER.info("Spooler had been dis-activated. To enable is set 'threads' count to a value greater than zero");
+            LOGGER.info("Spooler had been deactivated. To enable it set 'threads' count to a value greater than zero");
         }
     }
 

--- a/src/site/xdoc/server/config-mailetcontainer.xml
+++ b/src/site/xdoc/server/config-mailetcontainer.xml
@@ -49,7 +49,8 @@
             If this is set to a non-local email address, the mail server
             will still function, but will generate a warning on startup.</dd>
           <dt><strong>spooler.threads</strong></dt>
-          <dd>Number of simultaneous threads used to spool the mails.</dd>
+          <dd>Number of simultaneous threads used to spool the mails. Set to zero, it disables mail processing - use with
+              caution.</dd>
           <dt><strong>spooler.errorRepository</strong></dt>
           <dd>Mail repository to store email in after several unrecoverable errors. Mails failing processing, for which
               the Mailet Container could not handle Error, will be stored there after their processing had been attempted


### PR DESCRIPTION
This allows configuring which James instances, within a distributed topology, should
handle mail processing.