### PR TITLE
JAMES-3453 event-dead-letters-redeliver-all task blew up Cassandra

### DIFF
--- a/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/CassandraTableManager.java
+++ b/backends-common/cassandra/src/main/java/org/apache/james/backends/cassandra/init/CassandraTableManager.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.backends.cassandra.init;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
+
 import java.util.function.Predicate;
 
 import javax.inject.Inject;
@@ -65,7 +67,7 @@ public class CassandraTableManager {
         Flux.fromIterable(module.moduleTables())
                 .publishOn(Schedulers.elastic())
                 .map(CassandraTable::getName)
-                .flatMap(name -> truncate(executor, name))
+                .flatMap(name -> truncate(executor, name), DEFAULT_CONCURRENCY)
                 .then()
                 .block();
     }

--- a/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/DeleteByQueryPerformer.java
+++ b/backends-common/elasticsearch/src/main/java/org/apache/james/backends/es/DeleteByQueryPerformer.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.backends.es;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
+
 import org.apache.james.backends.es.search.ScrolledSearch;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
@@ -54,7 +56,7 @@ public class DeleteByQueryPerformer {
 
         return new ScrolledSearch(client, searchRequest).searchResponses()
             .filter(searchResponse -> searchResponse.getHits().getHits().length > 0)
-            .flatMap(searchResponse -> deleteRetrievedIds(searchResponse, routingKey))
+            .flatMap(searchResponse -> deleteRetrievedIds(searchResponse, routingKey), DEFAULT_CONCURRENCY)
             .then();
     }
 

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraAttachmentMapper.java
@@ -20,6 +20,7 @@
 package org.apache.james.mailbox.cassandra.mail;
 
 import static org.apache.james.blob.api.BlobStore.StoragePolicy.LOW_COST;
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -88,7 +89,7 @@ public class CassandraAttachmentMapper implements AttachmentMapper {
     public List<AttachmentMetadata> getAttachments(Collection<AttachmentId> attachmentIds) {
         Preconditions.checkArgument(attachmentIds != null);
         return Flux.fromIterable(attachmentIds)
-            .flatMap(this::getAttachmentsAsMono)
+            .flatMap(this::getAttachmentsAsMono, DEFAULT_CONCURRENCY)
             .collect(Guavate.toImmutableList())
             .block();
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraIndexTableHandler.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraIndexTableHandler.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mailbox.cassandra.mail;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
+
 import java.util.Collection;
 import java.util.List;
 
@@ -77,11 +79,11 @@ public class CassandraIndexTableHandler {
     public Mono<Void> updateIndexOnDelete(CassandraId mailboxId, Collection<MessageMetaData> metaData) {
         return Flux.mergeDelayError(Queues.XS_BUFFER_SIZE,
                 Flux.fromIterable(metaData)
-                    .flatMap(message -> updateFirstUnseenOnDelete(mailboxId, message.getFlags(), message.getUid())),
+                    .flatMap(message -> updateFirstUnseenOnDelete(mailboxId, message.getFlags(), message.getUid()), DEFAULT_CONCURRENCY),
                 Flux.fromIterable(metaData)
-                    .flatMap(message -> updateRecentOnDelete(mailboxId, message.getUid(), message.getFlags())),
+                    .flatMap(message -> updateRecentOnDelete(mailboxId, message.getUid(), message.getFlags()), DEFAULT_CONCURRENCY),
                 Flux.fromIterable(metaData)
-                    .flatMap(message -> updateDeletedMessageProjectionOnDelete(mailboxId, message.getUid(), message.getFlags())),
+                    .flatMap(message -> updateDeletedMessageProjectionOnDelete(mailboxId, message.getUid(), message.getFlags()), DEFAULT_CONCURRENCY),
                 decrementCountersOnDelete(mailboxId, metaData))
             .then();
     }

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMailboxDAO.java
@@ -31,6 +31,7 @@ import static org.apache.james.mailbox.cassandra.table.CassandraMailboxTable.MAI
 import static org.apache.james.mailbox.cassandra.table.CassandraMailboxTable.NAME;
 import static org.apache.james.mailbox.cassandra.table.CassandraMailboxTable.TABLE_NAME;
 import static org.apache.james.mailbox.cassandra.table.CassandraMailboxTable.UIDVALIDITY;
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 
 import javax.inject.Inject;
 
@@ -189,7 +190,7 @@ public class CassandraMailboxDAO {
     public Flux<Mailbox> retrieveAllMailboxes() {
         return executor.execute(listStatement.bind())
             .flatMapMany(cassandraUtils::convertToFlux)
-            .flatMap(this::toMailboxWithId);
+            .flatMap(this::toMailboxWithId, DEFAULT_CONCURRENCY);
     }
 
     private Mono<Mailbox> toMailboxWithId(Row row) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mailbox.cassandra.mail;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
+
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.Comparator;
@@ -386,7 +388,7 @@ public class CassandraMessageMapper implements MessageMapper {
     private Mono<FlagsUpdateStageResult> retryUpdatesStage(CassandraId mailboxId, FlagsUpdateCalculator flagsUpdateCalculator, List<ComposedMessageId> failed) {
         if (!failed.isEmpty()) {
             Flux<ComposedMessageIdWithMetaData> toUpdate = Flux.fromIterable(failed)
-                .flatMap(ids -> imapUidDAO.retrieve((CassandraMessageId) ids.getMessageId(), Optional.of((CassandraId) ids.getMailboxId())));
+                .flatMap(ids -> imapUidDAO.retrieve((CassandraMessageId) ids.getMessageId(), Optional.of((CassandraId) ids.getMailboxId())), DEFAULT_CONCURRENCY);
             return runUpdateStage(mailboxId, toUpdate, flagsUpdateCalculator);
         } else {
             return Mono.empty();

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraUserMailboxRightsDAO.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraUserMailboxRightsDAO.java
@@ -26,6 +26,7 @@ import static org.apache.james.mailbox.cassandra.table.CassandraUserMailboxRight
 import static org.apache.james.mailbox.cassandra.table.CassandraUserMailboxRightsTable.RIGHTS;
 import static org.apache.james.mailbox.cassandra.table.CassandraUserMailboxRightsTable.TABLE_NAME;
 import static org.apache.james.mailbox.cassandra.table.CassandraUserMailboxRightsTable.USER_NAME;
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -112,7 +113,8 @@ public class CassandraUserMailboxRightsDAO {
             .flatMap(entry -> cassandraAsyncExecutor.executeVoid(
                 delete.bind()
                     .setString(USER_NAME, entry.getKey().getName())
-                    .setUUID(MAILBOX_ID, cassandraId.asUuid())));
+                    .setUUID(MAILBOX_ID, cassandraId.asUuid())),
+                DEFAULT_CONCURRENCY);
     }
 
     private Flux<Void> addAll(CassandraId cassandraId, Stream<MailboxACL.Entry> addedEntries) {
@@ -121,7 +123,8 @@ public class CassandraUserMailboxRightsDAO {
                 insert.bind()
                     .setString(USER_NAME, entry.getKey().getName())
                     .setUUID(MAILBOX_ID, cassandraId.asUuid())
-                    .setString(RIGHTS, entry.getValue().serialize())));
+                    .setString(RIGHTS, entry.getValue().serialize())),
+                DEFAULT_CONCURRENCY);
     }
 
     public Mono<Optional<Rfc4314Rights>> retrieve(Username userName, CassandraId mailboxId) {

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesService.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/task/SolveMailboxInconsistenciesService.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.mailbox.cassandra.mail.task;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
+
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
@@ -408,15 +410,15 @@ public class SolveMailboxInconsistenciesService {
 
     private Flux<Result> processMailboxPathDaoInconsistencies(Context context) {
         return mailboxPathV3DAO.listAll()
-            .flatMap(this::detectMailboxPathDaoInconsistency)
-            .flatMap(inconsistency -> inconsistency.fix(context, mailboxDAO, mailboxPathV3DAO))
+            .flatMap(this::detectMailboxPathDaoInconsistency, DEFAULT_CONCURRENCY)
+            .flatMap(inconsistency -> inconsistency.fix(context, mailboxDAO, mailboxPathV3DAO), DEFAULT_CONCURRENCY)
             .doOnNext(any -> context.incrementProcessedMailboxPathEntries());
     }
 
     private Flux<Result> processMailboxDaoInconsistencies(Context context) {
         return mailboxDAO.retrieveAllMailboxes()
-            .flatMap(this::detectMailboxDaoInconsistency)
-            .flatMap(inconsistency -> inconsistency.fix(context, mailboxDAO, mailboxPathV3DAO))
+            .flatMap(this::detectMailboxDaoInconsistency, DEFAULT_CONCURRENCY)
+            .flatMap(inconsistency -> inconsistency.fix(context, mailboxDAO, mailboxPathV3DAO), DEFAULT_CONCURRENCY)
             .doOnNext(any -> context.incrementProcessedMailboxEntries());
     }
 

--- a/mailbox/event/event-memory/src/main/java/org/apache/james/mailbox/events/InVMEventBus.java
+++ b/mailbox/event/event-memory/src/main/java/org/apache/james/mailbox/events/InVMEventBus.java
@@ -94,13 +94,13 @@ public class InVMEventBus implements EventBus {
 
     private Mono<Void> keyDeliveries(Event event, Set<RegistrationKey> keys) {
         return Flux.fromIterable(registeredListenersByKeys(keys))
-            .flatMap(listener -> eventDelivery.deliver(listener, event, EventDelivery.DeliveryOption.none()))
+            .flatMap(listener -> eventDelivery.deliver(listener, event, EventDelivery.DeliveryOption.none()), EventBus.EXECUTION_RATE)
             .then();
     }
 
     private Mono<Void> groupDeliveries(Event event) {
         return Flux.fromIterable(groups.entrySet())
-            .flatMap(entry -> groupDelivery(event, entry.getValue(), entry.getKey()))
+            .flatMap(entry -> groupDelivery(event, entry.getValue(), entry.getKey()), EventBus.EXECUTION_RATE)
             .then();
     }
 

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/EventDispatcher.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/EventDispatcher.java
@@ -124,9 +124,9 @@ public class EventDispatcher {
     private Mono<Void> dispatchToLocalListeners(Event event, Set<RegistrationKey> keys) {
         return Flux.fromIterable(keys)
             .flatMap(key -> localListenerRegistry.getLocalMailboxListeners(key)
-                .map(listener -> Tuples.of(key, listener)))
+                .map(listener -> Tuples.of(key, listener)), EventBus.EXECUTION_RATE)
             .filter(pair -> pair.getT2().getExecutionMode() == MailboxListener.ExecutionMode.SYNCHRONOUS)
-            .flatMap(pair -> executeListener(event, pair.getT2(), pair.getT1()))
+            .flatMap(pair -> executeListener(event, pair.getT2(), pair.getT1()), EventBus.EXECUTION_RATE)
             .then();
     }
 

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupRegistration.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/GroupRegistration.java
@@ -138,7 +138,7 @@ class GroupRegistration implements Registration {
         return receiver.consumeManualAck(queueName.asString(), new ConsumeOptions().qos(EventBus.EXECUTION_RATE))
             .publishOn(Schedulers.parallel())
             .filter(delivery -> Objects.nonNull(delivery.getBody()))
-            .flatMap(this::deliver)
+            .flatMap(this::deliver, EventBus.EXECUTION_RATE)
             .subscribe();
     }
 

--- a/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/KeyRegistrationHandler.java
+++ b/mailbox/event/event-rabbitmq/src/main/java/org/apache/james/mailbox/events/KeyRegistrationHandler.java
@@ -97,7 +97,7 @@ class KeyRegistrationHandler {
 
         receiverSubscriber = Optional.of(receiver.consumeAutoAck(registrationQueue.asString(), new ConsumeOptions().qos(EventBus.EXECUTION_RATE))
             .subscribeOn(Schedulers.parallel())
-            .flatMap(this::handleDelivery)
+            .flatMap(this::handleDelivery, EventBus.EXECUTION_RATE)
             .subscribe());
     }
 
@@ -169,7 +169,7 @@ class KeyRegistrationHandler {
 
         return localListenerRegistry.getLocalMailboxListeners(registrationKey)
             .filter(listener -> !isLocalSynchronousListeners(eventBusId, listener))
-            .flatMap(listener -> executeListener(listener, event, registrationKey))
+            .flatMap(listener -> executeListener(listener, event, registrationKey), EventBus.EXECUTION_RATE)
             .then();
     }
 

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMessageIdMapper.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMessageIdMapper.java
@@ -20,6 +20,7 @@
 package org.apache.james.mailbox.inmemory.mail;
 
 import static org.apache.james.mailbox.store.mail.AbstractMessageMapper.UNLIMITED;
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 
 import java.util.Collection;
 import java.util.List;
@@ -71,7 +72,7 @@ public class InMemoryMessageIdMapper implements MessageIdMapper {
     @Override
     public Publisher<ComposedMessageIdWithMetaData> findMetadata(MessageId messageId) {
         return mailboxMapper.list()
-            .flatMap(mailbox -> messageMapper.findInMailboxReactive(mailbox, MessageRange.all(), MessageMapper.FetchType.Full, UNLIMITED))
+            .flatMap(mailbox -> messageMapper.findInMailboxReactive(mailbox, MessageRange.all(), MessageMapper.FetchType.Full, UNLIMITED), DEFAULT_CONCURRENCY)
             .map(message -> new ComposedMessageIdWithMetaData(
                 new ComposedMessageId(
                     message.getMailboxId(),
@@ -84,7 +85,7 @@ public class InMemoryMessageIdMapper implements MessageIdMapper {
     @Override
     public Flux<MailboxMessage> findReactive(Collection<MessageId> messageIds, MessageMapper.FetchType fetchType) {
         return mailboxMapper.list()
-            .flatMap(mailbox -> messageMapper.findInMailboxReactive(mailbox, MessageRange.all(), fetchType, UNLIMITED))
+            .flatMap(mailbox -> messageMapper.findInMailboxReactive(mailbox, MessageRange.all(), fetchType, UNLIMITED), DEFAULT_CONCURRENCY)
             .filter(message -> messageIds.contains(message.getMessageId()));
     }
 

--- a/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVault.java
+++ b/mailbox/plugin/deleted-messages-vault/src/main/java/org/apache/james/vault/blob/BlobStoreDeletedMessageVault.java
@@ -20,6 +20,7 @@
 package org.apache.james.vault.blob;
 
 import static org.apache.james.blob.api.BlobStore.StoragePolicy.LOW_COST;
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 
 import java.io.InputStream;
 import java.time.Clock;
@@ -174,7 +175,7 @@ public class BlobStoreDeletedMessageVault implements DeletedMessageVault {
             metricFactory.decoratePublisherWithTimerMetric(
                 DELETE_EXPIRED_MESSAGES_METRIC_NAME,
                 retentionQualifiedBuckets(beginningOfRetentionPeriod)
-                    .flatMap(bucketName -> deleteBucketData(bucketName).then(Mono.just(bucketName)))));
+                    .flatMap(bucketName -> deleteBucketData(bucketName).then(Mono.just(bucketName)), DEFAULT_CONCURRENCY)));
 
     }
 

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -22,6 +22,7 @@ package org.apache.james.mailbox.store;
 import static org.apache.james.mailbox.store.MailboxReactorUtils.block;
 import static org.apache.james.mailbox.store.MailboxReactorUtils.blockOptional;
 import static org.apache.james.mailbox.store.mail.AbstractMessageMapper.UNLIMITED;
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -583,7 +584,7 @@ public class StoreMailboxManager implements MailboxManager {
                                 .build(),
                             new MailboxIdRegistrationKey(sub.getMailboxId())))
                         .then(Mono.fromRunnable(() -> LOGGER.debug("Rename mailbox sub-mailbox {} to {}", subOriginalName, subNewName)));
-                })
+                }, DEFAULT_CONCURRENCY)
                 .then());
 
             return null;

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -21,6 +21,7 @@ package org.apache.james.mailbox.store;
 
 import static org.apache.james.mailbox.extension.PreDeletionHook.DeleteOperation;
 import static org.apache.james.mailbox.store.mail.AbstractMessageMapper.UNLIMITED;
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -697,7 +698,7 @@ public class StoreMessageManager implements MessageManager {
 
         Mono<DeleteOperation> deleteOperation = Flux.fromIterable(MessageRange.toRanges(uids))
             .publishOn(Schedulers.elastic())
-            .flatMap(range -> messageMapper.findInMailboxReactive(mailbox, range, FetchType.Metadata, UNLIMITED))
+            .flatMap(range -> messageMapper.findInMailboxReactive(mailbox, range, FetchType.Metadata, UNLIMITED), DEFAULT_CONCURRENCY)
             .map(mailboxMessage -> MetadataWithMailboxId.from(mailboxMessage.metaData(), mailboxMessage.getMailboxId()))
             .collect(Guavate.toImmutableList())
             .map(DeleteOperation::from);

--- a/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/CassandraBlobStoreDAO.java
+++ b/server/blob/blob-cassandra/src/main/java/org/apache/james/blob/cassandra/CassandraBlobStoreDAO.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.blob.cassandra;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
+
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -158,7 +160,7 @@ public class CassandraBlobStoreDAO implements BlobStoreDAO {
         return bucketDAO.listAll()
             .filter(bucketNameBlobIdPair -> bucketNameBlobIdPair.getKey().equals(bucketName))
             .map(Pair::getValue)
-            .flatMap(blobId -> delete(bucketName, blobId))
+            .flatMap(blobId -> delete(bucketName, blobId), DEFAULT_CONCURRENCY)
             .then();
     }
 

--- a/server/blob/blob-common/src/main/java/org/apache/james/blob/api/Store.java
+++ b/server/blob/blob-common/src/main/java/org/apache/james/blob/api/Store.java
@@ -40,6 +40,8 @@ public interface Store<T, I> {
 
     class Impl<T, I extends BlobPartsId> implements Store<T, I> {
 
+        public static final int DEFAULT_CONCURRENCY = 16;
+
         public interface ValueToSave {
             Mono<BlobId> saveIn(BucketName bucketName, BlobStore blobStore);
         }
@@ -108,7 +110,7 @@ public interface Store<T, I> {
         @Override
         public Publisher<Void> delete(I blobIds) {
             return Flux.fromIterable(blobIds.asMap().values())
-                .flatMap(id -> blobStore.delete(blobStore.getDefaultBucketName(), id))
+                .flatMap(id -> blobStore.delete(blobStore.getDefaultBucketName(), id), DEFAULT_CONCURRENCY)
                 .then();
         }
     }

--- a/server/container/guice/guice-common/src/main/java/org/apache/james/PeriodicalHealthChecks.java
+++ b/server/container/guice/guice-common/src/main/java/org/apache/james/PeriodicalHealthChecks.java
@@ -19,6 +19,8 @@
 
 package org.apache.james;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
+
 import java.util.Set;
 
 import javax.annotation.PreDestroy;
@@ -60,7 +62,7 @@ public class PeriodicalHealthChecks implements Startable {
     public void start() {
         disposable = Flux.interval(configuration.getPeriod(), scheduler)
             .flatMapIterable(any -> healthChecks)
-            .flatMap(healthCheck -> Mono.from(healthCheck.check()))
+            .flatMap(healthCheck -> Mono.from(healthCheck.check()), DEFAULT_CONCURRENCY)
             .doOnNext(this::logResult)
             .onErrorContinue(this::logError)
             .subscribeOn(Schedulers.elastic())

--- a/server/container/util/src/main/java/org/apache/james/util/reactor/Constants.java
+++ b/server/container/util/src/main/java/org/apache/james/util/reactor/Constants.java
@@ -1,0 +1,24 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.util.reactor;
+
+public interface Constants {
+    int DEFAULT_CONCURRENCY = 10;
+}

--- a/server/data/data-cassandra/src/main/java/org/apache/james/rrt/cassandra/migration/MappingsSourcesMigration.java
+++ b/server/data/data-cassandra/src/main/java/org/apache/james/rrt/cassandra/migration/MappingsSourcesMigration.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.rrt.cassandra.migration;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
+
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Optional;
@@ -112,7 +114,7 @@ public class MappingsSourcesMigration implements Migration {
     @Override
     public void apply() {
         cassandraRecipientRewriteTableDAO.getAllMappings()
-            .flatMap(this::migrate)
+            .flatMap(this::migrate, DEFAULT_CONCURRENCY)
             .then(Mono.fromRunnable(() -> {
                 if (errorMappingsCount.get() > 0) {
                     throw new MigrationException("MappingsSourcesMigration failed");

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/projections/MessageFastViewProjection.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/projections/MessageFastViewProjection.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.jmap.api.projections;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
+
 import java.util.Collection;
 import java.util.Map;
 
@@ -50,7 +52,7 @@ public interface MessageFastViewProjection {
 
         return Flux.fromIterable(messageIds)
             .flatMap(messageId -> Mono.from(this.retrieve(messageId))
-                .map(preview -> Pair.of(messageId, preview)))
+                .map(preview -> Pair.of(messageId, preview)), DEFAULT_CONCURRENCY)
             .collectMap(Pair::getLeft, Pair::getRight);
     }
 }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/DeliveryRunnable.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/remote/delivery/DeliveryRunnable.java
@@ -47,6 +47,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
+import reactor.util.concurrent.Queues;
 
 public class DeliveryRunnable implements Disposable {
     private static final Logger LOGGER = LoggerFactory.getLogger(DeliveryRunnable.class);
@@ -87,7 +88,7 @@ public class DeliveryRunnable implements Disposable {
     public void start() {
         remoteDeliveryScheduler = Schedulers.newBoundedElastic(Schedulers.DEFAULT_BOUNDED_ELASTIC_SIZE, Schedulers.DEFAULT_BOUNDED_ELASTIC_QUEUESIZE, "RemoteDelivery");
         disposable = Flux.from(queue.deQueue())
-            .flatMap(queueItem -> runStep(queueItem).subscribeOn(remoteDeliveryScheduler))
+            .flatMap(queueItem -> runStep(queueItem).subscribeOn(remoteDeliveryScheduler), Queues.SMALL_BUFFER_SIZE)
             .onErrorContinue(((throwable, nothing) -> LOGGER.error("Exception caught in RemoteDelivery", throwable)))
             .subscribeOn(remoteDeliveryScheduler)
             .subscribe();

--- a/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepository.java
+++ b/server/mailrepository/mailrepository-cassandra/src/main/java/org/apache/james/mailrepository/cassandra/CassandraMailRepository.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.mailrepository.cassandra;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 import static org.apache.james.util.ReactorUtils.publishIfPresent;
 
 import java.util.Collection;
@@ -121,7 +122,7 @@ public class CassandraMailRepository implements MailRepository {
     public void remove(Collection<Mail> toRemove) {
         Flux.fromIterable(toRemove)
             .map(MailKey::forMail)
-            .flatMap(this::removeAsync)
+            .flatMap(this::removeAsync, DEFAULT_CONCURRENCY)
             .then()
             .block();
     }
@@ -160,7 +161,7 @@ public class CassandraMailRepository implements MailRepository {
     @Override
     public void removeAll() {
         keysDAO.list(url)
-            .flatMap(this::removeAsync)
+            .flatMap(this::removeAsync, DEFAULT_CONCURRENCY)
             .then()
             .block();
     }

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMailboxesMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMailboxesMethod.java
@@ -19,6 +19,7 @@
 
 package org.apache.james.jmap.draft.methods;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 import static org.apache.james.util.ReactorUtils.context;
 import static org.apache.james.util.ReactorUtils.publishIfPresent;
 
@@ -144,7 +145,7 @@ public class GetMailboxesMethod implements Method {
                     .session(mailboxSession)
                     .usingPreloadedMailboxesMetadata(NO_PRELOADED_METADATA)
                     .build())
-                .subscribeOn(Schedulers.elastic()))
+                .subscribeOn(Schedulers.elastic()), DEFAULT_CONCURRENCY)
             .handle(publishIfPresent());
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MessageViewFactory.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/message/view/MessageViewFactory.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.jmap.draft.model.message.view;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
@@ -132,9 +134,9 @@ public interface MessageViewFactory<T extends MessageView> {
         static <T extends MessageView> Flux<T> toMessageViews(Flux<MessageResult> messageResults, FromMessageResult<T> converter) {
             return messageResults
                 .groupBy(MessageResult::getMessageId)
-                .flatMap(Flux::collectList)
+                .flatMap(Flux::collectList, DEFAULT_CONCURRENCY)
                 .filter(Predicate.not(List::isEmpty))
-                .flatMap(toMessageViews(converter));
+                .flatMap(toMessageViews(converter), DEFAULT_CONCURRENCY);
         }
 
         static Instant getDateFromHeaderOrInternalDateOtherwise(Message mimeMessage, MessageResult message) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/event/ComputeMessageFastViewProjectionListener.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/event/ComputeMessageFastViewProjectionListener.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.jmap.event;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
+
 import java.io.IOException;
 
 import javax.inject.Inject;
@@ -88,9 +90,9 @@ public class ComputeMessageFastViewProjectionListener implements MailboxListener
         return Flux.from(messageIdManager.getMessagesReactive(addedEvent.getMessageIds(), FetchGroup.FULL_CONTENT, session))
             .flatMap(Throwing.function(messageResult -> Mono.fromCallable(
                 () -> Pair.of(messageResult.getMessageId(), computeFastViewPrecomputedProperties(messageResult)))
-                    .subscribeOn(Schedulers.parallel())))
+                    .subscribeOn(Schedulers.parallel())), DEFAULT_CONCURRENCY)
             .publishOn(Schedulers.elastic())
-            .flatMap(message -> messageFastViewProjection.store(message.getKey(), message.getValue()))
+            .flatMap(message -> messageFastViewProjection.store(message.getKey(), message.getValue()), DEFAULT_CONCURRENCY)
             .then();
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/DefaultMailboxesProvisioner.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/DefaultMailboxesProvisioner.java
@@ -19,6 +19,7 @@
 package org.apache.james.jmap.http;
 
 import static org.apache.james.util.FunctionalUtils.negate;
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -73,7 +74,7 @@ class DefaultMailboxesProvisioner {
 
         return Flux.fromIterable(DefaultMailboxes.DEFAULT_MAILBOXES)
             .map(toMailboxPath(session))
-            .filterWhen(mailboxPath -> mailboxDoesntExist(mailboxPath, session))
+            .filterWhen(mailboxPath -> mailboxDoesntExist(mailboxPath, session), DEFAULT_CONCURRENCY)
             .concatMap(mailboxPath -> Mono.fromRunnable(() -> createMailbox(mailboxPath, session))
                 .subscribeOn(Schedulers.elastic()))
             .then();

--- a/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/routes/HealthCheckRoutes.java
+++ b/server/protocols/webadmin/webadmin-core/src/main/java/org/apache/james/webadmin/routes/HealthCheckRoutes.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.webadmin.routes;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
+
 import java.util.List;
 import java.util.Set;
 
@@ -185,7 +187,7 @@ public class HealthCheckRoutes implements PublicRoutes {
 
     private Flux<Result> executeHealthChecks() {
         return Flux.fromIterable(healthChecks)
-            .flatMap(HealthCheck::check)
+            .flatMap(HealthCheck::check, DEFAULT_CONCURRENCY)
             .doOnNext(this::logFailedCheck);
     }
 

--- a/server/protocols/webadmin/webadmin-mailbox-deleted-message-vault/src/main/java/org/apache/james/webadmin/vault/routes/RestoreService.java
+++ b/server/protocols/webadmin/webadmin-mailbox-deleted-message-vault/src/main/java/org/apache/james/webadmin/vault/routes/RestoreService.java
@@ -20,6 +20,7 @@
 package org.apache.james.webadmin.vault.routes;
 
 import static org.apache.james.mailbox.MessageManager.AppendCommand;
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 import static org.apache.james.webadmin.vault.routes.RestoreService.RestoreResult.RESTORE_FAILED;
 import static org.apache.james.webadmin.vault.routes.RestoreService.RestoreResult.RESTORE_SUCCEED;
 
@@ -74,7 +75,7 @@ class RestoreService {
         MessageManager restoreMessageManager = restoreMailboxManager(session);
 
         return Flux.from(deletedMessageVault.search(usernameToRestore, searchQuery))
-            .flatMap(deletedMessage -> appendToMailbox(restoreMessageManager, deletedMessage, session));
+            .flatMap(deletedMessage -> appendToMailbox(restoreMessageManager, deletedMessage, session), DEFAULT_CONCURRENCY);
     }
 
     private Mono<RestoreResult> appendToMailbox(MessageManager restoreMailboxManager, DeletedMessage deletedMessage, MailboxSession session) {

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/EventDeadLettersRedeliverService.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/EventDeadLettersRedeliverService.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.webadmin.service;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
+
 import javax.inject.Inject;
 
 import org.apache.james.mailbox.events.Event;
@@ -50,7 +52,7 @@ public class EventDeadLettersRedeliverService {
 
     Flux<Task.Result> redeliverEvents(EventRetriever eventRetriever) {
         return eventRetriever.retrieveEvents(deadLetters)
-            .flatMap(entry -> redeliverGroupEvents(entry.getT1(), entry.getT2(), entry.getT3()));
+            .flatMap(entry -> redeliverGroupEvents(entry.getT1(), entry.getT2(), entry.getT3()), DEFAULT_CONCURRENCY);
     }
 
     private Mono<Task.Result> redeliverGroupEvents(Group group, Event event, EventDeadLetters.InsertionId insertionId) {

--- a/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/EventRetriever.java
+++ b/server/protocols/webadmin/webadmin-mailbox/src/main/java/org/apache/james/webadmin/service/EventRetriever.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.webadmin.service;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
+
 import java.util.Optional;
 
 import org.apache.james.mailbox.events.Event;
@@ -50,7 +52,7 @@ public interface EventRetriever {
 
     default Flux<Tuple3<Group, Event, EventDeadLetters.InsertionId>> listGroupEvents(EventDeadLetters deadLetters, Group group) {
         return deadLetters.failedIds(group)
-            .flatMap(insertionId -> Flux.zip(Mono.just(group), deadLetters.failedEvent(group, insertionId), Mono.just(insertionId)));
+            .flatMap(insertionId -> Flux.zip(Mono.just(group), deadLetters.failedEvent(group, insertionId), Mono.just(insertionId)), DEFAULT_CONCURRENCY);
     }
 
     class AllEventsRetriever implements EventRetriever {
@@ -67,7 +69,7 @@ public interface EventRetriever {
         @Override
         public Flux<Tuple3<Group, Event, EventDeadLetters.InsertionId>> retrieveEvents(EventDeadLetters deadLetters) {
             return deadLetters.groupsWithFailedEvents()
-                .flatMap(group -> listGroupEvents(deadLetters, group));
+                .flatMap(group -> listGroupEvents(deadLetters, group), DEFAULT_CONCURRENCY);
         }
     }
 

--- a/server/queue/queue-memory/src/main/java/org/apache/james/queue/memory/MemoryMailQueueFactory.java
+++ b/server/queue/queue-memory/src/main/java/org/apache/james/queue/memory/MemoryMailQueueFactory.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.queue.memory;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
+
 import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.Instant;
@@ -101,7 +103,7 @@ public class MemoryMailQueueFactory implements MailQueueFactory<MemoryMailQueueF
                 .repeat()
                 .subscribeOn(Schedulers.elastic())
                 .flatMap(item ->
-                    Mono.fromRunnable(() -> inProcessingMailItems.add(item)).thenReturn(item))
+                    Mono.fromRunnable(() -> inProcessingMailItems.add(item)).thenReturn(item), DEFAULT_CONCURRENCY)
                 .map(item -> mailQueueItemDecoratorFactory.decorate(item, name));
         }
 

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueue.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueue.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.queue.rabbitmq;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
+
 import java.time.Duration;
 import java.time.Instant;
 
@@ -130,6 +132,6 @@ public class RabbitMQMailQueue implements ManageableMailQueue {
                 .thenReturn(item.getMail().getName());
 
         return mailQueueView.browseOlderThanReactive(olderThan)
-            .flatMap(requeue);
+            .flatMap(requeue, DEFAULT_CONCURRENCY);
     }
 }

--- a/server/task/task-memory/src/main/java/org/apache/james/task/SerialTaskManagerWorker.java
+++ b/server/task/task-memory/src/main/java/org/apache/james/task/SerialTaskManagerWorker.java
@@ -18,6 +18,7 @@
  ****************************************************************/
 package org.apache.james.task;
 
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 import static org.apache.james.util.ReactorUtils.publishIfPresent;
 
 import java.time.Duration;
@@ -96,7 +97,7 @@ public class SerialTaskManagerWorker implements TaskManagerWorker {
             .delayElement(pollingInterval, Schedulers.elastic())
             .repeat()
             .handle(publishIfPresent())
-            .flatMap(information -> Mono.from(listener.updated(taskWithId.getId(), information)).thenReturn(information));
+            .flatMap(information -> Mono.from(listener.updated(taskWithId.getId(), information)).thenReturn(information), DEFAULT_CONCURRENCY);
     }
 
 


### PR DESCRIPTION
```
$ curl -XGET http://127.0.0.1:8000/tasks/d6481452-0868-400c-bc7c-0a5e48350fbc | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   547    0   547    0     0   6702      0 --:--:-- --:--:-- --:--:--  6753
{
  "additionalInformation": {
    "type": "event-dead-letters-redeliver-all",
    "successfulRedeliveriesCount": 0,
    "failedRedeliveriesCount": 0,
    "group": null,
    "insertionId": null,
    "timestamp": "2020-11-24T05:07:12.243412Z"
  },
  "status": "canceledRequested",
  "taskId": "d6481452-0868-400c-bc7c-0a5e48350fbc",
  "startedDate": "2020-11-24T05:07:12.275+0000",
  "canceledDate": "2020-11-24T05:45:16.069+0000",
  "submitDate": "2020-11-24T05:07:12.183+0000",
  "submittedFrom": "linagora.com",
  "executedOn": "linagora.com",
  "cancelledFrom": "linagora.com",
  "type": "event-dead-letters-redeliver-all"
}
```

Manually aborted.

There was a failure, that did NOT marked the task as canceled: 

```
[ERROR] o.a.j.t.SerialTaskManagerWorker - Error while running task TaskId{value=d6481452-0868-400c-bc7c-0a5e48350fbc}
 => com.datastax.driver.core.exceptions.NoHostAvailableException
```

All subsequet tasks failed

```
[ERROR] o.a.j.t.e.d.RabbitMQWorkQueue - Unable to process taskId Optional[b74d18c5-de25-404e-aabf-45dffa505318]

[ERROR] o.a.j.t.e.d.RabbitMQWorkQueue - Unable to deserialize submitted Task b74d18c5-de25-404e-aabf-45dffa505318
```

The usual suspect: 3 nested reactor flatMaps calls overwhelming the Cassandra driver.

We should use lower defaults for Reactor flatmaps, and move away from the implicit query parameters...