### PR TITLE
JAMES-3139 Expose RabbitMQ channel & connection configuration 

### DIFF
--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/ReactorRabbitMQChannelPool.java
@@ -22,6 +22,7 @@ package org.apache.james.backends.rabbitmq;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Comparator;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.function.BiConsumer;
 
@@ -129,6 +130,17 @@ public class ReactorRabbitMQChannelPool implements ChannelPool, Startable {
 
         public static RequiresRetries builder() {
             return retries -> minBorrowDelay -> maxChannel -> new Configuration(minBorrowDelay, retries, maxChannel);
+        }
+
+        public static Configuration from(org.apache.commons.configuration2.Configuration configuration) {
+            Duration minBorrowDelay = Optional.ofNullable(configuration.getLong("channel.pool.min.delay.ms", null))
+                    .map(Duration::ofMillis)
+                    .orElse(MIN_BORROW_DELAY);
+
+            return builder()
+                .retries(configuration.getInt("channel.pool.retries", MAX_BORROW_RETRIES))
+                .minBorrowDelay(minBorrowDelay)
+                .maxChannel(configuration.getInt("channel.pool.size", MAX_CHANNELS_NUMBER));
         }
 
         private final Duration minBorrowDelay;

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/SimpleConnectionPool.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/SimpleConnectionPool.java
@@ -57,6 +57,12 @@ public class SimpleConnectionPool implements AutoCloseable {
             return retries -> initialDelay -> new Configuration(retries, initialDelay);
         }
 
+        public static Configuration from(org.apache.commons.configuration2.Configuration configuration) {
+            return builder()
+                .retries(configuration.getInt("connection.pool.retries", 10))
+                .initialDelay(Duration.ofMillis(configuration.getLong("connection.pool.min.delay.ms", 100)));
+        }
+
         private final int numRetries;
         private final Duration initialDelay;
 

--- a/backends-common/rabbitmq/src/test/java/org/apache/james/backends/rabbitmq/RabbitMQExtension.java
+++ b/backends-common/rabbitmq/src/test/java/org/apache/james/backends/rabbitmq/RabbitMQExtension.java
@@ -139,8 +139,11 @@ public class RabbitMQExtension implements BeforeAllCallback, BeforeEachCallback,
         dockerRestartPolicy.beforeEach(rabbitMQ);
 
         RabbitMQConnectionFactory connectionFactory = createRabbitConnectionFactory();
-        connectionPool = new SimpleConnectionPool(connectionFactory);
-        channelPool = new ReactorRabbitMQChannelPool(connectionPool.getResilientConnection(2, Duration.ofMillis(5)),
+        connectionPool = new SimpleConnectionPool(connectionFactory,
+            SimpleConnectionPool.Configuration.builder()
+                .retries(2)
+                .initialDelay(Duration.ofMillis(5)));
+        channelPool = new ReactorRabbitMQChannelPool(connectionPool.getResilientConnection(),
             ReactorRabbitMQChannelPool.Configuration.builder()
                 .retries(2)
                 .minBorrowDelay(Duration.ofMillis(5))

--- a/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/rabbitmq.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq-ldap/destination/conf/rabbitmq.properties
@@ -13,6 +13,22 @@ management.user=guest
 # Mandatory
 management.password=guest
 
+# Configure retries count to retrieve a connection. Exponential backoff is performed between each retries.
+# Optional integer, defaults to 10
+#connection.pool.retries=10
+# Configure initial duration (in ms) between two connection retries. Exponential backoff is performed between each retries.
+# Optional integer, defaults to 100
+#connection.pool.min.delay.ms=100
+# Configure retries count to retrieve a channel. Exponential backoff is performed between each retries.
+# Optional integer, defaults to 3
+#channel.pool.retries=3
+# Configure initial duration (in ms) between two channel retries. Exponential backoff is performed between each retries.
+# Optional integer, defaults to 50
+#channel.pool.min.delay.ms=50
+# Configure the size of the channel pool.
+# Optional integer, defaults to 3
+#channel.pool.size=3
+
 # Parameters for the Cassandra administrative view
 
 # Period of the window. Too large values will lead to wide rows while too little values might lead to many queries.

--- a/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/rabbitmq.properties
+++ b/dockerfiles/run/guice/cassandra-rabbitmq/destination/conf/rabbitmq.properties
@@ -13,6 +13,22 @@ management.user=guest
 # Mandatory
 management.password=guest
 
+# Configure retries count to retrieve a connection. Exponential backoff is performed between each retries.
+# Optional integer, defaults to 10
+#connection.pool.retries=10
+# Configure initial duration (in ms) between two connection retries. Exponential backoff is performed between each retries.
+# Optional integer, defaults to 100
+#connection.pool.min.delay.ms=100
+# Configure retries count to retrieve a channel. Exponential backoff is performed between each retries.
+# Optional integer, defaults to 3
+#channel.pool.retries=3
+# Configure initial duration (in ms) between two channel retries. Exponential backoff is performed between each retries.
+# Optional integer, defaults to 50
+#channel.pool.min.delay.ms=50
+# Configure the size of the channel pool.
+# Optional integer, defaults to 3
+#channel.pool.size=3
+
 # Parameters for the Cassandra administrative view
 
 # Period of the window. Too large values will lead to wide rows while too little values might lead to many queries.

--- a/docs/modules/servers/pages/distributed/configure/rabbitmq.adoc
+++ b/docs/modules/servers/pages/distributed/configure/rabbitmq.adoc
@@ -26,6 +26,26 @@ Details about URI format is in https://www.rabbitmq.com/management.html#usage-ui
 | management.password
 | password used to access management service
 
+| connection.pool.retries
+| Configure retries count to retrieve a connection. Exponential backoff is performed between each retries.
+Optional integer, defaults to 10
+
+| connection.pool.min.delay.ms
+| Configure initial duration (in ms) between two connection retries. Exponential backoff is performed between each retries.
+Optional integer, defaults to 100
+
+| channel.pool.retries
+| Configure retries count to retrieve a channel. Exponential backoff is performed between each retries.
+Optional integer, defaults to 3
+
+| channel.pool.min.delay.ms
+| Configure initial duration (in ms) between two channel retries. Exponential backoff is performed between each retries.
+Optional integer, defaults to 50
+
+| channel.pool.size
+| Configure the size of the channel pool.
+Optional integer, defaults to 3
+
 |===
 
 == RabbitMQ MailQueue Configuration

--- a/mpt/impl/imap-mailbox/rabbitmq/src/test/java/org/apache/james/mpt/imapmailbox/rabbitmq/host/RabbitMQEventBusHostSystem.java
+++ b/mpt/impl/imap-mailbox/rabbitmq/src/test/java/org/apache/james/mpt/imapmailbox/rabbitmq/host/RabbitMQEventBusHostSystem.java
@@ -20,6 +20,7 @@
 
 package org.apache.james.mpt.imapmailbox.rabbitmq.host;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.james.backends.rabbitmq.DockerRabbitMQ;
@@ -73,7 +74,10 @@ public class RabbitMQEventBusHostSystem extends JamesImapHostSystem {
     public void beforeTest() throws Exception {
         super.beforeTest();
 
-        connectionPool = new SimpleConnectionPool(dockerRabbitMQ.createRabbitConnectionFactory());
+        connectionPool = new SimpleConnectionPool(dockerRabbitMQ.createRabbitConnectionFactory(),
+            SimpleConnectionPool.Configuration.builder()
+                .retries(2)
+                .initialDelay(Duration.ofMillis(5)));
         reactorRabbitMQChannelPool = new ReactorRabbitMQChannelPool(connectionPool.getResilientConnection(),
             ReactorRabbitMQChannelPool.Configuration.DEFAULT);
         reactorRabbitMQChannelPool.start();

--- a/server/container/guice/queue/rabbitmq/src/main/java/org/apache/james/modules/queue/rabbitmq/RabbitMQModule.java
+++ b/server/container/guice/queue/rabbitmq/src/main/java/org/apache/james/modules/queue/rabbitmq/RabbitMQModule.java
@@ -92,8 +92,6 @@ public class RabbitMQModule extends AbstractModule {
 
         Multibinder.newSetBinder(binder(), StartUpCheck.class).addBinding().to(CassandraMailQueueViewStartUpCheck.class);
         Multibinder.newSetBinder(binder(), HealthCheck.class).addBinding().to(RabbitMQHealthCheck.class);
-
-        bind(ReactorRabbitMQChannelPool.Configuration.class).toInstance(ReactorRabbitMQChannelPool.Configuration.DEFAULT);
     }
 
     @Provides
@@ -176,5 +174,17 @@ public class RabbitMQModule extends AbstractModule {
     @Singleton
     public ReceiverProvider provideRabbitMQReceiver(SimpleConnectionPool simpleConnectionPool) {
         return () -> RabbitFlux.createReceiver(new ReceiverOptions().connectionMono(simpleConnectionPool.getResilientConnection()));
+    }
+
+    @Provides
+    @Singleton
+    public SimpleConnectionPool.Configuration provideConnectionPoolConfiguration() {
+        return SimpleConnectionPool.Configuration.DEFAULT;
+    }
+
+    @Provides
+    @Singleton
+    public ReactorRabbitMQChannelPool.Configuration provideChannelPoolConfiguration() {
+        return ReactorRabbitMQChannelPool.Configuration.DEFAULT;
     }
 }

--- a/server/container/guice/queue/rabbitmq/src/main/java/org/apache/james/modules/queue/rabbitmq/RabbitMQModule.java
+++ b/server/container/guice/queue/rabbitmq/src/main/java/org/apache/james/modules/queue/rabbitmq/RabbitMQModule.java
@@ -21,6 +21,7 @@ package org.apache.james.modules.queue.rabbitmq;
 import java.io.FileNotFoundException;
 
 import javax.inject.Named;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.apache.commons.configuration2.ex.ConfigurationException;
@@ -178,13 +179,23 @@ public class RabbitMQModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public SimpleConnectionPool.Configuration provideConnectionPoolConfiguration(@Named(RABBITMQ_CONFIGURATION_NAME) org.apache.commons.configuration2.Configuration configuration) {
-        return SimpleConnectionPool.Configuration.from(configuration);
+    public SimpleConnectionPool.Configuration provideConnectionPoolConfiguration(@Named(RABBITMQ_CONFIGURATION_NAME) Provider<org.apache.commons.configuration2.Configuration> configuration) {
+        try {
+            return SimpleConnectionPool.Configuration.from(configuration.get());
+        } catch (Exception e) {
+            LOGGER.info("Error while retrieving SimpleConnectionPool.Configuration, falling back to defaults.", e);
+            return SimpleConnectionPool.Configuration.DEFAULT;
+        }
     }
 
     @Provides
     @Singleton
-    public ReactorRabbitMQChannelPool.Configuration provideChannelPoolConfiguration(@Named(RABBITMQ_CONFIGURATION_NAME) org.apache.commons.configuration2.Configuration configuration) {
-        return ReactorRabbitMQChannelPool.Configuration.from(configuration);
+    public ReactorRabbitMQChannelPool.Configuration provideChannelPoolConfiguration(@Named(RABBITMQ_CONFIGURATION_NAME) Provider<org.apache.commons.configuration2.Configuration> configuration) {
+        try {
+            return ReactorRabbitMQChannelPool.Configuration.from(configuration.get());
+        } catch (Exception e) {
+            LOGGER.info("Error while retrieving ReactorRabbitMQChannelPool.Configuration, falling back to defaults.", e);
+            return ReactorRabbitMQChannelPool.Configuration.DEFAULT;
+        }
     }
 }

--- a/server/container/guice/queue/rabbitmq/src/main/java/org/apache/james/modules/queue/rabbitmq/RabbitMQModule.java
+++ b/server/container/guice/queue/rabbitmq/src/main/java/org/apache/james/modules/queue/rabbitmq/RabbitMQModule.java
@@ -178,13 +178,13 @@ public class RabbitMQModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public SimpleConnectionPool.Configuration provideConnectionPoolConfiguration() {
-        return SimpleConnectionPool.Configuration.DEFAULT;
+    public SimpleConnectionPool.Configuration provideConnectionPoolConfiguration(@Named(RABBITMQ_CONFIGURATION_NAME) org.apache.commons.configuration2.Configuration configuration) {
+        return SimpleConnectionPool.Configuration.from(configuration);
     }
 
     @Provides
     @Singleton
-    public ReactorRabbitMQChannelPool.Configuration provideChannelPoolConfiguration() {
-        return ReactorRabbitMQChannelPool.Configuration.DEFAULT;
+    public ReactorRabbitMQChannelPool.Configuration provideChannelPoolConfiguration(@Named(RABBITMQ_CONFIGURATION_NAME) org.apache.commons.configuration2.Configuration configuration) {
+        return ReactorRabbitMQChannelPool.Configuration.from(configuration);
     }
 }

--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/RabbitMQEventDeadLettersIntegrationTest.java
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/RabbitMQEventDeadLettersIntegrationTest.java
@@ -224,12 +224,7 @@ class RabbitMQEventDeadLettersIntegrationTest {
                     .maxRetries(MAX_RETRIES)
                     .firstBackoff(java.time.Duration.ofMillis(10))
                     .jitterFactor(0.2)
-                    .build()))
-            .overrideWith(binder -> binder.bind(ReactorRabbitMQChannelPool.Configuration.class)
-                .toInstance(ReactorRabbitMQChannelPool.Configuration.builder()
-                    .retries(2)
-                    .minBorrowDelay(java.time.Duration.ofMillis(5))
-                    .maxChannel(3))))
+                    .build())))
         .build();
 
     private static final String DOMAIN = "domain.tld";

--- a/src/site/xdoc/server/config-rabbitmq.xml
+++ b/src/site/xdoc/server/config-rabbitmq.xml
@@ -57,6 +57,26 @@
 
           <dt><strong>management.password</strong></dt>
           <dd>password used to access management service</dd>
+
+          <dt><strong>connection.pool.retries</strong></dt>
+          <dd>Configure retries count to retrieve a connection. Exponential backoff is performed between each retries.
+              Optional integer, defaults to 10</dd>
+
+          <dt><strong>connection.pool.min.delay.ms</strong></dt>
+          <dd>Configure initial duration (in ms) between two connection retries. Exponential backoff is performed between each retries.
+              Optional integer, defaults to 100</dd>
+
+          <dt><strong>channel.pool.retries</strong></dt>
+          <dd>Configure retries count to retrieve a channel. Exponential backoff is performed between each retries.
+              Optional integer, defaults to 3</dd>
+
+          <dt><strong>channel.pool.min.delay.ms</strong></dt>
+          <dd>Configure initial duration (in ms) between two channel retries. Exponential backoff is performed between each retries.
+              Optional integer, defaults to 50</dd>
+
+          <dt><strong>channel.pool.size</strong></dt>
+          <dd>Configure the size of the channel pool.
+              Optional integer, defaults to 3</dd>
       </dl>
   </section>
 


### PR DESCRIPTION
Easier to adapt:
 - to various needs
 - in case of inappropriate value

Addresses the fact that in case of RabbitMQ issue JMAP operation gets aborted by the reverse proxy after 1 minute (504 bad gateway). Administrators will be able to configure lower values to avoid this pitfall.