### PR TITLE
JAMES-1644 AccessTokenAuthenticationStrategy should read data only once

### DIFF
--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/AccessTokenAuthenticationStrategy.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/AccessTokenAuthenticationStrategy.java
@@ -49,7 +49,6 @@ public class AccessTokenAuthenticationStrategy implements AuthenticationStrategy
         return Mono.fromCallable(() -> authHeaders(httpRequest))
             .filter(tokenString -> !tokenString.startsWith("Bearer"))
             .map(AccessToken::fromString)
-            .filterWhen(accessTokenManager::isValid)
             .flatMap(item -> Mono.from(accessTokenManager.getUsernameFromToken(item)))
             .map(mailboxManager::createSystemSession)
             .onErrorResume(InvalidAccessToken.class, error -> Mono.error(new UnauthorizedException("Invalid access token", error)))


### PR DESCRIPTION
Today the same access token is read twice:
 - once upon 'isValid'
 - once upon 'getUsername'

Here is a capture of a single request...

![access_token](https://user-images.githubusercontent.com/6928740/102159990-2d9af780-3eb7-11eb-98a5-ebfc14dbe06f.png)


 We can remove intermediate call to isValid as getUsername will throw anyway.

