### PR TITLE
JAMES-3431 Modify BounceMailet

### DIFF
--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
@@ -453,6 +453,12 @@ public class DSNBounce extends GenericMailet implements RedirectNotify {
         buffer.append("Received-From-MTA: dns; " + originalMail.getRemoteHost())
             .append(LINE_BREAK);
 
+        originalMail.dsnParameters()
+            .flatMap(DsnParameters::getEnvIdParameter)
+            .ifPresent(envId -> buffer.append("Original-Envelope-Id: ")
+                .append(envId.asString())
+                .append(LINE_BREAK));
+
         for (MailAddress rec : originalMail.getRecipients()) {
             appendRecipient(buffer, rec, getDeliveryError(originalMail), originalMail.getLastUpdated());
         }

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.transport.mailets;
 
+import static org.apache.james.transport.mailets.remote.delivery.Bouncer.DELIVERY_ERROR;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.LocalDateTime;
@@ -59,7 +61,6 @@ import org.apache.james.transport.util.ReplyToUtils;
 import org.apache.james.transport.util.SenderUtils;
 import org.apache.james.transport.util.SpecialAddressesUtils;
 import org.apache.james.transport.util.TosUtils;
-import org.apache.mailet.AttributeName;
 import org.apache.mailet.AttributeUtils;
 import org.apache.mailet.Mail;
 import org.apache.mailet.base.DateFormats;
@@ -122,7 +123,6 @@ public class DSNBounce extends GenericMailet implements RedirectNotify {
     private static final Pattern DIAG_PATTERN = Patterns.compilePatternUncheckedException("^\\d{3}\\s.*$");
     private static final String MACHINE_PATTERN = "[machine]";
     private static final String LINE_BREAK = "\n";
-    private static final AttributeName DELIVERY_ERROR = AttributeName.of("delivery-error");
 
     private final DNSService dns;
     private final DateTimeFormatter dateFormatter;

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
@@ -412,6 +412,8 @@ public class DSNBounce extends GenericMailet implements RedirectNotify {
         StringBuilder builder = new StringBuilder();
 
         builder.append(bounceMessage()).append(LINE_BREAK);
+        Optional.ofNullable(originalMail.getMessage().getSubject())
+            .ifPresent(subject -> builder.append("Original email subject: ").append(subject).append(LINE_BREAK).append(LINE_BREAK));
         builder.append(action.asString()).append(" recipient(s):").append(LINE_BREAK);
         builder.append(originalMail.getRecipients()
                 .stream()

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
@@ -78,9 +78,10 @@ import com.google.common.collect.ImmutableSet;
 
 /**
  * <p>
- * Generates a Delivery Status Notification (DSN) Note that this is different
- * than a mail-client's reply, which would use the Reply-To or From header.
- * </p>
+ * Generates a Delivery Status Notification (DSN) as per RFC-3464 An Extensible Message Format for Delivery Status
+ * Notifications (https://tools.ietf.org/html/rfc3464).</p>
+ *
+ * <p>Note that this is different than a mail-client's reply, which would use the Reply-To or From header.</p>
  * <p>
  * Bounced messages are attached in their entirety (headers and content) and the
  * resulting MIME part type is "message/rfc822".<br>

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
@@ -29,6 +29,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -120,11 +121,11 @@ public class DSNBounce extends GenericMailet implements RedirectNotify {
     private static final Logger LOGGER = LoggerFactory.getLogger(DSNBounce.class);
 
     enum Action {
-        DELIVERED("delivered", false),
-        DELAYED("delayed", true),
-        FAILED("failed", true),
-        EXPANDED("expanded", false),
-        RELAYED("relayed", false);
+        DELIVERED("Delivered", false),
+        DELAYED("Delayed", true),
+        FAILED("Failed", true),
+        EXPANDED("Expanded", false),
+        RELAYED("Relayed", false);
 
         public static Optional<Action> parse(String serialized) {
             return Stream.of(Action.values())
@@ -411,7 +412,7 @@ public class DSNBounce extends GenericMailet implements RedirectNotify {
         StringBuilder builder = new StringBuilder();
 
         builder.append(bounceMessage()).append(LINE_BREAK);
-        builder.append("Failed recipient(s):").append(LINE_BREAK);
+        builder.append(action.asString()).append(" recipient(s):").append(LINE_BREAK);
         builder.append(originalMail.getRecipients()
                 .stream()
                 .map(MailAddress::asString)
@@ -476,7 +477,7 @@ public class DSNBounce extends GenericMailet implements RedirectNotify {
     private void appendRecipient(StringBuffer buffer, MailAddress mailAddress, String deliveryError, Date lastUpdated) {
         buffer.append(LINE_BREAK);
         buffer.append("Final-Recipient: rfc822; " + mailAddress.toString()).append(LINE_BREAK);
-        buffer.append("Action: ").append(action.asString()).append(LINE_BREAK);
+        buffer.append("Action: ").append(action.asString().toLowerCase(Locale.US)).append(LINE_BREAK);
         buffer.append("Status: " + deliveryError).append(LINE_BREAK);
         if (action.shouldIncludeDiagnostic()) {
             buffer.append("Diagnostic-Code: " + getDiagnosticType(deliveryError) + "; " + deliveryError).append(LINE_BREAK);

--- a/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
+++ b/server/mailet/mailets/src/main/java/org/apache/james/transport/mailets/DSNBounce.java
@@ -109,7 +109,7 @@ import com.google.common.collect.ImmutableSet;
  * </code>
  * </pre>
  *
- * @see org.apache.james.transport.mailets.AbstractNotify
+ * @see RedirectNotify
  */
 
 public class DSNBounce extends GenericMailet implements RedirectNotify {

--- a/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
+++ b/server/mailet/mailets/src/test/java/org/apache/james/transport/mailets/DSNBounceTest.java
@@ -87,7 +87,7 @@ public class DSNBounceTest {
 
     @Test
     void getAllowedInitParametersShouldReturnTheParameters() {
-        assertThat(dsnBounce.getAllowedInitParameters()).containsOnly("debug", "passThrough", "messageString", "attachment", "sender", "prefix");
+        assertThat(dsnBounce.getAllowedInitParameters()).containsOnly("debug", "passThrough", "messageString", "attachment", "sender", "prefix", "action");
     }
 
     @Test


### PR DESCRIPTION
It should :

 - Take into account EnvId DSN parameter positioned by the client
 - Take into account RET DSN parameter positioned by the client
 - Allow customizing the action
 - Allow a default status code rather than aggressively defaulting to unknown
 - Add original subject in the human readable message to ease reading

Use nested classes in tests