### PR TITLE
JAMES-1784 Users with `_` in their names cannot download attachments [JMAP-DRAFT]

### DIFF
--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/AttachmentAccessToken.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/AttachmentAccessToken.java
@@ -24,7 +24,9 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
 
+import com.github.steveash.guavate.Guavate;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
@@ -33,7 +35,7 @@ import com.google.common.collect.Iterables;
 
 public class AttachmentAccessToken implements SignedExpiringToken {
 
-    public static final String SEPARATOR = "_";
+    public static final char SEPARATOR = '_';
 
     public static Builder builder() {
         return new Builder();
@@ -42,14 +44,19 @@ public class AttachmentAccessToken implements SignedExpiringToken {
     public static AttachmentAccessToken from(String serializedAttachmentAccessToken, String blobId) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(serializedAttachmentAccessToken), "'AttachmentAccessToken' is mandatory");
         List<String> split = Splitter.on(SEPARATOR).splitToList(serializedAttachmentAccessToken);
-        Preconditions.checkArgument(split.size() == 3, "Wrong 'AttachmentAccessToken'");
+        Preconditions.checkArgument(split.size() >= 3, "Wrong 'AttachmentAccessToken'");
+
+        String username = Joiner.on(SEPARATOR)
+            .join(split.stream()
+                .limit(split.size() - 2)
+                .collect(Guavate.toImmutableList()));
 
         String defaultValue = null;
         return builder()
                 .blobId(blobId)
-                .username(Iterables.get(split, 0, defaultValue))
-                .expirationDate(ZonedDateTime.parse(Iterables.get(split, 1, defaultValue)))
-                .signature(Iterables.get(split, 2, defaultValue))
+                .username(username)
+                .expirationDate(ZonedDateTime.parse(Iterables.get(split, split.size() - 2, defaultValue)))
+                .signature(Iterables.get(split, split.size() - 1, defaultValue))
                 .build();
     }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/AttachmentAccessToken.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/draft/model/AttachmentAccessToken.java
@@ -86,7 +86,7 @@ public class AttachmentAccessToken implements SignedExpiringToken {
         }
 
         public Builder signature(String signature) {
-            this.signature = signature;
+            this.signature = signature.trim();
             return this;
         }
 

--- a/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/DownloadRoutes.java
+++ b/server/protocols/jmap-draft/src/main/java/org/apache/james/jmap/http/DownloadRoutes.java
@@ -174,6 +174,7 @@ public class DownloadRoutes implements JMAPRoutes {
                 .subscriberContext(jmapAuthContext(session)))
             .onErrorResume(UnauthorizedException.class, e -> handleAuthenticationFailure(response, LOGGER, e))
             .doOnEach(logOnError(e -> LOGGER.error("Unexpected error", e)))
+            .onErrorResume(IllegalArgumentException.class, e -> handleBadRequest(response, LOGGER, e))
             .onErrorResume(e -> handleInternalError(response, LOGGER, e))
             .subscriberContext(jmapContext(request))
             .subscriberContext(jmapAction("download-get"))

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/AttachmentAccessTokenTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/AttachmentAccessTokenTest.java
@@ -49,6 +49,13 @@ public class AttachmentAccessTokenTest {
     }
 
     @Test
+    public void extraSpacesShouldBeIgnored() {
+        AttachmentAccessToken attachmentAccessToken = new AttachmentAccessToken(USERNAME, BLOB_ID, EXPIRATION_DATE, SIGNATURE);
+        assertThat(AttachmentAccessToken.from(attachmentAccessToken.serialize() + " ", BLOB_ID))
+            .isEqualTo(attachmentAccessToken);
+    }
+
+    @Test
     public void fromShouldAcceptUsernamesWithUnderscores() {
         Username failingUsername = Username.of("bad_separator@usage.screwed");
         AttachmentAccessToken attachmentAccessToken = new AttachmentAccessToken(failingUsername.asString(), BLOB_ID, EXPIRATION_DATE, SIGNATURE);

--- a/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/AttachmentAccessTokenTest.java
+++ b/server/protocols/jmap-draft/src/test/java/org/apache/james/jmap/draft/model/AttachmentAccessTokenTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
+import org.apache.james.core.Username;
 import org.junit.Test;
 
 public class AttachmentAccessTokenTest {
@@ -38,6 +39,21 @@ public class AttachmentAccessTokenTest {
     public void getAsStringShouldNotContainBlobId() {
         assertThat(new AttachmentAccessToken(USERNAME, BLOB_ID, EXPIRATION_DATE, SIGNATURE).serialize())
             .isEqualTo(USERNAME + AttachmentAccessToken.SEPARATOR + EXPIRATION_DATE_STRING + AttachmentAccessToken.SEPARATOR + SIGNATURE);
+    }
+
+    @Test
+    public void fromShouldDeserializeAccessToken() {
+        AttachmentAccessToken attachmentAccessToken = new AttachmentAccessToken(USERNAME, BLOB_ID, EXPIRATION_DATE, SIGNATURE);
+        assertThat(AttachmentAccessToken.from(attachmentAccessToken.serialize(), BLOB_ID))
+            .isEqualTo(attachmentAccessToken);
+    }
+
+    @Test
+    public void fromShouldAcceptUsernamesWithUnderscores() {
+        Username failingUsername = Username.of("bad_separator@usage.screwed");
+        AttachmentAccessToken attachmentAccessToken = new AttachmentAccessToken(failingUsername.asString(), BLOB_ID, EXPIRATION_DATE, SIGNATURE);
+        assertThat(AttachmentAccessToken.from(attachmentAccessToken.serialize(), BLOB_ID))
+            .isEqualTo(attachmentAccessToken);
     }
 
     @Test


### PR DESCRIPTION
Because `_` is used as a delimiter within the token, and because
we expected a fixed number of parts, it could not be used in the
username.

We can relax this condition by counting separators by the end of
the token, allowing thus its usage in the username.

Also:

 - Return 400 upon IllegalArgumentException...
 - Trim tokens