### PR TITLE
JAMES-3469 EmailChangeRepository: API, contract test & memory implementation

### DIFF
--- a/server/container/guice/memory-guice/src/main/java/org/apache/james/modules/mailbox/MemoryMailboxModule.java
+++ b/server/container/guice/memory-guice/src/main/java/org/apache/james/modules/mailbox/MemoryMailboxModule.java
@@ -25,8 +25,8 @@ import javax.inject.Singleton;
 
 import org.apache.james.adapter.mailbox.UserRepositoryAuthenticator;
 import org.apache.james.adapter.mailbox.UserRepositoryAuthorizator;
-import org.apache.james.jmap.api.change.State;
 import org.apache.james.jmap.api.change.MailboxChangeRepository;
+import org.apache.james.jmap.api.change.State;
 import org.apache.james.jmap.memory.change.MemoryMailboxChangeRepository;
 import org.apache.james.mailbox.AttachmentContentLoader;
 import org.apache.james.mailbox.AttachmentManager;

--- a/server/container/guice/memory-guice/src/main/java/org/apache/james/modules/mailbox/MemoryMailboxModule.java
+++ b/server/container/guice/memory-guice/src/main/java/org/apache/james/modules/mailbox/MemoryMailboxModule.java
@@ -25,7 +25,7 @@ import javax.inject.Singleton;
 
 import org.apache.james.adapter.mailbox.UserRepositoryAuthenticator;
 import org.apache.james.adapter.mailbox.UserRepositoryAuthorizator;
-import org.apache.james.jmap.api.change.MailboxChange.State;
+import org.apache.james.jmap.api.change.State;
 import org.apache.james.jmap.api.change.MailboxChangeRepository;
 import org.apache.james.jmap.memory.change.MemoryMailboxChangeRepository;
 import org.apache.james.mailbox.AttachmentContentLoader;

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JmapGuiceProbe.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JmapGuiceProbe.java
@@ -27,6 +27,7 @@ import org.apache.james.core.Username;
 import org.apache.james.jmap.JMAPServer;
 import org.apache.james.jmap.api.change.MailboxChange;
 import org.apache.james.jmap.api.change.MailboxChangeRepository;
+import org.apache.james.jmap.api.change.State;
 import org.apache.james.jmap.api.model.AccountId;
 import org.apache.james.jmap.api.projections.MessageFastViewProjection;
 import org.apache.james.jmap.api.vacation.Vacation;
@@ -93,5 +94,9 @@ public class JmapGuiceProbe implements GuiceProbe {
 
     public void saveMailboxChange(MailboxChange change) {
         mailboxChangeRepository.save(change).block();
+    }
+
+    public State latestState(AccountId accountId) {
+        return mailboxChangeRepository.getLatestState(accountId).block();
     }
 }

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/change/CassandraMailboxChangeRepository.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/change/CassandraMailboxChangeRepository.java
@@ -21,10 +21,11 @@ package org.apache.james.jmap.cassandra.change;
 
 import java.util.Optional;
 
+import org.apache.james.jmap.api.change.Limit;
 import org.apache.james.jmap.api.change.MailboxChange;
-import org.apache.james.jmap.api.change.MailboxChange.Limit;
 import org.apache.james.jmap.api.change.MailboxChangeRepository;
 import org.apache.james.jmap.api.change.MailboxChanges;
+import org.apache.james.jmap.api.change.State;
 import org.apache.james.jmap.api.model.AccountId;
 
 import reactor.core.publisher.Mono;
@@ -37,18 +38,18 @@ public class CassandraMailboxChangeRepository implements MailboxChangeRepository
     }
 
     @Override
-    public Mono<MailboxChanges> getSinceState(AccountId accountId, MailboxChange.State state, Optional<Limit> maxChanges) {
+    public Mono<MailboxChanges> getSinceState(AccountId accountId, State state, Optional<Limit> maxChanges) {
         return Mono.empty();
     }
 
     @Override
-    public Mono<MailboxChanges> getSinceStateWithDelegation(AccountId accountId, MailboxChange.State state, Optional<Limit> maxChanges) {
+    public Mono<MailboxChanges> getSinceStateWithDelegation(AccountId accountId, State state, Optional<Limit> maxChanges) {
         return Mono.empty();
     }
 
     @Override
-    public Mono<MailboxChange.State> getLatestState(AccountId accountId) {
-        return Mono.just(MailboxChange.State.INITIAL);
+    public Mono<State> getLatestState(AccountId accountId) {
+        return Mono.just(State.INITIAL);
     }
 
     @Override

--- a/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/change/CassandraMailboxChangeRepository.java
+++ b/server/data/data-jmap-cassandra/src/main/java/org/apache/james/jmap/cassandra/change/CassandraMailboxChangeRepository.java
@@ -53,7 +53,7 @@ public class CassandraMailboxChangeRepository implements MailboxChangeRepository
     }
 
     @Override
-    public Mono<MailboxChange.State> getLatestStateWithDelegation(AccountId accountId) {
-        return Mono.just(MailboxChange.State.INITIAL);
+    public Mono<State> getLatestStateWithDelegation(AccountId accountId) {
+        return Mono.just(State.INITIAL);
     }
 }

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/EmailChange.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/EmailChange.java
@@ -34,22 +34,22 @@ import com.google.common.collect.ImmutableList;
 public class EmailChange {
     public static class Builder {
         @FunctionalInterface
-        public interface  RequireAccountId {
+        public interface RequireAccountId {
             RequireState accountId(AccountId accountId);
         }
 
         @FunctionalInterface
-        public interface  RequireState {
+        public interface RequireState {
             RequireDate state(State state);
         }
 
         @FunctionalInterface
-        public interface  RequireDate {
+        public interface RequireDate {
             RequireIsDelegated date(ZonedDateTime date);
         }
 
         @FunctionalInterface
-        public interface  RequireIsDelegated {
+        public interface RequireIsDelegated {
             Builder isDelegated(boolean isDelegated);
         }
 

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/EmailChange.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/EmailChange.java
@@ -1,0 +1,195 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.api.change;
+
+import java.time.ZonedDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.james.jmap.api.model.AccountId;
+import org.apache.james.mailbox.model.MessageId;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+public class EmailChange {
+    public static class Builder {
+        @FunctionalInterface
+        public interface  RequireAccountId {
+            RequireState accountId(AccountId accountId);
+        }
+
+        @FunctionalInterface
+        public interface  RequireState {
+            RequireDate state(State state);
+        }
+
+        @FunctionalInterface
+        public interface  RequireDate {
+            RequireIsDelegated date(ZonedDateTime date);
+        }
+
+        @FunctionalInterface
+        public interface  RequireIsDelegated {
+            Builder isDelegated(boolean isDelegated);
+        }
+
+        private final AccountId accountId;
+        private final State state;
+        private final ZonedDateTime date;
+        private final boolean isDelegated;
+        private final ImmutableList.Builder<MessageId> created;
+        private final ImmutableList.Builder<MessageId> updated;
+        private final ImmutableList.Builder<MessageId> destroyed;
+
+        private Builder(AccountId accountId, State state, ZonedDateTime date, boolean isDelegated) {
+            Preconditions.checkNotNull(accountId, "'accountId' should not be null");
+            Preconditions.checkNotNull(state, "'state' should not be null");
+            Preconditions.checkNotNull(date, "'date' should not be null");
+
+            this.accountId = accountId;
+            this.state = state;
+            this.date = date;
+            this.isDelegated = isDelegated;
+            this.destroyed = ImmutableList.builder();
+            this.updated = ImmutableList.builder();
+            this.created = ImmutableList.builder();
+        }
+
+        public Builder updated(MessageId... messageId) {
+            updated.add(messageId);
+            return this;
+        }
+
+        public Builder destroyed(MessageId... messageId) {
+            destroyed.add(messageId);
+            return this;
+        }
+
+        public Builder created(MessageId... messageId) {
+            created.add(messageId);
+            return this;
+        }
+
+        public Builder created(Collection<MessageId> messageIds) {
+            created.addAll(messageIds);
+            return this;
+        }
+
+        public Builder destroyed(Collection<MessageId> messageIds) {
+            destroyed.addAll(messageIds);
+            return this;
+        }
+
+        public Builder updated(Collection<MessageId> messageIds) {
+            updated.addAll(messageIds);
+            return this;
+        }
+
+        public EmailChange build() {
+            return new EmailChange(accountId, state, date, isDelegated, created.build(), updated.build(), destroyed.build());
+        }
+    }
+
+    public static Builder.RequireAccountId builder() {
+        return accountId -> state -> date -> isDelegated -> new Builder(accountId, state, date, isDelegated);
+    }
+
+    private final AccountId accountId;
+    private final State state;
+    private final ZonedDateTime date;
+    private final boolean isDelegated;
+    private final ImmutableList<MessageId> created;
+    private final ImmutableList<MessageId> updated;
+    private final ImmutableList<MessageId> destroyed;
+
+    private EmailChange(AccountId accountId, State state, ZonedDateTime date, boolean isDelegated, ImmutableList<MessageId> created, ImmutableList<MessageId> updated, ImmutableList<MessageId> destroyed) {
+        this.accountId = accountId;
+        this.state = state;
+        this.date = date;
+        this.isDelegated = isDelegated;
+        this.created = created;
+        this.updated = updated;
+        this.destroyed = destroyed;
+    }
+
+    public AccountId getAccountId() {
+        return accountId;
+    }
+
+    public State getState() {
+        return state;
+    }
+
+    public ZonedDateTime getDate() {
+        return date;
+    }
+
+    public List<MessageId> getCreated() {
+        return created;
+    }
+
+    public List<MessageId> getUpdated() {
+        return updated;
+    }
+
+    public List<MessageId> getDestroyed() {
+        return destroyed;
+    }
+
+    public boolean isDelegated() {
+        return isDelegated;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof EmailChange) {
+            EmailChange that = (EmailChange) o;
+            return Objects.equals(accountId, that.accountId)
+                && Objects.equals(state, that.state)
+                && Objects.equals(date, that.date)
+                && Objects.equals(isDelegated, that.isDelegated)
+                && Objects.equals(created, that.created)
+                && Objects.equals(updated, that.updated)
+                && Objects.equals(destroyed, that.destroyed);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(accountId, state, date, isDelegated, created, updated, destroyed);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("accountId", accountId)
+            .add("state", state)
+            .add("date", date)
+            .add("isDelegated", isDelegated)
+            .add("created", created)
+            .add("updated", updated)
+            .add("destroyed", destroyed)
+            .toString();
+    }
+}

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/EmailChangeRepository.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/EmailChangeRepository.java
@@ -1,0 +1,38 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.api.change;
+
+import java.util.Optional;
+
+import org.apache.james.jmap.api.model.AccountId;
+
+import reactor.core.publisher.Mono;
+
+public interface EmailChangeRepository {
+    Mono<Void> save(EmailChange change);
+
+    Mono<EmailChanges> getSinceState(AccountId accountId, State state, Optional<Limit> maxIdsToReturn);
+
+    Mono<EmailChanges> getSinceStateWithDelegation(AccountId accountId, State state, Optional<Limit> maxIdsToReturn);
+
+    Mono<State> getLatestState(AccountId accountId);
+
+    Mono<State> getLatestStateWithDelegation(AccountId accountId);
+}

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/EmailChanges.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/EmailChanges.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.mailbox.model.MessageId;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 public class EmailChanges {
@@ -99,7 +100,9 @@ public class EmailChanges {
             Set<MessageId> updatedTemp = new HashSet<>(updated);
             Set<MessageId> destroyedTemp = new HashSet<>(destroyed);
             createdTemp.addAll(change.getCreated());
-            updatedTemp.addAll(change.getUpdated());
+            updatedTemp.addAll(
+                Sets.difference(ImmutableSet.copyOf(change.getUpdated()),
+                createdTemp));
             destroyedTemp.addAll(change.getDestroyed());
 
             if (createdTemp.size() + updatedTemp.size() + destroyedTemp.size() > limit.getValue()) {
@@ -109,9 +112,9 @@ public class EmailChanges {
             }
 
             state = change.getState();
-            this.created.addAll(change.getCreated());
-            this.updated.addAll(change.getUpdated());
-            this.destroyed.addAll(change.getDestroyed());
+            created = createdTemp;
+            updated = updatedTemp;
+            destroyed = destroyedTemp;
 
             return this;
         }

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/EmailChanges.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/EmailChanges.java
@@ -1,0 +1,165 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.api.change;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.james.mailbox.model.MessageId;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+
+public class EmailChanges {
+
+    public static class Builder {
+
+        public static class EmailChangeCollector implements Collector<EmailChange, Builder, EmailChanges> {
+            private final Limit limit;
+            private final State state;
+
+            public EmailChangeCollector(State state, Limit limit) {
+                this.limit = limit;
+                this.state = state;
+            }
+
+            @Override
+            public Supplier<Builder> supplier() {
+                return () -> new Builder(state, limit);
+            }
+
+            public BiConsumer<Builder, EmailChange> accumulator() {
+                return Builder::add;
+            }
+
+            @Override
+            public BinaryOperator<Builder> combiner() {
+                throw new NotImplementedException("Not supported");
+            }
+
+            @Override
+            public Function<Builder, EmailChanges> finisher() {
+                return Builder::build;
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return Sets.immutableEnumSet(Characteristics.UNORDERED);
+            }
+        }
+
+        private State state;
+        private boolean hasMoreChanges;
+        private boolean canAddMoreItem;
+        private Limit limit;
+        private Set<MessageId> created;
+        private Set<MessageId> updated;
+        private Set<MessageId> destroyed;
+
+        public Builder(State state, Limit limit) {
+            this.limit = limit;
+            this.state = state;
+            this.hasMoreChanges = false;
+            this.canAddMoreItem = true;
+            this.created = new HashSet<>();
+            this.updated = new HashSet<>();
+            this.destroyed = new HashSet<>();
+        }
+
+        public Builder add(EmailChange change) {
+            if (!canAddMoreItem) {
+                return this;
+            }
+
+            Set<MessageId> createdTemp = new HashSet<>(created);
+            Set<MessageId> updatedTemp = new HashSet<>(updated);
+            Set<MessageId> destroyedTemp = new HashSet<>(destroyed);
+            createdTemp.addAll(change.getCreated());
+            updatedTemp.addAll(change.getUpdated());
+            destroyedTemp.addAll(change.getDestroyed());
+
+            if (createdTemp.size() + updatedTemp.size() + destroyedTemp.size() > limit.getValue()) {
+                hasMoreChanges = true;
+                canAddMoreItem = false;
+                return this;
+            }
+
+            state = change.getState();
+            this.created.addAll(change.getCreated());
+            this.updated.addAll(change.getUpdated());
+            this.destroyed.addAll(change.getDestroyed());
+
+            return this;
+        }
+
+        public EmailChanges build() {
+            return new EmailChanges(state, hasMoreChanges, created, updated, destroyed);
+        }
+    }
+
+    private State newState;
+    private final boolean hasMoreChanges;
+    private final Set<MessageId> created;
+    private final Set<MessageId> updated;
+    private final Set<MessageId> destroyed;
+
+    private EmailChanges(State newState, boolean hasMoreChanges, Set<MessageId> created, Set<MessageId> updated, Set<MessageId> destroyed) {
+        this.newState = newState;
+        this.hasMoreChanges = hasMoreChanges;
+        this.created = created;
+        this.updated = updated;
+        this.destroyed = destroyed;
+    }
+
+    public State getNewState() {
+        return newState;
+    }
+
+    public boolean hasMoreChanges() {
+        return hasMoreChanges;
+    }
+
+    public Set<MessageId> getCreated() {
+        return created;
+    }
+
+    public Set<MessageId> getUpdated() {
+        return updated;
+    }
+
+    public Set<MessageId> getDestroyed() {
+        return destroyed;
+    }
+
+    public List<MessageId> getAllChanges() {
+        return ImmutableList.<MessageId>builder()
+            .addAll(created)
+            .addAll(updated)
+            .addAll(destroyed)
+            .build();
+    }
+}

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/EmailChanges.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/EmailChanges.java
@@ -96,14 +96,24 @@ public class EmailChanges {
                 return this;
             }
 
-            Set<MessageId> createdTemp = new HashSet<>(created);
-            Set<MessageId> updatedTemp = new HashSet<>(updated);
             Set<MessageId> destroyedTemp = new HashSet<>(destroyed);
-            createdTemp.addAll(change.getCreated());
-            updatedTemp.addAll(
-                Sets.difference(ImmutableSet.copyOf(change.getUpdated()),
-                createdTemp));
-            destroyedTemp.addAll(change.getDestroyed());
+
+            Set<MessageId> createdTemp = Sets.difference(
+                ImmutableSet.<MessageId>builder()
+                    .addAll(created)
+                    .addAll(change.getCreated())
+                    .build(),
+                ImmutableSet.copyOf(change.getDestroyed()));
+            Set<MessageId> updatedTemp = Sets.difference(
+                ImmutableSet.<MessageId>builder()
+                    .addAll(updated)
+                    .addAll(Sets.difference(ImmutableSet.copyOf(change.getUpdated()),
+                        createdTemp))
+                    .build(),
+                ImmutableSet.copyOf(change.getDestroyed()));
+            destroyedTemp.addAll(Sets.difference(
+                ImmutableSet.copyOf(change.getDestroyed()),
+                created));
 
             if (createdTemp.size() + updatedTemp.size() + destroyedTemp.size() > limit.getValue()) {
                 hasMoreChanges = true;

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/Limit.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/Limit.java
@@ -17,28 +17,23 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.jmap.rfc8621.memory;
+package org.apache.james.jmap.api.change;
 
-import static org.apache.james.MemoryJamesServerMain.IN_MEMORY_SERVER_AGGREGATE_MODULE;
+import com.google.common.base.Preconditions;
 
-import org.apache.james.GuiceJamesServer;
-import org.apache.james.JamesServerBuilder;
-import org.apache.james.JamesServerExtension;
-import org.apache.james.jmap.api.change.State;
-import org.apache.james.jmap.rfc8621.contract.MailboxChangesMethodContract;
-import org.apache.james.modules.TestJMAPServerModule;
-import org.junit.jupiter.api.extension.RegisterExtension;
+public class Limit {
+    public static Limit of(int value) {
+        Preconditions.checkArgument(value > 0, "'limit' needs to be strictly positive");
+        return new Limit(value);
+    }
 
-public class MemoryMailboxChangesMethodTest implements MailboxChangesMethodContract {
-    @RegisterExtension
-    static JamesServerExtension testExtension = new JamesServerBuilder<>(JamesServerBuilder.defaultConfigurationProvider())
-        .server(configuration -> GuiceJamesServer.forConfiguration(configuration)
-            .combineWith(IN_MEMORY_SERVER_AGGREGATE_MODULE)
-            .overrideWith(new TestJMAPServerModule()))
-        .build();
+    private final int value;
 
-    @Override
-    public State.Factory stateFactory() {
-        return new State.DefaultFactory();
+    private Limit(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
     }
 }

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/MailboxChange.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/MailboxChange.java
@@ -22,6 +22,7 @@ package org.apache.james.jmap.api.change;
 import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -46,6 +47,8 @@ import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 
 import com.github.steveash.guavate.Guavate;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 public class MailboxChange {
@@ -74,6 +77,10 @@ public class MailboxChange {
         private Optional<List<MailboxId>> destroyed;
 
         private Builder(AccountId accountId, State state, ZonedDateTime date) {
+            Preconditions.checkNotNull(accountId, "'accountId' cannot be null");
+            Preconditions.checkNotNull(state, "'state' cannot be null");
+            Preconditions.checkNotNull(date, "'date' cannot be null");
+
             this.accountId = accountId;
             this.state = state;
             this.date = date;
@@ -338,5 +345,38 @@ public class MailboxChange {
 
     public List<MailboxId> getDestroyed() {
         return destroyed;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof MailboxChange) {
+            MailboxChange that = (MailboxChange) o;
+            return Objects.equals(accountId, that.accountId)
+                && Objects.equals(state, that.state)
+                && Objects.equals(date, that.date)
+                && Objects.equals(delegated, that.delegated)
+                && Objects.equals(created, that.created)
+                && Objects.equals(updated, that.updated)
+                && Objects.equals(destroyed, that.destroyed);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(accountId, state, date, delegated, created, updated, destroyed);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("accountId", accountId)
+            .add("state", state)
+            .add("date", date)
+            .add("isDelegated", delegated)
+            .add("created", created)
+            .add("updated", updated)
+            .add("destroyed", destroyed)
+            .toString();
     }
 }

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/MailboxChange.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/MailboxChange.java
@@ -22,9 +22,7 @@ package org.apache.james.jmap.api.change;
 import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -51,69 +49,6 @@ import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
 
 public class MailboxChange {
-
-    public static class State {
-        public static State INITIAL = of(UUID.fromString("2c9f1b12-b35a-43e6-9af2-0106fb53a943"));
-
-        public interface Factory {
-            State generate();
-        }
-
-        public static class DefaultFactory implements Factory {
-
-            @Override
-            public State generate() {
-                return of(UUID.randomUUID());
-            }
-        }
-
-        public static State of(UUID value) {
-            return new State(value);
-        }
-
-        private final UUID value;
-
-        private State(UUID value) {
-            this.value = value;
-        }
-
-        public UUID getValue() {
-            return value;
-        }
-
-        @Override
-        public final boolean equals(Object o) {
-            if (o instanceof State) {
-                State state = (State) o;
-
-                return Objects.equals(this.value, state.value);
-            }
-            return false;
-        }
-
-        @Override
-        public final int hashCode() {
-            return Objects.hash(value);
-        }
-    }
-
-    public static class Limit {
-
-        public static Limit of(int value) {
-            return new Limit(value);
-        }
-
-        private final int value;
-
-        private Limit(int value) {
-            this.value = value;
-        }
-
-        public int getValue() {
-            return value;
-        }
-    }
-
     @FunctionalInterface
     public interface RequiredAccountId {
         RequiredState accountId(AccountId accountId);

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/MailboxChangeRepository.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/MailboxChangeRepository.java
@@ -21,8 +21,6 @@ package org.apache.james.jmap.api.change;
 
 import java.util.Optional;
 
-import org.apache.james.jmap.api.change.MailboxChange.Limit;
-import org.apache.james.jmap.api.change.MailboxChange.State;
 import org.apache.james.jmap.api.model.AccountId;
 
 import reactor.core.publisher.Mono;

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/MailboxChanges.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/MailboxChanges.java
@@ -39,10 +39,10 @@ public class MailboxChanges {
     public static class MailboxChangesBuilder {
 
         public static class MailboxChangeCollector implements Collector<MailboxChange, MailboxChangesBuilder, MailboxChanges> {
-            private final MailboxChange.Limit limit;
-            private final MailboxChange.State state;
+            private final Limit limit;
+            private final State state;
 
-            public MailboxChangeCollector(MailboxChange.State state, MailboxChange.Limit limit) {
+            public MailboxChangeCollector(State state, Limit limit) {
                 this.limit = limit;
                 this.state = state;
             }
@@ -72,15 +72,15 @@ public class MailboxChanges {
             }
         }
 
-        private MailboxChange.State state;
+        private State state;
         private boolean hasMoreChanges;
         private boolean canAddMoreItem;
-        private MailboxChange.Limit limit;
+        private Limit limit;
         private Set<MailboxId> created;
         private Set<MailboxId> updated;
         private Set<MailboxId> destroyed;
 
-        public MailboxChangesBuilder(MailboxChange.State state, MailboxChange.Limit limit) {
+        public MailboxChangesBuilder(State state, Limit limit) {
             this.limit = limit;
             this.state = state;
             this.hasMoreChanges = false;
@@ -121,13 +121,13 @@ public class MailboxChanges {
         }
     }
 
-    private MailboxChange.State newState;
+    private State newState;
     private final boolean hasMoreChanges;
     private final Set<MailboxId> created;
     private final Set<MailboxId> updated;
     private final Set<MailboxId> destroyed;
 
-    private MailboxChanges(MailboxChange.State newState, boolean hasMoreChanges, Set<MailboxId> created, Set<MailboxId> updated, Set<MailboxId> destroyed) {
+    private MailboxChanges(State newState, boolean hasMoreChanges, Set<MailboxId> created, Set<MailboxId> updated, Set<MailboxId> destroyed) {
         this.newState = newState;
         this.hasMoreChanges = hasMoreChanges;
         this.created = created;
@@ -135,7 +135,7 @@ public class MailboxChanges {
         this.destroyed = destroyed;
     }
 
-    public MailboxChange.State getNewState() {
+    public State getNewState() {
         return newState;
     }
 

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/State.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/State.java
@@ -1,0 +1,81 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.api.change;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+
+public class State {
+    public interface Factory {
+        Factory DEFAULT = new DefaultFactory();
+
+        State generate();
+    }
+
+    public static class DefaultFactory implements Factory {
+        @Override
+        public State generate() {
+            return of(UUID.randomUUID());
+        }
+    }
+
+    public static final State INITIAL = of(UUID.fromString("2c9f1b12-b35a-43e6-9af2-0106fb53a943"));
+
+    public static State of(UUID value) {
+        Preconditions.checkNotNull(value, "State 'value' should not be null.");
+
+        return new State(value);
+    }
+
+    private final UUID value;
+
+    private State(UUID value) {
+        this.value = value;
+    }
+
+    public UUID getValue() {
+        return value;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof State) {
+            State state = (State) o;
+
+            return Objects.equals(this.value, state.value);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("value", value)
+            .toString();
+    }
+}

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/exception/ChangeNotFoundException.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/exception/ChangeNotFoundException.java
@@ -19,17 +19,17 @@
 
 package org.apache.james.jmap.api.exception;
 
-import org.apache.james.jmap.api.change.MailboxChange;
+import org.apache.james.jmap.api.change.State;
 
 public class ChangeNotFoundException extends RuntimeException {
-    private final MailboxChange.State state;
+    private final State state;
 
-    public ChangeNotFoundException(MailboxChange.State state, String msg) {
+    public ChangeNotFoundException(State state, String msg) {
         super(msg);
         this.state = state;
     }
 
-    public MailboxChange.State getState() {
+    public State getState() {
         return state;
     }
 }

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/memory/change/MemoryEmailChangeRepository.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/memory/change/MemoryEmailChangeRepository.java
@@ -1,0 +1,121 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.memory.change;
+
+import java.util.Comparator;
+import java.util.Optional;
+
+import org.apache.james.jmap.api.change.EmailChange;
+import org.apache.james.jmap.api.change.EmailChangeRepository;
+import org.apache.james.jmap.api.change.EmailChanges;
+import org.apache.james.jmap.api.change.EmailChanges.Builder.EmailChangeCollector;
+import org.apache.james.jmap.api.change.Limit;
+import org.apache.james.jmap.api.change.State;
+import org.apache.james.jmap.api.exception.ChangeNotFoundException;
+import org.apache.james.jmap.api.model.AccountId;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class MemoryEmailChangeRepository implements EmailChangeRepository {
+    public static final Limit DEFAULT_NUMBER_OF_CHANGES = Limit.of(5);
+
+    private final Multimap<AccountId, EmailChange> emailChangeMap;
+
+    public MemoryEmailChangeRepository() {
+        this.emailChangeMap = Multimaps.synchronizedListMultimap(ArrayListMultimap.create());
+    }
+
+    @Override
+    public Mono<Void> save(EmailChange change) {
+        Preconditions.checkNotNull(change.getAccountId());
+        Preconditions.checkNotNull(change.getState());
+
+        return Mono.just(emailChangeMap.put(change.getAccountId(), change)).then();
+    }
+
+    @Override
+    public Mono<State> getLatestState(AccountId accountId) {
+        return allChanges(accountId)
+            .filter(change -> !change.isDelegated())
+            .sort(Comparator.comparing(EmailChange::getDate))
+            .map(EmailChange::getState)
+            .last(State.INITIAL);
+    }
+
+    @Override
+    public Mono<EmailChanges> getSinceState(AccountId accountId, State state, Optional<Limit> maxChanges) {
+        Preconditions.checkNotNull(accountId);
+        Preconditions.checkNotNull(state);
+        maxChanges.ifPresent(limit -> Preconditions.checkArgument(limit.getValue() > 0, "maxChanges must be a positive integer"));
+
+        return resolveAllChanges(accountId, state)
+            .filter(change -> !change.isDelegated())
+            .collect(new EmailChangeCollector(state, maxChanges.orElse(DEFAULT_NUMBER_OF_CHANGES)));
+    }
+
+    @Override
+    public Mono<EmailChanges> getSinceStateWithDelegation(AccountId accountId, State state, Optional<Limit> maxChanges) {
+        Preconditions.checkNotNull(accountId);
+        Preconditions.checkNotNull(state);
+
+        return resolveAllChanges(accountId, state)
+            .collect(new EmailChangeCollector(state, maxChanges.orElse(DEFAULT_NUMBER_OF_CHANGES)));
+    }
+
+    @Override
+    public Mono<State> getLatestStateWithDelegation(AccountId accountId) {
+        return allChanges(accountId)
+            .sort(Comparator.comparing(EmailChange::getDate))
+            .map(EmailChange::getState)
+            .last(State.INITIAL);
+    }
+
+    private Flux<EmailChange> resolveAllChanges(AccountId accountId, State state) {
+        if (state.equals(State.INITIAL)) {
+            return allChanges(accountId);
+        }
+        return allChangesSince(accountId, state);
+    }
+
+    private Flux<EmailChange> allChangesSince(AccountId accountId, State state) {
+        return findByState(accountId, state)
+            .flatMapMany(currentState -> Flux.fromIterable(emailChangeMap.get(accountId))
+                .filter(change -> change.getDate().isAfter(currentState.getDate()))
+                .sort(Comparator.comparing(EmailChange::getDate)));
+    }
+
+    private Flux<EmailChange> allChanges(AccountId accountId) {
+        return Flux.fromIterable(emailChangeMap.get(accountId))
+            .sort(Comparator.comparing(EmailChange::getDate));
+    }
+
+    private Mono<EmailChange> findByState(AccountId accountId, State state) {
+        return Flux.fromIterable(emailChangeMap.get(accountId))
+            .filter(change -> change.getState().equals(state))
+            .switchIfEmpty(Mono.error(new ChangeNotFoundException(state, String.format("State '%s' could not be found", state.getValue()))))
+            .single();
+    }
+}

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/memory/change/MemoryMailboxChangeRepository.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/memory/change/MemoryMailboxChangeRepository.java
@@ -35,6 +35,7 @@ import org.apache.james.jmap.api.model.AccountId;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -45,7 +46,7 @@ public class MemoryMailboxChangeRepository implements MailboxChangeRepository {
     private final Multimap<AccountId, MailboxChange> mailboxChangeMap;
 
     public MemoryMailboxChangeRepository() {
-        this.mailboxChangeMap = ArrayListMultimap.create();
+        this.mailboxChangeMap = Multimaps.synchronizedListMultimap(ArrayListMultimap.create());
     }
 
     @Override

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/memory/change/MemoryMailboxChangeRepository.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/memory/change/MemoryMailboxChangeRepository.java
@@ -51,9 +51,6 @@ public class MemoryMailboxChangeRepository implements MailboxChangeRepository {
 
     @Override
     public Mono<Void> save(MailboxChange change) {
-        Preconditions.checkNotNull(change.getAccountId());
-        Preconditions.checkNotNull(change.getState());
-
         return Mono.just(mailboxChangeMap.put(change.getAccountId(), change)).then();
     }
 

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/memory/change/MemoryMailboxChangeRepository.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/memory/change/MemoryMailboxChangeRepository.java
@@ -24,8 +24,8 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.apache.james.jmap.api.change.MailboxChange;
-import org.apache.james.jmap.api.change.MailboxChange.Limit;
-import org.apache.james.jmap.api.change.MailboxChange.State;
+import org.apache.james.jmap.api.change.Limit;
+import org.apache.james.jmap.api.change.State;
 import org.apache.james.jmap.api.change.MailboxChangeRepository;
 import org.apache.james.jmap.api.change.MailboxChanges;
 import org.apache.james.jmap.api.change.MailboxChanges.MailboxChangesBuilder.MailboxChangeCollector;
@@ -60,7 +60,7 @@ public class MemoryMailboxChangeRepository implements MailboxChangeRepository {
     public Mono<MailboxChanges> getSinceState(AccountId accountId, State state, Optional<Limit> maxChanges) {
         Preconditions.checkNotNull(accountId);
         Preconditions.checkNotNull(state);
-        maxChanges.ifPresent(limit -> Preconditions.checkArgument(limit.getValue() > 0, "maxChanges must be a positive integer"));
+
         if (state.equals(State.INITIAL)) {
             return Flux.fromIterable(mailboxChangeMap.get(accountId))
                 .sort(Comparator.comparing(MailboxChange::getDate))

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/memory/change/MemoryMailboxChangeRepository.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/memory/change/MemoryMailboxChangeRepository.java
@@ -23,12 +23,12 @@ import java.util.Comparator;
 import java.util.Optional;
 import java.util.function.Predicate;
 
-import org.apache.james.jmap.api.change.MailboxChange;
 import org.apache.james.jmap.api.change.Limit;
-import org.apache.james.jmap.api.change.State;
+import org.apache.james.jmap.api.change.MailboxChange;
 import org.apache.james.jmap.api.change.MailboxChangeRepository;
 import org.apache.james.jmap.api.change.MailboxChanges;
 import org.apache.james.jmap.api.change.MailboxChanges.MailboxChangesBuilder.MailboxChangeCollector;
+import org.apache.james.jmap.api.change.State;
 import org.apache.james.jmap.api.exception.ChangeNotFoundException;
 import org.apache.james.jmap.api.model.AccountId;
 

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/EmailChangeRepositoryContract.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/EmailChangeRepositoryContract.java
@@ -498,7 +498,7 @@ public interface EmailChangeRepositoryContract {
             .state(STATE_0)
             .date(DATE.minusHours(3))
             .isDelegated(false)
-            .created(TestMessageId.of(1))
+            .created(TestMessageId.of(1), TestMessageId.of(9), TestMessageId.of(10))
             .build();
         EmailChange change1 = EmailChange.builder()
             .accountId(ACCOUNT_ID)
@@ -513,8 +513,8 @@ public interface EmailChangeRepositoryContract {
             .date(DATE.minusHours(1))
             .isDelegated(false)
             .created(TestMessageId.of(6), TestMessageId.of(7))
-            .updated(TestMessageId.of(2), TestMessageId.of(3))
-            .destroyed(TestMessageId.of(4))
+            .updated(TestMessageId.of(2), TestMessageId.of(3), TestMessageId.of(10))
+            .destroyed(TestMessageId.of(4), TestMessageId.of(9))
             .build();
         EmailChange change3 = EmailChange.builder()
             .accountId(ACCOUNT_ID)
@@ -523,7 +523,7 @@ public interface EmailChangeRepositoryContract {
             .isDelegated(false)
             .created(TestMessageId.of(8))
             .updated(TestMessageId.of(6), TestMessageId.of(7), TestMessageId.of(1))
-            .destroyed(TestMessageId.of(5))
+            .destroyed(TestMessageId.of(5), TestMessageId.of(10))
             .build();
         repository.save(oldState).block();
         repository.save(change1).block();
@@ -533,9 +533,9 @@ public interface EmailChangeRepositoryContract {
         EmailChanges emailChanges = repository.getSinceState(ACCOUNT_ID, STATE_0, Optional.of(Limit.of(20))).block();
 
         SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(emailChanges.getCreated()).containsExactlyInAnyOrder(TestMessageId.of(2), TestMessageId.of(3), TestMessageId.of(4), TestMessageId.of(5), TestMessageId.of(6), TestMessageId.of(7), TestMessageId.of(8));
+            softly.assertThat(emailChanges.getCreated()).containsExactlyInAnyOrder(TestMessageId.of(2), TestMessageId.of(3), TestMessageId.of(6), TestMessageId.of(7), TestMessageId.of(8));
             softly.assertThat(emailChanges.getUpdated()).containsExactlyInAnyOrder(TestMessageId.of(1));
-            softly.assertThat(emailChanges.getDestroyed()).containsExactlyInAnyOrder(TestMessageId.of(4), TestMessageId.of(5));
+            softly.assertThat(emailChanges.getDestroyed()).containsExactlyInAnyOrder(TestMessageId.of(9), TestMessageId.of(10));
         });
     }
 

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/EmailChangeRepositoryContract.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/EmailChangeRepositoryContract.java
@@ -28,7 +28,6 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.apache.james.jmap.api.change.State;
 import org.apache.james.jmap.api.exception.ChangeNotFoundException;
 import org.apache.james.jmap.api.model.AccountId;
 import org.apache.james.mailbox.model.TestMessageId;
@@ -523,7 +522,7 @@ public interface EmailChangeRepositoryContract {
             .date(DATE)
             .isDelegated(false)
             .created(TestMessageId.of(8))
-            .updated(TestMessageId.of(6), TestMessageId.of(7))
+            .updated(TestMessageId.of(6), TestMessageId.of(7), TestMessageId.of(1))
             .destroyed(TestMessageId.of(5))
             .build();
         repository.save(oldState).block();
@@ -535,7 +534,7 @@ public interface EmailChangeRepositoryContract {
 
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(emailChanges.getCreated()).containsExactlyInAnyOrder(TestMessageId.of(2), TestMessageId.of(3), TestMessageId.of(4), TestMessageId.of(5), TestMessageId.of(6), TestMessageId.of(7), TestMessageId.of(8));
-            softly.assertThat(emailChanges.getUpdated()).containsExactlyInAnyOrder(TestMessageId.of(2), TestMessageId.of(3), TestMessageId.of(6), TestMessageId.of(7));
+            softly.assertThat(emailChanges.getUpdated()).containsExactlyInAnyOrder(TestMessageId.of(1));
             softly.assertThat(emailChanges.getDestroyed()).containsExactlyInAnyOrder(TestMessageId.of(4), TestMessageId.of(5));
         });
     }

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/EmailChangeRepositoryContract.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/EmailChangeRepositoryContract.java
@@ -1,0 +1,587 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.api.change;
+
+import static org.apache.james.mailbox.fixture.MailboxFixture.BOB;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.apache.james.jmap.api.change.State;
+import org.apache.james.jmap.api.exception.ChangeNotFoundException;
+import org.apache.james.jmap.api.model.AccountId;
+import org.apache.james.mailbox.model.TestMessageId;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
+public interface EmailChangeRepositoryContract {
+    AccountId ACCOUNT_ID = AccountId.fromUsername(BOB);
+    ZonedDateTime DATE = ZonedDateTime.now();
+    State STATE_0 = State.of(UUID.randomUUID());
+
+    EmailChangeRepository emailChangeRepository();
+
+    @Test
+    default void saveChangeShouldSuccess() {
+        EmailChangeRepository repository = emailChangeRepository();
+
+        EmailChange change = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(STATE_0)
+            .date(DATE)
+            .isDelegated(false)
+            .created(TestMessageId.of(1))
+            .build();
+
+        assertThatCode(() -> repository.save(change).block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    default void getLatestStateShouldReturnInitialWhenEmpty() {
+        EmailChangeRepository repository = emailChangeRepository();
+
+        assertThat(repository.getLatestState(ACCOUNT_ID).block())
+            .isEqualTo(State.INITIAL);
+    }
+
+    @Test
+    default void getLatestStateShouldReturnLastPersistedState() {
+        EmailChangeRepository repository = emailChangeRepository();
+
+        EmailChange change1 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE.minusHours(2))
+            .isDelegated(false)
+            .created(TestMessageId.of(2))
+            .build();
+        EmailChange change2 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE.minusHours(1))
+            .isDelegated(false)
+            .created(TestMessageId.of(3))
+            .build();
+        EmailChange change3 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE)
+            .isDelegated(false)
+            .created(TestMessageId.of(4))
+            .build();
+        repository.save(change1).block();
+        repository.save(change2).block();
+        repository.save(change3).block();
+
+        assertThat(repository.getLatestState(ACCOUNT_ID).block())
+            .isEqualTo(change3.getState());
+    }
+
+    @Test
+    default void getChangesShouldSuccess() {
+        EmailChangeRepository repository = emailChangeRepository();
+
+        EmailChange oldState = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(STATE_0)
+            .date(DATE.minusHours(1))
+            .isDelegated(false)
+            .created(TestMessageId.of(1))
+            .build();
+        EmailChange change = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE)
+            .isDelegated(false)
+            .updated(TestMessageId.of(1))
+            .build();
+        repository.save(oldState).block();
+        repository.save(change).block();
+
+        assertThat(repository.getSinceState(ACCOUNT_ID, STATE_0, Optional.empty()).block().getAllChanges())
+            .hasSameElementsAs(change.getUpdated());
+    }
+
+    @Test
+    default void getChangesShouldReturnEmptyWhenNoNewerState() {
+        EmailChangeRepository repository = emailChangeRepository();
+
+        EmailChange oldState = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(STATE_0)
+            .date(DATE.minusHours(1))
+            .isDelegated(false)
+            .created(TestMessageId.of(1))
+            .build();
+        repository.save(oldState).block();
+
+        assertThat(repository.getSinceState(ACCOUNT_ID, STATE_0, Optional.empty()).block().getAllChanges())
+            .isEmpty();
+    }
+
+    @Test
+    default void getChangesShouldReturnCurrentStateWhenNoNewerState() {
+        EmailChangeRepository repository = emailChangeRepository();
+
+        EmailChange oldState = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(STATE_0)
+            .date(DATE.minusHours(1))
+            .isDelegated(false)
+            .created(TestMessageId.of(1))
+            .build();
+        repository.save(oldState).block();
+
+        assertThat(repository.getSinceState(ACCOUNT_ID, STATE_0, Optional.empty()).block().getNewState())
+            .isEqualTo(oldState.getState());
+    }
+
+    @Test
+    default void getChangesShouldLimitChanges() {
+        EmailChangeRepository repository = emailChangeRepository();
+
+        EmailChange oldState = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(STATE_0)
+            .date(DATE.minusHours(3))
+            .isDelegated(false)
+            .created(TestMessageId.of(1))
+            .build();
+        EmailChange change1 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE.minusHours(2))
+            .isDelegated(false)
+            .created(TestMessageId.of(2))
+            .build();
+        EmailChange change2 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE.minusHours(1))
+            .isDelegated(false)
+            .created(TestMessageId.of(3))
+            .build();
+        EmailChange change3 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE)
+            .isDelegated(false)
+            .created(TestMessageId.of(4))
+            .build();
+        EmailChange change4 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE.plusHours(1))
+            .isDelegated(false)
+            .created(TestMessageId.of(5))
+            .build();
+        repository.save(oldState).block();
+        repository.save(change1).block();
+        repository.save(change2).block();
+        repository.save(change3).block();
+        repository.save(change4).block();
+
+        assertThat(repository.getSinceState(ACCOUNT_ID, STATE_0, Optional.of(Limit.of(3))).block().getCreated())
+            .containsExactlyInAnyOrder(TestMessageId.of(2), TestMessageId.of(3), TestMessageId.of(4));
+    }
+
+    @Test
+    default void getChangesShouldReturnAllFromInitial() {
+        EmailChangeRepository repository = emailChangeRepository();
+
+        EmailChange oldState = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(STATE_0)
+            .date(DATE.minusHours(3))
+            .isDelegated(false)
+            .created(TestMessageId.of(1))
+            .build();
+        EmailChange change1 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE.minusHours(2))
+            .isDelegated(false)
+            .created(TestMessageId.of(2))
+            .build();
+        EmailChange change2 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE.minusHours(1))
+            .isDelegated(false)
+            .created(TestMessageId.of(3))
+            .build();
+        EmailChange change3 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE)
+            .isDelegated(false)
+            .created(TestMessageId.of(4))
+            .build();
+        repository.save(oldState).block();
+        repository.save(change1).block();
+        repository.save(change2).block();
+        repository.save(change3).block();
+
+        assertThat(repository.getSinceState(ACCOUNT_ID, State.INITIAL, Optional.of(Limit.of(3))).block().getCreated())
+            .containsExactlyInAnyOrder(TestMessageId.of(1), TestMessageId.of(2), TestMessageId.of(3));
+    }
+
+    @Test
+    default void getChangesFromInitialShouldReturnNewState() {
+        EmailChangeRepository repository = emailChangeRepository();
+        State state2 = State.of(UUID.randomUUID());
+
+        EmailChange oldState = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(STATE_0)
+            .date(DATE.minusHours(3))
+            .isDelegated(false)
+            .created(TestMessageId.of(1))
+            .build();
+        EmailChange change1 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE.minusHours(2))
+            .isDelegated(false)
+            .created(TestMessageId.of(2))
+            .build();
+        EmailChange change2 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(state2)
+            .date(DATE.minusHours(1))
+            .isDelegated(false)
+            .created(TestMessageId.of(3))
+            .build();
+        EmailChange change3 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE)
+            .isDelegated(false)
+            .created(TestMessageId.of(4))
+            .build();
+
+        repository.save(oldState).block();
+        repository.save(change1).block();
+        repository.save(change2).block();
+        repository.save(change3).block();
+
+        assertThat(repository.getSinceState(ACCOUNT_ID, State.INITIAL, Optional.of(Limit.of(3))).block().getNewState())
+            .isEqualTo(state2);
+    }
+
+    @Test
+    default void getChangesShouldLimitChangesWhenMaxChangesOmitted() {
+        EmailChangeRepository repository = emailChangeRepository();
+
+        EmailChange oldState = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(STATE_0)
+            .date(DATE.minusHours(2))
+            .isDelegated(false)
+            .created(TestMessageId.of(1))
+            .build();
+        EmailChange change1 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE.minusHours(1))
+            .isDelegated(false)
+            .created(TestMessageId.of(2), TestMessageId.of(3), TestMessageId.of(4), TestMessageId.of(5), TestMessageId.of(6))
+            .build();
+        EmailChange change2 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE)
+            .isDelegated(false)
+            .created(TestMessageId.of(7))
+            .build();
+
+        repository.save(oldState).block();
+        repository.save(change1).block();
+        repository.save(change2).block();
+
+        assertThat(repository.getSinceState(ACCOUNT_ID, STATE_0, Optional.empty()).block().getAllChanges())
+            .hasSameElementsAs(change1.getCreated());
+    }
+
+    @Test
+    default void getChangesShouldNotReturnMoreThanMaxChanges() {
+        EmailChangeRepository repository = emailChangeRepository();
+
+        EmailChange oldState = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(STATE_0)
+            .date(DATE.minusHours(2))
+            .isDelegated(false)
+            .created(TestMessageId.of(1))
+            .build();
+        EmailChange change1 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE.minusHours(1))
+            .isDelegated(false)
+            .created(TestMessageId.of(2), TestMessageId.of(3))
+            .build();
+        EmailChange change2 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE)
+            .isDelegated(false)
+            .created(TestMessageId.of(4), TestMessageId.of(5))
+            .build();
+        repository.save(oldState).block();
+        repository.save(change1).block();
+        repository.save(change2).block();
+
+        assertThat(repository.getSinceState(ACCOUNT_ID, STATE_0, Optional.of(Limit.of(3))).block().getAllChanges())
+            .hasSameElementsAs(change1.getCreated());
+    }
+
+    @Test
+    default void getChangesShouldReturnEmptyWhenNumberOfChangesExceedMaxChanges() {
+        EmailChangeRepository repository = emailChangeRepository();
+
+        EmailChange oldState = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(STATE_0)
+            .date(DATE.minusHours(2))
+            .isDelegated(false)
+            .created(TestMessageId.of(1))
+            .build();
+        EmailChange change1 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE.minusHours(1))
+            .isDelegated(false)
+            .created(TestMessageId.of(2), TestMessageId.of(3))
+            .build();
+        EmailChange change2 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE)
+            .isDelegated(false)
+            .created(TestMessageId.of(4), TestMessageId.of(5))
+            .build();
+        repository.save(oldState).block();
+        repository.save(change1).block();
+
+        assertThat(repository.getSinceState(ACCOUNT_ID, STATE_0, Optional.of(Limit.of(1))).block().getAllChanges())
+            .isEmpty();
+    }
+
+    @Test
+    default void getChangesShouldReturnNewState() {
+        EmailChangeRepository repository = emailChangeRepository();
+
+        EmailChange oldState = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(STATE_0)
+            .date(DATE.minusHours(2))
+            .isDelegated(false)
+            .created(TestMessageId.of(1))
+            .build();
+        EmailChange change1 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE.minusHours(1))
+            .isDelegated(false)
+            .created(TestMessageId.of(2), TestMessageId.of(3))
+            .build();
+        EmailChange change2 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE)
+            .isDelegated(false)
+            .updated(TestMessageId.of(2), TestMessageId.of(3))
+            .build();
+        repository.save(oldState).block();
+        repository.save(change1).block();
+        repository.save(change2).block();
+
+        assertThat(repository.getSinceState(ACCOUNT_ID, STATE_0, Optional.empty()).block().getNewState())
+            .isEqualTo(change2.getState());
+    }
+
+    @Test
+    default void hasMoreChangesShouldBeTrueWhenMoreChanges() {
+        EmailChangeRepository repository = emailChangeRepository();
+
+        EmailChange oldState = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(STATE_0)
+            .date(DATE.minusHours(2))
+            .isDelegated(false)
+            .created(TestMessageId.of(1))
+            .build();
+        EmailChange change1 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE.minusHours(1))
+            .isDelegated(false)
+            .created(TestMessageId.of(2), TestMessageId.of(3))
+            .build();
+        EmailChange change2 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE)
+            .isDelegated(false)
+            .updated(TestMessageId.of(2), TestMessageId.of(3))
+            .build();
+        repository.save(oldState).block();
+        repository.save(change1).block();
+        repository.save(change2).block();
+
+        assertThat(repository.getSinceState(ACCOUNT_ID, STATE_0, Optional.of(Limit.of(1))).block().hasMoreChanges())
+            .isTrue();
+    }
+
+    @Test
+    default void hasMoreChangesShouldBeFalseWhenNoMoreChanges() {
+        EmailChangeRepository repository = emailChangeRepository();
+
+        EmailChange oldState = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(STATE_0)
+            .date(DATE.minusHours(2))
+            .isDelegated(false)
+            .created(TestMessageId.of(1))
+            .build();
+        EmailChange change1 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE.minusHours(1))
+            .isDelegated(false)
+            .created(TestMessageId.of(2), TestMessageId.of(3))
+            .build();
+        EmailChange change2 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE)
+            .isDelegated(false)
+            .updated(TestMessageId.of(2), TestMessageId.of(3))
+            .build();
+        repository.save(oldState).block();
+        repository.save(change1).block();
+        repository.save(change2).block();
+
+        assertThat(repository.getSinceState(ACCOUNT_ID, STATE_0, Optional.of(Limit.of(4))).block().hasMoreChanges())
+            .isFalse();
+    }
+
+    @Test
+    default void changesShouldBeStoredInTheirRespectiveType() {
+        EmailChangeRepository repository = emailChangeRepository();
+
+
+        EmailChange oldState = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(STATE_0)
+            .date(DATE.minusHours(3))
+            .isDelegated(false)
+            .created(TestMessageId.of(1))
+            .build();
+        EmailChange change1 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE.minusHours(2))
+            .isDelegated(false)
+            .created(TestMessageId.of(2), TestMessageId.of(3), TestMessageId.of(4), TestMessageId.of(5))
+            .build();
+        EmailChange change2 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE.minusHours(1))
+            .isDelegated(false)
+            .created(TestMessageId.of(6), TestMessageId.of(7))
+            .updated(TestMessageId.of(2), TestMessageId.of(3))
+            .destroyed(TestMessageId.of(4))
+            .build();
+        EmailChange change3 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE)
+            .isDelegated(false)
+            .created(TestMessageId.of(8))
+            .updated(TestMessageId.of(6), TestMessageId.of(7))
+            .destroyed(TestMessageId.of(5))
+            .build();
+        repository.save(oldState).block();
+        repository.save(change1).block();
+        repository.save(change2).block();
+        repository.save(change3).block();
+
+        EmailChanges emailChanges = repository.getSinceState(ACCOUNT_ID, STATE_0, Optional.of(Limit.of(20))).block();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(emailChanges.getCreated()).containsExactlyInAnyOrder(TestMessageId.of(2), TestMessageId.of(3), TestMessageId.of(4), TestMessageId.of(5), TestMessageId.of(6), TestMessageId.of(7), TestMessageId.of(8));
+            softly.assertThat(emailChanges.getUpdated()).containsExactlyInAnyOrder(TestMessageId.of(2), TestMessageId.of(3), TestMessageId.of(6), TestMessageId.of(7));
+            softly.assertThat(emailChanges.getDestroyed()).containsExactlyInAnyOrder(TestMessageId.of(4), TestMessageId.of(5));
+        });
+    }
+
+    @Test
+    default void getChangesShouldIgnoreDuplicatedValues() {
+        EmailChangeRepository repository = emailChangeRepository();
+
+        EmailChange oldState = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(STATE_0)
+            .date(DATE.minusHours(2))
+            .isDelegated(false)
+            .created(TestMessageId.of(1))
+            .build();
+        EmailChange change1 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE.minusHours(1))
+            .isDelegated(false)
+            .updated(TestMessageId.of(1), TestMessageId.of(2))
+            .build();
+        EmailChange change2 = EmailChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(State.of(UUID.randomUUID()))
+            .date(DATE)
+            .isDelegated(false)
+            .updated(TestMessageId.of(1), TestMessageId.of(2))
+            .created(TestMessageId.of(3))
+            .build();
+        repository.save(oldState).block();
+        repository.save(change1).block();
+        repository.save(change2).block();
+
+        EmailChanges emailChanges = repository.getSinceState(ACCOUNT_ID, STATE_0, Optional.of(Limit.of(3))).block();
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(emailChanges.getUpdated()).containsExactly(TestMessageId.of(1), TestMessageId.of(2));
+            softly.assertThat(emailChanges.getCreated()).containsExactly(TestMessageId.of(3));
+        });
+    }
+
+    @Test
+    default void getChangesShouldFailWhenSinceStateNotFound() {
+        EmailChangeRepository repository = emailChangeRepository();
+
+        assertThatThrownBy(() -> repository.getSinceState(ACCOUNT_ID, STATE_0, Optional.empty()).block())
+            .isInstanceOf(ChangeNotFoundException.class);
+    }
+}

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/EmailChangeTest.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/EmailChangeTest.java
@@ -1,0 +1,75 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.api.change;
+
+import static org.apache.james.mailbox.fixture.MailboxFixture.BOB;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+import org.apache.james.jmap.api.model.AccountId;
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class EmailChangeTest {
+    AccountId ACCOUNT_ID = AccountId.fromUsername(BOB);
+    ZonedDateTime DATE = ZonedDateTime.now();
+
+    @Test
+    void shouldMatchBeanContract() {
+        EqualsVerifier.forClass(EmailChange.class)
+            .verify();
+    }
+
+    @Test
+    void shouldThrowOnNullAccountId() {
+        assertThatThrownBy(() ->
+            EmailChange.builder()
+                .accountId(null)
+                .state(State.of(UUID.randomUUID()))
+                .date(DATE.minusHours(2))
+                .isDelegated(false))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowOnNullState() {
+        assertThatThrownBy(() ->
+            EmailChange.builder()
+                .accountId(ACCOUNT_ID)
+                .state(null)
+                .date(DATE.minusHours(2))
+                .isDelegated(false))
+            .isInstanceOf(NullPointerException.class);;
+    }
+
+    @Test
+    void shouldThrowOnNullDate() {
+        assertThatThrownBy(() ->
+            EmailChange.builder()
+                .accountId(ACCOUNT_ID)
+                .state(State.of(UUID.randomUUID()))
+                .date(null)
+                .isDelegated(false))
+            .isInstanceOf(NullPointerException.class);;
+    }
+}

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/LimitTest.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/LimitTest.java
@@ -17,28 +17,29 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.jmap.rfc8621.memory;
+package org.apache.james.jmap.api.change;
 
-import static org.apache.james.MemoryJamesServerMain.IN_MEMORY_SERVER_AGGREGATE_MODULE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.apache.james.GuiceJamesServer;
-import org.apache.james.JamesServerBuilder;
-import org.apache.james.JamesServerExtension;
-import org.apache.james.jmap.api.change.State;
-import org.apache.james.jmap.rfc8621.contract.MailboxChangesMethodContract;
-import org.apache.james.modules.TestJMAPServerModule;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
 
-public class MemoryMailboxChangesMethodTest implements MailboxChangesMethodContract {
-    @RegisterExtension
-    static JamesServerExtension testExtension = new JamesServerBuilder<>(JamesServerBuilder.defaultConfigurationProvider())
-        .server(configuration -> GuiceJamesServer.forConfiguration(configuration)
-            .combineWith(IN_MEMORY_SERVER_AGGREGATE_MODULE)
-            .overrideWith(new TestJMAPServerModule()))
-        .build();
+class LimitTest {
+    @Test
+    void ofShouldThrowWhenNegative() {
+        assertThatThrownBy(() -> Limit.of(-1))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
 
-    @Override
-    public State.Factory stateFactory() {
-        return new State.DefaultFactory();
+    @Test
+    void ofShouldThrowWhenZero() {
+        assertThatThrownBy(() -> Limit.of(0))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void getValueShouldReturnSuppliedValue() {
+        assertThat(Limit.of(36).getValue())
+            .isEqualTo(36);
     }
 }

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/MailboxChangeRepositoryContract.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/MailboxChangeRepositoryContract.java
@@ -27,8 +27,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
-import org.apache.james.jmap.api.change.MailboxChange.Limit;
-import org.apache.james.jmap.api.change.MailboxChange.State;
 import org.apache.james.jmap.api.exception.ChangeNotFoundException;
 import org.apache.james.jmap.api.model.AccountId;
 import org.apache.james.mailbox.model.TestId;

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/MailboxChangeRepositoryContract.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/MailboxChangeRepositoryContract.java
@@ -147,27 +147,6 @@ public interface MailboxChangeRepositoryContract {
     }
 
     @Test
-    default void saveChangeShouldFailWhenNoAccountId() {
-        MailboxChangeRepository repository = mailboxChangeRepository();
-        State.Factory stateFactory = stateFactory();
-
-        MailboxChange change = MailboxChange.builder().accountId(null).state(stateFactory.generate()).date(DATE).created(ImmutableList.of(TestId.of(1))).build();
-
-        assertThatThrownBy(() -> repository.save(change).block())
-            .isInstanceOf(NullPointerException.class);
-    }
-
-    @Test
-    default void saveChangeShouldFailWhenNoState() {
-        MailboxChangeRepository repository = mailboxChangeRepository();
-
-        MailboxChange change = MailboxChange.builder().accountId(ACCOUNT_ID).state(null).date(DATE).created(ImmutableList.of(TestId.of(1))).build();
-
-        assertThatThrownBy(() -> repository.save(change).block())
-            .isInstanceOf(NullPointerException.class);
-    }
-
-    @Test
     default void getChangesShouldSuccess() {
         MailboxChangeRepository repository = mailboxChangeRepository();
         State.Factory stateFactory = stateFactory();

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/MailboxChangeRepositoryContract.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/MailboxChangeRepositoryContract.java
@@ -353,14 +353,24 @@ public interface MailboxChangeRepositoryContract {
         State.Factory stateFactory = stateFactory();
         State referenceState = stateFactory.generate();
 
-        MailboxChange oldState = MailboxChange.builder().accountId(ACCOUNT_ID).state(referenceState).date(DATE.minusHours(3)).created(ImmutableList.of(TestId.of(1))).build();
-        MailboxChange change1 = MailboxChange.builder().accountId(ACCOUNT_ID).state(stateFactory.generate()).date(DATE.minusHours(2)).created(ImmutableList.of(TestId.of(2), TestId.of(3), TestId.of(4), TestId.of(5))).build();
+        MailboxChange oldState = MailboxChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(referenceState)
+            .date(DATE.minusHours(3))
+            .created(ImmutableList.of(TestId.of(1), TestId.of(9), TestId.of(10)))
+            .build();
+        MailboxChange change1 = MailboxChange.builder()
+            .accountId(ACCOUNT_ID)
+            .state(stateFactory.generate())
+            .date(DATE.minusHours(2))
+            .created(ImmutableList.of(TestId.of(2), TestId.of(3), TestId.of(4), TestId.of(5)))
+            .build();
         MailboxChange change2 = MailboxChange.builder()
             .accountId(ACCOUNT_ID)
             .state(stateFactory.generate())
             .date(DATE.minusHours(1))
             .created(ImmutableList.of(TestId.of(6), TestId.of(7)))
-            .updated(ImmutableList.of(TestId.of(2), TestId.of(3)))
+            .updated(ImmutableList.of(TestId.of(2), TestId.of(3), TestId.of(9)))
             .destroyed(ImmutableList.of(TestId.of(4))).build();
         MailboxChange change3 = MailboxChange.builder()
             .accountId(ACCOUNT_ID)
@@ -368,7 +378,7 @@ public interface MailboxChangeRepositoryContract {
             .date(DATE)
             .created(ImmutableList.of(TestId.of(8)))
             .updated(ImmutableList.of(TestId.of(6), TestId.of(7)))
-            .destroyed(ImmutableList.of(TestId.of(5))).build();
+            .destroyed(ImmutableList.of(TestId.of(5), TestId.of(10))).build();
 
         repository.save(oldState).block();
         repository.save(change1).block();
@@ -378,9 +388,9 @@ public interface MailboxChangeRepositoryContract {
         MailboxChanges mailboxChanges = repository.getSinceState(ACCOUNT_ID, referenceState, Optional.of(Limit.of(20))).block();
 
         SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(mailboxChanges.getCreated()).containsExactlyInAnyOrder(TestId.of(2), TestId.of(3), TestId.of(4), TestId.of(5), TestId.of(6), TestId.of(7), TestId.of(8));
-            softly.assertThat(mailboxChanges.getUpdated()).containsExactlyInAnyOrder(TestId.of(2), TestId.of(3), TestId.of(6), TestId.of(7));
-            softly.assertThat(mailboxChanges.getDestroyed()).containsExactlyInAnyOrder(TestId.of(4), TestId.of(5));
+            softly.assertThat(mailboxChanges.getCreated()).containsExactlyInAnyOrder(TestId.of(2), TestId.of(3), TestId.of(6), TestId.of(7), TestId.of(8));
+            softly.assertThat(mailboxChanges.getUpdated()).containsExactlyInAnyOrder(TestId.of(9));
+            softly.assertThat(mailboxChanges.getDestroyed()).containsExactlyInAnyOrder(TestId.of(10));
         });
     }
 

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/MailboxChangeTest.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/MailboxChangeTest.java
@@ -1,0 +1,72 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.api.change;
+
+import static org.apache.james.mailbox.fixture.MailboxFixture.BOB;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+import org.apache.james.jmap.api.model.AccountId;
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class MailboxChangeTest {
+    AccountId ACCOUNT_ID = AccountId.fromUsername(BOB);
+    ZonedDateTime DATE = ZonedDateTime.now();
+
+    @Test
+    void shouldMatchBeanContract() {
+        EqualsVerifier.forClass(MailboxChange.class)
+            .verify();
+    }
+
+    @Test
+    void shouldThrowOnNullAccountId() {
+        assertThatThrownBy(() ->
+            MailboxChange.builder()
+                .accountId(null)
+                .state(State.of(UUID.randomUUID()))
+                .date(DATE.minusHours(2)))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowOnNullState() {
+        assertThatThrownBy(() ->
+            MailboxChange.builder()
+                .accountId(ACCOUNT_ID)
+                .state(null)
+                .date(DATE.minusHours(2)))
+            .isInstanceOf(NullPointerException.class);;
+    }
+
+    @Test
+    void shouldThrowOnNullDate() {
+        assertThatThrownBy(() ->
+            MailboxChange.builder()
+                .accountId(ACCOUNT_ID)
+                .state(State.of(UUID.randomUUID()))
+                .date(null))
+            .isInstanceOf(NullPointerException.class);;
+    }
+}

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/StateTest.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/api/change/StateTest.java
@@ -17,28 +17,34 @@
  * under the License.                                           *
  ****************************************************************/
 
-package org.apache.james.jmap.rfc8621.memory;
+package org.apache.james.jmap.api.change;
 
-import static org.apache.james.MemoryJamesServerMain.IN_MEMORY_SERVER_AGGREGATE_MODULE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.apache.james.GuiceJamesServer;
-import org.apache.james.JamesServerBuilder;
-import org.apache.james.JamesServerExtension;
-import org.apache.james.jmap.api.change.State;
-import org.apache.james.jmap.rfc8621.contract.MailboxChangesMethodContract;
-import org.apache.james.modules.TestJMAPServerModule;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import java.util.UUID;
 
-public class MemoryMailboxChangesMethodTest implements MailboxChangesMethodContract {
-    @RegisterExtension
-    static JamesServerExtension testExtension = new JamesServerBuilder<>(JamesServerBuilder.defaultConfigurationProvider())
-        .server(configuration -> GuiceJamesServer.forConfiguration(configuration)
-            .combineWith(IN_MEMORY_SERVER_AGGREGATE_MODULE)
-            .overrideWith(new TestJMAPServerModule()))
-        .build();
+import org.junit.jupiter.api.Test;
 
-    @Override
-    public State.Factory stateFactory() {
-        return new State.DefaultFactory();
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class StateTest {
+    @Test
+    void shouldMatchBeanContract() {
+        EqualsVerifier.forClass(State.class)
+            .verify();
+    }
+
+    @Test
+    void ofShouldThrowOnNull() {
+        assertThatThrownBy(() -> State.of(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void getValueShouldReturnSuppliedValue() {
+        UUID uuid = UUID.randomUUID();
+        assertThat(State.of(uuid).getValue())
+            .isEqualTo(uuid);
     }
 }

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/memory/change/MemoryEmailChangeRepositoryTest.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/memory/change/MemoryEmailChangeRepositoryTest.java
@@ -1,0 +1,39 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.memory.change;
+
+import org.apache.james.jmap.api.change.EmailChangeRepository;
+import org.apache.james.jmap.api.change.EmailChangeRepositoryContract;
+import org.apache.james.jmap.api.change.MailboxChangeRepository;
+import org.junit.jupiter.api.BeforeEach;
+
+public class MemoryEmailChangeRepositoryTest implements EmailChangeRepositoryContract {
+    EmailChangeRepository emailChangeRepository;
+
+    @BeforeEach
+    void setup() {
+        emailChangeRepository = new MemoryEmailChangeRepository();
+    }
+
+    @Override
+    public EmailChangeRepository emailChangeRepository() {
+        return emailChangeRepository;
+    }
+}

--- a/server/data/data-jmap/src/test/java/org/apache/james/jmap/memory/change/MemoryMailboxChangeRepositoryTest.java
+++ b/server/data/data-jmap/src/test/java/org/apache/james/jmap/memory/change/MemoryMailboxChangeRepositoryTest.java
@@ -19,19 +19,19 @@
 
 package org.apache.james.jmap.memory.change;
 
-import org.apache.james.jmap.api.change.MailboxChange;
 import org.apache.james.jmap.api.change.MailboxChangeRepository;
 import org.apache.james.jmap.api.change.MailboxChangeRepositoryContract;
+import org.apache.james.jmap.api.change.State;
 import org.junit.jupiter.api.BeforeEach;
 
 public class MemoryMailboxChangeRepositoryTest implements MailboxChangeRepositoryContract {
     MailboxChangeRepository mailboxChangeRepository;
-    MailboxChange.State.Factory stateFactory;
+    State.Factory stateFactory;
 
     @BeforeEach
     void setup() {
         mailboxChangeRepository = new MemoryMailboxChangeRepository();
-        stateFactory = new MailboxChange.State.DefaultFactory();
+        stateFactory = new State.DefaultFactory();
     }
 
     @Override
@@ -40,7 +40,7 @@ public class MemoryMailboxChangeRepositoryTest implements MailboxChangeRepositor
     }
 
     @Override
-    public MailboxChange.State.Factory stateFactory() {
+    public State.Factory stateFactory() {
         return stateFactory;
     }
 }

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxChangesMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/MailboxChangesMethodContract.scala
@@ -35,7 +35,7 @@ import org.apache.http.HttpStatus.SC_OK
 import org.apache.james.GuiceJamesServer
 import org.apache.james.core.Username
 import org.apache.james.jmap.api.change.MailboxChange
-import org.apache.james.jmap.api.change.MailboxChange.State
+import org.apache.james.jmap.api.change.State
 import org.apache.james.jmap.api.model.AccountId
 import org.apache.james.jmap.core.ResponseObject.SESSION_STATE
 import org.apache.james.jmap.draft.JmapGuiceProbe

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/Session.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/Session.scala
@@ -25,12 +25,10 @@ import java.util.UUID
 
 import com.google.common.hash.Hashing
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.auto._
 import eu.timepit.refined.refineV
 import eu.timepit.refined.string.Uuid
 import org.apache.james.core.Username
-import org.apache.james.jmap.api.change.MailboxChanges
-import org.apache.james.jmap.api.change.MailboxChange.{State => JavaState}
+import org.apache.james.jmap.api.change.{MailboxChanges, State => JavaState}
 import org.apache.james.jmap.core.CapabilityIdentifier.CapabilityIdentifier
 import org.apache.james.jmap.core.Id.Id
 import org.apache.james.jmap.core.State.INSTANCE

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/MailboxSerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/MailboxSerializer.scala
@@ -23,7 +23,7 @@ import eu.timepit.refined._
 import eu.timepit.refined.collection.NonEmpty
 import javax.inject.Inject
 import org.apache.james.core.{Domain, Username}
-import org.apache.james.jmap.api.change.MailboxChange.Limit
+import org.apache.james.jmap.api.change.Limit
 import org.apache.james.jmap.core.CapabilityIdentifier.CapabilityIdentifier
 import org.apache.james.jmap.core.{ClientId, Properties, SetError, State}
 import org.apache.james.jmap.mail.MailboxGet.{UnparsedMailboxId, UnparsedMailboxIdConstraint}

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/MailboxGet.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/MailboxGet.scala
@@ -22,7 +22,7 @@ package org.apache.james.jmap.mail
 import eu.timepit.refined
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.collection.NonEmpty
-import org.apache.james.jmap.api.change.MailboxChange.Limit
+import org.apache.james.jmap.api.change.Limit
 import org.apache.james.jmap.api.change.MailboxChanges
 import org.apache.james.jmap.core.{AccountId, Properties, State}
 import org.apache.james.jmap.mail.MailboxGet.UnparsedMailboxId

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxChangesMethod.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/method/MailboxChangesMethod.scala
@@ -21,7 +21,7 @@ package org.apache.james.jmap.method
 
 import eu.timepit.refined.auto._
 import javax.inject.Inject
-import org.apache.james.jmap.api.change.MailboxChange.{State => JavaState}
+import org.apache.james.jmap.api.change.{State => JavaState}
 import org.apache.james.jmap.api.change.MailboxChangeRepository
 import org.apache.james.jmap.api.model.{AccountId => JavaAccountId}
 import org.apache.james.jmap.core.CapabilityIdentifier.{CapabilityIdentifier, JMAP_MAIL}

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/change/MailboxChangeListenerTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/change/MailboxChangeListenerTest.scala
@@ -22,8 +22,7 @@ package org.apache.james.jmap.change
 import java.time.{Clock, ZonedDateTime}
 
 import javax.mail.Flags
-import org.apache.james.jmap.api.change.MailboxChange.State
-import org.apache.james.jmap.api.change.{MailboxChange, MailboxChangeRepository}
+import org.apache.james.jmap.api.change.{MailboxChange, MailboxChangeRepository, State}
 import org.apache.james.jmap.api.model.AccountId
 import org.apache.james.jmap.change.MailboxChangeListenerTest.ACCOUNT_ID
 import org.apache.james.jmap.memory.change.MemoryMailboxChangeRepository

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/change/MailboxChangeListenerTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/change/MailboxChangeListenerTest.scala
@@ -101,12 +101,10 @@ class MailboxChangeListenerTest {
 
   @Test
   def updateMailboxACLShouldStoreUpdatedEvent(): Unit = {
-    val state = stateFactory.generate()
-    repository.save(MailboxChange.builder().accountId(ACCOUNT_ID).state(state).date(ZonedDateTime.now).created(List[MailboxId](TestId.of(0)).asJava).build).block()
-
     val mailboxSession = MailboxSessionUtil.create(BOB)
     val path = MailboxPath.inbox(BOB)
     val inboxId: MailboxId = mailboxManager.createMailbox(MailboxPath.inbox(BOB), mailboxSession).get
+    val state: State = repository.getLatestState(ACCOUNT_ID).block()
 
     mailboxManager.applyRightsCommand(path, MailboxACL.command().forUser(ALICE).rights(MailboxACL.Right.Read).asAddition(), mailboxSession)
 


### PR DESCRIPTION
This work is based on Mailbox/changes

I decided to not generify & reuse MailboxChangesCollector as diverging behaviours will be caused by mailboxes updated properties handling.

This work include straight away support for delegation.

Also, some extra care had been put to remove unrelevant ids from the response, avoiding some uneeded requests down the line (see https://jmap.io/spec-core.html#changes created + updated, created + destroyed, updated + destroyed remarks).