### PR TITLE
JAMES-3471 Add MessageId in FlagsUpdated events

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/events/MailboxListener.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/events/MailboxListener.java
@@ -587,31 +587,26 @@ public interface MailboxListener {
      * A mailbox event related to updated flags
      */
     class FlagsUpdated extends MessageEvent {
-        private final List<MessageUid> uids;
-        private final List<MessageId> messageIds;
         private final List<UpdatedFlags> updatedFlags;
 
         public FlagsUpdated(MailboxSession.SessionId sessionId, Username username, MailboxPath path,
                             MailboxId mailboxId, List<UpdatedFlags> updatedFlags, EventId eventId) {
             super(sessionId, username, path, mailboxId, eventId);
             this.updatedFlags = ImmutableList.copyOf(updatedFlags);
-            this.uids = updatedFlags.stream()
-                .map(UpdatedFlags::getUid)
-                .collect(Guavate.toImmutableList());
-            this.messageIds = updatedFlags.stream()
-                .map(UpdatedFlags::getMessageId)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .collect(Guavate.toImmutableList());
         }
 
         @Override
         public Collection<MessageUid> getUids() {
-            return uids;
+            return updatedFlags.stream()
+                .map(UpdatedFlags::getUid)
+                .collect(Guavate.toImmutableList());
         }
 
         public Collection<MessageId> getMessageIds() {
-            return messageIds;
+            return updatedFlags.stream()
+                .map(UpdatedFlags::getMessageId)
+                .flatMap(Optional::stream)
+                .collect(Guavate.toImmutableList());
         }
 
         public List<UpdatedFlags> getUpdatedFlags() {
@@ -633,8 +628,6 @@ public interface MailboxListener {
                     && Objects.equals(this.username, that.username)
                     && Objects.equals(this.path, that.path)
                     && Objects.equals(this.mailboxId, that.mailboxId)
-                    && Objects.equals(this.uids, that.uids)
-                    && Objects.equals(this.messageIds, that.messageIds)
                     && Objects.equals(this.updatedFlags, that.updatedFlags);
             }
             return false;
@@ -642,7 +635,7 @@ public interface MailboxListener {
 
         @Override
         public final int hashCode() {
-            return Objects.hash(eventId, sessionId, username, path, mailboxId, uids, messageIds, updatedFlags);
+            return Objects.hash(eventId, sessionId, username, path, mailboxId, updatedFlags);
         }
     }
 

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/UpdatedFlags.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/UpdatedFlags.java
@@ -43,6 +43,7 @@ public class UpdatedFlags {
 
     public static class Builder {
         private MessageUid uid;
+        private Optional<MessageId> messageId = Optional.empty();
         private Flags oldFlags;
         private Flags newFlags;
         private Optional<ModSeq> modSeq = Optional.empty();
@@ -52,6 +53,16 @@ public class UpdatedFlags {
 
         public Builder uid(MessageUid uid) {
             this.uid = uid;
+            return this;
+        }
+
+        public Builder messageId(MessageId messageId) {
+            this.messageId = Optional.of(messageId);
+            return this;
+        }
+
+        public Builder messageId(Optional<MessageId> messageId) {
+            this.messageId = messageId;
             return this;
         }
 
@@ -71,22 +82,24 @@ public class UpdatedFlags {
         }
 
         public UpdatedFlags build() {
-            Preconditions.checkState(uid != null);
-            Preconditions.checkState(newFlags != null);
-            Preconditions.checkState(oldFlags != null);
+            Preconditions.checkNotNull(uid);
+            Preconditions.checkNotNull(newFlags);
+            Preconditions.checkNotNull(oldFlags);
             Preconditions.checkState(modSeq.isPresent());
-            return new UpdatedFlags(uid, modSeq.get(), oldFlags, newFlags);
+            return new UpdatedFlags(uid, messageId, modSeq.get(), oldFlags, newFlags);
         }
     }
 
     private final MessageUid uid;
+    private final Optional<MessageId> messageId;
     private final Flags oldFlags;
     private final Flags newFlags;
     private final Flags modifiedFlags;
     private final ModSeq modSeq;
 
-    private UpdatedFlags(MessageUid uid, ModSeq modSeq, Flags oldFlags, Flags newFlags) {
+    private UpdatedFlags(MessageUid uid, Optional<MessageId> messageId, ModSeq modSeq, Flags oldFlags, Flags newFlags) {
        this.uid = uid;
+       this.messageId = messageId;
        this.modSeq = modSeq;
        this.oldFlags = oldFlags;
        this.newFlags = newFlags;
@@ -177,7 +190,13 @@ public class UpdatedFlags {
     public MessageUid getUid() {
         return uid;
     }
-   
+
+    /**
+     * Return the uid for the message whichs {@link Flags} was updated
+     */
+    public Optional<MessageId> getMessageId() {
+        return messageId;
+    }
 
     /**
      * Gets an iterator for the system flags changed.
@@ -238,6 +257,7 @@ public class UpdatedFlags {
         UpdatedFlags that = (UpdatedFlags) other;
 
         return Objects.equals(uid, that.uid) &&
+                Objects.equals(messageId, that.messageId) &&
                 Objects.equals(oldFlags, that.oldFlags) &&
                 Objects.equals(newFlags, that.newFlags) &&
                 Objects.equals(modSeq, that.modSeq);
@@ -245,7 +265,7 @@ public class UpdatedFlags {
 
     @Override
     public final int hashCode() {
-        return Objects.hash(uid, oldFlags, newFlags, modSeq);
+        return Objects.hash(uid, messageId, oldFlags, newFlags, modSeq);
     }
     
     @Override

--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/UpdatedFlags.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/UpdatedFlags.java
@@ -91,6 +91,9 @@ public class UpdatedFlags {
     }
 
     private final MessageUid uid;
+    /**
+     * The usage of Optional here is for backward compatibility (to be able to still dequeue older events)
+     */
     private final Optional<MessageId> messageId;
     private final Flags oldFlags;
     private final Flags newFlags;

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageIdMapper.java
@@ -268,6 +268,7 @@ public class CassandraMessageIdMapper implements MessageIdMapper {
         return Pair.of(composedMessageIdWithMetaData.getComposedMessageId().getMailboxId(),
                 UpdatedFlags.builder()
                     .uid(composedMessageIdWithMetaData.getComposedMessageId().getUid())
+                    .messageId(composedMessageIdWithMetaData.getComposedMessageId().getMessageId())
                     .modSeq(composedMessageIdWithMetaData.getModSeq())
                     .oldFlags(oldFlags)
                     .newFlags(composedMessageIdWithMetaData.getFlags())

--- a/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
+++ b/mailbox/cassandra/src/main/java/org/apache/james/mailbox/cassandra/mail/CassandraMessageMapper.java
@@ -541,6 +541,7 @@ public class CassandraMessageMapper implements MessageMapper {
         if (identicalFlags(oldFlags, newFlags)) {
             return Mono.just(FlagsUpdateStageResult.success(UpdatedFlags.builder()
                 .uid(oldMetaData.getComposedMessageId().getUid())
+                .messageId(oldMetaData.getComposedMessageId().getMessageId())
                 .modSeq(oldMetaData.getModSeq())
                 .oldFlags(oldFlags)
                 .newFlags(newFlags)
@@ -552,6 +553,7 @@ public class CassandraMessageMapper implements MessageMapper {
                 if (success) {
                     return FlagsUpdateStageResult.success(UpdatedFlags.builder()
                         .uid(oldMetaData.getComposedMessageId().getUid())
+                        .messageId(oldMetaData.getComposedMessageId().getMessageId())
                         .modSeq(newModSeq)
                         .oldFlags(oldFlags)
                         .newFlags(newFlags)

--- a/mailbox/event/json/src/main/scala/org/apache/james/event/json/DTOs.scala
+++ b/mailbox/event/json/src/main/scala/org/apache/james/event/json/DTOs.scala
@@ -32,6 +32,7 @@ import org.apache.james.mailbox.model.{MessageId, MailboxACL => JavaMailboxACL, 
 import org.apache.james.mailbox.{FlagsBuilder, MessageUid, ModSeq}
 
 import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters._
 
 object DTOs {
 
@@ -142,14 +143,16 @@ object DTOs {
   object UpdatedFlags {
     def toUpdatedFlags(javaUpdatedFlags: JavaUpdatedFlags): UpdatedFlags = UpdatedFlags(
       javaUpdatedFlags.getUid,
+      javaUpdatedFlags.getMessageId.toScala,
       javaUpdatedFlags.getModSeq,
       Flags.fromJavaFlags(javaUpdatedFlags.getOldFlags),
       Flags.fromJavaFlags(javaUpdatedFlags.getNewFlags))
   }
 
-  case class UpdatedFlags(uid: MessageUid, modSeq: ModSeq, oldFlags: Flags, newFlags: Flags) {
+  case class UpdatedFlags(uid: MessageUid, messageId: Option[MessageId], modSeq: ModSeq, oldFlags: Flags, newFlags: Flags) {
     def toJava: JavaUpdatedFlags = JavaUpdatedFlags.builder()
       .uid(uid)
+      .messageId(messageId.toJava)
       .modSeq(modSeq)
       .oldFlags(Flags.toJavaFlags(oldFlags))
       .newFlags(Flags.toJavaFlags(newFlags))

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/MessageUtils.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/MessageUtils.java
@@ -74,6 +74,7 @@ class MessageUtils {
 
             updatedFlags.add(UpdatedFlags.builder()
                 .uid(member.getUid())
+                .messageId(member.getMessageId())
                 .modSeq(member.getModSeq())
                 .newFlags(newFlags)
                 .oldFlags(originalFlags)

--- a/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JpaMessageMapperTest.java
+++ b/mailbox/jpa/src/test/java/org/apache/james/mailbox/jpa/mail/JpaMessageMapperTest.java
@@ -20,10 +20,13 @@
 package org.apache.james.mailbox.jpa.mail;
 
 import org.apache.james.backends.jpa.JpaTestCluster;
+import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.mailbox.jpa.JPAMailboxFixture;
 import org.apache.james.mailbox.store.mail.model.MapperProvider;
 import org.apache.james.mailbox.store.mail.model.MessageMapperTest;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 class JpaMessageMapperTest extends MessageMapperTest {
 
@@ -37,5 +40,35 @@ class JpaMessageMapperTest extends MessageMapperTest {
     @AfterEach
     void cleanUp() {
         JPA_TEST_CLUSTER.clear(JPAMailboxFixture.MAILBOX_TABLE_NAMES);
+    }
+
+    @Disabled("JAMES-3471 messageId is not supported by JPA ")
+    @Test
+    public void flagsAdditionShouldReturnAnUpdatedFlagHighlightingTheAddition() throws MailboxException {
+
+    }
+
+    @Disabled("")
+    @Test
+    public void flagsReplacementShouldReturnAnUpdatedFlagHighlightingTheReplacement() throws MailboxException {
+
+    }
+
+    @Disabled("")
+    @Test
+    public void flagsRemovalShouldReturnAnUpdatedFlagHighlightingTheRemoval() throws MailboxException {
+
+    }
+
+    @Disabled("")
+    @Test
+    public void userFlagsUpdateShouldReturnCorrectUpdatedFlags() throws MailboxException {
+
+    }
+
+    @Disabled("")
+    @Test
+    public void userFlagsUpdateShouldReturnCorrectUpdatedFlagsWhenNoop() throws MailboxException {
+
     }
 }

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMessageMapper.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMessageMapper.java
@@ -194,6 +194,7 @@ public class MaildirMessageMapper extends AbstractMessageMapper {
 
                     updatedFlags.add(UpdatedFlags.builder()
                         .uid(member.getUid())
+                        .messageId(member.getMessageId())
                         .modSeq(member.getModSeq())
                         .newFlags(newFlags)
                         .oldFlags(originalFlags)

--- a/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMessageIdMapper.java
+++ b/mailbox/memory/src/main/java/org/apache/james/mailbox/inmemory/mail/InMemoryMessageIdMapper.java
@@ -151,6 +151,7 @@ public class InMemoryMessageIdMapper implements MessageIdMapper {
                 UpdatedFlags updatedFlags = UpdatedFlags.builder()
                     .modSeq(message.getModSeq())
                     .uid(message.getUid())
+                    .messageId(message.getMessageId())
                     .oldFlags(message.createFlags())
                     .newFlags(newState)
                     .build();

--- a/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AbstractMessageMapper.java
+++ b/mailbox/store/src/main/java/org/apache/james/mailbox/store/mail/AbstractMessageMapper.java
@@ -102,6 +102,7 @@ public abstract class AbstractMessageMapper extends TransactionalMapper implemen
             
             updatedFlags.add(UpdatedFlags.builder()
                 .uid(member.getUid())
+                .messageId(member.getMessageId())
                 .modSeq(member.getModSeq())
                 .newFlags(newFlags)
                 .oldFlags(originalFlags)

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerSideEffectTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/AbstractMessageIdManagerSideEffectTest.java
@@ -467,6 +467,7 @@ public abstract class AbstractMessageIdManagerSideEffectTest {
         ModSeq modSeq = messageResult.getModSeq();
         UpdatedFlags updatedFlags = UpdatedFlags.builder()
             .uid(messageUid)
+            .messageId(messageId)
             .modSeq(modSeq)
             .oldFlags(FLAGS)
             .newFlags(newFlags)

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageIdMapperTest.java
@@ -355,6 +355,7 @@ public abstract class MessageIdMapperTest {
         ModSeq modSeq = mapperProvider.highestModSeq(benwaInboxMailbox);
         UpdatedFlags expectedUpdatedFlags = UpdatedFlags.builder()
             .uid(message1.getUid())
+            .messageId(messageId)
             .modSeq(modSeq)
             .oldFlags(new Flags())
             .newFlags(newFlags)
@@ -382,6 +383,7 @@ public abstract class MessageIdMapperTest {
         ModSeq modSeq = mapperProvider.highestModSeq(benwaInboxMailbox);
         UpdatedFlags expectedUpdatedFlags = UpdatedFlags.builder()
             .uid(message1.getUid())
+            .messageId(messageId)
             .modSeq(modSeq)
             .oldFlags(messageFlags)
             .newFlags(newFlags)
@@ -411,6 +413,7 @@ public abstract class MessageIdMapperTest {
         ModSeq modSeq = mapperProvider.highestModSeq(benwaInboxMailbox);
         UpdatedFlags expectedUpdatedFlags = UpdatedFlags.builder()
             .uid(message1.getUid())
+            .messageId(messageId)
             .modSeq(modSeq)
             .oldFlags(messageFlags)
             .newFlags(new Flags(Flags.Flag.RECENT))
@@ -483,6 +486,7 @@ public abstract class MessageIdMapperTest {
         ModSeq modSeq = mapperProvider.highestModSeq(benwaInboxMailbox);
         UpdatedFlags expectedUpdatedFlags = UpdatedFlags.builder()
             .uid(message1.getUid())
+            .messageId(messageId)
             .modSeq(modSeq)
             .oldFlags(initialFlags)
             .newFlags(newFlags)
@@ -510,12 +514,14 @@ public abstract class MessageIdMapperTest {
         ModSeq modSeqBenwaWorkMailbox = mapperProvider.highestModSeq(benwaWorkMailbox);
         UpdatedFlags expectedUpdatedFlags = UpdatedFlags.builder()
             .uid(message1.getUid())
+            .messageId(messageId)
             .modSeq(modSeqBenwaInboxMailbox)
             .oldFlags(new Flags())
             .newFlags(newFlags)
             .build();
         UpdatedFlags expectedUpdatedFlags2 = UpdatedFlags.builder()
             .uid(message1InOtherMailbox.getUid())
+            .messageId(messageId)
             .modSeq(modSeqBenwaWorkMailbox)
             .oldFlags(new Flags())
             .newFlags(newFlags)
@@ -854,6 +860,7 @@ public abstract class MessageIdMapperTest {
                 ImmutableList.of(UpdatedFlags.builder()
                     .modSeq(modSeq)
                     .uid(message1.getUid())
+                    .messageId(message1.getMessageId())
                     .newFlags(flags)
                     .oldFlags(flags)
                     .build())));

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -709,6 +709,7 @@ public abstract class MessageMapperTest {
         assertThat(updatedFlags)
             .contains(UpdatedFlags.builder()
                 .uid(message1.getUid())
+                .messageId(message1.getMessageId())
                 .modSeq(modSeq.next())
                 .oldFlags(new Flags())
                 .newFlags(new Flags(Flags.Flag.FLAGGED))
@@ -723,6 +724,7 @@ public abstract class MessageMapperTest {
         assertThat(messageMapper.updateFlags(benwaInboxMailbox, message1.getUid(), new FlagsUpdateCalculator(new Flags(Flags.Flag.SEEN), FlagsUpdateMode.ADD)))
             .contains(UpdatedFlags.builder()
                     .uid(message1.getUid())
+                    .messageId(message1.getMessageId())
                     .modSeq(modSeq.next())
                     .oldFlags(new Flags(Flags.Flag.FLAGGED))
                     .newFlags(new FlagsBuilder().add(Flags.Flag.SEEN, Flags.Flag.FLAGGED).build())
@@ -756,6 +758,7 @@ public abstract class MessageMapperTest {
             .contains(
                 UpdatedFlags.builder()
                     .uid(message1.getUid())
+                    .messageId(message1.getMessageId())
                     .modSeq(modSeq.next())
                     .oldFlags(new FlagsBuilder().add(Flags.Flag.SEEN, Flags.Flag.FLAGGED).build())
                     .newFlags(new Flags(Flags.Flag.FLAGGED))
@@ -881,6 +884,7 @@ public abstract class MessageMapperTest {
             .contains(
                 UpdatedFlags.builder()
                     .uid(message1.getUid())
+                    .messageId(message1.getMessageId())
                     .modSeq(modSeq.next())
                     .oldFlags(new Flags())
                     .newFlags(new Flags(USER_FLAG))
@@ -897,6 +901,7 @@ public abstract class MessageMapperTest {
             .contains(
                 UpdatedFlags.builder()
                     .uid(message1.getUid())
+                    .messageId(message1.getMessageId())
                     .modSeq(message1.getModSeq())
                     .oldFlags(new Flags())
                     .newFlags(new Flags())

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -701,7 +701,7 @@ public abstract class MessageMapperTest {
     }
 
     @Test
-    void flagsReplacementShouldReturnAnUpdatedFlagHighlightingTheReplacement() throws MailboxException {
+    protected void flagsReplacementShouldReturnAnUpdatedFlagHighlightingTheReplacement() throws MailboxException {
         saveMessages();
         ModSeq modSeq = messageMapper.getHighestModSeq(benwaInboxMailbox);
         Optional<UpdatedFlags> updatedFlags = messageMapper.updateFlags(benwaInboxMailbox, message1.getUid(),
@@ -717,7 +717,7 @@ public abstract class MessageMapperTest {
     }
 
     @Test
-    void flagsAdditionShouldReturnAnUpdatedFlagHighlightingTheAddition() throws MailboxException {
+    protected void flagsAdditionShouldReturnAnUpdatedFlagHighlightingTheAddition() throws MailboxException {
         saveMessages();
         messageMapper.updateFlags(benwaInboxMailbox, message1.getUid(), new FlagsUpdateCalculator(new Flags(Flags.Flag.FLAGGED), FlagsUpdateMode.REPLACE));
         ModSeq modSeq = messageMapper.getHighestModSeq(benwaInboxMailbox);
@@ -750,7 +750,7 @@ public abstract class MessageMapperTest {
     }
 
     @Test
-    void flagsRemovalShouldReturnAnUpdatedFlagHighlightingTheRemoval() throws MailboxException {
+    protected void flagsRemovalShouldReturnAnUpdatedFlagHighlightingTheRemoval() throws MailboxException {
         saveMessages();
         messageMapper.updateFlags(benwaInboxMailbox, message1.getUid(), new FlagsUpdateCalculator(new FlagsBuilder().add(Flags.Flag.FLAGGED, Flags.Flag.SEEN).build(), FlagsUpdateMode.REPLACE));
         ModSeq modSeq = messageMapper.getHighestModSeq(benwaInboxMailbox);
@@ -877,7 +877,7 @@ public abstract class MessageMapperTest {
     }
 
     @Test
-    void userFlagsUpdateShouldReturnCorrectUpdatedFlags() throws Exception {
+    protected void userFlagsUpdateShouldReturnCorrectUpdatedFlags() throws Exception {
         saveMessages();
         ModSeq modSeq = messageMapper.getHighestModSeq(benwaInboxMailbox);
         assertThat(messageMapper.updateFlags(benwaInboxMailbox, message1.getUid(), new FlagsUpdateCalculator(new Flags(USER_FLAG), FlagsUpdateMode.ADD)))
@@ -892,7 +892,7 @@ public abstract class MessageMapperTest {
     }
 
     @Test
-    void userFlagsUpdateShouldReturnCorrectUpdatedFlagsWhenNoop() throws Exception {
+    protected void userFlagsUpdateShouldReturnCorrectUpdatedFlagsWhenNoop() throws Exception {
         saveMessages();
 
         assertThat(

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/MailboxChange.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/MailboxChange.java
@@ -52,27 +52,27 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 public class MailboxChange {
-    @FunctionalInterface
-    public interface RequiredAccountId {
-        RequiredState accountId(AccountId accountId);
-    }
-
-    @FunctionalInterface
-    public interface RequiredState {
-        RequiredDate state(State state);
-    }
-
-    @FunctionalInterface
-    public interface RequiredDate {
-        RequiredIsCountChange date(ZonedDateTime date);
-    }
-
-    @FunctionalInterface
-    public interface RequiredIsCountChange {
-        Builder isCountChange(boolean isCountChange);
-    }
-
     public static class Builder {
+        @FunctionalInterface
+        public interface RequiredAccountId {
+            RequiredState accountId(AccountId accountId);
+        }
+
+        @FunctionalInterface
+        public interface RequiredState {
+            RequiredDate state(State state);
+        }
+
+        @FunctionalInterface
+        public interface RequiredDate {
+            RequiredIsCountChange date(ZonedDateTime date);
+        }
+
+        @FunctionalInterface
+        public interface RequiredIsCountChange {
+            Builder isCountChange(boolean isCountChange);
+        }
+
         private final AccountId accountId;
         private final State state;
         private final ZonedDateTime date;
@@ -125,7 +125,7 @@ public class MailboxChange {
         }
     }
 
-    public static RequiredAccountId builder() {
+    public static Builder.RequiredAccountId builder() {
         return accountId -> state -> date -> isCountChange -> new Builder(accountId, state, date, isCountChange);
     }
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/MailboxChangeListener.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/MailboxChangeListener.scala
@@ -21,7 +21,6 @@ package org.apache.james.jmap.change
 
 import javax.inject.Inject
 import org.apache.james.jmap.api.change.{MailboxChange, MailboxChangeRepository}
-import org.apache.james.mailbox.MailboxManager
 import org.apache.james.mailbox.events.MailboxListener.{MailboxEvent, ReactiveGroupMailboxListener}
 import org.apache.james.mailbox.events.{Event, Group}
 import org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY
@@ -33,7 +32,6 @@ import scala.jdk.CollectionConverters._
 case class MailboxChangeListenerGroup() extends Group {}
 
 case class MailboxChangeListener @Inject() (mailboxChangeRepository: MailboxChangeRepository,
-                                            mailboxManager: MailboxManager,
                                             mailboxChangeFactory: MailboxChange.Factory) extends ReactiveGroupMailboxListener {
 
   override def reactiveEvent(event: Event): Publisher[Void] =

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/change/MailboxChangeListenerTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/change/MailboxChangeListenerTest.scala
@@ -67,7 +67,7 @@ class MailboxChangeListenerTest {
     stateFactory = new State.DefaultFactory
     mailboxChangeFactory = new MailboxChange.Factory(clock, mailboxManager, stateFactory)
     repository = new MemoryMailboxChangeRepository()
-    listener = MailboxChangeListener(repository, mailboxManager, mailboxChangeFactory)
+    listener = MailboxChangeListener(repository, mailboxChangeFactory)
     resources.getEventBus.register(listener)
   }
 


### PR DESCRIPTION
It's needed for being able to do Email/changes with the UpdatedFlags event, as we need to register the messageId for it.

I made sure to keep the serialization and deserialization valid with and without messageId