### PR TITLE
JAMES-3444 Perform JMAP TransportChecks only when JMAP is enabled

### DIFF
--- a/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/CamelMailetContainerModule.java
+++ b/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/CamelMailetContainerModule.java
@@ -242,8 +242,11 @@ public class CamelMailetContainerModule extends AbstractModule {
     @FunctionalInterface
     public interface ProcessorsCheck {
         static ProcessorsCheck noCheck() {
-            return any -> {
+            return new ProcessorsCheck() {
+                @Override
+                public void check(Multimap<String, MatcherMailetPair> processors) {
 
+                }
             };
         }
 

--- a/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/CamelMailetContainerModule.java
+++ b/server/container/guice/mailet/src/main/java/org/apache/james/modules/server/CamelMailetContainerModule.java
@@ -241,6 +241,12 @@ public class CamelMailetContainerModule extends AbstractModule {
 
     @FunctionalInterface
     public interface ProcessorsCheck {
+        static ProcessorsCheck noCheck() {
+            return any -> {
+
+            };
+        }
+
         void check(Multimap<String, MatcherMailetPair> processors) throws ConfigurationException;
 
         class Or implements ProcessorsCheck {

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JMAPModule.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JMAPModule.java
@@ -107,9 +107,6 @@ public class JMAPModule extends AbstractModule {
             Mail.LOCAL_DELIVERY,
             All.class,
             JMAPFiltering.class));
-    public static final ProcessorsCheck NO_CHECK = any -> {
-
-    };
 
     @Override
     protected void configure() {
@@ -149,7 +146,7 @@ public class JMAPModule extends AbstractModule {
         if (configuration.isEnabled()) {
             return VACATION_MAILET_CHECK;
         }
-        return NO_CHECK;
+        return ProcessorsCheck.noCheck();
     }
 
     @ProvidesIntoSet
@@ -157,7 +154,7 @@ public class JMAPModule extends AbstractModule {
         if (configuration.isEnabled()) {
             return FILTERING_MAILET_CHECK;
         }
-        return NO_CHECK;
+        return ProcessorsCheck.noCheck();
     }
 
     @ProvidesIntoSet

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JMAPModule.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/jmap/draft/JMAPModule.java
@@ -52,6 +52,7 @@ import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxManager.SearchCapabilities;
 import org.apache.james.mailbox.events.MailboxListener;
 import org.apache.james.modules.server.CamelMailetContainerModule;
+import org.apache.james.modules.server.CamelMailetContainerModule.ProcessorsCheck;
 import org.apache.james.queue.api.MailQueueItemDecoratorFactory;
 import org.apache.james.server.core.configuration.FileConfigurationProvider;
 import org.apache.james.transport.matchers.All;
@@ -86,26 +87,29 @@ public class JMAPModule extends AbstractModule {
                 throw new RuntimeException(e);
             }
         };
-    public static final CamelMailetContainerModule.ProcessorsCheck VACATION_MAILET_CHECK =
-        CamelMailetContainerModule.ProcessorsCheck.Or.of(
-            new CamelMailetContainerModule.ProcessorsCheck.Impl(
+    public static final ProcessorsCheck VACATION_MAILET_CHECK =
+        ProcessorsCheck.Or.of(
+            new ProcessorsCheck.Impl(
                 Mail.TRANSPORT,
                 RecipientIsLocal.class,
                 VacationMailet.class),
-            new CamelMailetContainerModule.ProcessorsCheck.Impl(
+            new ProcessorsCheck.Impl(
                 Mail.LOCAL_DELIVERY,
                 All.class,
                 VacationMailet.class));
-    public static final CamelMailetContainerModule.ProcessorsCheck FILTERING_MAILET_CHECK =
-        CamelMailetContainerModule.ProcessorsCheck.Or.of(
-        new CamelMailetContainerModule.ProcessorsCheck.Impl(
+    public static final ProcessorsCheck FILTERING_MAILET_CHECK =
+        ProcessorsCheck.Or.of(
+        new ProcessorsCheck.Impl(
             Mail.TRANSPORT,
             RecipientIsLocal.class,
             JMAPFiltering.class),
-        new CamelMailetContainerModule.ProcessorsCheck.Impl(
+        new ProcessorsCheck.Impl(
             Mail.LOCAL_DELIVERY,
             All.class,
             JMAPFiltering.class));
+    public static final ProcessorsCheck NO_CHECK = any -> {
+
+    };
 
     @Override
     protected void configure() {
@@ -123,10 +127,6 @@ public class JMAPModule extends AbstractModule {
         bind(HtmlTextExtractor.class).to(JsoupHtmlTextExtractor.class);
         Multibinder.newSetBinder(binder(), StartUpCheck.class).addBinding().to(RequiredCapabilitiesStartUpCheck.class);
 
-        Multibinder<CamelMailetContainerModule.ProcessorsCheck> transportProcessorChecks = Multibinder.newSetBinder(binder(), CamelMailetContainerModule.ProcessorsCheck.class);
-        transportProcessorChecks.addBinding().toInstance(VACATION_MAILET_CHECK);
-        transportProcessorChecks.addBinding().toInstance(FILTERING_MAILET_CHECK);
-
         bind(MailQueueItemDecoratorFactory.class).to(PostDequeueDecoratorFactory.class).in(Scopes.SINGLETON);
 
         Multibinder.newSetBinder(binder(), MailboxListener.GroupMailboxListener.class).addBinding().to(PropagateLookupRightListener.class);
@@ -142,6 +142,22 @@ public class JMAPModule extends AbstractModule {
         supportedCapabilities.addBinding().toInstance(DefaultCapabilities.SHARES_CAPABILITY());
         supportedCapabilities.addBinding().toInstance(DefaultCapabilities.VACATION_RESPONSE_CAPABILITY());
         supportedCapabilities.addBinding().toInstance(DefaultCapabilities.SUBMISSION_CAPABILITY());
+    }
+
+    @ProvidesIntoSet
+    ProcessorsCheck vacationMailetCheck(JMAPConfiguration configuration) {
+        if (configuration.isEnabled()) {
+            return VACATION_MAILET_CHECK;
+        }
+        return NO_CHECK;
+    }
+
+    @ProvidesIntoSet
+    ProcessorsCheck filteringMailetCheck(JMAPConfiguration configuration) {
+        if (configuration.isEnabled()) {
+            return FILTERING_MAILET_CHECK;
+        }
+        return NO_CHECK;
     }
 
     @ProvidesIntoSet


### PR DESCRIPTION
On gitter with one of our users:

https://github.com/devnewton reported:

{code:java}
Hello, I try to setup Apache James + Cassandra + LDAP following the documentation and Dockerfile configuration sample.

James crash at startup because of missing something related to JMAP: Missing org.apache.james.jmap.mailet.filter.JMAPFiltering in mailets configuration (mailetcontainer -> processors -> transport).

I tried to disable this protocol using enabled=false in conf/jmap.properties but it has no effect.
{code}

The short term solution for him is to had the missing mailet.

But does it even make sense, when JMAP is disabled, to require
people to configure JMAP mailets?

Maybe we should relax the checks and only perform them only when
JMAP is enabled. This should result in an easier to use mail server.