### PR TITLE
[NO_REVIEW] JAMES-3487 Java property to control MimeMessageInputStreamSource thre…

### DIFF
--- a/docs/modules/servers/pages/distributed/configure/index.adoc
+++ b/docs/modules/servers/pages/distributed/configure/index.adoc
@@ -79,7 +79,7 @@ of higher heap usage.
 
 
 | james.message.usememorycopy
-|Optional. Boolean. Defaults to false. Recommended value is true.
+|Optional. Boolean. Defaults to false. Recommended value is false.
 Should MimeMessageWrapper use a copy of the message in memory?
 
 |===

--- a/docs/modules/servers/pages/distributed/configure/index.adoc
+++ b/docs/modules/servers/pages/distributed/configure/index.adoc
@@ -60,3 +60,26 @@ By omitting these files, no extra behaviour is added.
 ** xref:distributed/configure/remote-delivery-error-handling.adoc[This page] proposes a simple strategy for RemoteDelivery error handling.
 ** xref:distributed/configure/collecting-contacts.adoc[This page] documents contact collection
 ** xref:distributed/configure/collecting-events.adoc[This page] documents event collection
+
+== System properties
+
+Some tuning can be done via system properties. This includes:
+
+.System properties
+|===
+| Property name | explanation
+
+| james.message.memory.threshold
+| (Optional). String (size, integer + size units, example: `12 KIB`, supported units are bytes KIB MIB GIB TIB). Defaults to 100KIB.
+This governs the threshold MimeMessageInputStreamSource relies on for storing MimeMessage content on disk.
+Below, data is stored in memory. Above data is stored on disk.
+Lower values will lead to longer processing time but will minimize heap memory usage. Modern SSD hardware
+should however support a high throughput. Higher values will lead to faster single mail processing at the cost
+of higher heap usage.
+
+
+| james.message.usememorycopy
+|Optional. Boolean. Defaults to false. Recommended value is true.
+Should MimeMessageWrapper use a copy of the message in memory?
+
+|===

--- a/server/container/util/src/test/java/org/apache/james/util/SizeFormatTest.java
+++ b/server/container/util/src/test/java/org/apache/james/util/SizeFormatTest.java
@@ -146,4 +146,10 @@ class SizeFormatTest {
             .isEqualTo(36L * 1024L * 1024L * 1024L);
     }
 
+    @Test
+    void parseAsByteCountShouldAcceptNoSpace() {
+        assertThat(SizeFormat.parseAsByteCount("36GiB"))
+            .isEqualTo(36L * 1024L * 1024L * 1024L);
+    }
+
 }

--- a/src/site/xdoc/server/config-system.xml
+++ b/src/site/xdoc/server/config-system.xml
@@ -166,7 +166,7 @@
                         </dd>
 
                     <dt><strong>james.message.usememorycopy</strong></dt>
-                    <dd>Optional. Boolean. Defaults to false. Recommended value is true. <br/>
+                    <dd>Optional. Boolean. Defaults to false. Recommended value is false. <br/>
                         Should MimeMessageWrapper use a copy of the message in memory?</dd>
                 </dl>
 

--- a/src/site/xdoc/server/config-system.xml
+++ b/src/site/xdoc/server/config-system.xml
@@ -151,6 +151,27 @@
 
             </subsection>
 
+            <subsection name="System properties">
+
+                <p>Some tuning can be done via system properties. This includes:</p>
+
+                <dl>
+                    <dt><strong>james.message.memory.threshold</strong></dt>
+                    <dd>(Optional). String (size, integer + size units, example: `12 KIB`, supported units are bytes KIB MIB GIB TIB). Defaults to 100KIB. <br/>
+                        This governs the threshold MimeMessageInputStreamSource relies on for storing MimeMessage content on disk. <br/>
+                        Below, data is stored in memory. Above data is stored on disk.
+                        Lower values will lead to longer processing time but will minimize heap memory usage. Modern SSD hardware
+                        should however support a high throughput. Higher values will lead to faster single mail processing at the cost
+                        of higher heap usage.
+                        </dd>
+
+                    <dt><strong>james.message.usememorycopy</strong></dt>
+                    <dd>Optional. Boolean. Defaults to false. Recommended value is true. <br/>
+                        Should MimeMessageWrapper use a copy of the message in memory?</dd>
+                </dl>
+
+            </subsection>
+
         </section>
 
     </body>


### PR DESCRIPTION
…shold

This governs the threshold MimeMessageInputStreamSource relies
on for storing MimeMessage content on disk.

Below, data is stored in memory. Above data is stored on disk.

Lower values will lead to longer processing time but will
minimize heap memory usage. Modern SSD hardware
should however support a high throughput. Higher values
will lead to faster single mail processing at the cost
of higher heap usage.

See https://github.com/apache/james-project/pull/285