### PR TITLE
JAMES-3471 JPA and maildir message mappers should not register Messag…

### DIFF
--- a/mailbox/api/src/main/java/org/apache/james/mailbox/model/UpdatedFlags.java
+++ b/mailbox/api/src/main/java/org/apache/james/mailbox/model/UpdatedFlags.java
@@ -274,10 +274,11 @@ public class UpdatedFlags {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(UpdatedFlags.class)
-                .add("uid", uid)
-                .add("oldFlags", oldFlags)
-                .add("newFlags", newFlags)
-                .add("modSeq", modSeq)
-                .toString();
+            .add("uid", uid)
+            .add("messageId", messageId)
+            .add("oldFlags", oldFlags)
+            .add("newFlags", newFlags)
+            .add("modSeq", modSeq)
+            .toString();
     }
 }

--- a/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/MessageUtils.java
+++ b/mailbox/jpa/src/main/java/org/apache/james/mailbox/jpa/mail/MessageUtils.java
@@ -74,7 +74,6 @@ class MessageUtils {
 
             updatedFlags.add(UpdatedFlags.builder()
                 .uid(member.getUid())
-                .messageId(member.getMessageId())
                 .modSeq(member.getModSeq())
                 .newFlags(newFlags)
                 .oldFlags(originalFlags)

--- a/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMessageMapper.java
+++ b/mailbox/maildir/src/main/java/org/apache/james/mailbox/maildir/mail/MaildirMessageMapper.java
@@ -194,7 +194,6 @@ public class MaildirMessageMapper extends AbstractMessageMapper {
 
                     updatedFlags.add(UpdatedFlags.builder()
                         .uid(member.getUid())
-                        .messageId(member.getMessageId())
                         .modSeq(member.getModSeq())
                         .newFlags(newFlags)
                         .oldFlags(originalFlags)

--- a/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
+++ b/mailbox/store/src/test/java/org/apache/james/mailbox/store/mail/model/MessageMapperTest.java
@@ -71,10 +71,11 @@ public abstract class MessageMapperTest {
     private static final int LIMIT = 10;
     private static final int BODY_START = 16;
     private static final UidValidity UID_VALIDITY = UidValidity.of(42);
-    private static final String USER_FLAG = "userFlag";
 
     private static final String CUSTOMS_USER_FLAGS_VALUE = "CustomsFlags";
     private static final Username BENWA = Username.of("benwa");
+
+    protected static final String USER_FLAG = "userFlag";
 
     private MapperProvider mapperProvider;
     protected MessageMapper messageMapper;


### PR DESCRIPTION
…eId when handling FlagsUpdated events

JPA and maildir implementation do not handle MessageId, thus it was a bug that needed to be fixed.
JpaMessageMapperTest has been adapted as well to override tests having messageId in FlagsUpdated objects.

This issue was introduced by #4192