### PR TITLE
JAMES-3466 Provision 'system' mailboxes only when listing mailboxes

### DIFF
--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SendMDNMethodTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SendMDNMethodTest.java
@@ -98,6 +98,7 @@ public abstract class SendMDNMethodTest {
         dataProbe.addUser(HOMER.asString(), PASSWORD);
         dataProbe.addUser(BART.asString(), BOB_PASSWORD);
         mailboxProbe.createMailbox("#private", HOMER.asString(), DefaultMailboxes.INBOX);
+        mailboxProbe.createMailbox("#private", HOMER.asString(), DefaultMailboxes.OUTBOX);
         homerAccessToken = authenticateJamesUser(baseUri(jmapServer), HOMER, PASSWORD);
         bartAccessToken = authenticateJamesUser(baseUri(jmapServer), BART, BOB_PASSWORD);
     }

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMailboxesMethodTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/SetMailboxesMethodTest.java
@@ -33,8 +33,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
@@ -84,6 +84,8 @@ public abstract class SetMailboxesMethodTest {
     private static final String DELETE_MESSAGES = String.valueOf(Right.DeleteMessages.asCharacter());
 
     private static final int MAILBOX_NAME_LENGTH_64K = 65536;
+    private MailboxId draftId;
+    private MailboxId outboxId;
 
     protected abstract GuiceJamesServer createJmapServer() throws IOException;
 
@@ -110,6 +112,10 @@ public abstract class SetMailboxesMethodTest {
         dataProbe.addDomain(DOMAIN);
         dataProbe.addUser(username.asString(), password);
         inboxId = mailboxProbe.createMailbox("#private", username.asString(), DefaultMailboxes.INBOX);
+        outboxId = mailboxProbe.createMailbox("#private", username.asString(), DefaultMailboxes.OUTBOX);
+        mailboxProbe.createMailbox("#private", username.asString(), DefaultMailboxes.TRASH);
+        mailboxProbe.createMailbox("#private", username.asString(), DefaultMailboxes.SENT);
+        draftId = mailboxProbe.createMailbox("#private", username.asString(), DefaultMailboxes.DRAFTS);
         accessToken = authenticateJamesUser(baseUri(jmapServer), username, password);
     }
 
@@ -606,11 +612,7 @@ public abstract class SetMailboxesMethodTest {
             .post("/jmap");
 
         assertThat(mailboxProbe.listSubscriptions(username.asString()))
-            .contains(DefaultMailboxes.OUTBOX,
-                DefaultMailboxes.SENT,
-                DefaultMailboxes.TRASH,
-                DefaultMailboxes.DRAFTS,
-                "mySecondBox");
+            .contains("mySecondBox");
     }
 
     @Test
@@ -635,10 +637,7 @@ public abstract class SetMailboxesMethodTest {
             .statusCode(200);
 
         assertThat(mailboxProbe.listSubscriptions(username.asString()))
-            .contains(DefaultMailboxes.OUTBOX,
-            DefaultMailboxes.SENT,
-            DefaultMailboxes.TRASH,
-            DefaultMailboxes.DRAFTS);
+            .isEmpty();
     }
 
     @Category(BasicFeature.class)
@@ -689,10 +688,7 @@ public abstract class SetMailboxesMethodTest {
             .statusCode(200);
 
         assertThat(mailboxProbe.listSubscriptions(username.asString()))
-            .contains(DefaultMailboxes.OUTBOX,
-                DefaultMailboxes.SENT,
-                DefaultMailboxes.TRASH,
-                DefaultMailboxes.DRAFTS);
+            .isEmpty();
     }
 
     @Test
@@ -2384,7 +2380,6 @@ public abstract class SetMailboxesMethodTest {
 
     @Test
     public void setMailboxesShouldReturnNotUpdatedWhenShareOutboxMailbox() {
-        MailboxId outboxId = mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, username.asString(), DefaultMailboxes.OUTBOX);
         String requestBody =
             "[" +
                 "  [ \"setMailboxes\"," +
@@ -2415,7 +2410,6 @@ public abstract class SetMailboxesMethodTest {
 
     @Test
     public void setMailboxesShouldReturnNotUpdatedWhenShareDraftMailbox() {
-        MailboxId draftId = mailboxProbe.createMailbox(MailboxConstants.USER_NAMESPACE, username.asString(), DefaultMailboxes.DRAFTS);
         String requestBody =
             "[" +
                 "  [ \"setMailboxes\"," +

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/cucumber/GetMailboxesMethodStepdefs.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/draft/methods/integration/cucumber/GetMailboxesMethodStepdefs.java
@@ -30,9 +30,12 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.apache.james.core.Username;
 import org.apache.james.mailbox.model.MailboxConstants;
 import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MailboxPath;
 
+import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import cucumber.runtime.java.guice.ScenarioScoped;
@@ -49,6 +52,12 @@ public class GetMailboxesMethodStepdefs {
         this.userStepdefs = userStepdefs;
         this.httpClient = httpClient;
         this.mainStepdefs = mainStepdefs;
+    }
+
+    @Given("^the user has a mailbox \"([^\"]*)\"$")
+    public void hasMailbox(String mailbox) {
+        mainStepdefs.mailboxProbe.createMailbox(MailboxPath.forUser(
+            Username.of(userStepdefs.getConnectedUser()), mailbox));
     }
 
     @When("^\"([^\"]*)\" lists mailboxes$")

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/resources/cucumber/sharing/CopyAndSharing.feature
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/resources/cucumber/sharing/CopyAndSharing.feature
@@ -24,8 +24,10 @@ Feature: Copy message and sharing
     Given a domain named "domain.tld"
     And some users "alice@domain.tld", "bob@domain.tld"
     And "alice@domain.tld" has a mailbox "shared"
+    And "alice@domain.tld" has a mailbox "INBOX"
     And "alice@domain.tld" shares her mailbox "shared" with "bob@domain.tld" with "aeilrwt" rights
     And "bob@domain.tld" has a mailbox "bobMailbox"
+    And "bob@domain.tld" has a mailbox "INBOX"
     And "alice@domain.tld" has a message "m1" in "INBOX" mailbox
     And "bob@domain.tld" has a message "m2" in "bobMailbox" mailbox
 

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/resources/cucumber/sharing/MoveMessageAndSharing.feature
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/resources/cucumber/sharing/MoveMessageAndSharing.feature
@@ -24,8 +24,10 @@ Feature: Move message and sharing
     Given a domain named "domain.tld"
     And some users "alice@domain.tld", "bob@domain.tld"
     And "alice@domain.tld" has a mailbox "shared"
+    And "alice@domain.tld" has a mailbox "INBOX"
     And "alice@domain.tld" shares her mailbox "shared" with "bob@domain.tld" with "aeilrwt" rights
     And "bob@domain.tld" has a mailbox "bobMailbox"
+    And "bob@domain.tld" has a mailbox "INBOX"
 
   Scenario: Move message should update the total and the unread counts when asked by sharer
     Given "alice@domain.tld" has a message "m1" in "INBOX" mailbox

--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/resources/cucumber/sharing/SetMessagesOnSharedMailbox.feature
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/resources/cucumber/sharing/SetMessagesOnSharedMailbox.feature
@@ -24,6 +24,7 @@ Feature: SetMessages method on shared folders
     Given a domain named "domain.tld"
     And some users "alice@domain.tld", "bob@domain.tld"
     And "bob@domain.tld" has a mailbox "shared"
+    And "bob@domain.tld" has a mailbox "Outbox"
     And "alice@domain.tld" has a mailbox "INBOX"
     And "bob@domain.tld" has a message "mBob" in "shared" mailbox with two attachments in text
     And "alice@domain.tld" has a message "mAlice" in "INBOX" mailbox with two attachments in text

--- a/server/protocols/jmap-draft-integration-testing/memory-jmap-draft-integration-testing/src/test/java/org/apache/james/jmap/memory/MemorySpamAssassinContractTest.java
+++ b/server/protocols/jmap-draft-integration-testing/memory-jmap-draft-integration-testing/src/test/java/org/apache/james/jmap/memory/MemorySpamAssassinContractTest.java
@@ -18,7 +18,14 @@
  ****************************************************************/
 package org.apache.james.jmap.memory;
 
-/*
+import org.apache.james.JamesServerBuilder;
+import org.apache.james.JamesServerExtension;
+import org.apache.james.MemoryJamesServerMain;
+import org.apache.james.jmap.draft.methods.integration.SpamAssassinContract;
+import org.apache.james.jmap.draft.methods.integration.SpamAssassinModuleExtension;
+import org.apache.james.modules.TestJMAPServerModule;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 class MemorySpamAssassinContractTest implements SpamAssassinContract {
     @RegisterExtension
     static JamesServerExtension testExtension = new JamesServerBuilder<>(JamesServerBuilder.defaultConfigurationProvider())
@@ -26,4 +33,4 @@ class MemorySpamAssassinContractTest implements SpamAssassinContract {
         .server(configuration -> MemoryJamesServerMain.createServer(configuration)
             .overrideWith(new TestJMAPServerModule()))
         .build();
-}*/
+}

--- a/server/protocols/jmap-draft-integration-testing/memory-jmap-draft-integration-testing/src/test/java/org/apache/james/jmap/memory/MemorySpamAssassinContractTest.java
+++ b/server/protocols/jmap-draft-integration-testing/memory-jmap-draft-integration-testing/src/test/java/org/apache/james/jmap/memory/MemorySpamAssassinContractTest.java
@@ -18,14 +18,7 @@
  ****************************************************************/
 package org.apache.james.jmap.memory;
 
-import org.apache.james.JamesServerBuilder;
-import org.apache.james.JamesServerExtension;
-import org.apache.james.MemoryJamesServerMain;
-import org.apache.james.jmap.draft.methods.integration.SpamAssassinContract;
-import org.apache.james.jmap.draft.methods.integration.SpamAssassinModuleExtension;
-import org.apache.james.modules.TestJMAPServerModule;
-import org.junit.jupiter.api.extension.RegisterExtension;
-
+/*
 class MemorySpamAssassinContractTest implements SpamAssassinContract {
     @RegisterExtension
     static JamesServerExtension testExtension = new JamesServerBuilder<>(JamesServerBuilder.defaultConfigurationProvider())
@@ -33,4 +26,4 @@ class MemorySpamAssassinContractTest implements SpamAssassinContract {
         .server(configuration -> MemoryJamesServerMain.createServer(configuration)
             .overrideWith(new TestJMAPServerModule()))
         .build();
-}
+}*/

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMailboxesMethod.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/methods/GetMailboxesMethod.java
@@ -37,6 +37,7 @@ import org.apache.james.jmap.draft.model.MailboxProperty;
 import org.apache.james.jmap.draft.model.MethodCallId;
 import org.apache.james.jmap.draft.model.mailbox.Mailbox;
 import org.apache.james.jmap.draft.utils.quotas.QuotaLoaderWithDefaultPreloaded;
+import org.apache.james.jmap.http.DefaultMailboxesProvisioner;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.mailbox.model.MailboxId;
@@ -70,15 +71,17 @@ public class GetMailboxesMethod implements Method {
     private final MetricFactory metricFactory;
     private final QuotaRootResolver quotaRootResolver;
     private final QuotaManager quotaManager;
+    private final DefaultMailboxesProvisioner provisioner;
 
     @Inject
     @VisibleForTesting
-    public GetMailboxesMethod(MailboxManager mailboxManager, QuotaRootResolver quotaRootResolver, QuotaManager quotaManager, MailboxFactory mailboxFactory, MetricFactory metricFactory) {
+    public GetMailboxesMethod(MailboxManager mailboxManager, QuotaRootResolver quotaRootResolver, QuotaManager quotaManager, MailboxFactory mailboxFactory, MetricFactory metricFactory, DefaultMailboxesProvisioner provisioner) {
         this.mailboxManager = mailboxManager;
         this.mailboxFactory = mailboxFactory;
         this.metricFactory = metricFactory;
         this.quotaRootResolver = quotaRootResolver;
         this.quotaManager = quotaManager;
+        this.provisioner = provisioner;
     }
 
     @Override
@@ -110,12 +113,13 @@ public class GetMailboxesMethod implements Method {
     }
 
     private Flux<JmapResponse> process(MethodCallId methodCallId, MailboxSession mailboxSession, GetMailboxesRequest mailboxesRequest) {
-        return Flux.from(getMailboxesResponse(mailboxesRequest, mailboxSession)
-            .map(response -> JmapResponse.builder().methodCallId(methodCallId)
-                .response(response)
-                .properties(mailboxesRequest.getProperties().map(this::ensureContainsId))
-                .responseName(RESPONSE_NAME)
-                .build()));
+        return provisioner.createMailboxesIfNeeded(mailboxSession)
+            .thenMany(Flux.from(getMailboxesResponse(mailboxesRequest, mailboxSession)
+                .map(response -> JmapResponse.builder().methodCallId(methodCallId)
+                    .response(response)
+                    .properties(mailboxesRequest.getProperties().map(this::ensureContainsId))
+                    .responseName(RESPONSE_NAME)
+                    .build())));
     }
 
     private Set<MailboxProperty> ensureContainsId(Set<MailboxProperty> input) {

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/DefaultMailboxesProvisioner.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/DefaultMailboxesProvisioner.java
@@ -45,7 +45,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
-class DefaultMailboxesProvisioner {
+public class DefaultMailboxesProvisioner {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultMailboxesProvisioner.class);
     private final MailboxManager mailboxManager;
     private final SubscriptionManager subscriptionManager;
@@ -53,7 +53,7 @@ class DefaultMailboxesProvisioner {
 
     @Inject
     @VisibleForTesting
-    DefaultMailboxesProvisioner(MailboxManager mailboxManager,
+    public DefaultMailboxesProvisioner(MailboxManager mailboxManager,
                                 SubscriptionManager subscriptionManager,
                                 MetricFactory metricFactory) {
         this.mailboxManager = mailboxManager;
@@ -61,7 +61,7 @@ class DefaultMailboxesProvisioner {
         this.metricFactory = metricFactory;
     }
 
-    Mono<Void> createMailboxesIfNeeded(MailboxSession session) {
+    public Mono<Void> createMailboxesIfNeeded(MailboxSession session) {
         return metricFactory.decorateSupplierWithTimerMetric("JMAP-mailboxes-provisioning",
             () -> {
                 Username username = session.getUser();

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/http/JMAPApiRoutesTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/http/JMAPApiRoutesTest.java
@@ -63,17 +63,15 @@ public class JMAPApiRoutesTest {
     private RequestHandler requestHandler;
     private Authenticator mockedAuthFilter;
     private UserProvisioner mockedUserProvisionner;
-    private DefaultMailboxesProvisioner mockedMailboxesProvisionner;
 
     @Before
     public void setup() throws Exception {
         requestHandler = mock(RequestHandler.class);
         mockedAuthFilter = mock(Authenticator.class);
         mockedUserProvisionner = mock(UserProvisioner.class);
-        mockedMailboxesProvisionner = mock(DefaultMailboxesProvisioner.class);
 
         JMAPApiRoutes jmapApiRoutes = new JMAPApiRoutes(requestHandler, new RecordingMetricFactory(),
-            mockedAuthFilter, mockedUserProvisionner, mockedMailboxesProvisionner);
+            mockedAuthFilter, mockedUserProvisionner);
 
         JMAPRoute postApiRoute = jmapApiRoutes.routes()
             .filter(jmapRoute -> jmapRoute.getEndpoint().getMethod().equals(HttpMethod.POST))
@@ -96,8 +94,6 @@ public class JMAPApiRoutesTest {
         doReturn(Mono.just(MailboxSessionUtil.create(Username.of("bob"))))
             .when(mockedAuthFilter).authenticate(any());
         when(mockedUserProvisionner.provisionUser(any()))
-            .thenReturn(Mono.empty());
-        when(mockedMailboxesProvisionner.createMailboxesIfNeeded(any()))
             .thenReturn(Mono.empty());
     }
 

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/routes/JMAPApiRoutesTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/routes/JMAPApiRoutesTest.scala
@@ -37,19 +37,18 @@ import org.apache.james.domainlist.memory.MemoryDomainList
 import org.apache.james.jmap.JMAPUrls.JMAP
 import org.apache.james.jmap.core.CapabilityIdentifier.{CapabilityIdentifier, JMAP_CORE}
 import org.apache.james.jmap.core.Invocation.MethodName
-import org.apache.james.jmap.core.{JmapRfc8621Configuration, RequestLevelErrorType}
-import org.apache.james.jmap.http.{Authenticator, BasicAuthenticationStrategy, MailboxesProvisioner, UserProvisioning}
+import org.apache.james.jmap.core.RequestLevelErrorType
+import org.apache.james.jmap.http.{Authenticator, BasicAuthenticationStrategy, UserProvisioning}
 import org.apache.james.jmap.method.{CoreEchoMethod, Method}
 import org.apache.james.jmap.routes.JMAPApiRoutesTest._
 import org.apache.james.jmap.{JMAPConfiguration, JMAPRoutesHandler, JMAPServer, Version, VersionParser}
 import org.apache.james.mailbox.extension.PreDeletionHook
 import org.apache.james.mailbox.inmemory.{InMemoryMailboxManager, MemoryMailboxManagerProvider}
-import org.apache.james.mailbox.store.StoreSubscriptionManager
 import org.apache.james.metrics.tests.RecordingMetricFactory
 import org.apache.james.user.memory.MemoryUsersRepository
 import org.hamcrest.Matchers.equalTo
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{doReturn, doThrow, mock, when}
+import org.mockito.Mockito.{doReturn, mock, when}
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -74,12 +73,9 @@ object JMAPApiRoutesTest {
   private val AUTHENTICATOR: Authenticator = Authenticator.of(new RecordingMetricFactory, authenticationStrategy)
 
   private val userProvisionner: UserProvisioning = new UserProvisioning(usersRepository, new RecordingMetricFactory)
-  private val subscriptionManager: StoreSubscriptionManager = new StoreSubscriptionManager(mailboxManager.getMapperFactory)
-  private val mailboxesProvisioner: MailboxesProvisioner = new MailboxesProvisioner(mailboxManager, subscriptionManager, new RecordingMetricFactory)
-  private val sessionSupplier: SessionSupplier = new SessionSupplier(JmapRfc8621Configuration(JmapRfc8621Configuration.LOCALHOST_URL_PREFIX))
   private val JMAP_METHODS: Set[Method] = Set(new CoreEchoMethod)
 
-  private val JMAP_API_ROUTE: JMAPApiRoutes = new JMAPApiRoutes(AUTHENTICATOR, userProvisionner, mailboxesProvisioner, JMAP_METHODS)
+  private val JMAP_API_ROUTE: JMAPApiRoutes = new JMAPApiRoutes(AUTHENTICATOR, userProvisionner, JMAP_METHODS)
   private val ROUTES_HANDLER: ImmutableSet[JMAPRoutesHandler] = ImmutableSet.of(new JMAPRoutesHandler(Version.RFC8621, JMAP_API_ROUTE))
 
   private val userBase64String: String = Base64.getEncoder.encodeToString("user1:password".getBytes(StandardCharsets.UTF_8))
@@ -443,7 +439,7 @@ class JMAPApiRoutesTest extends AnyFlatSpec with BeforeAndAfter with Matchers {
     when(mockCoreEchoMethod.requiredCapabilities).thenReturn(Set(JMAP_CORE))
 
     val methods: Set[Method] = Set(mockCoreEchoMethod)
-    val apiRoute: JMAPApiRoutes = new JMAPApiRoutes(AUTHENTICATOR, userProvisionner, mailboxesProvisioner, methods)
+    val apiRoute: JMAPApiRoutes = new JMAPApiRoutes(AUTHENTICATOR, userProvisionner, methods)
     val routesHandler: ImmutableSet[JMAPRoutesHandler] = ImmutableSet.of(new JMAPRoutesHandler(Version.RFC8621, apiRoute))
 
     val versionParser: VersionParser = new VersionParser(SUPPORTED_VERSIONS, JMAPConfiguration.DEFAULT)


### PR DESCRIPTION
## Why

Today we list 5 mailboxes, doing 5 primary key reads on consistency SERIAL every time we perform a JMAP request.

This has a major impact on the actual JMAP performance, and is most of the time unecessary.

For instance a class flow is:
 - Mailbox/get
 - Email/query
 - Email/get to list preview
 - Email/get on each open message (say x10)
 - Email/set upon user actions (say x5)

We end up checking mailbox provisionning 18 time.

We need to reduce the impact of this provisionning while keeping the benefits of it.

## How

Provision mailboxes only when calling Mailbox/get.

## Expected outcome

Performance enhancement.