### PR TITLE
JAMES-1717 VacationMailet should not return answers when no or empty …

### DIFF
--- a/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/VacationRelayIntegrationTest.java
+++ b/server/protocols/jmap-draft-integration-testing/jmap-draft-integration-testing-common/src/test/java/org/apache/james/jmap/VacationRelayIntegrationTest.java
@@ -105,7 +105,7 @@ public abstract class VacationRelayIntegrationTest {
         smtpClient.helo(DOMAIN);
         smtpClient.setSender(externalMail);
         smtpClient.rcpt("<" + USER_WITH_DOMAIN + ">");
-        smtpClient.sendShortMessageData("content");
+        smtpClient.sendShortMessageData("Reply-To: <" + externalMail + ">\r\n\r\ncontent");
 
         calmlyAwait.atMost(1, TimeUnit.MINUTES)
             .untilAsserted(() ->

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/mailet/VacationMailet.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/mailet/VacationMailet.java
@@ -24,6 +24,7 @@ import java.util.Locale;
 
 import javax.inject.Inject;
 import javax.mail.MessagingException;
+import javax.mail.internet.AddressException;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.core.MailAddress;
@@ -70,10 +71,15 @@ public class VacationMailet extends GenericMailet {
             if (!mail.hasSender()) {
                 return;
             }
-            if (! automaticallySentMailDetector.isAutomaticallySent(mail)) {
+            if (!automaticallySentMailDetector.isAutomaticallySent(mail)
+                    && mail.getMessage().getReplyTo().length > 0) {
                 ZonedDateTime processingDate = zonedDateTimeProvider.get();
                 mail.getRecipients()
                     .forEach(mailAddress -> manageVacation(mailAddress, mail, processingDate));
+            }
+        } catch (AddressException e) {
+            if (!e.getMessage().equals("Empty address")) {
+                LOGGER.warn("Can not process vacation for one or more recipients in {}", mail.getRecipients(), e);
             }
         } catch (Throwable e) {
             LOGGER.warn("Can not process vacation for one or more recipients in {}", mail.getRecipients(), e);

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/mailet/VacationMailetTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/mailet/VacationMailetTest.java
@@ -261,6 +261,26 @@ public class VacationMailetTest {
     }
 
     @Test
+    public void serviceShouldNotSendNotificationToEmptyReplyTo() throws Exception {
+        FakeMail mail = FakeMail.builder()
+            .name("name")
+            .fileName("noReplyTo.eml")
+            .recipient(originalRecipient)
+            .sender(new MailAddress("distant-noreply@apache.org"))
+            .build();
+
+        when(vacationRepository.retrieveVacation(AccountId.fromString(USERNAME)))
+            .thenReturn(Mono.just(VACATION));
+        when(zonedDateTimeProvider.get()).thenReturn(DATE_TIME_2017);
+        when(notificationRegistry.isRegistered(any(), any())).thenReturn(Mono.just(false));
+        when(automaticallySentMailDetector.isAutomaticallySent(mail)).thenReturn(false);
+
+        testee.service(mail);
+
+        verifyNoMoreInteractions(mailetContext);
+    }
+
+    @Test
     public void serviceShouldNotPropagateExceptionIfSendFails() throws Exception {
         when(vacationRepository.retrieveVacation(AccountId.fromString(USERNAME)))
             .thenReturn(Mono.just(VACATION));

--- a/server/protocols/jmap-draft/src/test/resources/noReplyTo.eml
+++ b/server/protocols/jmap-draft/src/test/resources/noReplyTo.eml
@@ -1,0 +1,69 @@
+Return-Path: <root-bounces@listes.apache.org>
+Content-Type: multipart/mixed; boundary="----------=_1433322346-12583-0"
+MIME-Version: 1.0
+From: "Content-filter at spam.apache.org" <postmaster@apache.org>
+Date: Wed, 3 Jun 2015 09:05:46 +0000 (UTC)
+To: <root@listes.apache.org>
+Message-ID: <VASs-IZaXqmZao@spam.apache.org>
+Subject: Original subject
+X-BeenThere: root@listes.apache.org
+Errors-To: root-bounces@listes.apache.org
+Sender: "root" <root-bounces@listes.apache.org>
+Reply-To: <>
+
+This is a multi-part message in MIME format...
+
+------------=_1433322346-12583-0
+Content-Type: text/plain; charset="UTF-8"
+Content-Disposition: inline
+Content-Transfer-Encoding: 7bit
+
+No viruses were found.
+
+Content type: Unchecked
+Internal reference code for the message is 12583-16/Ss-IZaXqmZao
+
+According to a 'Received:' trace, the message apparently originated at:
+  [198.252.153.129], [127.0.0.1] localhost [127.0.0.1] Authenticated sender:
+  quentin.h
+
+Return-Path: <quentin.h@apache.org>
+From: Quentin <quentin.h@apache.org>
+Message-ID: <556EC361.6000308@apache.org>
+Subject: XYZ
+Not quarantined.
+
+The message WILL BE relayed to:
+<xxx@apache.org>
+
+
+------------=_1433322346-12583-0
+Content-Type: text/rfc822-headers; name="header"
+Content-Disposition: inline; filename="header"
+Content-Transfer-Encoding: 7bit
+Content-Description: Message header section
+
+Return-Path: <quentin.h@apache.org>
+Message-ID: <556EC361.6000308@apache.org>
+Date: Wed, 03 Jun 2015 11:05:37 +0200
+From: Quentin <quentin.h@apache.org>
+MIME-Version: 1.0
+To: Yann <yann@apache.org>
+Subject: XYZ
+References: <556E332B.8020808@wootdevices.io> <556E3512.3050404@apache.org>
+In-Reply-To: <556E3512.3050404@apache.org>
+Content-Type: multipart/encrypted;
+ protocol="application/pgp-encrypted";
+ boundary="M0xVhKIvXqi85dG57o5RfCUAoFwhAw1Nh"
+
+------------=_1433322346-12583-0
+Content-Type: text/plain; charset="iso-8859-1"
+MIME-Version: 1.0
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+
+_______________________________________________
+root mailing list
+root@listes.apache.org
+https://listes.apache.org/cgi-bin/mailman/listinfo/root
+------------=_1433322346-12583-0--


### PR DESCRIPTION
…Reply-To header

Error spotted in the logs:

```
javax.mail.internet.AddressException: Empty address
	at javax.mail.internet.InternetAddress.checkAddress(InternetAddress.java:1275)
	at javax.mail.internet.InternetAddress.parse(InternetAddress.java:1215)
	at javax.mail.internet.InternetAddress.parseHeader(InternetAddress.java:777)
	at javax.mail.internet.MimeMessage.getAddressHeader(MimeMessage.java:756)
	at javax.mail.internet.MimeMessage.getReplyTo(MimeMessage.java:730)
	at javax.mail.internet.MimeMessage.reply(MimeMessage.java:1736)
	at javax.mail.internet.MimeMessage.reply(MimeMessage.java:1683)
	at org.apache.james.server.core.MimeMessageCopyOnWriteProxy.reply(MimeMessageCopyOnWriteProxy.java:483)
	at org.apache.james.jmap.mailet.VacationReply$Builder.generateMimeMessage(VacationReply.java:76)
	at org.apache.james.jmap.mailet.VacationReply$Builder.build(VacationReply.java:72)
	at org.apache.james.jmap.mailet.VacationMailet.sendNotification(VacationMailet.java:122)
	at org.apache.james.jmap.mailet.VacationMailet.sendNotificationIfRequired(VacationMailet.java:98)
	at org.apache.james.jmap.mailet.VacationMailet.manageVacation(VacationMailet.java:93)
	at org.apache.james.jmap.mailet.VacationMailet.lambda$service$0(VacationMailet.java:76)
	at com.google.common.collect.ImmutableList.forEach(ImmutableList.java:407)
	at com.google.common.collect.RegularImmutableAsList.forEach(RegularImmutableAsList.java:62)
	at org.apache.james.jmap.mailet.VacationMailet.service(VacationMailet.java:76)
	at org.apache.james.mailetcontainer.impl.camel.CamelProcessor.process(CamelProcessor.java:77)
	at org.apache.james.mailetcontainer.impl.camel.CamelMailetProcessor$MailetContainerRouteBuilder.handleMailet(CamelMailetProcessor.java:176)
	at org.apache.james.mailetcontainer.impl.camel.CamelMailetProcessor$MailetContainerRouteBuilder.lambda$configure$0(CamelMailetProcessor.java:153)
	at org.apache.camel.processor.DelegateSyncProcessor.process(DelegateSyncProcessor.java:63)
	at org.apache.camel.processor.RedeliveryErrorHandler.process(RedeliveryErrorHandler.java:548)
	at org.apache.camel.processor.CamelInternalProcessor.process(CamelInternalProcessor.java:201)
	at org.apache.camel.processor.RedeliveryErrorHandler.process(RedeliveryErrorHandler.java:548)
	at org.apache.camel.processor.CamelInternalProcessor.process(CamelInternalProcessor.java:201)
	at org.apache.camel.processor.MulticastProcessor.doProcessSequential(MulticastProcessor.java:715)
	at org.apache.camel.processor.MulticastProcessor.doProcessSequential(MulticastProcessor.java:638)
	at org.apache.camel.processor.MulticastProcessor.process(MulticastProcessor.java:248)
	at org.apache.camel.processor.Splitter.process(Splitter.java:129)
	at org.apache.camel.processor.RedeliveryErrorHandler.process(RedeliveryErrorHandler.java:548)
	at org.apache.camel.processor.CamelInternalProcessor.process(CamelInternalProcessor.java:201)
	at org.apache.camel.processor.Pipeline.process(Pipeline.java:138)
	at org.apache.camel.processor.Pipeline.process(Pipeline.java:101)
	at org.apache.camel.processor.CamelInternalProcessor.process(CamelInternalProcessor.java:201)
	at org.apache.camel.component.direct.DirectProducer.process(DirectProducer.java:76)
	at org.apache.camel.processor.SharedCamelInternalProcessor.process(SharedCamelInternalProcessor.java:186)
	at org.apache.camel.processor.SharedCamelInternalProcessor.process(SharedCamelInternalProcessor.java:86)
	at org.apache.camel.impl.ProducerCache$1.doInProducer(ProducerCache.java:541)
	at org.apache.camel.impl.ProducerCache$1.doInProducer(ProducerCache.java:506)
	at org.apache.camel.impl.ProducerCache.doInProducer(ProducerCache.java:369)
	at org.apache.camel.impl.ProducerCache.sendExchange(ProducerCache.java:506)
	at org.apache.camel.impl.ProducerCache.send(ProducerCache.java:229)
	at org.apache.camel.impl.DefaultProducerTemplate.send(DefaultProducerTemplate.java:144)
	at org.apache.camel.impl.DefaultProducerTemplate.sendBody(DefaultProducerTemplate.java:161)
	at org.apache.camel.impl.DefaultProducerTemplate.sendBody(DefaultProducerTemplate.java:168)
	at org.apache.james.mailetcontainer.impl.camel.CamelMailetProcessor.service(CamelMailetProcessor.java:68)
	at org.apache.james.mailetcontainer.lib.AbstractStateCompositeProcessor.handleWithProcessor(AbstractStateCompositeProcessor.java:89)
	at org.apache.james.mailetcontainer.lib.AbstractStateCompositeProcessor.service(AbstractStateCompositeProcessor.java:71)
	at org.apache.james.mailetcontainer.lib.AbstractStateMailetProcessor.toProcessor(AbstractStateMailetProcessor.java:151)
	at org.apache.james.mailetcontainer.impl.camel.CamelMailetProcessor.access$300(CamelMailetProcessor.java:51)
	at org.apache.james.mailetcontainer.impl.camel.CamelMailetProcessor$MailetContainerRouteBuilder.handleMailet(CamelMailetProcessor.java:183)
	at org.apache.james.mailetcontainer.impl.camel.CamelMailetProcessor$MailetContainerRouteBuilder.lambda$configure$0(CamelMailetProcessor.java:153)
	at org.apache.camel.processor.DelegateSyncProcessor.process(DelegateSyncProcessor.java:63)
	at org.apache.camel.processor.RedeliveryErrorHandler.process(RedeliveryErrorHandler.java:548)
	at org.apache.camel.processor.CamelInternalProcessor.process(CamelInternalProcessor.java:201)
	at org.apache.camel.processor.RedeliveryErrorHandler.process(RedeliveryErrorHandler.java:548)
	at org.apache.camel.processor.CamelInternalProcessor.process(CamelInternalProcessor.java:201)
	at org.apache.camel.processor.MulticastProcessor.doProcessSequential(MulticastProcessor.java:715)
	at org.apache.camel.processor.MulticastProcessor.doProcessSequential(MulticastProcessor.java:638)
	at org.apache.camel.processor.MulticastProcessor.process(MulticastProcessor.java:248)
	at org.apache.camel.processor.Splitter.process(Splitter.java:129)
	at org.apache.camel.processor.RedeliveryErrorHandler.process(RedeliveryErrorHandler.java:548)
	at org.apache.camel.processor.CamelInternalProcessor.process(CamelInternalProcessor.java:201)
	at org.apache.camel.processor.Pipeline.process(Pipeline.java:138)
	at org.apache.camel.processor.Pipeline.process(Pipeline.java:101)
	at org.apache.camel.processor.CamelInternalProcessor.process(CamelInternalProcessor.java:201)
	at org.apache.camel.component.direct.DirectProducer.process(DirectProducer.java:76)
	at org.apache.camel.processor.SharedCamelInternalProcessor.process(SharedCamelInternalProcessor.java:186)
	at org.apache.camel.processor.SharedCamelInternalProcessor.process(SharedCamelInternalProcessor.java:86)
	at org.apache.camel.impl.ProducerCache$1.doInProducer(ProducerCache.java:541)
	at org.apache.camel.impl.ProducerCache$1.doInProducer(ProducerCache.java:506)
	at org.apache.camel.impl.ProducerCache.doInProducer(ProducerCache.java:369)
	at org.apache.camel.impl.ProducerCache.sendExchange(ProducerCache.java:506)
	at org.apache.camel.impl.ProducerCache.send(ProducerCache.java:229)
	at org.apache.camel.impl.DefaultProducerTemplate.send(DefaultProducerTemplate.java:144)
	at org.apache.camel.impl.DefaultProducerTemplate.sendBody(DefaultProducerTemplate.java:161)
	at org.apache.camel.impl.DefaultProducerTemplate.sendBody(DefaultProducerTemplate.java:168)
	at org.apache.james.mailetcontainer.impl.camel.CamelMailetProcessor.service(CamelMailetProcessor.java:68)
	at org.apache.james.mailetcontainer.lib.AbstractStateCompositeProcessor.handleWithProcessor(AbstractStateCompositeProcessor.java:89)
	at org.apache.james.mailetcontainer.lib.AbstractStateCompositeProcessor.service(AbstractStateCompositeProcessor.java:71)
	at org.apache.james.mailetcontainer.impl.JamesMailSpooler.performProcessMail(JamesMailSpooler.java:159)
	at org.apache.james.mailetcontainer.impl.JamesMailSpooler.lambda$processMail$6(JamesMailSpooler.java:152)
	at reactor.core.publisher.MonoRunnable.subscribe(MonoRunnable.java:49)
	at reactor.core.publisher.MonoUsing.subscribe(MonoUsing.java:109)
	at reactor.core.publisher.Mono.subscribe(Mono.java:4210)
	at reactor.core.publisher.FluxFlatMap.trySubscribeScalarMap(FluxFlatMap.java:199)
	at reactor.core.publisher.MonoFlatMap.subscribeOrReturn(MonoFlatMap.java:53)
	at reactor.core.publisher.Mono.subscribe(Mono.java:4195)
	at reactor.core.publisher.MonoSubscribeOn$SubscribeOnSubscriber.run(MonoSubscribeOn.java:124)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:84)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:37)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```

  - 1. WARN log is overkill for this
  - 2. We can abort the computation before reading any data to the DB when Reply-To is missing.