### PR TITLE
[Proof Of Concept] POP3 server backed by MessageId and non-LWT based UID/ModSeq generation

### DIFF
--- a/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/StatementRecorder.java
+++ b/backends-common/cassandra/src/test/java/org/apache/james/backends/cassandra/StatementRecorder.java
@@ -42,6 +42,10 @@ public class StatementRecorder {
             return preparedStatementMatching(statement -> statement.preparedStatement().getQueryString().startsWith(statementString));
         }
 
+        static Selector preparedStatementContaining(String pattern) {
+            return preparedStatementMatching(statement -> statement.preparedStatement().getQueryString().contains(pattern));
+        }
+
         private static StatementRecorder.Selector preparedStatementMatching(Predicate<BoundStatement> condition) {
             return statements -> statements.stream()
                 .filter(BoundStatement.class::isInstance)

--- a/dockerfiles/compilation/java-11/compile.sh
+++ b/dockerfiles/compilation/java-11/compile.sh
@@ -59,9 +59,9 @@ git checkout $SHA1
 # Compilation
 
 if [ "$SKIPTESTS" = "skipTests" ]; then
-   mvn package -DskipTests ${MVN_ADDITIONAL_ARG_LINE}
+   mvn package -DskipTests -Djib.skip ${MVN_ADDITIONAL_ARG_LINE}
 else
-   mvn package ${MVN_ADDITIONAL_ARG_LINE}
+   mvn package -Djib.skip ${MVN_ADDITIONAL_ARG_LINE}
 fi
 
 # download glowroot jar

--- a/pom.xml
+++ b/pom.xml
@@ -1871,6 +1871,11 @@
             </dependency>
             <dependency>
                 <groupId>${james.groupId}</groupId>
+                <artifactId>james-server-webadmin-pop3</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${james.groupId}</groupId>
                 <artifactId>james-server-webadmin-rabbitmq</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1923,6 +1923,11 @@
             </dependency>
             <dependency>
                 <groupId>${james.groupId}</groupId>
+                <artifactId>protocols-pop3-distributed</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${james.groupId}</groupId>
                 <artifactId>queue-activemq-guice</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/server/container/guice/cassandra-rabbitmq-guice/pom.xml
+++ b/server/container/guice/cassandra-rabbitmq-guice/pom.xml
@@ -274,6 +274,10 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>protocols-pop3-distributed</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>queue-rabbitmq-guice</artifactId>
         </dependency>
         <dependency>

--- a/server/container/guice/cassandra-rabbitmq-guice/pom.xml
+++ b/server/container/guice/cassandra-rabbitmq-guice/pom.xml
@@ -265,6 +265,10 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-webadmin-pop3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-webadmin-rabbitmq</artifactId>
         </dependency>
         <dependency>

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
@@ -111,6 +111,7 @@ public class CassandraRabbitMQJamesServerMain implements JamesServerMain {
         new WebAdminServerModule(),
         new WebAdminReIndexingTaskSerializationModule(),
         new MessagesRoutesModule(),
+        new Pop3FixInconsistenciesWebAdminModule(),
         new WebAdminMailOverWebModule());
 
     public static final Module PROTOCOLS = Modules.combine(

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
@@ -192,6 +192,7 @@ public class CassandraRabbitMQJamesServerMain implements JamesServerMain {
             .combineWith(BlobStoreCacheModulesChooser.chooseModules(blobStoreConfiguration))
             .combineWith(SearchModuleChooser.chooseModules(searchConfiguration))
             .combineWith(new UsersRepositoryModuleChooser(new CassandraUsersRepositoryModule())
-                .chooseModules(configuration.getUsersRepositoryImplementation()));
+                .chooseModules(configuration.getUsersRepositoryImplementation()))
+            .overrideWith(new DistributedPop3Module());
     }
 }

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/CassandraRabbitMQJamesServerMain.java
@@ -25,6 +25,8 @@ import org.apache.james.data.UsersRepositoryModuleChooser;
 import org.apache.james.eventsourcing.eventstore.cassandra.EventNestedTypes;
 import org.apache.james.json.DTO;
 import org.apache.james.json.DTOModule;
+import org.apache.james.mailbox.store.mail.ModSeqProvider;
+import org.apache.james.mailbox.store.mail.UidProvider;
 import org.apache.james.modules.BlobExportMechanismModule;
 import org.apache.james.modules.CassandraConsistencyTaskSerializationModule;
 import org.apache.james.modules.DistributedTaskManagerModule;
@@ -86,6 +88,7 @@ import org.apache.james.modules.webadmin.InconsistencySolvingRoutesModule;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Module;
+import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
 import com.google.inject.util.Modules;
@@ -193,6 +196,12 @@ public class CassandraRabbitMQJamesServerMain implements JamesServerMain {
             .combineWith(SearchModuleChooser.chooseModules(searchConfiguration))
             .combineWith(new UsersRepositoryModuleChooser(new CassandraUsersRepositoryModule())
                 .chooseModules(configuration.getUsersRepositoryImplementation()))
-            .overrideWith(new DistributedPop3Module());
+            .overrideWith(new DistributedPop3Module())
+            .overrideWith(binder -> {
+                binder.bind(NoLWTUidProvider.class).in(Scopes.SINGLETON);
+                binder.bind(UidProvider.class).to(NoLWTUidProvider.class);
+                binder.bind(NoLWTModSeqProvider.class).in(Scopes.SINGLETON);
+                binder.bind(ModSeqProvider.class).to(NoLWTModSeqProvider.class);
+            });
     }
 }

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/DistributedPop3Module.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/DistributedPop3Module.java
@@ -1,0 +1,51 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.events.EventListener;
+import org.apache.james.pop3server.mailbox.CassandraPop3MetadataStore;
+import org.apache.james.pop3server.mailbox.DistributedMailboxAdapter;
+import org.apache.james.pop3server.mailbox.MailboxAdapterFactory;
+import org.apache.james.pop3server.mailbox.Pop3MetadataModule;
+import org.apache.james.pop3server.mailbox.Pop3MetadataStore;
+import org.apache.james.pop3server.mailbox.PopulateMetadataStoreListener;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
+
+public class DistributedPop3Module extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(CassandraPop3MetadataStore.class).in(Scopes.SINGLETON);
+        bind(Pop3MetadataStore.class).to(CassandraPop3MetadataStore.class);
+
+        Multibinder.newSetBinder(binder(), EventListener.ReactiveGroupEventListener.class)
+            .addBinding()
+            .to(PopulateMetadataStoreListener.class);
+
+        bind(DistributedMailboxAdapter.Factory.class).in(Scopes.SINGLETON);
+        bind(MailboxAdapterFactory.class).to(DistributedMailboxAdapter.Factory.class);
+
+        Multibinder<CassandraModule> cassandraDataDefinitions = Multibinder.newSetBinder(binder(), CassandraModule.class);
+        cassandraDataDefinitions.addBinding().toInstance(Pop3MetadataModule.MODULE);
+    }
+}

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/NoLWTModSeqProvider.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/NoLWTModSeqProvider.java
@@ -1,0 +1,197 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.update;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageModseqTable.MAILBOX_ID;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageModseqTable.NEXT_MODSEQ;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageModseqTable.TABLE_NAME;
+import static org.apache.james.util.ReactorUtils.publishIfPresent;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletionException;
+import java.util.function.Supplier;
+
+import javax.inject.Inject;
+
+import org.apache.james.backends.cassandra.init.configuration.CassandraConfiguration;
+import org.apache.james.backends.cassandra.init.configuration.CassandraConsistenciesConfiguration;
+import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
+import org.apache.james.mailbox.ModSeq;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.mail.CassandraModSeqProvider;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.store.mail.ModSeqProvider;
+
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.retry.Retry;
+
+/**
+ * Copy of {@link org.apache.james.mailbox.cassandra.mail.CassandraModSeqProvider} without LWT
+ *
+ * Warning ModSeq generated that way are not to be trusted and duplicates upon concurrent calls might exist.
+ *
+ * Changes to the original class are documented as JavaDoc
+ */
+public class NoLWTModSeqProvider implements ModSeqProvider {
+    private static <T> T unbox(Supplier<T> supplier) throws MailboxException {
+        try {
+            return supplier.get();
+        } catch (CompletionException e) {
+            if (e.getCause() instanceof CassandraModSeqProvider.ExceptionRelay) {
+                throw ((CassandraModSeqProvider.ExceptionRelay) e.getCause()).getUnderlying();
+            }
+            throw e;
+        }
+    }
+
+    private final CassandraAsyncExecutor cassandraAsyncExecutor;
+    private final long maxModSeqRetries;
+    private final PreparedStatement select;
+    private final PreparedStatement update;
+    private final PreparedStatement insert;
+    private final ConsistencyLevel consistencyLevel;
+
+    /**
+     * Uses regular consistency level
+     */
+    @Inject
+    public NoLWTModSeqProvider(Session session, CassandraConfiguration cassandraConfiguration,
+                                   CassandraConsistenciesConfiguration consistenciesConfiguration) {
+        this.cassandraAsyncExecutor = new CassandraAsyncExecutor(session);
+        this.consistencyLevel = consistenciesConfiguration.getRegular();
+        this.maxModSeqRetries = cassandraConfiguration.getModSeqMaxRetry();
+        this.insert = prepareInsert(session);
+        this.update = prepareUpdate(session);
+        this.select = prepareSelect(session);
+    }
+
+    /**
+     * Remove `IF NOT EXIST`
+     */
+    private PreparedStatement prepareInsert(Session session) {
+        return session.prepare(insertInto(TABLE_NAME)
+            .value(NEXT_MODSEQ, bindMarker(NEXT_MODSEQ))
+            .value(MAILBOX_ID, bindMarker(MAILBOX_ID)));
+    }
+
+    /**
+     * Remove `IF ...`
+     */
+    private PreparedStatement prepareUpdate(Session session) {
+        return session.prepare(update(TABLE_NAME)
+            .with(set(NEXT_MODSEQ, bindMarker(NEXT_MODSEQ)))
+            .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID))));
+    }
+
+    private PreparedStatement prepareSelect(Session session) {
+        return session.prepare(select(NEXT_MODSEQ)
+            .from(TABLE_NAME)
+            .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID))));
+    }
+
+    @Override
+    public ModSeq nextModSeq(Mailbox mailbox) throws MailboxException {
+        return nextModSeqReactive(mailbox.getMailboxId())
+            .blockOptional()
+            .orElseThrow(() -> new MailboxException("Can not retrieve modseq for " + mailbox.getMailboxId()));
+    }
+
+    @Override
+    public ModSeq nextModSeq(MailboxId mailboxId) throws MailboxException {
+        return nextModSeqReactive(mailboxId)
+            .blockOptional()
+            .orElseThrow(() -> new MailboxException("Can not retrieve modseq for " + mailboxId));
+    }
+
+    @Override
+    public ModSeq highestModSeq(Mailbox mailbox) throws MailboxException {
+        return highestModSeq(mailbox.getMailboxId());
+    }
+
+    @Override
+    public ModSeq highestModSeq(MailboxId mailboxId) throws MailboxException {
+        return unbox(() -> findHighestModSeq((CassandraId) mailboxId).block().orElse(ModSeq.first()));
+    }
+
+    private Mono<Optional<ModSeq>> findHighestModSeq(CassandraId mailboxId) {
+        return cassandraAsyncExecutor.executeSingleRowOptional(
+            select.bind()
+                .setUUID(MAILBOX_ID, mailboxId.asUuid())
+                .setConsistencyLevel(consistencyLevel))
+            .map(maybeRow -> maybeRow.map(row -> ModSeq.of(row.getLong(NEXT_MODSEQ))));
+    }
+
+    private Mono<ModSeq> tryInsertModSeq(CassandraId mailboxId, ModSeq modSeq) {
+        ModSeq nextModSeq = modSeq.next();
+        return cassandraAsyncExecutor.executeReturnApplied(
+            insert.bind()
+                .setUUID(MAILBOX_ID, mailboxId.asUuid())
+                .setLong(NEXT_MODSEQ, nextModSeq.asLong()))
+            .map(success -> successToModSeq(nextModSeq, success))
+            .handle(publishIfPresent());
+    }
+
+    /**
+     * Remove condition binding
+     */
+    private Mono<ModSeq> tryUpdateModSeq(CassandraId mailboxId, ModSeq modSeq) {
+        ModSeq nextModSeq = modSeq.next();
+        return cassandraAsyncExecutor.executeReturnApplied(
+            update.bind()
+                .setUUID(MAILBOX_ID, mailboxId.asUuid())
+                .setLong(NEXT_MODSEQ, nextModSeq.asLong()))
+            .map(success -> successToModSeq(nextModSeq, success))
+            .handle(publishIfPresent());
+    }
+
+    private Optional<ModSeq> successToModSeq(ModSeq modSeq, Boolean success) {
+        if (success) {
+            return Optional.of(modSeq);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Mono<ModSeq> nextModSeqReactive(MailboxId mailboxId) {
+        CassandraId cassandraId = (CassandraId) mailboxId;
+        Duration firstBackoff = Duration.ofMillis(10);
+
+        return findHighestModSeq(cassandraId)
+            .flatMap(maybeHighestModSeq -> maybeHighestModSeq
+                .map(highestModSeq -> tryUpdateModSeq(cassandraId, highestModSeq))
+                .orElseGet(() -> tryInsertModSeq(cassandraId, ModSeq.first())))
+            .single()
+            .retryWhen(Retry.backoff(maxModSeqRetries, firstBackoff).scheduler(Schedulers.elastic()));
+    }
+}

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/NoLWTUidProvider.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/NoLWTUidProvider.java
@@ -1,0 +1,221 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.update;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageUidTable.MAILBOX_ID;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageUidTable.NEXT_UID;
+import static org.apache.james.mailbox.cassandra.table.CassandraMessageUidTable.TABLE_NAME;
+import static org.apache.james.util.ReactorUtils.publishIfPresent;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.LongStream;
+
+import javax.inject.Inject;
+
+import org.apache.james.backends.cassandra.init.configuration.CassandraConfiguration;
+import org.apache.james.backends.cassandra.init.configuration.CassandraConsistenciesConfiguration;
+import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.Mailbox;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.store.mail.UidProvider;
+
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+import com.github.steveash.guavate.Guavate;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.retry.Retry;
+
+/**
+ * Copy of {@link org.apache.james.mailbox.cassandra.mail.CassandraUidProvider} without LWT
+ *
+ * Warning UID generated that way are not to be trusted and duplicates upon concurrent calls might exist.
+ *
+ * This is a best effort to maintain ascending UID, for the sake of maintaining an IMAP compatibility.
+ *
+ * Changes to the original class are documented as JavaDoc
+ */
+public class NoLWTUidProvider implements UidProvider {
+
+    private final CassandraAsyncExecutor executor;
+    private final long maxUidRetries;
+    private final PreparedStatement insertStatement;
+    private final PreparedStatement updateStatement;
+    private final PreparedStatement selectStatement;
+    private final ConsistencyLevel consistencyLevel;
+
+    /**
+     * Uses regular consistency level
+     */
+    @Inject
+    public NoLWTUidProvider(Session session, CassandraConfiguration cassandraConfiguration,
+                            CassandraConsistenciesConfiguration consistenciesConfiguration) {
+        this.executor = new CassandraAsyncExecutor(session);
+        this.consistencyLevel = consistenciesConfiguration.getRegular();
+        this.maxUidRetries = cassandraConfiguration.getUidMaxRetry();
+        this.selectStatement = prepareSelect(session);
+        this.updateStatement = prepareUpdate(session);
+        this.insertStatement = prepareInsert(session);
+    }
+
+    private PreparedStatement prepareSelect(Session session) {
+        return session.prepare(select(NEXT_UID)
+            .from(TABLE_NAME)
+            .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID))));
+    }
+
+    /**
+     * Remove `IF ...`
+     */
+    private PreparedStatement prepareUpdate(Session session) {
+        return session.prepare(update(TABLE_NAME)
+            .with(set(NEXT_UID, bindMarker(NEXT_UID)))
+            .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID))));
+    }
+
+    /**
+     * Remove `IF NOT EXIST`
+     */
+    private PreparedStatement prepareInsert(Session session) {
+        return session.prepare(insertInto(TABLE_NAME)
+            .value(NEXT_UID, bindMarker(NEXT_UID))
+            .value(MAILBOX_ID, bindMarker(MAILBOX_ID)));
+    }
+
+    @Override
+    public MessageUid nextUid(Mailbox mailbox) throws MailboxException {
+        return nextUid(mailbox.getMailboxId());
+    }
+
+    @Override
+    public MessageUid nextUid(MailboxId mailboxId) throws MailboxException {
+        CassandraId cassandraId = (CassandraId) mailboxId;
+        return nextUidReactive(cassandraId)
+            .blockOptional()
+            .orElseThrow(() -> new MailboxException("Error during Uid update"));
+    }
+
+    @Override
+    public Mono<MessageUid> nextUidReactive(MailboxId mailboxId) {
+        CassandraId cassandraId = (CassandraId) mailboxId;
+        Mono<MessageUid> updateUid = findHighestUid(cassandraId)
+            .flatMap(messageUid -> tryUpdateUid(cassandraId, messageUid));
+
+        Duration firstBackoff = Duration.ofMillis(10);
+        return updateUid
+            .switchIfEmpty(tryInsert(cassandraId))
+            .switchIfEmpty(updateUid)
+            .single()
+            .retryWhen(Retry.backoff(maxUidRetries, firstBackoff).scheduler(Schedulers.elastic()));
+    }
+
+    @Override
+    public Mono<List<MessageUid>> nextUids(MailboxId mailboxId, int count) {
+        CassandraId cassandraId = (CassandraId) mailboxId;
+
+        Mono<List<MessageUid>> updateUid = findHighestUid(cassandraId)
+            .flatMap(messageUid -> tryUpdateUid(cassandraId, messageUid, count)
+                .map(highest -> range(messageUid, highest)));
+
+        Duration firstBackoff = Duration.ofMillis(10);
+        return updateUid
+            .switchIfEmpty(tryInsert(cassandraId, count)
+                .map(highest -> range(MessageUid.MIN_VALUE, highest)))
+            .switchIfEmpty(updateUid)
+            .single()
+            .retryWhen(Retry.backoff(maxUidRetries, firstBackoff).scheduler(Schedulers.elastic()));
+    }
+
+    private List<MessageUid> range(MessageUid lowerExclusive, MessageUid higherInclusive) {
+        return LongStream.range(lowerExclusive.asLong() + 1, higherInclusive.asLong() + 1)
+            .mapToObj(MessageUid::of)
+            .collect(Guavate.toImmutableList());
+    }
+
+    @Override
+    public Optional<MessageUid> lastUid(Mailbox mailbox) {
+        return findHighestUid((CassandraId) mailbox.getMailboxId())
+            .blockOptional();
+    }
+
+    private Mono<MessageUid> findHighestUid(CassandraId mailboxId) {
+        return executor.executeSingleRow(
+            selectStatement.bind()
+                .setUUID(MAILBOX_ID, mailboxId.asUuid())
+                .setConsistencyLevel(consistencyLevel))
+            .map(row -> MessageUid.of(row.getLong(NEXT_UID)));
+    }
+
+    /**
+     * Remove condition binding
+     */
+    private Mono<MessageUid> tryUpdateUid(CassandraId mailboxId, MessageUid uid) {
+        return tryUpdateUid(mailboxId, uid, 1);
+    }
+
+    private Mono<MessageUid> tryUpdateUid(CassandraId mailboxId, MessageUid uid, int count) {
+        MessageUid nextUid = uid.next(count);
+        return executor.executeReturnApplied(
+            updateStatement.bind()
+                .setUUID(MAILBOX_ID, mailboxId.asUuid())
+                .setLong(NEXT_UID, nextUid.asLong()))
+            .map(success -> successToUid(nextUid, success))
+            .handle(publishIfPresent());
+    }
+
+    private Mono<MessageUid> tryInsert(CassandraId mailboxId) {
+        return executor.executeReturnApplied(
+            insertStatement.bind()
+                .setLong(NEXT_UID, MessageUid.MIN_VALUE.asLong())
+                .setUUID(MAILBOX_ID, mailboxId.asUuid()))
+            .map(success -> successToUid(MessageUid.MIN_VALUE, success))
+            .handle(publishIfPresent());
+    }
+
+    private Mono<MessageUid> tryInsert(CassandraId mailboxId, int count) {
+        return executor.executeReturnApplied(
+            insertStatement.bind()
+                .setLong(NEXT_UID, MessageUid.MIN_VALUE.next(count).asLong())
+                .setUUID(MAILBOX_ID, mailboxId.asUuid()))
+            .map(success -> successToUid(MessageUid.MIN_VALUE.next(count), success))
+            .handle(publishIfPresent());
+    }
+
+    private Optional<MessageUid> successToUid(MessageUid uid, Boolean success) {
+        if (success) {
+            return Optional.of(uid);
+        }
+        return Optional.empty();
+    }
+
+}

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/Pop3FixInconsistenciesTaskSerializationModule.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/Pop3FixInconsistenciesTaskSerializationModule.java
@@ -1,0 +1,53 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james;
+
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesAdditionalInformationDTO;
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesDTO;
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesService;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
+import org.apache.james.server.task.json.dto.TaskDTO;
+import org.apache.james.server.task.json.dto.TaskDTOModule;
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.webadmin.dto.DTOModuleInjections;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.ProvidesIntoSet;
+import com.google.inject.name.Named;
+
+public class Pop3FixInconsistenciesTaskSerializationModule extends AbstractModule {
+    @ProvidesIntoSet
+    public TaskDTOModule<? extends Task, ? extends TaskDTO> recomputeCurrentQuotasTask(MetaDataFixInconsistenciesService service) {
+        return MetaDataFixInconsistenciesDTO.module(service);
+    }
+
+    @Named(DTOModuleInjections.WEBADMIN_DTO)
+    @ProvidesIntoSet
+    public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO> metaDataFixInconsistenciesAdditionalInformationDTOForWebAdmin() {
+        return MetaDataFixInconsistenciesAdditionalInformationDTO.module();
+    }
+
+    @ProvidesIntoSet
+    public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO> metaDataFixInconsistenciesAdditionalInformationDTO() {
+        return MetaDataFixInconsistenciesAdditionalInformationDTO.module();
+    }
+}

--- a/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/Pop3FixInconsistenciesWebAdminModule.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/main/java/org/apache/james/Pop3FixInconsistenciesWebAdminModule.java
@@ -1,0 +1,22 @@
+package org.apache.james;
+
+import static org.apache.james.webadmin.routes.MailboxesRoutes.ALL_MAILBOXES_TASKS;
+
+import org.apache.james.pop3.webadmin.Pop3MetaDataFixInconsistenciesTaskRegistration;
+import org.apache.james.webadmin.tasks.TaskFromRequestRegistry;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Names;
+
+public class Pop3FixInconsistenciesWebAdminModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        install(new Pop3FixInconsistenciesTaskSerializationModule());
+
+        Multibinder.newSetBinder(binder(), TaskFromRequestRegistry.TaskRegistration.class, Names.named(ALL_MAILBOXES_TASKS))
+            .addBinding()
+            .to(Pop3MetaDataFixInconsistenciesTaskRegistration.class);
+    }
+}

--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/Pop3ServerContract.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/Pop3ServerContract.java
@@ -158,6 +158,7 @@ public interface Pop3ServerContract {
         List<POP3MessageInfo> pop3MessageInfos2 = ImmutableList.copyOf(pop3Client2.listUniqueIdentifiers());
         assertThat(pop3MessageInfos2).isEmpty();
         pop3Client.disconnect();
+        pop3Client2.disconnect();
     }
 
     @Test
@@ -321,6 +322,7 @@ public interface Pop3ServerContract {
         // Then RSET should cancen the delete
         pop3Client.reset();
         assertThat(ImmutableList.copyOf(pop3Client.listMessages())).hasSize(1);
+        pop3Client.disconnect();
         pop3Client.disconnect();
     }
 

--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/Pop3ServerContract.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/Pop3ServerContract.java
@@ -1,0 +1,559 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.james;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Reader;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.apache.commons.net.pop3.POP3Client;
+import org.apache.commons.net.pop3.POP3MessageInfo;
+import org.apache.james.jmap.JMAPTestingConstants;
+import org.apache.james.modules.protocols.ImapGuiceProbe;
+import org.apache.james.modules.protocols.Pop3GuiceProbe;
+import org.apache.james.modules.protocols.SmtpGuiceProbe;
+import org.apache.james.util.ClassLoaderUtils;
+import org.apache.james.utils.DataProbeImpl;
+import org.apache.james.utils.SMTPMessageSender;
+import org.apache.james.utils.SpoolerProbe;
+import org.apache.james.utils.TestIMAPClient;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import com.github.fge.lambdas.Throwing;
+import com.github.fge.lambdas.consumers.ThrowingConsumer;
+import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.CharStreams;
+
+public interface Pop3ServerContract {
+    String USER = "bob@examplebis.local";
+    String PASSWORD = "123456";
+    String DOMAIN = "examplebis.local";
+
+    @Test
+    default void mailsCanBeReadInPop3(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(USER, PASSWORD);
+
+        // Given a message in INBOX
+        SMTPMessageSender smtpMessageSender = new SMTPMessageSender(JMAPTestingConstants.DOMAIN);
+        smtpMessageSender.connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .sendMessage("bob@" + JMAPTestingConstants.DOMAIN, USER);
+        TestIMAPClient imapClient = new TestIMAPClient();
+        imapClient.connect("127.0.0.1", server.getProbe(ImapGuiceProbe.class).getImapPort())
+            .login(USER, PASSWORD)
+            .select("INBOX")
+            .awaitMessageCount(Awaitility.await(), 1);
+
+        // Them I can retrieve it in POP3
+        POP3Client pop3Client = new POP3Client();
+        pop3Client.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client.login(USER, PASSWORD);
+        List<POP3MessageInfo> pop3MessageInfos = ImmutableList.copyOf(pop3Client.listUniqueIdentifiers());
+        assertThat(pop3MessageInfos).hasSize(1);
+        Reader message = pop3Client.retrieveMessage(pop3MessageInfos.get(0).number);
+        assertThat(CharStreams.toString(message)).contains("subject: test\r\n\r\ncontent");
+        pop3Client.disconnect();
+    }
+
+    @Test
+    default void manyMessagesCanBeRetrievedWithPOP3(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(USER, PASSWORD);
+
+        // Given 50 messages in INBOX
+        SMTPMessageSender smtpMessageSender = new SMTPMessageSender(JMAPTestingConstants.DOMAIN);
+        smtpMessageSender.connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort());
+
+        IntStream.range(0, 50)
+            .forEach(Throwing.intConsumer(i -> smtpMessageSender.sendMessage("bob@" + JMAPTestingConstants.DOMAIN, USER)));
+
+        Thread.sleep(100);
+        Awaitility.await().untilAsserted(() -> assertThat(server.getProbe(SpoolerProbe.class).processingFinished()).isTrue());
+
+        // Them I can retrieve them in POP3
+        POP3Client pop3Client = new POP3Client();
+        pop3Client.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client.login(USER, PASSWORD);
+        List<POP3MessageInfo> pop3MessageInfos = ImmutableList.copyOf(pop3Client.listUniqueIdentifiers());
+        assertThat(pop3MessageInfos).hasSize(50);
+        // And all messages should be retrievable
+        IntStream.range(0, 50).forEach(Throwing.intConsumer(i -> {
+            Reader message = pop3Client.retrieveMessage(pop3MessageInfos.get(i).number);
+            assertThat(CharStreams.toString(message)).contains("subject: test\r\n\r\ncontent");
+        }));
+
+        pop3Client.disconnect();
+    }
+
+    @Test
+    default void aMailWithAnAttachmentCanBeRetrieved(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(USER, PASSWORD);
+
+        // Given 50 messages in INBOX
+        SMTPMessageSender smtpMessageSender = new SMTPMessageSender(JMAPTestingConstants.DOMAIN);
+        smtpMessageSender.connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort());
+        smtpMessageSender.sendMessageWithHeaders("bob@" + JMAPTestingConstants.DOMAIN, USER,
+            ClassLoaderUtils.getSystemResourceAsString("attachment.eml"));
+
+        Thread.sleep(100);
+        Awaitility.await().untilAsserted(() -> assertThat(server.getProbe(SpoolerProbe.class).processingFinished()).isTrue());
+
+        // Them I can retrieve them in POP3
+        POP3Client pop3Client = new POP3Client();
+        pop3Client.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client.login(USER, PASSWORD);
+        List<POP3MessageInfo> pop3MessageInfos = ImmutableList.copyOf(pop3Client.listUniqueIdentifiers());
+        assertThat(pop3MessageInfos).hasSize(1);
+        Reader message = pop3Client.retrieveMessage(pop3MessageInfos.get(0).number);
+        assertThat(CharStreams.toString(message)).endsWith(ClassLoaderUtils.getSystemResourceAsString("attachment.eml"));
+        pop3Client.disconnect();
+    }
+
+    @Test
+    default void pop3SizeShouldMatch(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(USER, PASSWORD);
+
+        // Given one message
+        SMTPMessageSender smtpMessageSender = new SMTPMessageSender(JMAPTestingConstants.DOMAIN);
+        smtpMessageSender.connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort());
+        smtpMessageSender.sendMessageWithHeaders("bob@" + JMAPTestingConstants.DOMAIN, USER,
+            ClassLoaderUtils.getSystemResourceAsString("attachment.eml"));
+
+        Thread.sleep(100);
+        Awaitility.await().untilAsserted(() -> assertThat(server.getProbe(SpoolerProbe.class).processingFinished()).isTrue());
+
+        // Then the advertized size is the downloadable size
+        POP3Client pop3Client = new POP3Client();
+        pop3Client.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client.login(USER, PASSWORD);
+        List<POP3MessageInfo> pop3MessageInfos = ImmutableList.copyOf(pop3Client.listMessages());
+        Reader message = pop3Client.retrieveMessage(pop3MessageInfos.get(0).number);
+        assertThat(pop3MessageInfos).hasSize(1);
+        assertThat(pop3MessageInfos.get(0).size).isEqualTo(CharStreams.toString(message).length());
+        pop3Client.disconnect();
+    }
+
+    @Test
+    default void mailReceivedDuringPOP3TransactionShouldBeIgnored(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(USER, PASSWORD);
+
+        // Given a TRANSACTION POP3 session
+        POP3Client pop3Client = new POP3Client();
+        pop3Client.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client.login(USER, PASSWORD);
+
+        // When a message is received
+        SMTPMessageSender smtpMessageSender = new SMTPMessageSender(JMAPTestingConstants.DOMAIN);
+        smtpMessageSender.connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort());
+        smtpMessageSender.sendMessageWithHeaders("bob@" + JMAPTestingConstants.DOMAIN, USER,
+            ClassLoaderUtils.getSystemResourceAsString("attachment.eml"));
+
+        Thread.sleep(100);
+        Awaitility.await().untilAsserted(() -> assertThat(server.getProbe(SpoolerProbe.class).processingFinished()).isTrue());
+
+        // Then the message is not shown for existing POP3 sessions
+        List<POP3MessageInfo> pop3MessageInfos = ImmutableList.copyOf(pop3Client.listMessages());
+        assertThat(pop3MessageInfos).isEmpty();
+        pop3Client.disconnect();
+    }
+
+    @Test
+    default void rsetShouldRefreshPOP3Session(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(USER, PASSWORD);
+
+        // Given a TRANSACTION POP3 session
+        POP3Client pop3Client = new POP3Client();
+        pop3Client.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client.login(USER, PASSWORD);
+
+        // When a message is received
+        SMTPMessageSender smtpMessageSender = new SMTPMessageSender(JMAPTestingConstants.DOMAIN);
+        smtpMessageSender.connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort());
+        smtpMessageSender.sendMessageWithHeaders("bob@" + JMAPTestingConstants.DOMAIN, USER,
+            ClassLoaderUtils.getSystemResourceAsString("attachment.eml"));
+
+        Thread.sleep(100);
+        Awaitility.await().untilAsserted(() -> assertThat(server.getProbe(SpoolerProbe.class).processingFinished()).isTrue());
+
+        // Then the message is not shown for existing POP3 sessions
+        pop3Client.reset();
+        List<POP3MessageInfo> pop3MessageInfos = ImmutableList.copyOf(pop3Client.listMessages());
+        assertThat(pop3MessageInfos).hasSize(1);
+        pop3Client.disconnect();
+    }
+
+    @Test
+    default void rsetShouldCancelDeletes(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(USER, PASSWORD);
+
+        // Given a message is received
+        SMTPMessageSender smtpMessageSender = new SMTPMessageSender(JMAPTestingConstants.DOMAIN);
+        smtpMessageSender.connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort());
+        smtpMessageSender.sendMessageWithHeaders("bob@" + JMAPTestingConstants.DOMAIN, USER,
+            ClassLoaderUtils.getSystemResourceAsString("attachment.eml"));
+        Thread.sleep(100);
+        Awaitility.await().untilAsserted(() -> assertThat(server.getProbe(SpoolerProbe.class).processingFinished()).isTrue());
+
+        // When I delete it in POP3
+        POP3Client pop3Client = new POP3Client();
+        pop3Client.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client.login(USER, PASSWORD);
+        List<POP3MessageInfo> pop3MessageInfos = ImmutableList.copyOf(pop3Client.listMessages());
+        assertThat(pop3MessageInfos).hasSize(1);
+        pop3Client.deleteMessage(pop3MessageInfos.get(0).number);
+
+        // Then RSET should cancen the delete
+        pop3Client.reset();
+        assertThat(ImmutableList.copyOf(pop3Client.listMessages())).hasSize(1);
+        pop3Client.disconnect();
+    }
+
+    @Test
+    default void deletesAreImmediateWithinASession(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(USER, PASSWORD);
+
+        // Given a message is received
+        SMTPMessageSender smtpMessageSender = new SMTPMessageSender(JMAPTestingConstants.DOMAIN);
+        smtpMessageSender.connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort());
+        smtpMessageSender.sendMessageWithHeaders("bob@" + JMAPTestingConstants.DOMAIN, USER,
+            ClassLoaderUtils.getSystemResourceAsString("attachment.eml"));
+        Thread.sleep(100);
+        Awaitility.await().untilAsserted(() -> assertThat(server.getProbe(SpoolerProbe.class).processingFinished()).isTrue());
+
+        // When I delete it in POP3
+        POP3Client pop3Client = new POP3Client();
+        pop3Client.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client.login(USER, PASSWORD);
+        List<POP3MessageInfo> pop3MessageInfos = ImmutableList.copyOf(pop3Client.listMessages());
+        assertThat(pop3MessageInfos).hasSize(1);
+        pop3Client.deleteMessage(pop3MessageInfos.get(0).number);
+
+        // Then RSET should cancen the delete
+        assertThat(ImmutableList.copyOf(pop3Client.listMessages())).isEmpty();
+        pop3Client.disconnect();
+    }
+
+    @Test
+    default void pendingDeletesAreNotSeenByOtherSessions(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(USER, PASSWORD);
+
+        // Given a message is received
+        SMTPMessageSender smtpMessageSender = new SMTPMessageSender(JMAPTestingConstants.DOMAIN);
+        smtpMessageSender.connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort());
+        smtpMessageSender.sendMessageWithHeaders("bob@" + JMAPTestingConstants.DOMAIN, USER,
+            ClassLoaderUtils.getSystemResourceAsString("attachment.eml"));
+        Thread.sleep(100);
+        Awaitility.await().untilAsserted(() -> assertThat(server.getProbe(SpoolerProbe.class).processingFinished()).isTrue());
+
+        // When I delete it in POP3
+        POP3Client pop3Client = new POP3Client();
+        pop3Client.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client.login(USER, PASSWORD);
+        List<POP3MessageInfo> pop3MessageInfos = ImmutableList.copyOf(pop3Client.listMessages());
+        assertThat(pop3MessageInfos).hasSize(1);
+        pop3Client.deleteMessage(pop3MessageInfos.get(0).number);
+
+        // Then other sessions can still retrieve them
+        POP3Client pop3Client2 = new POP3Client();
+        pop3Client2.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client2.login(USER, PASSWORD);
+        List<POP3MessageInfo> pop3MessageInfos2 = ImmutableList.copyOf(pop3Client2.listUniqueIdentifiers());
+        assertThat(pop3MessageInfos2).hasSize(1);
+        pop3Client.disconnect();
+    }
+
+    @Test
+    default void disconnectsShouldNotPerformPendingDeletes(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(USER, PASSWORD);
+
+        // Given a message is received
+        SMTPMessageSender smtpMessageSender = new SMTPMessageSender(JMAPTestingConstants.DOMAIN);
+        smtpMessageSender.connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort());
+        smtpMessageSender.sendMessageWithHeaders("bob@" + JMAPTestingConstants.DOMAIN, USER,
+            ClassLoaderUtils.getSystemResourceAsString("attachment.eml"));
+        Thread.sleep(100);
+        Awaitility.await().untilAsserted(() -> assertThat(server.getProbe(SpoolerProbe.class).processingFinished()).isTrue());
+
+        // When I delete it in POP3
+        POP3Client pop3Client = new POP3Client();
+        pop3Client.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client.login(USER, PASSWORD);
+        List<POP3MessageInfo> pop3MessageInfos = ImmutableList.copyOf(pop3Client.listMessages());
+        assertThat(pop3MessageInfos).hasSize(1);
+        pop3Client.deleteMessage(pop3MessageInfos.get(0).number);
+        pop3Client.disconnect();
+
+        // Then other sessions can still retrieve them
+        POP3Client pop3Client2 = new POP3Client();
+        pop3Client2.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client2.login(USER, PASSWORD);
+        List<POP3MessageInfo> pop3MessageInfos2 = ImmutableList.copyOf(pop3Client2.listUniqueIdentifiers());
+        assertThat(pop3MessageInfos2).hasSize(1);
+        pop3Client.disconnect();
+    }
+
+    @Test
+    default void linesStartingWithDotShouldBeWellHandled(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(USER, PASSWORD);
+
+        // Given one message
+        SMTPMessageSender smtpMessageSender = new SMTPMessageSender(JMAPTestingConstants.DOMAIN);
+        smtpMessageSender.connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort());
+        String content = "subject: test\r\n" +
+            "\r\n" +
+            ".content\r\n";
+        smtpMessageSender.sendMessageWithHeaders("bob@" + JMAPTestingConstants.DOMAIN, USER,
+            content);
+
+        Thread.sleep(100);
+        Awaitility.await().untilAsserted(() -> assertThat(server.getProbe(SpoolerProbe.class).processingFinished()).isTrue());
+
+        // Then the advertized size is the downloadable size
+        POP3Client pop3Client = new POP3Client();
+        pop3Client.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client.login(USER, PASSWORD);
+        List<POP3MessageInfo> pop3MessageInfos = ImmutableList.copyOf(pop3Client.listMessages());
+        Reader message = pop3Client.retrieveMessage(pop3MessageInfos.get(0).number);
+        assertThat(CharStreams.toString(message)).endsWith(content);
+        pop3Client.disconnect();
+    }
+
+    @Test
+    default void aBigMailCanBeRetrieved(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(USER, PASSWORD);
+
+        // Given 50 messages in INBOX
+        SMTPMessageSender smtpMessageSender = new SMTPMessageSender(JMAPTestingConstants.DOMAIN);
+        smtpMessageSender.connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort());
+        smtpMessageSender.sendMessageWithHeaders("bob@" + JMAPTestingConstants.DOMAIN, USER,
+            ClassLoaderUtils.getSystemResourceAsString("big.eml"));
+
+        Thread.sleep(100);
+        Awaitility.await().untilAsserted(() -> assertThat(server.getProbe(SpoolerProbe.class).processingFinished()).isTrue());
+
+        // Them I can retrieve them in POP3
+        POP3Client pop3Client = new POP3Client();
+        pop3Client.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client.login(USER, PASSWORD);
+        List<POP3MessageInfo> pop3MessageInfos = ImmutableList.copyOf(pop3Client.listUniqueIdentifiers());
+        assertThat(pop3MessageInfos).hasSize(1);
+        Reader message = pop3Client.retrieveMessage(pop3MessageInfos.get(0).number);
+        assertThat(CharStreams.toString(message))
+            .endsWith(ClassLoaderUtils.getSystemResourceAsString("big.eml"));
+        pop3Client.disconnect();
+    }
+
+    @Test
+    default void aMailCanBeSentToManyRecipients(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(USER, PASSWORD);
+        List<String> users = generateNUsers(10);
+        users.forEach((ThrowingConsumer<String>) user -> server.getProbe(DataProbeImpl.class)
+            .fluent()
+            .addUser(user, PASSWORD));
+
+
+        // Given 50 messages in INBOX
+        SMTPMessageSender smtpMessageSender = new SMTPMessageSender(JMAPTestingConstants.DOMAIN);
+        smtpMessageSender.connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort());
+        smtpMessageSender.sendMessageWithHeaders("bob@" + JMAPTestingConstants.DOMAIN, users,
+            ClassLoaderUtils.getSystemResourceAsString("attachment.eml"));
+
+        Thread.sleep(100);
+        Awaitility.await().untilAsserted(() -> assertThat(server.getProbe(SpoolerProbe.class).processingFinished()).isTrue());
+
+
+        users.forEach((ThrowingConsumer<String>) user -> {
+            // Them I can retrieve them in POP3
+            POP3Client pop3Client = new POP3Client();
+            pop3Client.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+            pop3Client.login(user, PASSWORD);
+            List<POP3MessageInfo> pop3MessageInfos = ImmutableList.copyOf(pop3Client.listUniqueIdentifiers());
+            assertThat(pop3MessageInfos).hasSize(1);
+            pop3Client.disconnect();
+        });
+    }
+
+    private List<String> generateNUsers(int nbUsers) {
+        return IntStream.range(0, nbUsers)
+            .boxed()
+            .map(index -> "user" + index + "@" + DOMAIN)
+            .collect(Guavate.toImmutableList());
+    }
+
+    @Test
+    default void messageCanBeDeleted(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(USER, PASSWORD);
+
+        // Given a message in INBOX
+        SMTPMessageSender smtpMessageSender = new SMTPMessageSender(JMAPTestingConstants.DOMAIN);
+        smtpMessageSender.connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort())
+            .sendMessage("bob@" + JMAPTestingConstants.DOMAIN, USER);
+        TestIMAPClient imapClient = new TestIMAPClient();
+        imapClient.connect("127.0.0.1", server.getProbe(ImapGuiceProbe.class).getImapPort())
+            .login(USER, PASSWORD)
+            .select("INBOX")
+            .awaitMessageCount(Awaitility.await(), 1);
+
+        // When I connect in POP3 and delete it
+        POP3Client pop3Client = new POP3Client();
+        pop3Client.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client.login(USER, PASSWORD);
+        pop3Client.deleteMessage(pop3Client.listUniqueIdentifiers()[0].number);
+        pop3Client.logout();
+
+        // Then subsequent POP3 sessions do not read it
+        POP3Client pop3Client2 = new POP3Client();
+        pop3Client2.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client2.login(USER, PASSWORD);
+        assertThat(pop3Client2.listUniqueIdentifiers()).isEmpty();
+        pop3Client2.disconnect();
+    }
+
+    @Test
+    default void manyMessagesCanBeDeletedWithPOP3(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(USER, PASSWORD);
+
+        // Given 50 messages in INBOX
+        SMTPMessageSender smtpMessageSender = new SMTPMessageSender(JMAPTestingConstants.DOMAIN);
+        smtpMessageSender.connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort());
+
+        IntStream.range(0, 50)
+            .forEach(Throwing.intConsumer(i -> smtpMessageSender.sendMessage("bob@" + JMAPTestingConstants.DOMAIN, USER)));
+
+        Thread.sleep(100);
+        Awaitility.await().untilAsserted(() -> assertThat(server.getProbe(SpoolerProbe.class).processingFinished()).isTrue());
+
+        // When I delete all of them
+        POP3Client pop3Client = new POP3Client();
+        pop3Client.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client.login(USER, PASSWORD);
+        List<POP3MessageInfo> pop3MessageInfos = ImmutableList.copyOf(pop3Client.listUniqueIdentifiers());
+        assertThat(pop3MessageInfos).hasSize(50);
+        pop3MessageInfos.forEach(Throwing.consumer(info -> pop3Client.deleteMessage(info.number)));
+        pop3Client.logout();
+
+        // Then subsequent POP3 sessions do not read it
+        POP3Client pop3Client2 = new POP3Client();
+        pop3Client2.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client2.login(USER, PASSWORD);
+        assertThat(pop3Client2.listUniqueIdentifiers()).isEmpty();
+        pop3Client2.disconnect();
+    }
+
+    @Test
+    default void deletingAMessageDeletesOnlyOne(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(USER, PASSWORD);
+
+        // Given 50 messages in INBOX
+        SMTPMessageSender smtpMessageSender = new SMTPMessageSender(JMAPTestingConstants.DOMAIN);
+        smtpMessageSender.connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort());
+
+        IntStream.range(0, 50)
+            .forEach(Throwing.intConsumer(i -> smtpMessageSender.sendMessage("bob@" + JMAPTestingConstants.DOMAIN, USER)));
+
+        Thread.sleep(100);
+        Awaitility.await().untilAsserted(() -> assertThat(server.getProbe(SpoolerProbe.class).processingFinished()).isTrue());
+
+        // When I delete all of them
+        POP3Client pop3Client = new POP3Client();
+        pop3Client.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client.login(USER, PASSWORD);
+        List<POP3MessageInfo> pop3MessageInfos = ImmutableList.copyOf(pop3Client.listUniqueIdentifiers());
+        assertThat(pop3MessageInfos).hasSize(50);
+        pop3Client.deleteMessage(pop3MessageInfos.get(45).number);
+        pop3Client.logout();
+
+        // Then subsequent POP3 sessions do not read it
+        POP3Client pop3Client2 = new POP3Client();
+        pop3Client2.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client2.login(USER, PASSWORD);
+        assertThat(pop3Client2.listUniqueIdentifiers()).hasSize(49);
+        pop3Client2.disconnect();
+    }
+
+    @Test
+    default void messagesShouldBeOrderedByReceivedDate(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(DOMAIN)
+            .addUser(USER, PASSWORD);
+
+        // Given two messages received
+        SMTPMessageSender smtpMessageSender = new SMTPMessageSender(JMAPTestingConstants.DOMAIN);
+        SMTPMessageSender sender = smtpMessageSender.connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort());
+        sender.sendMessageWithHeaders("bob@" + JMAPTestingConstants.DOMAIN, USER,
+            "Subject: Message 1\r\n\r\nBody 1");
+        Thread.sleep(100); // time necessary for the processing to start
+        Awaitility.await().untilAsserted(() -> assertThat(server.getProbe(SpoolerProbe.class)
+            .processingFinished()).isTrue());
+
+        sender.sendMessageWithHeaders("bob@" + JMAPTestingConstants.DOMAIN, USER,
+            "Subject: Message 2\r\n\r\nBody 2");
+        Thread.sleep(100); // time necessary for the processing to start
+        Awaitility.await().untilAsserted(() -> assertThat(server.getProbe(SpoolerProbe.class)
+            .processingFinished()).isTrue());
+
+        // When I connect in POP3 and read them
+        POP3Client pop3Client = new POP3Client();
+        pop3Client.connect("127.0.0.1", server.getProbe(Pop3GuiceProbe.class).getPop3Port());
+        pop3Client.login(USER, PASSWORD);
+        POP3MessageInfo[] pop3MessageInfos = pop3Client.listUniqueIdentifiers();
+
+        // then they are ordered by received at
+        assertThat(pop3MessageInfos).hasSize(2);
+        Reader message1 = pop3Client.retrieveMessage(pop3MessageInfos[0].number);
+        assertThat(CharStreams.toString(message1)).contains("Subject: Message 1");
+        Reader message2 = pop3Client.retrieveMessage(pop3MessageInfos[1].number);
+        assertThat(CharStreams.toString(message2)).contains("Subject: Message 2");
+        pop3Client.disconnect();
+    }
+}

--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/Pop3ServerContract.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/Pop3ServerContract.java
@@ -382,6 +382,7 @@ public interface Pop3ServerContract {
         List<POP3MessageInfo> pop3MessageInfos2 = ImmutableList.copyOf(pop3Client2.listUniqueIdentifiers());
         assertThat(pop3MessageInfos2).hasSize(1);
         pop3Client.disconnect();
+        pop3Client2.disconnect();
     }
 
     @Test

--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/WithCacheMutableTest.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/WithCacheMutableTest.java
@@ -19,11 +19,98 @@
 
 package org.apache.james;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.james.backends.cassandra.StatementRecorder;
+import org.apache.james.backends.cassandra.TestingSession;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.init.SessionWithInitializedTablesFactory;
+import org.apache.james.blob.cassandra.cache.CassandraBlobCacheModule;
+import org.apache.james.core.Username;
+import org.apache.james.jmap.JMAPTestingConstants;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.modules.MailboxProbeImpl;
+import org.apache.james.modules.protocols.SmtpGuiceProbe;
+import org.apache.james.utils.DataProbeImpl;
+import org.apache.james.utils.GuiceProbe;
+import org.apache.james.utils.SMTPMessageSender;
+import org.apache.james.utils.SpoolerProbe;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.datastax.driver.core.Session;
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Names;
+
 class WithCacheMutableTest implements MailsShouldBeWellReceived {
+    public static class TestingSessionProbe implements GuiceProbe {
+        private final TestingSession testingSession;
+
+        @Inject
+        private TestingSessionProbe(TestingSession testingSession) {
+            this.testingSession = testingSession;
+        }
+
+        public TestingSession getTestingSession() {
+            return testingSession;
+        }
+    }
+
+    public static class TestingSessionModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            Multibinder.newSetBinder(binder(), GuiceProbe.class)
+                .addBinding()
+                .to(TestingSessionProbe.class);
+
+            bind(Session.class)
+                .annotatedWith(Names.named("cache"))
+                .to(TestingSession.class);
+            bind(Session.class)
+                .to(TestingSession.class);
+            Multibinder.newSetBinder(binder(), CassandraModule.class).addBinding().toInstance(CassandraBlobCacheModule.MODULE);
+        }
+
+        @Provides
+        @Singleton
+        TestingSession provideSession(SessionWithInitializedTablesFactory factory) {
+            return new TestingSession(factory.get());
+        }
+    }
+
     @RegisterExtension
     static JamesServerExtension jamesServerExtension = WithCacheImmutableTest.baseExtensionBuilder()
         .lifeCycle(JamesServerExtension.Lifecycle.PER_TEST)
+        .overrideServerModule(new TestingSessionModule())
         .build();
+
+    @Test
+    void receivingAMailShouldNotPerformAnyLWT(GuiceJamesServer server) throws Exception {
+        server.getProbe(DataProbeImpl.class).fluent()
+            .addDomain(Pop3ServerContract.DOMAIN)
+            .addUser(Pop3ServerContract.USER, PASSWORD);
+        server.getProbe(MailboxProbeImpl.class)
+            .createMailbox(MailboxPath.inbox(Username.of(Pop3ServerContract.USER)));
+
+        // Given session recording is turned on
+        StatementRecorder statementRecorder = new StatementRecorder();
+        server.getProbe(TestingSessionProbe.class).getTestingSession()
+            .recordStatements(statementRecorder);
+
+        // When an email is received
+        SMTPMessageSender smtpMessageSender = new SMTPMessageSender(JMAPTestingConstants.DOMAIN);
+        smtpMessageSender.connect("127.0.0.1", server.getProbe(SmtpGuiceProbe.class).getSmtpPort());
+        smtpMessageSender.sendMessage("bob@" + JMAPTestingConstants.DOMAIN, Pop3ServerContract.USER);
+        Thread.sleep(100);
+        Awaitility.await().untilAsserted(() -> assertThat(server.getProbe(SpoolerProbe.class).processingFinished()).isTrue());
+
+        // Then no LWT was executed
+        assertThat(statementRecorder.listExecutedStatements(StatementRecorder.Selector.preparedStatementContaining(" IF ")))
+            .isEmpty();
+    }
 }

--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/WithDefaultAwsS3MutableTest.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/WithDefaultAwsS3MutableTest.java
@@ -22,7 +22,7 @@ package org.apache.james;
 import org.apache.james.modules.AwsS3BlobStoreExtension;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class WithDefaultAwsS3MutableTest implements MailsShouldBeWellReceived {
+public class WithDefaultAwsS3MutableTest implements MailsShouldBeWellReceived, Pop3ServerContract {
     @RegisterExtension
     static JamesServerExtension jamesServerExtension = CassandraRabbitMQJamesServerFixture.baseExtensionBuilder()
         .extension(new AwsS3BlobStoreExtension())

--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/WithDefaultAwsS3MutableTest.java
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/java/org/apache/james/WithDefaultAwsS3MutableTest.java
@@ -27,5 +27,6 @@ public class WithDefaultAwsS3MutableTest implements MailsShouldBeWellReceived, P
     static JamesServerExtension jamesServerExtension = CassandraRabbitMQJamesServerFixture.baseExtensionBuilder()
         .extension(new AwsS3BlobStoreExtension())
         .lifeCycle(JamesServerExtension.Lifecycle.PER_TEST)
+        .overrideServerModule(new POP3ViewProbeModule())
         .build();
 }

--- a/server/container/guice/cassandra-rabbitmq-guice/src/test/resources/cassandra.properties
+++ b/server/container/guice/cassandra-rabbitmq-guice/src/test/resources/cassandra.properties
@@ -1,0 +1,3 @@
+mailbox.read.strong.consistency=false
+message.read.strong.consistency=false
+message.write.strong.consistency.unsafe=false

--- a/server/container/guice/guice-common/src/test/java/org/apache/james/MailsShouldBeWellReceived.java
+++ b/server/container/guice/guice-common/src/test/java/org/apache/james/MailsShouldBeWellReceived.java
@@ -49,6 +49,7 @@ import org.apache.james.utils.TestIMAPClient;
 import org.apache.mailet.base.test.FakeMail;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.github.fge.lambdas.Throwing;
@@ -227,6 +228,7 @@ public interface MailsShouldBeWellReceived {
         }
     }
 
+    @Disabled("Unstable as we weakened UID generation consistency - only IMAP is affected")
     @Test
     default void oneHundredMailsShouldBeWellReceived(GuiceJamesServer server) throws Exception {
         server.getProbe(DataProbeImpl.class).fluent()

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -94,6 +94,7 @@
         <module>protocols/protocols-lmtp</module>
         <module>protocols/protocols-managesieve</module>
         <module>protocols/protocols-pop3</module>
+        <module>protocols/protocols-pop3-distributed</module>
         <module>protocols/protocols-smtp</module>
         <module>protocols/webadmin</module>
         <module>protocols/webadmin-cli</module>

--- a/server/protocols/protocols-pop3-distributed/pom.xml
+++ b/server/protocols/protocols-pop3-distributed/pom.xml
@@ -37,9 +37,23 @@
     <dependencies>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-backends-cassandra</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-backends-cassandra</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>apache-james-mailbox-api</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-mailbox-cassandra</artifactId>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
@@ -115,6 +129,11 @@
         <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/server/protocols/protocols-pop3-distributed/pom.xml
+++ b/server/protocols/protocols-pop3-distributed/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.james</groupId>
         <artifactId>james-server</artifactId>
-        <version>3.6.0-SNAPSHOT</version>
+        <version>3.7.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,11 +37,93 @@
     <dependencies>
         <dependency>
             <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-protocols-pop3</artifactId>
+            <artifactId>apache-james-mailbox-api</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-mailbox-memory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-mailbox-memory</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-mailbox-store</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>event-bus-api</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>james-server-data-jmap</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-data-memory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-filesystem-api</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-jmap-draft</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-protocols-library</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-protocols-pop3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-protocols-pop3</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>metrics-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>testing-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.protocols.groupId}</groupId>
+            <artifactId>protocols-api</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/server/protocols/protocols-pop3-distributed/pom.xml
+++ b/server/protocols/protocols-pop3-distributed/pom.xml
@@ -65,10 +65,6 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-data-jmap</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
             <artifactId>james-server-data-memory</artifactId>
             <scope>test</scope>
         </dependency>
@@ -77,10 +73,6 @@
             <artifactId>james-server-filesystem-api</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>${james.groupId}</groupId>
-            <artifactId>james-server-jmap-draft</artifactId>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>

--- a/server/protocols/protocols-pop3-distributed/pom.xml
+++ b/server/protocols/protocols-pop3-distributed/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.james</groupId>
+        <artifactId>james-server</artifactId>
+        <version>3.6.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>protocols-pop3-distributed</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Apache James :: Server :: POP3 :: Distributed</name>
+    <description>Distributed friendly implementation of a POP3 server. The use of messageId as an identifier enables
+    to use safely Cassandra multi-datacenters set up</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-protocols-pop3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-data-jmap</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/server/protocols/protocols-pop3-distributed/pom.xml
+++ b/server/protocols/protocols-pop3-distributed/pom.xml
@@ -57,6 +57,12 @@
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-mailbox-cassandra</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
             <artifactId>apache-james-mailbox-memory</artifactId>
             <scope>test</scope>
         </dependency>
@@ -69,11 +75,21 @@
         <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>apache-james-mailbox-store</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>blob-cassandra</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>event-bus-api</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-json</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -129,6 +145,16 @@
         <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/CassandraPop3MetadataStore.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/CassandraPop3MetadataStore.java
@@ -1,0 +1,125 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.pop3server.mailbox;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.delete;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static org.apache.james.pop3server.mailbox.Pop3MetadataModule.MAILBOX_ID;
+import static org.apache.james.pop3server.mailbox.Pop3MetadataModule.MESSAGE_ID;
+import static org.apache.james.pop3server.mailbox.Pop3MetadataModule.SIZE;
+import static org.apache.james.pop3server.mailbox.Pop3MetadataModule.TABLE_NAME;
+
+import javax.inject.Inject;
+
+import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.model.MailboxId;
+import org.reactivestreams.Publisher;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+
+public class CassandraPop3MetadataStore implements Pop3MetadataStore {
+    private final CassandraAsyncExecutor executor;
+
+    private final PreparedStatement list;
+    private final PreparedStatement add;
+    private final PreparedStatement remove;
+    private final PreparedStatement clear;
+
+    @Inject
+    public CassandraPop3MetadataStore(Session session) {
+        this.executor = new CassandraAsyncExecutor(session);
+        this.clear = prepareClear(session);
+        this.list = prepareList(session);
+        this.add = prepareAdd(session);
+        this.remove = prepareRemove(session);
+    }
+
+    private PreparedStatement prepareRemove(Session session) {
+        return session.prepare(delete()
+            .from(TABLE_NAME)
+            .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID)))
+            .and(eq(MESSAGE_ID, bindMarker(MESSAGE_ID))));
+    }
+
+    private PreparedStatement prepareClear(Session session) {
+        return session.prepare(delete()
+            .from(TABLE_NAME)
+            .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID))));
+    }
+
+    private PreparedStatement prepareAdd(Session session) {
+        return session.prepare(insertInto(TABLE_NAME)
+            .value(MAILBOX_ID, bindMarker(MAILBOX_ID))
+            .value(MESSAGE_ID, bindMarker(MESSAGE_ID))
+            .value(SIZE, bindMarker(SIZE)));
+    }
+
+    private PreparedStatement prepareList(Session session) {
+        return session.prepare(select()
+            .from(TABLE_NAME)
+            .where(eq(MAILBOX_ID, bindMarker(MAILBOX_ID))));
+    }
+
+    @Override
+    public Publisher<StatMetadata> stat(MailboxId mailboxId) {
+        CassandraId id = (CassandraId) mailboxId;
+
+        return executor.executeRows(list.bind()
+                .setUUID(MAILBOX_ID, id.asUuid()))
+            .map(row -> new StatMetadata(
+                CassandraMessageId.Factory.of(row.getUUID(MESSAGE_ID)),
+                row.getLong(SIZE)));
+    }
+
+    @Override
+    public Publisher<Void> add(MailboxId mailboxId, StatMetadata statMetadata) {
+        CassandraId id = (CassandraId) mailboxId;
+        CassandraMessageId messageId = (CassandraMessageId) statMetadata.getMessageId();
+
+        return executor.executeVoid(add.bind()
+            .setUUID(MAILBOX_ID, id.asUuid())
+            .setUUID(MESSAGE_ID, messageId.get())
+            .setLong(SIZE, statMetadata.getSize()));
+    }
+
+    @Override
+    public Publisher<Void> remove(MailboxId mailboxId, StatMetadata statMetadata) {
+        CassandraId id = (CassandraId) mailboxId;
+        CassandraMessageId messageId = (CassandraMessageId) statMetadata.getMessageId();
+
+        return executor.executeVoid(remove.bind()
+            .setUUID(MAILBOX_ID, id.asUuid())
+            .setUUID(MESSAGE_ID, messageId.get()));
+    }
+
+    @Override
+    public Publisher<Void> clear(MailboxId mailboxId) {
+        CassandraId id = (CassandraId) mailboxId;
+
+        return executor.executeVoid(clear.bind()
+            .setUUID(MAILBOX_ID, id.asUuid()));
+    }
+}

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/CassandraPop3MetadataStore.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/CassandraPop3MetadataStore.java
@@ -35,6 +35,7 @@ import org.apache.james.backends.cassandra.utils.CassandraAsyncExecutor;
 import org.apache.james.mailbox.cassandra.ids.CassandraId;
 import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
 import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MessageId;
 import org.reactivestreams.Publisher;
 
 import com.datastax.driver.core.PreparedStatement;
@@ -106,13 +107,13 @@ public class CassandraPop3MetadataStore implements Pop3MetadataStore {
     }
 
     @Override
-    public Publisher<Void> remove(MailboxId mailboxId, StatMetadata statMetadata) {
+    public Publisher<Void> remove(MailboxId mailboxId, MessageId messageId) {
         CassandraId id = (CassandraId) mailboxId;
-        CassandraMessageId messageId = (CassandraMessageId) statMetadata.getMessageId();
+        CassandraMessageId cassandraMessageId = (CassandraMessageId) messageId;
 
         return executor.executeVoid(remove.bind()
             .setUUID(MAILBOX_ID, id.asUuid())
-            .setUUID(MESSAGE_ID, messageId.get()));
+            .setUUID(MESSAGE_ID, cassandraMessageId.get()));
     }
 
     @Override

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/DistributedMailboxAdapter.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/DistributedMailboxAdapter.java
@@ -27,6 +27,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
 
+import javax.inject.Inject;
+
 import org.apache.james.jmap.api.projections.EmailQueryView;
 import org.apache.james.mailbox.MailboxManager;
 import org.apache.james.mailbox.MailboxSession;
@@ -45,6 +47,29 @@ import com.google.common.collect.ImmutableList;
 import reactor.core.scheduler.Schedulers;
 
 public class DistributedMailboxAdapter implements Mailbox {
+    public static class Factory implements MailboxAdapterFactory {
+        private final EmailQueryView emailQueryView;
+        private final MessageIdManager messageIdManager;
+        private final MessageId.Factory messageIdFactory;
+        private final MailboxManager mailboxManager;
+
+        @Inject
+        public Factory(EmailQueryView emailQueryView,
+                       MessageIdManager messageIdManager,
+                       MessageId.Factory messageIdFactory,
+                       MailboxManager mailboxManager) {
+            this.emailQueryView = emailQueryView;
+            this.messageIdManager = messageIdManager;
+            this.messageIdFactory = messageIdFactory;
+            this.mailboxManager = mailboxManager;
+        }
+
+        @Override
+        public Mailbox create(MessageManager manager, MailboxSession session) {
+            return new DistributedMailboxAdapter(emailQueryView, messageIdManager, messageIdFactory, mailboxManager, session, manager);
+        }
+    }
+
     private final EmailQueryView emailQueryView;
     private final MessageIdManager messageIdManager;
     private final MessageId.Factory messageIdFactory;

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/DistributedMailboxAdapter.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/DistributedMailboxAdapter.java
@@ -1,0 +1,155 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.pop3server.mailbox;
+
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.james.jmap.api.projections.EmailQueryView;
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.MessageIdManager;
+import org.apache.james.mailbox.MessageManager;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.FetchGroup;
+import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.model.MessageResult;
+import org.apache.james.protocols.pop3.mailbox.Mailbox;
+import org.apache.james.protocols.pop3.mailbox.MessageMetaData;
+
+import com.github.steveash.guavate.Guavate;
+import com.google.common.collect.ImmutableList;
+
+import reactor.core.scheduler.Schedulers;
+
+public class DistributedMailboxAdapter implements Mailbox {
+    private final EmailQueryView emailQueryView;
+    private final MessageIdManager messageIdManager;
+    private final MessageId.Factory messageIdFactory;
+    private final MailboxManager mailboxManager;
+    private final MailboxSession session;
+    private final MessageManager mailbox;
+
+    public DistributedMailboxAdapter(EmailQueryView emailQueryView, MessageIdManager messageIdManager, MessageId.Factory messageIdFactory, MailboxManager mailboxManager, MailboxSession session, MessageManager mailbox) {
+        this.emailQueryView = emailQueryView;
+        this.messageIdManager = messageIdManager;
+        this.messageIdFactory = messageIdFactory;
+        this.mailboxManager = mailboxManager;
+        this.session = session;
+        this.mailbox = mailbox;
+    }
+
+    @Override
+    public InputStream getMessageBody(String uid) throws IOException {
+        try {
+        MessageId messageId = messageIdFactory.fromString(uid);
+        Iterator<MessageResult> messages = messageIdManager.getMessage(messageId, FetchGroup.BODY_CONTENT, session).iterator();
+        if (messages.hasNext()) {
+            return messages.next().getBody().getInputStream();
+        } else {
+            return null;
+        }
+        } catch (MailboxException e) {
+            throw new IOException("Unable to retrieve message body for uid " + uid, e);
+        }
+    }
+
+    @Override
+    public InputStream getMessageHeaders(String uid) throws IOException {
+        try {
+            MessageId messageId = messageIdFactory.fromString(uid);
+            Iterator<MessageResult> messages = messageIdManager.getMessage(messageId, FetchGroup.HEADERS, session).iterator();
+            if (messages.hasNext()) {
+                return messages.next().getBody().getInputStream();
+            } else {
+                return null;
+            }
+        } catch (MailboxException e) {
+            throw new IOException("Unable to retrieve message body for uid " + uid, e);
+        }
+    }
+
+    @Override
+    public InputStream getMessage(String uid) throws IOException {
+        try {
+            MessageId messageId = messageIdFactory.fromString(uid);
+            Iterator<MessageResult> messages = messageIdManager.getMessage(messageId, FetchGroup.FULL_CONTENT, session).iterator();
+            if (messages.hasNext()) {
+                return messages.next().getFullContent().getInputStream();
+            } else {
+                return null;
+            }
+        } catch (MailboxException e) {
+            throw new IOException("Unable to retrieve message body for uid " + uid, e);
+        }
+    }
+
+    @Override
+    public List<MessageMetaData> getMessages() {
+        return emailQueryView.listMailboxContent(mailbox.getId())
+            .flatMap(messageId -> messageIdManager.getMessagesReactive(ImmutableList.of(messageId), FetchGroup.MINIMAL, session), DEFAULT_CONCURRENCY)
+            .distinct(MessageResult::getMessageId)
+            .map(message -> new MessageMetaData(message.getMessageId().serialize(), message.getSize()))
+            .collect(Guavate.toImmutableList())
+            .subscribeOn(Schedulers.elastic())
+            .block();
+    }
+
+    @Override
+    public void remove(String... uids) throws IOException {
+        ImmutableList<MessageId> messageIds = Stream.of(uids)
+            .map(messageIdFactory::fromString)
+            .collect(Guavate.toImmutableList());
+        try {
+            messageIdManager.delete(messageIds, session);
+        } catch (MailboxException e) {
+            throw new IOException("Unable to delete " + messageIds, e);
+        }
+    }
+
+    @Override
+    public String getIdentifier() throws IOException {
+        try {
+            mailboxManager.startProcessingRequest(session);
+            long validity = mailbox.getMailboxEntity()
+                .getUidValidity()
+                .asLong();
+            return Long.toString(validity);
+        } catch (MailboxException e) {
+            throw new IOException("Unable to retrieve indentifier for mailbox", e);
+        } finally {
+            mailboxManager.endProcessingRequest(session);
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            mailboxManager.logout(session);
+        } finally {
+            mailboxManager.endProcessingRequest(session);
+        }
+    }
+}

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/DistributedMailboxAdapter.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/DistributedMailboxAdapter.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.apache.james.jmap.api.projections.EmailQueryView;
 import org.apache.james.mailbox.MailboxManager;
@@ -43,6 +44,7 @@ import org.apache.james.protocols.pop3.mailbox.MessageMetaData;
 
 import com.github.steveash.guavate.Guavate;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 import reactor.core.scheduler.Schedulers;
 
@@ -57,7 +59,7 @@ public class DistributedMailboxAdapter implements Mailbox {
         public Factory(EmailQueryView emailQueryView,
                        MessageIdManager messageIdManager,
                        MessageId.Factory messageIdFactory,
-                       MailboxManager mailboxManager) {
+                       @Named("mailboxmanager") MailboxManager mailboxManager) {
             this.emailQueryView = emailQueryView;
             this.messageIdManager = messageIdManager;
             this.messageIdFactory = messageIdFactory;
@@ -138,6 +140,7 @@ public class DistributedMailboxAdapter implements Mailbox {
             .distinct(MessageResult::getMessageId)
             .map(message -> new MessageMetaData(message.getMessageId().serialize(), message.getSize()))
             .collect(Guavate.toImmutableList())
+            .map(Lists::reverse) // in order to have a similar ordering
             .subscribeOn(Schedulers.elastic())
             .block();
     }

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/DistributedMailboxAdapter.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/DistributedMailboxAdapter.java
@@ -87,36 +87,6 @@ public class DistributedMailboxAdapter implements Mailbox {
     }
 
     @Override
-    public InputStream getMessageBody(String uid) throws IOException {
-        try {
-        MessageId messageId = messageIdFactory.fromString(uid);
-        Iterator<MessageResult> messages = messageIdManager.getMessage(messageId, FetchGroup.BODY_CONTENT, session).iterator();
-        if (messages.hasNext()) {
-            return messages.next().getBody().getInputStream();
-        } else {
-            return null;
-        }
-        } catch (MailboxException e) {
-            throw new IOException("Unable to retrieve message body for uid " + uid, e);
-        }
-    }
-
-    @Override
-    public InputStream getMessageHeaders(String uid) throws IOException {
-        try {
-            MessageId messageId = messageIdFactory.fromString(uid);
-            Iterator<MessageResult> messages = messageIdManager.getMessage(messageId, FetchGroup.HEADERS, session).iterator();
-            if (messages.hasNext()) {
-                return messages.next().getBody().getInputStream();
-            } else {
-                return null;
-            }
-        } catch (MailboxException e) {
-            throw new IOException("Unable to retrieve message body for uid " + uid, e);
-        }
-    }
-
-    @Override
     public InputStream getMessage(String uid) throws IOException {
         try {
             MessageId messageId = messageIdFactory.fromString(uid);

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/DistributedMailboxAdapter.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/DistributedMailboxAdapter.java
@@ -111,19 +111,16 @@ public class DistributedMailboxAdapter implements Mailbox {
     }
 
     @Override
-    public void remove(String... uids) throws IOException {
+    public void remove(String... uids) {
         ImmutableList<MessageId> messageIds = Stream.of(uids)
             .map(messageIdFactory::fromString)
             .collect(Guavate.toImmutableList());
-        try {
-            Mono.from(messageIdManager.delete(messageIds, session))
-                .flatMap(deleteResult -> Flux.fromIterable(deleteResult.getDestroyed())
-                    .flatMap(messageId -> metadataStore.remove(mailbox.getId(), messageId))
-                    .then())
-                .block();
-        } catch (MailboxException e) {
-            throw new IOException("Unable to delete " + messageIds, e);
-        }
+
+        Mono.from(messageIdManager.delete(messageIds, session))
+            .flatMap(deleteResult -> Flux.fromIterable(deleteResult.getDestroyed())
+                .flatMap(messageId -> metadataStore.remove(mailbox.getId(), messageId))
+                .then())
+            .block();
     }
 
     @Override

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/MemoryPop3MetadataStore.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/MemoryPop3MetadataStore.java
@@ -51,8 +51,8 @@ public class MemoryPop3MetadataStore implements Pop3MetadataStore {
     }
 
     @Override
-    public Publisher<Void> remove(MailboxId mailboxId, StatMetadata statMetadata) {
-        return Mono.fromRunnable(() -> data.remove(mailboxId, statMetadata.getMessageId()));
+    public Publisher<Void> remove(MailboxId mailboxId, MessageId messageId) {
+        return Mono.fromRunnable(() -> data.remove(mailboxId, messageId));
     }
 
     @Override

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/MemoryPop3MetadataStore.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/MemoryPop3MetadataStore.java
@@ -1,0 +1,62 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.pop3server.mailbox;
+
+import java.util.function.Function;
+
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MessageId;
+import org.reactivestreams.Publisher;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Table;
+
+import reactor.core.publisher.Mono;
+
+public class MemoryPop3MetadataStore implements Pop3MetadataStore {
+    private final Table<MailboxId, MessageId, Long> data;
+
+    public MemoryPop3MetadataStore() {
+        data = HashBasedTable.create();
+    }
+
+    @Override
+    public Publisher<StatMetadata> stat(MailboxId mailboxId) {
+        return Mono.fromCallable(() -> ImmutableList.copyOf(data.row(mailboxId).entrySet()))
+            .flatMapIterable(Function.identity())
+            .map(entry -> new StatMetadata(entry.getKey(), entry.getValue()));
+    }
+
+    @Override
+    public Publisher<Void> add(MailboxId mailboxId, StatMetadata statMetadata) {
+        return Mono.fromRunnable(() -> data.put(mailboxId, statMetadata.getMessageId(), statMetadata.getSize()));
+    }
+
+    @Override
+    public Publisher<Void> remove(MailboxId mailboxId, StatMetadata statMetadata) {
+        return Mono.fromRunnable(() -> data.remove(mailboxId, statMetadata.getMessageId()));
+    }
+
+    @Override
+    public Publisher<Void> clear(MailboxId mailboxId) {
+        return Mono.fromRunnable(() -> data.row(mailboxId).clear());
+    }
+}

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/Pop3MetadataModule.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/Pop3MetadataModule.java
@@ -1,0 +1,45 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.pop3server.mailbox;
+
+import static com.datastax.driver.core.DataType.bigint;
+import static com.datastax.driver.core.DataType.uuid;
+import static org.apache.james.backends.cassandra.utils.CassandraConstants.DEFAULT_CACHED_ROW_PER_PARTITION;
+
+import org.apache.james.backends.cassandra.components.CassandraModule;
+
+import com.datastax.driver.core.schemabuilder.SchemaBuilder;
+
+public interface Pop3MetadataModule {
+    String TABLE_NAME = "pop3metadata";
+    String MAILBOX_ID = "mailboxId";
+    String MESSAGE_ID = "messageId";
+    String SIZE = "size";
+
+    CassandraModule MODULE = CassandraModule.table(TABLE_NAME)
+        .comment("Store metadata to answer efficiently the STAT queries based on the messageId. No further reads required on other tables.")
+        .options(options -> options
+            .caching(SchemaBuilder.KeyCaching.ALL, SchemaBuilder.rows(DEFAULT_CACHED_ROW_PER_PARTITION)))
+        .statement(statement -> statement
+            .addPartitionKey(MAILBOX_ID, uuid())
+            .addClusteringColumn(MESSAGE_ID, uuid())
+            .addColumn(SIZE, bigint()))
+        .build();
+}

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/Pop3MetadataStore.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/Pop3MetadataStore.java
@@ -1,0 +1,79 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.pop3server.mailbox;
+
+import java.util.Objects;
+
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MessageId;
+import org.reactivestreams.Publisher;
+
+
+public interface Pop3MetadataStore {
+    class StatMetadata {
+        private final MessageId messageId;
+        private final long size;
+
+        public StatMetadata(MessageId messageId, long size) {
+            this.messageId = messageId;
+            this.size = size;
+        }
+
+        public MessageId getMessageId() {
+            return messageId;
+        }
+
+        public long getSize() {
+            return size;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o instanceof StatMetadata) {
+                StatMetadata that = (StatMetadata) o;
+
+                return this.size == that.size
+                    && Objects.equals(this.messageId, that.messageId);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(messageId, size);
+        }
+
+        @Override
+        public String toString() {
+            return "StatMetadata{" +
+                "messageId=" + messageId +
+                ", size=" + size +
+                '}';
+        }
+    }
+
+    Publisher<StatMetadata> stat(MailboxId mailboxId);
+
+    Publisher<Void> add(MailboxId mailboxId, StatMetadata statMetadata);
+
+    Publisher<Void> remove(MailboxId mailboxId, StatMetadata statMetadata);
+
+    Publisher<Void> clear(MailboxId mailboxId);
+}

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/Pop3MetadataStore.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/Pop3MetadataStore.java
@@ -25,6 +25,8 @@ import org.apache.james.mailbox.model.MailboxId;
 import org.apache.james.mailbox.model.MessageId;
 import org.reactivestreams.Publisher;
 
+import com.google.common.base.MoreObjects;
+
 
 public interface Pop3MetadataStore {
     class StatMetadata {
@@ -69,6 +71,50 @@ public interface Pop3MetadataStore {
         }
     }
 
+    class FullMetadata extends StatMetadata {
+        private final MailboxId mailboxId;
+
+        public FullMetadata(MailboxId mailboxId, MessageId messageId, long size) {
+            super(messageId, size);
+            this.mailboxId = mailboxId;
+        }
+
+        public FullMetadata(MailboxId mailboxId, StatMetadata statMetadata) {
+            super(statMetadata.getMessageId(), statMetadata.getSize());
+            this.mailboxId = mailboxId;
+        }
+
+        public MailboxId getMailboxId() {
+            return mailboxId;
+        }
+
+        @Override
+        public final boolean equals(Object o) {
+            if (o instanceof FullMetadata) {
+                FullMetadata that = (FullMetadata) o;
+
+                return this.getSize() == that.getSize()
+                    && Objects.equals(this.getMessageId(), that.getMessageId())
+                    && Objects.equals(this.mailboxId, that.mailboxId);
+            }
+            return false;
+        }
+
+        @Override
+        public final int hashCode() {
+            return Objects.hash(mailboxId, this.getMessageId(), this.getSize());
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                .add("mailboxId", mailboxId)
+                .add("messageId", this.getMessageId())
+                .add("size", this.getSize())
+                .toString();
+        }
+    }
+
     Publisher<StatMetadata> stat(MailboxId mailboxId);
 
     Publisher<Void> add(MailboxId mailboxId, StatMetadata statMetadata);
@@ -76,4 +122,8 @@ public interface Pop3MetadataStore {
     Publisher<Void> remove(MailboxId mailboxId, MessageId messageId);
 
     Publisher<Void> clear(MailboxId mailboxId);
+
+    Publisher<FullMetadata> listAllEntries();
+
+    Publisher<FullMetadata> retrieve(MailboxId mailboxId, MessageId messageId);
 }

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/Pop3MetadataStore.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/Pop3MetadataStore.java
@@ -73,7 +73,7 @@ public interface Pop3MetadataStore {
 
     Publisher<Void> add(MailboxId mailboxId, StatMetadata statMetadata);
 
-    Publisher<Void> remove(MailboxId mailboxId, StatMetadata statMetadata);
+    Publisher<Void> remove(MailboxId mailboxId, MessageId messageId);
 
     Publisher<Void> clear(MailboxId mailboxId);
 }

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/PopulateMetadataStoreListener.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/PopulateMetadataStoreListener.java
@@ -1,0 +1,99 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.pop3server.mailbox;
+
+import javax.inject.Inject;
+
+import org.apache.james.events.Event;
+import org.apache.james.events.EventListener.ReactiveGroupEventListener;
+import org.apache.james.events.Group;
+import org.apache.james.mailbox.events.MailboxEvents.Added;
+import org.apache.james.mailbox.events.MailboxEvents.Expunged;
+import org.apache.james.mailbox.events.MailboxEvents.MailboxDeletion;
+import org.apache.james.mailbox.model.MessageMetaData;
+import org.apache.james.pop3server.mailbox.Pop3MetadataStore.StatMetadata;
+import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class PopulateMetadataStoreListener implements ReactiveGroupEventListener {
+    public static class PopulateMetadataStoreListenerGroup extends Group {
+
+    }
+
+    static final Group GROUP = new PopulateMetadataStoreListenerGroup();
+    private static final int CONCURRENCY = 5;
+
+    private final Pop3MetadataStore metadataStore;
+
+    @Inject
+    public PopulateMetadataStoreListener(Pop3MetadataStore metadataStore) {
+        this.metadataStore = metadataStore;
+    }
+
+    @Override
+    public Group getDefaultGroup() {
+        return GROUP;
+    }
+
+    @Override
+    public boolean isHandling(Event event) {
+        return event instanceof Added
+            || event instanceof Expunged
+            || event instanceof MailboxDeletion;
+    }
+
+    @Override
+    public Publisher<Void> reactiveEvent(Event event) {
+        if (event instanceof Added) {
+            return handleAdded((Added) event);
+        }
+        if (event instanceof Expunged) {
+            return handleExpunged((Expunged) event);
+        }
+        if (event instanceof MailboxDeletion) {
+            return handleMailboxDeletion((MailboxDeletion) event);
+        }
+        return Mono.empty();
+    }
+
+    private Publisher<Void> handleMailboxDeletion(MailboxDeletion mailboxDeletion) {
+        return metadataStore.clear(mailboxDeletion.getMailboxId());
+    }
+
+    private Publisher<Void> handleExpunged(Expunged expunged) {
+        return Flux.fromStream(expunged.getUids().stream()
+            .map(expunged::getMetaData))
+            .concatMap(message -> metadataStore.remove(expunged.getMailboxId(), new StatMetadata(message.getMessageId(), message.getSize())))
+            .then();
+    }
+
+    private Mono<Void> handleAdded(Added added) {
+        return Flux.fromStream(added.getUids().stream()
+            .map(added::getMetaData))
+            .flatMap(messageMetaData -> handleAdded(added, messageMetaData), CONCURRENCY)
+            .then();
+    }
+
+    private Mono<Void> handleAdded(Added added, MessageMetaData messageMetaData) {
+        return Mono.from(metadataStore.add(added.getMailboxId(), new StatMetadata(messageMetaData.getMessageId(), messageMetaData.getSize())));
+    }
+}

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/PopulateMetadataStoreListener.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/PopulateMetadataStoreListener.java
@@ -82,7 +82,7 @@ public class PopulateMetadataStoreListener implements ReactiveGroupEventListener
     private Publisher<Void> handleExpunged(Expunged expunged) {
         return Flux.fromStream(expunged.getUids().stream()
             .map(expunged::getMetaData))
-            .concatMap(message -> metadataStore.remove(expunged.getMailboxId(), new StatMetadata(message.getMessageId(), message.getSize())))
+            .concatMap(message -> metadataStore.remove(expunged.getMailboxId(), message.getMessageId()))
             .then();
     }
 

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/task/MessageInconsistenciesEntry.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/task/MessageInconsistenciesEntry.java
@@ -1,0 +1,83 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.pop3server.mailbox.task;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MessageInconsistenciesEntry {
+
+    public interface Builder {
+        @FunctionalInterface
+        interface RequireMailboxId {
+            RequireMessageId mailboxId(String mailboxId);
+        }
+
+        @FunctionalInterface
+        interface RequireMessageId {
+            MessageInconsistenciesEntry messageId(String messageId);
+        }
+
+        @FunctionalInterface
+        interface RequireMessageUid {
+            MessageInconsistenciesEntry messageUid(Long messageUid);
+        }
+    }
+
+    public static Builder.RequireMailboxId builder() {
+        return mailboxId -> messageId -> new MessageInconsistenciesEntry(mailboxId, messageId);
+    }
+
+    private final String mailboxId;
+    private final String messageId;
+
+    public MessageInconsistenciesEntry(@JsonProperty("mailboxId") String mailboxId,
+                                        @JsonProperty("messageId") String messageId) {
+        this.mailboxId = mailboxId;
+        this.messageId = messageId;
+    }
+
+    @JsonProperty("mailboxId")
+    public String getMailboxId() {
+        return mailboxId;
+    }
+
+    @JsonProperty("messageId")
+    public String getMessageId() {
+        return messageId;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o instanceof MessageInconsistenciesEntry) {
+            MessageInconsistenciesEntry that = (MessageInconsistenciesEntry) o;
+
+            return Objects.equals(this.mailboxId, that.mailboxId)
+                && Objects.equals(this.messageId, that.messageId);
+        }
+        return false;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(mailboxId, messageId);
+    }
+}

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/task/MetaDataFixInconsistenciesAdditionalInformationDTO.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/task/MetaDataFixInconsistenciesAdditionalInformationDTO.java
@@ -1,0 +1,137 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.pop3server.mailbox.task;
+
+import java.time.Instant;
+
+import org.apache.james.json.DTOModule;
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesService.RunningOptions;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+public class MetaDataFixInconsistenciesAdditionalInformationDTO implements AdditionalInformationDTO {
+
+    public static AdditionalInformationDTOModule<MetaDataFixInconsistenciesTask.AdditionalInformation, MetaDataFixInconsistenciesAdditionalInformationDTO> module() {
+        return DTOModule.forDomainObject(MetaDataFixInconsistenciesTask.AdditionalInformation.class)
+            .convertToDTO(MetaDataFixInconsistenciesAdditionalInformationDTO.class)
+            .toDomainObjectConverter(MetaDataFixInconsistenciesAdditionalInformationDTO::toDomainObject)
+            .toDTOConverter(MetaDataFixInconsistenciesAdditionalInformationDTO::toDto)
+            .typeName(MetaDataFixInconsistenciesTask.TASK_TYPE.asString())
+            .withFactory(AdditionalInformationDTOModule::new);
+    }
+
+    private static MetaDataFixInconsistenciesTask.AdditionalInformation toDomainObject(MetaDataFixInconsistenciesAdditionalInformationDTO dto) {
+        return new MetaDataFixInconsistenciesTask.AdditionalInformation(
+            dto.getTimestamp(),
+            dto.getRunningOptions(),
+            dto.getProcessedImapUidEntries(),
+            dto.getProcessedPop3MetaDataStoreEntries(),
+            dto.getStalePOP3Entries(),
+            dto.getMissingPOP3Entries(),
+            dto.getFixedInconsistencies(),
+            dto.getErrors());
+    }
+
+    private static MetaDataFixInconsistenciesAdditionalInformationDTO toDto(MetaDataFixInconsistenciesTask.AdditionalInformation details, String type) {
+        return new MetaDataFixInconsistenciesAdditionalInformationDTO(
+            details.timestamp(),
+            type,
+            details.getRunningOptions(),
+            details.getProcessedImapUidEntries(),
+            details.getProcessedPop3MetaDataStoreEntries(),
+            details.getStalePOP3Entries(),
+            details.getMissingPOP3Entries(),
+            details.getFixedInconsistencies(),
+            details.getErrors());
+    }
+
+    private final Instant timestamp;
+    private final String type;
+    private final RunningOptions runningOptions;
+    private final long processedImapUidEntries;
+    private final long processedPop3MetaDataStoreEntries;
+    private final long stalePOP3Entries;
+    private final long missingPOP3Entries;
+    private final ImmutableList<MessageInconsistenciesEntry> fixedInconsistencies;
+    private final ImmutableList<MessageInconsistenciesEntry> errors;
+
+    @JsonCreator
+    public MetaDataFixInconsistenciesAdditionalInformationDTO(@JsonProperty("timestamp") Instant timestamp,
+                                                              @JsonProperty("type") String type,
+                                                              @JsonProperty("runningOptions") RunningOptions runningOptions,
+                                                              @JsonProperty("processedImapUidEntries") long processedImapUidEntries,
+                                                              @JsonProperty("processedPop3MetaDataStoreEntries") long processedPop3MetaDataStoreEntries,
+                                                              @JsonProperty("stalePOP3Entries") long stalePOP3Entries,
+                                                              @JsonProperty("missingPOP3Entries") long missingPOP3Entries,
+                                                              @JsonProperty("fixedInconsistencies") ImmutableList<MessageInconsistenciesEntry> fixedInconsistencies,
+                                                              @JsonProperty("errors") ImmutableList<MessageInconsistenciesEntry> errors) {
+        this.timestamp = timestamp;
+        this.type = type;
+        this.runningOptions = runningOptions;
+        this.processedImapUidEntries = processedImapUidEntries;
+        this.processedPop3MetaDataStoreEntries = processedPop3MetaDataStoreEntries;
+        this.stalePOP3Entries = stalePOP3Entries;
+        this.missingPOP3Entries = missingPOP3Entries;
+        this.fixedInconsistencies = fixedInconsistencies;
+        this.errors = errors;
+    }
+
+    public RunningOptions getRunningOptions() {
+        return runningOptions;
+    }
+
+    public long getProcessedImapUidEntries() {
+        return processedImapUidEntries;
+    }
+
+    public long getProcessedPop3MetaDataStoreEntries() {
+        return processedPop3MetaDataStoreEntries;
+    }
+
+    public long getStalePOP3Entries() {
+        return stalePOP3Entries;
+    }
+
+    public long getMissingPOP3Entries() {
+        return missingPOP3Entries;
+    }
+
+    public ImmutableList<MessageInconsistenciesEntry> getFixedInconsistencies() {
+        return fixedInconsistencies;
+    }
+
+    public ImmutableList<MessageInconsistenciesEntry> getErrors() {
+        return errors;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+}

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/task/MetaDataFixInconsistenciesDTO.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/task/MetaDataFixInconsistenciesDTO.java
@@ -1,0 +1,69 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.pop3server.mailbox.task;
+
+import org.apache.james.json.DTOModule;
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesService.RunningOptions;
+import org.apache.james.server.task.json.dto.TaskDTO;
+import org.apache.james.server.task.json.dto.TaskDTOModule;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MetaDataFixInconsistenciesDTO implements TaskDTO {
+    public static TaskDTOModule<MetaDataFixInconsistenciesTask, MetaDataFixInconsistenciesDTO> module(MetaDataFixInconsistenciesService service) {
+        return DTOModule.forDomainObject(MetaDataFixInconsistenciesTask.class)
+            .convertToDTO(MetaDataFixInconsistenciesDTO.class)
+            .toDomainObjectConverter(dto -> toDomainObject(dto, service))
+            .toDTOConverter(MetaDataFixInconsistenciesDTO::toDto)
+            .typeName(MetaDataFixInconsistenciesTask.TASK_TYPE.asString())
+            .withFactory(TaskDTOModule::new);
+    }
+
+    private static MetaDataFixInconsistenciesTask toDomainObject(MetaDataFixInconsistenciesDTO dto,
+                                                                 MetaDataFixInconsistenciesService service) {
+        return new MetaDataFixInconsistenciesTask(service, dto.getRunningOptions());
+    }
+
+    private static MetaDataFixInconsistenciesDTO toDto(MetaDataFixInconsistenciesTask details, String type) {
+        return new MetaDataFixInconsistenciesDTO(
+            details.getRunningOptions(),
+            type);
+    }
+
+    private final RunningOptions runningOptions;
+    private final String type;
+
+    @JsonCreator
+    public MetaDataFixInconsistenciesDTO(@JsonProperty("runningOptions") RunningOptions runningOptions,
+                                         @JsonProperty("type") String type) {
+        this.runningOptions = runningOptions;
+        this.type = type;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    public RunningOptions getRunningOptions() {
+        return runningOptions;
+    }
+}

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/task/MetaDataFixInconsistenciesService.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/task/MetaDataFixInconsistenciesService.java
@@ -1,0 +1,457 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.pop3server.mailbox.task;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.inject.Inject;
+
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAOV3;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdToImapUidDAO;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.mailbox.store.mail.MessageMapper.FetchType;
+import org.apache.james.pop3server.mailbox.Pop3MetadataStore;
+import org.apache.james.task.Task;
+import org.apache.james.util.ReactorUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class MetaDataFixInconsistenciesService {
+
+    @FunctionalInterface
+    interface Inconsistency {
+        Mono<Task.Result> fix(Context context, CassandraMessageIdToImapUidDAO imapUidDAO, Pop3MetadataStore pop3MetadataStore);
+    }
+
+    static final Inconsistency NO_INCONSISTENCY = (context, imapUidDAO, pop3MetadataStore) -> Mono.just(Task.Result.COMPLETED);
+
+    private static class StalePOP3EntryConsistency implements Inconsistency {
+        private final MailboxId mailboxId;
+        private final MessageId messageId;
+
+        private StalePOP3EntryConsistency(MailboxId mailboxId, MessageId messageId) {
+            this.mailboxId = mailboxId;
+            this.messageId = messageId;
+        }
+
+        @Override
+        public Mono<Task.Result> fix(Context context,
+                                     CassandraMessageIdToImapUidDAO imapUidDAO,
+                                     Pop3MetadataStore pop3MetadataStore) {
+            return Mono.from(pop3MetadataStore.remove(mailboxId, messageId))
+                .doOnSuccess(any -> notifySuccess(context))
+                .thenReturn(Task.Result.COMPLETED)
+                .onErrorResume(error -> {
+                    notifyFailure(context);
+                    return Mono.just(Task.Result.PARTIAL);
+                });
+        }
+
+        private void notifyFailure(Context context) {
+            context.addErrors(MessageInconsistenciesEntry.builder()
+                .mailboxId(mailboxId.serialize())
+                .messageId(messageId.serialize()));
+            LOGGER.error("Failed to fix inconsistency for stale POP3 entry: {}", messageId);
+        }
+
+        private void notifySuccess(Context context) {
+            context.incrementStalePOP3Entries();
+            context.addFixedInconsistency(MessageInconsistenciesEntry.builder()
+                .mailboxId(mailboxId.serialize())
+                .messageId(messageId.serialize()));
+            LOGGER.info("Inconsistency fixed for stale POP3 entry: {}", messageId);
+        }
+    }
+
+    private static class MissingPOP3EntryInconsistency implements Inconsistency {
+        private final MailboxId mailboxId;
+        private final CassandraMessageId messageId;
+        private final CassandraMessageDAOV3 cassandraMessageDAOV3;
+
+        private MissingPOP3EntryInconsistency(MailboxId mailboxId,
+                                              CassandraMessageId messageId,
+                                              CassandraMessageDAOV3 cassandraMessageDAOV3) {
+            this.mailboxId = mailboxId;
+            this.messageId = messageId;
+            this.cassandraMessageDAOV3 = cassandraMessageDAOV3;
+        }
+
+        @Override
+        public Mono<Task.Result> fix(Context context,
+                                     CassandraMessageIdToImapUidDAO imapUidDAO,
+                                     Pop3MetadataStore pop3MetadataStore) {
+            return buildStatMetadata()
+                .flatMap(statMetadata -> Mono.from(pop3MetadataStore.add(mailboxId, statMetadata)))
+                .doOnSuccess(any -> notifySuccess(context))
+                .thenReturn(Task.Result.COMPLETED)
+                .onErrorResume(error -> {
+                    notifyFailure(context);
+                    return Mono.just(Task.Result.PARTIAL);
+                });
+        }
+
+        private Mono<Pop3MetadataStore.StatMetadata> buildStatMetadata() {
+            return cassandraMessageDAOV3.retrieveMessage(messageId, FetchType.Metadata)
+                .switchIfEmpty(Mono.error(new MailboxException("Message not found: " + messageId)))
+                .map(messageRepresentation -> new Pop3MetadataStore.StatMetadata(messageId, messageRepresentation.getSize()));
+        }
+
+
+        private void notifyFailure(Context context) {
+            context.addErrors(MessageInconsistenciesEntry.builder()
+                .mailboxId(mailboxId.serialize())
+                .messageId(messageId.serialize()));
+            LOGGER.error("Failed to fix inconsistency for missing POP3 entry: {}", messageId);
+        }
+
+        private void notifySuccess(Context context) {
+            context.incrementMissingPOP3Entries();
+            context.addFixedInconsistency(MessageInconsistenciesEntry.builder()
+                .mailboxId(mailboxId.serialize())
+                .messageId(messageId.serialize()));
+            LOGGER.info("Inconsistency fixed for missing POP3 entry: {}", messageId);
+        }
+    }
+
+    private static class FailToDetectInconsistency implements Inconsistency {
+        private final MailboxId mailboxId;
+        private final MessageId messageId;
+
+        private FailToDetectInconsistency(MailboxId mailboxId, MessageId messageId) {
+            this.mailboxId = mailboxId;
+            this.messageId = messageId;
+        }
+
+        @Override
+        public Mono<Task.Result> fix(Context context,
+                                     CassandraMessageIdToImapUidDAO imapUidDAO,
+                                     Pop3MetadataStore pop3MetadataStore) {
+            context.addErrors(MessageInconsistenciesEntry.builder()
+                .mailboxId(mailboxId.serialize())
+                .messageId(messageId.serialize()));
+            LOGGER.error("Failed to detect inconsistency: {}", messageId);
+            return Mono.just(Task.Result.PARTIAL);
+        }
+    }
+
+    public static class Context {
+        public static class Snapshot {
+            public static Builder builder() {
+                return new Builder();
+            }
+
+            public static class Builder {
+                private Optional<Long> processedImapUidEntries;
+                private Optional<Long> processedPop3MetaDataStoreEntries;
+                private Optional<Long> stalePOP3Entries;
+                private Optional<Long> missingPOP3Entries;
+                private ImmutableList.Builder<MessageInconsistenciesEntry> fixedInconsistencies;
+                private ImmutableList.Builder<MessageInconsistenciesEntry> errors;
+
+                Builder() {
+                    processedImapUidEntries = Optional.empty();
+                    processedPop3MetaDataStoreEntries = Optional.empty();
+                    stalePOP3Entries = Optional.empty();
+                    missingPOP3Entries = Optional.empty();
+                    fixedInconsistencies = ImmutableList.builder();
+                    errors = ImmutableList.builder();
+                }
+
+                public Builder processedImapUidEntries(long count) {
+                    this.processedImapUidEntries = Optional.of(count);
+                    return this;
+                }
+
+                public Builder processedPop3MetaDataStoreEntries(long count) {
+                    this.processedPop3MetaDataStoreEntries = Optional.of(count);
+                    return this;
+                }
+
+                public Builder stalePOP3Entries(long count) {
+                    this.stalePOP3Entries = Optional.of(count);
+                    return this;
+                }
+
+                public Builder missingPOP3Entries(long count) {
+                    this.missingPOP3Entries = Optional.of(count);
+                    return this;
+                }
+
+                public Builder addFixedInconsistencies(MessageInconsistenciesEntry messageInconsistenciesEntry) {
+                    fixedInconsistencies.add(messageInconsistenciesEntry);
+                    return this;
+                }
+
+                public Builder errors(MessageInconsistenciesEntry messageInconsistenciesEntry) {
+                    errors.add(messageInconsistenciesEntry);
+                    return this;
+                }
+
+                public Snapshot build() {
+                    return new Snapshot(
+                        processedImapUidEntries.orElse(0L),
+                        processedPop3MetaDataStoreEntries.orElse(0L),
+                        stalePOP3Entries.orElse(0L),
+                        missingPOP3Entries.orElse(0L),
+                        fixedInconsistencies.build(),
+                        errors.build());
+                }
+            }
+
+            private final long processedImapUidEntries;
+            private final long processedPop3MetaDataStoreEntries;
+            private final long stalePOP3Entries;
+            private final long missingPOP3Entries;
+            private final ImmutableList<MessageInconsistenciesEntry> fixedInconsistencies;
+            private final ImmutableList<MessageInconsistenciesEntry> errors;
+
+            public Snapshot(long processedImapUidEntries,
+                            long processedPop3MetaDataStoreEntries,
+                            long stalePOP3Entries,
+                            long missingPOP3Entries,
+                            ImmutableList<MessageInconsistenciesEntry> fixedInconsistencies,
+                            ImmutableList<MessageInconsistenciesEntry> errors) {
+                this.processedImapUidEntries = processedImapUidEntries;
+                this.processedPop3MetaDataStoreEntries = processedPop3MetaDataStoreEntries;
+                this.stalePOP3Entries = stalePOP3Entries;
+                this.missingPOP3Entries = missingPOP3Entries;
+                this.fixedInconsistencies = fixedInconsistencies;
+                this.errors = errors;
+            }
+
+            @Override
+            public final int hashCode() {
+                return Objects.hash(processedPop3MetaDataStoreEntries, processedImapUidEntries, errors, fixedInconsistencies);
+            }
+
+            @Override
+            public final boolean equals(Object obj) {
+                if (obj instanceof Snapshot) {
+                    Snapshot snapshot = (Snapshot) obj;
+                    return Objects.equals(this.processedPop3MetaDataStoreEntries, snapshot.processedPop3MetaDataStoreEntries)
+                        && Objects.equals(this.processedImapUidEntries, snapshot.processedImapUidEntries)
+                        && Objects.equals(this.fixedInconsistencies, snapshot.fixedInconsistencies)
+                        && Objects.equals(this.errors, snapshot.errors);
+                }
+                return false;
+            }
+
+            @Override
+            public String toString() {
+                return MoreObjects.toStringHelper(this)
+                    .add("processedPop3MetaDataStoreEntries", processedPop3MetaDataStoreEntries)
+                    .add("processedImapUidEntries", processedImapUidEntries)
+                    .add("stalePOP3Entries", stalePOP3Entries)
+                    .add("missingPOP3Entries", missingPOP3Entries)
+                    .add("fixedInconsistencies", fixedInconsistencies)
+                    .add("errors", errors)
+                    .toString();
+            }
+
+            public long getProcessedImapUidEntries() {
+                return processedImapUidEntries;
+            }
+
+            public long getProcessedPop3MetaDataStoreEntries() {
+                return processedPop3MetaDataStoreEntries;
+            }
+
+            public long getStalePOP3Entries() {
+                return stalePOP3Entries;
+            }
+
+            public long getMissingPOP3Entries() {
+                return missingPOP3Entries;
+            }
+
+            public ImmutableList<MessageInconsistenciesEntry> getFixedInconsistencies() {
+                return fixedInconsistencies;
+            }
+
+            public ImmutableList<MessageInconsistenciesEntry> getErrors() {
+                return errors;
+            }
+        }
+
+        private final AtomicLong processedImapUidEntries;
+        private final AtomicLong processedPop3MetaDataStoreEntries;
+        private final AtomicLong stalePOP3Entries;
+        private final AtomicLong missingPOP3Entries;
+        private final ConcurrentLinkedDeque<MessageInconsistenciesEntry> fixedInconsistencies;
+        private final ConcurrentLinkedDeque<MessageInconsistenciesEntry> errors;
+
+        public Context() {
+            this(new AtomicLong(), new AtomicLong(), new AtomicLong(), new AtomicLong(), ImmutableList.of(), ImmutableList.of());
+        }
+
+        private Context(AtomicLong processedImapUidEntries,
+                        AtomicLong processedPop3MetaDataStoreEntries,
+                        AtomicLong stalePOP3Entries,
+                        AtomicLong missingPOP3Entries,
+                        Collection<MessageInconsistenciesEntry> fixedInconsistencies,
+                        Collection<MessageInconsistenciesEntry> errors) {
+            this.processedImapUidEntries = processedImapUidEntries;
+            this.processedPop3MetaDataStoreEntries = processedPop3MetaDataStoreEntries;
+            this.stalePOP3Entries = stalePOP3Entries;
+            this.missingPOP3Entries = missingPOP3Entries;
+            this.fixedInconsistencies = new ConcurrentLinkedDeque<>(fixedInconsistencies);
+            this.errors = new ConcurrentLinkedDeque<>(errors);
+        }
+
+        void incrementProcessedImapUidEntries() {
+            processedImapUidEntries.incrementAndGet();
+        }
+
+        void incrementProcessedPop3MetaDataStoreEntries() {
+            processedPop3MetaDataStoreEntries.incrementAndGet();
+        }
+
+        void incrementStalePOP3Entries() {
+            stalePOP3Entries.getAndIncrement();
+        }
+
+        void incrementMissingPOP3Entries() {
+            missingPOP3Entries.incrementAndGet();
+        }
+
+        void addFixedInconsistency(MessageInconsistenciesEntry messageInconsistenciesEntry) {
+            fixedInconsistencies.add(messageInconsistenciesEntry);
+        }
+
+        void addErrors(MessageInconsistenciesEntry messageInconsistenciesEntry) {
+            errors.add(messageInconsistenciesEntry);
+        }
+
+        public Snapshot snapshot() {
+            return new Snapshot(
+                processedImapUidEntries.get(),
+                processedPop3MetaDataStoreEntries.get(),
+                stalePOP3Entries.get(),
+                missingPOP3Entries.get(),
+                ImmutableList.copyOf(fixedInconsistencies),
+                ImmutableList.copyOf(errors));
+        }
+    }
+
+    public static class RunningOptions {
+        public static RunningOptions withMessageRatePerSecond(int messageRatePerSecond) {
+            return new RunningOptions(messageRatePerSecond);
+        }
+
+        public static final RunningOptions DEFAULT = new RunningOptions(100);
+
+        private final int messagesPerSecond;
+
+        @JsonCreator
+        public RunningOptions(@JsonProperty("messagesPerSecond") int messagesPerSecond) {
+            Preconditions.checkArgument(messagesPerSecond > 0, "'messagesPerSecond' must be strictly positive");
+
+            this.messagesPerSecond = messagesPerSecond;
+        }
+
+        public int getMessagesPerSecond() {
+            return this.messagesPerSecond;
+        }
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetaDataFixInconsistenciesService.class);
+    private static final Duration PERIOD = Duration.ofSeconds(1);
+
+    private final CassandraMessageIdToImapUidDAO imapUidDAO;
+    private final Pop3MetadataStore pop3MetadataStore;
+    private final CassandraMessageDAOV3 cassandraMessageDAOV3;
+
+    @Inject
+    public MetaDataFixInconsistenciesService(CassandraMessageIdToImapUidDAO imapUidDAO,
+                                             Pop3MetadataStore pop3MetadataStore,
+                                             CassandraMessageDAOV3 cassandraMessageDAOV3) {
+        this.imapUidDAO = imapUidDAO;
+        this.pop3MetadataStore = pop3MetadataStore;
+        this.cassandraMessageDAOV3 = cassandraMessageDAOV3;
+    }
+
+    public Mono<Task.Result> fixInconsistencies(Context context, RunningOptions runningOptions) {
+        return Flux.concat(
+            fixInconsistenciesInPop3MetaDataStore(context, runningOptions),
+            fixInconsistenciesInImapUid(context, runningOptions))
+            .reduce(Task.Result.COMPLETED, Task::combine);
+
+    }
+
+    private Flux<Task.Result> fixInconsistenciesInPop3MetaDataStore(Context context, RunningOptions runningOptions) {
+        return Flux.from(pop3MetadataStore.listAllEntries())
+            .transform(ReactorUtils.<Pop3MetadataStore.FullMetadata, Task.Result>throttle()
+                .elements(runningOptions.getMessagesPerSecond())
+                .per(PERIOD)
+                .forOperation(fullMetadata -> detectStaleEntriesInPop3MetaDataStore(fullMetadata)
+                    .doOnNext(any -> context.incrementProcessedPop3MetaDataStoreEntries())
+                    .flatMap(inconsistency -> inconsistency.fix(context, imapUidDAO, pop3MetadataStore))));
+    }
+
+    private Mono<Inconsistency> detectStaleEntriesInPop3MetaDataStore(Pop3MetadataStore.FullMetadata fullMetadata) {
+        CassandraId mailboxId = (CassandraId) fullMetadata.getMailboxId();
+        CassandraMessageId messageId = (CassandraMessageId) fullMetadata.getMessageId();
+        return imapUidDAO.retrieve(messageId, Optional.of(mailboxId))
+            .next()
+            .flatMap(any -> Mono.just(NO_INCONSISTENCY))
+            .switchIfEmpty(Mono.just(new StalePOP3EntryConsistency(mailboxId, messageId)))
+            .onErrorResume(error -> Mono.just(new FailToDetectInconsistency(mailboxId, messageId)));
+    }
+
+    private Flux<Task.Result> fixInconsistenciesInImapUid(Context context, RunningOptions runningOptions) {
+        return imapUidDAO.retrieveAllMessages()
+            .transform(ReactorUtils.<ComposedMessageIdWithMetaData, Task.Result>throttle()
+                .elements(runningOptions.getMessagesPerSecond())
+                .per(PERIOD)
+                .forOperation(metaData -> detectMissingEntriesInPop3MetaDataStore(metaData)
+                    .doOnNext(any -> context.incrementProcessedImapUidEntries())
+                    .flatMap(inconsistency -> inconsistency.fix(context, imapUidDAO, pop3MetadataStore))));
+    }
+
+    private Mono<Inconsistency> detectMissingEntriesInPop3MetaDataStore(ComposedMessageIdWithMetaData messageFromImapUid) {
+        CassandraId mailboxId = (CassandraId) messageFromImapUid.getComposedMessageId().getMailboxId();
+        CassandraMessageId messageId = (CassandraMessageId) messageFromImapUid.getComposedMessageId().getMessageId();
+
+        return Flux.from(pop3MetadataStore.retrieve(mailboxId, messageId))
+            .next()
+            .flatMap(any -> Mono.just(NO_INCONSISTENCY))
+            .switchIfEmpty(Mono.just(new MissingPOP3EntryInconsistency(mailboxId, messageId, this.cassandraMessageDAOV3)))
+            .onErrorResume(error -> Mono.just(new FailToDetectInconsistency(mailboxId, messageId)));
+    }
+}

--- a/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/task/MetaDataFixInconsistenciesTask.java
+++ b/server/protocols/protocols-pop3-distributed/src/main/java/org/apache/james/pop3server/mailbox/task/MetaDataFixInconsistenciesTask.java
@@ -1,0 +1,151 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.pop3server.mailbox.task;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesService.Context;
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesService.RunningOptions;
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.task.TaskType;
+
+import com.google.common.collect.ImmutableList;
+
+import reactor.core.scheduler.Schedulers;
+
+public class MetaDataFixInconsistenciesTask implements Task {
+
+    public static final TaskType TASK_TYPE = TaskType.of("Pop3MetaDataFixInconsistenciesTask");
+
+    public static class AdditionalInformation implements TaskExecutionDetails.AdditionalInformation {
+
+        private static AdditionalInformation from(Context context,
+                                                  RunningOptions runningOptions) {
+            Context.Snapshot snapshot = context.snapshot();
+            return new AdditionalInformation(
+                Clock.systemUTC().instant(),
+                runningOptions,
+                snapshot.getProcessedImapUidEntries(),
+                snapshot.getProcessedPop3MetaDataStoreEntries(),
+                snapshot.getStalePOP3Entries(),
+                snapshot.getMissingPOP3Entries(),
+                snapshot.getFixedInconsistencies(),
+                snapshot.getErrors());
+        }
+
+        private final Instant timestamp;
+        private final RunningOptions runningOptions;
+        private final long processedImapUidEntries;
+        private final long processedPop3MetaDataStoreEntries;
+        private final long stalePOP3Entries;
+        private final long missingPOP3Entries;
+        private final ImmutableList<MessageInconsistenciesEntry> fixedInconsistencies;
+        private final ImmutableList<MessageInconsistenciesEntry> errors;
+
+        public AdditionalInformation(Instant timestamp,
+                                     RunningOptions runningOptions,
+                                     long processedImapUidEntries,
+                                     long processedPop3MetaDataStoreEntries,
+                                     long stalePOP3Entries,
+                                     long missingPOP3Entries,
+                                     ImmutableList<MessageInconsistenciesEntry> fixedInconsistencies,
+                                     ImmutableList<MessageInconsistenciesEntry> errors) {
+            this.timestamp = timestamp;
+            this.runningOptions = runningOptions;
+            this.processedImapUidEntries = processedImapUidEntries;
+            this.processedPop3MetaDataStoreEntries = processedPop3MetaDataStoreEntries;
+            this.stalePOP3Entries = stalePOP3Entries;
+            this.missingPOP3Entries = missingPOP3Entries;
+            this.fixedInconsistencies = fixedInconsistencies;
+            this.errors = errors;
+        }
+
+        public RunningOptions getRunningOptions() {
+            return runningOptions;
+        }
+
+        public long getProcessedImapUidEntries() {
+            return processedImapUidEntries;
+        }
+
+        public long getProcessedPop3MetaDataStoreEntries() {
+            return processedPop3MetaDataStoreEntries;
+        }
+
+        public long getStalePOP3Entries() {
+            return stalePOP3Entries;
+        }
+
+        public long getMissingPOP3Entries() {
+            return missingPOP3Entries;
+        }
+
+        public ImmutableList<MessageInconsistenciesEntry> getFixedInconsistencies() {
+            return fixedInconsistencies;
+        }
+
+        public ImmutableList<MessageInconsistenciesEntry> getErrors() {
+            return errors;
+        }
+
+        @Override
+        public Instant timestamp() {
+            return timestamp;
+        }
+    }
+
+    private final MetaDataFixInconsistenciesService metaDataFixInconsistenciesService;
+    private final Context context;
+    private final RunningOptions runningOptions;
+
+    @Inject
+    public MetaDataFixInconsistenciesTask(MetaDataFixInconsistenciesService metaDataFixInconsistenciesService,
+                                          RunningOptions runningOptions) {
+        this.metaDataFixInconsistenciesService = metaDataFixInconsistenciesService;
+        this.context = new Context();
+        this.runningOptions = runningOptions;
+    }
+
+    @Override
+    public Result run() throws InterruptedException {
+        return metaDataFixInconsistenciesService.fixInconsistencies(context, runningOptions)
+            .subscribeOn(Schedulers.elastic())
+            .block();
+    }
+
+    @Override
+    public TaskType type() {
+        return TASK_TYPE;
+    }
+
+    @Override
+    public Optional<TaskExecutionDetails.AdditionalInformation> details() {
+        return Optional.of(AdditionalInformation.from(context, runningOptions));
+    }
+
+    public RunningOptions getRunningOptions() {
+        return runningOptions;
+    }
+}

--- a/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/CassandraPop3MetadataStoreTest.java
+++ b/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/CassandraPop3MetadataStoreTest.java
@@ -1,0 +1,58 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.pop3server;
+
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.pop3server.mailbox.CassandraPop3MetadataStore;
+import org.apache.james.pop3server.mailbox.Pop3MetadataModule;
+import org.apache.james.pop3server.mailbox.Pop3MetadataStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class CassandraPop3MetadataStoreTest implements Pop3MetadataStoreContract {
+    @RegisterExtension
+    static CassandraClusterExtension cassandra = new CassandraClusterExtension(Pop3MetadataModule.MODULE);
+
+    CassandraPop3MetadataStore testee;
+
+    @BeforeEach
+    void setUp() {
+        testee = new CassandraPop3MetadataStore(cassandra.getCassandraCluster().getConf());
+    }
+
+    @Override
+    public Pop3MetadataStore testee() {
+        return testee;
+    }
+
+    @Override
+    public MailboxId generateMailboxId() {
+        return CassandraId.timeBased();
+    }
+
+    @Override
+    public MessageId generateMessageId() {
+        return new CassandraMessageId.Factory().generate();
+    }
+}

--- a/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/DistributedPop3ServerTest.java
+++ b/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/DistributedPop3ServerTest.java
@@ -1,0 +1,81 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.pop3server;
+
+import org.apache.james.filesystem.api.FileSystem;
+import org.apache.james.filesystem.api.mock.MockFileSystem;
+import org.apache.james.jmap.api.projections.EmailQueryView;
+import org.apache.james.jmap.event.PopulateEmailQueryViewListener;
+import org.apache.james.jmap.memory.projections.MemoryEmailQueryView;
+import org.apache.james.mailbox.MailboxManager;
+import org.apache.james.mailbox.MessageIdManager;
+import org.apache.james.mailbox.inmemory.manager.InMemoryIntegrationResources;
+import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.metrics.api.MetricFactory;
+import org.apache.james.metrics.tests.RecordingMetricFactory;
+import org.apache.james.pop3server.mailbox.DistributedMailboxAdapter;
+import org.apache.james.pop3server.mailbox.MailboxAdapterFactory;
+import org.apache.james.protocols.lib.mock.MockProtocolHandlerLoader;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.api.UsersRepositoryException;
+
+import com.google.inject.name.Names;
+
+public class DistributedPop3ServerTest extends POP3ServerTest {
+    protected void setUpServiceManager() throws Exception {
+        InMemoryIntegrationResources memoryIntegrationResources = InMemoryIntegrationResources.builder()
+            .authenticator((userid, passwd) -> {
+                try {
+                    return usersRepository.test(userid, passwd.toString());
+                } catch (UsersRepositoryException e) {
+                    e.printStackTrace();
+                    return false;
+                }
+            })
+            .fakeAuthorizator()
+            .inVmEventBus()
+            .defaultAnnotationLimits()
+            .defaultMessageParser()
+            .scanningSearchIndex()
+            .noPreDeletionHooks()
+            .storeQuotaManager()
+            .build();
+        mailboxManager = memoryIntegrationResources
+            .getMailboxManager();
+        MemoryEmailQueryView emailQueryView = new MemoryEmailQueryView();
+        fileSystem = new MockFileSystem();
+        mailboxManager.getEventBus().register(
+            new PopulateEmailQueryViewListener(
+                memoryIntegrationResources.getMessageIdManager(),
+                emailQueryView,
+                mailboxManager));
+
+        protocolHandlerChain = MockProtocolHandlerLoader.builder()
+            .put(binder -> binder.bind(UsersRepository.class).toInstance(usersRepository))
+            .put(binder -> binder.bind(MailboxManager.class).annotatedWith(Names.named("mailboxmanager")).toInstance(mailboxManager))
+            .put(binder -> binder.bind(FileSystem.class).toInstance(fileSystem))
+            .put(binder -> binder.bind(MailboxAdapterFactory.class).to(DistributedMailboxAdapter.Factory.class))
+            .put(binder -> binder.bind(EmailQueryView.class).toInstance(emailQueryView))
+            .put(binder -> binder.bind(MessageIdManager.class).toInstance(memoryIntegrationResources.getMessageIdManager()))
+            .put(binder -> binder.bind(MessageId.Factory.class).toInstance(memoryIntegrationResources.getMessageIdFactory()))
+            .put(binder -> binder.bind(MetricFactory.class).to(RecordingMetricFactory.class))
+            .build();
+    }
+}

--- a/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/MemoryPop3MetadataStoreTest.java
+++ b/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/MemoryPop3MetadataStoreTest.java
@@ -1,0 +1,54 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.pop3server;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.apache.james.mailbox.inmemory.InMemoryId;
+import org.apache.james.mailbox.inmemory.InMemoryMessageId;
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.pop3server.mailbox.MemoryPop3MetadataStore;
+import org.apache.james.pop3server.mailbox.Pop3MetadataStore;
+import org.junit.jupiter.api.BeforeEach;
+
+class MemoryPop3MetadataStoreTest implements Pop3MetadataStoreContract {
+    MemoryPop3MetadataStore testee;
+
+    @BeforeEach
+    void setUp() {
+        testee = new MemoryPop3MetadataStore();
+    }
+
+    @Override
+    public Pop3MetadataStore testee() {
+        return testee;
+    }
+
+    @Override
+    public MailboxId generateMailboxId() {
+        return InMemoryId.of(ThreadLocalRandom.current().nextInt(100000) + 100);
+    }
+
+    @Override
+    public MessageId generateMessageId() {
+        return InMemoryMessageId.of(ThreadLocalRandom.current().nextInt(100000) + 100);
+    }
+}

--- a/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/Pop3MetadataStoreContract.java
+++ b/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/Pop3MetadataStoreContract.java
@@ -1,0 +1,150 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.pop3server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.apache.james.mailbox.model.MailboxId;
+import org.apache.james.mailbox.model.MessageId;
+import org.apache.james.pop3server.mailbox.Pop3MetadataStore;
+import org.apache.james.pop3server.mailbox.Pop3MetadataStore.StatMetadata;
+import org.junit.jupiter.api.Test;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface Pop3MetadataStoreContract {
+
+    int SIZE_1 = 234;
+    int SIZE_2 = 456;
+
+    Pop3MetadataStore testee();
+
+    MailboxId generateMailboxId();
+
+    MessageId generateMessageId();
+
+    @Test
+    default void statShouldReturnEmptyByDefault() {
+        assertThat(
+            Flux.from(testee()
+                .stat(generateMailboxId()))
+                .collectList()
+                .block())
+            .isEmpty();
+    }
+
+    @Test
+    default void statShouldReturnPreviouslyAddedMetadata() {
+        MailboxId mailboxId = generateMailboxId();
+        StatMetadata metadata = new StatMetadata(generateMessageId(), SIZE_1);
+        Mono.from(testee().add(mailboxId, metadata)).block();
+
+        assertThat(
+            Flux.from(testee()
+                .stat(mailboxId))
+                .collectList()
+                .block())
+            .containsOnly(metadata);
+    }
+
+    @Test
+    default void statShouldReturnAllPreviouslyAddedMetadata() {
+        MailboxId mailboxId = generateMailboxId();
+        StatMetadata metadata1 = new StatMetadata(generateMessageId(), SIZE_1);
+        StatMetadata metadata2 = new StatMetadata(generateMessageId(), SIZE_2);
+        Mono.from(testee().add(mailboxId, metadata1)).block();
+        Mono.from(testee().add(mailboxId, metadata2)).block();
+
+        assertThat(
+            Flux.from(testee()
+                .stat(mailboxId))
+                .collectList()
+                .block())
+            .containsOnly(metadata1, metadata2);
+    }
+
+    @Test
+    default void statShouldNotReturnDeletedData() {
+        MailboxId mailboxId = generateMailboxId();
+        StatMetadata metadata1 = new StatMetadata(generateMessageId(), SIZE_1);
+        StatMetadata metadata2 = new StatMetadata(generateMessageId(), SIZE_2);
+        Mono.from(testee().add(mailboxId, metadata1)).block();
+        Mono.from(testee().add(mailboxId, metadata2)).block();
+
+        Mono.from(testee().remove(mailboxId, metadata2)).block();
+
+        assertThat(
+            Flux.from(testee()
+                .stat(mailboxId))
+                .collectList()
+                .block())
+            .containsOnly(metadata1);
+    }
+
+    @Test
+    default void statShouldNotReturnClearedData() {
+        MailboxId mailboxId = generateMailboxId();
+        StatMetadata metadata1 = new StatMetadata(generateMessageId(), SIZE_1);
+        StatMetadata metadata2 = new StatMetadata(generateMessageId(), SIZE_2);
+        Mono.from(testee().add(mailboxId, metadata1)).block();
+        Mono.from(testee().add(mailboxId, metadata2)).block();
+
+        Mono.from(testee().clear(mailboxId)).block();
+
+        assertThat(
+            Flux.from(testee()
+                .stat(mailboxId))
+                .collectList()
+                .block())
+            .isEmpty();
+    }
+
+    @Test
+    default void addShouldUpsert() {
+        MailboxId mailboxId = generateMailboxId();
+        MessageId messageId = generateMessageId();
+        StatMetadata metadata1 = new StatMetadata(messageId, SIZE_1);
+        StatMetadata metadata2 = new StatMetadata(messageId, SIZE_2);
+        Mono.from(testee().add(mailboxId, metadata1)).block();
+        Mono.from(testee().add(mailboxId, metadata2)).block();
+
+        assertThat(
+            Flux.from(testee()
+                .stat(mailboxId))
+                .collectList()
+                .block())
+            .containsOnly(metadata2);
+    }
+
+    @Test
+    default void clearShouldBeIdempotent() {
+        assertThatCode(() -> Mono.from(testee().clear(generateMailboxId())).block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    default void removeShouldBeIdempotent() {
+        StatMetadata metadata1= new StatMetadata(generateMessageId(), SIZE_1);
+        assertThatCode(() -> Mono.from(testee().remove(generateMailboxId(), metadata1)).block())
+            .doesNotThrowAnyException();
+    }
+}

--- a/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/Pop3MetadataStoreContract.java
+++ b/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/Pop3MetadataStoreContract.java
@@ -90,7 +90,7 @@ public interface Pop3MetadataStoreContract {
         Mono.from(testee().add(mailboxId, metadata1)).block();
         Mono.from(testee().add(mailboxId, metadata2)).block();
 
-        Mono.from(testee().remove(mailboxId, metadata2)).block();
+        Mono.from(testee().remove(mailboxId, metadata2.getMessageId())).block();
 
         assertThat(
             Flux.from(testee()
@@ -144,7 +144,7 @@ public interface Pop3MetadataStoreContract {
     @Test
     default void removeShouldBeIdempotent() {
         StatMetadata metadata1= new StatMetadata(generateMessageId(), SIZE_1);
-        assertThatCode(() -> Mono.from(testee().remove(generateMailboxId(), metadata1)).block())
+        assertThatCode(() -> Mono.from(testee().remove(generateMailboxId(), metadata1.getMessageId())).block())
             .doesNotThrowAnyException();
     }
 }

--- a/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/task/MetaDataFixInconsistenciesAdditionalInformationDTOTest.java
+++ b/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/task/MetaDataFixInconsistenciesAdditionalInformationDTOTest.java
@@ -1,0 +1,70 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.pop3server.task;
+
+import java.time.Instant;
+
+import org.apache.james.JsonSerializationVerifier;
+import org.apache.james.pop3server.mailbox.task.MessageInconsistenciesEntry;
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesAdditionalInformationDTO;
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesService;
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesTask;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+class MetaDataFixInconsistenciesAdditionalInformationDTOTest {
+    private static final Instant INSTANT = Instant.parse("2007-12-03T10:15:30.00Z");
+    private static final String JSON = "{" +
+        "  \"timestamp\":\"2007-12-03T10:15:30Z\"," +
+        "  \"type\":\"Pop3MetaDataFixInconsistenciesTask\"," +
+        "  \"runningOptions\":{\"messagesPerSecond\":36}," +
+        "  \"processedImapUidEntries\":12," +
+        "  \"processedPop3MetaDataStoreEntries\":13," +
+        "  \"stalePOP3Entries\":14," +
+        "  \"missingPOP3Entries\":15," +
+        "  \"fixedInconsistencies\":[" +
+        "     {\"mailboxId\":\"a\",\"messageId\":\"b\"}," +
+        "     {\"mailboxId\":\"c\",\"messageId\":\"d\"}" +
+        "  ]," +
+        "  \"errors\":[" +
+        "     {\"mailboxId\":\"e\",\"messageId\":\"f\"}," +
+        "     {\"mailboxId\":\"g\",\"messageId\":\"h\"}" +
+        "  ]" +
+        "}";
+
+    @Test
+    public void shouldMatchSerializableContract() throws Exception {
+        JsonSerializationVerifier.dtoModule(MetaDataFixInconsistenciesAdditionalInformationDTO.module())
+            .bean(new MetaDataFixInconsistenciesTask.AdditionalInformation(
+                INSTANT,
+                MetaDataFixInconsistenciesService.RunningOptions.withMessageRatePerSecond(36),
+                12, 13, 14, 15,
+                ImmutableList.of(
+                    new MessageInconsistenciesEntry("a", "b"),
+                    new MessageInconsistenciesEntry("c", "d")),
+                ImmutableList.of(
+                    new MessageInconsistenciesEntry("e", "f"),
+                    new MessageInconsistenciesEntry("g", "h"))
+            ))
+            .json(JSON)
+            .verify();
+    }
+}

--- a/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/task/MetaDataFixInconsistenciesDTOTest.java
+++ b/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/task/MetaDataFixInconsistenciesDTOTest.java
@@ -1,0 +1,44 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.pop3server.task;
+
+import static org.mockito.Mockito.mock;
+
+import org.apache.james.JsonSerializationVerifier;
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesDTO;
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesService;
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesTask;
+import org.junit.jupiter.api.Test;
+
+class MetaDataFixInconsistenciesDTOTest {
+    private static final String JSON = "{" +
+        "  \"type\":\"Pop3MetaDataFixInconsistenciesTask\"," +
+        "  \"runningOptions\":{\"messagesPerSecond\":36}" +
+        "}";
+
+    @Test
+    public void shouldMatchSerializableContract() throws Exception {
+        MetaDataFixInconsistenciesService service = mock(MetaDataFixInconsistenciesService.class);
+        JsonSerializationVerifier.dtoModule(MetaDataFixInconsistenciesDTO.module(service))
+            .bean(new MetaDataFixInconsistenciesTask(service, MetaDataFixInconsistenciesService.RunningOptions.withMessageRatePerSecond(36)))
+            .json(JSON)
+            .verify();
+    }
+}

--- a/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/task/MetaDataFixInconsistenciesServiceTest.java
+++ b/server/protocols/protocols-pop3-distributed/src/test/java/org/apache/james/pop3server/task/MetaDataFixInconsistenciesServiceTest.java
@@ -1,0 +1,389 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.pop3server.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Optional;
+
+import javax.mail.Flags;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.init.configuration.CassandraConfiguration;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.cassandra.CassandraBlobModule;
+import org.apache.james.blob.cassandra.CassandraBlobStoreFactory;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.ModSeq;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAOV3;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdToImapUidDAO;
+import org.apache.james.mailbox.cassandra.modules.CassandraMessageModule;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.ByteContent;
+import org.apache.james.mailbox.model.ComposedMessageId;
+import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
+import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
+import org.apache.james.metrics.tests.RecordingMetricFactory;
+import org.apache.james.pop3server.mailbox.CassandraPop3MetadataStore;
+import org.apache.james.pop3server.mailbox.Pop3MetadataModule;
+import org.apache.james.pop3server.mailbox.Pop3MetadataStore;
+import org.apache.james.pop3server.mailbox.Pop3MetadataStore.StatMetadata;
+import org.apache.james.pop3server.mailbox.task.MessageInconsistenciesEntry;
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesService;
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesService.Context;
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesService.RunningOptions;
+import org.apache.james.task.Task;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableList;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class MetaDataFixInconsistenciesServiceTest {
+
+    private static final CassandraId MAILBOX_ID = CassandraId.timeBased();
+    private static final CassandraMessageId MESSAGE_ID_1 = new CassandraMessageId.Factory().fromString("d2bee791-7e63-11ea-883c-95b84008f979");
+    private static final CassandraMessageId MESSAGE_ID_2 = new CassandraMessageId.Factory().fromString("eeeeeeee-7e63-11ea-883c-95b84008f979");
+    private static final MessageUid MESSAGE_UID_1 = MessageUid.of(1L);
+    private static final MessageUid MESSAGE_UID_2 = MessageUid.of(2L);
+    private static final ModSeq MOD_SEQ_1 = ModSeq.of(1L);
+    private static final ModSeq MOD_SEQ_2 = ModSeq.of(2L);
+    private static final String CONTENT_MESSAGE = "CONTENT 123 BLA BLA";
+
+    private static final ComposedMessageIdWithMetaData MESSAGE_1 = ComposedMessageIdWithMetaData.builder()
+        .composedMessageId(new ComposedMessageId(MAILBOX_ID, MESSAGE_ID_1, MESSAGE_UID_1))
+        .modSeq(MOD_SEQ_1)
+        .flags(new Flags())
+        .build();
+
+    private static final ComposedMessageIdWithMetaData MESSAGE_2 = ComposedMessageIdWithMetaData.builder()
+        .composedMessageId(new ComposedMessageId(MAILBOX_ID, MESSAGE_ID_2, MESSAGE_UID_2))
+        .modSeq(MOD_SEQ_2)
+        .flags(new Flags())
+        .build();
+
+    private static final StatMetadata STAT_METADATA_1 = new StatMetadata(MESSAGE_ID_1, CONTENT_MESSAGE.length());
+    private static final StatMetadata STAT_METADATA_2 = new StatMetadata(MESSAGE_ID_2, CONTENT_MESSAGE.length());
+    private static final MessageInconsistenciesEntry MESSAGE_INCONSISTENCIES_ENTRY_1 = MessageInconsistenciesEntry.builder()
+        .mailboxId(MAILBOX_ID.serialize())
+        .messageId(MESSAGE_ID_1.serialize());
+
+    private static final MessageInconsistenciesEntry MESSAGE_INCONSISTENCIES_ENTRY_2 = MessageInconsistenciesEntry.builder()
+        .mailboxId(MAILBOX_ID.serialize())
+        .messageId(MESSAGE_ID_2.serialize());
+
+    private static final SimpleMailboxMessage MAILBOX_MESSAGE_1 = SimpleMailboxMessage.builder()
+        .messageId(MESSAGE_ID_1)
+        .mailboxId(MAILBOX_ID)
+        .uid(MESSAGE_UID_1)
+        .internalDate(new Date())
+        .bodyStartOctet(16)
+        .size(CONTENT_MESSAGE.length())
+        .content(new ByteContent(CONTENT_MESSAGE.getBytes(StandardCharsets.UTF_8)))
+        .flags(new Flags())
+        .properties(new PropertyBuilder())
+        .addAttachments(ImmutableList.of())
+        .build();
+
+    private static final SimpleMailboxMessage MAILBOX_MESSAGE_2 = SimpleMailboxMessage.builder()
+        .messageId(MESSAGE_ID_2)
+        .mailboxId(MAILBOX_ID)
+        .uid(MESSAGE_UID_2)
+        .internalDate(new Date())
+        .bodyStartOctet(16)
+        .size(CONTENT_MESSAGE.length())
+        .content(new ByteContent(CONTENT_MESSAGE.getBytes(StandardCharsets.UTF_8)))
+        .flags(new Flags())
+        .properties(new PropertyBuilder())
+        .addAttachments(ImmutableList.of())
+        .build();
+
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(
+        CassandraModule.aggregateModules(
+            CassandraSchemaVersionModule.MODULE,
+            CassandraMessageModule.MODULE,
+            CassandraBlobModule.MODULE,
+            Pop3MetadataModule.MODULE));
+
+    private CassandraMessageIdToImapUidDAO imapUidDAO;
+    private Pop3MetadataStore pop3MetadataStore;
+    private CassandraMessageDAOV3 cassandraMessageDAOV3;
+    private MetaDataFixInconsistenciesService testee;
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandra) {
+        pop3MetadataStore = new CassandraPop3MetadataStore(cassandra.getConf());
+        imapUidDAO = new CassandraMessageIdToImapUidDAO(
+            cassandra.getConf(),
+            cassandraCluster.getCassandraConsistenciesConfiguration(),
+            new CassandraMessageId.Factory(),
+            CassandraConfiguration.DEFAULT_CONFIGURATION);
+
+        cassandraMessageDAOV3 = new CassandraMessageDAOV3(
+            cassandra.getConf(),
+            cassandra.getTypesProvider(),
+            CassandraBlobStoreFactory.forTesting(cassandra.getConf(), new RecordingMetricFactory())
+                .passthrough(),
+            new HashBlobId.Factory(),
+            cassandraCluster.getCassandraConsistenciesConfiguration());
+        testee = new MetaDataFixInconsistenciesService(imapUidDAO, pop3MetadataStore, cassandraMessageDAOV3);
+    }
+
+    @Test
+    void fixInconsistenciesShouldReturnCompletedWhenNoData() {
+        assertThat(testee.fixInconsistencies(new Context(), RunningOptions.DEFAULT).block())
+            .isEqualTo(Task.Result.COMPLETED);
+    }
+
+    @Test
+    void fixInconsistenciesShouldReturnCompletedWhenConsistentData() {
+        imapUidDAO.insert(MESSAGE_1).block();
+        Mono.from(pop3MetadataStore.add(MAILBOX_ID, STAT_METADATA_1)).block();
+
+        assertThat(testee.fixInconsistencies(new Context(), RunningOptions.DEFAULT).block())
+            .isEqualTo(Task.Result.COMPLETED);
+    }
+
+    @Test
+    void fixInconsistenciesShouldReturnPartialWhenFailure() {
+        imapUidDAO.insert(MESSAGE_1).block();
+        assertThat(testee.fixInconsistencies(new Context(), RunningOptions.DEFAULT).block())
+            .isEqualTo(Task.Result.PARTIAL);
+    }
+
+    @Test
+    void fixInconsistenciesShouldNotAlterStateWhenConsistentData() {
+        imapUidDAO.insert(MESSAGE_1).block();
+        Mono.from(pop3MetadataStore.add(MAILBOX_ID, STAT_METADATA_1)).block();
+        testee.fixInconsistencies(new Context(), RunningOptions.DEFAULT).block();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(imapUidDAO.retrieveAllMessages().collectList().block())
+                .containsExactlyInAnyOrder(MESSAGE_1);
+            softly.assertThat(Flux.from(pop3MetadataStore.listAllEntries()).collectList().block())
+                .containsExactlyInAnyOrder(new Pop3MetadataStore.FullMetadata(MAILBOX_ID, STAT_METADATA_1));
+        });
+    }
+
+    @Test
+    void contextShouldNotBeUpdatedWhenNoData() {
+        Context context = new Context();
+        testee.fixInconsistencies(context, RunningOptions.DEFAULT).block();
+        assertThat(context.snapshot())
+            .isEqualTo(new Context().snapshot());
+    }
+
+    @Test
+    void contextShouldBeUpdatedWhenConsistentData() {
+        Context context = new Context();
+        imapUidDAO.insert(MESSAGE_1).block();
+        Mono.from(pop3MetadataStore.add(MAILBOX_ID, STAT_METADATA_1)).block();
+        testee.fixInconsistencies(context, RunningOptions.DEFAULT).block();
+
+        assertThat(context.snapshot())
+            .isEqualTo(Context.Snapshot.builder()
+                .processedImapUidEntries(1)
+                .processedPop3MetaDataStoreEntries(1)
+                .build());
+    }
+
+    @Test
+    void contextShouldBeUpdatedWhenStalePOP3Entries() throws MailboxException {
+        Context context = new Context();
+        Mono.from(pop3MetadataStore.add(MAILBOX_ID, STAT_METADATA_1)).block();
+        cassandraMessageDAOV3.save(MAILBOX_MESSAGE_1).block();
+        testee.fixInconsistencies(context, RunningOptions.DEFAULT).block();
+
+        assertThat(context.snapshot())
+            .isEqualTo(Context.Snapshot.builder()
+                .processedPop3MetaDataStoreEntries(1)
+                .stalePOP3Entries(1)
+                .addFixedInconsistencies(MESSAGE_INCONSISTENCIES_ENTRY_1)
+                .build());
+    }
+
+    @Test
+    void contextShouldBeUpdatedWhenMissingPOP3Entries() throws MailboxException {
+        Context context = new Context();
+        imapUidDAO.insert(MESSAGE_1).block();
+        cassandraMessageDAOV3.save(MAILBOX_MESSAGE_1).block();
+
+        testee.fixInconsistencies(context, RunningOptions.DEFAULT).block();
+
+        assertThat(context.snapshot())
+            .isEqualTo(Context.Snapshot.builder()
+                .processedImapUidEntries(1)
+                .missingPOP3Entries(1)
+                .addFixedInconsistencies(MESSAGE_INCONSISTENCIES_ENTRY_1)
+                .build());
+    }
+
+    @Test
+    void contextShouldBeUpdatedWhenMissingPOP3EntriesAndMissingMailboxMessage() {
+        Context context = new Context();
+        imapUidDAO.insert(MESSAGE_1).block();
+        testee.fixInconsistencies(context, RunningOptions.DEFAULT).block();
+
+        assertThat(context.snapshot())
+            .isEqualTo(Context.Snapshot.builder()
+                .processedImapUidEntries(1)
+                .missingPOP3Entries(1)
+                .errors(MESSAGE_INCONSISTENCIES_ENTRY_1)
+                .build());
+    }
+
+    @Nested
+    class ImapUidScanningTest {
+        @Test
+        void fixInconsistenciesShouldReturnCompletedWhenInconsistentData() throws MailboxException {
+            imapUidDAO.insert(MESSAGE_1).block();
+            cassandraMessageDAOV3.save(MAILBOX_MESSAGE_1).block();
+
+            assertThat(testee.fixInconsistencies(new Context(), RunningOptions.DEFAULT).block())
+                .isEqualTo(Task.Result.COMPLETED);
+        }
+
+        @Test
+        void fixInconsistenciesShouldResolveInconsistentData() throws MailboxException {
+            imapUidDAO.insert(MESSAGE_1).block();
+            cassandraMessageDAOV3.save(MAILBOX_MESSAGE_1).block();
+            testee.fixInconsistencies(new Context(), RunningOptions.DEFAULT).block();
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(imapUidDAO.retrieveAllMessages().collectList().block())
+                    .containsExactlyInAnyOrder(MESSAGE_1);
+                softly.assertThat(Flux.from(pop3MetadataStore.listAllEntries()).collectList().block())
+                    .containsExactlyInAnyOrder(new Pop3MetadataStore.FullMetadata(MAILBOX_ID, STAT_METADATA_1));
+            });
+        }
+
+        @Test
+        void fixInconsistenciesShouldResolveWhenMixCase() throws MailboxException {
+            imapUidDAO.insert(MESSAGE_1).block();
+            cassandraMessageDAOV3.save(MAILBOX_MESSAGE_1).block();
+            imapUidDAO.insert(MESSAGE_2).block();
+            cassandraMessageDAOV3.save(MAILBOX_MESSAGE_2).block();
+
+            Mono.from(pop3MetadataStore.add(MAILBOX_ID, STAT_METADATA_1)).block();
+            Context context = new Context();
+            testee.fixInconsistencies(context, RunningOptions.DEFAULT).block();
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(imapUidDAO.retrieveAllMessages().collectList().block())
+                    .hasSameElementsAs(ImmutableList.of(MESSAGE_1, MESSAGE_2));
+                softly.assertThat(Flux.from(pop3MetadataStore.listAllEntries()).collectList().block())
+                    .hasSameElementsAs(ImmutableList.of(new Pop3MetadataStore.FullMetadata(MAILBOX_ID, STAT_METADATA_1),
+                        new Pop3MetadataStore.FullMetadata(MAILBOX_ID, STAT_METADATA_2)));
+                softly.assertThat(context.snapshot())
+                    .isEqualTo(Context.Snapshot.builder()
+                        .processedPop3MetaDataStoreEntries(1)
+                        .processedImapUidEntries(2)
+                        .missingPOP3Entries(1)
+                        .addFixedInconsistencies(MESSAGE_INCONSISTENCIES_ENTRY_2)
+                        .build());
+            });
+        }
+
+        @Test
+        void pop3MetaDataShouldCorrectSizeWhenResolved() throws MailboxException {
+            imapUidDAO.insert(MESSAGE_1).block();
+            cassandraMessageDAOV3.save(MAILBOX_MESSAGE_1).block();
+            testee.fixInconsistencies(new Context(), RunningOptions.DEFAULT).block();
+
+            assertThat(Flux.from(pop3MetadataStore.stat(MAILBOX_ID))
+                .collectList()
+                .block()
+                .stream()
+                .filter(statMetadata -> statMetadata.getMessageId().equals(MESSAGE_ID_1))
+                .findFirst()
+                .get()
+                .getSize())
+                .isEqualTo(CONTENT_MESSAGE.length());
+        }
+    }
+
+    @Nested
+    class POP3MetaDataStoreScanningTest {
+
+        @Test
+        void fixInconsistenciesShouldReturnCompletedWhenInconsistentData() throws MailboxException {
+            Mono.from(pop3MetadataStore.add(MAILBOX_ID, STAT_METADATA_1)).block();
+            cassandraMessageDAOV3.save(MAILBOX_MESSAGE_1).block();
+
+            assertThat(testee.fixInconsistencies(new Context(), RunningOptions.DEFAULT).block())
+                .isEqualTo(Task.Result.COMPLETED);
+        }
+
+        @Test
+        void fixInconsistenciesShouldResolveInconsistentData() throws MailboxException {
+            Mono.from(pop3MetadataStore.add(MAILBOX_ID, STAT_METADATA_1)).block();
+            cassandraMessageDAOV3.save(MAILBOX_MESSAGE_1).block();
+
+            testee.fixInconsistencies(new Context(), RunningOptions.DEFAULT).block();
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(imapUidDAO.retrieve(MESSAGE_ID_1, Optional.of(MAILBOX_ID)).collectList().block())
+                    .hasSize(0);
+                softly.assertThat(Flux.from(pop3MetadataStore.stat(MAILBOX_ID)).collectList().block())
+                    .hasSize(0);
+            });
+        }
+
+        @Test
+        void fixInconsistenciesShouldResolveWhenMixCase() throws MailboxException {
+            Mono.from(pop3MetadataStore.add(MAILBOX_ID, STAT_METADATA_1)).block();
+            cassandraMessageDAOV3.save(MAILBOX_MESSAGE_1).block();
+            Mono.from(pop3MetadataStore.add(MAILBOX_ID, STAT_METADATA_2)).block();
+            cassandraMessageDAOV3.save(MAILBOX_MESSAGE_2).block();
+
+            imapUidDAO.insert(MESSAGE_1).block();
+            Context context = new Context();
+            testee.fixInconsistencies(context, RunningOptions.DEFAULT).block();
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(imapUidDAO.retrieveAllMessages().collectList().block())
+                    .hasSameElementsAs(ImmutableList.of(MESSAGE_1));
+                softly.assertThat(Flux.from(pop3MetadataStore.listAllEntries()).collectList().block())
+                    .hasSameElementsAs(ImmutableList.of(new Pop3MetadataStore.FullMetadata(MAILBOX_ID, STAT_METADATA_1)));
+                softly.assertThat(context.snapshot())
+                    .isEqualTo(Context.Snapshot.builder()
+                        .processedPop3MetaDataStoreEntries(2)
+                        .processedImapUidEntries(1)
+                        .stalePOP3Entries(1)
+                        .addFixedInconsistencies(MESSAGE_INCONSISTENCIES_ENTRY_2)
+                        .build());
+            });
+        }
+    }
+}

--- a/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/RabbitMQWebAdminServerTaskSerializationIntegrationImmutableTest.java
+++ b/server/protocols/webadmin-integration-test/distributed-webadmin-integration-test/src/test/java/org/apache/james/webadmin/integration/rabbitmq/RabbitMQWebAdminServerTaskSerializationIntegrationImmutableTest.java
@@ -120,6 +120,27 @@ class RabbitMQWebAdminServerTaskSerializationIntegrationImmutableTest {
     }
 
     @Test
+    void fixPop3InconsistenciesShouldCompleteWhenNoMail() {
+        String taskId = with()
+            .post("/mailboxes?task=fixPop3Inconsistencies")
+            .jsonPath()
+            .get("taskId");
+
+        given()
+            .basePath(TasksRoutes.BASE)
+        .when()
+            .get(taskId + "/await")
+        .then()
+            .body("status", is("completed"))
+            .body("taskId", is(notNullValue()))
+            .body("type", is("Pop3MetaDataFixInconsistenciesTask"))
+            .body("additionalInformation.processedImapUidEntries", is(0))
+            .body("additionalInformation.processedPop3MetaDataStoreEntries", is(0))
+            .body("additionalInformation.stalePOP3Entries", is(0))
+            .body("additionalInformation.missingPOP3Entries", is(0));
+    }
+
+    @Test
     void clearMailQueueShouldCompleteWhenNoQueryParameters() {
         String firstMailQueue = with()
                 .basePath(MailQueueRoutes.BASE_URL)

--- a/server/protocols/webadmin/pom.xml
+++ b/server/protocols/webadmin/pom.xml
@@ -44,6 +44,7 @@
         <module>webadmin-mailbox-deleted-message-vault</module>
         <module>webadmin-mailqueue</module>
         <module>webadmin-mailrepository</module>
+        <module>webadmin-pop3</module>
         <module>webadmin-rabbitmq</module>
         <module>webadmin-swagger</module>
     </modules>

--- a/server/protocols/webadmin/webadmin-pop3/README.md
+++ b/server/protocols/webadmin/webadmin-pop3/README.md
@@ -5,7 +5,7 @@ We introduced an additional webadmin endpoint allowing fixing possible inconsist
 In order to run this task:
 
 ```bash
-curl -XPOST 'http://ip:port/mailboxes?action=fixPop3Inconsistencies'
+curl -XPOST 'http://ip:port/mailboxes?task=fixPop3Inconsistencies'
 ```
 
 Will schedule a task for deleting stale and inserting missing POP3 meta data entries.

--- a/server/protocols/webadmin/webadmin-pop3/README.md
+++ b/server/protocols/webadmin/webadmin-pop3/README.md
@@ -1,0 +1,40 @@
+# Pop3 fix inconsistencies
+
+We introduced an additional webadmin endpoint allowing fixing possible inconsistencies.
+
+In order to run this task:
+
+```bash
+curl -XPOST 'http://ip:port/mailboxes?action=fixPop3Inconsistencies'
+```
+
+Will schedule a task for deleting stale and inserting missing POP3 meta data entries.
+
+[More details about endpoints returning a task](https://james.staged.apache.org/james-project/3.6.0/servers/distributed/operate/webadmin.html#_endpoints_returning_a_task).
+
+The scheduled task will have the following type `Pop3MetaDataFixInconsistenciesTask` and the following additionalInformation:
+
+```json
+{
+    "type": "Pop3MetaDataFixInconsistenciesTask",
+    "runningOptions": {
+        "messagesPerSecond": 100
+    },
+    "processedImapUidEntries": 0,
+    "processedPop3MetaDataStoreEntries": 1,
+    "stalePOP3Entries": 1,
+    "missingPOP3Entries": 0,
+    "fixedInconsistencies": [
+        {
+            "mailboxId": "6fdae960-c72f-11eb-9b1d-973b9140e460",
+            "messageId": "6ffca230-c72f-11eb-9b1d-973b9140e460"
+        }
+    ],
+    "errors": [
+        {
+            "mailboxId": "7fdae960-c72f-11eb-9b1d-973b9140e460",
+            "messageId": "7fdae960-c72f-11eb-2222-973b9140e460"
+        }
+    ]
+}
+```

--- a/server/protocols/webadmin/webadmin-pop3/pom.xml
+++ b/server/protocols/webadmin/webadmin-pop3/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.james</groupId>
+        <artifactId>james-server</artifactId>
+        <version>3.7.0-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>james-server-webadmin-pop3</artifactId>
+    <name>POP3 :: WebAdmin</name>
+    <description>Expose task to fix inconsistencies of POP3Metadata</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-backends-cassandra</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>apache-james-mailbox-cassandra</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>blob-cassandra</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-task-memory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-webadmin-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>james-server-webadmin-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>metrics-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>protocols-pop3-distributed</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${james.groupId}</groupId>
+            <artifactId>testing-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/server/protocols/webadmin/webadmin-pop3/src/main/java/org/apache/james/pop3/webadmin/Pop3MetaDataFixInconsistenciesTaskRegistration.java
+++ b/server/protocols/webadmin/webadmin-pop3/src/main/java/org/apache/james/pop3/webadmin/Pop3MetaDataFixInconsistenciesTaskRegistration.java
@@ -1,0 +1,45 @@
+package org.apache.james.pop3.webadmin;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesService;
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesService.RunningOptions;
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesTask;
+import org.apache.james.task.Task;
+import org.apache.james.webadmin.tasks.TaskFromRequestRegistry.TaskRegistration;
+import org.apache.james.webadmin.tasks.TaskRegistrationKey;
+
+import com.google.common.base.Preconditions;
+
+import spark.Request;
+
+public class Pop3MetaDataFixInconsistenciesTaskRegistration extends TaskRegistration {
+    private static final TaskRegistrationKey REGISTRATION_KEY = TaskRegistrationKey.of("fixPop3Inconsistencies");
+
+    @Inject
+    public Pop3MetaDataFixInconsistenciesTaskRegistration(MetaDataFixInconsistenciesService fixInconsistenciesService) {
+        super(REGISTRATION_KEY, request -> fixInconsistencies(fixInconsistenciesService, request));
+    }
+
+    private static Task fixInconsistencies(MetaDataFixInconsistenciesService fixInconsistenciesService, Request request) {
+        RunningOptions runningOptions = getMessagesPerSecond(request)
+            .map(RunningOptions::withMessageRatePerSecond)
+            .orElse(RunningOptions.DEFAULT);
+        return new MetaDataFixInconsistenciesTask(fixInconsistenciesService, runningOptions);
+    }
+
+    private static Optional<Integer> getMessagesPerSecond(Request req) {
+        try {
+            return Optional.ofNullable(req.queryParams("messagesPerSecond"))
+                .map(Integer::parseInt)
+                .map(msgPerSeconds -> {
+                    Preconditions.checkArgument(msgPerSeconds > 0, "'messagesPerSecond' must be strictly positive");
+                    return msgPerSeconds;
+                });
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException("'messagesPerSecond' must be numeric");
+        }
+    }
+}

--- a/server/protocols/webadmin/webadmin-pop3/src/test/java/org/apache/james/pop3/webadmin/Pop3MetaDataFixInconsistenciesRoutesTest.java
+++ b/server/protocols/webadmin/webadmin-pop3/src/test/java/org/apache/james/pop3/webadmin/Pop3MetaDataFixInconsistenciesRoutesTest.java
@@ -1,0 +1,302 @@
+package org.apache.james.pop3.webadmin;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.mail.Flags;
+
+import org.apache.james.backends.cassandra.CassandraCluster;
+import org.apache.james.backends.cassandra.CassandraClusterExtension;
+import org.apache.james.backends.cassandra.components.CassandraModule;
+import org.apache.james.backends.cassandra.init.configuration.CassandraConfiguration;
+import org.apache.james.backends.cassandra.versions.CassandraSchemaVersionModule;
+import org.apache.james.blob.api.HashBlobId;
+import org.apache.james.blob.cassandra.CassandraBlobModule;
+import org.apache.james.blob.cassandra.CassandraBlobStoreFactory;
+import org.apache.james.json.DTOConverter;
+import org.apache.james.mailbox.MessageUid;
+import org.apache.james.mailbox.ModSeq;
+import org.apache.james.mailbox.cassandra.ids.CassandraId;
+import org.apache.james.mailbox.cassandra.ids.CassandraMessageId;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageDAOV3;
+import org.apache.james.mailbox.cassandra.mail.CassandraMessageIdToImapUidDAO;
+import org.apache.james.mailbox.cassandra.modules.CassandraMessageModule;
+import org.apache.james.mailbox.exception.MailboxException;
+import org.apache.james.mailbox.model.ByteContent;
+import org.apache.james.mailbox.model.ComposedMessageId;
+import org.apache.james.mailbox.model.ComposedMessageIdWithMetaData;
+import org.apache.james.mailbox.store.mail.model.impl.PropertyBuilder;
+import org.apache.james.mailbox.store.mail.model.impl.SimpleMailboxMessage;
+import org.apache.james.metrics.tests.RecordingMetricFactory;
+import org.apache.james.pop3server.mailbox.CassandraPop3MetadataStore;
+import org.apache.james.pop3server.mailbox.Pop3MetadataModule;
+import org.apache.james.pop3server.mailbox.Pop3MetadataStore;
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesAdditionalInformationDTO;
+import org.apache.james.pop3server.mailbox.task.MetaDataFixInconsistenciesService;
+import org.apache.james.task.Hostname;
+import org.apache.james.task.MemoryTaskManager;
+import org.apache.james.task.TaskManager;
+import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.WebAdminServer;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.routes.TasksRoutes;
+import org.apache.james.webadmin.tasks.TaskFromRequestRegistry;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableList;
+
+import io.restassured.RestAssured;
+import spark.Service;
+
+public class Pop3MetaDataFixInconsistenciesRoutesTest {
+
+    private static final class Pop3MetaDataFixInconsistenciesRoute implements Routes {
+
+        private final TaskManager taskManager;
+        private final MetaDataFixInconsistenciesService fixInconsistenciesService;
+
+        private Pop3MetaDataFixInconsistenciesRoute(TaskManager taskManager,
+                                                    MetaDataFixInconsistenciesService fixInconsistenciesService) {
+            this.taskManager = taskManager;
+            this.fixInconsistenciesService = fixInconsistenciesService;
+        }
+
+        @Override
+        public String getBasePath() {
+            return BASE_PATH;
+        }
+
+        @Override
+        public void define(Service service) {
+            service.post(BASE_PATH,
+                TaskFromRequestRegistry.builder()
+                    .registrations(new Pop3MetaDataFixInconsistenciesTaskRegistration(fixInconsistenciesService))
+                    .parameterName("task")
+                    .buildAsRoute(taskManager),
+                new JsonTransformer());
+        }
+    }
+
+    private static final String BASE_PATH = "/mailboxes";
+    private static final CassandraId MAILBOX_ID = CassandraId.timeBased();
+    private static final CassandraMessageId MESSAGE_ID_1 = new CassandraMessageId.Factory().fromString("d2bee791-7e63-11ea-883c-95b84008f979");
+    private static final MessageUid MESSAGE_UID_1 = MessageUid.of(1L);
+    private static final ModSeq MOD_SEQ_1 = ModSeq.of(1L);
+    private static final ComposedMessageIdWithMetaData MESSAGE_1 = ComposedMessageIdWithMetaData.builder()
+        .composedMessageId(new ComposedMessageId(MAILBOX_ID, MESSAGE_ID_1, MESSAGE_UID_1))
+        .modSeq(MOD_SEQ_1)
+        .flags(new Flags())
+        .build();
+    private static final SimpleMailboxMessage MAILBOX_MESSAGE_1 = SimpleMailboxMessage.builder()
+        .messageId(MESSAGE_ID_1)
+        .mailboxId(MAILBOX_ID)
+        .uid(MESSAGE_UID_1)
+        .internalDate(new Date())
+        .bodyStartOctet(16)
+        .size("CONTENT_MESSAGE".length())
+        .content(new ByteContent("CONTENT_MESSAGE".getBytes(StandardCharsets.UTF_8)))
+        .flags(new Flags())
+        .properties(new PropertyBuilder())
+        .addAttachments(ImmutableList.of())
+        .build();
+
+
+    private WebAdminServer webAdminServer;
+    private MemoryTaskManager taskManager;
+    private CassandraMessageIdToImapUidDAO imapUidDAO;
+    private CassandraMessageDAOV3 cassandraMessageDAOV3;
+
+    @RegisterExtension
+    static CassandraClusterExtension cassandraCluster = new CassandraClusterExtension(CassandraModule.aggregateModules(
+        CassandraSchemaVersionModule.MODULE,
+        CassandraMessageModule.MODULE,
+        CassandraBlobModule.MODULE,
+        Pop3MetadataModule.MODULE));
+
+    @BeforeEach
+    void setUp(CassandraCluster cassandra) {
+        Pop3MetadataStore pop3MetadataStore = new CassandraPop3MetadataStore(cassandra.getConf());
+        imapUidDAO = new CassandraMessageIdToImapUidDAO(
+            cassandra.getConf(),
+            cassandraCluster.getCassandraConsistenciesConfiguration(),
+            new CassandraMessageId.Factory(),
+            CassandraConfiguration.DEFAULT_CONFIGURATION);
+
+        cassandraMessageDAOV3 = new CassandraMessageDAOV3(
+            cassandra.getConf(),
+            cassandra.getTypesProvider(),
+            CassandraBlobStoreFactory.forTesting(cassandra.getConf(), new RecordingMetricFactory())
+                .passthrough(),
+            new HashBlobId.Factory(),
+            cassandraCluster.getCassandraConsistenciesConfiguration());
+        MetaDataFixInconsistenciesService fixInconsistenciesService = new MetaDataFixInconsistenciesService(imapUidDAO, pop3MetadataStore, cassandraMessageDAOV3);
+
+        taskManager = new MemoryTaskManager(new Hostname("foo"));
+
+        Pop3MetaDataFixInconsistenciesRoute routeTestee = new Pop3MetaDataFixInconsistenciesRoute(taskManager, fixInconsistenciesService);
+        TasksRoutes tasksRoutes = new TasksRoutes(taskManager, new JsonTransformer(), DTOConverter.of(MetaDataFixInconsistenciesAdditionalInformationDTO.module()));
+        webAdminServer = WebAdminUtils.createWebAdminServer(routeTestee, tasksRoutes).start();
+
+        RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)
+            .setBasePath(BASE_PATH)
+            .build();
+    }
+
+    @AfterEach
+    void stop() {
+        webAdminServer.destroy();
+        taskManager.stop();
+    }
+
+    @Test
+    void taskShouldSuccess() {
+        given()
+            .queryParam("task", "fixPop3Inconsistencies")
+            .post()
+        .then()
+            .statusCode(HttpStatus.CREATED_201)
+            .body("taskId", notNullValue());
+    }
+
+    @Test
+    void taskShouldSuccessWithRunningOption() {
+        given()
+            .queryParam("task", "fixPop3Inconsistencies")
+            .queryParam("messagesPerSecond", "5")
+            .post()
+        .then()
+            .statusCode(HttpStatus.CREATED_201)
+            .body("taskId", notNullValue());
+    }
+
+    @Test
+    void taskShouldFailWhenMessagesPerSecondsIsInvalid() {
+        given()
+            .queryParam("task", "fixPop3Inconsistencies")
+            .queryParam("messagesPerSecond", "invalid")
+            .post()
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400)
+            .body("details", containsString("'messagesPerSecond' must be numeric"));
+    }
+
+    @Test
+    void taskShouldFailWhenMessagesPerSecondsIsNotStrictlyPositive() {
+        given()
+            .queryParam("task", "fixPop3Inconsistencies")
+            .queryParam("messagesPerSecond", "-1")
+            .post()
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST_400)
+            .body("details", containsString("'messagesPerSecond' must be strictly positive"));
+    }
+
+    @Test
+    void taskShouldReturnDetail() {
+        String taskId = given()
+            .queryParam("task", "fixPop3Inconsistencies")
+            .post()
+            .jsonPath()
+            .get("taskId");
+        given()
+            .basePath(TasksRoutes.BASE)
+            .when()
+            .get(taskId + "/await")
+        .then()
+            .body("type", Matchers.is("Pop3MetaDataFixInconsistenciesTask"))
+            .body("taskId", is(notNullValue()))
+            .body("additionalInformation.type", is("Pop3MetaDataFixInconsistenciesTask"))
+            .body("additionalInformation.runningOptions.messagesPerSecond", is(100))
+            .body("additionalInformation.processedImapUidEntries", is(notNullValue()))
+            .body("additionalInformation.processedPop3MetaDataStoreEntries", is(notNullValue()))
+            .body("additionalInformation.stalePOP3Entries", is(notNullValue()))
+            .body("additionalInformation.missingPOP3Entries", is(notNullValue()))
+            .body("additionalInformation.fixedInconsistencies", is(notNullValue()))
+            .body("additionalInformation.errors", is(notNullValue()));
+    }
+
+    @Test
+    void taskWithMessagesPerSecondShouldReturnDetail() {
+        String taskId = given()
+            .queryParam("task", "fixPop3Inconsistencies")
+            .queryParam("messagesPerSecond", "250")
+            .post()
+            .jsonPath()
+            .get("taskId");
+
+        given()
+            .basePath(TasksRoutes.BASE)
+            .when()
+            .get(taskId + "/await")
+        .then()
+            .body("type", Matchers.is("Pop3MetaDataFixInconsistenciesTask"))
+            .body("taskId", is(notNullValue()))
+            .body("status", is("completed"))
+            .body("additionalInformation.type", is("Pop3MetaDataFixInconsistenciesTask"))
+            .body("additionalInformation.runningOptions.messagesPerSecond", is(250))
+            .body("additionalInformation.processedImapUidEntries", is(notNullValue()))
+            .body("additionalInformation.processedPop3MetaDataStoreEntries", is(notNullValue()))
+            .body("additionalInformation.stalePOP3Entries", is(notNullValue()))
+            .body("additionalInformation.missingPOP3Entries", is(notNullValue()))
+            .body("additionalInformation.fixedInconsistencies", is(notNullValue()))
+            .body("additionalInformation.errors", is(notNullValue()));
+    }
+
+    @Test
+    void errorsPropertyShouldBeNotEmptyWhenProcessFailure() {
+        // Failure, Because missing data in CassandraMessageDAOV3
+        imapUidDAO.insert(MESSAGE_1).block();
+
+        String taskId = given()
+            .queryParam("task", "fixPop3Inconsistencies")
+            .queryParam("messagesPerSecond", "250")
+            .post()
+            .jsonPath()
+            .get("taskId");
+
+        given()
+            .basePath(TasksRoutes.BASE)
+            .when()
+            .get(taskId + "/await")
+        .then()
+            .body("type", Matchers.is("Pop3MetaDataFixInconsistenciesTask"))
+            .body("status", is("failed"))
+            .body("additionalInformation.errors[0].mailboxId", is(MAILBOX_ID.serialize()))
+            .body("additionalInformation.errors[0].messageId", is(MESSAGE_ID_1.serialize()));
+    }
+
+    @Test
+    void fixedInconsistenciesPropertyShouldBeNotEmptyWhenProcessCompleted() throws MailboxException {
+        imapUidDAO.insert(MESSAGE_1).block();
+        cassandraMessageDAOV3.save(MAILBOX_MESSAGE_1).block();
+
+        String taskId = given()
+            .queryParam("task", "fixPop3Inconsistencies")
+            .queryParam("messagesPerSecond", "250")
+            .post()
+            .jsonPath()
+            .get("taskId");
+
+        given()
+            .basePath(TasksRoutes.BASE)
+            .when()
+            .get(taskId + "/await")
+        .then()
+            .body("type", Matchers.is("Pop3MetaDataFixInconsistenciesTask"))
+            .body("status", is("completed"))
+            .body("additionalInformation.fixedInconsistencies[0].mailboxId", is(MAILBOX_ID.serialize()))
+            .body("additionalInformation.fixedInconsistencies[0].messageId", is(MESSAGE_ID_1.serialize()));
+    }
+
+}


### PR DESCRIPTION
Reopens https://github.com/linagora/james-project/pull/4319

This ships the following changes compared to previous version:

  - Rebase on master. This includes :
       - reactive `StoreMessageIdManager::delete` no longer throws.
       - We can now rely on interfaces to override UID and ModSeq generation
  - Add a strong POP3 integration test suite (deletes, many message receival, etc...)
  - Fix POP3 deletes. Metadata cleanup was asynchronous and upon processing delays, the metadata were not cleaned up when the next client connects, causing issues of "half present messages". To do so we leverage deletes indempotance, and delete them a first time synchronously for the sake of POP3 correctness then deletes them a second time asynchronously to leverage the eventBus relyability.
  - We furthermore added a "on the fly" dandling metadata clean up, that will not be exposed to future POP3 sessions.
  
  Commits from https://github.com/linagora/james-project/pull/4321/commits/cbfa7e7fd30a6fd7a7ee6aacf6d9d1e751c91fd7 are new.
  
  Cc @Arsnael review please.