### PR TITLE
JAMES-3485 JMAP: Sending a message reads too much data in Cassandra

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/MultimailboxesSearchQuery.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/MultimailboxesSearchQuery.java
@@ -40,6 +40,8 @@ public class MultimailboxesSearchQuery {
     public interface Namespace {
         boolean keepAccessible(Mailbox mailbox);
 
+        boolean accessDelegatedMailboxes();
+
         MailboxQuery associatedMailboxSearchQuery();
     }
 
@@ -60,6 +62,11 @@ public class MultimailboxesSearchQuery {
             return MailboxQuery.privateMailboxesBuilder(session)
                 .matchesAllMailboxNames()
                 .build();
+        }
+
+        @Override
+        public boolean accessDelegatedMailboxes() {
+            return false;
         }
     }
 
@@ -82,6 +89,11 @@ public class MultimailboxesSearchQuery {
         @Override
         public boolean equals(Object obj) {
             return obj instanceof AccessibleNamespace;
+        }
+
+        @Override
+        public boolean accessDelegatedMailboxes() {
+            return true;
         }
     }
     

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreAttachmentManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreAttachmentManager.java
@@ -23,9 +23,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.AttachmentManager;
 import org.apache.james.mailbox.MailboxSession;
@@ -41,7 +45,10 @@ import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.fge.lambdas.Throwing;
 import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 public class StoreAttachmentManager implements AttachmentManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(StoreAttachmentManager.class);
@@ -70,9 +77,7 @@ public class StoreAttachmentManager implements AttachmentManager {
 
     @Override
     public List<AttachmentMetadata> getAttachments(List<AttachmentId> attachmentIds, MailboxSession mailboxSession) throws MailboxException {
-        List<AttachmentId> accessibleAttachmentIds = attachmentIds.stream()
-            .filter(attachmentId -> userHasAccessToAttachment(attachmentId, mailboxSession))
-            .collect(Guavate.toImmutableList());
+        Collection<AttachmentId> accessibleAttachmentIds = keepAccessible(attachmentIds, mailboxSession);
 
         return attachmentMapperFactory.getAttachmentMapper(mailboxSession).getAttachments(accessibleAttachmentIds);
     }
@@ -93,11 +98,48 @@ public class StoreAttachmentManager implements AttachmentManager {
         }
     }
 
+    private Collection<AttachmentId> keepAccessible(Collection<AttachmentId> attachmentIds, MailboxSession mailboxSession) {
+        try {
+            Set<AttachmentId> referencedByMessages = referencedInUserMessages(attachmentIds, mailboxSession);
+            ImmutableSet<AttachmentId> owned = Sets.difference(ImmutableSet.copyOf(attachmentIds), referencedByMessages)
+                .stream()
+                .filter(Throwing.<AttachmentId>predicate(id -> isReferencedInUserMessages(id, mailboxSession)).sneakyThrow())
+                .collect(Guavate.toImmutableSet());
+
+            return ImmutableSet.<AttachmentId>builder()
+                .addAll(referencedByMessages)
+                .addAll(owned)
+                .build();
+        } catch (MailboxException e) {
+            LOGGER.warn("Error while checking attachment related accessible message ids", e);
+            throw new RuntimeException(e);
+        }
+    }
+
     private boolean isReferencedInUserMessages(AttachmentId attachmentId, MailboxSession mailboxSession) throws MailboxException {
         Collection<MessageId> relatedMessageIds = getRelatedMessageIds(attachmentId, mailboxSession);
         return !messageIdManager
             .accessibleMessages(relatedMessageIds, mailboxSession)
             .isEmpty();
+    }
+
+    private Set<AttachmentId> referencedInUserMessages(Collection<AttachmentId> attachmentIds, MailboxSession mailboxSession) throws MailboxException {
+        Map<MessageId, Collection<AttachmentId>> entries = attachmentIds.stream()
+            .flatMap(Throwing.<AttachmentId, Stream<Pair<MessageId, AttachmentId>>>function(
+                attachmentId -> getRelatedMessageIds(attachmentId, mailboxSession).stream()
+                    .map(messageId -> Pair.of(messageId, attachmentId)))
+                .sneakyThrow())
+            .collect(Guavate.toImmutableListMultimap(
+                Pair::getKey,
+                Pair::getValue))
+            .asMap();
+
+        Set<MessageId> accessibleMessages = messageIdManager.accessibleMessages(entries.keySet(), mailboxSession);
+
+        return entries.entrySet().stream()
+            .filter(entry -> accessibleMessages.contains(entry.getKey()))
+            .flatMap(entry -> entry.getValue().stream())
+            .collect(Guavate.toImmutableSet());
     }
 
     private boolean isExplicitlyAOwner(AttachmentId attachmentId, MailboxSession mailboxSession) throws MailboxException {

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreAttachmentManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreAttachmentManager.java
@@ -103,7 +103,7 @@ public class StoreAttachmentManager implements AttachmentManager {
             Set<AttachmentId> referencedByMessages = referencedInUserMessages(attachmentIds, mailboxSession);
             ImmutableSet<AttachmentId> owned = Sets.difference(ImmutableSet.copyOf(attachmentIds), referencedByMessages)
                 .stream()
-                .filter(Throwing.<AttachmentId>predicate(id -> isReferencedInUserMessages(id, mailboxSession)).sneakyThrow())
+                .filter(Throwing.<AttachmentId>predicate(id -> isExplicitlyAOwner(id, mailboxSession)).sneakyThrow())
                 .collect(Guavate.toImmutableSet());
 
             return ImmutableSet.<AttachmentId>builder()

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMailboxManager.java
@@ -749,10 +749,6 @@ public class StoreMailboxManager implements MailboxManager {
         }
     }
 
-    private Flux<Mailbox> getAllReadableMailbox(MailboxQuery mailboxQuery, MailboxSession session) throws MailboxException {
-        return searchMailboxes(mailboxQuery, session, Right.Read);
-    }
-
     private Flux<Mailbox> filterReadable(ImmutableSet<MailboxId> inMailboxes, MailboxSession session) throws MailboxException {
         MailboxMapper mailboxMapper = mailboxSessionMapperFactory.getMailboxMapper(session);
         return Flux.fromIterable(inMailboxes)

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageIdManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageIdManager.java
@@ -73,7 +73,6 @@ import org.apache.james.mailbox.store.mail.model.Message;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 import org.apache.james.mailbox.store.quota.QuotaChecker;
 import org.apache.james.util.FunctionalUtils;
-import org.apache.james.util.ReactorUtils;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageIdManager.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/StoreMessageIdManager.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import javax.inject.Inject;
 import javax.mail.Flags;
@@ -72,6 +73,7 @@ import org.apache.james.mailbox.store.mail.model.Message;
 import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
 import org.apache.james.mailbox.store.quota.QuotaChecker;
 import org.apache.james.util.FunctionalUtils;
+import org.apache.james.util.ReactorUtils;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -141,13 +143,17 @@ public class StoreMessageIdManager implements MessageIdManager {
     @Override
     public Set<MessageId> accessibleMessages(Collection<MessageId> messageIds, MailboxSession mailboxSession) throws MailboxException {
         MessageIdMapper messageIdMapper = mailboxSessionMapperFactory.getMessageIdMapper(mailboxSession);
-        List<MailboxMessage> messageList = messageIdMapper.find(messageIds, MessageMapper.FetchType.Metadata);
+        ImmutableList<ComposedMessageIdWithMetaData> idList = Flux.fromIterable(messageIds)
+            .flatMap(messageIdMapper::findMetadata, DEFAULT_CONCURRENCY)
+            .collect(Guavate.toImmutableList())
+            .block();
 
-        ImmutableSet<MailboxId> allowedMailboxIds = getAllowedMailboxIds(mailboxSession, messageList, Right.Read);
+        ImmutableSet<MailboxId> allowedMailboxIds = getAllowedMailboxIds(mailboxSession, idList.stream()
+            .map(id -> id.getComposedMessageId().getMailboxId()), Right.Read);
 
-        return messageList.stream()
-            .filter(message -> allowedMailboxIds.contains(message.getMailboxId()))
-            .map(MailboxMessage::getMessageId)
+        return idList.stream()
+            .filter(id -> allowedMailboxIds.contains(id.getComposedMessageId().getMailboxId()))
+            .map(id -> id.getComposedMessageId().getMessageId())
             .collect(Guavate.toImmutableSet());
     }
 
@@ -181,9 +187,8 @@ public class StoreMessageIdManager implements MessageIdManager {
             .flatMap(Function.identity(), DEFAULT_CONCURRENCY);
     }
 
-    private ImmutableSet<MailboxId> getAllowedMailboxIds(MailboxSession mailboxSession, List<MailboxMessage> messageList, Right... rights) throws MailboxException {
-        return MailboxReactorUtils.block(Flux.fromIterable(messageList)
-            .map(MailboxMessage::getMailboxId)
+    private ImmutableSet<MailboxId> getAllowedMailboxIds(MailboxSession mailboxSession, Stream<MailboxId> idList, Right... rights) throws MailboxException {
+        return MailboxReactorUtils.block(Flux.fromStream(idList)
             .distinct()
             .filterWhen(hasRightsOnMailboxReactive(mailboxSession, rights), DEFAULT_CONCURRENCY)
             .collect(Guavate.toImmutableSet()));
@@ -213,7 +218,9 @@ public class StoreMessageIdManager implements MessageIdManager {
         MessageIdMapper messageIdMapper = mailboxSessionMapperFactory.getMessageIdMapper(mailboxSession);
 
         List<MailboxMessage> messageList = messageIdMapper.find(messageIds, MessageMapper.FetchType.Metadata);
-        ImmutableSet<MailboxId> allowedMailboxIds = getAllowedMailboxIds(mailboxSession, messageList, Right.DeleteMessages);
+        ImmutableSet<MailboxId> allowedMailboxIds = getAllowedMailboxIds(mailboxSession, messageList
+            .stream()
+            .map(MailboxMessage::getMailboxId), Right.DeleteMessages);
 
         ImmutableSet<MessageId> accessibleMessages = messageList.stream()
             .filter(message -> allowedMailboxIds.contains(message.getMailboxId()))

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MailboxMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/MailboxMapper.java
@@ -29,6 +29,7 @@ import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MailboxPath;
 import org.apache.james.mailbox.model.UidValidity;
 import org.apache.james.mailbox.model.search.MailboxQuery;
+import org.apache.james.mailbox.model.search.Wildcard;
 import org.apache.james.mailbox.store.transaction.Mapper;
 
 import reactor.core.publisher.Flux;
@@ -80,6 +81,17 @@ public interface MailboxMapper extends Mapper {
      * Return a List of {@link Mailbox} which name is like the given name
      */
     Flux<Mailbox> findMailboxWithPathLike(MailboxQuery.UserBound query);
+
+    default Flux<MailboxId> userMailboxes(Username username) {
+        return findMailboxWithPathLike(
+            MailboxQuery.builder()
+                .privateNamespace()
+                .username(username)
+                .expression(Wildcard.INSTANCE)
+                .build()
+                .asUserBound())
+            .map(Mailbox::getMailboxId);
+    }
 
     /**
      * Return if the given {@link Mailbox} has children


### PR DESCRIPTION
Reading glowroot, I notice sending messages triggers many Cassandra requests.

See attached screenshots:

 - [1] should overall requests. We can spot a very high number of mailboxes reads, acl reads, and message reads. The analysis of the traces entries shows that:
 - [2] attachment validation leads to many reads. For each attachment, 7 Cassandra reads is performed (checking both if the attachment had been uploaded or belongs to a message the user can read). Interestingly enough, a code analysis shows that:
    - messagev3 reads are uneeded upon attachment checks
    - AttachmentManager already expose grouped reads for attachments, but this API is not leveraged for perfomance enhancements.
 - [3] the request ends up mostly reading ACLs.
This is linked to a full account search to retrieve the message that had been answered/forwarded. By retrieving mailboxes - and thus acls, we perform many unneeded reads.

We expect a sharp drop in request count by:

 - Avoiding reading messagev3 table upon attachment right checks.
 - Grouping right validation for attachment at always attachments belongs to the same draft message.
 - Reworking all mailbox search to less read ACLs.