### PR TITLE
JAMES-3604 Improve RabbitMQ resiliency

### DIFF
--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/Constants.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/Constants.java
@@ -43,10 +43,4 @@ public interface Constants {
     String DIRECT_EXCHANGE = "direct";
 
     AMQP.BasicProperties NO_PROPERTIES = new AMQP.BasicProperties();
-
-    ImmutableMap<String, Object> NO_ARGUMENTS = ImmutableMap.of();
-
-    static ImmutableMap<String, Object> deadLetterQueue(String deadLetterQueueName) {
-        return ImmutableMap.of("x-dead-letter-exchange", deadLetterQueueName);
-    }
 }

--- a/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/QueueArguments.java
+++ b/backends-common/rabbitmq/src/main/java/org/apache/james/backends/rabbitmq/QueueArguments.java
@@ -1,0 +1,42 @@
+package org.apache.james.backends.rabbitmq;
+
+import com.google.common.collect.ImmutableMap;
+
+public class QueueArguments {
+    public static class Builder {
+        @FunctionalInterface
+        public interface RequiresReplicationFactor {
+            Builder replicationFactor(int replicationFactor);
+        }
+
+        private final ImmutableMap.Builder<String, Object> arguments;
+
+        public Builder() {
+            arguments = ImmutableMap.builder();
+        }
+
+        public RequiresReplicationFactor quorumQueue() {
+            arguments.put("x-queue-type", "quorum");
+            return this::replicationFactor;
+        }
+
+        private Builder replicationFactor(int replicationFactor) {
+            arguments.put("x-quorum-initial-group-size", replicationFactor);
+            return this;
+        }
+
+        public Builder deadLetter(String deadLetterQueueName) {
+            arguments.put("x-dead-letter-exchange", deadLetterQueueName);
+            return this;
+        }
+
+        public ImmutableMap<String, Object> build() {
+            return arguments.build();
+        }
+    }
+    public static ImmutableMap<String, Object> NO_ARGUMENTS = ImmutableMap.of();
+
+    public static Builder builder() {
+        return new Builder();
+    }
+}

--- a/backends-common/rabbitmq/src/test/java/org/apache/james/backends/rabbitmq/DockerRabbitMQ.java
+++ b/backends-common/rabbitmq/src/test/java/org/apache/james/backends/rabbitmq/DockerRabbitMQ.java
@@ -254,7 +254,11 @@ public class DockerRabbitMQ {
     }
 
     public RabbitMQConnectionFactory createRabbitConnectionFactory() throws URISyntaxException {
-        RabbitMQConfiguration rabbitMQConfiguration = RabbitMQConfiguration.builder()
+        return new RabbitMQConnectionFactory(getConfiguration());
+    }
+
+    public RabbitMQConfiguration getConfiguration() throws URISyntaxException {
+        return RabbitMQConfiguration.builder()
             .amqpUri(amqpUri())
             .managementUri(managementUri())
             .managementCredentials(DEFAULT_MANAGEMENT_CREDENTIAL)
@@ -266,7 +270,5 @@ public class DockerRabbitMQ {
             .shutdownTimeoutInMs(SHUTDOWN_TIMEOUT_OF_ONE_HUNDRED_MILLISECOND)
             .networkRecoveryIntervalInMs(NETWORK_RECOVERY_INTERVAL_OF_ONE_HUNDRED_MILLISECOND)
             .build();
-
-        return new RabbitMQConnectionFactory(rabbitMQConfiguration);
     }
 }

--- a/docs/modules/servers/pages/distributed/configure/rabbitmq.adoc
+++ b/docs/modules/servers/pages/distributed/configure/rabbitmq.adoc
@@ -77,6 +77,14 @@ Optional string, defaults to empty string
 | ssl.keystore.password
 | Configure the keystore password. If configured then "ssl.keystore" must also be configured,
 Optional string, defaults to empty string
+
+| quorum.queues.enable
+| Boolean. Whether to activate Quorum queue usage for use cases that benefits from it (work queue).
+Quorum queues enables high availability.
+False (default value) results in the usage of classic queues.
+
+| quorum.queues.replication.factor
+| Strictly positive integer. The replication factor to use when creating quorum queues.
 |===
 
 == RabbitMQ MailQueue Configuration

--- a/event-bus/distributed/src/main/java/org/apache/james/events/EventDispatcher.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/EventDispatcher.java
@@ -25,7 +25,7 @@ import static org.apache.james.backends.rabbitmq.Constants.DIRECT_EXCHANGE;
 import static org.apache.james.backends.rabbitmq.Constants.DURABLE;
 import static org.apache.james.backends.rabbitmq.Constants.EMPTY_ROUTING_KEY;
 import static org.apache.james.backends.rabbitmq.Constants.EXCLUSIVE;
-import static org.apache.james.backends.rabbitmq.Constants.NO_ARGUMENTS;
+import static org.apache.james.backends.rabbitmq.QueueArguments.NO_ARGUMENTS;
 import static org.apache.james.events.RabbitMQEventBus.EVENT_BUS_ID;
 
 import java.nio.charset.StandardCharsets;

--- a/event-bus/distributed/src/main/java/org/apache/james/events/EventDispatcher.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/EventDispatcher.java
@@ -156,7 +156,7 @@ public class EventDispatcher {
     }
 
     private Mono<Void> remoteGroupsDispatch(byte[] serializedEvent, Event event) {
-        return remoteDispatch(serializedEvent, Collections.singletonList(RoutingKey.empty()))
+        return remoteDispatchWithAcks(serializedEvent, Collections.singletonList(RoutingKey.empty()))
             .doOnError(ex -> LOGGER.error(
                 "cannot dispatch event of type '{}' belonging '{}' with id '{}' to remote groups, store it into dead letter",
                 event.getClass().getSimpleName(),
@@ -179,6 +179,16 @@ public class EventDispatcher {
             return Mono.empty();
         }
         return sender.send(toMessages(serializedEvent, routingKeys));
+    }
+
+    private Mono<Void> remoteDispatchWithAcks(byte[] serializedEvent, Collection<RoutingKey> routingKeys) {
+        if (routingKeys.isEmpty()) {
+            return Mono.empty();
+        }
+        return sender.sendWithPublishConfirms(toMessages(serializedEvent, routingKeys))
+            .filter(outboundMessageResult -> !outboundMessageResult.isAck())
+            .next()
+            .handle((result, sink) -> sink.error(new Exception("Publish was not acked")));
     }
 
     private Flux<OutboundMessage> toMessages(byte[] serializedEvent, Collection<RoutingKey> routingKeys) {

--- a/event-bus/distributed/src/main/java/org/apache/james/events/RabbitMQEventBus.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/RabbitMQEventBus.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
+import org.apache.james.backends.rabbitmq.RabbitMQConfiguration;
 import org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPool;
 import org.apache.james.backends.rabbitmq.ReceiverProvider;
 import org.apache.james.lifecycle.api.Startable;
@@ -51,6 +52,7 @@ public class RabbitMQEventBus implements EventBus, Startable {
     private final Sender sender;
     private final ReceiverProvider receiverProvider;
     private final ReactorRabbitMQChannelPool channelPool;
+    private final RabbitMQConfiguration configuration;
 
     private volatile boolean isRunning;
     private volatile boolean isStopping;
@@ -63,7 +65,7 @@ public class RabbitMQEventBus implements EventBus, Startable {
                             RetryBackoffConfiguration retryBackoff,
                             RoutingKeyConverter routingKeyConverter,
                             EventDeadLetters eventDeadLetters, MetricFactory metricFactory, ReactorRabbitMQChannelPool channelPool,
-                            EventBusId eventBusId) {
+                            EventBusId eventBusId, RabbitMQConfiguration configuration) {
         this.namingStrategy = namingStrategy;
         this.sender = sender;
         this.receiverProvider = receiverProvider;
@@ -74,6 +76,7 @@ public class RabbitMQEventBus implements EventBus, Startable {
         this.routingKeyConverter = routingKeyConverter;
         this.retryBackoff = retryBackoff;
         this.eventDeadLetters = eventDeadLetters;
+        this.configuration = configuration;
         this.isRunning = false;
         this.isStopping = false;
     }
@@ -83,7 +86,7 @@ public class RabbitMQEventBus implements EventBus, Startable {
 
             LocalListenerRegistry localListenerRegistry = new LocalListenerRegistry();
             keyRegistrationHandler = new KeyRegistrationHandler(namingStrategy, eventBusId, eventSerializer, sender, receiverProvider, routingKeyConverter, localListenerRegistry, listenerExecutor, retryBackoff);
-            groupRegistrationHandler = new GroupRegistrationHandler(namingStrategy, eventSerializer, channelPool, sender, receiverProvider, retryBackoff, eventDeadLetters, listenerExecutor, eventBusId);
+            groupRegistrationHandler = new GroupRegistrationHandler(namingStrategy, eventSerializer, channelPool, sender, receiverProvider, retryBackoff, eventDeadLetters, listenerExecutor, eventBusId, configuration);
             eventDispatcher = new EventDispatcher(namingStrategy, eventBusId, eventSerializer, sender, localListenerRegistry, listenerExecutor, eventDeadLetters);
 
             eventDispatcher.start();
@@ -98,7 +101,7 @@ public class RabbitMQEventBus implements EventBus, Startable {
 
             LocalListenerRegistry localListenerRegistry = new LocalListenerRegistry();
             keyRegistrationHandler = new KeyRegistrationHandler(namingStrategy, eventBusId, eventSerializer, sender, receiverProvider, routingKeyConverter, localListenerRegistry, listenerExecutor, retryBackoff);
-            groupRegistrationHandler = new GroupRegistrationHandler(namingStrategy, eventSerializer, channelPool, sender, receiverProvider, retryBackoff, eventDeadLetters, listenerExecutor, eventBusId);
+            groupRegistrationHandler = new GroupRegistrationHandler(namingStrategy, eventSerializer, channelPool, sender, receiverProvider, retryBackoff, eventDeadLetters, listenerExecutor, eventBusId, configuration);
             eventDispatcher = new EventDispatcher(namingStrategy, eventBusId, eventSerializer, sender, localListenerRegistry, listenerExecutor, eventDeadLetters);
 
             keyRegistrationHandler.declareQueue();

--- a/event-bus/distributed/src/main/java/org/apache/james/events/RabbitMQEventBus.java
+++ b/event-bus/distributed/src/main/java/org/apache/james/events/RabbitMQEventBus.java
@@ -85,7 +85,7 @@ public class RabbitMQEventBus implements EventBus, Startable {
         if (!isRunning && !isStopping) {
 
             LocalListenerRegistry localListenerRegistry = new LocalListenerRegistry();
-            keyRegistrationHandler = new KeyRegistrationHandler(namingStrategy, eventBusId, eventSerializer, sender, receiverProvider, routingKeyConverter, localListenerRegistry, listenerExecutor, retryBackoff);
+            keyRegistrationHandler = new KeyRegistrationHandler(namingStrategy, eventBusId, eventSerializer, sender, receiverProvider, routingKeyConverter, localListenerRegistry, listenerExecutor, retryBackoff, configuration);
             groupRegistrationHandler = new GroupRegistrationHandler(namingStrategy, eventSerializer, channelPool, sender, receiverProvider, retryBackoff, eventDeadLetters, listenerExecutor, eventBusId, configuration);
             eventDispatcher = new EventDispatcher(namingStrategy, eventBusId, eventSerializer, sender, localListenerRegistry, listenerExecutor, eventDeadLetters);
 
@@ -100,7 +100,7 @@ public class RabbitMQEventBus implements EventBus, Startable {
         if (!isRunning && !isStopping) {
 
             LocalListenerRegistry localListenerRegistry = new LocalListenerRegistry();
-            keyRegistrationHandler = new KeyRegistrationHandler(namingStrategy, eventBusId, eventSerializer, sender, receiverProvider, routingKeyConverter, localListenerRegistry, listenerExecutor, retryBackoff);
+            keyRegistrationHandler = new KeyRegistrationHandler(namingStrategy, eventBusId, eventSerializer, sender, receiverProvider, routingKeyConverter, localListenerRegistry, listenerExecutor, retryBackoff, configuration);
             groupRegistrationHandler = new GroupRegistrationHandler(namingStrategy, eventSerializer, channelPool, sender, receiverProvider, retryBackoff, eventDeadLetters, listenerExecutor, eventBusId, configuration);
             eventDispatcher = new EventDispatcher(namingStrategy, eventBusId, eventSerializer, sender, localListenerRegistry, listenerExecutor, eventDeadLetters);
 

--- a/event-bus/distributed/src/test/java/org/apache/james/events/NetworkErrorTest.java
+++ b/event-bus/distributed/src/test/java/org/apache/james/events/NetworkErrorTest.java
@@ -44,7 +44,7 @@ class NetworkErrorTest {
     private RabbitMQEventBus eventBus;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         MemoryEventDeadLetters memoryEventDeadLetters = new MemoryEventDeadLetters();
 
 
@@ -54,7 +54,7 @@ class NetworkErrorTest {
         eventBus = new RabbitMQEventBus(new NamingStrategy("test"), rabbitMQExtension.getSender(), rabbitMQExtension.getReceiverProvider(),
             eventSerializer, RETRY_BACKOFF_CONFIGURATION, routingKeyConverter,
             memoryEventDeadLetters, new RecordingMetricFactory(), rabbitMQExtension.getRabbitChannelPool(),
-            EventBusId.random());
+            EventBusId.random(), rabbitMQExtension.getRabbitMQ().getConfiguration());
 
         eventBus.start();
     }

--- a/event-bus/distributed/src/test/java/org/apache/james/events/RabbitMQEventBusDeadLetterQueueUpgradeTest.java
+++ b/event-bus/distributed/src/test/java/org/apache/james/events/RabbitMQEventBusDeadLetterQueueUpgradeTest.java
@@ -52,7 +52,7 @@ class RabbitMQEventBusDeadLetterQueueUpgradeTest {
     private RabbitMQEventBus eventBus;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         MemoryEventDeadLetters memoryEventDeadLetters = new MemoryEventDeadLetters();
 
         EventSerializer eventSerializer = new TestEventSerializer();
@@ -61,7 +61,7 @@ class RabbitMQEventBusDeadLetterQueueUpgradeTest {
         eventBus = new RabbitMQEventBus(NAMING_STRATEGY, rabbitMQExtension.getSender(), rabbitMQExtension.getReceiverProvider(),
             eventSerializer, RETRY_BACKOFF_CONFIGURATION, routingKeyConverter,
             memoryEventDeadLetters, new RecordingMetricFactory(), rabbitMQExtension.getRabbitChannelPool(),
-            EventBusId.random());
+            EventBusId.random(), rabbitMQExtension.getRabbitMQ().getConfiguration());
 
         eventBus.start();
     }

--- a/event-bus/distributed/src/test/java/org/apache/james/events/RabbitMQEventBusTest.java
+++ b/event-bus/distributed/src/test/java/org/apache/james/events/RabbitMQEventBusTest.java
@@ -24,7 +24,7 @@ import static org.apache.james.backends.rabbitmq.Constants.DIRECT_EXCHANGE;
 import static org.apache.james.backends.rabbitmq.Constants.DURABLE;
 import static org.apache.james.backends.rabbitmq.Constants.EMPTY_ROUTING_KEY;
 import static org.apache.james.backends.rabbitmq.Constants.EXCLUSIVE;
-import static org.apache.james.backends.rabbitmq.Constants.NO_ARGUMENTS;
+import static org.apache.james.backends.rabbitmq.QueueArguments.NO_ARGUMENTS;
 import static org.apache.james.events.EventBusConcurrentTestContract.newCountingListener;
 import static org.apache.james.events.EventBusTestFixture.ALL_GROUPS;
 import static org.apache.james.events.EventBusTestFixture.EVENT;
@@ -115,7 +115,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
     }
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         memoryEventDeadLetters = new MemoryEventDeadLetters();
 
         eventSerializer = new TestEventSerializer();
@@ -151,15 +151,15 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
             .block();
     }
 
-    private RabbitMQEventBus newEventBus() {
+    private RabbitMQEventBus newEventBus() throws Exception {
         return newEventBus(TEST_NAMING_STRATEGY, rabbitMQExtension.getSender(), rabbitMQExtension.getReceiverProvider());
     }
 
-    private RabbitMQEventBus newEventBus(NamingStrategy namingStrategy, Sender sender, ReceiverProvider receiverProvider) {
+    private RabbitMQEventBus newEventBus(NamingStrategy namingStrategy, Sender sender, ReceiverProvider receiverProvider) throws Exception {
         return new RabbitMQEventBus(namingStrategy, sender, receiverProvider, eventSerializer,
             EventBusTestFixture.RETRY_BACKOFF_CONFIGURATION, routingKeyConverter,
             memoryEventDeadLetters, new RecordingMetricFactory(),
-            rabbitMQExtension.getRabbitChannelPool(), EventBusId.random());
+            rabbitMQExtension.getRabbitChannelPool(), EventBusId.random(), rabbitMQExtension.getRabbitMQ().getConfiguration());
     }
 
     @Override
@@ -456,7 +456,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
                 private RabbitMQEventBus rabbitMQEventBusWithNetWorkIssue;
 
                 @BeforeEach
-                void beforeEach() {
+                void beforeEach() throws Exception {
                     rabbitMQEventBusWithNetWorkIssue = newEventBus(TEST_NAMING_STRATEGY, rabbitMQNetWorkIssueExtension.getSender(), rabbitMQNetWorkIssueExtension.getReceiverProvider());
                 }
 
@@ -820,7 +820,7 @@ class RabbitMQEventBusTest implements GroupContract.SingleEventBusGroupContract,
         private RabbitMQEventBus otherEventBus;
 
         @BeforeEach
-        void beforeEach() {
+        void beforeEach() throws Exception {
             otherEventBus = newEventBus(new NamingStrategy("other"), rabbitMQExtension.getSender(), rabbitMQExtension.getReceiverProvider());
             otherEventBus.start();
         }

--- a/mpt/impl/imap-mailbox/rabbitmq/src/test/java/org/apache/james/mpt/imapmailbox/rabbitmq/host/RabbitMQEventBusHostSystem.java
+++ b/mpt/impl/imap-mailbox/rabbitmq/src/test/java/org/apache/james/mpt/imapmailbox/rabbitmq/host/RabbitMQEventBusHostSystem.java
@@ -113,7 +113,7 @@ public class RabbitMQEventBusHostSystem extends JamesImapHostSystem {
             defaultImapProcessorFactory);
     }
 
-    private RabbitMQEventBus createEventBus() {
+    private RabbitMQEventBus createEventBus() throws Exception {
         InMemoryMessageId.Factory messageIdFactory = new InMemoryMessageId.Factory();
         InMemoryId.Factory mailboxIdFactory = new InMemoryId.Factory();
         MailboxEventSerializer eventSerializer = new MailboxEventSerializer(mailboxIdFactory, messageIdFactory, new DefaultUserQuotaRootResolver.DefaultQuotaRootDeserializer());
@@ -121,7 +121,7 @@ public class RabbitMQEventBusHostSystem extends JamesImapHostSystem {
         return new RabbitMQEventBus(new NamingStrategy("mailboxEvent-"), reactorRabbitMQChannelPool.getSender(), reactorRabbitMQChannelPool::createReceiver,
             eventSerializer, RetryBackoffConfiguration.DEFAULT, routingKeyConverter, new MemoryEventDeadLetters(),
             new RecordingMetricFactory(),
-            reactorRabbitMQChannelPool, EventBusId.random());
+            reactorRabbitMQChannelPool, EventBusId.random(), dockerRabbitMQ.getConfiguration());
     }
 
     @Override

--- a/server/apps/distributed-app/sample-configuration/rabbitmq.properties
+++ b/server/apps/distributed-app/sample-configuration/rabbitmq.properties
@@ -29,6 +29,14 @@ management.password=guest
 # Optional integer, defaults to 3
 #channel.pool.size=3
 
+# Boolean. Whether to activate Quorum queue usage for use cases that benefits from it (work queue).
+# Quorum queues enables high availability.
+# False (default value) results in the usage of classic queues.
+#quorum.queues.enable=true
+
+# Strictly positive integer. The replication factor to use when creating quorum queues.
+#quorum.queues.replication.factor
+
 # Parameters for the Cassandra administrative view
 
 # Period of the window. Too large values will lead to wide rows while too little values might lead to many queries.

--- a/server/container/guice/distributed/src/main/java/org/apache/james/modules/event/JMAPEventBusModule.java
+++ b/server/container/guice/distributed/src/main/java/org/apache/james/modules/event/JMAPEventBusModule.java
@@ -21,6 +21,7 @@ package org.apache.james.modules.event;
 
 import javax.inject.Named;
 
+import org.apache.james.backends.rabbitmq.RabbitMQConfiguration;
 import org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPool;
 import org.apache.james.backends.rabbitmq.ReceiverProvider;
 import org.apache.james.backends.rabbitmq.SimpleConnectionPool;
@@ -72,15 +73,16 @@ public class JMAPEventBusModule extends AbstractModule {
     @Singleton
     @Named(InjectionKeys.JMAP)
     RabbitMQEventBus provideJmapEventBus(Sender sender, ReceiverProvider receiverProvider,
-                                 JmapEventSerializer eventSerializer,
-                                 RetryBackoffConfiguration retryBackoffConfiguration,
-                                 EventDeadLetters eventDeadLetters,
-                                 MetricFactory metricFactory, ReactorRabbitMQChannelPool channelPool,
-                                 @Named(InjectionKeys.JMAP) EventBusId eventBusId) {
+                                         JmapEventSerializer eventSerializer,
+                                         RetryBackoffConfiguration retryBackoffConfiguration,
+                                         EventDeadLetters eventDeadLetters,
+                                         MetricFactory metricFactory, ReactorRabbitMQChannelPool channelPool,
+                                         @Named(InjectionKeys.JMAP) EventBusId eventBusId,
+                                         RabbitMQConfiguration configuration) {
         return new RabbitMQEventBus(
             JMAP_NAMING_STRATEGY,
             sender, receiverProvider, eventSerializer, retryBackoffConfiguration, new RoutingKeyConverter(ImmutableSet.of(new Factory())),
-            eventDeadLetters, metricFactory, channelPool, eventBusId);
+            eventDeadLetters, metricFactory, channelPool, eventBusId, configuration);
     }
 
     @Provides

--- a/server/container/guice/distributed/src/main/java/org/apache/james/modules/event/JMAPEventBusModule.java
+++ b/server/container/guice/distributed/src/main/java/org/apache/james/modules/event/JMAPEventBusModule.java
@@ -65,8 +65,8 @@ public class JMAPEventBusModule extends AbstractModule {
     }
 
     @ProvidesIntoSet
-    SimpleConnectionPool.ReconnectionHandler provideReconnectionHandler(@Named(InjectionKeys.JMAP) EventBusId eventBusId) {
-        return new KeyReconnectionHandler(JMAP_NAMING_STRATEGY, eventBusId);
+    SimpleConnectionPool.ReconnectionHandler provideReconnectionHandler(@Named(InjectionKeys.JMAP) EventBusId eventBusId, RabbitMQConfiguration configuration) {
+        return new KeyReconnectionHandler(JMAP_NAMING_STRATEGY, eventBusId, configuration);
     }
 
     @Provides

--- a/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Enqueuer.java
+++ b/server/queue/queue-rabbitmq/src/main/java/org/apache/james/queue/rabbitmq/Enqueuer.java
@@ -30,6 +30,7 @@ import javax.mail.internet.MimeMessage;
 
 import org.apache.james.blob.api.Store;
 import org.apache.james.blob.mail.MimeMessagePartsId;
+import org.apache.james.mailbox.exception.MailboxException;
 import org.apache.james.metrics.api.Metric;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.queue.api.MailQueue;
@@ -110,7 +111,15 @@ class Enqueuer {
             EMPTY_ROUTING_KEY,
             basicProperties,
             getMailReferenceBytes(mailReference));
-        return sender.send(Mono.just(data));
+        return sender.sendWithPublishConfirms(Mono.just(data))
+            .next()
+            .handle((result, sink) -> {
+                if (!result.isAck()) {
+                    sink.error(new MailboxException("Publish was not acked"));
+                } else {
+                    sink.complete();
+                }
+            });
     }
 
     private EnqueuedItem toEnqueuedItems(MailReference mailReference) {

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueConfigurationChangeTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueConfigurationChangeTest.java
@@ -115,7 +115,7 @@ class RabbitMQMailQueueConfigurationChangeTest {
         mqManagementApi.deleteAllQueues();
     }
 
-    private RabbitMQMailQueue getRabbitMQMailQueue(CassandraCluster cassandra, CassandraMailQueueViewConfiguration mailQueueViewConfiguration) {
+    private RabbitMQMailQueue getRabbitMQMailQueue(CassandraCluster cassandra, CassandraMailQueueViewConfiguration mailQueueViewConfiguration) throws Exception {
         CassandraMailQueueView.Factory mailQueueViewFactory = CassandraMailQueueViewTestFactory.factory(clock,
             cassandra.getConf(),
             mailQueueViewConfiguration,
@@ -137,7 +137,7 @@ class RabbitMQMailQueueConfigurationChangeTest {
             clock,
             new RawMailQueueItemDecoratorFactory(),
             mailQueueSizeConfiguration);
-        RabbitMQMailQueueFactory mailQueueFactory = new RabbitMQMailQueueFactory(rabbitMQExtension.getSender(), mqManagementApi, privateFactory);
+        RabbitMQMailQueueFactory mailQueueFactory = new RabbitMQMailQueueFactory(rabbitMQExtension.getSender(), mqManagementApi, privateFactory, rabbitMQExtension.getRabbitMQ().getConfiguration());
         assertThat(performStartUpCheck(cassandra.getConf(), mailQueueViewConfiguration)).isEqualTo(StartUpCheck.ResultType.GOOD);
         return mailQueueFactory.createQueue(SPOOL);
     }
@@ -154,7 +154,7 @@ class RabbitMQMailQueueConfigurationChangeTest {
     }
 
     @Test
-    void increasingBucketCountShouldAllowBrowsingAllQueueElements(CassandraCluster cassandra) {
+    void increasingBucketCountShouldAllowBrowsingAllQueueElements(CassandraCluster cassandra) throws Exception {
         RabbitMQMailQueue mailQueue = getRabbitMQMailQueue(cassandra, DEFAULT_CONFIGURATION);
 
         enqueueSomeMails(mailQueue, namePatternForSlice(1), 10);
@@ -194,7 +194,7 @@ class RabbitMQMailQueueConfigurationChangeTest {
     }
 
     @Test
-    void divideSliceWindowShouldAllowBrowsingAllQueueElements(CassandraCluster cassandra) {
+    void divideSliceWindowShouldAllowBrowsingAllQueueElements(CassandraCluster cassandra) throws Exception {
         RabbitMQMailQueue mailQueue = getRabbitMQMailQueue(cassandra, DEFAULT_CONFIGURATION);
 
         clock.setInstant(IN_SLICE_1);

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMQMailQueueTest.java
@@ -943,7 +943,7 @@ class RabbitMQMailQueueTest {
             new RawMailQueueItemDecoratorFactory(),
             configuration);
         mqManagementApi = new RabbitMQMailQueueManagement(rabbitMQExtension.managementAPI());
-        mailQueueFactory = new RabbitMQMailQueueFactory(rabbitMQExtension.getSender(), mqManagementApi, factory);
+        mailQueueFactory = new RabbitMQMailQueueFactory(rabbitMQExtension.getSender(), mqManagementApi, factory, rabbitMQExtension.getRabbitMQ().getConfiguration());
         mailQueue = mailQueueFactory.createQueue(SPOOL);
     }
 }

--- a/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMqMailQueueFactoryTest.java
+++ b/server/queue/queue-rabbitmq/src/test/java/org/apache/james/queue/rabbitmq/RabbitMqMailQueueFactoryTest.java
@@ -81,7 +81,7 @@ class RabbitMqMailQueueFactoryTest implements MailQueueFactoryContract<RabbitMQM
             new RawMailQueueItemDecoratorFactory(),
             configuration);
         mqManagementApi = new RabbitMQMailQueueManagement(rabbitMQExtension.managementAPI());
-        mailQueueFactory = new RabbitMQMailQueueFactory(rabbitMQExtension.getSender(), mqManagementApi, privateFactory);
+        mailQueueFactory = new RabbitMQMailQueueFactory(rabbitMQExtension.getSender(), mqManagementApi, privateFactory, rabbitMQExtension.getRabbitMQ().getConfiguration());
     }
 
     @AfterEach

--- a/src/site/xdoc/server/config-rabbitmq.xml
+++ b/src/site/xdoc/server/config-rabbitmq.xml
@@ -110,6 +110,14 @@
           <dt><strong>ssl.keystore.password</strong></dt>
           <dd>Configure the keystore password. If configured then "ssl.keystore" must also be configured,
               Optional string, defaults to empty string</dd>
+
+          <dt><strong>quorum.queues.enable</strong></dt>
+          <dd>Boolean. Whether to activate Quorum queue usage for use cases that benefits from it (work queue).
+              Quorum queues enables high availability.
+              False (default value) results in the usage of classic queues.</dd>
+
+          <dt><strong>quorum.queues.replication.factor</strong></dt>
+          <dd> Strictly positive integer. The replication factor to use when creating quorum queues.</dd>
       </dl>
   </section>
 


### PR DESCRIPTION
 - [x] Allow the use of Quorum queues for the EventBus and the MailQueues
 - [x] Use publish confirms as recommended
 - [ ] Allow via the configuration to pass several contact points
 - [ ] Measure performance costs of publish confirms

To be done later:

 - [ ] Once we deployed a RabbitMQ cluster in one of our environments at Linagora, and once we did deploy Quorum queues with a replication factor of 3, we will perform a quick return of experience.