### PR TITLE
JAMES 3400 Add mailbox commands

### DIFF
--- a/server/protocols/webadmin-cli/README.md
+++ b/server/protocols/webadmin-cli/README.md
@@ -72,8 +72,6 @@ Note: the command line before ENTITY will be documented as {cli}.
    - [Delete a mailbox and its children](#delete-a-mailbox-and-its-children)
    - [Delete all mailboxes of a user](#delete-all-mailboxes-of-a-user)
    - [Get mailboxes list](#get-mailboxes-list)
-   - [Reindex a user mailboxes](#reindex-a-user-mailboxes)
-   - [Reindex all users mailboxes](#reindex-all-users-mailboxes)
 - [Manage Domain Mappings](#manage-domain-mappings)
    - [Listing all domain mappings](#listing-all-domain-mappings)
    - [Listing all destination domains for a source domain](#listing-all-destination-domains-for-a-source-domain)
@@ -221,24 +219,6 @@ Resource name usernameToBeUsed should be an existing user
 ```
 
 Resource name usernameToBeUsed should be an existing user
-
-### Reindex a user mailboxes
-
-```
-{cli} mailbox reindex <usernameToBeUsed>
-```
-
-Will schedule a task for reIndexing all the mails in “usernameToBeUsed” mailboxes.
-
-Resource name usernameToBeUsed should be an existing user
-
-### Reindex all users mailboxes
-
-```
-{cli} mailbox reindexAll
-```
-
-Will schedule a task for reIndexing all the mails stored on this James server.
 
 ## Manage Domain Mappings
 

--- a/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/WebAdminCli.java
+++ b/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/WebAdminCli.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import org.apache.james.cli.domain.DomainCommand;
+import org.apache.james.cli.mailbox.MailboxCommand;
 import org.apache.james.cli.user.UserCommand;
 import org.apache.james.httpclient.FeignClientFactory;
 import org.apache.james.httpclient.JwtToken;
@@ -75,6 +76,7 @@ public class WebAdminCli implements Callable<Integer> {
             .addSubcommand(new CommandLine.HelpCommand())
             .addSubcommand(new DomainCommand(out, parent, err))
             .addSubcommand(new UserCommand(out, parent, err))
+            .addSubcommand(new MailboxCommand(out, parent, err))
             .execute(args);
     }
 

--- a/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxCommand.java
+++ b/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxCommand.java
@@ -1,0 +1,57 @@
+/******************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one     *
+ * or more contributor license agreements.  See the NOTICE file   *
+ * distributed with this work for additional information          *
+ * regarding copyright ownership.  The ASF licenses this file     *
+ * to you under the Apache License, Version 2.0 (the              *
+ * "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at     *
+ *                                                                *
+ * http://www.apache.org/licenses/LICENSE-2.0                     *
+ *                                                                *
+ * Unless required by applicable law or agreed to in writing,     *
+ * software distributed under the License is distributed on an    *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY         *
+ * KIND, either express or implied.  See the License for the      *
+ * specific language governing permissions and limitations        *
+ * under the License.                                             *
+ ******************************************************************/
+
+package org.apache.james.cli.mailbox;
+
+import java.io.PrintStream;
+import java.util.concurrent.Callable;
+
+import org.apache.james.cli.WebAdminCli;
+import org.apache.james.httpclient.MailboxClient;
+
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "mailbox",
+    description = "Manage Mailboxes",
+    subcommands = {
+        MailboxCreateCommand.class
+    })
+public class MailboxCommand implements Callable<Integer> {
+
+    protected final WebAdminCli webAdminCli;
+    protected final PrintStream out;
+    protected final PrintStream err;
+
+    public MailboxCommand(PrintStream out, WebAdminCli webAdminCli, PrintStream err) {
+        this.out = out;
+        this.webAdminCli = webAdminCli;
+        this.err = err;
+    }
+
+    @Override
+    public Integer call() {
+        return WebAdminCli.CLI_FINISHED_SUCCEED;
+    }
+
+    public MailboxClient fullyQualifiedURL(String partOfUrl) {
+        return webAdminCli.feignClientFactory(err).target(MailboxClient.class, webAdminCli.jamesUrl + partOfUrl);
+    }
+
+}

--- a/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxCommand.java
+++ b/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxCommand.java
@@ -31,7 +31,8 @@ import picocli.CommandLine;
     name = "mailbox",
     description = "Manage Mailboxes",
     subcommands = {
-        MailboxCreateCommand.class
+        MailboxCreateCommand.class,
+        MailboxExistCommand.class
     })
 public class MailboxCommand implements Callable<Integer> {
 

--- a/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxCreateCommand.java
+++ b/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxCreateCommand.java
@@ -50,7 +50,7 @@ public class MailboxCreateCommand implements Callable<Integer> {
             MailboxClient mailboxClient = mailboxCommand.fullyQualifiedURL("/users");
             Response rs = mailboxClient.createAMailbox(userName, mailboxName);
             if (rs.status() == CREATED_CODE) {
-                mailboxCommand.out.println("The mailbox now exists on the server.");
+                mailboxCommand.out.println("The mailbox was created successfully.");
                 return WebAdminCli.CLI_FINISHED_SUCCEED;
             } else if (rs.status() == BAD_REQUEST_CODE) {
                 mailboxCommand.err.println(rs.body());

--- a/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxCreateCommand.java
+++ b/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxCreateCommand.java
@@ -50,7 +50,7 @@ public class MailboxCreateCommand implements Callable<Integer> {
             MailboxClient mailboxClient = mailboxCommand.fullyQualifiedURL("/users");
             Response rs = mailboxClient.createAMailbox(userName, mailboxName);
             if (rs.status() == CREATED_CODE) {
-                mailboxCommand.out.println("The mailbox was created successfully.");
+                mailboxCommand.out.println("The mailbox now exists on the server.");
                 return WebAdminCli.CLI_FINISHED_SUCCEED;
             } else if (rs.status() == BAD_REQUEST_CODE) {
                 mailboxCommand.err.println(rs.body());

--- a/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxCreateCommand.java
+++ b/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxCreateCommand.java
@@ -1,0 +1,71 @@
+/******************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one     *
+ * or more contributor license agreements.  See the NOTICE file   *
+ * distributed with this work for additional information          *
+ * regarding copyright ownership.  The ASF licenses this file     *
+ * to you under the Apache License, Version 2.0 (the              *
+ * "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at     *
+ *                                                                *
+ * http://www.apache.org/licenses/LICENSE-2.0                     *
+ *                                                                *
+ * Unless required by applicable law or agreed to in writing,     *
+ * software distributed under the License is distributed on an    *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY         *
+ * KIND, either express or implied.  See the License for the      *
+ * specific language governing permissions and limitations        *
+ * under the License.                                             *
+ ******************************************************************/
+
+package org.apache.james.cli.mailbox;
+
+import java.util.concurrent.Callable;
+
+import org.apache.james.cli.WebAdminCli;
+import org.apache.james.httpclient.MailboxClient;
+
+import feign.Response;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "create",
+    description = "Create a new mailbox")
+public class MailboxCreateCommand implements Callable<Integer> {
+
+    public static final int CREATED_CODE = 204;
+    public static final int INVALID_MAILBOX_NAME_CODE = 400;
+    public static final int USERNAME_NOT_EXIST_CODE = 404;
+
+    @CommandLine.ParentCommand MailboxCommand mailboxCommand;
+
+    @CommandLine.Parameters(description = "Username")
+    String userName;
+
+    @CommandLine.Parameters(description = "Mailbox's name to be created")
+    String mailboxName;
+
+    @Override
+    public Integer call() {
+        try {
+            MailboxClient mailboxClient = mailboxCommand.fullyQualifiedURL("/users");
+            Response rs = mailboxClient.createAMailbox(userName, mailboxName);
+            if (rs.status() == CREATED_CODE) {
+                mailboxCommand.out.println("The mailbox was created successfully.");
+                return WebAdminCli.CLI_FINISHED_SUCCEED;
+            } else if (rs.status() == INVALID_MAILBOX_NAME_CODE) {
+                mailboxCommand.out.println("Invalid mailbox name.\n" +
+                    "Resource name mailboxNameToBeCreated should not be empty, nor contain # & % * characters.");
+                return WebAdminCli.CLI_FINISHED_FAILED;
+            } else if (rs.status() == USERNAME_NOT_EXIST_CODE) {
+                mailboxCommand.out.println("The user name does not exist.\n" +
+                    "Resource name usernameToBeUsed should be an existing user.");
+                return WebAdminCli.CLI_FINISHED_FAILED;
+            }
+            return WebAdminCli.CLI_FINISHED_FAILED;
+        } catch (Exception e) {
+            e.printStackTrace(mailboxCommand.err);
+            return WebAdminCli.CLI_FINISHED_FAILED;
+        }
+    }
+
+}

--- a/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxCreateCommand.java
+++ b/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxCreateCommand.java
@@ -33,7 +33,7 @@ import picocli.CommandLine;
 public class MailboxCreateCommand implements Callable<Integer> {
 
     public static final int CREATED_CODE = 204;
-    public static final int INVALID_MAILBOX_NAME_CODE = 400;
+    public static final int BAD_REQUEST_CODE = 400;
     public static final int USERNAME_NOT_EXIST_CODE = 404;
 
     @CommandLine.ParentCommand MailboxCommand mailboxCommand;
@@ -52,13 +52,11 @@ public class MailboxCreateCommand implements Callable<Integer> {
             if (rs.status() == CREATED_CODE) {
                 mailboxCommand.out.println("The mailbox was created successfully.");
                 return WebAdminCli.CLI_FINISHED_SUCCEED;
-            } else if (rs.status() == INVALID_MAILBOX_NAME_CODE) {
-                mailboxCommand.out.println("Invalid mailbox name.\n" +
-                    "Resource name mailboxNameToBeCreated should not be empty, nor contain # & % * characters.");
+            } else if (rs.status() == BAD_REQUEST_CODE) {
+                mailboxCommand.err.println(rs.body());
                 return WebAdminCli.CLI_FINISHED_FAILED;
             } else if (rs.status() == USERNAME_NOT_EXIST_CODE) {
-                mailboxCommand.out.println("The user name does not exist.\n" +
-                    "Resource name usernameToBeUsed should be an existing user.");
+                mailboxCommand.err.println(rs.body());
                 return WebAdminCli.CLI_FINISHED_FAILED;
             }
             return WebAdminCli.CLI_FINISHED_FAILED;

--- a/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxDeleteAllCommand.java
+++ b/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxDeleteAllCommand.java
@@ -19,12 +19,13 @@
 
 package org.apache.james.cli.mailbox;
 
-import feign.Response;
+import java.util.concurrent.Callable;
+
 import org.apache.james.cli.WebAdminCli;
 import org.apache.james.httpclient.MailboxClient;
-import picocli.CommandLine;
 
-import java.util.concurrent.Callable;
+import feign.Response;
+import picocli.CommandLine;
 
 @CommandLine.Command(
         name = "deleteAll",

--- a/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxDeleteAllCommand.java
+++ b/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxDeleteAllCommand.java
@@ -19,43 +19,44 @@
 
 package org.apache.james.cli.mailbox;
 
-import java.io.PrintStream;
-import java.util.concurrent.Callable;
-
+import feign.Response;
 import org.apache.james.cli.WebAdminCli;
 import org.apache.james.httpclient.MailboxClient;
-
 import picocli.CommandLine;
 
+import java.util.concurrent.Callable;
+
 @CommandLine.Command(
-    name = "mailbox",
-    description = "Manage Mailboxes",
-    subcommands = {
-        MailboxCreateCommand.class,
-        MailboxExistCommand.class,
-        MailboxListCommand.class,
-        MailboxDeleteCommand.class,
-        MailboxDeleteAllCommand.class
-    })
-public class MailboxCommand implements Callable<Integer> {
+        name = "deleteAll",
+        description = "Delete all mailboxes of a user")
+public class MailboxDeleteAllCommand implements Callable<Integer> {
 
-    protected final WebAdminCli webAdminCli;
-    protected final PrintStream out;
-    protected final PrintStream err;
+    public static final int DELETED_CODE = 204;
+    public static final int NOT_FOUND_CODE = 404;
 
-    public MailboxCommand(PrintStream out, WebAdminCli webAdminCli, PrintStream err) {
-        this.out = out;
-        this.webAdminCli = webAdminCli;
-        this.err = err;
-    }
+    @CommandLine.ParentCommand MailboxCommand mailboxCommand;
+
+    @CommandLine.Parameters(description = "Username")
+    String userName;
 
     @Override
     public Integer call() {
-        return WebAdminCli.CLI_FINISHED_SUCCEED;
-    }
-
-    public MailboxClient fullyQualifiedURL(String partOfUrl) {
-        return webAdminCli.feignClientFactory(err).target(MailboxClient.class, webAdminCli.jamesUrl + partOfUrl);
+        try {
+            MailboxClient mailboxClient = mailboxCommand.fullyQualifiedURL("/users");
+            Response rs = mailboxClient.deleteAllMailboxes(userName);
+            if (rs.status() == DELETED_CODE) {
+                mailboxCommand.out.println("The user do not have mailboxes anymore.");
+                return WebAdminCli.CLI_FINISHED_SUCCEED;
+            } else if (rs.status() == NOT_FOUND_CODE) {
+                mailboxCommand.err.println("The user name does not exist.");
+                return WebAdminCli.CLI_FINISHED_FAILED;
+            }
+            return WebAdminCli.CLI_FINISHED_FAILED;
+        } catch (Exception e) {
+            e.printStackTrace(mailboxCommand.err);
+            return WebAdminCli.CLI_FINISHED_FAILED;
+        }
     }
 
 }
+

--- a/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxDeleteCommand.java
+++ b/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxDeleteCommand.java
@@ -19,42 +19,52 @@
 
 package org.apache.james.cli.mailbox;
 
-import java.io.PrintStream;
 import java.util.concurrent.Callable;
 
 import org.apache.james.cli.WebAdminCli;
 import org.apache.james.httpclient.MailboxClient;
 
+import feign.Response;
 import picocli.CommandLine;
 
 @CommandLine.Command(
-    name = "mailbox",
-    description = "Manage Mailboxes",
-    subcommands = {
-        MailboxCreateCommand.class,
-        MailboxExistCommand.class,
-        MailboxListCommand.class,
-        MailboxDeleteCommand.class
-    })
-public class MailboxCommand implements Callable<Integer> {
+    name = "delete",
+    description = "Delete a mailbox and its children")
+public class MailboxDeleteCommand implements Callable<Integer> {
 
-    protected final WebAdminCli webAdminCli;
-    protected final PrintStream out;
-    protected final PrintStream err;
+    public static final int DELETED_CODE = 204;
+    public static final int BAD_REQUEST_CODE = 400;
+    public static final int NOT_FOUND_CODE = 404;
 
-    public MailboxCommand(PrintStream out, WebAdminCli webAdminCli, PrintStream err) {
-        this.out = out;
-        this.webAdminCli = webAdminCli;
-        this.err = err;
-    }
+    @CommandLine.ParentCommand MailboxCommand mailboxCommand;
+
+    @CommandLine.Parameters(description = "Username")
+    String userName;
+
+    @CommandLine.Parameters (description = "Mailbox's name to be deleted")
+    String mailboxName;
+
 
     @Override
     public Integer call() {
-        return WebAdminCli.CLI_FINISHED_SUCCEED;
-    }
-
-    public MailboxClient fullyQualifiedURL(String partOfUrl) {
-        return webAdminCli.feignClientFactory(err).target(MailboxClient.class, webAdminCli.jamesUrl + partOfUrl);
+        try {
+            MailboxClient mailboxClient = mailboxCommand.fullyQualifiedURL("/users");
+            Response rs = mailboxClient.deleteAMailbox(userName, mailboxName);
+            if (rs.status() == DELETED_CODE) {
+                mailboxCommand.out.println("The mailbox now does not exist on the server.");
+                return WebAdminCli.CLI_FINISHED_SUCCEED;
+            } else if (rs.status() == BAD_REQUEST_CODE) {
+                mailboxCommand.err.println(rs.body());
+                return WebAdminCli.CLI_FINISHED_FAILED;
+            } else if (rs.status() == NOT_FOUND_CODE) {
+                mailboxCommand.err.println(rs.body());
+                return WebAdminCli.CLI_FINISHED_FAILED;
+            }
+            return WebAdminCli.CLI_FINISHED_FAILED;
+        } catch (Exception e) {
+            e.printStackTrace(mailboxCommand.err);
+            return WebAdminCli.CLI_FINISHED_FAILED;
+        }
     }
 
 }

--- a/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxExistCommand.java
+++ b/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxExistCommand.java
@@ -53,8 +53,7 @@ public class MailboxExistCommand implements Callable<Integer> {
                 mailboxCommand.out.println("The mailbox exists.");
                 return WebAdminCli.CLI_FINISHED_SUCCEED;
             } else if (rs.status() == INVALID_MAILBOX_NAME_CODE) {
-                mailboxCommand.out.println("Invalid mailbox name\n" +
-                    "Resource name mailboxNameToBeTested should not be empty, nor contain # & % * characters.");
+                mailboxCommand.err.println(rs.body());
                 return WebAdminCli.CLI_FINISHED_FAILED;
             } else if (rs.status() == NOT_EXISTED_CODE) {
                 mailboxCommand.out.println("Either the user name or the mailbox does not exist.");

--- a/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxExistCommand.java
+++ b/server/protocols/webadmin-cli/src/main/java/org/apache/james/cli/mailbox/MailboxExistCommand.java
@@ -1,0 +1,72 @@
+/******************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one     *
+ * or more contributor license agreements.  See the NOTICE file   *
+ * distributed with this work for additional information          *
+ * regarding copyright ownership.  The ASF licenses this file     *
+ * to you under the Apache License, Version 2.0 (the              *
+ * "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at     *
+ *                                                                *
+ * http://www.apache.org/licenses/LICENSE-2.0                     *
+ *                                                                *
+ * Unless required by applicable law or agreed to in writing,     *
+ * software distributed under the License is distributed on an    *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY         *
+ * KIND, either express or implied.  See the License for the      *
+ * specific language governing permissions and limitations        *
+ * under the License.                                             *
+ ******************************************************************/
+
+package org.apache.james.cli.mailbox;
+
+import java.util.concurrent.Callable;
+
+import org.apache.james.cli.WebAdminCli;
+import org.apache.james.httpclient.MailboxClient;
+
+import feign.Response;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "exist",
+    description = "Check if a mailbox exists")
+public class MailboxExistCommand implements Callable<Integer> {
+
+    public static final int EXISTED_CODE = 204;
+    public static final int INVALID_MAILBOX_NAME_CODE = 400;
+    public static final int NOT_EXISTED_CODE = 404;
+
+    @CommandLine.ParentCommand MailboxCommand mailboxCommand;
+
+    @CommandLine.Parameters(description = "Username to be checked")
+    String userName;
+
+    @CommandLine.Parameters(description = "Mailbox's name to be tested existence")
+    String mailboxName;
+
+    @Override
+    public Integer call() {
+        try {
+            MailboxClient mailboxClient = mailboxCommand.fullyQualifiedURL("/users");
+            Response rs = mailboxClient.doesExist(userName, mailboxName);
+            if (rs.status() == EXISTED_CODE) {
+                mailboxCommand.out.println("The mailbox exists.");
+                return WebAdminCli.CLI_FINISHED_SUCCEED;
+            } else if (rs.status() == INVALID_MAILBOX_NAME_CODE) {
+                mailboxCommand.out.println("Invalid mailbox name\n" +
+                    "Resource name mailboxNameToBeTested should not be empty, nor contain # & % * characters.");
+                return WebAdminCli.CLI_FINISHED_FAILED;
+            } else if (rs.status() == NOT_EXISTED_CODE) {
+                mailboxCommand.out.println("Either the user name or the mailbox does not exist.");
+                return WebAdminCli.CLI_FINISHED_SUCCEED;
+            }
+            return WebAdminCli.CLI_FINISHED_FAILED;
+        } catch (Exception e) {
+            e.printStackTrace(mailboxCommand.err);
+            return WebAdminCli.CLI_FINISHED_FAILED;
+        }
+    }
+
+}
+
+

--- a/server/protocols/webadmin-cli/src/main/java/org/apache/james/httpclient/MailboxClient.java
+++ b/server/protocols/webadmin-cli/src/main/java/org/apache/james/httpclient/MailboxClient.java
@@ -28,4 +28,7 @@ public interface MailboxClient {
     @RequestLine("PUT /{userNameToBeUsed}/mailboxes/{mailboxNameToBeCreated}")
     Response createAMailbox(@Param("userNameToBeUsed") String userName, @Param("mailboxNameToBeCreated") String mailboxName);
 
+    @RequestLine("GET /{usernameToBeUsed}/mailboxes/{mailboxNameToBeTested}")
+    Response doesExist(@Param("usernameToBeUsed") String userName, @Param("mailboxNameToBeTested") String mailboxName);
+
 }

--- a/server/protocols/webadmin-cli/src/main/java/org/apache/james/httpclient/MailboxClient.java
+++ b/server/protocols/webadmin-cli/src/main/java/org/apache/james/httpclient/MailboxClient.java
@@ -37,4 +37,7 @@ public interface MailboxClient {
     @RequestLine("DELETE /{usernameToBeUsed}/mailboxes/{mailboxNameToBeDeleted}")
     Response deleteAMailbox(@Param("usernameToBeUsed") String userName, @Param("mailboxNameToBeDeleted") String mailboxName);
 
+    @RequestLine("DELETE /{usernameToBeUsed}/mailboxes")
+    Response deleteAllMailboxes(@Param("usernameToBeUsed") String userName);
+
 }

--- a/server/protocols/webadmin-cli/src/main/java/org/apache/james/httpclient/MailboxClient.java
+++ b/server/protocols/webadmin-cli/src/main/java/org/apache/james/httpclient/MailboxClient.java
@@ -1,0 +1,31 @@
+/******************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one     *
+ * or more contributor license agreements.  See the NOTICE file   *
+ * distributed with this work for additional information          *
+ * regarding copyright ownership.  The ASF licenses this file     *
+ * to you under the Apache License, Version 2.0 (the              *
+ * "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at     *
+ *                                                                *
+ * http://www.apache.org/licenses/LICENSE-2.0                     *
+ *                                                                *
+ * Unless required by applicable law or agreed to in writing,     *
+ * software distributed under the License is distributed on an    *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY         *
+ * KIND, either express or implied.  See the License for the      *
+ * specific language governing permissions and limitations        *
+ * under the License.                                             *
+ ******************************************************************/
+
+package org.apache.james.httpclient;
+
+import feign.Param;
+import feign.RequestLine;
+import feign.Response;
+
+public interface MailboxClient {
+
+    @RequestLine("PUT /{userNameToBeUsed}/mailboxes/{mailboxNameToBeCreated}")
+    Response createAMailbox(@Param("userNameToBeUsed") String userName, @Param("mailboxNameToBeCreated") String mailboxName);
+
+}

--- a/server/protocols/webadmin-cli/src/main/java/org/apache/james/httpclient/MailboxClient.java
+++ b/server/protocols/webadmin-cli/src/main/java/org/apache/james/httpclient/MailboxClient.java
@@ -34,4 +34,7 @@ public interface MailboxClient {
     @RequestLine("GET /{usernameToBeUsed}/mailboxes")
     Response getMailboxList(@Param("usernameToBeUsed") String userName);
 
+    @RequestLine("DELETE /{usernameToBeUsed}/mailboxes/{mailboxNameToBeDeleted}")
+    Response deleteAMailbox(@Param("usernameToBeUsed") String userName, @Param("mailboxNameToBeDeleted") String mailboxName);
+
 }

--- a/server/protocols/webadmin-cli/src/main/java/org/apache/james/httpclient/model/MailboxName.java
+++ b/server/protocols/webadmin-cli/src/main/java/org/apache/james/httpclient/model/MailboxName.java
@@ -17,21 +17,21 @@
  * under the License.                                             *
  ******************************************************************/
 
-package org.apache.james.httpclient;
+package org.apache.james.httpclient.model;
 
-import feign.Param;
-import feign.RequestLine;
-import feign.Response;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-public interface MailboxClient {
+public class MailboxName {
 
-    @RequestLine("PUT /{userNameToBeUsed}/mailboxes/{mailboxNameToBeCreated}")
-    Response createAMailbox(@Param("userNameToBeUsed") String userName, @Param("mailboxNameToBeCreated") String mailboxName);
+    @JsonProperty("mailboxName")
+    private String mailboxName;
 
-    @RequestLine("GET /{usernameToBeUsed}/mailboxes/{mailboxNameToBeTested}")
-    Response doesExist(@Param("usernameToBeUsed") String userName, @Param("mailboxNameToBeTested") String mailboxName);
+    @JsonProperty("mailboxId")
+    private String mailboxId;
 
-    @RequestLine("GET /{usernameToBeUsed}/mailboxes")
-    Response getMailboxList(@Param("usernameToBeUsed") String userName);
+    public String getMailboxName() {
+        return mailboxName;
+    }
 
 }

--- a/server/protocols/webadmin-cli/src/main/java/org/apache/james/httpclient/model/MailboxName.java
+++ b/server/protocols/webadmin-cli/src/main/java/org/apache/james/httpclient/model/MailboxName.java
@@ -19,7 +19,6 @@
 
 package org.apache.james.httpclient.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class MailboxName {

--- a/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
+++ b/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
@@ -185,4 +185,68 @@ public class MailboxManageTest {
         assertThat(outputStreamCaptor.toString()).isEmpty();
     }
 
+    @Test
+    void mailboxDeleteAParentMailboxWithTwoAddedChildrenMailboxShouldDeleteThemAll(GuiceJamesServer server) throws Exception {
+        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
+        dataProbe = server.getProbe(DataProbeImpl.class);
+        dataProbe.fluent().addDomain("linagora.com")
+            .addUser("hqtran@linagora.com", "123456");
+
+        WebAdminCli.executeFluent(new PrintStream(new ByteArrayOutputStream()), new PrintStream(new ByteArrayOutputStream()),
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "create", "hqtran@linagora.com", "INBOX.1");
+
+        WebAdminCli.executeFluent(new PrintStream(new ByteArrayOutputStream()), new PrintStream(new ByteArrayOutputStream()),
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "create", "hqtran@linagora.com", "INBOX.2");
+
+        int exitCode = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "delete", "hqtran@linagora.com", "INBOX");
+
+        WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
+                "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "list", "hqtran@linagora.com");
+
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("The mailbox now does not exist on the server.");
+    }
+
+    @Test
+    void mailboxDeleteWithNonExistingUsernameShouldFail(GuiceJamesServer server) throws Exception {
+        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
+        dataProbe = server.getProbe(DataProbeImpl.class);
+        dataProbe.fluent().addDomain("linagora.com");
+
+        int exitCode = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
+                "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "delete", "hqtran@linagora.com", "INBOX");
+
+        assertThat(exitCode).isEqualTo(1);
+        assertThat(errorStreamCaptor.toString()).contains("User does not exist");
+    }
+
+    @Test
+    void mailboxDeleteWithInvalidMailboxNameShouldFail(GuiceJamesServer server) throws Exception {
+        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
+        dataProbe = server.getProbe(DataProbeImpl.class);
+        dataProbe.fluent().addDomain("linagora.com")
+                .addUser("hqtran@linagora.com", "123456");
+
+        int exitCode = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
+                "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "delete", "hqtran@linagora.com", "IN#BOX");
+
+        assertThat(exitCode).isEqualTo(1);
+        assertThat(errorStreamCaptor.toString()).contains("Attempt to delete an invalid mailbox");
+    }
+
+    @Test
+    void mailboxDeleteWithInvalidUsernameShouldFail(GuiceJamesServer server) throws Exception {
+        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
+        dataProbe = server.getProbe(DataProbeImpl.class);
+        dataProbe.fluent().addDomain("linagora.com")
+                .addUser("hqtran@linagora.com", "123456");
+
+        int exitCode = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
+                "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "delete", "hqtr@an@linagora.com", "INBOX");
+
+        assertThat(exitCode).isEqualTo(1);
+        assertThat(errorStreamCaptor.toString()).contains("Attempt to delete an invalid mailbox");
+    }
+
 }

--- a/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
+++ b/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
@@ -95,4 +95,62 @@ public class MailboxManageTest {
             "Resource name usernameToBeUsed should be an existing user.");
     }
 
+    @Test
+    void mailboxExistWithExistedUsernameAndExistedMailboxNameShouldSucceed(GuiceJamesServer server) throws Exception {
+        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
+        dataProbe = server.getProbe(DataProbeImpl.class);
+        dataProbe.fluent().addDomain("linagora.com")
+            .addUser("hqtran@linagora.com", "123456");
+
+        WebAdminCli.executeFluent(new PrintStream(new ByteArrayOutputStream()), new PrintStream(new ByteArrayOutputStream()),
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "create", "hqtran@linagora.com", "INBOX");
+
+        int exitCode = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "exist", "hqtran@linagora.com", "INBOX");
+
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("The mailbox exists.");
+    }
+
+    @Test
+    void mailboxExistWithInvalidMailboxNameShouldFail(GuiceJamesServer server) throws Exception {
+        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
+        dataProbe = server.getProbe(DataProbeImpl.class);
+        dataProbe.fluent().addDomain("linagora.com")
+            .addUser("hqtran@linagora.com", "123456");
+
+        int exitCode = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "exist", "hqtran@linagora.com", "#INBOX");
+
+        assertThat(exitCode).isEqualTo(1);
+        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("Invalid mailbox name\n" +
+            "Resource name mailboxNameToBeTested should not be empty, nor contain # & % * characters.");
+    }
+
+    @Test
+    void mailboxExistWithExistedUserAndNonExistingMailboxNameShouldFail(GuiceJamesServer server) throws Exception {
+        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
+        dataProbe = server.getProbe(DataProbeImpl.class);
+        dataProbe.fluent().addDomain("linagora.com")
+            .addUser("hqtran@linagora.com", "123456");
+
+        int exitCode = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "exist", "hqtran@linagora.com", "INBOX");
+
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("Either the user name or the mailbox does not exist.");
+    }
+
+    @Test
+    void mailboxExistWithNonExistingUserAndNonExistingMailboxNameShouldFail(GuiceJamesServer server) {
+        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
+        dataProbe = server.getProbe(DataProbeImpl.class);
+
+        int exitCode = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "exist", "hqtran@linagora.com", "INBOX");
+
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("Either the user name or the mailbox does not exist.");
+    }
+
 }

--- a/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
+++ b/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
@@ -33,6 +33,7 @@ import org.apache.james.util.Port;
 import org.apache.james.utils.DataProbeImpl;
 import org.apache.james.utils.WebAdminGuiceProbe;
 import org.apache.james.webadmin.integration.WebadminIntegrationTestModule;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -49,6 +50,13 @@ public class MailboxManageTest {
     private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
     private final ByteArrayOutputStream errorStreamCaptor = new ByteArrayOutputStream();
     private DataProbeImpl dataProbe;
+    private Port port;
+
+    @BeforeEach
+    void setUp(GuiceJamesServer server) {
+        port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
+        dataProbe = server.getProbe(DataProbeImpl.class);
+    }
 
     @Test
     void mailboxCreateWithExistedUsernameAndValidMailboxNameShouldSucceed(GuiceJamesServer server) throws Exception {
@@ -247,9 +255,7 @@ public class MailboxManageTest {
     }
 
     @Test
-    void mailboxDeleteAllWithExistingUserShouldDeleteAllMailboxes(GuiceJamesServer server) throws Exception {
-        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
-        dataProbe = server.getProbe(DataProbeImpl.class);
+    void mailboxDeleteAllWithExistingUserShouldDeleteAllMailboxes() throws Exception {
         dataProbe.fluent().addDomain("linagora.com")
                 .addUser("hqtran@linagora.com", "123456");
 
@@ -270,9 +276,7 @@ public class MailboxManageTest {
     }
 
     @Test
-    void mailboxDeleteAllWithNonExistingUsernameShouldFail(GuiceJamesServer server) throws Exception {
-        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
-        dataProbe = server.getProbe(DataProbeImpl.class);
+    void mailboxDeleteAllWithNonExistingUsernameShouldFail() throws Exception {
         dataProbe.fluent().addDomain("linagora.com");
 
         int exitCode = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),

--- a/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
+++ b/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
@@ -144,9 +144,7 @@ public class MailboxManageTest {
     }
 
     @Test
-    void mailboxListWithTwoAddedMailboxesAndExistedUsernameShouldShowMailboxesNameExactly(GuiceJamesServer server) throws Exception {
-        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
-        dataProbe = server.getProbe(DataProbeImpl.class);
+    void mailboxListWithTwoAddedMailboxesAndExistedUsernameShouldShowMailboxesNameExactly() throws Exception {
         dataProbe.fluent().addDomain("linagora.com")
             .addUser("hqtran@linagora.com", "123456");
 
@@ -164,10 +162,7 @@ public class MailboxManageTest {
     }
 
     @Test
-    void mailboxListWithNonExistingUsernameShouldFail(GuiceJamesServer server) {
-        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
-
-
+    void mailboxListWithNonExistingUsernameShouldFail() {
         int exitCode = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
             "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "list", "hqtran@linagora.com");
 

--- a/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
+++ b/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
@@ -292,8 +292,7 @@ public class MailboxManageTest {
                 "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "list", "hqtran@linagora.com");
 
         assertThat(exitCode).isEqualTo(0);
-        assertThat(outputStreamCaptor.toString()).isEqualTo("The user do not have mailboxes anymore.\n"
-            + "");
+        assertThat(outputStreamCaptor.toString()).isEqualTo("The user do not have mailboxes anymore.\n");
     }
 
     @Test

--- a/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
+++ b/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
@@ -223,7 +223,8 @@ public class MailboxManageTest {
                 "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "list", "hqtran@linagora.com");
 
         assertThat(exitCode).isEqualTo(0);
-        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("The mailbox now does not exist on the server.");
+        assertThat(outputStreamCaptor.toString()).isEqualTo("The mailbox now does not exist on the server.\n"
+            + "");
     }
 
     @Test
@@ -279,7 +280,8 @@ public class MailboxManageTest {
                 "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "list", "hqtran@linagora.com");
 
         assertThat(exitCode).isEqualTo(0);
-        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("The user do not have mailboxes anymore.");
+        assertThat(outputStreamCaptor.toString()).isEqualTo("The user do not have mailboxes anymore.\n"
+            + "");
     }
 
     @Test

--- a/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
+++ b/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
@@ -121,8 +121,7 @@ public class MailboxManageTest {
             "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "exist", "hqtran@linagora.com", "#INBOX");
 
         assertThat(exitCode).isEqualTo(1);
-        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("Invalid mailbox name\n" +
-            "Resource name mailboxNameToBeTested should not be empty, nor contain # & % * characters.");
+        assertThat(errorStreamCaptor.toString()).contains("400");
     }
 
     @Test

--- a/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
+++ b/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
@@ -184,16 +184,28 @@ public class MailboxManageTest {
             .addUser("hqtran@linagora.com", "123456");
 
         WebAdminCli.executeFluent(new PrintStream(new ByteArrayOutputStream()), new PrintStream(new ByteArrayOutputStream()),
-            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "create", "hqtran@linagora.com", "INBOX.1");
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "create", "hqtran@linagora.com", "INBOX1");
 
         WebAdminCli.executeFluent(new PrintStream(new ByteArrayOutputStream()), new PrintStream(new ByteArrayOutputStream()),
-            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "create", "hqtran@linagora.com", "INBOX.2");
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "create", "hqtran@linagora.com", "INBOX2");
 
         int exitCode = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
             "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "list", "hqtran@linagora.com");
 
         assertThat(exitCode).isEqualTo(0);
-        assertThat(outputStreamCaptor.toString()).isEqualTo("INBOX\nINBOX.1\nINBOX.2\n");
+        assertThat(outputStreamCaptor.toString()).isEqualTo("INBOX1\nINBOX2\n");
+    }
+
+    @Test
+    void mailboxListWithAValidUserAndNonExistingMailboxesShouldShowNothing() throws Exception {
+        dataProbe.fluent().addDomain("linagora.com")
+            .addUser("hqtran@linagora.com", "123456");
+
+        int exitCode = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "list", "hqtran@linagora.com");
+
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(outputStreamCaptor.toString()).isEqualTo("");
     }
 
     @Test

--- a/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
+++ b/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
@@ -96,9 +96,7 @@ public class MailboxManageTest {
     }
 
     @Test
-    void mailboxExistWithExistedUsernameAndExistedMailboxNameShouldSucceed(GuiceJamesServer server) throws Exception {
-        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
-        dataProbe = server.getProbe(DataProbeImpl.class);
+    void mailboxExistWithExistedUsernameAndExistedMailboxNameShouldSucceed() throws Exception {
         dataProbe.fluent().addDomain("linagora.com")
             .addUser("hqtran@linagora.com", "123456");
 
@@ -113,9 +111,7 @@ public class MailboxManageTest {
     }
 
     @Test
-    void mailboxExistWithInvalidMailboxNameShouldFail(GuiceJamesServer server) throws Exception {
-        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
-        dataProbe = server.getProbe(DataProbeImpl.class);
+    void mailboxExistWithInvalidMailboxNameShouldFail() throws Exception {
         dataProbe.fluent().addDomain("linagora.com")
             .addUser("hqtran@linagora.com", "123456");
 
@@ -127,9 +123,7 @@ public class MailboxManageTest {
     }
 
     @Test
-    void mailboxExistWithExistedUserAndNonExistingMailboxNameShouldFail(GuiceJamesServer server) throws Exception {
-        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
-        dataProbe = server.getProbe(DataProbeImpl.class);
+    void mailboxExistWithExistedUserAndNonExistingMailboxNameShouldFail() throws Exception {
         dataProbe.fluent().addDomain("linagora.com")
             .addUser("hqtran@linagora.com", "123456");
 
@@ -141,10 +135,7 @@ public class MailboxManageTest {
     }
 
     @Test
-    void mailboxExistWithNonExistingUserAndNonExistingMailboxNameShouldFail(GuiceJamesServer server) {
-        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
-        dataProbe = server.getProbe(DataProbeImpl.class);
-
+    void mailboxExistWithNonExistingUserAndNonExistingMailboxNameShouldFail() {
         int exitCode = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
             "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "exist", "hqtran@linagora.com", "INBOX");
 

--- a/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
+++ b/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
@@ -59,9 +59,7 @@ public class MailboxManageTest {
     }
 
     @Test
-    void mailboxCreateWithExistedUsernameAndValidMailboxNameShouldSucceed(GuiceJamesServer server) throws Exception {
-        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
-        dataProbe = server.getProbe(DataProbeImpl.class);
+    void mailboxCreateWithExistedUsernameAndValidMailboxNameShouldSucceed() throws Exception {
         dataProbe.fluent().addDomain("linagora.com")
             .addUser("hqtran@linagora.com", "123456");
 
@@ -77,9 +75,7 @@ public class MailboxManageTest {
     }
 
     @Test
-    void mailboxCreateWithExistedUsernameAndInvalidMailboxNameShouldFail(GuiceJamesServer server) throws Exception {
-        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
-        dataProbe = server.getProbe(DataProbeImpl.class);
+    void mailboxCreateWithExistedUsernameAndInvalidMailboxNameShouldFail() throws Exception {
         dataProbe.fluent().addDomain("linagora.com")
             .addUser("hqtran@linagora.com", "123456");
 
@@ -91,9 +87,7 @@ public class MailboxManageTest {
     }
 
     @Test
-    void mailboxCreateWithNonExistingUsernameShouldFail(GuiceJamesServer server) {
-        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
-
+    void mailboxCreateWithNonExistingUsernameShouldFail() {
         int exitCode = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
             "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "create", "hqtran@linagora.com", "INBOX");
 

--- a/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
+++ b/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
@@ -235,8 +235,7 @@ public class MailboxManageTest {
                 "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "list", "hqtran@linagora.com");
 
         assertThat(exitCode).isEqualTo(0);
-        assertThat(outputStreamCaptor.toString()).isEqualTo("The mailbox now does not exist on the server.\n"
-            + "");
+        assertThat(outputStreamCaptor.toString()).isEqualTo("The mailbox now does not exist on the server.\n");
     }
 
     @Test

--- a/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
+++ b/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
@@ -292,6 +292,7 @@ public class MailboxManageTest {
                 "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "list", "hqtran@linagora.com");
 
         assertThat(exitCode).isEqualTo(0);
+        // The outputStreamCaptor should capture the result of deleteAll command and the result of list command(which is nothing)
         assertThat(outputStreamCaptor.toString()).isEqualTo("The user do not have mailboxes anymore.\n");
     }
 

--- a/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
+++ b/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
@@ -70,7 +70,7 @@ public class MailboxManageTest {
             "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "exist", "hqtran@linagora.com", "INBOX");
 
         assertThat(exitCode).isEqualTo(0);
-        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("The mailbox was created successfully.\n" +
+        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("The mailbox now exists on the server.\n" +
             "The mailbox exists.");
     }
 
@@ -93,6 +93,41 @@ public class MailboxManageTest {
 
         assertThat(exitCode).isEqualTo(1);
         assertThat(errorStreamCaptor.toString()).contains("404");
+    }
+
+    @Test
+    void mailboxCreateWithAlreadyExistingMailboxShouldSucceed() throws Exception {
+        dataProbe.fluent().addDomain("linagora.com")
+            .addUser("hqtran@linagora.com", "123456");
+
+        int exitCode = WebAdminCli.executeFluent(new PrintStream(new ByteArrayOutputStream()), new PrintStream(new ByteArrayOutputStream()),
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "create", "hqtran@linagora.com", "INBOX");
+
+        int exitCode2 = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "create", "hqtran@linagora.com", "INBOX");
+
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(exitCode2).isEqualTo(0);
+        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("The mailbox now exists on the server.");
+    }
+
+    @Test
+    void mailboxCreateSubMailboxesShouldSucceed() throws Exception {
+        dataProbe.fluent().addDomain("linagora.com")
+            .addUser("hqtran@linagora.com", "123456");
+
+        int exitCode = WebAdminCli.executeFluent(new PrintStream(new ByteArrayOutputStream()), new PrintStream(new ByteArrayOutputStream()),
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "create", "hqtran@linagora.com", "INBOX.1");
+
+        int exitCode2 = WebAdminCli.executeFluent(new PrintStream(new ByteArrayOutputStream()), new PrintStream(new ByteArrayOutputStream()),
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "create", "hqtran@linagora.com", "INBOX.2");
+
+        WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "list", "hqtran@linagora.com");
+
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(exitCode2).isEqualTo(0);
+        assertThat(outputStreamCaptor.toString()).isEqualTo("INBOX\nINBOX.1\nINBOX.2\n");
     }
 
     @Test

--- a/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
+++ b/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
@@ -235,6 +235,7 @@ public class MailboxManageTest {
                 "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "list", "hqtran@linagora.com");
 
         assertThat(exitCode).isEqualTo(0);
+        // The outputStreamCaptor should capture the result of delete command and the result of list command(which is nothing)
         assertThat(outputStreamCaptor.toString()).isEqualTo("The mailbox now does not exist on the server.\n");
     }
 

--- a/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
+++ b/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
@@ -79,8 +79,7 @@ public class MailboxManageTest {
             "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "create", "hqtran@linagora.com", "#&%*INBOX");
 
         assertThat(exitCode).isEqualTo(1);
-        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("Invalid mailbox name.\n" +
-            "Resource name mailboxNameToBeCreated should not be empty, nor contain # & % * characters.");
+        assertThat(errorStreamCaptor.toString()).contains("400");
     }
 
     @Test
@@ -91,8 +90,7 @@ public class MailboxManageTest {
             "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "create", "hqtran@linagora.com", "INBOX");
 
         assertThat(exitCode).isEqualTo(1);
-        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("The user name does not exist.\n" +
-            "Resource name usernameToBeUsed should be an existing user.");
+        assertThat(errorStreamCaptor.toString()).contains("404");
     }
 
     @Test

--- a/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
+++ b/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
@@ -1,0 +1,98 @@
+/******************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one     *
+ * or more contributor license agreements.  See the NOTICE file   *
+ * distributed with this work for additional information          *
+ * regarding copyright ownership.  The ASF licenses this file     *
+ * to you under the Apache License, Version 2.0 (the              *
+ * "License"); you may not use this file except in compliance     *
+ * with the License.  You may obtain a copy of the License at     *
+ *                                                                *
+ * http://www.apache.org/licenses/LICENSE-2.0                     *
+ *                                                                *
+ * Unless required by applicable law or agreed to in writing,     *
+ * software distributed under the License is distributed on an    *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY         *
+ * KIND, either express or implied.  See the License for the      *
+ * specific language governing permissions and limitations        *
+ * under the License.                                             *
+ ******************************************************************/
+
+package org.apache.james.cli;
+
+import static org.apache.james.MemoryJamesServerMain.IN_MEMORY_SERVER_AGGREGATE_MODULE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.apache.james.GuiceJamesServer;
+import org.apache.james.JamesServerBuilder;
+import org.apache.james.JamesServerExtension;
+import org.apache.james.modules.TestJMAPServerModule;
+import org.apache.james.util.Port;
+import org.apache.james.utils.DataProbeImpl;
+import org.apache.james.utils.WebAdminGuiceProbe;
+import org.apache.james.webadmin.integration.WebadminIntegrationTestModule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class MailboxManageTest {
+
+    @RegisterExtension
+    static JamesServerExtension testExtension = new JamesServerBuilder<>(JamesServerBuilder.defaultConfigurationProvider())
+        .server(configuration -> GuiceJamesServer.forConfiguration(configuration)
+            .combineWith(IN_MEMORY_SERVER_AGGREGATE_MODULE)
+            .overrideWith(new WebadminIntegrationTestModule())
+            .overrideWith(new TestJMAPServerModule()))
+        .build();
+
+    private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream errorStreamCaptor = new ByteArrayOutputStream();
+    private DataProbeImpl dataProbe;
+
+    @Test
+    void mailboxCreateWithExistedUsernameAndValidMailboxNameShouldSucceed(GuiceJamesServer server) throws Exception {
+        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
+        dataProbe = server.getProbe(DataProbeImpl.class);
+        dataProbe.fluent().addDomain("linagora.com")
+            .addUser("hqtran@linagora.com", "123456");
+
+        int exitCode = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "create", "hqtran@linagora.com", "INBOX");
+
+        WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "exist", "hqtran@linagora.com", "INBOX");
+
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("The mailbox was created successfully.\n" +
+            "The mailbox exists.");
+    }
+
+    @Test
+    void mailboxCreateWithExistedUsernameAndInvalidMailboxNameShouldFail(GuiceJamesServer server) throws Exception {
+        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
+        dataProbe = server.getProbe(DataProbeImpl.class);
+        dataProbe.fluent().addDomain("linagora.com")
+            .addUser("hqtran@linagora.com", "123456");
+
+        int exitCode = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "create", "hqtran@linagora.com", "#&%*INBOX");
+
+        assertThat(exitCode).isEqualTo(1);
+        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("Invalid mailbox name.\n" +
+            "Resource name mailboxNameToBeCreated should not be empty, nor contain # & % * characters.");
+    }
+
+    @Test
+    void mailboxCreateWithNonExistingUsernameShouldFail(GuiceJamesServer server) {
+        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
+
+        int exitCode = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
+            "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "create", "hqtran@linagora.com", "INBOX");
+
+        assertThat(exitCode).isEqualTo(1);
+        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("The user name does not exist.\n" +
+            "Resource name usernameToBeUsed should be an existing user.");
+    }
+
+}

--- a/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
+++ b/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
@@ -171,9 +171,7 @@ public class MailboxManageTest {
     }
 
     @Test
-    void mailboxDeleteAParentMailboxWithTwoAddedChildrenMailboxShouldDeleteThemAll(GuiceJamesServer server) throws Exception {
-        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
-        dataProbe = server.getProbe(DataProbeImpl.class);
+    void mailboxDeleteAParentMailboxWithTwoAddedChildrenMailboxShouldDeleteThemAll() throws Exception {
         dataProbe.fluent().addDomain("linagora.com")
             .addUser("hqtran@linagora.com", "123456");
 
@@ -194,9 +192,7 @@ public class MailboxManageTest {
     }
 
     @Test
-    void mailboxDeleteWithNonExistingUsernameShouldFail(GuiceJamesServer server) throws Exception {
-        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
-        dataProbe = server.getProbe(DataProbeImpl.class);
+    void mailboxDeleteWithNonExistingUsernameShouldFail() throws Exception {
         dataProbe.fluent().addDomain("linagora.com");
 
         int exitCode = WebAdminCli.executeFluent(new PrintStream(outputStreamCaptor), new PrintStream(errorStreamCaptor),
@@ -207,9 +203,7 @@ public class MailboxManageTest {
     }
 
     @Test
-    void mailboxDeleteWithInvalidMailboxNameShouldFail(GuiceJamesServer server) throws Exception {
-        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
-        dataProbe = server.getProbe(DataProbeImpl.class);
+    void mailboxDeleteWithInvalidMailboxNameShouldFail() throws Exception {
         dataProbe.fluent().addDomain("linagora.com")
                 .addUser("hqtran@linagora.com", "123456");
 
@@ -221,9 +215,7 @@ public class MailboxManageTest {
     }
 
     @Test
-    void mailboxDeleteWithInvalidUsernameShouldFail(GuiceJamesServer server) throws Exception {
-        Port port = server.getProbe(WebAdminGuiceProbe.class).getWebAdminPort();
-        dataProbe = server.getProbe(DataProbeImpl.class);
+    void mailboxDeleteWithInvalidUsernameShouldFail() throws Exception {
         dataProbe.fluent().addDomain("linagora.com")
                 .addUser("hqtran@linagora.com", "123456");
 

--- a/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
+++ b/server/protocols/webadmin-cli/src/test/java/org/apache/james/cli/MailboxManageTest.java
@@ -70,7 +70,7 @@ public class MailboxManageTest {
             "--url", "http://127.0.0.1:" + port.getValue(), "mailbox", "exist", "hqtran@linagora.com", "INBOX");
 
         assertThat(exitCode).isEqualTo(0);
-        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("The mailbox now exists on the server.\n" +
+        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("The mailbox was created successfully.\n" +
             "The mailbox exists.");
     }
 
@@ -108,7 +108,7 @@ public class MailboxManageTest {
 
         assertThat(exitCode).isEqualTo(0);
         assertThat(exitCode2).isEqualTo(0);
-        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("The mailbox now exists on the server.");
+        assertThat(outputStreamCaptor.toString().trim()).isEqualTo("The mailbox was created successfully.");
     }
 
     @Test


### PR DESCRIPTION
During the coding process, i found a difference between james webadmin doc and reality.

https://james.apache.org/server/manage-webadmin.html#Listing_user_mailboxes            Listing user mailboxes part
The document write the response body is : 
```
[{"mailboxName":"INBOX"},{"mailboxName":"outbox"}]
```
But actually it is:
```
[{"mailboxName":"INBOX","mailboxId":"1"},{"mailboxName":"INBOX.1","mailboxId":"2"},{"mailboxName":"INBOX.2","mailboxId":"3"}]
```

  