### PR TITLE
JAMES-3491 JMAP events for WebSocket PUSH

### DIFF
--- a/server/container/guice/cassandra-guice/src/main/java/org/apache/james/CassandraJamesServerMain.java
+++ b/server/container/guice/cassandra-guice/src/main/java/org/apache/james/CassandraJamesServerMain.java
@@ -46,6 +46,7 @@ import org.apache.james.modules.mailrepository.CassandraMailRepositoryModule;
 import org.apache.james.modules.metrics.CassandraMetricsModule;
 import org.apache.james.modules.protocols.IMAPServerModule;
 import org.apache.james.modules.protocols.JMAPServerModule;
+import org.apache.james.modules.protocols.JmapEventBusModule;
 import org.apache.james.modules.protocols.LMTPServerModule;
 import org.apache.james.modules.protocols.ManageSieveServerModule;
 import org.apache.james.modules.protocols.POP3ServerModule;
@@ -111,6 +112,7 @@ public class CassandraJamesServerMain implements JamesServerMain {
         new ProtocolHandlerModule(),
         new SMTPServerModule(),
         new JMAPServerModule(),
+        new JmapEventBusModule(),
         WEBADMIN);
 
     public static final Module PLUGINS = Modules.combine(

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
@@ -26,6 +26,7 @@ import org.apache.james.modules.DistributedTaskSerializationModule;
 import org.apache.james.modules.blobstore.BlobStoreCacheModulesChooser;
 import org.apache.james.modules.blobstore.BlobStoreConfiguration;
 import org.apache.james.modules.blobstore.BlobStoreModulesChooser;
+import org.apache.james.modules.event.JMAPEventBusModule;
 import org.apache.james.modules.event.RabbitMQEventBusModule;
 import org.apache.james.modules.queue.rabbitmq.RabbitMQModule;
 import org.apache.james.modules.server.JMXServerModule;
@@ -40,6 +41,7 @@ public class CassandraRabbitMQJamesServerMain implements JamesServerMain {
             .override(Modules.combine(REQUIRE_TASK_MANAGER_MODULE, new DistributedTaskManagerModule()))
             .with(new RabbitMQModule(),
                 new RabbitMailQueueRoutesModule(),
+                new JMAPEventBusModule(),
                 new RabbitMQEventBusModule(),
                 new DistributedTaskSerializationModule());
 

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/event/JMAPEventBusModule.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/event/JMAPEventBusModule.java
@@ -33,10 +33,8 @@ import org.apache.james.events.RabbitMQEventBus;
 import org.apache.james.events.RetryBackoffConfiguration;
 import org.apache.james.events.RoutingKeyConverter;
 import org.apache.james.jmap.InjectionKeys;
-import org.apache.james.jmap.change.EventDTOModule;
 import org.apache.james.jmap.change.Factory;
 import org.apache.james.jmap.change.JmapEventSerializer;
-import org.apache.james.jmap.change.StateChangeEventDTO$;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.utils.InitializationOperation;
 import org.apache.james.utils.InitilizationOperationBuilder;
@@ -45,7 +43,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.ProvidesIntoSet;
 import com.google.inject.name.Names;
 
@@ -57,9 +54,6 @@ public class JMAPEventBusModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(EventBusId.class).annotatedWith(Names.named(InjectionKeys.JMAP)).toInstance(EventBusId.random());
-
-        Multibinder.newSetBinder(binder(), EventDTOModule.class).addBinding()
-            .toInstance(StateChangeEventDTO$.MODULE$.dtoModule());
     }
 
     @ProvidesIntoSet

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/event/JMAPEventBusModule.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/modules/event/JMAPEventBusModule.java
@@ -1,0 +1,98 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.modules.event;
+
+import javax.inject.Named;
+
+import org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPool;
+import org.apache.james.backends.rabbitmq.ReceiverProvider;
+import org.apache.james.backends.rabbitmq.SimpleConnectionPool;
+import org.apache.james.events.EventBus;
+import org.apache.james.events.EventBusId;
+import org.apache.james.events.EventDeadLetters;
+import org.apache.james.events.KeyReconnectionHandler;
+import org.apache.james.events.NamingStrategy;
+import org.apache.james.events.RabbitMQEventBus;
+import org.apache.james.events.RetryBackoffConfiguration;
+import org.apache.james.events.RoutingKeyConverter;
+import org.apache.james.jmap.InjectionKeys;
+import org.apache.james.jmap.change.EventDTOModule;
+import org.apache.james.jmap.change.Factory;
+import org.apache.james.jmap.change.JmapEventSerializer;
+import org.apache.james.jmap.change.StateChangeEventDTO$;
+import org.apache.james.metrics.api.MetricFactory;
+import org.apache.james.utils.InitializationOperation;
+import org.apache.james.utils.InitilizationOperationBuilder;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.multibindings.ProvidesIntoSet;
+import com.google.inject.name.Names;
+
+import reactor.rabbitmq.Sender;
+
+public class JMAPEventBusModule extends AbstractModule {
+    public static final NamingStrategy JMAP_NAMING_STRATEGY = new NamingStrategy("jmapEvent");
+
+    @Override
+    protected void configure() {
+        bind(EventBusId.class).annotatedWith(Names.named(InjectionKeys.JMAP)).toInstance(EventBusId.random());
+
+        Multibinder.newSetBinder(binder(), EventDTOModule.class).addBinding()
+            .toInstance(StateChangeEventDTO$.MODULE$.dtoModule());
+    }
+
+    @ProvidesIntoSet
+    InitializationOperation workQueue(@Named(InjectionKeys.JMAP) RabbitMQEventBus instance) {
+        return InitilizationOperationBuilder
+            .forClass(RabbitMQEventBus.class)
+            .init(instance::start);
+    }
+
+    @ProvidesIntoSet
+    SimpleConnectionPool.ReconnectionHandler provideReconnectionHandler(@Named(InjectionKeys.JMAP) EventBusId eventBusId) {
+        return new KeyReconnectionHandler(JMAP_NAMING_STRATEGY, eventBusId);
+    }
+
+    @Provides
+    @Singleton
+    @Named(InjectionKeys.JMAP)
+    RabbitMQEventBus provideJmapEventBus(Sender sender, ReceiverProvider receiverProvider,
+                                 JmapEventSerializer eventSerializer,
+                                 RetryBackoffConfiguration retryBackoffConfiguration,
+                                 EventDeadLetters eventDeadLetters,
+                                 MetricFactory metricFactory, ReactorRabbitMQChannelPool channelPool,
+                                 @Named(InjectionKeys.JMAP) EventBusId eventBusId) {
+        return new RabbitMQEventBus(
+            JMAP_NAMING_STRATEGY,
+            sender, receiverProvider, eventSerializer, retryBackoffConfiguration, new RoutingKeyConverter(ImmutableSet.of(new Factory())),
+            eventDeadLetters, metricFactory, channelPool, eventBusId);
+    }
+
+    @Provides
+    @Singleton
+    @Named(InjectionKeys.JMAP)
+    EventBus provideJmapEventBus(@Named(InjectionKeys.JMAP) RabbitMQEventBus rabbitMQEventBus) {
+        return rabbitMQEventBus;
+    }
+}

--- a/server/container/guice/memory-guice/src/main/java/org/apache/james/MemoryJamesServerMain.java
+++ b/server/container/guice/memory-guice/src/main/java/org/apache/james/MemoryJamesServerMain.java
@@ -32,6 +32,7 @@ import org.apache.james.modules.eventstore.MemoryEventStoreModule;
 import org.apache.james.modules.mailbox.MemoryMailboxModule;
 import org.apache.james.modules.protocols.IMAPServerModule;
 import org.apache.james.modules.protocols.JMAPServerModule;
+import org.apache.james.modules.protocols.JmapEventBusModule;
 import org.apache.james.modules.protocols.LMTPServerModule;
 import org.apache.james.modules.protocols.ManageSieveServerModule;
 import org.apache.james.modules.protocols.POP3ServerModule;
@@ -99,6 +100,7 @@ public class MemoryJamesServerMain implements JamesServerMain {
         new SpamAssassinListenerModule());
 
     public static final Module JMAP = Modules.combine(
+        new JmapEventBusModule(),
         new JmapTasksModule(),
         new MemoryDataJmapModule(),
         new JMAPServerModule());

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/modules/protocols/JmapEventBusModule.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/modules/protocols/JmapEventBusModule.java
@@ -1,0 +1,14 @@
+package org.apache.james.modules.protocols;
+
+import org.apache.james.events.EventBus;
+import org.apache.james.jmap.InjectionKeys;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
+
+public class JmapEventBusModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(EventBus.class).annotatedWith(Names.named(InjectionKeys.JMAP)).to(EventBus.class);
+    }
+}

--- a/server/container/guice/protocols/jmap/src/main/java/org/apache/james/modules/protocols/JmapEventBusModule.java
+++ b/server/container/guice/protocols/jmap/src/main/java/org/apache/james/modules/protocols/JmapEventBusModule.java
@@ -1,3 +1,22 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
 package org.apache.james.modules.protocols;
 
 import org.apache.james.events.EventBus;

--- a/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/JmapChange.java
+++ b/server/data/data-jmap/src/main/java/org/apache/james/jmap/api/change/JmapChange.java
@@ -19,6 +19,8 @@
 
 package org.apache.james.jmap.api.change;
 
-public interface JmapChange {
+import org.apache.james.jmap.api.model.AccountId;
 
+public interface JmapChange {
+    AccountId getAccountId();
 }

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/CustomMethodContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/CustomMethodContract.scala
@@ -71,7 +71,7 @@ object CustomMethodContract {
       |      "mayCreateTopLevelMailbox" : true
       |    },
       |    "urn:ietf:params:jmap:websocket": {
-      |      "supportsPush": false,
+      |      "supportsPush": true,
       |      "url": "http://domain.com/jmap/ws"
       |    },
       |    "urn:apache:james:params:jmap:mail:quota": {},
@@ -90,7 +90,7 @@ object CustomMethodContract {
       |          "submissionExtensions": []
       |        },
       |        "urn:ietf:params:jmap:websocket": {
-      |            "supportsPush": false,
+      |            "supportsPush": true,
       |            "url": "http://domain.com/jmap/ws"
       |        },
       |        "urn:ietf:params:jmap:core" : {

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/SessionRoutesContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/SessionRoutesContract.scala
@@ -64,7 +64,7 @@ object SessionRoutesContract {
                          |      "mayCreateTopLevelMailbox" : true
                          |    },
                          |    "urn:ietf:params:jmap:websocket": {
-                         |      "supportsPush": false,
+                         |      "supportsPush": true,
                          |      "url": "http://domain.com/jmap/ws"
                          |    },
                          |    "urn:apache:james:params:jmap:mail:quota": {},
@@ -82,7 +82,7 @@ object SessionRoutesContract {
                          |          "submissionExtensions": []
                          |        },
                          |        "urn:ietf:params:jmap:websocket": {
-                         |            "supportsPush": false,
+                         |            "supportsPush": true,
                          |            "url": "http://domain.com/jmap/ws"
                          |        },
                          |        "urn:ietf:params:jmap:core" : {

--- a/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/WebSocketContract.scala
+++ b/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/WebSocketContract.scala
@@ -502,6 +502,76 @@ trait WebSocketContract {
   }
 
   @Test
+  // For client compatibility purposes
+  def specifiedUnHandledDataTypesShouldNotBeRejected(server: GuiceJamesServer): Unit = {
+    val bobPath = MailboxPath.inbox(BOB)
+    val accountId: AccountId = AccountId.fromUsername(BOB)
+    val mailboxId = server.getProbe(classOf[MailboxProbeImpl]).createMailbox(bobPath)
+
+    Thread.sleep(100)
+
+    val response: Either[String, List[String]] =
+      authenticatedRequest(server)
+        .response(asWebSocket[Identity, List[String]] {
+          ws =>
+            ws.send(WebSocketFrame.text(
+              """{
+                |  "@type": "WebSocketPushEnable",
+                |  "dataTypes": ["Mailbox", "Email", "VacationResponse", "Thread", "Identity", "EmailSubmission", "EmailDelivery"]
+                |}""".stripMargin))
+
+            Thread.sleep(100)
+
+            ws.send(WebSocketFrame.text(
+              s"""{
+                 |  "@type": "Request",
+                 |  "requestId": "req-36",
+                 |  "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
+                 |  "methodCalls": [
+                 |    ["Email/set", {
+                 |      "accountId": "$ACCOUNT_ID",
+                 |      "create": {
+                 |        "aaaaaa":{
+                 |          "mailboxIds": {
+                 |             "${mailboxId.serialize}": true
+                 |          }
+                 |        }
+                 |      }
+                 |    }, "c1"]]
+                 |}""".stripMargin))
+
+            List(
+              ws.receive()
+                .map { case t: Text =>
+                  t.payload
+                },
+              ws.receive()
+                .map { case t: Text =>
+                  t.payload
+                },
+              ws.receive()
+                .map { case t: Text =>
+                  t.payload
+                })
+        })
+        .send(backend)
+        .body
+
+    Thread.sleep(100)
+
+    val jmapGuiceProbe: JmapGuiceProbe = server.getProbe(classOf[JmapGuiceProbe])
+    val emailState: String = jmapGuiceProbe.getLatestEmailState(accountId).getValue.toString
+    val mailboxState: String = jmapGuiceProbe.getLatestMailboxState(accountId).getValue.toString
+
+    val mailboxStateChange: String = s"""{"@type":"StateChange","changed":{"$ACCOUNT_ID":{"Mailbox":"$mailboxState"}}}"""
+    val emailStateChange: String = s"""{"@type":"StateChange","changed":{"$ACCOUNT_ID":{"Email":"$emailState"}}}"""
+
+    assertThat(response.toOption.get.asJava)
+      .hasSize(3) // email notification + mailbox notification + API response
+      .contains(mailboxStateChange, emailStateChange)
+  }
+
+  @Test
   def dataTypesShouldDefaultToAll(server: GuiceJamesServer): Unit = {
     val bobPath = MailboxPath.inbox(BOB)
     val accountId: AccountId = AccountId.fromUsername(BOB)

--- a/server/protocols/jmap-rfc-8621/pom.xml
+++ b/server/protocols/jmap-rfc-8621/pom.xml
@@ -65,6 +65,16 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-json</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-core</artifactId>
         </dependency>
         <dependency>

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/AccountIdRegistrationKey.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/AccountIdRegistrationKey.scala
@@ -24,7 +24,7 @@ import org.apache.james.events.RegistrationKey
 import org.apache.james.jmap.api.model.AccountId
 
 case class Factory() extends RegistrationKey.Factory {
-  override def forClass(): Class[_ <: RegistrationKey] = classOf[AccountIdRegistrationKey]
+  override val forClass: Class[_ <: RegistrationKey] = classOf[AccountIdRegistrationKey]
 
   override def fromString(asString: String): RegistrationKey = AccountIdRegistrationKey(AccountId.fromString(asString))
 }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/AccountIdRegistrationKey.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/AccountIdRegistrationKey.scala
@@ -1,0 +1,33 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *  http://www.apache.org/licenses/LICENSE-2.0                  *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.change
+
+import org.apache.james.events.RegistrationKey
+import org.apache.james.jmap.api.model.AccountId
+
+case class Factory() extends RegistrationKey.Factory {
+  override def forClass(): Class[_ <: RegistrationKey] = classOf[AccountIdRegistrationKey]
+
+  override def fromString(asString: String): RegistrationKey = AccountIdRegistrationKey(AccountId.fromString(asString))
+}
+
+case class AccountIdRegistrationKey(accountId: AccountId) extends RegistrationKey {
+  override def asString(): String = accountId.getIdentifier
+}

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/AccountIdRegistrationKey.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/AccountIdRegistrationKey.scala
@@ -19,6 +19,7 @@
 
 package org.apache.james.jmap.change
 
+import org.apache.james.core.Username
 import org.apache.james.events.RegistrationKey
 import org.apache.james.jmap.api.model.AccountId
 
@@ -26,6 +27,10 @@ case class Factory() extends RegistrationKey.Factory {
   override def forClass(): Class[_ <: RegistrationKey] = classOf[AccountIdRegistrationKey]
 
   override def fromString(asString: String): RegistrationKey = AccountIdRegistrationKey(AccountId.fromString(asString))
+}
+
+object AccountIdRegistrationKey {
+  def of(username: Username): AccountIdRegistrationKey = AccountIdRegistrationKey(AccountId.fromUsername(username))
 }
 
 case class AccountIdRegistrationKey(accountId: AccountId) extends RegistrationKey {

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/EventDTOModule.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/EventDTOModule.scala
@@ -1,0 +1,38 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.change
+
+import org.apache.james.events.Event
+import org.apache.james.json.{DTO, DTOModule}
+
+
+trait EventDTO extends DTO
+
+object EventDTOModule {
+  def forEvent[EventTypeT <: Event](eventType: Class[EventTypeT]) = new DTOModule.Builder[EventTypeT](eventType)
+}
+
+case class EventDTOModule[T <: Event, U <: EventDTO](converter: DTOModule.DTOConverter[T, U],
+                                                     toDomainObjectConverter: DTOModule.DomainObjectConverter[T, U],
+                                                     domainObjectType: Class[T],
+                                                     dtoType: Class[U],
+                                                     typeName: String) extends DTOModule[T, U](converter, toDomainObjectConverter, domainObjectType, dtoType, typeName) {
+  override def toDTO(domainObject: T) : U = super.toDTO(domainObject)
+}

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/JmapEventSerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/JmapEventSerializer.scala
@@ -1,0 +1,76 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.change
+
+import java.util.Optional
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import javax.inject.Inject
+import org.apache.james.core.Username
+import org.apache.james.events.Event.EventId
+import org.apache.james.events.{Event, EventSerializer}
+import org.apache.james.jmap.core.State
+import org.apache.james.json.JsonGenericSerializer
+
+import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters._
+
+object StateChangeEventDTO {
+  val dtoModule: EventDTOModule[StateChangeEvent, StateChangeEventDTO] = EventDTOModule.forEvent(classOf[StateChangeEvent])
+    .convertToDTO(classOf[StateChangeEventDTO])
+    .toDomainObjectConverter(dto => dto.toDomainObject)
+    .toDTOConverter((event, aType) => StateChangeEventDTO.toDTO(event))
+    .typeName(classOf[StateChangeEvent].getCanonicalName)
+    .withFactory(EventDTOModule.apply);
+
+  def toDTO(event: StateChangeEvent): StateChangeEventDTO = StateChangeEventDTO(
+    getType = classOf[StateChangeEvent].getCanonicalName,
+    getEventId = event.eventId.getId.toString,
+    getUsername = event.username.asString(),
+    getMailboxState = event.mailboxState.map(_.value).map(_.toString).toJava,
+    getEmailState = event.emailState.map(_.value).map(_.toString).toJava)
+}
+
+case class StateChangeEventDTO(@JsonProperty("type") getType: String,
+                               @JsonProperty("eventId") getEventId: String,
+                               @JsonProperty("username") getUsername: String,
+                               @JsonProperty("mailboxState") getMailboxState: Optional[String],
+                               @JsonProperty("emailState") getEmailState: Optional[String]) extends EventDTO {
+  def toDomainObject: StateChangeEvent = StateChangeEvent(
+    eventId = EventId.of(getEventId),
+    username = Username.of(getUsername),
+    mailboxState = getMailboxState.toScala.map(State.fromStringUnchecked),
+    emailState = getEmailState.toScala.map(State.fromStringUnchecked))
+}
+
+case class JmapEventSerializer(dtoModules: Set[EventDTOModule[Event, EventDTO]]) extends EventSerializer {
+  @Inject
+  def this(javaModules: java.util.Set[EventDTOModule[Event, EventDTO]]) {
+    this(javaModules.asScala.toSet)
+  }
+
+  private val genericSerializer: JsonGenericSerializer[Event, EventDTO] = JsonGenericSerializer
+    .forModules(dtoModules.asJava)
+    .withoutNestedType()
+
+  override def toJson(event: Event): String = genericSerializer.serialize(event)
+
+  override def asEvent(serialized: String): Event = genericSerializer.deserialize(serialized)
+}

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/JmapEventSerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/JmapEventSerializer.scala
@@ -22,14 +22,12 @@ package org.apache.james.jmap.change
 import java.util.Optional
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import javax.inject.Inject
 import org.apache.james.core.Username
 import org.apache.james.events.Event.EventId
 import org.apache.james.events.{Event, EventSerializer}
 import org.apache.james.jmap.core.State
 import org.apache.james.json.JsonGenericSerializer
 
-import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
 
 object StateChangeEventDTO {
@@ -60,17 +58,14 @@ case class StateChangeEventDTO(@JsonProperty("type") getType: String,
     emailState = getEmailState.toScala.map(State.fromStringUnchecked))
 }
 
-case class JmapEventSerializer(dtoModules: Set[EventDTOModule[Event, EventDTO]]) extends EventSerializer {
-  @Inject
-  def this(javaModules: java.util.Set[EventDTOModule[Event, EventDTO]]) {
-    this(javaModules.asScala.toSet)
-  }
-
-  private val genericSerializer: JsonGenericSerializer[Event, EventDTO] = JsonGenericSerializer
-    .forModules(dtoModules.asJava)
+case class JmapEventSerializer() extends EventSerializer {
+  private val genericSerializer: JsonGenericSerializer[StateChangeEvent, StateChangeEventDTO] = JsonGenericSerializer
+    .forModules(StateChangeEventDTO.dtoModule)
     .withoutNestedType()
 
-  override def toJson(event: Event): String = genericSerializer.serialize(event)
+  override def toJson(event: Event): String = event match {
+    case stateChangeEvent: StateChangeEvent => genericSerializer.serialize(stateChangeEvent)
+  }
 
   override def asEvent(serialized: String): Event = genericSerializer.deserialize(serialized)
 }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChange.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChange.scala
@@ -25,7 +25,7 @@ import org.apache.james.events.Event.EventId
 import org.apache.james.jmap.core.{AccountId, State, StateChange}
 
 object TypeName {
-  val ALL: Set[TypeName] = Set(EmailTypeName, MailboxTypeName)
+  val ALL: Set[TypeName] = Set(EmailTypeName, MailboxTypeName, ThreadTypeName, IdentityTypeName, EmailSubmissionTypeName, EmailDeliveryTypeName)
 }
 
 sealed trait TypeName {
@@ -40,6 +40,21 @@ case object MailboxTypeName extends TypeName {
 }
 case object EmailTypeName extends TypeName {
   override val asString: String = "Email"
+}
+case object ThreadTypeName extends TypeName {
+  override val asString: String = "Thread"
+}
+case object IdentityTypeName extends TypeName {
+  override val asString: String = "Identity"
+}
+case object EmailSubmissionTypeName extends TypeName {
+  override val asString: String = "EmailSubmission"
+}
+case object EmailDeliveryTypeName extends TypeName {
+  override val asString: String = "EmailDelivery"
+}
+case object VacationResponseTypeName extends TypeName {
+  override val asString: String = "VacationResponse"
 }
 
 case class TypeState(changes: Map[TypeName, State]) {

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChange.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChange.scala
@@ -38,7 +38,14 @@ case object EmailTypeName extends TypeName {
   override def asString(): String = "Email"
 }
 
-case class TypeState(changes: Map[TypeName, State])
+case class TypeState(changes: Map[TypeName, State]) {
+
+  def filter(types: Set[TypeName]): Option[TypeState] = Option(changes.filter {
+    case (typeName, _) => types.contains(typeName)
+  })
+    .filter(_.nonEmpty)
+    .map(TypeState)
+}
 
 case class StateChangeEvent(eventId: EventId,
                             username: Username,

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChange.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChange.scala
@@ -24,6 +24,10 @@ import org.apache.james.events.Event
 import org.apache.james.events.Event.EventId
 import org.apache.james.jmap.core.{AccountId, State, StateChange}
 
+object TypeName {
+  val ALL: Set[TypeName] = Set(EmailTypeName, MailboxTypeName)
+}
+
 sealed trait TypeName {
   def asMap(maybeState: Option[State]): Map[TypeName, State] =
     maybeState.map(state => Map[TypeName, State](this -> state))

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChange.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChange.scala
@@ -51,7 +51,6 @@ case class StateChangeEvent(eventId: EventId,
                             username: Username,
                             mailboxState: Option[State],
                             emailState: Option[State]) extends Event {
-
   def asStateChange: StateChange =
     StateChange(Map(AccountId.from(username).fold(
       failure => throw new IllegalArgumentException(failure),
@@ -60,9 +59,9 @@ case class StateChangeEvent(eventId: EventId,
         MailboxTypeName.asMap(mailboxState) ++
           EmailTypeName.asMap(emailState))))
 
-  override def getUsername: Username = username
+  override val getUsername: Username = username
 
-  override def isNoop: Boolean = mailboxState.isEmpty && emailState.isEmpty
+  override val isNoop: Boolean = mailboxState.isEmpty && emailState.isEmpty
 
-  override def getEventId: EventId = eventId
+  override val getEventId: EventId = eventId
 }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChange.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChange.scala
@@ -22,17 +22,21 @@ package org.apache.james.jmap.change
 import org.apache.james.core.Username
 import org.apache.james.events.Event
 import org.apache.james.events.Event.EventId
-import org.apache.james.jmap.core.{AccountId, State}
+import org.apache.james.jmap.core.{AccountId, State, StateChange}
 
 sealed trait TypeName {
   def asMap(maybeState: Option[State]): Map[TypeName, State] =
     maybeState.map(state => Map[TypeName, State](this -> state))
       .getOrElse(Map())
-}
-case object MailboxTypeName extends TypeName
-case object EmailTypeName extends TypeName
 
-case class StateChange(changes: Map[AccountId, TypeState])
+  def asString(): String
+}
+case object MailboxTypeName extends TypeName {
+  override def asString(): String = "Mailbox"
+}
+case object EmailTypeName extends TypeName {
+  override def asString(): String = "Email"
+}
 
 case class TypeState(changes: Map[TypeName, State])
 
@@ -51,7 +55,7 @@ case class StateChangeEvent(eventId: EventId,
 
   override def getUsername: Username = username
 
-  override def isNoop: Boolean = false
+  override def isNoop: Boolean = mailboxState.isEmpty && emailState.isEmpty
 
   override def getEventId: EventId = eventId
 }

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChange.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChange.scala
@@ -1,0 +1,57 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.change
+
+import org.apache.james.core.Username
+import org.apache.james.events.Event
+import org.apache.james.events.Event.EventId
+import org.apache.james.jmap.core.{AccountId, State}
+
+sealed trait TypeName {
+  def asMap(maybeState: Option[State]): Map[TypeName, State] =
+    maybeState.map(state => Map[TypeName, State](this -> state))
+      .getOrElse(Map())
+}
+case object MailboxTypeName extends TypeName
+case object EmailTypeName extends TypeName
+
+case class StateChange(changes: Map[AccountId, TypeState])
+
+case class TypeState(changes: Map[TypeName, State])
+
+case class StateChangeEvent(eventId: EventId,
+                            username: Username,
+                            mailboxState: Option[State],
+                            emailState: Option[State]) extends Event {
+
+  def asStateChange: StateChange =
+    StateChange(Map(AccountId.from(username).fold(
+      failure => throw new IllegalArgumentException(failure),
+      success => success) ->
+      TypeState(
+        MailboxTypeName.asMap(mailboxState) ++
+          EmailTypeName.asMap(emailState))))
+
+  override def getUsername: Username = username
+
+  override def isNoop: Boolean = false
+
+  override def getEventId: EventId = eventId
+}

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChange.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChange.scala
@@ -32,10 +32,10 @@ sealed trait TypeName {
   def asString(): String
 }
 case object MailboxTypeName extends TypeName {
-  override def asString(): String = "Mailbox"
+  override val asString: String = "Mailbox"
 }
 case object EmailTypeName extends TypeName {
-  override def asString(): String = "Email"
+  override val asString: String = "Email"
 }
 
 case class TypeState(changes: Map[TypeName, State]) {

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChangeListener.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChangeListener.scala
@@ -1,0 +1,47 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.change
+
+import java.nio.charset.StandardCharsets
+
+import org.apache.james.events.Event
+import org.apache.james.events.EventListener.ReactiveEventListener
+import org.apache.james.jmap.json.ResponseSerializer
+import org.reactivestreams.Publisher
+import play.api.libs.json.Json
+import reactor.core.scala.publisher.SMono
+import reactor.core.scheduler.Schedulers
+import reactor.netty.http.websocket.WebsocketOutbound
+
+case class StateChangeListener(outbound: WebsocketOutbound) extends ReactiveEventListener {
+  override def reactiveEvent(event: Event): Publisher[Void] = event match {
+    case stateChangeEvent: StateChangeEvent =>
+      val stateChange = stateChangeEvent.asStateChange
+      val jsonString = Json.stringify(ResponseSerializer.serialize(stateChange))
+      SMono(outbound.sendString(SMono.just[String](jsonString), StandardCharsets.UTF_8))
+        .subscribeOn(Schedulers.elastic)
+    case _ => SMono.empty
+  }
+
+  override def isHandling(event: Event): Boolean = event match {
+    case _: StateChangeEvent => true
+    case _ => false
+  }
+}

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChangeListener.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChangeListener.scala
@@ -21,21 +21,22 @@ package org.apache.james.jmap.change
 
 import org.apache.james.events.Event
 import org.apache.james.events.EventListener.ReactiveEventListener
-import org.apache.james.jmap.core.StateChange
+import org.apache.james.jmap.core.WebSocketOutboundMessage
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Sinks
 import reactor.core.publisher.Sinks.EmitFailureHandler.FAIL_FAST
 import reactor.core.scala.publisher.SMono
 
-case class StateChangeListener(types: Set[TypeName], sink: Sinks.Many[StateChange]) extends ReactiveEventListener {
-  override def reactiveEvent(event: Event): Publisher[Void] = event match {
-    case stateChangeEvent: StateChangeEvent =>
-      SMono.fromCallable(() => {
-        val stateChange = stateChangeEvent.asStateChange.filter(types)
-        stateChange.foreach(next => sink.emitNext(next, FAIL_FAST))
-      }).asJava().`then`()
-    case _ => SMono.empty
-  }
+case class StateChangeListener(types: Set[TypeName], sink: Sinks.Many[WebSocketOutboundMessage]) extends ReactiveEventListener {
+  override def reactiveEvent(event: Event): Publisher[Void] =
+    event match {
+      case stateChangeEvent: StateChangeEvent =>
+        SMono.fromCallable(() => {
+          val stateChange = stateChangeEvent.asStateChange.filter(types)
+          stateChange.foreach(next => sink.emitNext(next, FAIL_FAST))
+        }).asJava().`then`()
+      case _ => SMono.empty
+    }
 
   override def isHandling(event: Event): Boolean = event match {
     case _: StateChangeEvent => true

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChangeListener.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/change/StateChangeListener.scala
@@ -31,10 +31,10 @@ case class StateChangeListener(types: Set[TypeName], sink: Sinks.Many[WebSocketO
   override def reactiveEvent(event: Event): Publisher[Void] =
     event match {
       case stateChangeEvent: StateChangeEvent =>
-        SMono.fromCallable(() => {
-          val stateChange = stateChangeEvent.asStateChange.filter(types)
-          stateChange.foreach(next => sink.emitNext(next, FAIL_FAST))
-        }).asJava().`then`()
+        SMono.fromCallable(() =>
+          stateChangeEvent.asStateChange.filter(types)
+            .foreach(next => sink.emitNext(next, FAIL_FAST)))
+          .asJava().`then`()
       case _ => SMono.empty
     }
 

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/Capabilities.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/Capabilities.scala
@@ -36,7 +36,7 @@ object DefaultCapabilities {
       collationAlgorithms = List("i;unicode-casemap")))
 
   def webSocketCapability(url: URL) = WebSocketCapability(
-    properties = WebSocketCapabilityProperties(SupportsPush(false), url))
+    properties = WebSocketCapabilityProperties(SupportsPush(true), url))
 
   val MAIL_CAPABILITY = MailCapability(
     properties = MailCapabilityProperties(

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/Session.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/Session.scala
@@ -80,6 +80,12 @@ object State {
 
   val INSTANCE: State = fromJava(JavaState.INITIAL)
 
+  def fromStringUnchecked(value: String): State = 
+    refineV[Uuid](value)
+      .fold(
+        failure => throw new IllegalArgumentException(failure),
+        success => State.fromString(success))
+
   def fromString(value: UUIDString): State = State(UUID.fromString(value.value))
 
   def fromMailboxChanges(mailboxChanges: MailboxChanges): State = fromJava(mailboxChanges.getNewState)

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/WebSocketTransport.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/WebSocketTransport.scala
@@ -19,7 +19,7 @@
 
 package org.apache.james.jmap.core
 
-import org.apache.james.jmap.change.TypeState
+import org.apache.james.jmap.change.{TypeName, TypeState}
 
 sealed trait WebSocketInboundMessage
 
@@ -33,4 +33,12 @@ case class WebSocketResponse(requestId: Option[RequestId], responseObject: Respo
 
 case class WebSocketError(requestId: Option[RequestId], problemDetails: ProblemDetails) extends WebSocketOutboundMessage
 
-case class StateChange(changes: Map[AccountId, TypeState]) extends WebSocketOutboundMessage
+case class StateChange(changes: Map[AccountId, TypeState]) extends WebSocketOutboundMessage {
+
+  def filter(types: Set[TypeName]): Option[StateChange] =
+    Option(changes.flatMap {
+      case (accountId, typeState) => typeState.filter(types).map(typeState => (accountId, typeState))
+    })
+    .filter(_.nonEmpty)
+    .map(StateChange)
+}

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/WebSocketTransport.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/WebSocketTransport.scala
@@ -42,3 +42,5 @@ case class StateChange(changes: Map[AccountId, TypeState]) extends WebSocketOutb
     .filter(_.nonEmpty)
     .map(StateChange)
 }
+
+case class WebSocketPushEnable(dataTypes: Set[TypeName]) extends WebSocketInboundMessage

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/WebSocketTransport.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/WebSocketTransport.scala
@@ -43,4 +43,4 @@ case class StateChange(changes: Map[AccountId, TypeState]) extends WebSocketOutb
     .map(StateChange)
 }
 
-case class WebSocketPushEnable(dataTypes: Set[TypeName]) extends WebSocketInboundMessage
+case class WebSocketPushEnable(dataTypes: Option[Set[TypeName]]) extends WebSocketInboundMessage

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/WebSocketTransport.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/core/WebSocketTransport.scala
@@ -19,6 +19,8 @@
 
 package org.apache.james.jmap.core
 
+import org.apache.james.jmap.change.TypeState
+
 sealed trait WebSocketInboundMessage
 
 sealed trait WebSocketOutboundMessage
@@ -30,3 +32,5 @@ case class WebSocketRequest(requestId: Option[RequestId], requestObject: Request
 case class WebSocketResponse(requestId: Option[RequestId], responseObject: ResponseObject) extends WebSocketOutboundMessage
 
 case class WebSocketError(requestId: Option[RequestId], problemDetails: ProblemDetails) extends WebSocketOutboundMessage
+
+case class StateChange(changes: Map[AccountId, TypeState]) extends WebSocketOutboundMessage

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/ResponseSerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/ResponseSerializer.scala
@@ -25,7 +25,7 @@ import java.net.URL
 import eu.timepit.refined.refineV
 import io.netty.handler.codec.http.HttpResponseStatus
 import org.apache.james.core.Username
-import org.apache.james.jmap.change.{EmailTypeName, MailboxTypeName, TypeName, TypeState}
+import org.apache.james.jmap.change.{EmailDeliveryTypeName, EmailSubmissionTypeName, EmailTypeName, IdentityTypeName, MailboxTypeName, ThreadTypeName, TypeName, TypeState, VacationResponseTypeName}
 import org.apache.james.jmap.core
 import org.apache.james.jmap.core.CapabilityIdentifier.CapabilityIdentifier
 import org.apache.james.jmap.core.Id.IdConstraint
@@ -189,6 +189,11 @@ object ResponseSerializer {
   private implicit val typeNameReads: Reads[TypeName] = {
     case JsString(MailboxTypeName.asString) => JsSuccess(MailboxTypeName)
     case JsString(EmailTypeName.asString) => JsSuccess(EmailTypeName)
+    case JsString(ThreadTypeName.asString) => JsSuccess(ThreadTypeName)
+    case JsString(IdentityTypeName.asString) => JsSuccess(IdentityTypeName)
+    case JsString(EmailSubmissionTypeName.asString) => JsSuccess(EmailSubmissionTypeName)
+    case JsString(EmailDeliveryTypeName.asString) => JsSuccess(EmailDeliveryTypeName)
+    case JsString(VacationResponseTypeName.asString) => JsSuccess(VacationResponseTypeName)
     case _ => JsError("Expecting a JsString as typeName")
   }
   private implicit val webSocketPushEnableReads: Reads[WebSocketPushEnable] = Json.reads[WebSocketPushEnable]

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/ResponseSerializer.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/ResponseSerializer.scala
@@ -25,7 +25,7 @@ import java.net.URL
 import eu.timepit.refined.refineV
 import io.netty.handler.codec.http.HttpResponseStatus
 import org.apache.james.core.Username
-import org.apache.james.jmap.change.{TypeName, TypeState}
+import org.apache.james.jmap.change.{EmailTypeName, MailboxTypeName, TypeName, TypeState}
 import org.apache.james.jmap.core
 import org.apache.james.jmap.core.CapabilityIdentifier.CapabilityIdentifier
 import org.apache.james.jmap.core.Id.IdConstraint
@@ -187,8 +187,8 @@ object ResponseSerializer {
     case _ => JsError("Expecting a JsObject to represent a webSocket inbound request")
   }
   private implicit val typeNameReads: Reads[TypeName] = {
-    case JsString(value) if value.equals(MailboxTypeName.asString()) => JsSuccess(MailboxTypeName)
-    case JsString(value) if value.equals(EmailTypeName.asString()) => JsSuccess(EmailTypeName)
+    case JsString(MailboxTypeName.asString) => JsSuccess(MailboxTypeName)
+    case JsString(EmailTypeName.asString) => JsSuccess(EmailTypeName)
     case _ => JsError("Expecting a JsString as typeName")
   }
   private implicit val webSocketPushEnableReads: Reads[WebSocketPushEnable] = Json.reads[WebSocketPushEnable]

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/package.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/json/package.scala
@@ -43,7 +43,7 @@ package object json {
     case _ => JsError("Expecting mailboxId value to be a boolean")
   }
 
-  def mapWrites[K, V](keyWriter: K => String, valueWriter: Writes[V]): Writes[Map[K, V]] =
+  def mapWrites[K, V](keyWriter: K => String, valueWriter: Writes[V]): OWrites[Map[K, V]] =
     (ids: Map[K, V]) => {
       ids.foldLeft(JsObject.empty)((jsObject, kv) => {
         val (key: K, value: V) = kv

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/WebSocketRoutes.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/WebSocketRoutes.scala
@@ -26,13 +26,15 @@ import io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE
 import io.netty.handler.codec.http.HttpMethod
 import io.netty.handler.codec.http.websocketx.WebSocketFrame
 import javax.inject.{Inject, Named}
+import org.apache.james.events.{EventBus, Registration}
 import org.apache.james.jmap.HttpConstants.JSON_CONTENT_TYPE
 import org.apache.james.jmap.JMAPUrls.JMAP_WS
-import org.apache.james.jmap.core.{ProblemDetails, RequestId, WebSocketError, WebSocketOutboundMessage, WebSocketRequest, WebSocketResponse}
+import org.apache.james.jmap.change.{AccountIdRegistrationKey, StateChangeListener}
+import org.apache.james.jmap.core.{ProblemDetails, RequestId, WebSocketError, WebSocketOutboundMessage, WebSocketPushEnable, WebSocketRequest, WebSocketResponse}
 import org.apache.james.jmap.http.rfc8621.InjectionKeys
 import org.apache.james.jmap.http.{Authenticator, UserProvisioning}
 import org.apache.james.jmap.json.ResponseSerializer
-import org.apache.james.jmap.{Endpoint, JMAPRoute, JMAPRoutes}
+import org.apache.james.jmap.{Endpoint, JMAPRoute, JMAPRoutes, InjectionKeys => JMAPInjectionKeys}
 import org.apache.james.mailbox.MailboxSession
 import org.slf4j.{Logger, LoggerFactory}
 import reactor.core.publisher.Mono
@@ -45,8 +47,21 @@ object WebSocketRoutes {
   val LOGGER: Logger = LoggerFactory.getLogger(classOf[WebSocketRoutes])
 }
 
+case class ClientContext(outbound: WebsocketOutbound, pushRegistration: Option[Registration], session: MailboxSession) {
+  def latest(clientContext: ClientContext): ClientContext = {
+    clean
+    clientContext
+  }
+
+  def clean: ClientContext = {
+    pushRegistration.foreach(_.unregister())
+    ClientContext(outbound, None, session)
+  }
+}
+
 class WebSocketRoutes @Inject() (@Named(InjectionKeys.RFC_8621) val authenticator: Authenticator,
                                  userProvisioner: UserProvisioning,
+                                 @Named(JMAPInjectionKeys.JMAP) eventBus: EventBus,
                                  jmapApi: JMAPApi) extends JMAPRoutes {
 
   override def routes(): stream.Stream[JMAPRoute] = stream.Stream.of(
@@ -70,7 +85,8 @@ class WebSocketRoutes @Inject() (@Named(InjectionKeys.RFC_8621) val authenticato
       .`then`()
   }
 
-  private def handleWebSocketConnection(session: MailboxSession)(in: WebsocketInbound, out: WebsocketOutbound): Mono[Void] =
+  private def handleWebSocketConnection(session: MailboxSession)(in: WebsocketInbound, out: WebsocketOutbound): Mono[Void] = {
+    val context = ClientContext(out, None, session)
     SFlux[WebSocketFrame](in.aggregateFrames()
       .receiveFrames())
       .map(frame => {
@@ -78,27 +94,38 @@ class WebSocketRoutes @Inject() (@Named(InjectionKeys.RFC_8621) val authenticato
         frame.content().readBytes(bytes)
         new String(bytes, StandardCharsets.UTF_8)
       })
-      .flatMap(handleClientMessages(session))
-      .onErrorResume(e => SMono.just[WebSocketOutboundMessage](asError(None)(e)))
-      .map(ResponseSerializer.serialize)
-      .map(_.toString)
-      .flatMap(response => out.sendString(SMono.just(response), StandardCharsets.UTF_8))
+      .flatMap(message => handleClientMessages(context)(message))
+      .reduce((c1: ClientContext, c2: ClientContext) => c1.latest(c2))
+      .map[ClientContext](context => context.clean)
       .`then`()
       .asJava()
       .`then`()
+  }
 
-  private def handleClientMessages(session: MailboxSession)(message: String): SMono[WebSocketOutboundMessage] =
+  private def handleClientMessages(clientContext: ClientContext)(message: String): SMono[ClientContext] =
     ResponseSerializer.deserializeWebSocketInboundMessage(message)
       .fold(invalid => {
-        val error = asError(None)(new IllegalArgumentException(invalid.toString()))
-        SMono.just[WebSocketOutboundMessage](error)
+        val error = ResponseSerializer.serialize(asError(None)(new IllegalArgumentException(invalid.toString())))
+        SMono(clientContext.outbound.sendString(SMono.just(error.toString()), StandardCharsets.UTF_8)
+          .`then`())
+          .`then`(SMono.just(clientContext))
       }, {
           case request: WebSocketRequest =>
-            jmapApi.process(request.requestObject, session)
+            jmapApi.process(request.requestObject, clientContext.session)
               .map[WebSocketOutboundMessage](WebSocketResponse(request.requestId, _))
               .onErrorResume(e => SMono.just(asError(request.requestId)(e)))
               .subscribeOn(Schedulers.elastic)
-        })
+              .onErrorResume(e => SMono.just[WebSocketOutboundMessage](asError(None)(e)))
+              .map(ResponseSerializer.serialize)
+              .map(_.toString)
+              .flatMap(response => SMono(clientContext.outbound.sendString(SMono.just(response), StandardCharsets.UTF_8).`then`()))
+              .`then`(SMono.just(clientContext))
+          case pushEnable: WebSocketPushEnable =>
+            SMono(eventBus.register(
+                StateChangeListener(pushEnable.dataTypes, clientContext.outbound),
+                AccountIdRegistrationKey.of(clientContext.session.getUser)))
+              .map((registration: Registration) => ClientContext(clientContext.outbound, Some(registration), clientContext.session))
+      })
 
   private def handleHttpHandshakeError(throwable: Throwable, response: HttpServerResponse): SMono[Void] =
     respondDetails(response, ProblemDetails.forThrowable(throwable))

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/WebSocketRoutes.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/WebSocketRoutes.scala
@@ -90,9 +90,10 @@ class WebSocketRoutes @Inject() (@Named(InjectionKeys.RFC_8621) val authenticato
   private def handleWebSocketConnection(session: MailboxSession)(in: WebsocketInbound, out: WebsocketOutbound): Mono[Void] = {
     val sink: Sinks.Many[WebSocketOutboundMessage] = Sinks.many().multicast().onBackpressureBuffer()
 
-    out.sendString(sink.asFlux()
-      .map(ResponseSerializer.serialize)
-      .map(Json.stringify),
+    out.sendString(
+      sink.asFlux()
+        .map(ResponseSerializer.serialize)
+        .map(Json.stringify),
       StandardCharsets.UTF_8).`then`
       .subscribeOn(Schedulers.elastic())
       .subscribe()

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/WebSocketRoutes.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/WebSocketRoutes.scala
@@ -88,7 +88,7 @@ class WebSocketRoutes @Inject() (@Named(InjectionKeys.RFC_8621) val authenticato
   }
 
   private def handleWebSocketConnection(session: MailboxSession)(in: WebsocketInbound, out: WebsocketOutbound): Mono[Void] = {
-    val sink: Sinks.Many[WebSocketOutboundMessage] = Sinks.many().multicast().onBackpressureBuffer()
+    val sink: Sinks.Many[WebSocketOutboundMessage] = Sinks.many().unicast().onBackpressureBuffer()
 
     out.sendString(
       sink.asFlux()

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/WebSocketRoutes.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/WebSocketRoutes.scala
@@ -30,7 +30,7 @@ import javax.inject.{Inject, Named}
 import org.apache.james.events.{EventBus, Registration}
 import org.apache.james.jmap.HttpConstants.JSON_CONTENT_TYPE
 import org.apache.james.jmap.JMAPUrls.JMAP_WS
-import org.apache.james.jmap.change.{AccountIdRegistrationKey, StateChangeListener}
+import org.apache.james.jmap.change.{AccountIdRegistrationKey, StateChangeListener, TypeName}
 import org.apache.james.jmap.core.{ProblemDetails, RequestId, WebSocketError, WebSocketOutboundMessage, WebSocketPushEnable, WebSocketRequest, WebSocketResponse}
 import org.apache.james.jmap.http.rfc8621.InjectionKeys
 import org.apache.james.jmap.http.{Authenticator, UserProvisioning}
@@ -128,7 +128,7 @@ class WebSocketRoutes @Inject() (@Named(InjectionKeys.RFC_8621) val authenticato
               .`then`()
           case pushEnable: WebSocketPushEnable =>
             SMono(eventBus.register(
-                StateChangeListener(pushEnable.dataTypes, clientContext.outbound),
+                StateChangeListener(pushEnable.dataTypes.getOrElse(TypeName.ALL), clientContext.outbound),
                 AccountIdRegistrationKey.of(clientContext.session.getUser)))
               .doOnNext(newRegistration => clientContext.withRegistration(newRegistration))
               .`then`()

--- a/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/WebSocketRoutes.scala
+++ b/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/routes/WebSocketRoutes.scala
@@ -20,6 +20,7 @@
 package org.apache.james.jmap.routes
 
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicReference
 import java.util.stream
 
 import io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE
@@ -30,13 +31,15 @@ import org.apache.james.events.{EventBus, Registration}
 import org.apache.james.jmap.HttpConstants.JSON_CONTENT_TYPE
 import org.apache.james.jmap.JMAPUrls.JMAP_WS
 import org.apache.james.jmap.change.{AccountIdRegistrationKey, StateChangeListener}
-import org.apache.james.jmap.core.{ProblemDetails, RequestId, StateChange, WebSocketError, WebSocketOutboundMessage, WebSocketPushEnable, WebSocketRequest, WebSocketResponse}
+import org.apache.james.jmap.core.{ProblemDetails, RequestId, WebSocketError, WebSocketOutboundMessage, WebSocketPushEnable, WebSocketRequest, WebSocketResponse}
 import org.apache.james.jmap.http.rfc8621.InjectionKeys
 import org.apache.james.jmap.http.{Authenticator, UserProvisioning}
 import org.apache.james.jmap.json.ResponseSerializer
 import org.apache.james.jmap.{Endpoint, JMAPRoute, JMAPRoutes, InjectionKeys => JMAPInjectionKeys}
 import org.apache.james.mailbox.MailboxSession
 import org.slf4j.{Logger, LoggerFactory}
+import play.api.libs.json.Json
+import reactor.core.publisher.Sinks.EmitFailureHandler
 import reactor.core.publisher.{Mono, Sinks}
 import reactor.core.scala.publisher.{SFlux, SMono}
 import reactor.core.scheduler.Schedulers
@@ -47,16 +50,18 @@ object WebSocketRoutes {
   val LOGGER: Logger = LoggerFactory.getLogger(classOf[WebSocketRoutes])
 }
 
-case class ClientContext(outbound: WebsocketOutbound, pushRegistration: Option[Registration], session: MailboxSession) {
-  def latest(clientContext: ClientContext): ClientContext = {
-    clean
-    clientContext
-  }
+case class ClientContext(outbound: Sinks.Many[WebSocketOutboundMessage], pushRegistration: AtomicReference[Registration], session: MailboxSession) {
 
-  def clean: ClientContext = {
-    pushRegistration.foreach(_.unregister())
-    ClientContext(outbound, None, session)
-  }
+  def withRegistration(registration: Registration): Unit = Option(pushRegistration.getAndSet(registration))
+    .foreach(oldRegistration => SMono.fromCallable(() => oldRegistration.unregister())
+      .subscribeOn(Schedulers.elastic())
+      .subscribe())
+
+  def clean(): Unit =
+    Option(pushRegistration.getAndSet(null))
+      .foreach(registration => SMono.fromCallable(() => registration.unregister())
+        .subscribeOn(Schedulers.elastic())
+        .subscribe())
 }
 
 class WebSocketRoutes @Inject() (@Named(InjectionKeys.RFC_8621) val authenticator: Authenticator,
@@ -86,7 +91,16 @@ class WebSocketRoutes @Inject() (@Named(InjectionKeys.RFC_8621) val authenticato
   }
 
   private def handleWebSocketConnection(session: MailboxSession)(in: WebsocketInbound, out: WebsocketOutbound): Mono[Void] = {
-    val context = ClientContext(out, None, session)
+    val sink: Sinks.Many[WebSocketOutboundMessage] = Sinks.many().unicast().onBackpressureError()
+
+    out.sendString(sink.asFlux()
+      .map(ResponseSerializer.serialize)
+      .map(Json.stringify),
+      StandardCharsets.UTF_8).`then`
+      .subscribeOn(Schedulers.elastic())
+      .subscribe()
+
+    val context = ClientContext(sink, new AtomicReference[Registration](), session)
     SFlux[WebSocketFrame](in.aggregateFrames()
       .receiveFrames())
       .map(frame => {
@@ -95,20 +109,17 @@ class WebSocketRoutes @Inject() (@Named(InjectionKeys.RFC_8621) val authenticato
         new String(bytes, StandardCharsets.UTF_8)
       })
       .flatMap(message => handleClientMessages(context)(message))
-      .reduce((c1: ClientContext, c2: ClientContext) => c1.latest(c2))
-      .map[ClientContext](context => context.clean)
+      .doOnTerminate(context.clean)
       .`then`()
       .asJava()
       .`then`()
   }
 
-  private def handleClientMessages(clientContext: ClientContext)(message: String): SMono[ClientContext] =
+  private def handleClientMessages(clientContext: ClientContext)(message: String): SMono[Unit] =
     ResponseSerializer.deserializeWebSocketInboundMessage(message)
       .fold(invalid => {
-        val error = ResponseSerializer.serialize(asError(None)(new IllegalArgumentException(invalid.toString())))
-        SMono(clientContext.outbound.sendString(SMono.just(error.toString()), StandardCharsets.UTF_8)
-          .`then`())
-          .`then`(SMono.just(clientContext))
+        val error = asError(None)(new IllegalArgumentException(invalid.toString()))
+        SMono.fromCallable(() => clientContext.outbound.emitNext(error, EmitFailureHandler.FAIL_FAST))
       }, {
           case request: WebSocketRequest =>
             jmapApi.process(request.requestObject, clientContext.session)
@@ -116,22 +127,14 @@ class WebSocketRoutes @Inject() (@Named(InjectionKeys.RFC_8621) val authenticato
               .onErrorResume(e => SMono.just(asError(request.requestId)(e)))
               .subscribeOn(Schedulers.elastic)
               .onErrorResume(e => SMono.just[WebSocketOutboundMessage](asError(None)(e)))
-              .map(ResponseSerializer.serialize)
-              .map(_.toString)
-              .flatMap(response => SMono(clientContext.outbound.sendString(SMono.just(response), StandardCharsets.UTF_8).`then`()))
-              .`then`(SMono.just(clientContext))
+              .doOnNext(next => clientContext.outbound.emitNext(next, EmitFailureHandler.FAIL_FAST))
+              .`then`()
           case pushEnable: WebSocketPushEnable =>
-            val sink: Sinks.Many[StateChange] = Sinks.many().unicast().onBackpressureError()
             SMono(eventBus.register(
-                StateChangeListener(pushEnable.dataTypes, sink),
+                StateChangeListener(pushEnable.dataTypes, clientContext.outbound),
                 AccountIdRegistrationKey.of(clientContext.session.getUser)))
-              .map((registration: Registration) => ClientContext(clientContext.outbound, Some(registration), clientContext.session))
-              .doOnNext(context => sink.asFlux()
-                .map(ResponseSerializer.serialize)
-                .map(_.toString)
-                .flatMap(response => SMono(context.outbound.sendString(SMono.just(response), StandardCharsets.UTF_8).`then`()))
-                .subscribeOn(Schedulers.elastic())
-                .subscribe())
+              .doOnNext(newRegistration => clientContext.withRegistration(newRegistration))
+              .`then`()
       })
 
   private def handleHttpHandshakeError(throwable: Throwable, response: HttpServerResponse): SMono[Void] =

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/change/AccountIdRegistrationKeyTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/change/AccountIdRegistrationKeyTest.scala
@@ -1,0 +1,52 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *  http://www.apache.org/licenses/LICENSE-2.0                  *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.change
+
+import org.apache.james.jmap.api.model.AccountId
+import org.assertj.core.api.Assertions.{assertThat, assertThatThrownBy}
+import org.junit.jupiter.api.Test
+
+class AccountIdRegistrationKeyTest {
+  private val ID: String = "29883977c13473ae7cb7678ef767cbfbaffc8a44a6e463d971d23a65c1dc4af6"
+
+  private val FACTORY: Factory = Factory()
+
+  private val ACCOUNT_ID_REGISTRATION_KEY: AccountIdRegistrationKey = AccountIdRegistrationKey(AccountId.fromString(ID))
+
+  @Test
+  def asStringShouldReturnSerializedAccountId(): Unit = {
+    assertThat(ACCOUNT_ID_REGISTRATION_KEY.asString()).isEqualTo(ID)
+  }
+
+  @Test
+  def fromStringShouldReturnCorrespondingRegistrationKey(): Unit = {
+    assertThat(FACTORY.fromString(ID)).isEqualTo(ACCOUNT_ID_REGISTRATION_KEY)
+  }
+
+  @Test
+  def fromStringShouldThrowOnNullValues(): Unit = {
+    assertThatThrownBy(() => FACTORY.fromString(null)).isInstanceOf(classOf[IllegalArgumentException])
+  }
+
+  @Test
+  def fromStringShouldThrowOnEmptyValues(): Unit = {
+    assertThatThrownBy(() => FACTORY.fromString("")).isInstanceOf(classOf[IllegalArgumentException])
+  }
+}

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/change/StateChangeEventSerializerTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/change/StateChangeEventSerializerTest.scala
@@ -1,0 +1,70 @@
+ /***************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james.jmap.change
+
+import org.apache.james.JsonSerializationVerifier
+import org.apache.james.core.Username
+import org.apache.james.events.Event.EventId
+import org.apache.james.jmap.change.StateChangeEventSerializerTest.{EVENT, EVENT_JSON}
+import org.apache.james.jmap.core.State
+import org.apache.james.json.JsonGenericSerializer
+import org.apache.james.json.JsonGenericSerializer.UnknownTypeException
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+
+object StateChangeEventSerializerTest {
+  val EVENT_ID: EventId = EventId.of("6e0dd59d-660e-4d9b-b22f-0354479f47b4")
+  val USERNAME: Username = Username.of("bob")
+  val EVENT: StateChangeEvent = StateChangeEvent(EVENT_ID, USERNAME, Some(State.INSTANCE), Some(State.fromStringUnchecked("2d9f1b12-b35a-43e6-9af2-0106fb53a943")))
+  val EVENT_JSON: String =
+    """{
+      |  "eventId":"6e0dd59d-660e-4d9b-b22f-0354479f47b4",
+      |  "username":"bob",
+      |  "mailboxState":"2c9f1b12-b35a-43e6-9af2-0106fb53a943",
+      |  "emailState":"2d9f1b12-b35a-43e6-9af2-0106fb53a943",
+      |  "type":"org.apache.james.jmap.change.StateChangeEvent"
+      |}""".stripMargin
+}
+
+class StateChangeEventSerializerTest {
+  @Test
+  def shouldSerializeKnownEvent(): Unit =
+    JsonSerializationVerifier.serializer(JsonGenericSerializer
+      .forModules(StateChangeEventDTO.dtoModule)
+      .withoutNestedType())
+      .bean(EVENT)
+      .json(EVENT_JSON)
+      .verify()
+
+  @Test
+  def shouldThrowWhenDeserializeUnknownEvent(): Unit =
+    assertThatThrownBy(() =>
+      JsonGenericSerializer
+        .forModules(StateChangeEventDTO.dtoModule)
+        .withoutNestedType()
+        .deserialize("""{
+                       |  "eventId":"6e0dd59d-660e-4d9b-b22f-0354479f47b4",
+                       |  "username":"bob",
+                       |  "mailboxState":"2c9f1b12-b35a-43e6-9af2-0106fb53a943",
+                       |  "emailState":"2d9f1b12-b35a-43e6-9af2-0106fb53a943",
+                       |  "type":"org.apache.james.jmap.change.Unknown"
+                       |}""".stripMargin))
+      .isInstanceOf(classOf[UnknownTypeException])
+}

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/change/StateChangeListenerTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/change/StateChangeListenerTest.scala
@@ -21,7 +21,7 @@ package org.apache.james.jmap.change
 
 import org.apache.james.core.Username
 import org.apache.james.events.Event.EventId
-import org.apache.james.jmap.core.{AccountId, State, StateChange}
+import org.apache.james.jmap.core.{AccountId, State, StateChange, WebSocketOutboundMessage}
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Sinks
@@ -36,7 +36,7 @@ class StateChangeListenerTest {
 
   @Test
   def reactiveEventShouldSendAnOutboundMessage(): Unit = {
-    val sink: Sinks.Many[StateChange] = Sinks.many().unicast().onBackpressureBuffer()
+    val sink: Sinks.Many[WebSocketOutboundMessage] = Sinks.many().unicast().onBackpressureBuffer()
     val event = StateChangeEvent(eventId = eventId,
       username = Username.of("bob"),
       mailboxState = Some(mailboxState),
@@ -54,7 +54,7 @@ class StateChangeListenerTest {
 
   @Test
   def reactiveEventShouldOmitUnwantedTypes(): Unit = {
-    val sink: Sinks.Many[StateChange] = Sinks.many().unicast().onBackpressureBuffer()
+    val sink: Sinks.Many[WebSocketOutboundMessage] = Sinks.many().unicast().onBackpressureBuffer()
     val event = StateChangeEvent(eventId = eventId,
       username = Username.of("bob"),
       mailboxState = Some(mailboxState),
@@ -71,7 +71,7 @@ class StateChangeListenerTest {
 
   @Test
   def reactiveEventShouldFilterOutUnwantedEvents(): Unit = {
-    val sink: Sinks.Many[StateChange] = Sinks.many().unicast().onBackpressureBuffer()
+    val sink: Sinks.Many[WebSocketOutboundMessage] = Sinks.many().unicast().onBackpressureBuffer()
     val event = StateChangeEvent(eventId = eventId,
       username = Username.of("bob"),
       mailboxState = None,

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/change/StateChangeListenerTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/change/StateChangeListenerTest.scala
@@ -1,0 +1,67 @@
+/***************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap.change
+
+import java.nio.charset.Charset
+
+import net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson
+import org.apache.james.core.Username
+import org.apache.james.events.Event.EventId
+import org.apache.james.jmap.core.State
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{mock, verify, when}
+import org.reactivestreams.Publisher
+import reactor.core.scala.publisher.SMono
+import reactor.netty.NettyOutbound
+import reactor.netty.http.websocket.WebsocketOutbound
+
+class StateChangeListenerTest {
+  private val outbound: WebsocketOutbound = mock(classOf[WebsocketOutbound])
+
+  @Test
+  def reactiveEventShouldSendAnOutboundMessage(): Unit = {
+    val event = StateChangeEvent(eventId = EventId.of("6e0dd59d-660e-4d9b-b22f-0354479f47b4"),
+      username = Username.of("bob"),
+      mailboxState = Some(State.fromStringUnchecked("2f9f1b12-b35a-43e6-9af2-0106fb53a943")),
+      emailState = Some(State.fromStringUnchecked("2d9f1b12-b35a-43e6-9af2-0106fb53a943")))
+    val listener = StateChangeListener(outbound)
+    val nettyOutbound = mock(classOf[NettyOutbound])
+    when(outbound.sendString(any(), any())).thenReturn(nettyOutbound)
+
+    listener.reactiveEvent(event)
+
+    val captor: ArgumentCaptor[Publisher[String]] = ArgumentCaptor.forClass(classOf[Publisher[String]])
+    verify(outbound).sendString(captor.capture(), any(classOf[Charset]))
+    assertThatJson(SMono(captor.getValue).block()).isEqualTo(
+      """
+        |{
+        |  "@type":"StateChange",
+        |  "changed":{
+        |    "81b637d8fcd2c6da6359e6963113a1170de795e4b725b84d1e0b4cfd9ec58ce9":{
+        |      "Mailbox":"2f9f1b12-b35a-43e6-9af2-0106fb53a943",
+        |      "Email":"2d9f1b12-b35a-43e6-9af2-0106fb53a943"
+        |    }
+        |  }
+        |}
+        |""".stripMargin)
+  }
+}

--- a/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/routes/SessionRoutesTest.scala
+++ b/server/protocols/jmap-rfc-8621/src/test/scala/org/apache/james/jmap/routes/SessionRoutesTest.scala
@@ -143,7 +143,7 @@ class SessionRoutesTest extends AnyFlatSpec with BeforeAndAfter with Matchers {
                          |      "mayCreateTopLevelMailbox" : true
                          |    },
                          |    "urn:ietf:params:jmap:websocket": {
-                         |      "supportsPush": false,
+                         |      "supportsPush": true,
                          |      "url": "http://localhost/jmap/ws"
                          |    },
                          |    "urn:apache:james:params:jmap:mail:quota": {},
@@ -161,7 +161,7 @@ class SessionRoutesTest extends AnyFlatSpec with BeforeAndAfter with Matchers {
                          |          "submissionExtensions": []
                          |        },
                          |        "urn:ietf:params:jmap:websocket": {
-                         |            "supportsPush": false,
+                         |            "supportsPush": true,
                          |            "url": "http://localhost/jmap/ws"
                          |        },
                          |        "urn:ietf:params:jmap:core" : {

--- a/server/protocols/jmap/src/main/java/org/apache/james/jmap/InjectionKeys.java
+++ b/server/protocols/jmap/src/main/java/org/apache/james/jmap/InjectionKeys.java
@@ -1,0 +1,24 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jmap;
+
+public interface InjectionKeys {
+    String JMAP = "JMAP";
+}


### PR DESCRIPTION
Here are the steps toward JMAP PUSH, potentially handled via other tickets, provided here for a broader understanding.

 - [X] Define a JMAP `StateChange` POJO that can be sent over WebSocket
 - [X] Define an event for the StateChange object, that can be fined on the JMAP eventBus
 - [x] Define a JMAP listener `StateChangeListener` that given a StateChangeEvent will emit a serialized `StateChange` on a WebsocketOutbound. Provide simple unit test for it, mocking the outbound if needed.
 - [x] Define an AccountIdRegistrationKey and the associated factory (@LanKhuat )
 - [x] Create a `WebSocketPushEnable` POJO (see https://tools.ietf.org/html/rfc8887 4.3.5.2) (@LanKhuat )
 - [x] JMAP ResponseSerializer::deserializeWebSocketInboundMessage should allow deserializing `WebSocketPushEnable` POJO (@LanKhuat )
 - [x] Inject another named eventBus `@Named("JMAP")`
 - [x] Given a MailboxEvent, MailboxChangeListener should emit `StateChangeEvent` on the JMAP eventbus. Provide unit test as part of `MailboxChangeListener` test suite.
 - [x] `WebSocketRoutes` need to register `StateChangeListener` on the JMAP eventBus for the current accountId upon receiving `WebSocketPushEnable`
  - [x] Integration tests for this