### PR TITLE
JAMES-2037 CassandraMessageMapper::listAllMessageUids should not rely…

### DIFF
--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -123,8 +123,7 @@ public class CassandraMessageMapper implements MessageMapper {
     @Override
     public Flux<MessageUid> listAllMessageUids(Mailbox mailbox) {
         CassandraId cassandraId = (CassandraId) mailbox.getMailboxId();
-        return messageIdDAO.retrieveMessages(cassandraId, MessageRange.all(), Limit.unlimited())
-            .map(metaData -> metaData.getComposedMessageId().getUid());
+        return messageIdDAO.listUids(cassandraId);
     }
 
     @Override

--- a/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/CassandraReIndexerImplTest.java
+++ b/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/CassandraReIndexerImplTest.java
@@ -78,6 +78,7 @@ public class CassandraReIndexerImplTest {
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
+        cassandra.getConf().printStatements();
         mailboxManager = CassandraMailboxManagerProvider.provideMailboxManager(cassandra, PreDeletionHooks.NO_PRE_DELETION_HOOK);
         MailboxSessionMapperFactory mailboxSessionMapperFactory = mailboxManager.getMapperFactory();
         messageSearchIndex = mock(ListeningMessageSearchIndex.class);
@@ -130,7 +131,7 @@ public class CassandraReIndexerImplTest {
             cassandra.getConf()
                 .registerScenario(fail()
                     .forever()
-                    .whenQueryStartsWith("SELECT messageId,mailboxId,uid,modSeq,flagAnswered,flagDeleted,flagDraft,flagFlagged,flagRecent,flagSeen,flagUser,userFlags FROM messageIdTable WHERE mailboxId=:mailboxId;"));
+                    .whenQueryStartsWith("SELECT uid FROM messageIdTable WHERE mailboxId=:mailboxId;"));
 
             Task task = reIndexer.reIndex(ReIndexer.RunningOptions.DEFAULT);
             Task.Result result = task.run();
@@ -149,7 +150,7 @@ public class CassandraReIndexerImplTest {
             cassandra.getConf()
                 .registerScenario(fail()
                     .forever()
-                    .whenQueryStartsWith("SELECT messageId,mailboxId,uid,modSeq,flagAnswered,flagDeleted,flagDraft,flagFlagged,flagRecent,flagSeen,flagUser,userFlags FROM messageIdTable WHERE mailboxId=:mailboxId;"));
+                    .whenQueryStartsWith("SELECT uid FROM messageIdTable WHERE mailboxId=:mailboxId;"));
 
             Task task = reIndexer.reIndex(ReIndexer.RunningOptions.DEFAULT);
             task.run();
@@ -169,7 +170,7 @@ public class CassandraReIndexerImplTest {
             cassandra.getConf()
                 .registerScenario(fail()
                     .forever()
-                    .whenQueryStartsWith("SELECT messageId,mailboxId,uid,modSeq,flagAnswered,flagDeleted,flagDraft,flagFlagged,flagRecent,flagSeen,flagUser,userFlags FROM messageIdTable WHERE mailboxId=:mailboxId;"));
+                    .whenQueryStartsWith("SELECT uid FROM messageIdTable WHERE mailboxId=:mailboxId;"));
 
             Task task = reIndexer.reIndex(mailbox.getId(), ReIndexer.RunningOptions.DEFAULT);
             Task.Result result = task.run();
@@ -188,7 +189,7 @@ public class CassandraReIndexerImplTest {
             cassandra.getConf()
                 .registerScenario(fail()
                     .forever()
-                    .whenQueryStartsWith("SELECT messageId,mailboxId,uid,modSeq,flagAnswered,flagDeleted,flagDraft,flagFlagged,flagRecent,flagSeen,flagUser,userFlags FROM messageIdTable WHERE mailboxId=:mailboxId;"));
+                    .whenQueryStartsWith("SELECT uid FROM messageIdTable WHERE mailboxId=:mailboxId;"));
 
             Task task = reIndexer.reIndex(mailbox.getId(), ReIndexer.RunningOptions.DEFAULT);
             task.run();
@@ -208,7 +209,7 @@ public class CassandraReIndexerImplTest {
             cassandra.getConf()
                 .registerScenario(fail()
                     .forever()
-                    .whenQueryStartsWith("SELECT messageId,mailboxId,uid,modSeq,flagAnswered,flagDeleted,flagDraft,flagFlagged,flagRecent,flagSeen,flagUser,userFlags FROM messageIdTable WHERE mailboxId=:mailboxId;"));
+                    .whenQueryStartsWith("SELECT uid FROM messageIdTable WHERE mailboxId=:mailboxId;"));
 
             Task task = reIndexer.reIndex(USERNAME, ReIndexer.RunningOptions.DEFAULT);
             Task.Result result = task.run();
@@ -227,7 +228,7 @@ public class CassandraReIndexerImplTest {
             cassandra.getConf()
                 .registerScenario(fail()
                     .forever()
-                    .whenQueryStartsWith("SELECT messageId,mailboxId,uid,modSeq,flagAnswered,flagDeleted,flagDraft,flagFlagged,flagRecent,flagSeen,flagUser,userFlags FROM messageIdTable WHERE mailboxId=:mailboxId;"));
+                    .whenQueryStartsWith("SELECT uid FROM messageIdTable WHERE mailboxId=:mailboxId;"));
 
             Task task = reIndexer.reIndex(USERNAME, ReIndexer.RunningOptions.DEFAULT);
             task.run();
@@ -247,7 +248,7 @@ public class CassandraReIndexerImplTest {
             cassandra.getConf()
                 .registerScenario(fail()
                     .forever()
-                    .whenQueryStartsWith("SELECT messageId,mailboxId,uid,modSeq,flagAnswered,flagDeleted,flagDraft,flagFlagged,flagRecent,flagSeen,flagUser,userFlags FROM messageIdTable WHERE mailboxId=:mailboxId;"));
+                    .whenQueryStartsWith("SELECT uid FROM messageIdTable WHERE mailboxId=:mailboxId;"));
 
             Task task = reIndexer.reIndex(new ReIndexingExecutionFailures(
                 ImmutableList.of(new ReIndexingFailure(mailbox.getId(),
@@ -270,7 +271,7 @@ public class CassandraReIndexerImplTest {
             cassandra.getConf()
                 .registerScenario(fail()
                     .forever()
-                    .whenQueryStartsWith("SELECT messageId,mailboxId,uid,modSeq,flagAnswered,flagDeleted,flagDraft,flagFlagged,flagRecent,flagSeen,flagUser,userFlags FROM messageIdTable WHERE mailboxId=:mailboxId;"));
+                    .whenQueryStartsWith("SELECT uid FROM messageIdTable WHERE mailboxId=:mailboxId;"));
 
             Task task = reIndexer.reIndex(new ReIndexingExecutionFailures(
                 ImmutableList.of(new ReIndexingFailure(mailbox.getId(),

--- a/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/CassandraReIndexerImplTest.java
+++ b/mailbox/tools/indexer/src/test/java/org/apache/mailbox/tools/indexer/CassandraReIndexerImplTest.java
@@ -78,7 +78,6 @@ public class CassandraReIndexerImplTest {
 
     @BeforeEach
     void setUp(CassandraCluster cassandra) {
-        cassandra.getConf().printStatements();
         mailboxManager = CassandraMailboxManagerProvider.provideMailboxManager(cassandra, PreDeletionHooks.NO_PRE_DELETION_HOOK);
         MailboxSessionMapperFactory mailboxSessionMapperFactory = mailboxManager.getMapperFactory();
         messageSearchIndex = mock(ListeningMessageSearchIndex.class);


### PR DESCRIPTION
… on ComposedMessageIdWithMetaData

This avoids unneeded objects instantiation and empowers memory footprint optimization for IMAP SELECT,
both at the driver level & db level (avoids transmitting all information, rows are smaller) and both
at the applicative level (avoids a flag extraction, avoid MODSEQ-MailboxId-MessageId-ComposedMessageId-
ComposedMessageIdWithMetaData instantiation)

As a record, for a SELECT on 160.000 messages mailbox, the allocated memory is 519 MB so almost 3,6 KB per message, putting pressure on both the heap and garbage collection.