### PR TITLE
JAMES-2884 Improve JMAP annotated documentation

### DIFF
--- a/docs/modules/servers/pages/distributed/configure/jmap.adoc
+++ b/docs/modules/servers/pages/distributed/configure/jmap.adoc
@@ -93,6 +93,6 @@ Contributions enhancing support are furthermore welcomed.
 The list of tested JMAP clients are:
 
  - [OpenPaaS](https://open-paas.org/) is actively using the draft version of the JMAP implementation. Migration to
- RFC-8621 is planed.
+ RFC-8621 is planned.
  - Experiments had been run on top of [LTT.RS](https://github.com/iNPUTmice/lttrs-android). Version in the Accept
  headers needs to be explicitly set to `rfc-8621`. [Read more](https://github.com/linagora/james-project/pull/4089).

--- a/docs/modules/servers/pages/distributed/configure/jmap.adoc
+++ b/docs/modules/servers/pages/distributed/configure/jmap.adoc
@@ -77,3 +77,22 @@ This token can then be passed as `Bearer` of the `Authorization` header :
     curl -H "Authorization: Bearer $token" -XPOST http://127.0.0.1:80/jmap -d '...'
 
 The public key can be referenced as `jwt.publickeypem.url` of the `jmap.properties` configuration file.
+
+== Annotated specification
+
+The [annotated documentation](https://github.com/apache/james-project/tree/master/server/protocols/jmap-rfc-8621/doc/specs/spec)
+presents the limits of the JMAP RFC-8621 implementation part of the Apache James project.
+
+Some methods / types are not yet implemented, some implementations are naive, and the PUSH is not supported yet.
+
+Users are invited to read these limitations before using actively the JMAP RFC-8621 implementation, and should ensure their
+client applications only uses supported operations.
+
+Contributions enhancing support are furthermore welcomed.
+
+The list of tested JMAP clients are:
+
+ - [OpenPaaS](https://open-paas.org/) is actively using the draft version of the JMAP implementation. Migration to
+ RFC-8621 is planed.
+ - Experiments had been run on top of [LTT.RS](https://github.com/iNPUTmice/lttrs-android). Version in the Accept
+ headers needs to be explicitly set to `rfc-8621`. [Read more](https://github.com/linagora/james-project/pull/4089).

--- a/server/protocols/jmap-rfc-8621/doc/specs/spec/authentication.mdown
+++ b/server/protocols/jmap-rfc-8621/doc/specs/spec/authentication.mdown
@@ -1,0 +1,32 @@
+# Authentication
+
+JMAP RFC-8620 deliberately do not address authentication concerns, and only assume authenticated requests are handled.
+
+Discovery of available authentication mechanism is not part of the JMAP specification.
+
+This document summarizes available authentication mechanism on top of JMAP RFC-8621  implementation as part of the James
+project.
+
+## Basic authentication
+
+James JMAP RFC-8621 supports [Basic Authentication](https://en.wikipedia.org/wiki/Basic_access_authentication).
+
+Please note that while convenient for testing purpose, this authentication mechanism should not be used for production
+workflow: the credentials are transmitted again and over again, should be retained in memory, authentication is
+challenged for each request...
+
+## JWT authentication
+
+We rely on a third party software to supply a signed JWT token, valid according to the James JWT public key.
+If valid, the request is blindly trusted.
+
+[Read more](https://github.com/apache/james-project/blob/master/docs/modules/servers/pages/distributed/configure/jmap.adoc#generating-a-jwt-key-pair).
+
+## Implementing new authentication mechanisms
+
+Administrator might need to adapt authentication to their needs.
+
+To implement custom authentication mechanisms, you need to implement `org.apache.james.jmap.http.AuthenticationStrategy`
+and register it in `RFC8621MethodsModule::provideAuthenticator`.
+
+Note that the Apache James project would happily welcome contributions regarding support of other authentication flows.

--- a/server/protocols/jmap-rfc-8621/doc/specs/spec/authentication.mdown
+++ b/server/protocols/jmap-rfc-8621/doc/specs/spec/authentication.mdown
@@ -1,6 +1,6 @@
 # Authentication
 
-JMAP RFC-8620 deliberately do not address authentication concerns, and only assume authenticated requests are handled.
+JMAP RFC-8620 deliberately does not address authentication concerns, and only assumes authenticated requests are handled.
 
 Discovery of available authentication mechanism is not part of the JMAP specification.
 

--- a/server/protocols/jmap-rfc-8621/doc/specs/spec/authentication.mdown
+++ b/server/protocols/jmap-rfc-8621/doc/specs/spec/authentication.mdown
@@ -4,7 +4,7 @@ JMAP RFC-8620 deliberately do not address authentication concerns, and only assu
 
 Discovery of available authentication mechanism is not part of the JMAP specification.
 
-This document summarizes available authentication mechanism on top of JMAP RFC-8621  implementation as part of the James
+This document summarizes available authentication mechanism on top of JMAP RFC-8621 implementation as part of the James
 project.
 
 ## Basic authentication

--- a/src/site/xdoc/server/config-jmap.xml
+++ b/src/site/xdoc/server/config-jmap.xml
@@ -118,7 +118,7 @@
 
                 <ul>The list of tested JMAP clients are:
                     <li><a href="https://open-paas.org/">OpenPaaS</a> is actively using the draft version of the JMAP implementation. Migration to
-                    RFC-8621 is planed.</li>
+                    RFC-8621 is planned.</li>
                     <li>Experiments had been run on top of <a href="https://github.com/iNPUTmice/lttrs-android">LTT.RS</a>. Version in the Accept
                         headers needs to be explicitly set to `rfc-8621`. <a href="https://github.com/linagora/james-project/pull/4089">Read more</a>.</li>
                 </ul>

--- a/src/site/xdoc/server/config-jmap.xml
+++ b/src/site/xdoc/server/config-jmap.xml
@@ -104,6 +104,25 @@
                     <li><b>JMAP-RFC-8621</b>: <em>Accept: application/json; jmapVersion=rfc-8621</em></li>
                 </ul>
             </subsection>
+
+            <subsection name="Annotated specification">
+                <p>The <a href="https://github.com/apache/james-project/tree/master/server/protocols/jmap-rfc-8621/doc/specs/spec">annotated documentation</a>
+                presents the limits of the JMAP RFC-8621 implementation part of the Apache James project.</p>
+
+                <p>Some methods / types are not yet implemented, some implementations are naive, and the PUSH is not supported yet.</p>
+
+                <p>Users are invited to read these limitations before using actively the JMAP RFC-8621 implementation, and should ensure their
+                client applications only uses supported operations.</p>
+
+                <p>Contributions enhancing support are furthermore welcomed.</p>
+
+                <ul>The list of tested JMAP clients are:
+                    <li><a href="https://open-paas.org/">OpenPaaS</a> is actively using the draft version of the JMAP implementation. Migration to
+                    RFC-8621 is planed.</li>
+                    <li>Experiments had been run on top of <a href="https://github.com/iNPUTmice/lttrs-android">LTT.RS</a>. Version in the Accept
+                        headers needs to be explicitly set to `rfc-8621`. <a href="https://github.com/linagora/james-project/pull/4089">Read more</a>.</li>
+                </ul>
+            </subsection>
         </section>
 
     </body>


### PR DESCRIPTION
 - 1. Point to it from server documentation
 - 2. List tested clients
 - 3. Document authentication