### PR TITLE
JAMES-3588 Mailet to propagate encoutered error

### DIFF
--- a/mailet/standard/src/main/java/org/apache/james/transport/mailets/PropagateError.java
+++ b/mailet/standard/src/main/java/org/apache/james/transport/mailets/PropagateError.java
@@ -1,0 +1,44 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.transport.mailets;
+
+import javax.mail.MessagingException;
+
+import org.apache.mailet.Mail;
+import org.apache.mailet.base.GenericMailet;
+
+/**
+ * Propagates the error to the calling context.
+ *
+ * <code>&lt;mailet match=&quot;All&quot; class=&quot;PropagateError&quot;&gt;
+ *     &lt;onMailetException&gt;propagate&lt;/onMailetException&gt;
+ * &lt;/mailet&gt;</code>
+ */
+public class PropagateError extends GenericMailet {
+    @Override
+    public void service(Mail mail) throws MessagingException {
+        throw new MessagingException("Propagating previously encountered mailet processing errors: " + mail.getErrorMessage());
+    }
+
+    @Override
+    public String getMailetInfo() {
+        return "PropagateError";
+    }
+}


### PR DESCRIPTION
Can be configured in the mailet container error processor to propagate errors to the calling context. Usefull for instance for error management with LMTP

EG:

```
        <processor state="error" enableJmx="true">
            <mailet match="All" class="MetricsMailet">
                <metricName>mailetContainerErrors</metricName>
            </mailet>
            <!-- If you want to notify the sender of the failure -->
            <mailet match="All" class="Bounce">
                <onMailetException>ignore</onMailetException>
            </mailet>
            <!-- Propagation of error to calling context - can be used to fail the LMTP transaction -->
            <mailet match="All" class="PropagateError">
                <onMailetException>propagate</onMailetException>
            </mailet>
        </processor>
```