### PR TITLE
JAMES-2037 Search by uid 1:9223372036854775807 is a list all 

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/SearchQuery.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/SearchQuery.java
@@ -523,7 +523,7 @@ public class SearchQuery implements Serializable {
      *            <code>NumericRange</code>'s, not null
      * @return <code>Criterion</code>, not null
      */
-    public static Criterion uid(UidRange[] range) {
+    public static Criterion uid(UidRange... range) {
         return new UidCriterion(range);
     }
 

--- a/mailbox/lucene/src/test/java/org/apache/james/mailbox/lucene/search/LuceneMailboxMessageSearchIndexTest.java
+++ b/mailbox/lucene/src/test/java/org/apache/james/mailbox/lucene/search/LuceneMailboxMessageSearchIndexTest.java
@@ -419,7 +419,7 @@ class LuceneMailboxMessageSearchIndexTest {
     void uidSearchShouldMatch() throws Exception {
         Calendar cal = Calendar.getInstance();
         cal.setTime(new Date());
-        SearchQuery query = SearchQuery.of(SearchQuery.uid(new SearchQuery.UidRange[] {new SearchQuery.UidRange(uid1)}));
+        SearchQuery query = SearchQuery.of(SearchQuery.uid(new SearchQuery.UidRange(uid1)));
         Stream<MessageUid> result = index.search(session, mailbox, query).toStream();
         assertThat(result).containsExactly(uid1);
     }
@@ -428,7 +428,7 @@ class LuceneMailboxMessageSearchIndexTest {
     void uidRangeSearchShouldMatch() throws Exception {
         Calendar cal = Calendar.getInstance();
         cal.setTime(new Date());
-        SearchQuery query = SearchQuery.of(SearchQuery.uid(new SearchQuery.UidRange[] {new SearchQuery.UidRange(uid1), new SearchQuery.UidRange(uid3,uid4)}));
+        SearchQuery query = SearchQuery.of(SearchQuery.uid(new SearchQuery.UidRange(uid1), new SearchQuery.UidRange(uid3,uid4)));
         Stream<MessageUid> result = index.search(session, mailbox, query).toStream();
         assertThat(result).containsExactly(uid1, uid3, uid4);
     }
@@ -583,7 +583,7 @@ class LuceneMailboxMessageSearchIndexTest {
     
     @Test
     void notOperatorShouldReverseMatching() throws Exception {
-        SearchQuery query = SearchQuery.of(SearchQuery.not(SearchQuery.uid(new SearchQuery.UidRange[] { new SearchQuery.UidRange(uid1)})));
+        SearchQuery query = SearchQuery.of(SearchQuery.not(SearchQuery.uid(new SearchQuery.UidRange(uid1))));
 
         Stream<MessageUid> result = index.search(session, mailbox, query).toStream();
         assertThat(result).containsExactly(uid3, uid4);

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageManager.java
@@ -126,6 +126,7 @@ public class StoreMessageManager implements MessageManager {
      */
     protected static final Flags MINIMAL_PERMANET_FLAGS;
     private static final SearchQuery LIST_ALL_QUERY = SearchQuery.of(SearchQuery.all());
+    private static final SearchQuery LIST_FROM_ONE = SearchQuery.of(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.MIN_VALUE, MessageUid.MAX_VALUE)));
 
     private static class MediaType {
         final String mediaType;
@@ -708,7 +709,7 @@ public class StoreMessageManager implements MessageManager {
 
     @Override
     public Flux<MessageUid> search(SearchQuery query, MailboxSession mailboxSession) throws MailboxException {
-        if (query.equals(LIST_ALL_QUERY)) {
+        if (query.equals(LIST_ALL_QUERY) || query.equals(LIST_FROM_ONE)) {
             return listAllMessageUids(mailboxSession);
         }
         return index.search(mailboxSession, getMailboxEntity(), query);

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/AbstractMessageSearchIndexTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/AbstractMessageSearchIndexTest.java
@@ -1073,8 +1073,9 @@ public abstract class AbstractMessageSearchIndexTest {
 
     @Test
     void uidShouldreturnExistingUidsOnTheGivenRanges() throws Exception {
-        SearchQuery.UidRange[] numericRanges = {new SearchQuery.UidRange(m2.getUid(), m4.getUid()), new SearchQuery.UidRange(m6.getUid(), m7.getUid())};
-        SearchQuery searchQuery = SearchQuery.of(SearchQuery.uid(numericRanges));
+        SearchQuery searchQuery = SearchQuery.of(SearchQuery.uid(
+            new SearchQuery.UidRange(m2.getUid(), m4.getUid()),
+            new SearchQuery.UidRange(m6.getUid(), m7.getUid())));
 
         assertThat(messageSearchIndex.search(session, mailbox, searchQuery).toStream())
             .containsOnly(m2.getUid(), m3.getUid(), m4.getUid(), m6.getUid(), m7.getUid());
@@ -1189,9 +1190,8 @@ public abstract class AbstractMessageSearchIndexTest {
 
     @Test
     protected void sortOnCcShouldWork() throws Exception {
-        SearchQuery.UidRange[] numericRanges = {new SearchQuery.UidRange(m2.getUid(), m5.getUid())};
         SearchQuery searchQuery = SearchQuery.builder()
-            .andCriteria(SearchQuery.uid(numericRanges))
+            .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(m2.getUid(), m5.getUid())))
             .sorts(new Sort(SortClause.MailboxCc))
             .build();
 
@@ -1205,9 +1205,8 @@ public abstract class AbstractMessageSearchIndexTest {
 
     @Test
     protected void sortOnFromShouldWork() throws Exception {
-        SearchQuery.UidRange[] numericRanges = {new SearchQuery.UidRange(m2.getUid(), m5.getUid())};
         SearchQuery searchQuery = SearchQuery.builder()
-            .andCriteria(SearchQuery.uid(numericRanges))
+            .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(m2.getUid(), m5.getUid())))
             .sorts(new Sort(SortClause.MailboxFrom))
             .build();
 
@@ -1221,9 +1220,8 @@ public abstract class AbstractMessageSearchIndexTest {
 
     @Test
     protected void sortOnToShouldWork() throws Exception {
-        SearchQuery.UidRange[] numericRanges = {new SearchQuery.UidRange(m2.getUid(), m5.getUid())};
         SearchQuery searchQuery = SearchQuery.builder()
-            .andCriteria(SearchQuery.uid(numericRanges))
+            .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(m2.getUid(), m5.getUid())))
             .sorts(new Sort(SortClause.MailboxTo))
             .build();
 
@@ -1237,9 +1235,8 @@ public abstract class AbstractMessageSearchIndexTest {
 
     @Test
     void sortOnSubjectShouldWork() throws Exception {
-        SearchQuery.UidRange[] numericRanges = {new SearchQuery.UidRange(m2.getUid(), m5.getUid())};
         SearchQuery searchQuery = SearchQuery.builder()
-            .andCriteria(SearchQuery.uid(numericRanges))
+            .andCriteria(SearchQuery.uid(new SearchQuery.UidRange(m2.getUid(), m5.getUid())))
             .sorts(new Sort(SortClause.BaseSubject))
             .build();
 

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/SearchUtilsTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/search/SearchUtilsTest.java
@@ -457,21 +457,21 @@ class SearchUtilsTest {
     void testShouldMatchUidRange() throws Exception {
         builder.setKey(1, MessageUid.of(1729));
         MailboxMessage row = builder.build();
-        assertThat(messageSearches.isMatch(SearchQuery.uid(range(MessageUid.of(1), MessageUid.of(1))), row, recent)).isFalse();
-        assertThat(messageSearches.isMatch(SearchQuery.uid(range(MessageUid.of(1728), MessageUid.of(1728))), row,
+        assertThat(messageSearches.isMatch(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(1), MessageUid.of(1))), row, recent)).isFalse();
+        assertThat(messageSearches.isMatch(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(1728), MessageUid.of(1728))), row,
                 recent)).isFalse();
-        assertThat(messageSearches.isMatch(SearchQuery.uid(range(MessageUid.of(1729), MessageUid.of(1729))), row,
+        assertThat(messageSearches.isMatch(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(1729), MessageUid.of(1729))), row,
                 recent)).isTrue();
-        assertThat(messageSearches.isMatch(SearchQuery.uid(range(MessageUid.of(1730), MessageUid.of(1730))), row,
+        assertThat(messageSearches.isMatch(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(1730), MessageUid.of(1730))), row,
                 recent)).isFalse();
-        assertThat(messageSearches.isMatch(SearchQuery.uid(range(MessageUid.of(1), MessageUid.of(1728))), row,
+        assertThat(messageSearches.isMatch(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(1), MessageUid.of(1728))), row,
                 recent)).isFalse();
-        assertThat(messageSearches.isMatch(SearchQuery.uid(range(MessageUid.of(1), MessageUid.of(1729))), row,
+        assertThat(messageSearches.isMatch(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(1), MessageUid.of(1729))), row,
                 recent)).isTrue();
-        assertThat(messageSearches.isMatch(SearchQuery.uid(range(MessageUid.of(1729), MessageUid.of(1800))), row,
+        assertThat(messageSearches.isMatch(SearchQuery.uid(new SearchQuery.UidRange(MessageUid.of(1729), MessageUid.of(1800))), row,
                 recent)).isTrue();
         assertThat(messageSearches.isMatch(SearchQuery
-                .uid(range(MessageUid.of(1730), MessageUid.MAX_VALUE)), row, recent)).isFalse();
+                .uid(new SearchQuery.UidRange(MessageUid.of(1730), MessageUid.MAX_VALUE)), row, recent)).isFalse();
         assertThat(messageSearches.isMatch(SearchQuery.uid(range(MessageUid.of(1730),
                 MessageUid.MAX_VALUE, MessageUid.of(1), MessageUid.of(1728))), row, recent)).isFalse();
         assertThat(messageSearches.isMatch(SearchQuery.uid(range(MessageUid.of(1730), MessageUid.MAX_VALUE,
@@ -749,10 +749,6 @@ class SearchUtilsTest {
                         .headerExists(DATE_FIELD)), row, recent)).isFalse();
         assertThat(messageSearches.isMatch(SearchQuery.and(SearchQuery.all(),
                 SearchQuery.all()), row, recent)).isTrue();
-    }
-    
-    SearchQuery.UidRange[] range(MessageUid low, MessageUid high) {
-        return new SearchQuery.UidRange[]{ new SearchQuery.UidRange(low, high) };
     }
 
     SearchQuery.UidRange[] range(MessageUid lowOne, MessageUid highOne,


### PR DESCRIPTION
As such, like LIST_ALL_QUERY, it should be resolved against
primary storage.

We found the following pattern to be very frequent in our
IMAP logs:

```
SearchOperation{key=SearchKey{type=TYPE_UID, date=null, size=0, value=null, seconds=-1, modSeq=-1, uids=[IdRange : TYPE: FROM UID: MessageUid{uid=1}:MessageUid{uid=9223372036854775807}], sequences=null, keys=Optional.empty}, options=[]}
```