### PR TITLE
JAMES-3431 RecipientRewriteTableProcessor needs to modify DSN parameters

### DIFF
--- a/mailet/api/src/main/java/org/apache/mailet/DsnParameters.java
+++ b/mailet/api/src/main/java/org/apache/mailet/DsnParameters.java
@@ -424,6 +424,10 @@ public class DsnParameters {
         this.rcptParameters = rcptParameters;
     }
 
+    public DsnParameters withRcptParameters(Map<MailAddress, RecipientDsnParameters> rcptParameters) {
+        return new DsnParameters(envIdParameter, retParameter, ImmutableMap.copyOf(rcptParameters));
+    }
+
     public Optional<EnvId> getEnvIdParameter() {
         return envIdParameter;
     }


### PR DESCRIPTION
ORCPT is preserved (should not be rewritten):

```
The purpose of ORCPT is to preserve the original recipient of an email message, for example, if it is forwarded to another address.
```

(source: https://www.lifewire.com/what-is-dsn-delivery-status-notification-for-smtp-email-3860942, for what it is worth)